### PR TITLE
Planted symlinks can no longer hijack browser-snapshot writes (salvage #85722)

### DIFF
--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -229,6 +229,39 @@ class TestTruncateSnapshot:
         content = Path(stored).read_text(encoding="utf-8")
         assert "STOREDSNAPSHOTSECRET" not in content
 
+    def test_stored_snapshot_refuses_planted_symlink(self, tmp_path, monkeypatch):
+        """A pre-planted symlink at the content-hash path must not be
+        followed to its target — only the link itself may be replaced.
+
+        Mirrors web_tools._store_full_text's use of write_text_exclusive
+        (overwrite=True) for the same cache/web directory and naming
+        scheme: a legitimate re-snapshot of the same page state safely
+        replaces a same-path symlink with a real file, never writing
+        through it onto whatever the link points at.
+        """
+        import hashlib
+        from pathlib import Path
+        from tools.browser_tool import _store_full_snapshot
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        snapshot = "\n".join(f"- line {i}" for i in range(50))
+        # No secret-like content, so redact_sensitive_text leaves it
+        # unchanged and the digest is predictable from the raw text.
+        digest = hashlib.sha256(snapshot.encode("utf-8")).hexdigest()[:10]
+
+        cache_dir = tmp_path / "cache" / "web"
+        cache_dir.mkdir(parents=True)
+        victim = tmp_path / "victim.txt"
+        victim.write_text("original", encoding="utf-8")
+        planted = cache_dir / f"browser-snapshot-{digest}.txt"
+        planted.symlink_to(victim)
+
+        stored = _store_full_snapshot(snapshot)
+        assert stored is not None
+        assert victim.read_text(encoding="utf-8") == "original"  # link target untouched
+        assert not planted.is_symlink()  # link replaced by a real file
+        assert Path(stored).read_text(encoding="utf-8") == snapshot
+
     def test_truncated_snapshot_appends_stored_pointer(self):
         """Truncated snapshots point at the stored full text for read_file paging."""
         from tools.browser_tool import _truncate_snapshot

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3149,11 +3149,18 @@ def _store_full_snapshot(snapshot_text: str) -> Optional[str]:
                 + f"\n\n[... stored copy truncated at {MAX_STORED_SNAPSHOT_CHARS:,} chars "
                 f"of {len(content):,} ...]"
             )
+        from tools.spill_safety import ensure_spill_dir, write_text_exclusive
+
         cache_dir = get_hermes_dir("cache/web", "web_cache")
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        ensure_spill_dir(cache_dir, private=False)
         digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:10]
         path = cache_dir / f"browser-snapshot-{digest}.txt"
-        path.write_text(content, encoding="utf-8")
+        # Deterministic filename in a well-known dir: refuse symlinks via
+        # lstat-unlink + exclusive create. Re-snapshotting the same page
+        # state legitimately overwrites (same content-hash name). Not
+        # private: cache/web is bind-mounted into remote backends whose
+        # container UID must be able to read it.
+        write_text_exclusive(path, content, private=False, overwrite=True)
         return str(path)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Failed to store full browser snapshot: %s", exc)


### PR DESCRIPTION
## Summary
A planted symlink in `~/.hermes/cache/web/` can no longer redirect a browser-snapshot write onto an arbitrary file — `_store_full_snapshot()` now goes through the same symlink-safe writer (`write_text_exclusive`, lstat-unlink + exclusive create) that `web_extract`'s `_store_full_text` already uses. Salvage of #85722 by @pierrenode.

Root cause: snapshot files use deterministic content-hash names in a well-known directory, and `Path.write_text()` follows a pre-planted symlink at that path, writing page content through the link onto its target.

## Changes
- `tools/browser_tool.py`: `_store_full_snapshot()` uses `ensure_spill_dir` + `write_text_exclusive(private=False, overwrite=True)` (cache/web stays world-readable for remote-backend bind mounts; same-content re-snapshots still legitimately overwrite).
- `tests/tools/test_browser_hardening.py`: regression test — planted symlink's target untouched, link replaced by a real file.

Cherry-picked onto current main (the original branch predated the snapshot LLM-summarization removal in #94401); contributor authorship preserved.

## Validation
| | Before | After |
|---|---|---|
| Planted symlink at content-hash path | write follows link onto target | link unlinked, real file created, target untouched |
| tests/tools/test_browser_hardening.py | — | 23 passed |

## Infographic

![Snapshot files: symlink-safe writes](https://v3b.fal.media/files/b/0aa7b5cb/XjQ_vnuqHbknd5p9Hyd4F_Mh4jkZG4.png)
