### PR TITLE
fix(guardrails): give a halted turn one tool-free wrap-up call

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2535,6 +2535,20 @@ def run_conversation(
         # last also keeps breakpoints off messages that the orphan sweep or
         # the thinking-only drop is about to remove or merge away.
         tools_for_api = agent.tools
+        # Guardrail-halt wrap-up: this one call offers no tools so the model
+        # writes a real summary of what it observed instead of resuming the
+        # halted loop. Consumed here so the following call re-arms tools.
+        #
+        # This is the only place the toolset may narrow mid-conversation, and
+        # it is deliberately the LAST call of the turn: an empty list makes
+        # the transports omit ``tools`` entirely (they gate on truthiness), so
+        # the request prefix diverges for this one call and the next turn --
+        # which sends the full toolset again -- re-matches the prefix cached
+        # before the halt. Nothing mutates ``agent.tools``, so no later turn
+        # sees a changed toolset.
+        if getattr(agent, "_toolguard_suppress_tools_next_call", False):
+            agent._toolguard_suppress_tools_next_call = False
+            tools_for_api = []
         if agent._use_prompt_caching and agent.provider != "moa":
             _static_system_prefix = getattr(agent, "_cached_system_prompt_static", None)
             _initial_cache_plan = build_prompt_cache_plan(
@@ -7458,6 +7472,30 @@ def run_conversation(
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
+                    if not getattr(agent, "_toolguard_wrapup_used", False):
+                        # Give the model one tool-free call to write the final
+                        # answer before ending the turn. The canned response
+                        # below discards everything the model actually
+                        # observed -- partial results, the concrete blocker --
+                        # and reads as a crash to the user. Suppressing tools
+                        # for exactly one call bounds the loop just as hard.
+                        #
+                        # No synthetic user message is injected: the guardrail
+                        # explanation already reached the model on the tool
+                        # RESULT (append_toolguard_guidance), so the wrap-up
+                        # call continues the normal
+                        # assistant -> tool -> assistant alternation.
+                        # A second halt after the wrap-up falls through to the
+                        # canned response.
+                        agent._toolguard_wrapup_used = True
+                        agent._toolguard_last_halt_decision = decision
+                        agent._tool_guardrail_halt_decision = None
+                        agent._toolguard_suppress_tools_next_call = True
+                        agent._emit_status(
+                            f"⚠️ Tool guardrail halted {decision.tool_name}: "
+                            f"{decision.code} — requesting a final summary"
+                        )
+                        continue
                     _turn_exit_reason = "guardrail_halt"
                     final_response = agent._toolguard_controlled_halt_response(decision)
                     agent._emit_status(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2538,6 +2538,10 @@ def run_conversation(
         # Guardrail-halt wrap-up: this one call offers no tools so the model
         # writes a real summary of what it observed instead of resuming the
         # halted loop. Consumed here so the following call re-arms tools.
+        # It is an ordinary iteration for accounting purposes -- a guardrailed
+        # turn costs one API call more than it used to, paid from the same
+        # iteration budget (or, if the halt landed on the last budgeted call,
+        # from the one-more-chance grace flag).
         #
         # This is the only place the toolset may narrow mid-conversation, and
         # it is deliberately the LAST call of the turn: an empty list makes
@@ -7491,6 +7495,23 @@ def run_conversation(
                         agent._toolguard_last_halt_decision = decision
                         agent._tool_guardrail_halt_decision = None
                         agent._toolguard_suppress_tools_next_call = True
+                        # The wrap-up call is paid from the same iteration
+                        # budget as any other call, so a guardrailed turn
+                        # costs one call more than it used to. When the halt
+                        # lands on the LAST budgeted call the loop condition
+                        # is already false, and a bare ``continue`` would drop
+                        # out of the loop entirely -- skipping the wrap-up and
+                        # the canned fallback below it, leaving the turn with
+                        # no ``guardrail_halt`` exit reason. Borrow upstream's
+                        # one-more-chance grace flag for exactly that case: it
+                        # both re-opens the loop condition and skips the
+                        # budget consume, and it is cleared on entry to the
+                        # iteration, so the turn still ends right after.
+                        if not (
+                            api_call_count < agent.max_iterations
+                            and agent.iteration_budget.remaining > 0
+                        ):
+                            agent._budget_grace_call = True
                         agent._emit_status(
                             f"⚠️ Tool guardrail halted {decision.tool_name}: "
                             f"{decision.code} — requesting a final summary"

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -607,6 +607,13 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Guardrail-halt wrap-up: one tool-free summary call per turn. The
+    # decision is preserved separately because the wrap-up clears the live
+    # attribute so the loop can make that final call (turn_finalizer falls
+    # back to it for turn-result metadata).
+    agent._toolguard_wrapup_used = False
+    agent._toolguard_suppress_tools_next_call = False
+    agent._toolguard_last_halt_decision = None
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -727,8 +727,15 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
-    if agent._tool_guardrail_halt_decision is not None:
-        result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+    # Prefer the live halt decision; fall back to the one preserved by the
+    # wrap-up path in conversation_loop, which clears the live attribute so
+    # the loop can make one final tool-free call. Without the fallback a
+    # wrapped-up halt would report no guardrail at all.
+    _guard_halt = agent._tool_guardrail_halt_decision or getattr(
+        agent, "_toolguard_last_halt_decision", None
+    )
+    if _guard_halt is not None:
+        result["guardrail"] = _guard_halt.to_metadata()
     # Persistence failures already set failed=True + an explanation in
     # final_response; also stamp `error` so gateway surfaces status="error"
     # (and desktop can toast the cause) instead of a quiet complete frame.

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -531,19 +531,105 @@ def test_wrapup_preserves_guardrail_metadata_on_the_turn_result():
     assert result.get("guardrail"), "guardrail metadata lost through the wrap-up"
 
 
+def _always_calls_tools():
+    """A model that never stops calling tools, tool-free wrap-up included.
+
+    Unbounded on purpose: a fixed response list would let the turn end by
+    running out of seeded responses, which looks identical to the branch the
+    test means to pin.
+    """
+    counter = {"n": 0}
+
+    def _respond(*_args, **_kwargs):
+        counter["n"] += 1
+        return _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("web_search", json.dumps({"query": "same"}), f"c{counter['n']}")
+            ],
+        )
+
+    return _respond
+
+
 def test_second_halt_after_wrapup_falls_back_to_canned_response():
     """Only one wrap-up per turn — a model that keeps calling tools through
     the wrap-up gets the bounded canned halt, so the loop still terminates."""
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
-    # Every response is another tool call: the wrap-up never produces prose.
-    agent.client.chat.completions.create.side_effect = [
-        _mock_response(
-            content="",
-            finish_reason="tool_calls",
-            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "same"}), f"c{i}")],
-        )
-        for i in range(12)
-    ]
+    agent.client.chat.completions.create.side_effect = _always_calls_tools()
+    agent._disable_streaming = True
+    statuses: list[str] = []
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_emit_status", side_effect=lambda m, *a, **k: statuses.append(str(m))),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert "stopped retrying" in result["final_response"]
+    # Termination came from the second-halt branch, not from exhausting the
+    # iteration budget: the halt fired well inside it...
+    calls = len(agent.client.chat.completions.create.call_args_list)
+    assert calls < agent.max_iterations, calls
+    # ...and exactly two halts were recorded — the wrap-up, then the fallback.
+    halts = [s for s in statuses if "Tool guardrail halted" in s]
+    assert len(halts) == 2, halts
+    assert "requesting a final summary" in halts[0]
+    assert "requesting a final summary" not in halts[1]
+
+
+# ── the halt landing on the last budgeted call ────────────────────────────
+#
+# The wrap-up ``continue``s to the top of the loop, so if the halt lands on
+# the last call the loop condition is already false. Without the grace flag
+# the turn would fall out of the loop having made neither the wrap-up call
+# nor the canned fallback under it, ending with no ``guardrail_halt`` at all.
+# (Only the iteration edge is exercised here: build_turn_context rebuilds
+# ``iteration_budget`` from ``max_iterations`` every turn, so the budget can
+# only run out at or after that same point.)
+
+
+def _assert_wrapped_up_at_the_edge(agent, result, budget_summary):
+    """The summary came from the wrap-up, not from the post-loop
+    max-iterations fallback.
+
+    Both end in a tool-free call, so the discriminator has to be which code
+    path produced it: ``_handle_max_iterations`` must never run, and its
+    signature -- a synthetic user message asking for a summary -- must be
+    absent from the request actually sent.
+    """
+    calls = agent.client.chat.completions.create.call_args_list
+    sent_tools = [kw.get("tools") for _, kw in calls]
+    assert not sent_tools[-1], "the wrap-up call never happened"
+    budget_summary.assert_not_called()
+    roles = [m["role"] for m in calls[-1][1]["messages"]]
+    assert roles.count("user") == 1, roles
+    assert roles[-1] == "tool", roles[-3:]
+    assert result["final_response"] == "Partial results before the stop."
+    assert result.get("guardrail"), "guardrail metadata lost at the budget edge"
+
+
+def test_wrapup_still_runs_when_halt_lands_on_the_last_iteration():
+    """max_iterations is reached by the halting call itself."""
+    # 3 tool-calling iterations is exactly what this config needs to halt.
+    # 3 tool-calling iterations is exactly what this config needs to halt.
+    agent = _make_agent("web_search", max_iterations=3, config=_hard_stop_config())
+
+    with patch.object(agent, "_handle_max_iterations") as budget_summary:
+        result = _run_halting_turn(agent, summary="Partial results before the stop.")
+
+    _assert_wrapped_up_at_the_edge(agent, result, budget_summary)
+
+
+def test_canned_fallback_still_reached_when_halt_lands_on_the_last_iteration():
+    """And when the wrap-up call itself halts again at the budget edge, the
+    turn still ends on the canned halt rather than an empty response."""
+    agent = _make_agent("web_search", max_iterations=3, config=_hard_stop_config())
+    agent.client.chat.completions.create.side_effect = _always_calls_tools()
     agent._disable_streaming = True
     with (
         patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -423,3 +423,135 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+
+# ── guardrail-halt wrap-up ────────────────────────────────────────────────
+#
+# A halt used to end the turn on a fixed "I stopped retrying X" string, which
+# discards everything the model actually observed. The wrap-up gives it one
+# tool-free call to write the real answer. Two invariants matter as much as
+# the behavior: the toolset narrows for exactly ONE call (and never by
+# mutating agent.tools), and no synthetic user message is injected.
+
+
+def _model_that_loops_until_tools_are_withdrawn(summary: str):
+    """Stand-in for a real model: keeps re-issuing the same failing call while
+    tools are offered, and can only answer in prose once they are withdrawn.
+
+    Keying off the ``tools`` kwarg (rather than a fixed response list) is the
+    point — it ties the wrap-up's observable contract, "no tools offered", to
+    the behavior it is supposed to buy, "the model writes the answer".
+    """
+    counter = {"n": 0}
+
+    def _respond(*_args, **kwargs):
+        if not kwargs.get("tools"):
+            return _mock_response(content=summary, finish_reason="stop")
+        counter["n"] += 1
+        return _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("web_search", json.dumps({"query": "same"}), f"c{counter['n']}")
+            ],
+        )
+
+    return _respond
+
+
+def _run_halting_turn(agent, summary="Here is what I found before I was stopped."):
+    agent.client.chat.completions.create.side_effect = (
+        _model_that_loops_until_tools_are_withdrawn(summary)
+    )
+    agent._disable_streaming = True
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+    return result
+
+
+def test_wrapup_suppresses_tools_for_exactly_one_call():
+    """The halt call offers no tools; nothing else in the turn is affected,
+    and agent.tools itself is never mutated (a changed toolset would follow
+    the conversation into later turns and break the prompt cache)."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    tools_before = list(agent.tools)
+
+    result = _run_halting_turn(agent)
+
+    sent_tools = [
+        kw.get("tools") for _, kw in agent.client.chat.completions.create.call_args_list
+    ]
+    toolless = [i for i, t in enumerate(sent_tools) if not t]
+    assert len(toolless) == 1, f"expected exactly one tool-free call, got {toolless}"
+    # ...and it is the last call of the turn.
+    assert toolless[0] == len(sent_tools) - 1
+    assert agent.tools == tools_before
+    assert result["final_response"]
+
+
+def test_wrapup_injects_no_synthetic_user_message():
+    """AGENTS.md message hygiene: no user message may be fabricated mid-loop,
+    and roles must never repeat back to back."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+
+    _run_halting_turn(agent)
+
+    _, last_kwargs = agent.client.chat.completions.create.call_args_list[-1]
+    roles = [m["role"] for m in last_kwargs["messages"]]
+    # Exactly one user message: the real prompt.
+    assert roles.count("user") == 1, roles
+    # The wrap-up call is entered straight off tool results.
+    assert roles[-1] == "tool", roles[-3:]
+    for a, b in zip(roles, roles[1:]):
+        assert not (a == b == "user"), f"consecutive user messages: {roles}"
+
+
+def test_wrapup_final_response_is_the_models_summary_not_the_canned_string():
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+
+    result = _run_halting_turn(agent, summary="I hit a 404 wall; here are partial results.")
+
+    assert result["final_response"] == "I hit a 404 wall; here are partial results."
+    assert "stopped retrying" not in result["final_response"]
+
+
+def test_wrapup_preserves_guardrail_metadata_on_the_turn_result():
+    """The wrap-up clears the live halt attribute so the loop can make the
+    final call; the turn result must still report the guardrail."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+
+    result = _run_halting_turn(agent)
+
+    assert result.get("guardrail"), "guardrail metadata lost through the wrap-up"
+
+
+def test_second_halt_after_wrapup_falls_back_to_canned_response():
+    """Only one wrap-up per turn — a model that keeps calling tools through
+    the wrap-up gets the bounded canned halt, so the loop still terminates."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    # Every response is another tool call: the wrap-up never produces prose.
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "same"}), f"c{i}")],
+        )
+        for i in range(12)
+    ]
+    agent._disable_streaming = True
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert "stopped retrying" in result["final_response"]


