### PR TITLE
test(desktop): js-tests no longer flakes on the syntax-diff mock's leaked rejection (#94415)

### DIFF
--- a/apps/desktop/src/components/chat/diff-lines.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.test.tsx
@@ -7,11 +7,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // covers the *pending* state, so the rejection throws past it to the nearest
 // error boundary — which in production is the whole workspace `ContribBoundary`
 // — and blanks the transcript instead of degrading to the plain colored diff.
-vi.mock('./syntax-diff', () => {
-  throw new Error(
-    'Failed to fetch dynamically imported module: file:///Hermes.app/Contents/Resources/app.asar/dist/assets/syntax-diff-Bo0962zh.js'
-  )
-})
+//
+// The mock resolves to a component that throws the fetch error during render —
+// the same way React surfaces a rejected lazy payload (a rejected import
+// re-throws at render time). Do NOT throw inside the factory itself: a
+// throwing factory leaves rejected promises in the vitest mocker registry,
+// and under CI load one escapes as an "unhandled error during the test run"
+// attributed to whichever sibling test file the worker is running (#94415).
+vi.mock('./syntax-diff', () => ({
+  default: () => {
+    throw new Error(
+      'Failed to fetch dynamically imported module: file:///Hermes.app/Contents/Resources/app.asar/dist/assets/syntax-diff-Bo0962zh.js'
+    )
+  }
+}))
 
 import { ErrorBoundary } from '@/components/error-boundary'
 


### PR DESCRIPTION
## Summary

The desktop `js-tests` CI job no longer intermittently fails on unrelated green code. Fixes #94415.

Root cause: `diff-lines.test.tsx` mocked the lazy `./syntax-diff` module with a `vi.mock` factory that **threw**. vitest hoists the factory and registers its module promise in the mocker registry; a throwing factory leaves rejected promises there, and under CI load one escapes as `Vitest caught 1 unhandled error during the test run` attributed to whichever sibling file the worker is running (`user-message-edit.test.tsx` in run 32803716726) — killing the whole `check:test:ui` step on Python-only merges.

## Changes

- `apps/desktop/src/components/chat/diff-lines.test.tsx`: the mock factory now resolves to a component that throws the fetch error during render — the same way React surfaces a rejected lazy payload — so no rejected promise ever sits in the mocker registry. Comment documents the trap.

## Validation

| | Result |
|---|---|
| Regression pin intact (sabotage: local syntax-diff ErrorBoundary removed from diff-lines.tsx) | test FAILS — still guards #93479 |
| Boundary restored | test passes |
| Full ui project (3 consecutive runs) | 596 files / 5,729 tests green, zero unhandled errors |

**Live repro:** the exact CI shape (throwing factory → unhandled error crossing into a sibling file) is load/scheduling-dependent and did not fire in 10 local pair-runs or 3 full-project runs on this box; the red/green evidence is CI run 32803716726 itself (failed, then passed via `--failed` rerun on the identical tree). The fix removes the rejected-promise source outright rather than tuning timing.

## Infographic

![Flaky mock sealed](https://v3b.fal.media/files/b/0aa7b5dd/fqV5W3YzMq6-qjIPOQyeI_NNIOQLCo.png)
