### PR TITLE
fix(gateway): recover explicit computer-use screenshot paths

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1823,6 +1823,146 @@ _TOOL_MEDIA_RE = re.compile(
 )
 
 
+_COMPUTER_USE_CAPTURE_BASENAME_RE = re.compile(
+    r"^computer_use_[0-9a-f]{32}\.(?:png|jpe?g)$",
+    re.IGNORECASE,
+)
+_COMPUTER_USE_CAPTURE_SUMMARY_RE = re.compile(
+    r"\(shareable screenshot saved to "
+    r"(?P<path>(?:[A-Za-z]:[/\\]|/|\\\\)[^\r\n]*?"
+    r"computer_use_[0-9a-f]{32}\.(?:png|jpe?g))\)",
+    re.IGNORECASE,
+)
+
+
+def _computer_use_capture_basename(path: Any) -> str:
+    """Return a canonical capture basename for either path separator style."""
+    value = str(path or "").strip().strip("`\"'")
+    basename = re.split(r"[/\\]", value)[-1]
+    if _COMPUTER_USE_CAPTURE_BASENAME_RE.fullmatch(basename):
+        return basename.lower()
+    return ""
+
+
+def _iter_computer_use_capture_paths(content: Any):
+    """Yield persisted screenshot paths from computer_use result content.
+
+    The tool can return JSON, a multimodal content list, or a text fallback.
+    The latter two retain the canonical path in the human-readable summary
+    even though the multimodal envelope's ``meta`` dictionary is not stored in
+    the tool message.
+    """
+    if isinstance(content, str):
+        for match in _COMPUTER_USE_CAPTURE_SUMMARY_RE.finditer(content):
+            yield match.group("path").strip()
+        stripped = content.strip()
+        if stripped.startswith(("{", "[")):
+            try:
+                payload = json.loads(stripped)
+            except Exception:
+                payload = None
+            if isinstance(payload, (dict, list)):
+                yield from _iter_computer_use_capture_paths(payload)
+        return
+
+    if isinstance(content, list):
+        for part in content:
+            yield from _iter_computer_use_capture_paths(part)
+        return
+
+    if not isinstance(content, dict):
+        return
+
+    screenshot_path = content.get("screenshot_path")
+    if isinstance(screenshot_path, str):
+        yield screenshot_path
+    meta = content.get("meta")
+    if isinstance(meta, dict) and isinstance(meta.get("screenshot_path"), str):
+        yield meta["screenshot_path"]
+    for field in ("content", "text", "text_summary", "summary"):
+        nested = content.get(field)
+        if isinstance(nested, (str, dict, list)):
+            yield from _iter_computer_use_capture_paths(nested)
+
+
+def _repair_explicit_computer_use_media_paths(
+    response: str,
+    messages: List[Dict[str, Any]],
+    history_offset: int = 0,
+) -> str:
+    """Recover model-mangled paths for explicitly requested screenshots.
+
+    ``computer_use`` persists a bounded screenshot and gives its absolute path
+    to the model. Some models rewrite a Windows path into a POSIX-looking path
+    before emitting ``MEDIA:``, which makes the gateway reject the nonexistent
+    path. Repair only an already-explicit directive whose unique generated
+    basename matches a canonical screenshot path from this turn. This does not
+    auto-attach ordinary computer-use captures, and normal media path
+    validation still runs after the repair.
+    """
+    if "MEDIA:" not in response:
+        return response
+
+    if history_offset and len(messages) >= history_offset:
+        turn_messages = messages[history_offset:]
+    elif history_offset:
+        # Compression can invalidate the original slice boundary. Recover the
+        # current turn from its last user message; fail closed if none remains.
+        last_user = next(
+            (
+                index
+                for index in range(len(messages) - 1, -1, -1)
+                if messages[index].get("role") == "user"
+            ),
+            None,
+        )
+        turn_messages = messages[last_user:] if last_user is not None else []
+    else:
+        turn_messages = messages
+
+    tool_name_by_call_id: Dict[str, str] = {}
+    for msg in turn_messages:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            call_id = call.get("id") or call.get("call_id")
+            fn = call.get("function") or {}
+            name = str(fn.get("name") or call.get("name") or "")
+            if call_id and name:
+                tool_name_by_call_id[str(call_id)] = name
+
+    canonical_by_basename: Dict[str, str] = {}
+    for msg in turn_messages:
+        if msg.get("role") not in {"tool", "function"}:
+            continue
+        call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
+        tool_name = str(
+            msg.get("name")
+            or msg.get("tool_name")
+            or tool_name_by_call_id.get(call_id)
+            or ""
+        )
+        if tool_name != "computer_use":
+            continue
+        for path in _iter_computer_use_capture_paths(msg.get("content")):
+            basename = _computer_use_capture_basename(path)
+            if basename and re.match(r"^(?:[A-Za-z]:[/\\]|/|\\\\)", path):
+                canonical_by_basename[basename] = path
+
+    if not canonical_by_basename:
+        return response
+
+    media_files, _ = BasePlatformAdapter.extract_media(response)
+    repaired = response
+    for emitted_path, _is_voice in media_files:
+        canonical = canonical_by_basename.get(
+            _computer_use_capture_basename(emitted_path)
+        )
+        if canonical and emitted_path != canonical:
+            repaired = repaired.replace(emitted_path, canonical)
+    return repaired
+
+
 def _collect_auto_append_media_tags(
     messages: List[Dict[str, Any]],
     history_offset: int = 0,
@@ -6429,6 +6569,20 @@ class TurnRunner:
             except Exception:
                 pass
             reset_current_session_key(_approval_session_token)
+        # Canonicalize an explicitly emitted computer-use screenshot path at
+        # the common result boundary. The streaming finalizer below and the
+        # normal non-streaming delivery path must see the same response;
+        # repairing only during later media scanning leaves streaming with the
+        # model-mangled path and a rejected attachment.
+        if isinstance(result, dict):
+            _result_final = result.get("final_response")
+            if isinstance(_result_final, str):
+                result["final_response"] = _repair_explicit_computer_use_media_paths(
+                    _result_final,
+                    result.get("messages", []),
+                    history_offset=len(agent_history),
+                )
+
         ctx.result_holder[0] = result
 
         # Signal the stream consumer that the agent is done. Pass the

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -11,6 +11,7 @@ make_image tool several turns earlier must not leak onto a later
 text-only reply, even when the path-based dedup set fails to capture it.
 """
 
+import json
 import re
 from unittest.mock import MagicMock
 
@@ -104,6 +105,114 @@ def extract_media_tags_broken(result_messages):
 
 class TestMediaExtraction:
     """Tests for MEDIA tag extraction from tool results."""
+
+    def test_repairs_explicit_computer_use_media_path_from_json_result(self):
+        from gateway.run import _repair_explicit_computer_use_media_paths
+
+        capture_name = "computer_use_0123456789abcdef0123456789abcdef.png"
+        canonical = rf"C:\Users\Alice\AppData\Local\hermes\cache\images\{capture_name}"
+        response = (
+            "Here is the screenshot.\n"
+            f"MEDIA:/Users/Alice/AppData/Local/hermes/cache/images/{capture_name}"
+        )
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "capture", "function": {"name": "computer_use"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "capture",
+                "content": json.dumps({"screenshot_path": canonical}),
+            },
+        ]
+
+        repaired = _repair_explicit_computer_use_media_paths(response, messages)
+
+        assert repaired == f"Here is the screenshot.\nMEDIA:{canonical}"
+
+    def test_repairs_explicit_path_from_multimodal_text_summary(self):
+        from gateway.run import _repair_explicit_computer_use_media_paths
+
+        capture_name = "computer_use_fedcba9876543210fedcba9876543210.jpg"
+        canonical = rf"D:\Hermes Data\cache\images\{capture_name}"
+        response = f'MEDIA:"/Users/Alice/Hermes Data/cache/images/{capture_name}"'
+        messages = [
+            {
+                "role": "tool",
+                "name": "computer_use",
+                "tool_call_id": "capture",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "capture mode=screen 1920x1080\n"
+                            f"  (shareable screenshot saved to {canonical})"
+                        ),
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+                    },
+                ],
+            }
+        ]
+
+        repaired = _repair_explicit_computer_use_media_paths(response, messages)
+
+        assert repaired == f'MEDIA:"{canonical}"'
+
+    def test_does_not_auto_attach_computer_use_capture(self):
+        from gateway.run import _repair_explicit_computer_use_media_paths
+
+        capture_name = "computer_use_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png"
+        canonical = rf"C:\Users\Alice\AppData\Local\hermes\cache\images\{capture_name}"
+        messages = [
+            {
+                "role": "tool",
+                "name": "computer_use",
+                "content": json.dumps({"screenshot_path": canonical}),
+            }
+        ]
+
+        assert (
+            _repair_explicit_computer_use_media_paths("Done.", messages)
+            == "Done."
+        )
+
+    def test_does_not_rewrite_unmatched_or_previous_turn_capture(self):
+        from gateway.run import _repair_explicit_computer_use_media_paths
+
+        old_name = "computer_use_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.png"
+        current_name = "computer_use_cccccccccccccccccccccccccccccccc.png"
+        old_canonical = rf"C:\cache\images\{old_name}"
+        current_canonical = rf"C:\cache\images\{current_name}"
+        history = [
+            {
+                "role": "tool",
+                "name": "computer_use",
+                "content": json.dumps({"screenshot_path": old_canonical}),
+            },
+        ]
+        current_turn = [
+            {"role": "user", "content": "Send the current screenshot."},
+            {
+                "role": "tool",
+                "name": "computer_use",
+                "content": json.dumps({"screenshot_path": current_canonical}),
+            },
+        ]
+        response = f"MEDIA:/Users/Alice/cache/images/{old_name}"
+
+        repaired = _repair_explicit_computer_use_media_paths(
+            response,
+            history + current_turn,
+            history_offset=len(history),
+        )
+
+        assert repaired == response
 
     def test_gateway_auto_append_ignores_media_examples_in_skill_docs(self):
         """Skill/documentation examples must not be appended as real attachments."""


### PR DESCRIPTION
## What does this PR do?

Recovers the canonical persisted `computer_use` screenshot path when a model explicitly asks the gateway to attach that screenshot but rewrites a Windows path into a nonexistent POSIX-looking path.

`computer_use` already persists a bounded screenshot and exposes its absolute path. A model can turn `C:\Users\Alice\...\computer_use_<uuid>.png` into `/Users/Alice/.../computer_use_<uuid>.png` when emitting `MEDIA:`, so the gateway rejects the attachment as unsafe or nonexistent.

The repair is deliberately narrow: it runs only when the final response already contains an explicit `MEDIA:` directive, and only when the directive's generated `computer_use_<uuid>` basename exactly matches a canonical screenshot path returned by `computer_use` in the current turn. It does not add `computer_use` to automatic media append, so screenshots used for ordinary computer control remain private to model context. Existing media path validation still runs after recovery.

## Related Issue

No public issue. This was reproduced from a support diagnostic without carrying customer or deployment identifiers into the change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: recover an explicitly emitted, model-mangled screenshot path from the matching current-turn `computer_use` result before either streaming or non-streaming delivery finalizes.
- `tests/gateway/test_media_extraction.py`: cover JSON and multimodal tool-result shapes, no-auto-attach behavior, and current-turn isolation.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_media_extraction.py -q -j 4`.
2. Return a canonical Windows `screenshot_path` from `computer_use`, then finalize with `MEDIA:/Users/Alice/.../computer_use_<same-uuid>.png`; confirm the response is repaired to the canonical Windows path and the existing media-delivery validation accepts the real file.
3. Confirm a `computer_use` result without an explicit final `MEDIA:` directive does not add or deliver an attachment, and that a previous-turn or different screenshot basename is not rewritten.

Local static verification completed: both changed files parse successfully and `git diff --check` passes. The Python test suite was not run locally under this workstation's focused-test policy; GitHub CI is expected to execute the added regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: static validation only; behavioral coverage is delegated to CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented in the helper
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — matching accepts Windows, POSIX, and UNC canonical paths without changing platform validation
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Generalized failure shape before the fix:

```text
computer_use screenshot_path: C:\Users\Alice\AppData\Local\hermes\cache\images\computer_use_<uuid>.png
model final: MEDIA:/Users/Alice/AppData/Local/hermes/cache/images/computer_use_<uuid>.png
gateway: Skipping unsafe MEDIA directive path
```