### PR TITLE
Memory provider prompt guidance no longer appears when its tools are gated off (#81014, salvage #81058)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -107,6 +107,29 @@ def memory_provider_tools_enabled(
         return False
 
 
+def memory_provider_tools_exposed(agent: Any) -> bool:
+    """Whether external memory-provider tools are exposed on ``agent``.
+
+    Same gate as ``inject_memory_provider_tools`` so the provider's
+    ``system_prompt_block()`` and its tool schemas are presented to the
+    model together — otherwise the system prompt would advertise tools
+    that don't exist in the tool surface (#81014).
+    """
+    tools = getattr(agent, "tools", None)
+    if isinstance(tools, (list, tuple)):
+        memory_tool_present = any(
+            isinstance(tool, dict) and tool.get("function", {}).get("name") == "memory"
+            for tool in tools
+        )
+    else:
+        memory_tool_present = False
+    return memory_provider_tools_enabled(
+        getattr(agent, "enabled_toolsets", None),
+        getattr(agent, "disabled_toolsets", None),
+        memory_tool_present=memory_tool_present,
+    )
+
+
 def inject_memory_provider_tools(agent: Any) -> int:
     """Append external memory-provider tool schemas to an agent tool surface."""
     memory_manager = getattr(agent, "_memory_manager", None)
@@ -119,11 +142,7 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
-    if not memory_provider_tools_enabled(
-        getattr(agent, "enabled_toolsets", None),
-        getattr(agent, "disabled_toolsets", None),
-        memory_tool_present="memory" in existing_tool_names,
-    ):
+    if not memory_provider_tools_exposed(agent):
         return 0
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -143,6 +143,22 @@ def inject_memory_provider_tools(agent: Any) -> int:
         if isinstance(tool, dict)
     }
     if not memory_provider_tools_exposed(agent):
+        # A provider is configured but the memory toolset is gated off
+        # (platform_toolsets / disabled_toolsets). Say so once — a silent
+        # return 0 here made #81014 undiagnosable: the provider looked
+        # "half on" with no clue which config key suppressed its tools.
+        _providers = [
+            p for p in (getattr(memory_manager, "providers", None) or [])
+            if getattr(p, "name", "") != "builtin"
+        ]
+        if _providers:
+            logger.info(
+                "Memory provider(s) %s configured but the 'memory' toolset is "
+                "gated off for this session (platform_toolsets / "
+                "agent.disabled_toolsets) — provider tools and system-prompt "
+                "block are both withheld.",
+                [getattr(p, "name", type(p).__name__) for p in _providers],
+            )
         return 0
 
     get_schemas = getattr(memory_manager, "get_all_tool_schemas", None)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -838,14 +838,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if user_block:
                 volatile_parts.append(user_block)
 
-    # External memory provider system prompt block (additive to built-in)
+    # External memory provider system prompt block (additive to built-in).
+    # Gated on the same check ``inject_memory_provider_tools`` uses so we
+    # never advertise provider tools that the agent's toolset configuration
+    # has already gated off (#81014).
     if agent._memory_manager:
         try:
-            _ext_mem_block = agent._memory_manager.build_system_prompt()
-            if _ext_mem_block:
-                volatile_parts.append(_ext_mem_block)
+            from agent.memory_manager import memory_provider_tools_exposed as _mem_exposed
         except Exception:
-            pass
+            _mem_exposed = None
+        if _mem_exposed is None or _mem_exposed(agent):
+            try:
+                _ext_mem_block = agent._memory_manager.build_system_prompt()
+                if _ext_mem_block:
+                    volatile_parts.append(_ext_mem_block)
+            except Exception:
+                pass
 
     # Plugin sections are intentionally confined to one coarse anchor in the
     # volatile tail. This preserves deterministic ordering and lets a resumed

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1382,3 +1382,85 @@ class TestTrivialPromptClassifier:
                   "hello world", "ok so what's next", "what's my name",
                   "hey can you check the logs", "continue the migration plan"):
             assert not is_trivial_prompt(t), f"expected non-trivial: {t!r}"
