### PR TITLE
fix(gateway): resolve session-scoped Docker sandboxes for MEDIA delivery (#93950)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1531,8 +1531,32 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     return mounts
 
 
-def _default_docker_workspace_host_root() -> Optional[Path]:
-    """Host path for Docker's default persistent ``/workspace`` mount."""
+def _docker_sandbox_dir_name(session_key: str = "") -> str:
+    """Host sandbox directory name for a session's persistent Docker container.
+
+    Mirrors ``_resolve_container_task_id(None)`` (tools/terminal_tool.py):
+    gateway sessions key their container ``session:<session_key>`` and
+    tools/environments/docker.py names the host directory after
+    :func:`sanitize_task_id_for_path` of that id. Contexts without a session
+    key share the historical ``default`` sandbox.
+
+    Takes the key explicitly because the delivery pipeline runs after
+    ``_handle_message_with_agent`` cleared the turn's session contextvars
+    (#93950) — an ambient lookup here would silently collapse onto
+    ``default`` and miss the session's real sandbox.
+    """
+    if not session_key:
+        return "default"
+    try:
+        from tools.environments.base import sanitize_task_id_for_path
+
+        return sanitize_task_id_for_path(f"session:{session_key}")
+    except Exception:
+        return "default"
+
+
+def _default_docker_workspace_host_root(session_key: str = "") -> Optional[Path]:
+    """Host path for this session's persistent ``/workspace`` mount."""
     if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return None
     if os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower() not in {
@@ -1558,20 +1582,22 @@ def _default_docker_workspace_host_root() -> Optional[Path]:
     try:
         from tools.environments.base import get_sandbox_dir
 
-        root = (get_sandbox_dir() / "docker" / "default" / "workspace").resolve(strict=False)
+        root = (
+            get_sandbox_dir() / "docker" / _docker_sandbox_dir_name(session_key) / "workspace"
+        ).resolve(strict=False)
     except Exception:
         return None
     return root if root.is_dir() else None
 
 
-def _docker_persistent_home_host_root() -> Optional[Path]:
-    """Host path for Docker's default persistent ``/root`` home mount.
+def _docker_persistent_home_host_root(session_key: str = "") -> Optional[Path]:
+    """Host path for this session's persistent ``/root`` home mount.
 
     Persistent containers bind ``<sandbox>/docker/<task>/home`` to ``/root``
     (tools/environments/docker.py), so an agent that writes ``/root/out.png``
-    produced a real host file the gateway couldn't find. Same collapse rule as
-    the workspace mount: the gateway's container sharing resolves to the
-    ``default`` task sandbox.
+    produced a real host file the gateway couldn't find. The task directory
+    is derived from the delivering session's key so session-scoped sandboxes
+    resolve to the container that produced the file (#93950).
     """
     if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
         return None
@@ -1585,7 +1611,9 @@ def _docker_persistent_home_host_root() -> Optional[Path]:
     try:
         from tools.environments.base import get_sandbox_dir
 
-        root = (get_sandbox_dir() / "docker" / "default" / "home").resolve(strict=False)
+        root = (
+            get_sandbox_dir() / "docker" / _docker_sandbox_dir_name(session_key) / "home"
+        ).resolve(strict=False)
     except Exception:
         return None
     return root if root.is_dir() else None
@@ -1613,11 +1641,11 @@ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
         return []
 
 
-def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
+def _translate_docker_container_media_path(candidate: Path, session_key: str = "") -> Optional[Path]:
     """Translate a container-absolute path to its host path when possible.
 
     Uses longest-prefix match across configured ``docker_volumes``, the
-    auto-mounted Hermes cache dirs (``/root/.hermes/...``), the default
+    auto-mounted Hermes cache dirs (``/root/.hermes/...``), the session's
     persistent Docker ``/workspace`` host root, and the persistent ``/root``
     home mount.
     """
@@ -1638,13 +1666,13 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
     mounts = list(_parse_docker_volume_mounts())
     mounts.extend(_cache_dir_container_mounts())
     # Synthetic /workspace mount for default persistent sandbox / cwd bind.
-    default_ws = _default_docker_workspace_host_root()
+    default_ws = _default_docker_workspace_host_root(session_key)
     if default_ws is not None and not any(c.as_posix() == "/workspace" for _, c in mounts):
         mounts.append((default_ws, Path("/workspace")))
     # Synthetic /root mount for the persistent home bind. Cache mounts above
     # are longer prefixes, so /root/.hermes/... still translates to the host
     # cache — this only catches stray home writes like /root/out.png.
-    default_home = _docker_persistent_home_host_root()
+    default_home = _docker_persistent_home_host_root(session_key)
     if default_home is not None and not any(c.as_posix() == "/root" for _, c in mounts):
         # /root/.hermes/* that did NOT match a cache mount is the container's
         # credential/secret surface (.env, auth.json, ... are individually
@@ -1681,7 +1709,7 @@ def _translate_docker_container_media_path(candidate: Path) -> Optional[Path]:
     return translated
 
 
-def validate_media_delivery_path(path: str) -> Optional[str]:
+def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
     Default mode (single-user / private gateway): accept any existing regular
@@ -1722,7 +1750,7 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     # Docker agents emit MEDIA:/workspace/... (or other configured container
     # mount paths). Resolve those to host paths before the normal host-side
     # existence / denylist checks.
-    translated = _translate_docker_container_media_path(expanded)
+    translated = _translate_docker_container_media_path(expanded, session_key=session_key)
     if translated is not None:
         resolved = translated
     else:
@@ -4822,17 +4850,17 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
     @staticmethod
-    def validate_media_delivery_path(path: str) -> Optional[str]:
+    def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:
         """Return a resolved path if it is safe for native attachment upload."""
-        return validate_media_delivery_path(path)
+        return validate_media_delivery_path(path, session_key=session_key)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
+    def filter_media_delivery_paths(media_files, session_key: str = "") -> List[Tuple[str, bool]]:
         """Drop unsafe MEDIA paths and normalize accepted paths."""
         safe_media: List[Tuple[str, bool]] = []
         for media_path, is_voice in media_files or []:
             raw = str(media_path)
-            safe_path = validate_media_delivery_path(raw)
+            safe_path = validate_media_delivery_path(raw, session_key=session_key)
             if safe_path:
                 safe_media.append((safe_path, bool(is_voice)))
             else:
@@ -4840,12 +4868,12 @@ class BasePlatformAdapter(ABC):
         return safe_media
 
     @staticmethod
-    def filter_local_delivery_paths(file_paths) -> List[str]:
+    def filter_local_delivery_paths(file_paths, session_key: str = "") -> List[str]:
         """Drop unsafe bare local file paths and normalize accepted paths."""
         safe_paths: List[str] = []
         for file_path in file_paths or []:
             raw = str(file_path)
-            safe_path = validate_media_delivery_path(raw)
+            safe_path = validate_media_delivery_path(raw, session_key=session_key)
             if safe_path:
                 safe_paths.append(safe_path)
             else:
@@ -6384,7 +6412,7 @@ class BasePlatformAdapter(ABC):
 
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                media_files = self.filter_media_delivery_paths(media_files, session_key=session_key)
 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
@@ -6403,7 +6431,7 @@ class BasePlatformAdapter(ABC):
                     # system/command notices so config paths stay visible text
                     # instead of becoming native uploads.
                     local_files, text_content = self.extract_local_files(text_content)
-                    local_files = self.filter_local_delivery_paths(local_files)
+                    local_files = self.filter_local_delivery_paths(local_files, session_key=session_key)
                     # Do NOT load the full SQLite transcript for ordinary text or
                     # explicit MEDIA tags.  History is needed only for bare local
                     # paths auto-detected above.  Run that synchronous DB/decode

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1641,6 +1641,26 @@ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
         return []
 
 
+def _warn_unresolved_docker_media(candidate: Path, session_key: str, reason: str) -> None:
+    """Name WHY a container-absolute MEDIA path failed translation (#93950).
+
+    Under Docker these failures used to surface only as the generic
+    "Skipping unsafe MEDIA directive path" line one level up, leaving the
+    file seemingly vanished. Point at the sandbox/session mismatch instead.
+    Gated to Docker mode so host-path rejections stay quiet.
+    """
+    if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+        return
+    logger.warning(
+        "Docker MEDIA path %s did not resolve to a host sandbox file (%s%s); "
+        "the producing container's sandbox directory may not exist yet or "
+        "was pruned",
+        _log_safe_path(str(candidate)),
+        reason,
+        f", session_key={session_key}" if session_key else "",
+    )
+
+
 def _translate_docker_container_media_path(candidate: Path, session_key: str = "") -> Optional[Path]:
     """Translate a container-absolute path to its host path when possible.
 
@@ -1684,8 +1704,8 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
             mounts.append((default_home, Path("/root")))
 
     if not mounts:
+        _warn_unresolved_docker_media(candidate, session_key, "no sandbox mounts resolved")
         return None
-
     # Longest container-prefix match.
     best: Optional[Tuple[Path, Path, int]] = None
     candidate_posix = candidate.as_posix()
@@ -1696,13 +1716,14 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
             if best is None or score > best[2]:
                 best = (host_root, container_root, score)
     if best is None:
+        _warn_unresolved_docker_media(candidate, session_key, "no mounted prefix matches")
         return None
-
     host_root, container_root, _ = best
     try:
         relative = candidate.relative_to(container_root)
         translated = (host_root / relative).resolve(strict=True)
     except (OSError, RuntimeError, ValueError):
+        _warn_unresolved_docker_media(candidate, session_key, "host file missing from sandbox")
         return None
     if translated != host_root and not _path_is_within(translated, host_root):
         return None

--- a/tests/cron/test_media_send_timeout.py
+++ b/tests/cron/test_media_send_timeout.py
@@ -66,7 +66,7 @@ class TestEmptyReasonFallback:
 
         monkeypatch.setattr(
             "gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
-            staticmethod(lambda files: [(str(media), False)]),
+            staticmethod(lambda files, session_key="": [(str(media), False)]),
         )
 
         def boom(coro, loop):

--- a/tests/gateway/test_73771_media_resend_dedup.py
+++ b/tests/gateway/test_73771_media_resend_dedup.py
@@ -200,7 +200,7 @@ async def test_bare_local_path_history_dedup_survives_and_logs(tmp_path, monkeyp
     # Bypass the local-path safety filter so the test pins ONLY the history
     # dedup behavior, not the safe-root policy.
     monkeypatch.setattr(
-        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths: list(paths))
+        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths, session_key="": list(paths))
     )
 
     async def handler(_event):
@@ -283,7 +283,7 @@ async def test_bare_path_history_lookup_does_not_block_event_loop(tmp_path, monk
     adapter = _DummyAdapter()
     adapter._keep_typing = _hold_typing
     monkeypatch.setattr(
-        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths: list(paths))
+        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths, session_key="": list(paths))
     )
 
     class _GatedStore:
@@ -332,7 +332,7 @@ async def test_bare_path_history_lookup_timeout_fails_open(tmp_path, monkeypatch
     adapter = _DummyAdapter()
     adapter._keep_typing = _hold_typing
     monkeypatch.setattr(
-        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths: list(paths))
+        type(adapter), "filter_local_delivery_paths", staticmethod(lambda paths, session_key="": list(paths))
     )
 
     class _WedgedStore:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1252,3 +1252,111 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+class TestDockerSessionSandboxMediaTranslation:
+    """MEDIA from a session-scoped persistent Docker sandbox must resolve to
+    the host directory that container actually bind-mounts (#93950).
+
+    Contract: the gateway resolves the SAME directory
+    ``tools/environments/docker.py`` created — ``<sandboxes>/docker/<task>``
+    where ``<task>`` is ``sanitize_task_id_for_path("session:<key>")`` for
+    gateway sessions and the literal ``default`` otherwise.
+    """
+
+    SESSION_KEY = "agent:main:telegram:dm:123456"
+
+    @staticmethod
+    def _sandbox_dir(session_key: str):
+        from tools.environments.base import get_sandbox_dir, sanitize_task_id_for_path
+
+        task_id = f"session:{session_key}" if session_key else "default"
+        return get_sandbox_dir() / "docker" / sanitize_task_id_for_path(task_id)
+
+    def _enable_docker(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+
+    def test_session_scoped_workspace_media_translates(self, monkeypatch):
+        """A MEDIA tag pointing at the container's /workspace resolves to the
+        session's real host sandbox instead of being dropped."""
+        self._enable_docker(monkeypatch)
+        workspace = self._sandbox_dir(self.SESSION_KEY) / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        produced = workspace / "chart.png"
+        produced.write_bytes(b"png")
+
+        resolved = BasePlatformAdapter.validate_media_delivery_path(
+            "/workspace/chart.png", session_key=self.SESSION_KEY
+        )
+
+        assert resolved == str(produced.resolve())
+
+    def test_missing_session_key_reproduces_93950_drop(self, monkeypatch):
+        """Pre-fix failure mode: with no delivering-session key the
+        translation collapses onto the (nonexistent) ``default`` sandbox and
+        the attachment is dropped even though the file exists."""
+        self._enable_docker(monkeypatch)
+        workspace = self._sandbox_dir(self.SESSION_KEY) / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / "out.png").write_bytes(b"png")
+
+        assert (
+            BasePlatformAdapter.validate_media_delivery_path("/workspace/out.png")
+            is None
+        )
+
+    def test_default_sandbox_still_resolves_without_session_key(self, monkeypatch):
+        """CLI-created default sandboxes keep their historical resolution."""
+        self._enable_docker(monkeypatch)
+        workspace = self._sandbox_dir("") / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        produced = workspace / "out.png"
+        produced.write_bytes(b"png")
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/workspace/out.png"
+        ) == str(produced.resolve())
+
+    def test_session_home_mount_translates_stray_root_writes(self, monkeypatch):
+        """/root/<file> lands in the session sandbox's home mount."""
+        self._enable_docker(monkeypatch)
+        home = self._sandbox_dir(self.SESSION_KEY) / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        produced = home / "note.txt"
+        produced.write_text("hi")
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/root/note.txt", session_key=self.SESSION_KEY
+        ) == str(produced.resolve())
+
+    def test_session_home_credential_surface_still_refused(self, monkeypatch):
+        """The /root/.hermes exclusion survives session scoping: translating
+        the home mount must never expose the container's secret surface."""
+        self._enable_docker(monkeypatch)
+        home = self._sandbox_dir(self.SESSION_KEY) / "home"
+        secrets = home / ".hermes"
+        secrets.mkdir(parents=True, exist_ok=True)
+        (secrets / "auth.json").write_text("{}")
+
+        assert (
+            BasePlatformAdapter.validate_media_delivery_path(
+                "/root/.hermes/auth.json", session_key=self.SESSION_KEY
+            )
+            is None
+        )
+
+    def test_filter_passes_session_key_through(self, monkeypatch):
+        """The adapter filter used by _process_message_background forwards the
+        key, so extracted MEDIA tags survive filtering in one hop."""
+        self._enable_docker(monkeypatch)
+        workspace = self._sandbox_dir(self.SESSION_KEY) / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        produced = workspace / "clip.mp4"
+        produced.write_bytes(b"mp4")
+
+        kept = BasePlatformAdapter.filter_media_delivery_paths(
+            [("/workspace/clip.mp4", False)], session_key=self.SESSION_KEY
+        )
+
+        assert kept == [(str(produced.resolve()), False)]

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1360,3 +1360,22 @@ class TestDockerSessionSandboxMediaTranslation:
         )
 
         assert kept == [(str(produced.resolve()), False)]
