### PR TITLE
fix(compression): abort instead of dropping context on empty summarizer content

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3325,12 +3325,16 @@ class ContextCompressor(ContextEngine):
         # strictly better than discarding context for a transient blip
         # (#29559, #25585). Independent of abort_on_summary_failure.
         self._last_summary_network_failure: bool = False
-        # Set when the summarizer returns a well-formed response with empty
-        # content (see the guard in _generate_summary): the provider is
-        # degraded/broken, not permanently misconfigured, so compress() must
-        # ABORT and preserve the session unchanged rather than drop the
-        # middle window for a placeholder marker (#94448). Retrying once the
-        # provider recovers is strictly better than destroying context.
+        # Set when the summarizer produced no usable checkpoint at all: a
+        # well-formed response with empty content (see the guard in
+        # _generate_summary), or the auxiliary boundary's own "no usable
+        # response" terminal errors — None response / invalid response with
+        # missing or malformed choices (_validate_llm_response, #7264). All
+        # three shapes mean the provider is degraded/broken, not permanently
+        # misconfigured, so compress() must ABORT and preserve the session
+        # unchanged rather than drop the middle window for a placeholder
+        # marker (#94448). Retrying once the provider recovers is strictly
+        # better than destroying context.
         self._last_summary_empty_content_failure: bool = False
         # retrying on the main model, record the failure so gateway /
         # CLI callers can still warn the user even though compression
@@ -5145,14 +5149,21 @@ This compaction should PRIORITISE preserving all information related to the focu
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
             _is_streaming_closed = _is_connection_error(e)