### PR DESCRIPTION
## What does this PR do?

A tool-loop guardrail halt ends the turn on a fixed string from
`_toolguard_controlled_halt_response` — "I stopped retrying X". That discards
everything the model actually observed (partial results, the concrete
blocker) and reads to the user as a crash rather than a deliberate stop.

The model now gets exactly one more API call with **no tools offered**, so it
writes the real final answer. The loop stays bounded just as hard: no tools
means no further tool execution, and a second halt in the same turn falls
through to the existing canned response.

## Related Issue

Part of #64804 — its second half: *"...and its halt discards partial
results."* #64803 covers the first half (the no-progress false-positive) and
explicitly does not touch this path. Deliberately **not** using an
auto-closing keyword, since #64804 stays open until both halves land.

### Relationship to #64322 / #92433 — not a duplicate

#92433 (and #64363 before it) give the model a rebound **with tools** after a
recoverable `block`, so it can self-correct and finish the task. That is a
different mechanism solving a different half, and it leaves this path intact:
on a terminal `halt`, or any second blocked batch in the turn, #92433 falls
straight through to `_toolguard_controlled_halt_response(decision)` and the
canned string is still emitted. It defers that outcome by one attempt; it
never removes it.

This PR replaces the string at that terminal point. The two compose — rebound
first (recover if you can), wrap-up at the end (explain rather than emit
boilerplate) — and touch adjacent lines in the same branch, so whichever
lands second should keep both, rebound first. Happy to rebase on top of
#92433 if you'd rather take that one first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py`
  - First halt per turn preserves the decision, clears the live attribute,
    requests suppression, and `continue`s instead of breaking.
  - Suppression is applied where `tools_for_api` is initialized, so the
    prompt-cache plan built immediately below describes the request actually
    sent.