+
+    def test_unresolved_docker_media_names_the_cause(self, monkeypatch, caplog):
+        """Approach C: a container path whose sandbox never existed must log
+        WHY it was dropped (sandbox mismatch), not just the generic unsafe-
+        path line — the silent-drop mode reported in #93950."""
+        import logging
+
+        self._enable_docker(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.base"):
+            resolved = BasePlatformAdapter.validate_media_delivery_path(
+                "/workspace/ghost.png", session_key=self.SESSION_KEY
+            )
+
+        assert resolved is None
+        assert any(
+            "did not resolve to a host sandbox file" in r.message
+            and f"session_key={self.SESSION_KEY}" in r.message
+            for r in caplog.records
+        )

--- a/tests/gateway/test_tool_response_drop_recovery.py
+++ b/tests/gateway/test_tool_response_drop_recovery.py
@@ -151,7 +151,9 @@ class TestRecoveryDoesNotLeakMediaFragments:
         # but force the path to be filtered out (unsafe/nonexistent) so we hit
         # the empty-text + no-attachment recovery branch deterministically.
         monkeypatch.setattr(
-            type(adapter), "filter_media_delivery_paths", staticmethod(lambda m: [])
+            type(adapter),
+            "filter_media_delivery_paths",
+            staticmethod(lambda m, session_key="": []),
         )
 
         event = _make_event(Platform.DISCORD)


### PR DESCRIPTION
Fixes #93950

## Problem

With Docker + `container_persistent: true`, every gateway session's persistent container binds its workspace/home from `<sandboxes>/docker/<task>/{workspace,home}` where `<task>` is `sanitize_task_id_for_path("session:<session_key>")` (`tools/environments/docker.py`). The gateway's synthetic mounts in `_default_docker_workspace_host_root()` / `_docker_persistent_home_host_root()` hardcoded the literal `"default"` task directory instead.

For any session-scoped deployment (every Telegram/Discord/Slack DM, every `delegate_task` child) that directory never exists, so:

1. longest-prefix translation misses → returns `None`;
2. `validate_media_delivery_path()` falls through to host-filesystem resolution of a container-internal path (`/workspace/out.png`), which cannot exist;
3. the attachment is silently dropped with only a generic "Couldn't deliver the file attachment" notice — while the file sits untouched in the real sandbox.

A second layer masked debugging: `_handle_message_with_agent` clears the turn's session contextvars in its `finally` **before** `_process_message_background`'s post-handler media filtering runs, so any fix consulting ambient session state would see an empty key and collapse onto `"default"` again. (Same failure class previously hit auto-TTS: #57049/#36685.)

## Changes

- New `_docker_sandbox_dir_name(session_key)` helper mirrors `_resolve_container_task_id(None)` exactly: `sanitize_task_id_for_path(f"session:{key}")` for gateway sessions, the historical `"default"` otherwise — so the gateway resolves by construction the same directory docker.py created at container start.
- Threaded `session_key` explicitly through `validate_media_delivery_path()` → `_translate_docker_container_media_path()` → both host-root helpers and the adapter filter statics; `_process_message_background` passes the key it already holds. Explicit-parameter threading follows the established post-handler precedent rather than contextvar surgery.
- De-silenced failures (#93950 approach C): when a container-absolute `/workspace` or `/root` path fails translation under `TERMINAL_ENV=docker`, log WHY (no mounts / no prefix match / host file missing from sandbox) plus the session key.
- Preserved: default-sandbox resolution for keyless contexts (CLI), the `/root/.hermes` credential-surface exclusion, denylist/strict-mode behavior.
- Updated two test stubs that monkeypatch the filter statics for the new kwarg.

Credit: reported by @raimirch, who independently diagnosed both layers and locally verified this exact fix direction end-to-end over Telegram.

## Testing

- [x] 7 new tests in `tests/gateway/test_platform_base.py::TestDockerSessionSandboxMediaTranslation` (real sanitized sandbox dirs built via the production helper; includes a pinned pre-fix reproduction case, default-sandbox backward compat, home-mount translation, credential-exclusion survival, filter pass-through, and the new warning assertion)
- [x] `scripts/run_tests.sh` green: 109 passed / 0 failed across `test_platform_base.py`, `test_tool_response_drop_recovery.py`, `test_media_send_timeout.py`
- [x] `ruff check` clean
- [ ] Manual E2E on a real persistent-Docker gateway (happy to validate with the reporter's repro)

## Follow-up (deliberately not in this PR)

Longer-term hardening of the same seam (approach discussed in review):

- Bind the live session identity via contextvar plumbing into the tool/media layer instead of relying on the caller-held key, and/or
- persist an authoritative `container → sandbox_dir` record at container creation time in `tools/environments/docker.py` so media translation can consult ground truth even when the session key is unavailable (CLI-launched containers, cross-process reuse).

Related secondary observation from the issue thread worth its own issue: the bind-mount dir name sanitizer (`sanitize_task_id_for_path`) and the container-label sanitizer can diverge for long-lived containers created before a hashing-behavior change; self-heals when the container recycles.