-            # The empty-content guard above raises a RuntimeError with this
-            # exact message; distinguish it from other RuntimeErrors (e.g.
-            # "no LLM provider configured", handled earlier) so a genuinely
-            # empty response from a degraded provider can be flagged for the
-            # abort path below instead of falling into the destructive
-            # generic-failure branch (#94448).
-            _is_empty_content = (
-                isinstance(e, RuntimeError) and "returned empty content" in _err_str
+            # The empty-content guard above raises a RuntimeError with the
+            # first message below; the auxiliary boundary's own
+            # _validate_llm_response (#7264) raises the other two terminal
+            # "no usable response" shapes — a None response, or a response
+            # missing/malformed choices[0].message — once its own
+            # recovery/fallback has been exhausted. Distinguish all three
+            # from other RuntimeErrors (e.g. "no LLM provider configured",
+            # handled earlier) so a genuinely unusable response from a
+            # degraded provider is flagged for the abort path below instead
+            # of falling into the destructive generic-failure branch
+            # (#94448).
+            _is_empty_content = isinstance(e, RuntimeError) and (
+                "returned empty content" in _err_str
+                or "returned none response" in _err_str
+                or "returned invalid response" in _err_str
             )
             # Authentication, permission, and exhausted-quota failures are NOT
             # transient or fixable by retrying the same request. Flag them so

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3325,6 +3325,13 @@ class ContextCompressor(ContextEngine):
         # strictly better than discarding context for a transient blip
         # (#29559, #25585). Independent of abort_on_summary_failure.
         self._last_summary_network_failure: bool = False
+        # Set when the summarizer returns a well-formed response with empty
+        # content (see the guard in _generate_summary): the provider is
+        # degraded/broken, not permanently misconfigured, so compress() must
+        # ABORT and preserve the session unchanged rather than drop the
+        # middle window for a placeholder marker (#94448). Retrying once the
+        # provider recovers is strictly better than destroying context.
+        self._last_summary_empty_content_failure: bool = False
         # retrying on the main model, record the failure so gateway /
         # CLI callers can still warn the user even though compression
         # succeeded.  Silent recovery would hide the broken config.
@@ -5075,6 +5082,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_error = None
             self._last_summary_auth_failure = False
             self._last_summary_network_failure = False
+            self._last_summary_empty_content_failure = False
             return self._with_summary_prefix(summary)
         except Exception as e:
             # ``call_llm`` raises ``RuntimeError`` for two very different cases:
@@ -5137,6 +5145,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
             _is_streaming_closed = _is_connection_error(e)
+            # The empty-content guard above raises a RuntimeError with this
+            # exact message; distinguish it from other RuntimeErrors (e.g.
+            # "no LLM provider configured", handled earlier) so a genuinely
+            # empty response from a degraded provider can be flagged for the
+            # abort path below instead of falling into the destructive
+            # generic-failure branch (#94448).
+            _is_empty_content = (
+                isinstance(e, RuntimeError) and "returned empty content" in _err_str
+            )
             # Authentication, permission, and exhausted-quota failures are NOT
             # transient or fixable by retrying the same request. Flag them so
             # compress() preserves the session instead of rotating into a
@@ -5244,6 +5261,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             # the auth-failure carve-out; independent of abort_on_summary_failure.
             if _is_streaming_closed:
                 self._last_summary_network_failure = True
+            elif _is_empty_content:
+                self._last_summary_empty_content_failure = True
             logger.warning(
                 "Failed to generate context summary: %s. "
                 "Further summary attempts paused for %d seconds.",
@@ -7284,8 +7303,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_compress_aborted = False
         self._last_compress_refused_would_grow = False
         self._last_compression_made_progress = False
-        # NOTE: do NOT reset _last_summary_auth_failure or
-        # _last_summary_network_failure here.  These flags are set by
+        # NOTE: do NOT reset _last_summary_auth_failure,
+        # _last_summary_network_failure, or _last_summary_empty_content_failure
+        # here.  These flags are set by
         # _generate_summary() on a terminal failure and are already cleared on
         # a successful summary.  Resetting them eagerly defeats the cooldown
         # protection: _generate_summary() returns None from the cooldown
@@ -7654,6 +7674,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             self.abort_on_summary_failure
             or self._last_summary_auth_failure
             or self._last_summary_network_failure
+            or self._last_summary_empty_content_failure
         ):
             n_skipped = compress_end - compress_start
             self._last_summary_dropped_count = 0  # nothing actually dropped
@@ -7663,6 +7684,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                 telemetry["failure_class"] = "summary_auth_failure"
             elif self._last_summary_network_failure:
                 telemetry["failure_class"] = "summary_network_failure"
+            elif self._last_summary_empty_content_failure:
+                telemetry["failure_class"] = "summary_empty_content_failure"
             else:
                 telemetry["failure_class"] = "summary_generation_aborted"
             # Roll back the self-heal rehydration so this aborted attempt is a
@@ -7687,6 +7710,15 @@ This compaction should PRIORITISE preserving all information related to the focu
                         "error — aborting compression. %d message(s) preserved "
                         "unchanged; the session was NOT rotated. This is "
                         "transient: retry with /compress once connectivity "
+                        "recovers, or continue the conversation as-is.",
+                        n_skipped,
+                    )
+                elif self._last_summary_empty_content_failure:
+                    logger.warning(
+                        "Summary generation failed with an empty response from "
+                        "the provider — aborting compression. %d message(s) "
+                        "preserved unchanged; the session was NOT rotated. This "
+                        "is transient: retry with /compress once the provider "
                         "recovers, or continue the conversation as-is.",
                         n_skipped,
                     )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -288,6 +288,7 @@ _COMPRESSOR_ATTEMPT_STATE_FIELDS = (
     "_last_compress_aborted",
     "_last_summary_auth_failure",
     "_last_summary_network_failure",
+    "_last_summary_empty_content_failure",
     "_last_aux_model_failure_error",
     "_last_aux_model_failure_model",
     "_summary_model_fallen_back",

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2863,6 +2863,56 @@ class TestCooldownReentryAbort:
         assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
 
+    def test_auxiliary_none_response_aborts_compression(self):
+        """#94459 review: the auxiliary boundary's own terminal "None
+        response" error (_validate_llm_response, #7264) is a sibling of the
+        empty-content case and must ABORT the same way, not fall through to
+        the destructive static-fallback path."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=RuntimeError("Auxiliary compression: LLM returned None response"),
+        ):
+            first = c.compress(msgs, current_tokens=999999, force=True)
+        assert first == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_empty_content_failure is True
+
+    def test_auxiliary_invalid_response_aborts_compression(self):
+        """Same sibling coverage for the malformed/missing-choices terminal
+        error (_validate_llm_response, #7264)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=RuntimeError(
+                "Auxiliary compression: LLM returned invalid response "
+                "(type=str): 'oops'. Expected object with .choices[0].message "
+                "— check provider adapter or custom endpoint compatibility."
+            ),
+        ):
+            first = c.compress(msgs, current_tokens=999999, force=True)
+        assert first == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_empty_content_failure is True
+
 
 class TestDoubleCompactionSummaryRole:
     """PR #52160 (salvaged from #52167): when only the system prompt is

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -688,6 +688,9 @@ class TestNonStringContent:
         assert summary != SUMMARY_PREFIX
         # Transient cooldown engaged so we don't immediately retry the bad proxy.
         assert c._summary_failure_cooldown_until > 0
+        # #94448: flagged so compress() aborts instead of dropping the middle
+        # window via the destructive static-fallback path.
+        assert c._last_summary_empty_content_failure is True
 
 
 
@@ -2818,6 +2821,39 @@ class TestCooldownReentryAbort:
         assert first == msgs
         assert c._last_compress_aborted is True
         assert c._last_summary_auth_failure is True
+
+        second = c.compress(msgs, current_tokens=999999)
+        assert second == msgs, (
+            "Second compress during cooldown must abort (preserve messages), "
+            "not drop the middle window via static-fallback"
+        )
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+
+    def test_empty_content_failure_aborts_compression(self):
+        """#94448: a well-formed but empty-content summary response must
+        ABORT compression (preserve messages unchanged) instead of taking
+        the destructive static-fallback path that drops the middle window.
+        Cooldown re-entry must also keep aborting, same as network/auth."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            first = c.compress(msgs, current_tokens=999999, force=True)
+        assert first == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_empty_content_failure is True
 
         second = c.compress(msgs, current_tokens=999999)
         assert second == msgs, (


### PR DESCRIPTION
## What

Context compression detects an empty/whitespace summary response from the
aux LLM and correctly refuses to store it as a prefix-only summary (`#11978`,
`#11914`). But that detection only raises a generic `RuntimeError` — it is
never classified alongside the existing network/auth abort carve-outs
(`_last_summary_network_failure` / `_last_summary_auth_failure`). With the
server default `compression.abort_on_summary_failure: false`, an empty-content
failure therefore falls through to the destructive Phase-4 fallback path,
which drops the entire middle window and replaces it with a static "summary
unavailable" handoff.

Reported in #94448: a 547-message / ~500K-token session compacted down to 20
messages after the aux summarizer (`opencode-go` / `deepseek-v4-flash`)
returned empty content while the provider was degrading — ~338K tokens of
context permanently lost, even though the same class of failure (a broken
provider, not a broken request) is already handled correctly for connection
drops and auth errors.

## Fix

- Add `_last_summary_empty_content_failure`, set when `_generate_summary`'s
  terminal failure path matches the existing "returned empty content" guard
  (after any main-model fallback retry has already been tried), mirroring how
  `_is_streaming_closed` sets `_last_summary_network_failure`.
- `compress()`'s abort condition (and its telemetry `failure_class` /
  log message) now also checks this flag, so an empty-content failure ABORTS
  compression and preserves the session unchanged instead of destroying the
  middle window — exactly the network/auth failure treatment this issue asks
  for.