+
+
+# ---------------------------------------------------------------------------
+# System-prompt gate parity — #81014
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptGateParity:
+    """The memory provider's ``system_prompt_block()`` must be injected only
+    when ``inject_memory_provider_tools`` would actually expose its tools.
+
+    Otherwise the agent receives instructions for tools that don't exist
+    in its tool surface (issue #81014).
+    """
+
+    def _agent_with_provider(
+        self,
+        *,
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        tools=None,
+        prompt_block="Use mnemosyne_remember to save facts.",
+    ):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("mnemosyne", tools=[
+            {"name": "mnemosyne_remember", "description": "Remember", "parameters": {}},
+        ])
+        provider._prompt_block = prompt_block
+        mgr.add_provider(provider)
+        agent = SimpleNamespace(
+            _memory_manager=mgr,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            tools=list(tools) if tools is not None else [],
+        )
+        return agent, mgr, provider
+
+    def test_tools_exposed_when_memory_in_enabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is True
+
+    def test_tools_hidden_when_memory_in_disabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(disabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is False
+
+    def test_tools_hidden_when_memory_not_in_enabled_toolsets(self):
+        from agent.memory_manager import memory_provider_tools_exposed
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["web_search"])
+        assert memory_provider_tools_exposed(agent) is False
+
+    def test_tools_exposed_when_memory_tool_already_present(self):
+        """The built-in "memory" tool is a sufficient opt-in even when the
+        toolset gate says nothing about memory."""
+        from agent.memory_manager import memory_provider_tools_exposed
+        tools = [
+            {"type": "function", "function": {"name": "memory", "description": "x", "parameters": {}}},
+        ]
+        agent, _mgr, _p = self._agent_with_provider(enabled_toolsets=["web_search"], tools=tools)
+        assert memory_provider_tools_exposed(agent) is True
+
+    def test_inject_and_exposed_share_the_same_gate(self):
+        """``inject_memory_provider_tools`` and ``memory_provider_tools_exposed``
+        must agree — both determine whether provider tools are presented to
+        the model (#81014)."""
+        from agent.memory_manager import inject_memory_provider_tools, memory_provider_tools_exposed
+
+        # Disabled toolsets — neither path should add or advertise provider tools.
+        agent, _mgr, _p = self._agent_with_provider(disabled_toolsets=["memory"])
+        assert memory_provider_tools_exposed(agent) is False
+        assert inject_memory_provider_tools(agent) == 0
+
+        # Enabled with "memory" — both paths must add/advertise.
+        agent, _mgr, _p = self._agent_with_provider(
+            enabled_toolsets=["memory"], tools=[]
+        )
+        assert memory_provider_tools_exposed(agent) is True
+        added = inject_memory_provider_tools(agent)
+        assert added == 1
+        names = {t["function"]["name"] for t in agent.tools}
+        assert "mnemosyne_remember" in names

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -490,3 +490,61 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestMemoryProviderSystemPromptGating:
+    """Issue #81014: the provider's ``system_prompt_block()`` must be gated
+    on the same ``memory_provider_tools_enabled`` check as tool injection.
+    Otherwise the agent receives instructions for tools that don't exist in
+    its tool surface.
+    """
+
+    @staticmethod
+    def _make_fake_manager(prompt_block: str):
+        """Build a MemoryManager-like object exposing only what
+        ``build_system_prompt_parts`` touches."""
+        from unittest.mock import MagicMock
+        mgr = MagicMock()
+        mgr.build_system_prompt.return_value = prompt_block
+        return mgr
+
+    def _agent(self, *, enabled_toolsets, disabled_toolsets, prompt_block):
+        return _make_agent(
+            valid_tool_names=["skills_list"],
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            _memory_manager=self._make_fake_manager(prompt_block),
+        )
+
+    def test_block_injected_when_memory_toolset_enabled(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=["memory"],
+            disabled_toolsets=None,
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=["memory"], disabled_toolsets=None)
+        assert block in full
+
+    def test_block_dropped_when_memory_toolset_disabled(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=None,
+            disabled_toolsets=["memory"],
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=None, disabled_toolsets=["memory"])
+        assert block not in full
+
+    def test_block_dropped_when_memory_not_in_enabled_toolsets(self):
+        block = "PROVIDER_BLOCK_SENTINEL"
+        agent = self._agent(
+            enabled_toolsets=["web_search"],
+            disabled_toolsets=None,
+            prompt_block=block,
+        )
+        full = _build(build_system_prompt, _memory_manager=agent._memory_manager,
+                      enabled_toolsets=["web_search"], disabled_toolsets=None)
+        assert block not in full


### PR DESCRIPTION
## Summary

External memory providers (Mnemosyne, Honcho, etc.) no longer inject their system-prompt instructions when the memory toolset is gated off — the model stops receiving "use mnemosyne_remember" guidance for tools that don't exist in its tool surface (#81014). Salvage of #81058 by @Enough1122, who withdrew it during his own backlog cleanup.

Same bug class as #94404 (prompt advertising uncallable tools), one subsystem over.

## Changes

- `agent/memory_manager.py`: new `memory_provider_tools_exposed(agent)` — the single gate shared by tool injection and prompt injection (cherry-picked from #81058, authorship preserved).
- `agent/system_prompt.py`: the external-provider prompt block is only appended when that gate passes.
- `agent/memory_manager.py` (follow-up commit): when a configured provider's tools are gated off, an INFO log names the withheld providers and the gating config keys — the silent `return 0` made the divergence undiagnosable.
- Tests: gate-parity suite from #81058 (`TestSystemPromptGateParity` + system-prompt cases).

## Validation

| Probe (real `AIAgent._build_system_prompt()` with a fake provider attached) | Before (main) | After |
|---|---|---|
| memory toolset OFF → provider block in prompt | leaked | withheld |
| memory toolset ON → provider block in prompt | present | present (unchanged) |

Targeted suites green: `tests/agent/test_memory_provider.py`, `tests/agent/test_system_prompt.py` (107 passed).

**Live repro:** identical fake-provider probe leaks `mnemosyne_remember` into the prompt on origin/main with `enabled_toolsets=['file','terminal']`; withheld on this branch; still present when `memory` is enabled.

## Infographic

![Memory Prompt Matches the Toolset](https://v3b.fal.media/files/b/0aa7b5ae/z154wONYvWBRCsYf_kqkR_qWm4ceKp.png)
