### PR TITLE
feat(mcp): bind portable workflows to session capabilities

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -24,6 +24,10 @@ from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
+from agent.auxiliary_context import (
+    exception_log_detail as _aux_exception_log_detail,
+    exception_log_traceback as _aux_exception_log_traceback,
+)
 from agent.secret_scope import get_secret as _get_secret
 
 try:
@@ -3254,7 +3258,8 @@ def create_anthropic_message(
                     except Exception:
                         logger.debug(
                             "%son_response callback failed",
-                            log_prefix, exc_info=True,
+                            log_prefix,
+                            exc_info=_aux_exception_log_traceback(),
                         )
                 if callable(on_stream_event):
                     # Consume the event stream manually so each event can
@@ -3266,7 +3271,8 @@ def create_anthropic_message(
                         except Exception:
                             logger.debug(
                                 "%son_stream_event callback failed",
-                                log_prefix, exc_info=True,
+                                log_prefix,
+                                exc_info=_aux_exception_log_traceback(),
                             )
                 return stream.get_final_message()
         except Exception as exc:
@@ -3276,7 +3282,7 @@ def create_anthropic_message(
                 "%sAnthropic Messages stream unavailable; falling back to "
                 "messages.create(): %s",
                 log_prefix,
-                exc,
+                _aux_exception_log_detail(exc),
             )
 
     create_kwargs = dict(api_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -62,6 +62,13 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
 
+from agent.auxiliary_context import (
+    AUXILIARY_CALL_CONTEXT,
+    exception_log_detail as _aux_exception_log_detail,
+    exception_log_traceback as _aux_exception_log_traceback,
+    sensitive_content_active as _aux_sensitive_content,
+)
+
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # openai SDK pulls a large type tree (~240 ms cold, including responses/*,
 # graders/*). We expose `OpenAI` here as a thin proxy that imports the SDK on
@@ -336,7 +343,10 @@ def _aux_interrupt_cancel_requested() -> bool:
         try:
             return bool(event.is_set())
         except Exception:
-            logger.debug("aux interrupt cancel event check failed", exc_info=True)
+            logger.debug(
+                "aux interrupt cancel event check failed",
+                exc_info=_aux_exception_log_traceback(),
+            )
             return False
     check = getattr(_aux_interrupt_protection, "cancel_check", None)
     if not callable(check):
@@ -344,7 +354,10 @@ def _aux_interrupt_cancel_requested() -> bool:
     try:
         return bool(check())
     except Exception:
-        logger.debug("aux interrupt cancel check failed", exc_info=True)
+        logger.debug(
+            "aux interrupt cancel check failed",
+            exc_info=_aux_exception_log_traceback(),
+        )
         return False
 
 
@@ -397,7 +410,10 @@ def _captured_aux_cancel_requested(cancel_check: Callable[[], Any]) -> bool:
     try:
         return bool(cancel_check())
     except Exception:
-        logger.debug("captured aux cancel check failed", exc_info=True)
+        logger.debug(
+            "captured aux cancel check failed",
+            exc_info=_aux_exception_log_traceback(),
+        )
         return False
 
 
@@ -453,7 +469,10 @@ def _notify_aux_progress() -> None:
     try:
         hook()
     except Exception:
-        logger.debug("aux progress hook failed", exc_info=True)
+        logger.debug(
+            "aux progress hook failed",
+            exc_info=_aux_exception_log_traceback(),
+        )
 
 
 def _aux_progress_active() -> bool:
@@ -882,7 +901,11 @@ def _fast_model_from_catalog(provider_id: str) -> str:
         except Exception:
             # Not an API-key provider, or nothing configured yet. The anonymous
             # fetch below still works for the catalogs that allow it.
-            logger.debug("No credentials for %s catalog", provider_id, exc_info=True)
+            logger.debug(
+                "No credentials for %s catalog",
+                provider_id,
+                exc_info=_aux_exception_log_traceback(),
+            )
 
         if not base_url:
             base_url = str(getattr(get_provider_profile(provider_id), "base_url", "") or "")
@@ -896,7 +919,11 @@ def _fast_model_from_catalog(provider_id: str) -> str:
             api_key=api_key or None, base_url=base_url, timeout=3.0
         ) or {}
     except Exception:
-        logger.debug("Fast-model catalog lookup failed for %s", provider_id, exc_info=True)
+        logger.debug(
+            "Fast-model catalog lookup failed for %s",
+            provider_id,
+            exc_info=_aux_exception_log_traceback(),
+        )
         return ""
 
     ids = sorted((str(m) for m in catalog), key=_model_recency_key, reverse=True)
@@ -945,7 +972,11 @@ def _get_aux_model_for_provider(provider_id: str, *, prefer_fast: bool = False) 
                 if live:
                     return live
             except Exception:
-                logger.debug("resolve_aux_model failed for %s", provider_id, exc_info=True)
+                logger.debug(
+                    "resolve_aux_model failed for %s",
+                    provider_id,
+                    exc_info=_aux_exception_log_traceback(),
+                )
 
     if profile is not None and profile.default_aux_model:
         return profile.default_aux_model
@@ -1379,14 +1410,22 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
     try:
         pool = load_pool(provider)
     except Exception as exc:
-        logger.debug("Auxiliary client: could not load pool for %s: %s", provider, exc)
+        logger.debug(
+            "Auxiliary client: could not load pool for %s: %s",
+            provider,
+            _aux_exception_log_detail(exc),
+        )
         return False, None
     if not pool or not pool.has_credentials():
         return False, None
     try:
         return True, pool.select()
     except Exception as exc:
-        logger.debug("Auxiliary client: could not select pool entry for %s: %s", provider, exc)
+        logger.debug(
+            "Auxiliary client: could not select pool entry for %s: %s",
+            provider,
+            _aux_exception_log_detail(exc),
+        )
         return True, None
 
 
@@ -1395,7 +1434,11 @@ def _peek_pool_entry(provider: str) -> Optional[Any]:
     try:
         pool = load_pool(provider)
     except Exception as exc:
-        logger.debug("Auxiliary client: could not load pool for %s (peek): %s", provider, exc)
+        logger.debug(
+            "Auxiliary client: could not load pool for %s (peek): %s",
+            provider,
+            _aux_exception_log_detail(exc),
+        )
         return None
     if not pool or not pool.has_credentials():
         return None
@@ -1409,7 +1452,11 @@ def _peek_pool_entry(provider: str) -> Optional[Any]:
         if callable(peek_fn):
             return peek_fn()
     except Exception as exc:
-        logger.debug("Auxiliary client: could not peek pool entry for %s: %s", provider, exc)
+        logger.debug(
+            "Auxiliary client: could not peek pool entry for %s: %s",
+            provider,
+            _aux_exception_log_detail(exc),
+        )
     return None
 
 
@@ -1661,7 +1708,8 @@ class _CodexCompletionsAdapter:
             except Exception as exc:
                 logger.warning(
                     "Auxiliary client: failed to sanitize tool schemas for "
-                    "Codex/xAI Responses path: %s", exc,
+                    "Codex/xAI Responses path: %s",
+                    _aux_exception_log_detail(exc),
                 )
             converted = []
             for t in tools:
@@ -1727,7 +1775,8 @@ class _CodexCompletionsAdapter:
                     resp_kwargs["prompt_cache_retention"] = _cache_retention
         except Exception:
             logger.debug(
-                "Codex auxiliary: prompt_cache_key derivation skipped", exc_info=True
+                "Codex auxiliary: prompt_cache_key derivation skipped",
+                exc_info=_aux_exception_log_traceback(),
             )
 
         # Stream and collect the response
@@ -1738,6 +1787,7 @@ class _CodexCompletionsAdapter:
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
         timeout_timer: Optional[threading.Timer] = None
+        timeout_context = contextvars.copy_context()
         # A protected provider call may outlive its owning compression attempt:
         # the owner returns promptly on hard cancellation while this adapter is
         # still blocked in the SDK stream on its isolated worker. Timer threads
@@ -1782,7 +1832,7 @@ class _CodexCompletionsAdapter:
                         logger.debug(
                             "Codex auxiliary: cancelled attempt stream close "
                             "during timeout failed",
-                            exc_info=True,
+                            exc_info=_aux_exception_log_traceback(),
                         )
                 return
             close = getattr(self._client, "close", None)
@@ -1790,7 +1840,10 @@ class _CodexCompletionsAdapter:
                 try:
                     close()
                 except Exception:
-                    logger.debug("Codex auxiliary: client close during timeout failed", exc_info=True)
+                    logger.debug(
+                        "Codex auxiliary: client close during timeout failed",
+                        exc_info=_aux_exception_log_traceback(),
+                    )
             # The cached auxiliary client wraps this same ``self._client``
             # (or *is* a ``CodexAuxiliaryClient`` whose ``_real_client`` is
             # this instance).  After we close the httpx transport above, the
@@ -1800,7 +1853,10 @@ class _CodexCompletionsAdapter:
             try:
                 _evict_cached_client_instance(self._client)
             except Exception:
-                logger.debug("Codex auxiliary: cache eviction on timeout failed", exc_info=True)
+                logger.debug(
+                    "Codex auxiliary: cache eviction on timeout failed",
+                    exc_info=_aux_exception_log_traceback(),
+                )
 
         def _check_cancelled() -> None:
             if deadline is not None and time.monotonic() >= deadline:
@@ -1827,7 +1883,11 @@ class _CodexCompletionsAdapter:
 
         try:
             if total_timeout:
-                timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
+                timeout_timer = threading.Timer(
+                    float(total_timeout),
+                    timeout_context.run,
+                    args=(_close_client_on_timeout,),
+                )
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
@@ -1880,7 +1940,7 @@ class _CodexCompletionsAdapter:
                     except Exception:
                         logger.debug(
                             "Codex auxiliary: late cancelled attempt stream close failed",
-                            exc_info=True,
+                            exc_info=_aux_exception_log_traceback(),
                         )
             try:
                 # Some Codex-compatible hosts accept ``stream=True`` but return
@@ -1948,7 +2008,10 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
-            logger.debug("Codex auxiliary Responses API call failed: %s", exc)
+            logger.debug(
+                "Codex auxiliary Responses API call failed: %s",
+                _aux_exception_log_detail(exc),
+            )
             raise
         finally:
             if timeout_timer is not None:
@@ -2510,7 +2573,9 @@ def _maybe_wrap_anthropic(
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "
-            "OpenAI-wire client.", base_url, exc,
+            "OpenAI-wire client.",
+            base_url,
+            _aux_exception_log_detail(exc),
         )
         return client_obj
 
@@ -2558,7 +2623,7 @@ def _read_nous_auth() -> Optional[dict]:
             return None
         return provider
     except Exception as exc:
-        logger.debug("Could not read Nous auth: %s", exc)
+        logger.debug("Could not read Nous auth: %s", _aux_exception_log_detail(exc))
         return None
 
 
@@ -2594,7 +2659,10 @@ def _resolve_nous_pool_runtime_api(*, force_refresh: bool = False) -> Optional[t
 
         pool = load_pool("nous")
     except Exception as exc:
-        logger.debug("Auxiliary Nous pool credential resolution failed: %s", exc)
+        logger.debug(
+            "Auxiliary Nous pool credential resolution failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None
 
     if not pool or not pool.has_credentials():
@@ -2603,7 +2671,10 @@ def _resolve_nous_pool_runtime_api(*, force_refresh: bool = False) -> Optional[t
     try:
         entry = pool.select()
     except Exception as exc:
-        logger.debug("Auxiliary Nous pool selection failed: %s", exc)
+        logger.debug(
+            "Auxiliary Nous pool selection failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None
 
     if entry is None:
@@ -2618,7 +2689,10 @@ def _resolve_nous_pool_runtime_api(*, force_refresh: bool = False) -> Optional[t
         try:
             refreshed = pool.try_refresh_current()
         except Exception as exc:
-            logger.debug("Auxiliary Nous pool refresh failed: %s", exc)
+            logger.debug(
+                "Auxiliary Nous pool refresh failed: %s",
+                _aux_exception_log_detail(exc),
+            )
             refreshed = None
         if refreshed is None:
             return None
@@ -2658,7 +2732,10 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
             force_refresh=force_refresh,
         )
     except Exception as exc:
-        logger.debug("Auxiliary Nous runtime credential resolution failed: %s", exc)
+        logger.debug(
+            "Auxiliary Nous runtime credential resolution failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None
 
     api_key = str(creds.get("api_key") or "").strip()
@@ -2706,14 +2783,20 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
                 if api_key and base_url:
                     return api_key, base_url
     except Exception as exc:
-        logger.debug("Auxiliary xAI OAuth pool credential resolution failed: %s", exc)
+        logger.debug(
+            "Auxiliary xAI OAuth pool credential resolution failed: %s",
+            _aux_exception_log_detail(exc),
+        )
 
     try:
         from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
 
         creds = resolve_xai_oauth_runtime_credentials()
     except Exception as exc:
-        logger.debug("Auxiliary xAI OAuth runtime credential resolution failed: %s", exc)
+        logger.debug(
+            "Auxiliary xAI OAuth runtime credential resolution failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None
 
     api_key = str(creds.get("api_key") or "").strip()
@@ -2762,7 +2845,10 @@ def _read_codex_access_token() -> Optional[str]:
 
         return access_token.strip()
     except Exception as exc:
-        logger.debug("Could not read Codex auth for auxiliary client: %s", exc)
+        logger.debug(
+            "Could not read Codex auth for auxiliary client: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None
 
 
@@ -3046,7 +3132,9 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
             logger.debug(
                 "Auxiliary/%s: recommended-models lookup failed (%s); "
                 "falling back to %s",
-                "vision" if vision else "text", exc, model,
+                "vision" if vision else "text",
+                _aux_exception_log_detail(exc),
+                model,
             )
 
     if runtime is not None:
@@ -3100,7 +3188,8 @@ def _refresh_nous_recommended_model(
     except Exception as exc:
         logger.debug(
             "Nous recommended-model refresh failed (%s); using default %s",
-            exc, _NOUS_MODEL,
+            _aux_exception_log_detail(exc),
+            _NOUS_MODEL,
         )
     if fresh and fresh.strip().lower() != stale:
         return fresh
@@ -3249,7 +3338,9 @@ def _resolve_moa_aggregator(preset_name: Optional[str]) -> Tuple[Optional[str], 
             return agg_provider, agg_model
     except Exception:
         logger.debug(
-            "MoA aggregator resolution failed for preset %r", preset_name, exc_info=True
+            "MoA aggregator resolution failed for preset %r",
+            preset_name,
+            exc_info=_aux_exception_log_traceback(),
         )
     return None, None
 
@@ -3305,19 +3396,18 @@ _RUNTIME_MAIN_CONTEXT: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("auxiliary_runtime_main", default=None)
 )
 
-_RELAY_AUX_CALL_CONTEXT: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
-    contextvars.ContextVar("auxiliary_relay_call", default=None)
-)
+_RELAY_AUX_CALL_CONTEXT = AUXILIARY_CALL_CONTEXT
 
 
 def _relay_auxiliary_call(callback):
-    """Give every physical retry in one auxiliary call a shared Relay identity."""
+    """Install per-call policy and a shared Relay identity for physical retries."""
 
     @functools.wraps(callback)
     def wrapped(*args, **kwargs):
         task = args[0] if args else kwargs.get("task")
         token = _RELAY_AUX_CALL_CONTEXT.set({
             "task": str(task or "unknown"),
+            "sensitive_content": bool(kwargs.get("sensitive_content", False)),
             "request_id": f"aux-{uuid.uuid4().hex}",
             "attempt_count": 0,
             "provider": "",
@@ -3344,6 +3434,7 @@ def _relay_auxiliary_call_async(callback):
         task = args[0] if args else kwargs.get("task")
         token = _RELAY_AUX_CALL_CONTEXT.set({
             "task": str(task or "unknown"),
+            "sensitive_content": bool(kwargs.get("sensitive_content", False)),
             "request_id": f"aux-{uuid.uuid4().hex}",
             "attempt_count": 0,
             "provider": "",
@@ -3393,7 +3484,7 @@ def _relay_auxiliary_metadata(
     api_mode: str | None = None,
 ) -> tuple[str, str, dict[str, Any]] | None:
     context = _RELAY_AUX_CALL_CONTEXT.get()
-    if context is None:
+    if context is None or context.get("sensitive_content"):
         return None
     attempt_count = int(context.get("attempt_count") or 0)
     context["attempt_count"] = attempt_count + 1
@@ -3631,7 +3722,10 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
 
         runtime = resolve_runtime_provider(requested="custom")
     except Exception as exc:
-        logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
+        logger.debug(
+            "Auxiliary client: custom runtime resolution failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         runtime = None
 
     if not isinstance(runtime, dict):
@@ -3898,10 +3992,13 @@ def _try_azure_foundry(
             target_model=model,
         )
     except AuthError as exc:
-        logger.debug("Auxiliary azure-foundry: %s", exc)
+        logger.debug("Auxiliary azure-foundry: %s", _aux_exception_log_detail(exc))
         return None, None
     except Exception as exc:
-        logger.debug("Auxiliary azure-foundry runtime error: %s", exc)
+        logger.debug(
+            "Auxiliary azure-foundry runtime error: %s",
+            _aux_exception_log_detail(exc),
+        )
         return None, None
 
     api_key = runtime.get("api_key")
@@ -4250,7 +4347,10 @@ def _nous_portal_account_has_fresh_paid_access() -> bool:
         account_info = get_nous_portal_account_info(force_fresh=True)
         return account_info.paid_service_access is True
     except Exception as exc:
-        logger.debug("Auxiliary Nous paid-entitlement refresh check failed: %s", exc)
+        logger.debug(
+            "Auxiliary Nous paid-entitlement refresh check failed: %s",
+            _aux_exception_log_detail(exc),
+        )
         return False
 
 
@@ -4709,7 +4809,12 @@ def _pool_cache_hint(
 
 def _pool_error_context(exc: Exception) -> Dict[str, Any]:
     status = getattr(exc, "status_code", None)
-    payload: Dict[str, Any] = {"message": str(exc)}
+    payload: Dict[str, Any] = {}
+    # Credential pools persist this context to disk. A provider exception can
+    # echo its request body, so sensitive calls retain only structural status
+    # and never persist the exception message alongside the credential.
+    if not _aux_sensitive_content():
+        payload["message"] = str(exc)
     if status is not None:
         payload["status_code"] = status
     return payload
@@ -4770,7 +4875,11 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     try:
         pool = load_pool(normalized)
     except Exception as load_exc:
-        logger.debug("Auxiliary client: could not load pool for %s recovery: %s", normalized, load_exc)
+        logger.debug(
+            "Auxiliary client: could not load pool for %s recovery: %s",
+            normalized,
+            _aux_exception_log_detail(load_exc),
+        )
         return False
     if not pool or not pool.has_credentials():
         return False
@@ -5043,7 +5152,11 @@ def _refresh_provider_credentials(provider: str) -> bool:
             _evict_cached_clients(normalized)
             return True
     except Exception as exc:
-        logger.debug("Auxiliary provider credential refresh failed for %s: %s", normalized, exc)
+        logger.debug(
+            "Auxiliary provider credential refresh failed for %s: %s",
+            normalized,
+            _aux_exception_log_detail(exc),
+        )
         return False
     return False
 
@@ -5344,7 +5457,9 @@ def _call_fallback_candidate_sync(
         logger.warning(
             "Auxiliary %s: fallback candidate %s has a stale/unrefreshable "
             "credential (%s) — skipping to next fallback",
-            task or "call", fb_label, fb_err,
+            task or "call",
+            fb_label,
+            _aux_exception_log_detail(fb_err),
         )
         return None
 
@@ -5447,7 +5562,9 @@ async def _call_fallback_candidate_async(
         logger.warning(
             "Auxiliary %s (async): fallback candidate %s has a stale/unrefreshable "
             "credential (%s) — skipping to next fallback",
-            task or "call", fb_label, fb_err,
+            task or "call",
+            fb_label,
+            _aux_exception_log_detail(fb_err),
         )
         return None
 
@@ -5659,7 +5776,9 @@ def _candidate_context_window(
     except Exception as exc:
         logger.debug(
             "Auxiliary fallback: could not resolve context window for %s/%s: %s",
-            provider, model, exc,
+            provider,
+            model,
+            _aux_exception_log_detail(exc),
         )
         return None
     # ``get_model_context_length`` returns an int (with a 256K default
@@ -5869,7 +5988,11 @@ def _try_main_fallback_chain(
 
         chain = get_fallback_chain(load_config_readonly())
     except Exception as exc:
-        logger.debug("Auxiliary %s: could not load main fallback chain: %s", task or "call", exc)
+        logger.debug(
+            "Auxiliary %s: could not load main fallback chain: %s",
+            task or "call",
+            _aux_exception_log_detail(exc),
+        )
         return None, None, ""
 
     if not chain:
@@ -5900,7 +6023,12 @@ def _try_main_fallback_chain(
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
         except Exception as exc:
-            logger.debug("Auxiliary %s: main fallback %s failed to resolve: %s", task or "call", label, exc)
+            logger.debug(
+                "Auxiliary %s: main fallback %s failed to resolve: %s",
+                task or "call",
+                label,
+                _aux_exception_log_detail(exc),
+            )
             fb_client, resolved_model = None, None
         if fb_client is not None:
             if min_ctx is not None:
@@ -7063,7 +7191,7 @@ def resolve_provider_client(
             client = _VertexOpenAI(api_key=token, base_url=base_url)
         except Exception as exc:
             logger.warning("resolve_provider_client: cannot create Vertex "
-                           "client: %s", exc)
+                           "client: %s", _aux_exception_log_detail(exc))
             return None, None
         logger.debug("resolve_provider_client: vertex (%s)", final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -7130,7 +7258,7 @@ def resolve_provider_client(
                 real_client = build_anthropic_bedrock_client(region)
             except ImportError as exc:
                 logger.warning("resolve_provider_client: cannot create Bedrock "
-                               "client: %s", exc)
+                               "client: %s", _aux_exception_log_detail(exc))
                 return None, None
             client = AnthropicAuxiliaryClient(
                 real_client, final_model, api_key="aws-sdk",
@@ -8787,7 +8915,7 @@ def _build_call_kwargs(
         logger.debug(
             "_build_call_kwargs: provider profile projection failed for %s: %s",
             provider,
-            exc,
+            _aux_exception_log_detail(exc),
         )
 
     kwargs.update(profile_top_level)
@@ -8905,7 +9033,7 @@ def _validate_llm_response(
 def _complete_relay_auxiliary_call(*, outcome: str = "success") -> None:
     """Close one auxiliary logical call after acceptance or terminal failure."""
     context = _RELAY_AUX_CALL_CONTEXT.get()
-    if context is None:
+    if context is None or context.get("sensitive_content"):
         return
     from agent import relay_llm
 
@@ -8938,7 +9066,7 @@ def _fail_relay_auxiliary_call() -> None:
     except Exception:
         logger.warning(
             "Relay auxiliary failure finalization failed",
-            exc_info=True,
+            exc_info=_aux_exception_log_traceback(),
         )
 
 
@@ -9146,7 +9274,9 @@ def _create_with_progress(
         # plain call reproduces the real error for the normal except-chains.
         logger.debug(
             "Auxiliary %s: streamed request failed (%s); retrying "
-            "non-streaming", task or "call", exc,
+            "non-streaming",
+            task or "call",
+            _aux_exception_log_detail(exc),
         )
         return client.chat.completions.create(**kwargs)
 
@@ -9361,8 +9491,17 @@ def call_llm(
     stream: bool = False,
     stream_options: dict = None,
     route_info: Optional[Dict[str, str]] = None,
+    sensitive_content: bool = False,
+    allow_provider_fallback: bool = True,
 ) -> Any:
-    """Run an auxiliary LLM request, applying the configured task limit."""
+    """Run an auxiliary LLM request, applying the configured task limit.
+
+    ``sensitive_content`` keeps the request outside Relay/request capture and
+    redacts exception details from auxiliary-client logs. Setting
+    ``allow_provider_fallback`` to ``False`` pins the call to its selected
+    provider while retaining bounded same-provider retries and credential
+    refreshes.
+    """
     semaphore = _acquire_sync_aux_semaphore(task)
     if semaphore is not None:
         semaphore.acquire()
@@ -9386,6 +9525,7 @@ def call_llm(
             stream=stream,
             stream_options=stream_options,
             route_info=route_info,
+            allow_provider_fallback=allow_provider_fallback,
         )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -9432,6 +9572,7 @@ def _call_llm_impl(
     stream: bool = False,
     stream_options: dict = None,
     route_info: Optional[Dict[str, str]] = None,
+    allow_provider_fallback: bool = True,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -9463,6 +9604,9 @@ def _call_llm_impl(
             output can stream to the user.
         stream_options: Passed through to the request when stream is True
             (e.g. {"include_usage": True}).
+        allow_provider_fallback: When False, never invoke a provider other
+            than the one selected for this call. Same-provider retries and
+            credential refreshes remain enabled.
 
     Returns:
         Response object with .choices[0].message.content, OR — when stream=True —
@@ -9493,7 +9637,12 @@ def _call_llm_impl(
             async_mode=False,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (
+            allow_provider_fallback
+            and client is None
+            and resolved_provider != "auto"
+            and not resolved_base_url
+        ):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -9530,7 +9679,11 @@ def _call_llm_impl(
             # tasks because fallback entries may use OAuth / credential-pool
             # auth (for example openai-codex).
             _explicit = (resolved_provider or "").strip().lower()
-            if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
+            if (
+                allow_provider_fallback
+                and _explicit
+                and _explicit not in {"auto", "openrouter", "custom"}
+            ):
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
                     task, _explicit,
                 )
@@ -9549,7 +9702,7 @@ def _call_llm_impl(
             # Pass model=None so each provider uses its own default —
             # resolved_model may be an OpenRouter-format slug that doesn't
             # work on other providers.
-            if client is None and not resolved_base_url:
+            if allow_provider_fallback and client is None and not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
                 client, final_model = _get_cached_client(
@@ -9679,7 +9832,7 @@ def _call_llm_impl(
                 logger.info(
                     "Auxiliary compression: timeout on the critical path; "
                     "skipping same-provider retry and falling back: %s",
-                    transient_err,
+                    _aux_exception_log_detail(transient_err),
                 )
                 raise
             _max_transient_retries = _transient_retry_count()
@@ -9690,7 +9843,7 @@ def _call_llm_impl(
                     "Auxiliary %s: transient transport error (attempt %d/%d); "
                     "retrying same provider after %.1fs before fallback: %s",
                     task or "call", _attempt, _max_transient_retries, _backoff,
-                    _last_transient,
+                    _aux_exception_log_detail(_last_transient),
                 )
                 time.sleep(_backoff)
                 try:
@@ -10067,7 +10220,11 @@ def _call_llm_impl(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        if (
+            allow_provider_fallback
+            and should_fallback
+            and (is_auto or is_capacity_error)
+        ):
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):
@@ -10088,7 +10245,8 @@ def _call_llm_impl(
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
-                        task or "call", reason, resolved_provider, first_err)
+                        task or "call", reason, resolved_provider,
+                        _aux_exception_log_detail(first_err))
 
             # Narrow the configured-chain skip to the exact model that
             # failed ONLY for model-specific failures. Auth (401) and
@@ -10173,7 +10331,7 @@ def _call_llm_impl(
                 _evict_cached_client_instance(client)
             except Exception:
                 logger.debug("Auxiliary: cache eviction after connection error failed",
-                             exc_info=True)
+                             exc_info=_aux_exception_log_traceback())
         raise
 
 
@@ -10250,8 +10408,14 @@ async def async_call_llm(
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    sensitive_content: bool = False,
+    allow_provider_fallback: bool = True,
 ) -> Any:
-    """Run an asynchronous auxiliary LLM request under the configured limit."""
+    """Run an asynchronous auxiliary LLM request under the configured limit.
+
+    See :func:`call_llm` for the sensitive-content and provider-pinning
+    contracts.
+    """
     semaphore = _acquire_async_aux_semaphore(task)
     if semaphore is not None:
         await semaphore.acquire()
@@ -10271,6 +10435,7 @@ async def async_call_llm(
             extra_body=extra_body,
             reasoning_config=reasoning_config,
             route_info=route_info,
+            allow_provider_fallback=allow_provider_fallback,
         )
     finally:
         if semaphore is not None:
@@ -10293,6 +10458,7 @@ async def _async_call_llm_impl(
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    allow_provider_fallback: bool = True,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -10316,7 +10482,12 @@ async def _async_call_llm_impl(
             async_mode=True,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (
+            allow_provider_fallback
+            and client is None
+            and resolved_provider != "auto"
+            and not resolved_base_url
+        ):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -10349,7 +10520,11 @@ async def _async_call_llm_impl(
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
-            if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
+            if (
+                allow_provider_fallback
+                and _explicit
+                and _explicit not in {"auto", "openrouter", "custom"}
+            ):
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
                     task, _explicit,
                 )
@@ -10365,7 +10540,7 @@ async def _async_call_llm_impl(
                         f"was found. Set the {_explicit.upper()}_API_KEY environment "
                         f"variable, or switch to a different provider with `hermes model`."
                     )
-            if client is None and not resolved_base_url:
+            if allow_provider_fallback and client is None and not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
                 client, final_model = _get_cached_client(
@@ -10449,13 +10624,14 @@ async def _async_call_llm_impl(
                 logger.info(
                     "Auxiliary compression (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",
-                    transient_err,
+                    _aux_exception_log_detail(transient_err),
                 )
                 raise
             logger.info(
                 "Auxiliary %s (async): transient transport error; retrying "
                 "once on the same provider before fallback: %s",
-                task or "call", transient_err,
+                task or "call",
+                _aux_exception_log_detail(transient_err),
             )
             return _validate_llm_response(
                 await _relay_async_completion(
@@ -10769,7 +10945,11 @@ async def _async_call_llm_impl(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        if (
+            allow_provider_fallback
+            and should_fallback
+            and (is_auto or is_capacity_error)
+        ):
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):
@@ -10786,7 +10966,8 @@ async def _async_call_llm_impl(
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
-                        task or "call", reason, resolved_provider, first_err)
+                        task or "call", reason, resolved_provider,
+                        _aux_exception_log_detail(first_err))
 
             # Narrow the configured-chain skip to the exact model that
             # failed ONLY for model-specific failures. Auth (401) and
@@ -10876,5 +11057,5 @@ async def _async_call_llm_impl(
                 _evict_cached_client_instance(client)
             except Exception:
                 logger.debug("Auxiliary (async): cache eviction after connection error failed",
-                             exc_info=True)
+                             exc_info=_aux_exception_log_traceback())
         raise

--- a/agent/auxiliary_context.py
+++ b/agent/auxiliary_context.py
@@ -1,0 +1,39 @@
+"""Per-call privacy context shared by auxiliary provider adapters.
+
+This module is intentionally dependency-light so provider-specific adapters can
+honor the auxiliary client's privacy boundary without importing the client
+router (which would create import cycles).
+"""
+
+import contextvars
+from typing import Any, Dict, Optional
+
+
+AUXILIARY_CALL_CONTEXT: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+    contextvars.ContextVar("auxiliary_relay_call", default=None)
+)
+
+
+def sensitive_content_active() -> bool:
+    """Return whether the active auxiliary call carries sensitive content."""
+    context = AUXILIARY_CALL_CONTEXT.get()
+    return bool(context and context.get("sensitive_content"))
+
+
+def exception_log_detail(exc: BaseException) -> str:
+    """Keep provider/request details out of logs for sensitive calls."""
+    if sensitive_content_active():
+        return f"<{type(exc).__name__}: details redacted>"
+    return str(exc)
+
+
+def exception_log_traceback() -> bool:
+    """Suppress traceback rendering when it could echo sensitive content."""
+    return not sensitive_content_active()
+
+
+def content_log_detail(value: Any) -> str:
+    """Redact provider-supplied content while preserving ordinary diagnostics."""
+    if sensitive_content_active():
+        return "<sensitive content: details redacted>"
+    return str(value)

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import httpx
 
 from agent.bounded_response import read_streaming_error_body
+from agent.auxiliary_context import content_log_detail as _aux_content_log_detail
 from agent.gemini_schema import sanitize_gemini_tool_parameters
 
 logger = logging.getLogger(__name__)
@@ -871,7 +872,10 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
             try:
                 payload = json.loads(data)
             except json.JSONDecodeError:
-                logger.debug("Non-JSON Gemini SSE line: %s", data[:200])
+                logger.debug(
+                    "Non-JSON Gemini SSE line: %s",
+                    _aux_content_log_detail(data[:200]),
+                )
                 continue
             if isinstance(payload, dict):
                 yield payload

--- a/docs/security/agent-plugin-session-capabilities.md
+++ b/docs/security/agent-plugin-session-capabilities.md
@@ -1,0 +1,104 @@
+# Agent Plugin session capabilities
+
+Portable Agent Plugins are normally untrusted model-tool packages. They do not
+receive Hermes platform, profile, session, message, or active-turn identifiers.
+An MCP server that must bridge one reviewed workflow into a private platform can
+request an explicit `sessionCapability`, but the request is denied unless the
+profile grants the exact installed package and server binding.
+
+## Threat model
+
+A plugin name, MCP tool description, toolset entry, Unix socket, or same-user
+process is not an authority boundary. A sibling process may read same-user files
+or connect to same-user sockets. A model may forge ordinary tool arguments. A
+package update can change executable bytes while retaining its name.
+
+Session capabilities therefore bind every call to host-owned identity and
+current runtime state. They are intended for narrow fixed-workflow relays, not
+generic phone, browser, terminal, or arbitrary tool proxies.
+
+## Package request
+
+An Agent Plugin requests capability metadata for one packaged MCP server in its
+`plugin.json` extension:
+
+```json
+{
+  "extensions": {
+    "com.hermes": {
+      "sessionCapability": ["workflows"]
+    }
+  }
+}
+```
+
+The named server must be a valid packaged stdio MCP server. A Python server must
+launch with `-I -S -B` and an in-package regular script. Bare ambient
+executables, remote transports, symlinks, Python bytecode caches, and executable
+content outside the approved package root fail closed.
+
+## Profile grant
+
+The profile grants one exact package/server binding and canonical package
+digest:
+
+```yaml
+plugins:
+  trusted_session_context:
+    - binding: example-plugin:workflows
+      digest: sha256:<canonical-package-digest>
+```
+
+Plugin discovery does not grant trust. Before every capability mint Hermes
+rereads consent, rejects caches or symlinks, recomputes the package digest, and
+checks the approved binding. Updating any included package byte changes the
+digest and requires a new explicit grant.
+
+## Per-call binding
+
+For an authorised call Hermes mints a short-lived process-local HMAC capability
+in MCP request `_meta`. The signed claims bind at least:
+
+- audience and exact package/server binding;
+- workflow name and canonical arguments;
+- profile, platform, session, message, and tool-call identity;
+- connection/turn sequence, expiry, and single-use nonce.
+
+The receiving private relay must verify the complete claim, expected workflow
+sequence, active turn, and replay ledger. It must not accept any of those values
+from ordinary model arguments. A blank or nonmatching session cannot become a
+proactive call.
+
+Capabilities are process-local. Restarting Hermes invalidates every outstanding
+capability. A capability for one package, server, workflow, payload, profile, or
+turn cannot be reused for another.
+
+## Cancellation and ambiguous outcomes
+
+Standard MCP `notifications/cancelled` is bound to the exact request ID. The
+stdio server, private relay, platform dispatcher, downstream MCP client, and
+device server must propagate cancellation so delayed side effects do not keep
+running silently.
+
+Cancellation or transport loss after mutation handoff may have an ambiguous
+outcome. Mutating workflows must use a stable operation identity derived from
+trusted call identity and retry only with the byte-identical payload. An exact
+historical receipt is success; a conflicting payload fails; an unprovable
+outcome remains unknown rather than being relabeled as not committed.
+
+## Operational checks
+
+Before enabling a capability package:
+
+1. run `hermes plugins doctor --ci <package>`;
+2. verify the package is cache-free and symlink-free;
+3. review its canonical digest and executable command;
+4. add the exact digest-bound profile grant;
+5. expose only the intended static MCP toolset to the target platform;
+6. keep any raw downstream tools private and schema-pinned;
+7. restart the gateway and inspect effective runtime tool discovery;
+8. test cancellation, replay, expiry, wrong audience/binding/workflow/payload,
+   package-update revocation, and ambiguous mutation recovery.
+
+Do not use SOUL, skills, platform hints, tool descriptions, socket permissions,
+or model-visible policy text as substitutes for these checks.

--- a/docs/security/agent-plugin-session-capabilities.md
+++ b/docs/security/agent-plugin-session-capabilities.md
@@ -54,6 +54,11 @@ rereads consent, rejects caches or symlinks, recomputes the package digest, and
 checks the approved binding. Updating any included package byte changes the
 digest and requires a new explicit grant.
 
+The dashboard MCP page lists enabled portable MCP servers as read-only,
+plugin-managed entries. Their lifecycle stays on the Plugins page; ordinary
+MCP config endpoints cannot toggle, test, or delete a capability-bearing
+package server independently of its reviewed package.
+
 ## Per-call binding
 
 For an authorised call Hermes mints a short-lived process-local HMAC capability

--- a/hermes_cli/agent_plugins.py
+++ b/hermes_cli/agent_plugins.py
@@ -9,8 +9,10 @@ Python code.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Mapping, Tuple
@@ -70,10 +72,182 @@ class AgentPluginPackage:
     description: str
     root: Path
     data_root: Path
+    content_digest: str
     manifest: Mapping[str, Any]
     skills: Tuple[AgentPluginSkill, ...]
     mcp_servers: Mapping[str, Dict[str, Any]]
     diagnostics: Tuple[AgentPluginDiagnostic, ...]
+
+
+_DIGEST_EXCLUDED_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
+_DIGEST_EXCLUDED_FILES = frozenset({".DS_Store"})
+
+
+def canonical_package_digest(plugin_root: Path) -> str:
+    """Hash the exact portable package contents using a stable file framing.
+
+    VCS metadata and generated interpreter/test caches are intentionally not
+    authority-bearing.  Everything else is: replacing code, manifests,
+    documentation, or bundled assets changes the grant digest.  Symlinks and
+    special files fail closed because their meaning is installation-dependent.
+    """
+
+    root = Path(plugin_root).resolve(strict=True)
+    if not root.is_dir():
+        raise AgentPluginError("plugin root must be a directory")
+    entries: list[tuple[str, Path]] = []
+    for current, dirs, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        kept_dirs: list[str] = []
+        for name in sorted(dirs):
+            path = current_path / name
+            if name in _DIGEST_EXCLUDED_DIRS:
+                continue
+            if path.is_symlink():
+                entries.append((path.relative_to(root).as_posix(), path))
+                continue
+            kept_dirs.append(name)
+        dirs[:] = kept_dirs
+        for name in sorted(files):
+            path = current_path / name
+            if (
+                name in _DIGEST_EXCLUDED_FILES
+                or name.endswith((".pyc", ".pyo"))
+            ):
+                continue
+            if not path.is_symlink() and not path.is_file():
+                raise AgentPluginError(
+                    "portable package digest allows regular files only"
+                )
+            relative = path.relative_to(root).as_posix()
+            entries.append((relative, path))
+
+    digest = hashlib.sha256(b"hermes-agent-plugin-package-v1\0")
+    for relative, path in sorted(entries):
+        encoded_name = relative.encode("utf-8")
+        try:
+            content = (
+                b"symlink-v1\0" + os.readlink(path).encode("utf-8")
+                if path.is_symlink()
+                else b"file-v1\0" + path.read_bytes()
+            )
+        except (OSError, UnicodeError) as exc:
+            raise AgentPluginError(
+                f"portable package file cannot be read: {relative}"
+            ) from exc
+        digest.update(len(encoded_name).to_bytes(8, "big"))
+        digest.update(encoded_name)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _package_contains_symlink(root: Path) -> bool:
+    for current, dirs, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        for name in (*dirs, *files):
+            if (current_path / name).is_symlink():
+                return True
+    return False
+
+
+def package_has_executable_cache(plugin_root: Path) -> bool:
+    """Return true when Python could execute ungranted cached bytecode."""
+
+    root = Path(plugin_root).resolve(strict=True)
+    for current, dirs, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        kept: list[str] = []
+        for name in dirs:
+            if name in {".git", ".hg", ".svn"}:
+                continue
+            if name == "__pycache__":
+                return True
+            kept.append(name)
+        dirs[:] = kept
+        if any(name.endswith((".pyc", ".pyo")) for name in files):
+            return True
+        # A symlink named like executable cache is authority-unsafe too.
+        if any(
+            (current_path / name).is_symlink()
+            and (name == "__pycache__" or name.endswith((".pyc", ".pyo")))
+            for name in (*dirs, *files)
+        ):
+            return True
+    return False
+
+
+def _harden_capability_launch(
+    server: Dict[str, Any], plugin_root: Path
+) -> str | None:
+    """Pin a privileged stdio launch to reviewed package or host bytes.
+
+    Returns a diagnostic message on failure. Direct Python launches are
+    rewritten away from mutable ``PATH`` resolution to the interpreter already
+    in Hermes' TCB. Other runtimes must be an executable regular file reached
+    through the package's translated ``./...`` command form and therefore be
+    included in the package digest.
+    """
+
+    command = server.get("command")
+    if not isinstance(command, str) or not command:
+        return "sessionCapability requires a pinned stdio executable"
+    command_path = Path(command)
+    python_name = re.fullmatch(
+        r"python(?:[0-9]+(?:\.[0-9]+)*)?(?:\.exe)?",
+        command.lower(),
+    )
+    if not command_path.is_absolute() and python_name is not None:
+        args = server.get("args")
+        env = server.get("env")
+        if not (
+            isinstance(args, list)
+            and len(args) >= 4
+            and args[:3] == ["-I", "-S", "-B"]
+            and isinstance(env, Mapping)
+            and env.get("PYTHONDONTWRITEBYTECODE") == "1"
+        ):
+            return (
+                "sessionCapability Python servers require -I -S -B, an in-package "
+                "script, and PYTHONDONTWRITEBYTECODE=1"
+            )
+        script = Path(args[3])
+        if (
+            not script.is_absolute()
+            or not _inside(script, plugin_root)
+            or script.is_symlink()
+            or not script.is_file()
+        ):
+            return "sessionCapability Python script must be a regular in-package file"
+        try:
+            host_python = Path(sys.executable).resolve(strict=True)
+        except OSError:
+            return "sessionCapability host Python executable is unavailable"
+        if not host_python.is_file() or not os.access(host_python, os.X_OK):
+            return "sessionCapability host Python executable is unavailable"
+        server["command"] = str(host_python)
+        return None
+
+    if not command_path.is_absolute():
+        return "sessionCapability rejects bare ambient executables"
+    if (
+        not _inside(command_path, plugin_root)
+        or command_path.is_symlink()
+        or not command_path.is_file()
+        or not os.access(command_path, os.X_OK)
+    ):
+        return "sessionCapability executable must be a regular in-package file"
+    return None
 
 
 def _inside(path: Path, root: Path) -> bool:
@@ -531,16 +705,79 @@ def load_agent_plugin(plugin_root: Path, data_root: Path) -> AgentPluginPackage:
     root = Path(plugin_root).resolve(strict=True)
     if not root.is_dir():
         raise AgentPluginError("plugin root must be a directory")
+    content_digest = canonical_package_digest(root)
     manifest, diagnostics = _validate_manifest(root)
     resolved_data = Path(data_root).resolve(strict=False)
     skills = _discover_skills(root, diagnostics)
     mcp_servers = _discover_mcp(root, resolved_data, diagnostics)
+    # Hermes-specific request for a host-minted, call-bound capability.  The
+    # package cannot grant this privilege to itself: PluginManager separately
+    # requires a profile grant bound to this exact content digest.
+    hermes_extension = (manifest.get("extensions") or {}).get("com.hermes")
+    capability_names: set[str] = set()
+    if isinstance(hermes_extension, dict):
+        raw_capability = hermes_extension.get("sessionCapability")
+        if isinstance(raw_capability, list) and all(
+            isinstance(value, str) and value for value in raw_capability
+        ):
+            capability_names = set(raw_capability)
+        elif raw_capability is not None:
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    "manifest",
+                    "com.hermes.sessionCapability must be an array of MCP server names",
+                )
+            )
+        if "forwardSessionContext" in hermes_extension:
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    "manifest",
+                    "com.hermes.forwardSessionContext is unsupported; request sessionCapability instead",
+                )
+            )
+    for server_name in capability_names:
+        server = mcp_servers.get(server_name)
+        if server is None:
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    f"mcp:{server_name}",
+                    "sessionCapability names no valid packaged MCP server",
+                )
+            )
+            continue
+        if _package_contains_symlink(root):
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    f"mcp:{server_name}",
+                    "sessionCapability is unavailable for packages containing symlinks",
+                )
+            )
+            continue
+        if package_has_executable_cache(root):
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    f"mcp:{server_name}",
+                    "sessionCapability is unavailable while Python bytecode caches exist",
+                )
+            )
+            continue
+        launch_error = _harden_capability_launch(server, root)
+        if launch_error is not None:
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    f"mcp:{server_name}",
+                    launch_error,
+                )
+            )
+            continue
+        server["request_session_capability"] = True
     return AgentPluginPackage(
         name=manifest["name"],
         version=manifest.get("version", ""),
         description=manifest.get("description", ""),
         root=root,
         data_root=resolved_data,
+        content_digest=content_digest,
         manifest=dict(manifest),
         skills=skills,
         mcp_servers=mcp_servers,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4342,22 +4342,24 @@ class PluginManager:
 
         return manifests
 
-    def has_enabled_portable_mcp(self, raw_config: Mapping[str, Any]) -> bool:
-        """Probe enabled portable MCP packages without loading plugins.
+    def get_enabled_portable_mcp_server_descriptors(
+        self, raw_config: Mapping[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Describe enabled portable MCP packages without loading plugins.
 
         The directory manifest collection is shared with full discovery, so
         native ``plugin.yaml`` precedence, source ordering, depth limits, and
         project-plugin gating cannot diverge between startup and runtime.
         """
         if _env_enabled("HERMES_SAFE_MODE"):
-            return False
+            return []
 
         plugins_config = raw_config.get("plugins")
         if not isinstance(plugins_config, dict):
-            return False
+            return []
         enabled_value = plugins_config.get("enabled")
         if not isinstance(enabled_value, list):
-            return False
+            return []
         enabled = {value for value in enabled_value if isinstance(value, str)}
         disabled_value = plugins_config.get("disabled", [])
         disabled = (
@@ -4366,16 +4368,16 @@ class PluginManager:
             else set()
         )
         if not enabled:
-            return False
+            return []
 
         winners: Dict[str, PluginManifest] = {}
         for manifest in self._collect_directory_manifests():
             winners[manifest.key or manifest.name] = manifest
 
-        for manifest in winners.values():
+        descriptors: List[Dict[str, Any]] = []
+        for lookup_key, manifest in sorted(winners.items()):
             if not manifest.portable:
                 continue
-            lookup_key = manifest.key or manifest.name
             if lookup_key in disabled or manifest.name in disabled:
                 continue
             if lookup_key not in enabled and manifest.name not in enabled:
@@ -4383,20 +4385,36 @@ class PluginManager:
             try:
                 from hermes_cli.agent_plugins import _discover_mcp
 
-                if _discover_mcp(
+                servers = _discover_mcp(
                     Path(manifest.path),
                     get_hermes_home()
                     / "plugin-data"
                     / (manifest.skill_namespace or lookup_key),
                     [],
                     create_data=False,
-                ):
-                    return True
+                )
             except (OSError, RuntimeError, ValueError):
                 # Full discovery will report component diagnostics. Startup
                 # probing should fail closed for an unreadable package.
                 continue
-        return False
+            prefix = f"{manifest.skill_namespace}__"
+            for server_name, config in sorted(servers.items()):
+                descriptors.append(
+                    {
+                        "name": f"{prefix}{server_name}",
+                        "server_name": server_name,
+                        "plugin": manifest.name,
+                        "plugin_key": lookup_key,
+                        "plugin_version": manifest.version,
+                        "config": dict(config),
+                    }
+                )
+        return descriptors
+
+    def has_enabled_portable_mcp(self, raw_config: Mapping[str, Any]) -> bool:
+        """Probe enabled portable MCP packages without loading plugins."""
+
+        return bool(self.get_enabled_portable_mcp_server_descriptors(raw_config))
 
     # -----------------------------------------------------------------------
     # Directory scanning

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4406,7 +4406,13 @@ class PluginManager:
                         "plugin": manifest.name,
                         "plugin_key": lookup_key,
                         "plugin_version": manifest.version,
-                        "config": dict(config),
+                        "transport": (
+                            "http"
+                            if config.get("url")
+                            else "stdio"
+                            if config.get("command")
+                            else "unknown"
+                        ),
                     }
                 )
         return descriptors

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import hashlib
+import hmac
 import importlib.metadata
 import importlib.util
 import inspect
@@ -635,6 +636,42 @@ def _portable_skill_namespace(key: str) -> str:
     slug = slug.strip("-_") or "plugin"
     digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
     return f"agent-plugin-{slug}-{digest}"
+
+
+def _trusted_portable_session_capability_bindings() -> Dict[str, str]:
+    """Return exact profile-approved ``binding -> package digest`` grants.
+
+    Legacy string entries intentionally do not grant authority: a name-only
+    grant survives arbitrary package replacement.  Object grants are accepted
+    only with the exact two-field shape ``{binding, digest}``.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        plugins = (load_config() or {}).get("plugins") or {}
+    except Exception:
+        return {}
+    if not isinstance(plugins, Mapping):
+        return {}
+    raw = plugins.get("trusted_session_context") or []
+    if not isinstance(raw, list):
+        return {}
+    digest_re = re.compile(r"^sha256:[0-9a-f]{64}$")
+    result: Dict[str, str] = {}
+    for item in raw:
+        if not isinstance(item, Mapping) or set(item) != {"binding", "digest"}:
+            continue
+        binding = item.get("binding")
+        digest = item.get("digest")
+        if (
+            isinstance(binding, str)
+            and binding == binding.strip()
+            and 0 < len(binding.encode("utf-8")) <= 256
+            and isinstance(digest, str)
+            and digest_re.fullmatch(digest) is not None
+        ):
+            result[binding] = digest
+    return result
 
 
 def _display_author(value: object) -> str:
@@ -5121,6 +5158,7 @@ class PluginManager:
                         skill.name,
                         exc,
                     )
+            trusted_capabilities = _trusted_portable_session_capability_bindings()
             for server_name, config in package.mcp_servers.items():
                 internal_name = f"{manifest.skill_namespace}__{server_name}"
                 if internal_name in self._portable_mcp_servers:
@@ -5130,7 +5168,32 @@ class PluginManager:
                         internal_name,
                     )
                     continue
-                self._portable_mcp_servers[internal_name] = dict(config)
+                translated = dict(config)
+                requested = bool(translated.pop("request_session_capability", False))
+                binding = f"{lookup_key}:{server_name}"
+                granted_digest = trusted_capabilities.get(binding)
+                if requested and hmac.compare_digest(
+                    granted_digest or "", package.content_digest
+                ):
+                    translated["session_capability"] = {
+                        "audience": (
+                            f"com.hermes.mcp/portable/{package.name}/{server_name}"
+                        ),
+                        "binding": binding,
+                        "package_digest": package.content_digest,
+                        "package_root": str(package.root),
+                    }
+                elif requested:
+                    logger.warning(
+                        "Agent Plugin '%s' MCP server '%s' requested trusted "
+                        "session capability but exact digest approval '%s' is absent "
+                        "(loaded digest %s)",
+                        lookup_key,
+                        server_name,
+                        binding,
+                        package.content_digest,
+                    )
+                self._portable_mcp_servers[internal_name] = translated
             loaded.enabled = True
         except Exception as exc:
             loaded.error = str(exc)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1636,9 +1636,47 @@ def cmd_capabilities(name: Optional[str] = None) -> None:
             cap for cap in CAPABILITY_REGISTRY
             if plugin_capability_granted(key, cap)
         }
-        if not declared and not effective and name is None:
+        portable = None
+        directory = Path(entry[4]).resolve() if entry[4] else None
+        if directory is not None and (directory / "plugin.json").is_file():
+            try:
+                from hermes_cli.agent_plugins import (
+                    canonical_package_digest,
+                    read_agent_plugin_manifest,
+                )
+                from hermes_cli.plugins import (
+                    _trusted_portable_session_capability_bindings,
+                )
+
+                manifest, _diagnostics = read_agent_plugin_manifest(directory)
+                extension = (manifest.get("extensions") or {}).get("com.hermes")
+                requested = (
+                    extension.get("sessionCapability")
+                    if isinstance(extension, dict)
+                    else []
+                )
+                requested = [
+                    item for item in requested
+                    if isinstance(item, str) and item
+                ] if isinstance(requested, list) else []
+                digest = canonical_package_digest(directory)
+                grants = _trusted_portable_session_capability_bindings()
+                portable = {
+                    "digest": digest,
+                    "servers": [
+                        {
+                            "name": server,
+                            "binding": f"{key}:{server}",
+                            "granted": grants.get(f"{key}:{server}") == digest,
+                        }
+                        for server in requested
+                    ],
+                }
+            except Exception:
+                portable = {"digest": "unavailable", "servers": []}
+        if not declared and not effective and portable is None and name is None:
             continue
-        rows.append((key, entry[3], declared, granted, effective))
+        rows.append((key, entry[3], declared, granted, effective, portable))
 
     if name is not None and not rows:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
@@ -1648,7 +1686,7 @@ def cmd_capabilities(name: Optional[str] = None) -> None:
         console.print("[dim]No plugins declare or hold capabilities.[/dim]")
         return
 
-    for key, source, declared, granted, effective in sorted(rows):
+    for key, source, declared, granted, effective, portable in sorted(rows):
         console.print(f"[bold]{key}[/bold] [dim]({source})[/dim]")
         if not declared:
             console.print("  declared: [dim](none)[/dim]")
@@ -1665,6 +1703,20 @@ def cmd_capabilities(name: Optional[str] = None) -> None:
                 f"  {cap}: [green]granted[/green] "
                 "[dim](not declared in manifest)[/dim]"
             )
+        if portable is not None:
+            console.print(
+                "  portable package digest: "
+                f"[dim]{portable['digest']}[/dim]"
+            )
+            for server in portable["servers"]:
+                state = (
+                    "[green]granted for this digest[/green]"
+                    if server["granted"]
+                    else "[yellow]not granted for this digest[/yellow]"
+                )
+                console.print(
+                    f"  session capability {server['binding']}: {state}"
+                )
 
 
 def _resolve_tool_override_grant(
@@ -3055,7 +3107,19 @@ def cmd_plugin_doctor(target: str = ".", *, ci: bool = False) -> None:
     from hermes_cli.plugin_dev import doctor_plugin
 
     report = doctor_plugin(target)
-    Console().print(report.format_text())
+    console = Console()
+    console.print(report.format_text())
+    portable_root = Path(target).expanduser().resolve()
+    if (portable_root / "plugin.json").is_file():
+        try:
+            from hermes_cli.agent_plugins import canonical_package_digest
+
+            console.print(
+                "Portable package digest: "
+                f"[dim]{canonical_package_digest(portable_root)}[/dim]"
+            )
+        except Exception as exc:
+            console.print(f"Portable package digest: [red]unavailable ({exc})[/red]")
     if ci and not report.ok:
         raise SystemExit(1)
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2693,7 +2693,10 @@ def _get_platform_tools(
         _named = [str(t) for t in _explicit if isinstance(t, str) and t]
         if (
             _named
-            and not any(validate_toolset(t) for t in _named)
+            and not any(
+                validate_toolset(t) or t in enabled_mcp_servers
+                for t in _named
+            )
             and platform not in _warned_invalid_platform_toolsets
         ):
             _warned_invalid_platform_toolsets.add(platform)

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -61,17 +61,58 @@ _CONFIG_MUTATION_LOCK = LateState("_CONFIG_MUTATION_LOCK")
 @router.get("/api/mcp/servers")
 async def list_mcp_servers(profile: Optional[str] = None):
     from hermes_cli.mcp_config import _get_mcp_servers
+    from hermes_cli.plugins import PluginManager
 
     def _read():
         with _profile_scope(profile):
-            return _get_mcp_servers()
+            configured = _get_mcp_servers()
+            try:
+                managed = PluginManager().get_enabled_portable_mcp_server_descriptors(
+                    load_config()
+                )
+            except Exception:
+                _log.exception("Portable MCP dashboard discovery failed")
+                managed = []
+            return configured, managed
 
-    servers = await asyncio.to_thread(_read)
-    return {
-        "servers": [
-            _mcp_server_summary(name, cfg) for name, cfg in sorted(servers.items())
-        ]
-    }
+    configured, managed = await asyncio.to_thread(_read)
+    summaries = []
+    for name, cfg in sorted(configured.items()):
+        summary = _mcp_server_summary(name, cfg)
+        summary.update(
+            {
+                "display_name": name,
+                "source": "profile",
+                "managed_by": None,
+                "plugin_version": None,
+                "read_only": False,
+            }
+        )
+        summaries.append(summary)
+
+    for descriptor in managed:
+        name = descriptor["name"]
+        if name in configured:
+            # Runtime loading gives an explicitly configured server priority
+            # over a portable MCP with the same internal name.
+            continue
+        summary = _mcp_server_summary(name, descriptor["config"])
+        plugin = descriptor["plugin"]
+        server_name = descriptor["server_name"]
+        summary.update(
+            {
+                "display_name": f"{plugin} / {server_name}",
+                "source": "plugin",
+                "managed_by": plugin,
+                "plugin_version": descriptor["plugin_version"] or None,
+                "read_only": True,
+                "enabled": True,
+            }
+        )
+        summaries.append(summary)
+
+    summaries.sort(key=lambda item: (item["display_name"].casefold(), item["name"]))
+    return {"servers": summaries}
 
 
 @router.post("/api/mcp/servers")

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -96,19 +96,24 @@ async def list_mcp_servers(profile: Optional[str] = None):
             # Runtime loading gives an explicitly configured server priority
             # over a portable MCP with the same internal name.
             continue
-        summary = _mcp_server_summary(name, descriptor["config"])
         plugin = descriptor["plugin"]
         server_name = descriptor["server_name"]
-        summary.update(
-            {
-                "display_name": f"{plugin} / {server_name}",
-                "source": "plugin",
-                "managed_by": plugin,
-                "plugin_version": descriptor["plugin_version"] or None,
-                "read_only": True,
-                "enabled": True,
-            }
-        )
+        summary = {
+            "name": name,
+            "display_name": f"{plugin} / {server_name}",
+            "transport": descriptor["transport"],
+            "url": None,
+            "command": None,
+            "args": [],
+            "env": {},
+            "auth": None,
+            "enabled": True,
+            "tools": None,
+            "source": "plugin",
+            "managed_by": plugin,
+            "plugin_version": descriptor["plugin_version"] or None,
+            "read_only": True,
+        }
         summaries.append(summary)
 
     summaries.sort(key=lambda item: (item["display_name"].casefold(), item["name"]))

--- a/tests/agent/test_auxiliary_sensitive_content.py
+++ b/tests/agent/test_auxiliary_sensitive_content.py
@@ -1,0 +1,294 @@
+"""Privacy-boundary tests for sensitive auxiliary model calls."""
+
+import asyncio
+import logging
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import auxiliary_client, relay_llm
+
+
+_CANARY = "PRIVATE-TRANSCRIPT-CANARY-7f42"
+
+
+class _CanaryTransportError(Exception):
+    pass
+
+
+def _response(content: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _rendered_logs(records) -> str:
+    formatter = logging.Formatter("%(levelname)s %(message)s")
+    return "\n".join(formatter.format(record) for record in records)
+
+
+def _pin_resolution(monkeypatch, client) -> None:
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_resolve_task_provider_model",
+        lambda *_args, **_kwargs: (
+            "selected-provider",
+            "selected-model",
+            None,
+            None,
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (client, "selected-model"),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_is_transient_transport_error",
+        lambda exc: isinstance(exc, _CanaryTransportError),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_is_connection_error",
+        lambda exc: isinstance(exc, _CanaryTransportError),
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_evict_cached_client_instance",
+        lambda _client: None,
+    )
+
+
+def test_sensitive_sync_call_redacts_logs_bypasses_relay_and_stays_on_provider(
+    monkeypatch,
+    caplog,
+):
+    primary = MagicMock()
+    primary.base_url = "https://selected.example/v1"
+    primary.chat.completions.create.side_effect = _CanaryTransportError(
+        f"provider echoed {_CANARY}"
+    )
+    fallback = MagicMock()
+    fallback.chat.completions.create.return_value = _response("fallback")
+    _pin_resolution(monkeypatch, primary)
+    monkeypatch.setattr(auxiliary_client, "_transient_retry_count", lambda: 1)
+    monkeypatch.setattr(auxiliary_client.time, "sleep", lambda _delay: None)
+    relay_call = MagicMock(side_effect=AssertionError("Relay captured request"))
+    monkeypatch.setattr(relay_llm, "execute_current", relay_call)
+    configured_fallback = MagicMock(
+        return_value=(fallback, "fallback-model", "fallback-provider")
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_try_configured_fallback_chain",
+        configured_fallback,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+        with pytest.raises(_CanaryTransportError):
+            auxiliary_client.call_llm(
+                task="privacy_test",
+                messages=[{"role": "user", "content": _CANARY}],
+                sensitive_content=True,
+                allow_provider_fallback=False,
+            )
+
+    assert primary.chat.completions.create.call_count == 2
+    fallback.chat.completions.create.assert_not_called()
+    configured_fallback.assert_not_called()
+    relay_call.assert_not_called()
+    assert _CANARY not in _rendered_logs(caplog.records)
+    assert any("details redacted" in record.getMessage() for record in caplog.records)
+    assert auxiliary_client._RELAY_AUX_CALL_CONTEXT.get() is None
+
+
+@pytest.mark.asyncio
+async def test_sensitive_async_call_redacts_logs_bypasses_relay_and_stays_on_provider(
+    monkeypatch,
+    caplog,
+):
+    primary = MagicMock()
+    primary.base_url = "https://selected.example/v1"
+    primary.chat.completions.create = AsyncMock(
+        side_effect=_CanaryTransportError(f"provider echoed {_CANARY}")
+    )
+    fallback = MagicMock()
+    fallback.chat.completions.create = AsyncMock(return_value=_response("fallback"))
+    _pin_resolution(monkeypatch, primary)
+    relay_call = AsyncMock(side_effect=AssertionError("Relay captured request"))
+    monkeypatch.setattr(relay_llm, "execute_current_async", relay_call)
+    configured_fallback = MagicMock(
+        return_value=(MagicMock(), "fallback-model", "fallback-provider")
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_try_configured_fallback_chain",
+        configured_fallback,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_to_async_client",
+        lambda *_args, **_kwargs: (fallback, "fallback-model"),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+        with pytest.raises(_CanaryTransportError):
+            await auxiliary_client.async_call_llm(
+                task="privacy_test",
+                messages=[{"role": "user", "content": _CANARY}],
+                sensitive_content=True,
+                allow_provider_fallback=False,
+            )
+
+    assert primary.chat.completions.create.await_count == 2
+    fallback.chat.completions.create.assert_not_awaited()
+    configured_fallback.assert_not_called()
+    relay_call.assert_not_awaited()
+    assert _CANARY not in _rendered_logs(caplog.records)
+    assert any("details redacted" in record.getMessage() for record in caplog.records)
+    assert auxiliary_client._RELAY_AUX_CALL_CONTEXT.get() is None
+
+
+def test_sensitive_context_reaches_codex_timeout_thread(monkeypatch, caplog):
+    closed = threading.Event()
+
+    class _EmptyStream:
+        def __iter__(self):
+            return iter(())
+
+        def close(self):
+            return None
+
+    class _SlowResponses:
+        def create(self, **_kwargs):
+            time.sleep(0.05)
+            return _EmptyStream()
+
+    def close_client():
+        closed.set()
+        raise RuntimeError(f"close echoed {_CANARY}")
+
+    client = SimpleNamespace(responses=_SlowResponses(), close=close_client)
+    adapter = auxiliary_client._CodexCompletionsAdapter(client, "selected-model")
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_evict_cached_client_instance",
+        lambda _client: None,
+    )
+
+    @auxiliary_client._relay_auxiliary_call
+    def run(*, sensitive_content=False):
+        return adapter.create(
+            messages=[{"role": "user", "content": _CANARY}],
+            timeout=0.01,
+        )
+
+    with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+        with pytest.raises(TimeoutError):
+            run(sensitive_content=True)
+
+    assert closed.wait(0.5)
+    assert _CANARY not in _rendered_logs(caplog.records)
+    assert any(
+        "client close during timeout failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_sensitive_provider_error_is_not_persisted_in_pool_context():
+    error = _CanaryTransportError(f"provider echoed {_CANARY}")
+    error.status_code = 429
+
+    @auxiliary_client._relay_auxiliary_call
+    def capture(*, sensitive_content=False):
+        return auxiliary_client._pool_error_context(error)
+
+    assert capture(sensitive_content=True) == {"status_code": 429}
+    assert capture() == {
+        "message": f"provider echoed {_CANARY}",
+        "status_code": 429,
+    }
+
+
+def test_sensitive_context_redacts_nested_anthropic_provider_error(caplog):
+    class _UnavailableStream:
+        def __enter__(self):
+            raise RuntimeError(f"stream not supported; provider echoed {_CANARY}")
+
+        def __exit__(self, _exc_type, _exc, _tb):
+            return False
+
+    class _Messages:
+        def stream(self, **_kwargs):
+            return _UnavailableStream()
+
+        def create(self, **_kwargs):
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="ok")],
+                stop_reason="end_turn",
+                usage=SimpleNamespace(
+                    input_tokens=1,
+                    output_tokens=1,
+                    total_tokens=2,
+                ),
+            )
+
+    adapter = auxiliary_client._AnthropicCompletionsAdapter(
+        SimpleNamespace(messages=_Messages()),
+        "claude-sonnet-4-6",
+    )
+
+    @auxiliary_client._relay_auxiliary_call
+    def run(*, sensitive_content=False):
+        return adapter.create(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": _CANARY}],
+        )
+
+    with caplog.at_level(logging.DEBUG, logger="agent.anthropic_adapter"):
+        response = run(sensitive_content=True)
+
+    assert response.choices[0].message.content == "ok"
+    assert _CANARY not in _rendered_logs(caplog.records)
+    assert any("details redacted" in record.getMessage() for record in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="agent.anthropic_adapter"):
+        run()
+
+    assert _CANARY in _rendered_logs(caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_sensitive_context_redacts_nested_gemini_sse_content(caplog):
+    from agent.gemini_native_adapter import _iter_sse_events
+
+    class _Response:
+        def iter_text(self):
+            return iter(
+                [
+                    f"data: malformed provider echo {_CANARY}\n",
+                    'data: {"candidates": []}\n',
+                ]
+            )
+
+    @auxiliary_client._relay_auxiliary_call_async
+    async def run(*, sensitive_content=False):
+        return await asyncio.to_thread(lambda: list(_iter_sse_events(_Response())))
+
+    with caplog.at_level(logging.DEBUG, logger="agent.gemini_native_adapter"):
+        assert await run(sensitive_content=True) == [{"candidates": []}]
+
+    assert _CANARY not in _rendered_logs(caplog.records)
+    assert any("details redacted" in record.getMessage() for record in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="agent.gemini_native_adapter"):
+        await run()
+
+    assert _CANARY in _rendered_logs(caplog.records)

--- a/tests/hermes_cli/test_agent_plugins.py
+++ b/tests/hermes_cli/test_agent_plugins.py
@@ -75,6 +75,296 @@ def test_loads_manifest_skill_and_stdio_server(tmp_path: Path) -> None:
     assert (tmp_path / "data").is_dir()
 
 
+def test_hermes_extension_opts_named_server_into_host_minted_capability(
+    tmp_path: Path,
+) -> None:
+    import sys
+
+    (tmp_path / "server.py").write_text("# reviewed\n", encoding="utf-8")
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(
+            extensions={
+                "com.hermes": {"sessionCapability": ["workflow"]}
+            }
+        ),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {
+                    "type": "stdio",
+                    "command": "python",
+                    "args": ["-I", "-S", "-B", "${PLUGIN_ROOT}/server.py"],
+                    "env": {"PYTHONDONTWRITEBYTECODE": "1"},
+                },
+                "ordinary": {"type": "stdio", "command": "python"},
+            },
+        },
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert package.mcp_servers["workflow"]["request_session_capability"] is True
+    assert package.mcp_servers["workflow"]["command"] == str(
+        Path(sys.executable).resolve(strict=True)
+    )
+    assert "session_capability" not in package.mcp_servers["workflow"]
+    assert "session_capability" not in package.mcp_servers["ordinary"]
+    assert package.content_digest.startswith("sha256:")
+    assert package.diagnostics == ()
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"type": "stdio", "command": "python", "args": ["server.py"]},
+        {
+            "type": "stdio",
+            "command": "python3",
+            "args": ["-I", "-S", "-B", "server.py"],
+        },
+        {
+            "type": "stdio",
+            "command": "python",
+            "args": ["-I", "-B", "-S", "server.py"],
+            "env": {"PYTHONDONTWRITEBYTECODE": "1"},
+        },
+    ],
+)
+def test_session_capability_rejects_nonisolated_python_launch(
+    tmp_path: Path, entry: dict
+) -> None:
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {"$schema": MCP_SCHEMA_V1, "mcpServers": {"workflow": entry}},
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert "request_session_capability" not in package.mcp_servers["workflow"]
+    assert any("require -I -S -B" in item.message for item in package.diagnostics)
+
+
+def test_session_capability_python_command_ignores_mutable_path_override(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import sys
+
+    hostile = tmp_path / "hostile-bin"
+    hostile.mkdir()
+    fake_python = hostile / "python"
+    fake_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    fake_python.chmod(0o700)
+    package_root = tmp_path / "plugin"
+    package_root.mkdir()
+    (package_root / "server.py").write_text("# reviewed\n", encoding="utf-8")
+    _write_json(
+        package_root / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        package_root / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {
+                    "type": "stdio",
+                    "command": "python",
+                    "args": ["-I", "-S", "-B", "${PLUGIN_ROOT}/server.py"],
+                    "env": {"PYTHONDONTWRITEBYTECODE": "1"},
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("PATH", str(hostile))
+
+    package = load_agent_plugin(package_root, tmp_path / "data")
+
+    server = package.mcp_servers["workflow"]
+    assert server["request_session_capability"] is True
+    assert server["command"] == str(Path(sys.executable).resolve(strict=True))
+    assert server["command"] != str(fake_python)
+
+
+def test_session_capability_rejects_python_script_from_plugin_data(
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "plugin"
+    package_root.mkdir()
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    (data_root / "server.py").write_text("# mutable data\n", encoding="utf-8")
+    _write_json(
+        package_root / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        package_root / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {
+                    "type": "stdio",
+                    "command": "python",
+                    "args": ["-I", "-S", "-B", "${PLUGIN_DATA}/server.py"],
+                    "env": {"PYTHONDONTWRITEBYTECODE": "1"},
+                }
+            },
+        },
+    )
+
+    package = load_agent_plugin(package_root, data_root)
+
+    assert "request_session_capability" not in package.mcp_servers["workflow"]
+    assert any("in-package file" in item.message for item in package.diagnostics)
+
+
+@pytest.mark.parametrize("command", ["node", "bash"])
+def test_session_capability_rejects_bare_ambient_nonpython_command(
+    tmp_path: Path, command: str
+) -> None:
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {"type": "stdio", "command": command}
+            },
+        },
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert "request_session_capability" not in package.mcp_servers["workflow"]
+    assert any("bare ambient" in item.message for item in package.diagnostics)
+
+
+def test_session_capability_allows_digest_included_package_executable(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "server"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {"type": "stdio", "command": "./server"}
+            },
+        },
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    server = package.mcp_servers["workflow"]
+    assert server["request_session_capability"] is True
+    assert server["command"] == str(executable.resolve())
+
+
+@pytest.mark.parametrize(
+    "forward",
+    ["workflow", [""], [1], {"workflow": True}],
+)
+def test_invalid_hermes_session_forwarding_extension_is_nonfatal(
+    tmp_path: Path, forward: object
+) -> None:
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(
+            extensions={
+                "com.hermes": {"sessionCapability": forward}
+            }
+        ),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {"type": "stdio", "command": "python"}
+            },
+        },
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert "request_session_capability" not in package.mcp_servers["workflow"]
+    assert "session_capability" not in package.mcp_servers["workflow"]
+    assert any("sessionCapability" in item.message for item in package.diagnostics)
+
+
+def test_unknown_forwarded_server_does_not_widen_another_server(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(
+            extensions={
+                "com.hermes": {"sessionCapability": ["missing"]}
+            }
+        ),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "ordinary": {"type": "stdio", "command": "python"}
+            },
+        },
+    )
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert "request_session_capability" not in package.mcp_servers["ordinary"]
+    assert "session_capability" not in package.mcp_servers["ordinary"]
+    assert any(item.scope == "mcp:missing" for item in package.diagnostics)
+
+
+def test_session_capability_rejects_executable_python_cache(tmp_path: Path) -> None:
+    import py_compile
+
+    _write_json(
+        tmp_path / "plugin.json",
+        _manifest(extensions={"com.hermes": {"sessionCapability": ["workflow"]}}),
+    )
+    _write_json(
+        tmp_path / "mcp.json",
+        {
+            "$schema": MCP_SCHEMA_V1,
+            "mcpServers": {
+                "workflow": {"type": "stdio", "command": "python"}
+            },
+        },
+    )
+    source = tmp_path / "server.py"
+    source.write_text("VALUE = 'reviewed'\n", encoding="utf-8")
+    cache = tmp_path / "__pycache__" / "server.cpython-313.pyc"
+    cache.parent.mkdir()
+    py_compile.compile(str(source), cfile=str(cache), doraise=True)
+
+    package = load_agent_plugin(tmp_path, tmp_path / "data")
+
+    assert "request_session_capability" not in package.mcp_servers["workflow"]
+    assert any("bytecode caches" in item.message for item in package.diagnostics)
+
+
 @pytest.mark.parametrize(
     "manifest",
     [

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -46,6 +46,49 @@ class TestMcpEndpoints:
         srv = self.client.get("/api/mcp/servers").json()["servers"][0]
         assert srv["env"]["API_KEY"] != "sk-secret-1234567890"
 
+    def test_list_includes_read_only_portable_plugin_mcps(self, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        self.client.post(
+            "/api/mcp/servers",
+            json={"name": "configured", "url": "https://example.com/mcp"},
+        )
+
+        class FakeManager:
+            def get_enabled_portable_mcp_server_descriptors(self, raw_config):
+                assert "configured" in raw_config["mcp_servers"]
+                return [
+                    {
+                        "name": "agent-plugin-hermes-g2-workflows__workflows",
+                        "server_name": "workflows",
+                        "plugin": "hermes-g2-workflows",
+                        "plugin_key": "hermes-g2-workflows",
+                        "plugin_version": "0.3.2",
+                        "config": {
+                            "command": "/plugin/server.py",
+                            "args": ["-I", "-S", "-B"],
+                        },
+                    }
+                ]
+
+        monkeypatch.setattr(plugins_mod, "PluginManager", FakeManager)
+
+        response = self.client.get("/api/mcp/servers")
+        assert response.status_code == 200
+        servers = {item["source"]: item for item in response.json()["servers"]}
+
+        configured = servers["profile"]
+        assert configured["name"] == "configured"
+        assert configured["read_only"] is False
+        assert configured["managed_by"] is None
+
+        managed = servers["plugin"]
+        assert managed["display_name"] == "hermes-g2-workflows / workflows"
+        assert managed["managed_by"] == "hermes-g2-workflows"
+        assert managed["plugin_version"] == "0.3.2"
+        assert managed["read_only"] is True
+        assert managed["enabled"] is True
+
     def test_http_bearer_auth_separates_secret_from_config(
         self, _isolate_hermes_home
     ):

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -64,11 +64,16 @@ class TestMcpEndpoints:
                         "plugin": "hermes-g2-workflows",
                         "plugin_key": "hermes-g2-workflows",
                         "plugin_version": "0.3.2",
-                        "config": {
-                            "command": "/plugin/server.py",
-                            "args": ["-I", "-S", "-B"],
-                        },
-                    }
+                        "transport": "stdio",
+                    },
+                    {
+                        "name": "configured",
+                        "server_name": "shadow",
+                        "plugin": "shadow-plugin",
+                        "plugin_key": "shadow-plugin",
+                        "plugin_version": "9.9.9",
+                        "transport": "stdio",
+                    },
                 ]
 
         monkeypatch.setattr(plugins_mod, "PluginManager", FakeManager)
@@ -88,6 +93,10 @@ class TestMcpEndpoints:
         assert managed["plugin_version"] == "0.3.2"
         assert managed["read_only"] is True
         assert managed["enabled"] is True
+        assert managed["command"] is None
+        assert managed["args"] == []
+        assert managed["env"] == {}
+        assert len(response.json()["servers"]) == 2
 
     def test_http_bearer_auth_separates_secret_from_config(
         self, _isolate_hermes_home

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -217,7 +217,7 @@ class TestPluginDiscovery:
         assert descriptor["server_name"] == "worker"
         assert descriptor["plugin"] == "portable.test"
         assert descriptor["plugin_key"] == "portable.test"
-        assert descriptor["config"]["command"] == "python"
+        assert descriptor["transport"] == "stdio"
         assert manager._plugins["portable.test"].enabled is True
         assert manager._plugins["native"].enabled is True
         assert manager._plugins["native"].module is not None
@@ -341,6 +341,14 @@ class TestPluginDiscovery:
         assert manager._plugins["portable.test"].enabled is False
         assert manager.list_plugin_skill_metadata() == []
         assert manager.get_portable_mcp_servers() == {}
+        assert manager.get_enabled_portable_mcp_server_descriptors(
+            {
+                "plugins": {
+                    "enabled": ["portable.test"],
+                    "disabled": ["portable.test"],
+                }
+            }
+        ) == []
 
     def test_portable_author_object_is_normalized_to_stable_string(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -212,6 +212,93 @@ class TestPluginDiscovery:
         assert manager._plugins["native"].enabled is True
         assert manager._plugins["native"].module is not None
 
+    @pytest.mark.parametrize("approval", ["none", "legacy-string", "digest-object"])
+    def test_portable_session_capability_requires_digest_bound_profile_approval(
+        self, tmp_path, monkeypatch, approval
+    ):
+        from hermes_cli.agent_plugins import (
+            MCP_SCHEMA_V1,
+            PLUGIN_SCHEMA_V1,
+            canonical_package_digest,
+        )
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / "home"
+        plugin = home / "plugins" / "portable"
+        plugin.mkdir(parents=True)
+        (plugin / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "$schema": PLUGIN_SCHEMA_V1,
+                    "name": "portable.test",
+                    "extensions": {
+                        "com.hermes": {
+                            "sessionCapability": ["workflow"]
+                        }
+                    },
+                }
+            )
+        )
+        (plugin / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "$schema": MCP_SCHEMA_V1,
+                    "mcpServers": {
+                        "workflow": {
+                            "type": "stdio",
+                            "command": "python",
+                            "args": ["-I", "-S", "-B", "${PLUGIN_ROOT}/server.py"],
+                            "env": {"PYTHONDONTWRITEBYTECODE": "1"},
+                        }
+                    },
+                }
+            )
+        )
+        (plugin / "server.py").write_text("# reviewed\n")
+        plugins_config = {"enabled": ["portable.test"]}
+        digest = canonical_package_digest(plugin)
+        if approval == "legacy-string":
+            plugins_config["trusted_session_context"] = [
+                "portable.test:workflow"
+            ]
+        elif approval == "digest-object":
+            plugins_config["trusted_session_context"] = [{
+                "binding": "portable.test:workflow",
+                "digest": digest,
+            }]
+        home.mkdir(exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": plugins_config})
+        )
+        empty_bundled = tmp_path / "bundled"
+        empty_bundled.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path / "os-home"))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(
+            plugins_mod, "get_bundled_plugins_dir", lambda: empty_bundled
+        )
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        [config] = manager.get_portable_mcp_servers().values()
+        authority = config.get("session_capability")
+        assert (isinstance(authority, dict)) is (approval == "digest-object")
+        assert "request_session_capability" not in config
+        if isinstance(authority, dict):
+            assert authority["package_digest"] == digest
+            assert authority["binding"] == "portable.test:workflow"
+            assert authority["audience"] == (
+                "com.hermes.mcp/portable/portable.test/workflow"
+            )
+
+            # The same sticky name-only grant cannot authorize replaced bytes.
+            (plugin / "server.py").write_text("# replacement\n")
+            replaced = PluginManager()
+            replaced.discover_and_load()
+            [replaced_config] = replaced.get_portable_mcp_servers().values()
+            assert "session_capability" not in replaced_config
+
     def test_disabled_portable_plugin_registers_nothing(self, tmp_path, monkeypatch):
         from hermes_cli.agent_plugins import PLUGIN_SCHEMA_V1
         from hermes_cli import plugins as plugins_mod

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -208,6 +208,16 @@ class TestPluginDiscovery:
         assert set(manager.get_portable_mcp_servers()) == {
             qualified["name"].split(":", 1)[0] + "__worker"
         }
+        [descriptor] = manager.get_enabled_portable_mcp_server_descriptors(
+            {"plugins": {"enabled": ["portable.test", "native"]}}
+        )
+        assert descriptor["name"] == (
+            qualified["name"].split(":", 1)[0] + "__worker"
+        )
+        assert descriptor["server_name"] == "worker"
+        assert descriptor["plugin"] == "portable.test"
+        assert descriptor["plugin_key"] == "portable.test"
+        assert descriptor["config"]["command"] == "python"
         assert manager._plugins["portable.test"].enabled is True
         assert manager._plugins["native"].enabled is True
         assert manager._plugins["native"].module is not None

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -74,6 +74,23 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_explicit_mcp_server_names_do_not_emit_zero_toolset_warning(caplog):
+    """Raw MCP server names are valid platform allowlist entries even though
+    they are not static toolsets and only gain registry aliases at discovery."""
+    import hermes_cli.tools_config as _tc
+
+    _tc._warned_invalid_platform_toolsets.discard("test-surface")
+    config = {
+        "mcp_servers": {"portable-workflows": {"command": "reviewed-runtime"}},
+        "platform_toolsets": {"test-surface": ["portable-workflows"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        assert _get_platform_tools(config, "test-surface") == {"portable-workflows"}
+
+    assert not any("#38798" in r.getMessage() for r in caplog.records)
+
+
 
 
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -107,6 +107,63 @@ class TestProfileScopedEnv:
 
 class TestProfileScopedMcp:
 
+    def test_mcp_list_includes_only_selected_profiles_portable_plugins(
+        self, client, isolated_profiles
+    ):
+        from hermes_cli.agent_plugins import MCP_SCHEMA_V1, PLUGIN_SCHEMA_V1
+
+        worker_home = isolated_profiles["worker_beta"]
+        plugin_dir = worker_home / "plugins" / "worker-portable"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "$schema": PLUGIN_SCHEMA_V1,
+                    "name": "worker.portable",
+                    "version": "1.2.3",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (plugin_dir / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "$schema": MCP_SCHEMA_V1,
+                    "mcpServers": {
+                        "workflow": {"type": "stdio", "command": "python"}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        worker_cfg = _cfg(worker_home)
+        worker_cfg["plugins"] = {"enabled": ["worker.portable"]}
+        (worker_home / "config.yaml").write_text(
+            yaml.safe_dump(worker_cfg), encoding="utf-8"
+        )
+
+        worker_response = client.get(
+            "/api/mcp/servers", params={"profile": "worker_beta"}
+        )
+        assert worker_response.status_code == 200
+        [managed] = [
+            server
+            for server in worker_response.json()["servers"]
+            if server["source"] == "plugin"
+        ]
+        assert managed["display_name"] == "worker.portable / workflow"
+        assert managed["plugin_version"] == "1.2.3"
+        assert managed["read_only"] is True
+        assert managed["command"] is None
+        assert managed["env"] == {}
+
+        default_response = client.get("/api/mcp/servers")
+        assert default_response.status_code == 200
+        assert all(
+            server["source"] != "plugin"
+            for server in default_response.json()["servers"]
+        )
+
     def test_mcp_bearer_secret_is_profile_scoped(self, client, isolated_profiles):
         secret = "worker-only-secret"
         response = client.post(

--- a/tests/tools/test_mcp_capability.py
+++ b/tests/tools/test_mcp_capability.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import copy
+import math
+
+import pytest
+
+from tools.mcp_capability import (
+    McpCapabilityError,
+    mint_mcp_capability,
+    verify_mcp_capability,
+)
+
+
+AUDIENCE = "com.hermes.mcp/portable/example-workflows/workflows"
+ARGS = {"title": "Review roadmap", "lane": "today"}
+SESSION = {
+    "platform": "wearable",
+    "profile": "test-profile",
+    "chat_id": "device",
+    "session_id": "agent:main:wearable:dm:device",
+    "message_id": "wearable-turn-1-call",
+    "tool_call_id": "tool-call-opaque-1",
+}
+
+
+def _mint():
+    return mint_mcp_capability(
+        audience=AUDIENCE,
+        binding="example-workflows:workflows",
+        package_digest="sha256:" + "a" * 64,
+        workflow="workflow_create_task",
+        arguments=ARGS,
+        session=SESSION,
+        now=100,
+        ttl_seconds=10,
+    )
+
+
+def _verify(capability, **overrides):
+    values = {
+        "expected_audience": AUDIENCE,
+        "expected_workflow": "workflow_create_task",
+        "expected_arguments": ARGS,
+        "now": 105,
+    }
+    values.update(overrides)
+    return verify_mcp_capability(capability, **values)
+
+
+def test_round_trip_binds_every_active_turn_identity_and_package_digest():
+    claims = _verify(_mint())
+    assert {key: claims[key] for key in SESSION} == SESSION
+    assert claims["package_digest"] == "sha256:" + "a" * 64
+    assert claims["audience"] == AUDIENCE
+    assert claims["workflow"] == "workflow_create_task"
+
+
+@pytest.mark.parametrize(
+    ("override", "value"),
+    [
+        ("expected_audience", AUDIENCE + ".stolen"),
+        ("expected_workflow", "workflow_set_timer"),
+        ("expected_arguments", {"title": "Changed", "lane": "today"}),
+        ("now", 110),
+        ("now", 99),
+    ],
+)
+def test_wrong_audience_workflow_arguments_or_lifetime_is_rejected(override, value):
+    with pytest.raises(McpCapabilityError):
+        _verify(_mint(), **{override: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("version", True),
+        ("issued_at", True),
+        ("expires_at", True),
+        ("message_id", ""),
+        ("tool_call_id", " call "),
+        ("package_digest", "sha256:wrong"),
+    ],
+)
+def test_tampered_claims_fail_signature_and_strict_shape(field, value):
+    capability = _mint()
+    capability["claims"][field] = value
+    with pytest.raises(McpCapabilityError):
+        _verify(capability)
+
+
+def test_extra_claim_and_bad_signature_are_rejected():
+    extra = _mint()
+    extra["claims"]["extra"] = "no"
+    with pytest.raises(McpCapabilityError):
+        _verify(extra)
+    bad_signature = _mint()
+    bad_signature["signature"] = "0" * 64
+    with pytest.raises(McpCapabilityError):
+        _verify(bad_signature)
+
+
+def test_nonfinite_model_arguments_are_never_signed():
+    with pytest.raises(McpCapabilityError):
+        mint_mcp_capability(
+            audience=AUDIENCE,
+            binding="example-workflows:workflows",
+            package_digest="sha256:" + "a" * 64,
+            workflow="workflow_create_task",
+            arguments={"value": math.nan},
+            session=SESSION,
+            now=100,
+        )
+
+
+def test_oversized_model_arguments_are_never_signed():
+    with pytest.raises(McpCapabilityError, match="capability bound"):
+        mint_mcp_capability(
+            audience=AUDIENCE,
+            binding="example-workflows:workflows",
+            package_digest="sha256:" + "a" * 64,
+            workflow="workflow_create_task",
+            arguments={"title": "x" * (64 * 1024)},
+            session=SESSION,
+            now=100,
+        )
+
+
+def test_call_time_package_replacement_revokes_discovery_grant(tmp_path, monkeypatch):
+    from hermes_cli.agent_plugins import canonical_package_digest
+    from hermes_cli import plugins as plugins_module
+    from tools import mcp_tool
+
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "plugin.json").write_text("{}", encoding="utf-8")
+    (package / "server.py").write_text("# reviewed\n", encoding="utf-8")
+    digest = canonical_package_digest(package)
+    authority = {
+        "audience": AUDIENCE,
+        "binding": "example-workflows:workflows",
+        "package_digest": digest,
+        "package_root": str(package),
+    }
+    monkeypatch.setattr(
+        plugins_module,
+        "_trusted_portable_session_capability_bindings",
+        lambda: {authority["binding"]: digest},
+    )
+    monkeypatch.setattr(mcp_tool, "_hermes_session_call_meta", lambda: SESSION)
+
+    meta = mcp_tool._prepare_session_capability(
+        "internal-server", "workflow_create_task", ARGS, authority
+    )
+    capability_value = meta["com.hermes/capability"]
+    claims = verify_mcp_capability(
+        capability_value,
+        expected_audience=AUDIENCE,
+        expected_workflow="workflow_create_task",
+        expected_arguments=ARGS,
+        now=capability_value["claims"]["issued_at"],
+    )
+    assert claims["package_digest"] == digest
+
+    cache = package / "__pycache__"
+    cache.mkdir()
+    (cache / "server.cpython-313.pyc").write_bytes(b"crafted-bytecode")
+    with pytest.raises(PermissionError):
+        mcp_tool._prepare_session_capability(
+            "internal-server", "workflow_create_task", ARGS, authority
+        )
+    (cache / "server.cpython-313.pyc").unlink()
+    cache.rmdir()
+
+    (package / "server.py").write_text("# replaced after discovery\n", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        mcp_tool._prepare_session_capability(
+            "internal-server", "workflow_create_task", ARGS, authority
+        )

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -576,6 +576,197 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_opted_in_server_receives_host_minted_capability_not_arguments(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result("ok", is_error=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        authority = {
+            "audience": "com.hermes.mcp/portable/example/workflow",
+            "binding": "example:workflow",
+            "package_digest": "sha256:" + "a" * 64,
+            "package_root": "/approved/package",
+        }
+        expected_meta = {
+            "com.hermes/capability": {
+                "claims": {"workflow": "greet", "tool_call_id": "call-opaque-31"},
+                "signature": "opaque",
+            }
+        }
+
+        try:
+            handler = _make_tool_handler(
+                "test_srv", "greet", 120, session_capability=authority
+            )
+            from tools.approval import (
+                reset_current_observability_context,
+                set_current_observability_context,
+            )
+            correlation = set_current_observability_context(
+                turn_id="turn-7",
+                tool_call_id="call-opaque-31",
+                session_id="session-7",
+            )
+            with (
+                patch(
+                    "tools.mcp_tool._prepare_session_capability",
+                    return_value=expected_meta,
+                ),
+                self._patch_mcp_loop(),
+            ):
+                try:
+                    result = json.loads(handler({"name": "world"}))
+                finally:
+                    reset_current_observability_context(correlation)
+            assert result["result"] == "ok"
+            mock_session.call_tool.assert_called_once_with(
+                "greet",
+                arguments={"name": "world"},
+                meta=expected_meta,
+            )
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_capability_snapshot_survives_background_loop_without_cross_talk(self):
+        """Concurrent callers retain their host-bound event and tool-call IDs."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        import tools.mcp_tool as mcp_mod
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.approval import (
+            reset_current_observability_context,
+            set_current_observability_context,
+        )
+
+        seen: list[dict] = []
+
+        class Session:
+            async def call_tool(self, name, arguments=None, **kwargs):
+                await asyncio.sleep(0.01)
+                seen.append(dict(kwargs["meta"]["com.hermes/capability"]["claims"]))
+                return _make_call_result(name, is_error=False)
+
+        server = _make_mock_server("test_srv", session=Session())
+        mcp_mod._servers["test_srv"] = server
+        started_here = mcp_mod._mcp_loop is None or not mcp_mod._mcp_loop.is_running()
+        if started_here:
+            mcp_mod._ensure_mcp_loop()
+        authority = {
+            "audience": "com.hermes.mcp/portable/example/workflow",
+            "binding": "example:workflow",
+            "package_digest": "sha256:" + "a" * 64,
+            "package_root": "/approved/package",
+        }
+        handler = mcp_mod._make_tool_handler(
+            "test_srv", "greet", 10, session_capability=authority
+        )
+
+        def fake_prepare(_server, workflow, _arguments, _authority):
+            claims = mcp_mod._hermes_session_call_meta()
+            claims["workflow"] = workflow
+            return {
+                "com.hermes/capability": {
+                    "claims": claims,
+                    "signature": "opaque",
+                }
+            }
+
+        def invoke(index: int) -> str:
+            session_tokens = set_session_vars(
+                platform="wearable",
+                source="wearable",
+                chat_id="device-context",
+                message_id=f"event-{index}",
+                session_id=f"session-{index}",
+                profile="test-profile",
+            )
+            correlation = set_current_observability_context(
+                turn_id=f"turn-{index}",
+                tool_call_id=f"call-{index}",
+                session_id=f"session-{index}",
+            )
+            try:
+                return handler({"index": index})
+            finally:
+                reset_current_observability_context(correlation)
+                clear_session_vars(session_tokens)
+
+        try:
+            with patch.object(
+                mcp_mod, "_prepare_session_capability", side_effect=fake_prepare
+            ), ThreadPoolExecutor(max_workers=2) as pool:
+                results = list(pool.map(invoke, (1, 2)))
+            assert all("error" not in json.loads(item) for item in results)
+            assert {
+                (item["message_id"], item["tool_call_id"], item["session_id"])
+                for item in seen
+            } == {
+                ("event-1", "call-1", "session-1"),
+                ("event-2", "call-2", "session-2"),
+            }
+        finally:
+            mcp_mod._servers.pop("test_srv", None)
+            if started_here:
+                mcp_mod._stop_mcp_loop()
+
+    def test_capability_is_minted_once_and_reused_on_transport_recovery(self):
+        import tools.mcp_tool as mcp_mod
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            side_effect=[
+                RuntimeError("expired transport session"),
+                _make_call_result("recovered", is_error=False),
+            ]
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        mcp_mod._servers["test_srv"] = server
+        authority = {
+            "audience": "com.hermes.mcp/portable/example/workflow",
+            "binding": "example:workflow",
+            "package_digest": "sha256:" + "a" * 64,
+            "package_root": "/approved/package",
+        }
+        capability_meta = {
+            "com.hermes/capability": {
+                "claims": {"nonce": "one-logical-call"},
+                "signature": "opaque",
+            }
+        }
+
+        def retry(_server_name, _exc, call_once, _operation):
+            return call_once()
+
+        try:
+            handler = mcp_mod._make_tool_handler(
+                "test_srv", "greet", 10, session_capability=authority
+            )
+            with (
+                patch.object(
+                    mcp_mod,
+                    "_prepare_session_capability",
+                    return_value=capability_meta,
+                ) as mint,
+                patch.object(
+                    mcp_mod, "_handle_auth_error_and_retry", side_effect=retry
+                ),
+                self._patch_mcp_loop(),
+            ):
+                result = json.loads(handler({"name": "world"}))
+            assert result["result"] == "recovered"
+            mint.assert_called_once()
+            assert mock_session.call_tool.await_count == 2
+            first_meta = mock_session.call_tool.await_args_list[0].kwargs["meta"]
+            second_meta = mock_session.call_tool.await_args_list[1].kwargs["meta"]
+            assert first_meta is capability_meta
+            assert second_meta is capability_meta
+        finally:
+            mcp_mod._servers.pop("test_srv", None)
+
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -702,11 +702,32 @@ class TestToolHandler:
                 results = list(pool.map(invoke, (1, 2)))
             assert all("error" not in json.loads(item) for item in results)
             assert {
-                (item["message_id"], item["tool_call_id"], item["session_id"])
+                (
+                    item["platform"],
+                    item["profile"],
+                    item["chat_id"],
+                    item["message_id"],
+                    item["tool_call_id"],
+                    item["session_id"],
+                )
                 for item in seen
             } == {
-                ("event-1", "call-1", "session-1"),
-                ("event-2", "call-2", "session-2"),
+                (
+                    "wearable",
+                    "test-profile",
+                    "device-context",
+                    "event-1",
+                    "call-1",
+                    "session-1",
+                ),
+                (
+                    "wearable",
+                    "test-profile",
+                    "device-context",
+                    "event-2",
+                    "call-2",
+                    "session-2",
+                ),
             }
         finally:
             mcp_mod._servers.pop("test_srv", None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,21 @@ def reset_current_observability_context(
     _approval_turn_id.reset(turn_token)
 
 
+def get_current_observability_context() -> dict[str, str]:
+    """Return correlation IDs bound around the current model tool dispatch.
+
+    These values originate in the host executor, not in model-authored tool
+    arguments. Integrations may use the opaque ``tool_call_id`` as part of an
+    idempotency key, but it is correlation metadata rather than user identity
+    or authorization on its own.
+    """
+    return {
+        "turn_id": _approval_turn_id.get() or "",
+        "tool_call_id": _approval_tool_call_id.get() or "",
+        "session_id": _approval_session_id.get() or "",
+    }
+
+
 def get_current_session_key(default: str = "default") -> str:
     """Return the active session key, preferring context-local state.
 

--- a/tools/mcp_capability.py
+++ b/tools/mcp_capability.py
@@ -1,0 +1,249 @@
+"""Process-local capabilities for privileged portable MCP workflow calls.
+
+The signing key never leaves the Hermes gateway process.  Portable MCP
+servers receive only the signed envelope and must pass it unchanged to a
+trusted in-process verifier before any native action is dispatched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import re
+import secrets
+import time
+from typing import Any, Mapping
+
+
+CAPABILITY_META_KEY = "com.hermes/capability"
+CAPABILITY_VERSION = 1
+CAPABILITY_TTL_SECONDS = 300
+MAX_CAPABILITY_TTL_SECONDS = 300
+MAX_SAFE_INTEGER = 9_007_199_254_740_991
+MAX_CAPABILITY_ARGUMENT_BYTES = 64 * 1024
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+_NONCE_RE = re.compile(r"^[0-9a-f]{32}$")
+_SIGNING_KEY = secrets.token_bytes(32)
+_CLAIM_FIELDS = frozenset({
+    "version",
+    "audience",
+    "binding",
+    "package_digest",
+    "platform",
+    "profile",
+    "chat_id",
+    "session_id",
+    "message_id",
+    "tool_call_id",
+    "workflow",
+    "arguments_sha256",
+    "issued_at",
+    "expires_at",
+    "nonce",
+})
+
+
+class McpCapabilityError(PermissionError):
+    """A portable MCP capability was absent, malformed, or unauthorized."""
+
+
+def _canonical_json(value: Any) -> str:
+    def _reject_constant(_value: str) -> None:
+        raise ValueError("non-finite JSON number")
+
+    # Round-trip through the JSON data model so custom mappings, tuples, and
+    # non-finite numbers cannot gain implementation-dependent signatures.
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    parsed = json.loads(encoded, parse_constant=_reject_constant)
+    return json.dumps(
+        parsed,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def canonical_arguments_digest(arguments: Any) -> str:
+    """Return the canonical SHA-256 digest for exact model arguments."""
+
+    if not isinstance(arguments, Mapping):
+        raise McpCapabilityError("MCP workflow arguments must be an object")
+    try:
+        canonical = _canonical_json(dict(arguments))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise McpCapabilityError("MCP workflow arguments are not strict JSON") from exc
+    encoded = canonical.encode("utf-8")
+    if len(encoded) > MAX_CAPABILITY_ARGUMENT_BYTES:
+        raise McpCapabilityError("MCP workflow arguments exceed the capability bound")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _bounded_identity(value: Any, *, maximum: int = 256) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum
+        or any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
+    ):
+        raise McpCapabilityError("MCP capability identity is malformed")
+    return value
+
+
+def _session_claims(session: Mapping[str, Any]) -> dict[str, str]:
+    required = {
+        "platform",
+        "profile",
+        "chat_id",
+        "session_id",
+        "message_id",
+        "tool_call_id",
+    }
+    if not isinstance(session, Mapping) or not required <= set(session):
+        raise McpCapabilityError("The exact active Hermes turn is required")
+    return {key: _bounded_identity(session.get(key)) for key in sorted(required)}
+
+
+def _signature(claims: Mapping[str, Any]) -> str:
+    encoded = _canonical_json(dict(claims)).encode("utf-8")
+    return hmac.new(_SIGNING_KEY, encoded, hashlib.sha256).hexdigest()
+
+
+def mint_mcp_capability(
+    *,
+    audience: str,
+    binding: str,
+    package_digest: str,
+    workflow: str,
+    arguments: Mapping[str, Any],
+    session: Mapping[str, Any],
+    now: int | None = None,
+    ttl_seconds: int = CAPABILITY_TTL_SECONDS,
+) -> dict[str, Any]:
+    """Mint one capability for one exact logical public workflow call."""
+
+    audience = _bounded_identity(audience)
+    binding = _bounded_identity(binding)
+    workflow = _bounded_identity(workflow, maximum=128)
+    if (
+        not isinstance(package_digest, str)
+        or _DIGEST_RE.fullmatch(package_digest) is None
+    ):
+        raise McpCapabilityError("Portable package digest is malformed")
+    if (
+        type(ttl_seconds) is not int
+        or not 1 <= ttl_seconds <= MAX_CAPABILITY_TTL_SECONDS
+    ):
+        raise McpCapabilityError("MCP capability lifetime is invalid")
+    issued_at = int(time.time()) if now is None else now
+    if (
+        type(issued_at) is not int
+        or not 0 < issued_at <= MAX_SAFE_INTEGER - ttl_seconds
+    ):
+        raise McpCapabilityError("MCP capability timestamp is invalid")
+
+    claims: dict[str, Any] = {
+        "version": CAPABILITY_VERSION,
+        "audience": audience,
+        "binding": binding,
+        "package_digest": package_digest,
+        **_session_claims(session),
+        "workflow": workflow,
+        "arguments_sha256": canonical_arguments_digest(arguments),
+        "issued_at": issued_at,
+        "expires_at": issued_at + ttl_seconds,
+        "nonce": secrets.token_hex(16),
+    }
+    return {"claims": claims, "signature": _signature(claims)}
+
+
+def verify_mcp_capability(
+    capability: Any,
+    *,
+    expected_audience: str,
+    expected_workflow: str,
+    expected_arguments: Mapping[str, Any],
+    now: int | None = None,
+) -> dict[str, Any]:
+    """Verify a capability and return a detached claims dictionary.
+
+    Active-turn and replay checks are deliberately left to the native bridge,
+    which owns that live state.  Every structural and signed binding check is
+    performed here before those checks run.
+    """
+
+    if not isinstance(capability, dict) or set(capability) != {"claims", "signature"}:
+        raise McpCapabilityError("MCP capability is malformed")
+    claims = capability.get("claims")
+    signature = capability.get("signature")
+    if not isinstance(claims, dict) or set(claims) != _CLAIM_FIELDS:
+        raise McpCapabilityError("MCP capability claims are malformed")
+    if not isinstance(signature, str) or _HEX_RE.fullmatch(signature) is None:
+        raise McpCapabilityError("MCP capability signature is malformed")
+    try:
+        expected_signature = _signature(claims)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise McpCapabilityError("MCP capability claims are malformed") from exc
+    if not hmac.compare_digest(signature, expected_signature):
+        raise McpCapabilityError("MCP capability signature is invalid")
+
+    if (
+        type(claims.get("version")) is not int
+        or claims["version"] != CAPABILITY_VERSION
+    ):
+        raise McpCapabilityError("MCP capability version is invalid")
+    for key in (
+        "audience",
+        "binding",
+        "platform",
+        "profile",
+        "chat_id",
+        "session_id",
+        "message_id",
+        "tool_call_id",
+    ):
+        _bounded_identity(claims.get(key))
+    _bounded_identity(claims.get("workflow"), maximum=128)
+    if _DIGEST_RE.fullmatch(str(claims.get("package_digest", ""))) is None:
+        raise McpCapabilityError("MCP capability package digest is malformed")
+    if _HEX_RE.fullmatch(str(claims.get("arguments_sha256", ""))) is None:
+        raise McpCapabilityError("MCP capability arguments digest is malformed")
+    if _NONCE_RE.fullmatch(str(claims.get("nonce", ""))) is None:
+        raise McpCapabilityError("MCP capability nonce is malformed")
+
+    issued_at = claims.get("issued_at")
+    expires_at = claims.get("expires_at")
+    if (
+        type(issued_at) is not int
+        or type(expires_at) is not int
+        or not 0 < issued_at < expires_at <= MAX_SAFE_INTEGER
+        or expires_at - issued_at > MAX_CAPABILITY_TTL_SECONDS
+    ):
+        raise McpCapabilityError("MCP capability lifetime is malformed")
+    current = int(time.time()) if now is None else now
+    if type(current) is not int or current < issued_at or current >= expires_at:
+        raise McpCapabilityError("MCP capability is not currently valid")
+
+    if not hmac.compare_digest(
+        claims["audience"], _bounded_identity(expected_audience)
+    ):
+        raise McpCapabilityError("MCP capability audience is invalid")
+    if not hmac.compare_digest(
+        claims["workflow"], _bounded_identity(expected_workflow, maximum=128)
+    ):
+        raise McpCapabilityError("MCP capability workflow is invalid")
+    expected_digest = canonical_arguments_digest(expected_arguments)
+    if not hmac.compare_digest(claims["arguments_sha256"], expected_digest):
+        raise McpCapabilityError("MCP capability arguments are invalid")
+    return dict(claims)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -114,7 +114,7 @@ from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, List, Mapping, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -6029,7 +6029,111 @@ def _ensure_healthy_or_recycle(server: Any, server_name: str) -> None:
         _signal_reconnect(server)
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+def _hermes_session_call_meta() -> dict[str, Any]:
+    """Return trusted per-call Hermes session metadata for an opted-in MCP.
+
+    The model cannot supply or override this envelope: it is attached through
+    MCP's request ``_meta`` field after tool arguments have already been
+    selected. Keeping identity out of ``arguments`` lets a local bridge enforce
+    exact platform/turn authority without accepting a model-authored platform
+    or message-id claim.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return {"version": 1}
+
+    names = {
+        "platform": "HERMES_SESSION_PLATFORM",
+        "source": "HERMES_SESSION_SOURCE",
+        "chat_id": "HERMES_SESSION_CHAT_ID",
+        "message_id": "HERMES_SESSION_MESSAGE_ID",
+        "session_id": "HERMES_SESSION_ID",
+        "profile": "HERMES_SESSION_PROFILE",
+    }
+    payload: dict[str, Any] = {"version": 1}
+    for key, env_name in names.items():
+        value = str(get_session_env(env_name, "") or "")
+        if value:
+            payload[key] = value
+    if not payload.get("session_id"):
+        session_key = str(get_session_env("HERMES_SESSION_KEY", "") or "")
+        if session_key:
+            payload["session_id"] = session_key
+    try:
+        from tools.approval import get_current_observability_context
+
+        tool_call_id = str(
+            get_current_observability_context().get("tool_call_id") or ""
+        )
+        if tool_call_id:
+            payload["tool_call_id"] = tool_call_id
+    except Exception:
+        pass
+    return payload
+
+
+def _prepare_session_capability(
+    server_name: str,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    authority: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Mint one package-bound capability before any MCP transport attempt."""
+
+    expected_fields = {
+        "audience", "binding", "package_digest", "package_root",
+    }
+    if not isinstance(authority, Mapping) or set(authority) != expected_fields:
+        raise PermissionError("Portable MCP capability authority is malformed")
+    audience = authority.get("audience")
+    binding = authority.get("binding")
+    granted_digest = authority.get("package_digest")
+    package_root = authority.get("package_root")
+    if not all(isinstance(value, str) and value for value in authority.values()):
+        raise PermissionError("Portable MCP capability authority is malformed")
+
+    # Re-read profile consent and re-hash the package at the moment authority
+    # is minted.  Discovery-time approval cannot survive an on-disk package
+    # replacement, and a hand-written native MCP config cannot self-authorize.
+    from hermes_cli.agent_plugins import (
+        canonical_package_digest,
+        package_has_executable_cache,
+    )
+    from hermes_cli.plugins import _trusted_portable_session_capability_bindings
+    from tools.mcp_capability import CAPABILITY_META_KEY, mint_mcp_capability
+
+    approved = _trusted_portable_session_capability_bindings().get(binding)
+    import hmac
+
+    if not isinstance(approved, str) or not hmac.compare_digest(
+        approved, granted_digest
+    ):
+        raise PermissionError("Portable MCP capability grant is absent or stale")
+    if package_has_executable_cache(package_root):
+        raise PermissionError("Portable MCP package contains executable bytecode cache")
+    actual_digest = canonical_package_digest(package_root)
+    if not hmac.compare_digest(actual_digest, granted_digest):
+        raise PermissionError("Portable MCP package changed after approval")
+
+    capability = mint_mcp_capability(
+        audience=audience,
+        binding=binding,
+        package_digest=granted_digest,
+        workflow=tool_name,
+        arguments=arguments,
+        session=_hermes_session_call_meta(),
+    )
+    return {CAPABILITY_META_KEY: capability}
+
+
+def _make_tool_handler(
+    server_name: str,
+    tool_name: str,
+    tool_timeout: float,
+    *,
+    session_capability: Mapping[str, Any] | None = None,
+):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
@@ -6068,6 +6172,25 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     f"approaches or ask the user to check the MCP server."
                 )
             # Cooldown elapsed → fall through as a half-open probe.
+
+        # Snapshot once per logical call, outside the coroutine that may run a
+        # second time during auth/session recovery.  Both transport attempts
+        # therefore carry a byte-identical nonce, expiry, identities and
+        # arguments digest.
+        call_meta: dict[str, Any] | None = None
+        if session_capability is not None:
+            try:
+                call_meta = _prepare_session_capability(
+                    server_name, tool_name, args, session_capability
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Refusing portable MCP capability for %s/%s: %s",
+                    server_name,
+                    tool_name,
+                    exc,
+                )
+                return tool_error("Portable MCP workflow authorization failed")
 
         server = _get_connected_server_for_call(server_name)
         if not server:
@@ -6115,6 +6238,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
+                    call_kwargs: dict[str, Any] = {}
+                    if call_meta is not None:
+                        call_kwargs["meta"] = call_meta
                     # Fast-fail (#81995): a stdio subprocess that is already
                     # dead must not own this call slot — fail immediately
                     # instead of waiting out the full tool timeout on a
@@ -6132,7 +6258,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             f"exited; failing the call fast instead of "
                             f"waiting {float(tool_timeout):.0f}s"
                         )
-                    _call_coro = server.session.call_tool(tool_name, arguments=args)
+                    _call_coro = server.session.call_tool(
+                        tool_name,
+                        arguments=args,
+                        **call_kwargs,
+                    )
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
@@ -7167,7 +7297,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name,
+                    mcp_tool.name,
+                    server.tool_timeout,
+                    session_capability=config.get("session_capability"),
                 ),
                 "check_fn": check_fn,
             }
@@ -7449,7 +7582,12 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             name=registry_name,
             toolset=toolset_name,
             schema=schema,
-            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            handler=_make_tool_handler(
+                name,
+                raw_name,
+                tool_timeout,
+                session_capability=config.get("session_capability"),
+            ),
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1472,6 +1472,7 @@ export interface SkillHubScan {
 
 export interface McpServer {
   name: string;
+  display_name?: string;
   transport: "http" | "stdio" | "unknown";
   url: string | null;
   command: string | null;
@@ -1480,6 +1481,10 @@ export interface McpServer {
   auth: "header" | "oauth" | null;
   enabled: boolean;
   tools: string[] | null;
+  source?: "profile" | "plugin";
+  managed_by?: string | null;
+  plugin_version?: string | null;
+  read_only?: boolean;
 }
 
 export interface McpCatalogEntry {

--- a/web/src/pages/McpPage.tsx
+++ b/web/src/pages/McpPage.tsx
@@ -604,7 +604,7 @@ export default function McpPage() {
         {servers.length === 0 && (
           <Card>
             <CardContent className="py-8 text-center text-sm text-muted-foreground">
-              No MCP servers configured.
+              No MCP servers configured or provided by enabled plugins.
             </CardContent>
           </Card>
         )}
@@ -612,6 +612,7 @@ export default function McpPage() {
         {servers.map((server) => {
           const envCount = Object.keys(server.env ?? {}).length;
           const result = testResults[server.name];
+          const isPluginManaged = server.source === "plugin";
 
           return (
             <Card key={server.name}>
@@ -624,7 +625,7 @@ export default function McpPage() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <span className="font-medium text-sm truncate">
-                      {server.name}
+                      {server.display_name ?? server.name}
                     </span>
                     <Badge
                       tone={TRANSPORT_TONE[server.transport] ?? "secondary"}
@@ -637,10 +638,18 @@ export default function McpPage() {
                         {server.auth === "header" ? "bearer" : server.auth}
                       </Badge>
                     )}
+                    {isPluginManaged && <Badge tone="secondary">plugin</Badge>}
                     {!server.enabled && <Badge tone="outline">disabled</Badge>}
                   </div>
                   <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                    {server.transport === "http" ? (
+                    {isPluginManaged ? (
+                      <span>
+                        Managed by Agent Plugin {server.managed_by}
+                        {server.plugin_version
+                          ? ` v${server.plugin_version}`
+                          : ""}
+                      </span>
+                    ) : server.transport === "http" ? (
                       <span className="font-mono truncate">
                         {server.url ?? "—"}
                       </span>
@@ -651,7 +660,7 @@ export default function McpPage() {
                           .join(" ") || "—"}
                       </span>
                     )}
-                    {envCount > 0 && (
+                    {!isPluginManaged && envCount > 0 && (
                       <span>
                         {envCount} env var{envCount === 1 ? "" : "s"}
                       </span>
@@ -677,61 +686,67 @@ export default function McpPage() {
                 </div>
 
                 <div className="flex items-center gap-1 shrink-0">
-                  {server.auth === "oauth" && (
-                    <Button
-                      ghost
-                      size="sm"
-                      title="Authenticate with OAuth"
-                      onClick={() => handleAuthenticate(server)}
-                      disabled={authenticating === server.name}
-                      prefix={
-                        authenticating === server.name ? (
-                          <Spinner />
-                        ) : (
-                          <KeyRound />
-                        )
-                      }
-                    >
-                      Authenticate
-                    </Button>
+                  {isPluginManaged ? (
+                    <Badge tone="success">enabled</Badge>
+                  ) : (
+                    <>
+                      {server.auth === "oauth" && (
+                        <Button
+                          ghost
+                          size="sm"
+                          title="Authenticate with OAuth"
+                          onClick={() => handleAuthenticate(server)}
+                          disabled={authenticating === server.name}
+                          prefix={
+                            authenticating === server.name ? (
+                              <Spinner />
+                            ) : (
+                              <KeyRound />
+                            )
+                          }
+                        >
+                          Authenticate
+                        </Button>
+                      )}
+
+                      <Button
+                        ghost
+                        size="sm"
+                        title={server.enabled ? "Disable" : "Enable"}
+                        aria-label={server.enabled ? "Disable" : "Enable"}
+                        onClick={() => handleToggleEnabled(server)}
+                        disabled={togglingName === server.name}
+                        prefix={
+                          togglingName === server.name ? <Spinner /> : <Power />
+                        }
+                        className={server.enabled ? "text-success" : undefined}
+                      >
+                        {server.enabled ? "Disable" : "Enable"}
+                      </Button>
+
+                      <Button
+                        ghost
+                        size="icon"
+                        title="Test connection"
+                        aria-label="Test connection"
+                        onClick={() => handleTest(server)}
+                        disabled={testing === server.name}
+                      >
+                        {testing === server.name ? <Spinner /> : <Zap />}
+                      </Button>
+
+                      <Button
+                        ghost
+                        destructive
+                        size="icon"
+                        title="Delete"
+                        aria-label="Delete"
+                        onClick={() => serverDelete.requestDelete(server.name)}
+                      >
+                        <Trash2 />
+                      </Button>
+                    </>
                   )}
-
-                  <Button
-                    ghost
-                    size="sm"
-                    title={server.enabled ? "Disable" : "Enable"}
-                    aria-label={server.enabled ? "Disable" : "Enable"}
-                    onClick={() => handleToggleEnabled(server)}
-                    disabled={togglingName === server.name}
-                    prefix={
-                      togglingName === server.name ? <Spinner /> : <Power />
-                    }
-                    className={server.enabled ? "text-success" : undefined}
-                  >
-                    {server.enabled ? "Disable" : "Enable"}
-                  </Button>
-
-                  <Button
-                    ghost
-                    size="icon"
-                    title="Test connection"
-                    aria-label="Test connection"
-                    onClick={() => handleTest(server)}
-                    disabled={testing === server.name}
-                  >
-                    {testing === server.name ? <Spinner /> : <Zap />}
-                  </Button>
-
-                  <Button
-                    ghost
-                    destructive
-                    size="icon"
-                    title="Delete"
-                    aria-label="Delete"
-                    onClick={() => serverDelete.requestDelete(server.name)}
-                  >
-                    <Trash2 />
-                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -320,8 +320,9 @@ Browse, search, and toggle installed skills and toolsets, and install new ones f
 
 ### MCP
 
-Manage [MCP](./mcp) servers without the CLI. The same `mcp_servers`
-block in `config.yaml` that `hermes mcp` reads from.
+Manage [MCP](./mcp) servers without the CLI. The page combines the
+profile-owned `mcp_servers` block from `config.yaml` with MCP servers supplied
+by enabled portable Agent Plugins.
 
 **Your MCP servers:**
 
@@ -330,6 +331,9 @@ block in `config.yaml` that `hermes mcp` reads from.
 - **Test** — connect to a server, list its tools, and disconnect — verifies the connection before the agent depends on it
 - **Remove** — delete a server from the config
 - Secret-shaped env values are redacted in the list view
+- **Agent Plugin MCPs** — shown as enabled, read-only entries with their owning
+  plugin and version. Enable, disable, update, or remove those servers through
+  the Plugins page so the package and its MCP cannot drift apart.
 
 **Catalog:** browse the Nous-approved MCP servers (the bundled `optional-mcps/`
 catalog) and install any of them with one click. Entries that need API keys


### PR DESCRIPTION
## Summary

- Add content-digest-bound profile grants for portable Agent Plugin MCP servers that explicitly request sessionCapability.
- Mint a short-lived per-call HMAC capability in MCP request metadata, bound to the audience, package/server binding, package bytes, workflow arguments, and active Hermes turn identities.
- Recheck consent and package bytes on every call, reject symlinks and bytecode caches, and pin privileged stdio launches to reviewed executables.
- Surface the canonical package digest through plugin capability and doctor commands.
- Show enabled portable MCP servers in the profile MCP dashboard as read-only, plugin-managed entries instead of omitting them from the runtime inventory.
- Keep dashboard discovery manifest-only and return ownership/version/transport metadata without package paths, commands, environment, headers, or capability material.
- Document receiver-side replay, cancellation, active-turn, ambiguous-mutation, and dashboard ownership requirements.

## Security model

A portable package cannot authorize itself. Hermes requires an exact digest-bound profile grant and inserts all authority metadata after model arguments have been selected. The mechanism is generic and adds no platform-specific model tools. Plugin-provided MCPs remain lifecycle-owned by their reviewed package, so ordinary MCP configuration endpoints cannot independently toggle or delete them.

## Validation

- 291 tests passed across the modified Agent Plugin, plugin manager, tool configuration, MCP client, and capability suites.
- 163 supporting plugin command, plugin doctor, and approval tests passed.
- 83 focused dashboard, profile-isolation, and portable-plugin tests passed after the dashboard inventory change.
- Web TypeScript, ESLint, and production build passed.
- Ruff checks passed for every affected Python file.
- New capability module and test file pass Ruff format checks.