- Reset the flag on a successful summary, same as the other two failure
  flags.
- `agent/conversation_compression.py`: added the new flag to
  `_COMPRESSOR_ATTEMPT_STATE_FIELDS` so it round-trips through the existing
  attempt-state snapshot/restore used for pre-commit hard-cancel, consistent
  with `_last_summary_auth_failure` / `_last_summary_network_failure` already
  being there.

Out of scope: PR #70321 (recover the summary from `reasoning`/`reasoning_content`
when `content` is empty) addresses a different, non-overlapping case — a
summarizer that *did* produce output but put it in the reasoning field. This
fix is for when there is genuinely no usable output at all.

## Testing

Added/updated tests in `tests/agent/test_context_compressor.py`:

- `TestNonStringContent::test_none_content_treated_as_failure_not_empty_summary`
  — now also asserts `_last_summary_empty_content_failure is True`.
- `TestCooldownReentryAbort::test_empty_content_failure_aborts_compression`
  (new) — an empty-content response aborts `compress()` (messages unchanged),
  and a second `compress()` call during the cooldown re-entry window still
  aborts rather than falling through to the static fallback.

Confirmed the new test fails without the fix:

```
$ git checkout HEAD~1 -- agent/context_compressor.py   # revert only the fix
$ scripts/run_tests.sh tests/agent/test_context_compressor.py -k "empty_content or network_failure or auth_failure" -q
...
FAILED tests/agent/test_context_compressor.py::TestCooldownReentryAbort::test_empty_content_failure_aborts_compression
E       assert first == msgs
E       At index 2 diff: {'role': 'user', 'content': "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted...
1 failed, 6 passed, 132 deselected in 1.86s
$ git checkout HEAD -- agent/context_compressor.py     # restore the fix
```

With the fix, full targeted run:

```
$ scripts/run_tests.sh tests/agent/test_context_compressor.py -q
=== Summary: 1 files, 139 tests passed, 0 failed (100% complete) in 6.5s (8 workers) ===

$ scripts/run_tests.sh tests/run_agent/test_compression_abort_state_reset.py \
    tests/gateway/test_compression_failure_session_sync.py \
    tests/agent/test_context_compressor.py \
    tests/agent/test_context_compressor_cross_session_guard.py \
    tests/agent/test_context_compressor_session_end_clears_state.py \
    tests/agent/test_compression_attempt_telemetry.py \
    tests/agent/test_compression_interrupt_protection.py -q
=== Summary: 7 files, 158 tests passed, 0 failed (100% complete) in 8.7s (8 workers) ===
```

`ruff check` on both changed source files: all checks passed.

## AI assistance disclosure

This PR was prepared by an autonomous Claude-based coding agent (Anthropic
Claude, Sonnet 5) operating against the issue tracker, with the diff and test
evidence above generated and verified by the agent before push.

## Related

- Closes #94448
- Distinct from #70321 (empty `content` recovered from `reasoning` field —
  different failure mode, no overlap)
