### PR TITLE
fix(gateway): close finalize/send_draft race on Slack native streams

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3345,8 +3345,10 @@ class SlackAdapter(BasePlatformAdapter):
         # for "no active stream" and opening a duplicate one (#94435).
         stream["sealing"] = True
         ts = stream["ts"]
-        ok = await self._seal_stream(chat_id, stream, final_text=text)
-        self._active_streams.pop(chat_id, None)
+        try:
+            ok = await self._seal_stream(chat_id, stream, final_text=text)
+        finally:
+            self._active_streams.pop(chat_id, None)
         if not ok:
             # Could not stop the stream — post normally so the user still
             # gets the final answer; the dangling stream times out on

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1064,9 +1064,13 @@ class SlackAdapter(BasePlatformAdapter):
         self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         # Native streaming (chat.startStream/appendStream/stopStream) state.
         # One active stream per chat, keyed by chat_id. Each value:
-        # {"ts": str, "draft_id": int, "sent": str, "started": float}
+        # {"ts": str, "draft_id": int, "sent": str, "started": float,
+        #  "sealing": bool (optional)}
         # ``sent`` is the raw (pre-mrkdwn) text streamed so far — deltas are
         # computed against it because the streaming API is append-only.
+        # ``sealing`` is set by _try_finalize_stream while it awaits
+        # chat.stopStream, so a concurrently delivered frame from the
+        # stream consumer task can recognize the stream is being finalized.
         self._active_streams: Dict[str, Dict[str, Any]] = {}
         # Set after the first startStream failure that indicates the Slack
         # app lacks the streaming feature (Agents & AI Apps not enabled /
@@ -3172,6 +3176,15 @@ class SlackAdapter(BasePlatformAdapter):
         client = self._get_client(chat_id)
         stream = self._active_streams.get(chat_id)
 
+        if stream is not None and stream.get("sealing"):
+            # _try_finalize_stream is sealing this stream on another task
+            # (the stream consumer runs concurrently with the finalize
+            # call). This frame's content is already covered by the
+            # finalize: appending would race chat.stopStream and fail with
+            # message_not_in_streaming_state, and treating the eventual pop
+            # as "no active stream" would open a duplicate one (#94435).
+            return SendResult(success=True, message_id=stream.get("ts"))
+
         try:
             if stream is not None and stream.get("draft_id") != draft_id:
                 # New segment started while a prior stream is open — seal the
@@ -3324,9 +3337,16 @@ class SlackAdapter(BasePlatformAdapter):
         # everything, so require substance before claiming the send.
         if not sent or not text.startswith(sent):
             return None
-        self._active_streams.pop(chat_id, None)
+        # Mark sealing *before* awaiting the seal call, and pop only after
+        # it returns. A frame from the stream consumer task can run during
+        # that await; the "sealing" flag lets send_draft recognize this
+        # stream as being finalized instead of racing an append against an
+        # already-sealed ts, or — had we popped first — mistaking the gap
+        # for "no active stream" and opening a duplicate one (#94435).
+        stream["sealing"] = True
         ts = stream["ts"]
         ok = await self._seal_stream(chat_id, stream, final_text=text)
+        self._active_streams.pop(chat_id, None)
         if not ok:
             # Could not stop the stream — post normally so the user still
             # gets the final answer; the dangling stream times out on

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -211,3 +211,35 @@ class TestDisconnectCleanup:
         await adapter.disconnect()
         client.chat_stopStream.assert_awaited()
         assert not adapter._active_streams
+
+
+class TestFinalizeSendDraftRace:
+    @pytest.mark.asyncio
+    async def test_late_frame_during_seal_is_dropped_not_orphaned(self):
+        """#94435: the stream consumer runs as a separate task from the
+        turn's finalize send(). A frame it delivers while chat.stopStream is
+        still in flight must be dropped, not appended to the sealing ts
+        (message_not_in_streaming_state) nor mistaken for "no active
+        stream" and given a duplicate chat.startStream."""
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Hello wo", metadata=META)
+
+        late_frame = {}
+
+        async def _stop_stream_races_with_late_frame(*args, **kwargs):
+            late_frame["result"] = await adapter.send_draft(
+                "D1", 7, "Hello world!", metadata=META
+            )
+            return {"ok": True}
+
+        client.chat_stopStream = AsyncMock(
+            side_effect=_stop_stream_races_with_late_frame
+        )
+
+        result = await adapter.send("D1", "Hello world, done.", metadata=META)
+
+        assert result.success
+        assert late_frame["result"].success
+        client.chat_appendStream.assert_not_awaited()
+        client.chat_startStream.assert_awaited_once()
+        assert "D1" not in adapter._active_streams

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -17,6 +17,7 @@ Behaviour contract:
   * disconnect(): dangling streams sealed.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -242,4 +243,20 @@ class TestFinalizeSendDraftRace:
         assert late_frame["result"].success
         client.chat_appendStream.assert_not_awaited()
         client.chat_startStream.assert_awaited_once()
