### PR TITLE
fix(desktop): allow project creation for a lone profile in All-profiles view

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -449,6 +449,20 @@ describe('createProject', () => {
     expect(request).toHaveBeenCalledWith('projects.create', expect.objectContaining({ profile: 'default' }))
   })
 
+  it('still refuses project creation in All-profiles view when the profile roster has not loaded yet', async () => {
+    $activeGatewayProfile.set('default')
+    $profiles.set([])
+    setShowAllProfiles(true)
+
+    const request = vi.fn()
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(createProject({ folders: ['/srv/demo'], name: 'Demo' })).rejects.toThrow(
+      'Projects are unavailable while viewing all profiles'
+    )
+    expect(request).not.toHaveBeenCalled()
+  })
+
   it('still refuses project creation in All-profiles view when more than one profile exists', async () => {
     $activeGatewayProfile.set('default')
     $profiles.set([profile('default', true), profile('work')])

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
+import { $activeGatewayProfile, $profiles, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
+import type { ProfileInfo } from '@/types/hermes'
 
 import {
   $activeProjectId,
@@ -86,6 +87,16 @@ const getHermesConfig = vi.mocked(hermes.getHermesConfig)
 const notifications = await import('@/store/notifications')
 const notify = vi.mocked(notifications.notify)
 
+const profile = (name: string, isDefault = false): ProfileInfo => ({
+  has_env: false,
+  is_default: isDefault,
+  model: null,
+  name,
+  path: `/tmp/hermes/${name}`,
+  provider: null,
+  skill_count: 0
+})
+
 function deferred<T>() {
   let resolve!: (value: T) => void
 
@@ -137,6 +148,7 @@ describe('projects RPC profile forwarding', () => {
     $activeProjectId.set(null)
     $projectTree.set([])
     setShowAllProfiles(false)
+    $profiles.set([])
   })
 
   it('forwards the normalized active profile to project read RPCs', async () => {
@@ -163,6 +175,9 @@ describe('projects RPC profile forwarding', () => {
     const gateway = { connectionState: 'open', request }
     activeGateway.mockReturnValue(gateway as never)
     gatewayAtom.set(gateway as never)
+    // Multiple profiles: All-profiles view genuinely has no single profile to
+    // disambiguate to, unlike the lone-profile case (#94430).
+    $profiles.set([profile('default', true), profile('coder')])
     setShowAllProfiles(true)
 
     await refreshProjects()
@@ -402,6 +417,50 @@ describe('createProject', () => {
     setSidebarAgentsGrouped(false)
     $activeProjectId.set(null)
     $projectsRpcAvailable.set(null)
+    setShowAllProfiles(false)
+    $profiles.set([])
+  })
+
+  afterEach(() => {
+    setShowAllProfiles(false)
+    $profiles.set([])
+  })
+
+  it('creates the project for a lone profile even while All-profiles view is enabled (#94430)', async () => {
+    $activeGatewayProfile.set('default')
+    $profiles.set([profile('default', true)])
+    setShowAllProfiles(true)
+
+    const created = { folders: [], id: 'p_new', name: 'Demo', primary_path: '/srv/demo' }
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.create') {
+        return { project: created }
+      }
+
+      return { active_id: 'p_new', projects: [created], scoped_session_ids: [] }
+    })
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    const result = await createProject({ folders: ['/srv/demo'], name: 'Demo' })
+
+    expect(result).toEqual(created)
+    expect(request).toHaveBeenCalledWith('projects.create', expect.objectContaining({ profile: 'default' }))
+  })
+
+  it('still refuses project creation in All-profiles view when more than one profile exists', async () => {
+    $activeGatewayProfile.set('default')
+    $profiles.set([profile('default', true), profile('work')])
+    setShowAllProfiles(true)
+
+    const request = vi.fn()
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await expect(createProject({ folders: ['/srv/demo'], name: 'Demo' })).rejects.toThrow(
+      'Projects are unavailable while viewing all profiles'
+    )
+    expect(request).not.toHaveBeenCalled()
   })
 
   it('creates the project and flips into the grouped view so a blank slate shows it', async () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -364,8 +364,11 @@ function projectProfile(): null | string {
   // user (`multiProfile && profileScope === ALL_PROFILES`, sidebar/index.tsx)
   // so the UI looks unchanged in this state. Mirror that gate here: with only
   // one profile there's nothing to disambiguate, so resolve to it instead of
-  // hard-failing project creation with an inscrutable error.
-  return $profiles.get().length > 1 ? null : profile
+  // hard-failing project creation with an inscrutable error. An empty roster
+  // means the profile list hasn't loaded (or failed to), not that there's
+  // genuinely one profile, so it must keep refusing rather than resolve to a
+  // possibly-stale `$activeGatewayProfile`.
+  return $profiles.get().length === 1 ? profile : null
 }
 
 function projectParams(

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -18,6 +18,7 @@ import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $profiles,
   $profileScope,
   ALL_PROFILES,
   normalizeProfileKey,
@@ -350,7 +351,21 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
 function projectProfile(): null | string {
   const profile = normalizeProfileKey($activeGatewayProfile.get())
 
-  return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile
+  if (profile === ALL_PROFILES) {
+    return null
+  }
+
+  if ($profileScope.get() !== ALL_PROFILES) {
+    return profile
+  }
+
+  // The "All profiles" toggle persists regardless of profile count, and the
+  // sidebar deliberately never renders the grouped view for a lone-profile
+  // user (`multiProfile && profileScope === ALL_PROFILES`, sidebar/index.tsx)
+  // so the UI looks unchanged in this state. Mirror that gate here: with only
+  // one profile there's nothing to disambiguate, so resolve to it instead of
+  // hard-failing project creation with an inscrutable error.
+  return $profiles.get().length > 1 ? null : profile
 }
 
 function projectParams(


### PR DESCRIPTION
## What does this PR do?

Fixes #94430: a **single-profile** user who has the persisted "Show all
profiles" sidebar toggle enabled cannot create a Desktop project. The
create dialog fails with `Projects are unavailable while viewing all
profiles` even though the sidebar looks completely normal (no grouping,
no profile tags) — nothing on screen hints at the cause, and the toggle
persists across restarts, so the breakage looks permanent.

## Root Cause

`apps/desktop/src/store/projects.ts`'s `projectProfile()` resolved to
`null` whenever the sidebar scope was `ALL_PROFILES`, regardless of how
many profiles actually exist — and `projectParams()` then throws on a
null profile. But `apps/desktop/src/app/chat/sidebar/index.tsx` already
gates the all-profiles **rendering** behind `multiProfile &&
profileScope === ALL_PROFILES` specifically so a lone-profile user is
never stranded in a grouped view. `projectProfile()` applied no such
exemption to the same scope atom, so a lone-profile user landed in a
UI that looked unchanged while Projects silently hard-failed.

## Fix

Mirror the sidebar's gate in `projectProfile()`: when scope is
`ALL_PROFILES` but there is only one profile, resolve to that profile
instead of `null`. With more than one profile, the original "unavailable"
behavior is unchanged — there's genuinely no way to disambiguate which
profile's project store to use.

## How to Test

1. Have exactly one profile.
2. Enable "All profiles" view via the sidebar filter menu.
3. Attempt to create a project (+Project) — it now succeeds instead of
   throwing the toast error.
4. With two or more profiles and "All profiles" enabled, project
   creation still correctly refuses (nothing to disambiguate).

## Test Plan / Evidence

Added two regression tests in `apps/desktop/src/store/projects.test.ts`
(`describe('createProject')`), and updated an existing test whose setup
never actually populated `$profiles`, so it happened to pass by
coincidence rather than exercising the intended multi-profile case.

```
$ npx vitest run --project ui src/store/projects.test.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)
```

A/B guard — reverted only `apps/desktop/src/store/projects.ts` to
`HEAD` (`git checkout HEAD -- apps/desktop/src/store/projects.ts`)
while keeping the new test, and reran:

```
FAIL  |ui| src/store/projects.test.ts > createProject > creates the project
for a lone profile even while All-profiles view is enabled (#94430)
Error: Projects are unavailable while viewing all profiles
 ❯ projectParams src/store/projects.ts:361:11
 ❯ Module.createProject src/store/projects.ts:908:7
```

confirming the new test fails without the fix and reproduces the exact
error from the issue report.

Also ran the broader store + sidebar suite to check for regressions:

```
$ npx vitest run --project ui src/store src/app/chat/sidebar
 Test Files  123 passed (123)
      Tests  1340 passed (1340)
```

`npx eslint src/store/projects.ts src/store/projects.test.ts` and
`npx tsc -p . --noEmit` are both clean.

## AI assistance disclosure

This change was authored with AI assistance (Claude).

## Checklist

- [x] Read CONTRIBUTING.md and AGENTS.md
- [x] Conventional commit (`fix(desktop): ...`)
- [x] Searched open PRs for overlap; none touch `store/projects.ts` /
      `store/profile.ts` or this symptom
- [x] Focused change only (no unrelated diffs, no dependency/lockfile edits)
- [x] Added regression tests, verified they fail without the fix
- [x] Lint + typecheck clean on touched files

## Update (addressing automated review feedback)

- Fixed an edge case flagged in review: `$profiles.get().length > 1 ? null : profile`
  also treated a not-yet-loaded/failed profile roster (`length === 0`) as
  "lone profile," letting project creation proceed against a possibly-stale
  `$activeGatewayProfile` instead of refusing. Changed to
  `$profiles.get().length === 1 ? profile : null` so an empty roster keeps
  refusing, same as before this PR. Added a regression test for that case
  (`createProject > still refuses ... when the profile roster has not
  loaded yet`) and confirmed it fails without the fix.
- Confirmed intentional (per review point 3): `projectProfile()` also feeds
  the read RPCs, so lone-profile + All-profiles-view users now get
  profile-scoped session lists where they previously got unscoped ones.
  This is the desired consistency with the write path fixed here, not a
  side effect.

Re-verified after the change:

```
$ npx vitest run --project ui src/store/projects.test.ts
 Test Files  1 passed (1)
      Tests  42 passed (42)

$ npx vitest run --project ui src/store src/app/chat/sidebar
 Test Files  123 passed (123)
      Tests  1341 passed (1341)
```

`eslint src/store/projects.ts src/store/projects.test.ts` and
`tsc -p . --noEmit` both clean.

Left the shared-helper suggestion (extracting `isAllProfilesEffective`)
out of scope: `projectProfile()`'s single call site doesn't share code
with the sidebar's `multiProfile` check today (different atoms, different
consumers), so the extraction would be a refactor rather than something
this bugfix depends on.