- `agent/turn_context.py`: reset the three wrap-up fields per turn.
- `agent/turn_finalizer.py`: fall back to the preserved decision when
  stamping `guardrail` metadata, since the wrap-up clears the live attribute.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: 5 tests.

## AGENTS.md invariants

Both relevant invariants are avoided by construction, not worked around:

**Prompt caching.** `agent.tools` is never mutated, so no later turn sees a
changed toolset. Suppression goes through the existing `tools_for_api`
parameter rather than reaching into `build_api_kwargs`, so
`_redecorate_prompt_cache_for_provider` still runs. An empty list makes the
transports omit `tools` entirely (they gate on truthiness, e.g.
`agent/transports/chat_completions.py:541`), so no invalid empty array goes
on the wire. Because the wrap-up is deliberately the **last** call of the
turn, the next turn re-sends the full toolset and re-matches the prefix
cached before the halt. The residual cost is one cache miss on a rare
failure path — stated plainly rather than claimed to be zero.

**Message hygiene.** Nothing synthetic is injected. The guardrail explanation
already reaches the model on the tool RESULT via `append_toolguard_guidance`,
so the wrap-up call continues the normal `assistant -> tool -> assistant`
alternation. A test asserts there is exactly one `user` message (the real
prompt) and no consecutive same-role messages.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_tool_guardrails.py tests/agent/test_stall_guards.py` — 57 passed.
2. Broader sweep: `scripts/run_tests.sh tests/agent tests/run_agent tests/gateway` — the only failures are 5 that reproduce identically on a clean `main` checkout (`test_scale_to_zero` x2, `test_shutdown_forensics`, `test_systemd_notify`, and the load-flaky `lsp/test_client_e2e`).
3. Manual: set `tool_loop_guardrails.hard_stop_enabled: true`, drive a model into a repeated identical failing call, and watch the turn end on the model's own summary of what it found and what blocked it instead of "I stopped retrying...".

The tests assert the observable contract rather than the implementation: the
stand-in model keys off whether tools were offered, tying "tools withdrawn"
to "model answers in prose". They cover exactly one tool-free call (and that
it is last), `agent.tools` left intact, no synthetic user message, the
summary replacing the canned string, guardrail metadata surviving, and the
second-halt fallback still terminating the loop.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing issues and PRs to make sure this isn't a duplicate (see the #64322 / #92433 note above)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suites and compared failures against a clean `main` baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or API surface added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure control-flow change, no file I/O, process, or terminal handling)