+        assert "D1" not in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_stream_popped_even_if_seal_raises(self):
+        """If chat.stopStream raises instead of returning, the stream entry
+        must still be popped — otherwise it's stuck with sealing=True
+        forever and every later send_draft for that chat silently drops
+        content (early-return at the top of send_draft)."""
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Hello wo", metadata=META)
+
+        client.chat_stopStream = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter.send("D1", "Hello world, done.", metadata=META)
+
         assert "D1" not in adapter._active_streams


### PR DESCRIPTION
## What

Fixes #94435: Slack's native-streaming adapter could post the same answer
twice (or open an orphan streamed message) because `_try_finalize_stream`
removed the stream's bookkeeping entry from `_active_streams` *before*
awaiting `chat.stopStream`.

## Why this causes duplicates

`_try_finalize_stream` (called from `send()` when the turn's final answer is
ready) used to do:

```python
self._active_streams.pop(chat_id, None)      # synchronous, immediate
ok = await self._seal_stream(chat_id, stream, final_text=text)
```

The stream consumer that delivers incremental frames runs as a **separate
asyncio task** and can call `send_draft()` at any point during that
`await`. Depending on exact timing, `send_draft` observes one of two bad
states:

- The entry is *still present* (read happened before the pop, or on a
  timing where the two operations interleave) → it takes the append path
  and calls `chat.appendStream` against a `ts` that's in the process of
  being sealed → Slack returns `message_not_in_streaming_state`. That
  failure isn't in the adapter's feature-gate marker list, so it isn't
  handled specially — it just fails the frame, which (per the issue's
  logs) cascades into a `chat.update` fallback and ultimately a second
  `chat.postMessage` with the full answer.
- The entry is *already popped* → `send_draft` sees "no active stream" and
  opens a brand new `chat.startStream`, producing an orphan bubble in the
  same thread.

## Fix

Mark the stream entry `"sealing": True` before awaiting `_seal_stream`, and
only pop it from `_active_streams` after the seal call returns. `send_draft`
now checks this flag first and drops any frame that arrives while a seal is
in flight (returning success — the content is already covered by the
finalize) instead of racing `chat.appendStream` or starting a duplicate
stream.

Scoped to the adapter's own `_active_streams` bookkeeping — no changes to
`gateway/run.py`'s stream-consumer task lifecycle were needed to close this
particular race.

## Test

Added `TestFinalizeSendDraftRace::test_late_frame_during_seal_is_dropped_not_orphaned`
in `tests/gateway/test_slack_native_streaming.py`, which makes the mocked
`chat.stopStream` call recursively invoke `send_draft` for the same
chat/draft while the "seal" is in flight — reproducing the exact
interleaving described in the issue.

Confirmed the test fails without the fix (`git checkout HEAD~1 --
plugins/platforms/slack/adapter.py`, keeping only the test change):

```
FAILED tests/gateway/test_slack_native_streaming.py::TestFinalizeSendDraftRace::test_late_frame_during_seal_is_dropped_not_orphaned
AssertionError: Expected chat_startStream to have been awaited once. Awaited 2 times.
1 failed, 18 passed in 1.35s
```

And passes with the fix applied:

```
$ python -m pytest tests/gateway/test_slack_native_streaming.py -q
...................
19 passed in 0.66s

$ python -m pytest tests/gateway/test_slack_native_streaming.py tests/gateway/test_slack_block_kit_adapter.py -q
.............................
29 passed in 0.85s
```

`scripts/check-windows-footguns.py` and `ruff check` on both changed files
are clean.

## AI assistance disclosure

This change was prepared by an autonomous AI coding agent (Claude, via
Claude Code) working from the issue's own root-cause analysis and log
excerpts. The fix, test, and this description were generated by the agent;
no human wrote the code by hand prior to this PR.
