### PR TITLE
feat(kanban): add profile execution statistics

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -801,9 +801,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     # --- stats ---
     p_stats = sub.add_parser(
-        "stats", help="Per-status + per-assignee counts + oldest-ready age",
+        "stats", help="Profile execution, assignment, queue, and failure statistics",
     )
     p_stats.add_argument("--json", action="store_true")
+    p_stats.add_argument("--profile", default=None, help="Filter to one profile's assignments and attempts")
+    p_stats.add_argument("--tenant", default=None, help="Filter tasks to one tenant")
+    p_stats.add_argument("--status", choices=sorted(kb.VALID_STATUSES), default=None)
+    p_stats.add_argument("--since", type=kb._to_epoch, default=None, metavar="EPOCH_OR_ISO")
+    p_stats.add_argument("--until", type=kb._to_epoch, default=None, metavar="EPOCH_OR_ISO")
+    p_stats.add_argument("--include-archived", action="store_true", help="Include archived task history")
 
     # --- notify subscribe / list / remove ---
     p_nsub = sub.add_parser(
@@ -2918,22 +2924,27 @@ def _cmd_watch(args: argparse.Namespace) -> int:
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:
+    from hermes_cli import kanban_stats
     with kb.connect_closing() as conn:
-        stats = kb.board_stats(conn)
+        stats = kanban_stats.build_report(
+            conn,
+            profile=args.profile,
+            tenant=args.tenant,
+            status=args.status,
+            since=args.since,
+            until=args.until,
+            include_archived=args.include_archived,
+        )
     if getattr(args, "json", False):
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
-    print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
-        print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
-    if stats["by_assignee"]:
-        print("\nBy assignee:")
-        for who, counts in sorted(stats["by_assignee"].items()):
-            parts = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
-            print(f"  {who:20s}  {parts}")
-    age = stats["oldest_ready_age_seconds"]
-    if age is not None:
-        print(f"\nOldest ready task age: {int(age)}s")
+    print(f"Board: {stats['board']}  tasks={stats['task_count']}  attempts={stats['attempt_count']}")
+    print("\nProfile                              state             assigned attempts running failed completed")
+    for row in stats["profiles"]:
+        print(f"{row['name'][:34]:34s}  {row['telemetry_state']:16s}  "
+              f"{row['assigned_tasks']:8d} {row['attempts']:8d} {row['running_attempts']:7d} "
+              f"{row['failed_attempts']:6d} {row['completed_tasks']:9d}")
+    print("\nCounts are distinct task rows for assignments/completions and task_runs for attempts.")
     return 0
 
 

--- a/hermes_cli/kanban_stats.py
+++ b/hermes_cli/kanban_stats.py
@@ -1,0 +1,238 @@
+"""Profile and routing statistics for the Kanban board.
+
+The report deliberately keeps task-level and attempt-level measurements
+separate.  Task rows describe assignment and lifecycle; task_runs rows
+represent execution attempts.  Historical rows are never rewritten, so a
+reassignment is visible as the current assignment plus the profile that
+actually claimed each attempt.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+import json
+from collections import Counter, defaultdict
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+_TERMINAL_FAILURES = {"crashed", "timed_out", "failed", "spawn_failed", "gave_up"}
+_EVENT_BUCKETS = {
+    "reclaimed": "reclaimed",
+    "protocol_violation": "protocol_violating",
+    "stale": "stale",
+    "recomputed_ready": "dependency_releases",
+    "dependency_released": "dependency_releases",
+}
+
+
+def _percentile(values: list[float], percentile: float) -> Optional[float]:
+    if not values:
+        return None
+    return float(statistics.quantiles(values, n=100, method="inclusive")[int(percentile) - 1]) if len(values) > 1 else float(values[0])
+
+
+def _summary(values: list[float]) -> dict[str, Optional[float]]:
+    return {
+        "average_seconds": round(statistics.fmean(values), 3) if values else None,
+        "median_seconds": round(float(statistics.median(values)), 3) if values else None,
+        "p95_seconds": round(_percentile(values, 95) or 0, 3) if values else None,
+    }
+
+
+def _task_type(row: Any) -> str:
+    return str(row["workflow_template_id"] or row["workspace_kind"] or "untyped")
+
+
+def build_report(
+    conn,
+    *,
+    profile: Optional[str] = None,
+    tenant: Optional[str] = None,
+    status: Optional[str] = None,
+    since: Optional[int] = None,
+    until: Optional[int] = None,
+    include_archived: bool = False,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    """Build a bounded, secret-free report for one already-scoped board.
+
+    ``since``/``until`` filter task creation and run start timestamps.  A
+    profile's task assignment counts use ``tasks.assignee`` while execution
+    counts use the immutable ``task_runs.profile`` attribution.  This avoids
+    turning reassignment into false historical work.
+    """
+    now = int(time.time() if now is None else now)
+    clauses: list[str] = []
+    params: list[Any] = []
+    if not include_archived:
+        clauses.append("t.status != 'archived'")
+    if tenant is not None:
+        clauses.append("t.tenant = ?")
+        params.append(tenant)
+    if status is not None:
+        clauses.append("t.status = ?")
+        params.append(status)
+    if profile is not None:
+        clauses.append("(t.assignee = ? OR EXISTS (SELECT 1 FROM task_runs rp WHERE rp.task_id = t.id AND rp.profile = ?))")
+        params.extend([profile, profile])
+    if since is not None:
+        clauses.append("t.created_at >= ?")
+        params.append(int(since))
+    if until is not None:
+        clauses.append("t.created_at <= ?")
+        params.append(int(until))
+    where = " AND ".join(clauses) or "1=1"
+    tasks = conn.execute(
+        "SELECT t.id, t.assignee, t.status, t.tenant, t.created_at, "
+        "t.started_at, t.completed_at, t.workspace_kind, t.workflow_template_id "
+        f"FROM tasks t WHERE {where}", params,
+    ).fetchall()
+    task_ids = [row["id"] for row in tasks]
+    runs: list[Any] = []
+    events: list[Any] = []
+    if task_ids:
+        marks = ",".join("?" for _ in task_ids)
+        run_params: list[Any] = list(task_ids)
+        run_where = f"r.task_id IN ({marks})"
+        if since is not None:
+            run_where += " AND r.started_at >= ?"
+            run_params.append(int(since))
+        if until is not None:
+            run_where += " AND r.started_at <= ?"
+            run_params.append(int(until))
+        if profile is not None:
+            run_where += " AND r.profile = ?"
+            run_params.append(profile)
+        runs = conn.execute(f"SELECT r.* FROM task_runs r WHERE {run_where} ORDER BY r.started_at, r.id", run_params).fetchall()
+        events = conn.execute(
+            f"SELECT e.kind, e.task_id, e.payload FROM task_events e WHERE e.task_id IN ({marks})", task_ids
+        ).fetchall()
+
+    registry = {item["name"]: bool(item["on_disk"]) for item in kb.known_assignees(conn)}
+    by_profile: dict[str, dict[str, Any]] = defaultdict(lambda: {
+        "assigned_tasks": 0, "task_status": Counter(), "attempts": 0,
+        "running_attempts": 0, "completed_tasks": 0, "blocked_tasks": 0,
+        "failed_attempts": 0, "reclaimed": 0, "retried_tasks": 0,
+        "protocol_violating": 0, "stale": 0, "dependency_releases": 0,
+        "durations": [], "queue_wait": [], "blocker_classes": Counter(),
+        "task_types": Counter(), "_task_ids": set(), "_attempt_task_ids": set(),
+    })
+    for name, on_disk in registry.items():
+        by_profile[name]["on_disk"] = on_disk
+    if profile is not None and profile not in by_profile:
+        by_profile[profile]["on_disk"] = profile in registry
+    task_by_id = {row["id"]: row for row in tasks}
+    for row in tasks:
+        if profile is None or row["assignee"] == profile:
+            if row["assignee"]:
+                item = by_profile[row["assignee"]]
+                item["assigned_tasks"] += 1
+                item["task_status"][row["status"]] += 1
+                item["task_types"][_task_type(row)] += 1
+                item["_task_ids"].add(row["id"])
+    for run in runs:
+        name = run["profile"] or "unattributed"
+        item = by_profile[name]
+        item["attempts"] += 1
+        item["_attempt_task_ids"].add(run["task_id"])
+        if run["status"] == "running":
+            item["running_attempts"] += 1
+        if run["outcome"] == "completed":
+            item.setdefault("_completed_task_ids", set()).add(run["task_id"])
+        if run["outcome"] == "blocked":
+            item["blocked_tasks"] += 1
+        if run["outcome"] in _TERMINAL_FAILURES:
+            item["failed_attempts"] += 1
+        if run["ended_at"] is not None:
+            item["durations"].append(max(0, int(run["ended_at"]) - int(run["started_at"])))
+        task = task_by_id.get(run["task_id"])
+        if task is not None:
+            item["queue_wait"].append(max(0, int(run["started_at"]) - int(task["created_at"])))
+        if run["outcome"] == "reclaimed":
+            item["reclaimed"] += 1
+    for event in events:
+        bucket = _EVENT_BUCKETS.get(event["kind"])
+        if not bucket:
+            if event["kind"] == "blocked":
+                task = task_by_id.get(event["task_id"])
+                name = (task["assignee"] if task is not None else None) or "unattributed"
+                blocker = "blocked"
+                try:
+                    payload = json.loads(event["payload"]) if event["payload"] else {}
+                    blocker = str(payload.get("kind") or payload.get("block_kind") or blocker)
+                except (TypeError, ValueError, AttributeError):
+                    pass
+                by_profile[name]["blocker_classes"][blocker] += 1
+            continue
+        # Attribute lifecycle events to the current assignee; run attribution
+        # remains immutable above and is the source of attempt metrics.
+        task = task_by_id.get(event["task_id"])
+        name = (task["assignee"] if task is not None else None) or "unattributed"
+        if profile is not None and name != profile:
+            continue
+        by_profile[name][bucket] += 1
+    for item in by_profile.values():
+        item["retried_tasks"] = sum(1 for task_id in item["_attempt_task_ids"] if sum(1 for r in runs if r["task_id"] == task_id) > 1)
+        item["completed_tasks"] = len(item.get("_completed_task_ids", set()))
+
+    profiles = []
+    for name in sorted(by_profile):
+        item = by_profile[name]
+        observed_attempts = item["attempts"] > 0
+        if name == "unattributed":
+            telemetry_state = "unavailable"
+        elif observed_attempts:
+            telemetry_state = "observed_work"
+        elif item["on_disk"]:
+            telemetry_state = "observed_zero"
+        else:
+            telemetry_state = "unavailable"
+        profiles.append({
+            "name": name,
+            "on_disk": bool(item["on_disk"]),
+            "telemetry_state": telemetry_state,
+            "assigned_tasks": item["assigned_tasks"],
+            "task_status": dict(sorted(item["task_status"].items())),
+            "attempts": item["attempts"],
+            "running_attempts": item["running_attempts"],
+            "completed_tasks": item["completed_tasks"],
+            "blocked_tasks": item["blocked_tasks"],
+            "failed_attempts": item["failed_attempts"],
+            "reclaimed": item["reclaimed"],
+            "retried_tasks": item["retried_tasks"],
+            "protocol_violating": item["protocol_violating"],
+            "stale": item["stale"],
+            "dependency_releases": item["dependency_releases"],
+            "duration": _summary(item["durations"]),
+            "queue_wait": _summary(item["queue_wait"]),
+            "blocker_classes": dict(sorted(item["blocker_classes"].items())),
+            "task_types": dict(sorted(item["task_types"].items())),
+        })
+    by_status = Counter(row["status"] for row in tasks)
+    by_assignee: dict[str, dict[str, int]] = defaultdict(dict)
+    for row in tasks:
+        if row["assignee"]:
+            counts = by_assignee[row["assignee"]]
+            counts[row["status"]] = counts.get(row["status"], 0) + 1
+    ready_times = [int(row["created_at"]) for row in tasks if row["status"] == "ready"]
+    return {
+        "schema_version": 1,
+        "board": kb.get_current_board(),
+        "generated_at": now,
+        "filters": {"profile": profile, "tenant": tenant, "status": status, "since": since, "until": until, "include_archived": include_archived},
+        "task_count": len(tasks),
+        "attempt_count": len(runs),
+        "by_status": dict(sorted(by_status.items())),
+        "by_assignee": {name: dict(sorted(counts.items())) for name, counts in sorted(by_assignee.items())},
+        "oldest_ready_age_seconds": max(0, now - min(ready_times)) if ready_times else None,
+        "profiles": profiles,
+        "notes": {
+            "attempts_are_task_runs": True,
+            "task_counts_are_distinct_task_rows": True,
+            "profile_attribution": "task_runs.profile for attempts; tasks.assignee for assignments and lifecycle events",
+            "secret_safe": True,
+        },
+    }

--- a/tests/hermes_cli/test_kanban_profile_stats.py
+++ b/tests/hermes_cli/test_kanban_profile_stats.py
@@ -1,0 +1,76 @@
+"""Focused validation for the profile statistics report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_stats
+
+
+def _home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_empty_report_has_no_profiles_or_attempts(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        report = kanban_stats.build_report(conn, now=100)
+    assert report["task_count"] == 0
+    assert report["attempt_count"] == 0
+    assert report["profiles"] == []
+    assert report["notes"]["attempts_are_task_runs"] is True
+
+
+def test_report_distinguishes_tasks_from_retried_attempts_and_block_kinds(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="retry me", assignee="alice", tenant="acme")
+        archived_id = kb.create_task(conn, title="old", assignee="alice", tenant="acme")
+        conn.execute("UPDATE tasks SET status='archived' WHERE id=?", (archived_id,))
+        conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at, ended_at, outcome) "
+            "VALUES (?, 'alice', 'done', 110, 130, 'crashed'), (?, 'alice', 'done', 140, 170, 'completed')",
+            (task_id, task_id),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, 'blocked', ?, 120)",
+            (task_id, json.dumps({"kind": "needs_input"})),
+        )
+        conn.commit()
+        report = kanban_stats.build_report(conn, tenant="acme", now=200)
+        row = next(item for item in report["profiles"] if item["name"] == "alice")
+    assert report["task_count"] == 1
+    assert report["attempt_count"] == 2
+    assert row["assigned_tasks"] == 1
+    assert row["attempts"] == 2
+    assert row["retried_tasks"] == 1
+    assert row["completed_tasks"] == 1
+    assert row["failed_attempts"] == 1
+    assert row["blocker_classes"] == {"needs_input": 1}
+
+
+def test_archived_and_profile_filters_are_explicit(tmp_path, monkeypatch):
+    _home(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        live = kb.create_task(conn, title="live", assignee="alice")
+        old = kb.create_task(conn, title="old", assignee="bob")
+        conn.execute("UPDATE tasks SET status='archived' WHERE id=?", (old,))
+        conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, started_at, ended_at, outcome) "
+            "VALUES (?, 'alice', 'done', 100, 110, 'completed'), (?, 'bob', 'done', 100, 110, 'completed')",
+            (live, old),
+        )
+        conn.commit()
+        filtered = kanban_stats.build_report(conn, profile="alice")
+        archived = kanban_stats.build_report(conn, include_archived=True)
+    assert filtered["task_count"] == 1
+    assert filtered["attempt_count"] == 1
+    assert archived["task_count"] == 2
+    assert archived["attempt_count"] == 2

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -213,6 +213,16 @@ hermes kanban list
 hermes kanban stats
 ```
 
+`stats` is a secret-safe, attempt-aware profile report. It keeps distinct task-row counts (assignment, lifecycle, and completed tasks) from `task_runs` attempt counts, and identifies `observed_zero` configured profiles separately from `unavailable` attribution (for example, a deleted profile or a run without a recorded profile). Use filters when investigating a routing window:
+
+```bash
+hermes kanban stats --profile researcher --tenant default --since 2026-08-01
+hermes kanban stats --status blocked --json
+hermes kanban stats --include-archived --until 2026-08-31
+```
+
+The report attributes attempts to the immutable `task_runs.profile`, while current assignment and blocker lifecycle signals use `tasks.assignee`; this makes reassignment and retries visible without rewriting history. Duration and queue-wait summaries are in seconds, with average, median, and p95 values. Operators can use high running/queue-wait values to identify overload, `observed_zero` to identify capacity, and failed/protocol/stale/reclaimed counts to identify routing or worker-protocol problems. The report is scoped to the selected board (`--board <slug>`), and archived history is opt-in.
+
 When the dispatcher picks up `t_abcd` and spawns the `researcher` profile, the very first thing that worker's model does is call `kanban_show()` to read its task. It doesn't run `hermes kanban show t_abcd`.
 
 ### Gateway-embedded dispatcher (default)


### PR DESCRIPTION
## Summary
- add secret-safe profile/task/attempt statistics for Kanban
- support profile, tenant, status, and time-window filters plus archived history
- distinguish observed zero activity from unavailable attribution
- add focused edge-case validation and operator documentation

## Verification
- 
- exercised {
  "schema_version": 1,
  "board": "hermesagent",
  "generated_at": 1787633212,
  "filters": {
    "profile": null,
    "tenant": null,
    "status": null,
    "since": null,
    "until": null,
    "include_archived": false
  },
  "task_count": 14,
  "attempt_count": 22,
  "by_status": {
    "blocked": 1,
    "done": 3,
    "ready": 4,
    "running": 4,
    "todo": 2
  },
  "by_assignee": {
    "architect": {
      "done": 1,
      "ready": 2,
      "running": 1
    },
    "engineering": {
      "done": 1,
      "ready": 1,
      "running": 2,
      "todo": 1
    },
    "runtime-ops": {
      "done": 1,
      "ready": 1,
      "running": 1
    },
    "tester": {
      "blocked": 1,
      "todo": 1
    }
  },
  "oldest_ready_age_seconds": 2424,
  "profiles": [
    {
      "name": "architect",
      "on_disk": true,
      "telemetry_state": "observed_work",
      "assigned_tasks": 4,
      "task_status": {
        "done": 1,
        "ready": 2,
        "running": 1
      },
      "attempts": 7,
      "running_attempts": 1,
      "completed_tasks": 1,
      "blocked_tasks": 0,
      "failed_attempts": 5,
      "reclaimed": 0,
      "retried_tasks": 1,
      "protocol_violating": 5,
      "stale": 0,
      "dependency_releases": 0,
      "duration": {
        "average_seconds": 42.167,
        "median_seconds": 15.5,
        "p95_seconds": 129.0
      },
      "queue_wait": {
        "average_seconds": 241.286,
        "median_seconds": 63.0,
        "p95_seconds": 989.6
      },
      "blocker_classes": {},
      "task_types": {
        "scratch": 4
      }
    },
    {
      "name": "default",
      "on_disk": true,
      "telemetry_state": "observed_zero",
      "assigned_tasks": 0,
      "task_status": {},
      "attempts": 0,
      "running_attempts": 0,
      "completed_tasks": 0,
      "blocked_tasks": 0,
      "failed_attempts": 0,
      "reclaimed": 0,
      "retried_tasks": 0,
      "protocol_violating": 0,
      "stale": 0,
      "dependency_releases": 0,
      "duration": {
        "average_seconds": null,
        "median_seconds": null,
        "p95_seconds": null
      },
      "queue_wait": {
        "average_seconds": null,
        "median_seconds": null,
        "p95_seconds": null
      },
      "blocker_classes": {},
      "task_types": {}
    },
    {
      "name": "engineering",
      "on_disk": true,
      "telemetry_state": "observed_work",
      "assigned_tasks": 5,
      "task_status": {
        "done": 1,
        "ready": 1,
        "running": 2,
        "todo": 1
      },
      "attempts": 10,
      "running_attempts": 2,
      "completed_tasks": 1,
      "blocked_tasks": 0,
      "failed_attempts": 7,
      "reclaimed": 0,
      "retried_tasks": 2,
      "protocol_violating": 7,
      "stale": 0,
      "dependency_releases": 0,
      "duration": {
        "average_seconds": 30.25,
        "median_seconds": 22.5,
        "p95_seconds": 70.3
      },
      "queue_wait": {
        "average_seconds": 462.8,
        "median_seconds": 55.5,
        "p95_seconds": 1674.15
      },
      "blocker_classes": {},
      "task_types": {
        "scratch": 5
      }
    },
    {
      "name": "runtime-ops",
      "on_disk": true,
      "telemetry_state": "observed_work",
      "assigned_tasks": 3,
      "task_status": {
        "done": 1,
        "ready": 1,
        "running": 1
      },
      "attempts": 4,
      "running_attempts": 1,
      "completed_tasks": 1,
      "blocked_tasks": 0,
      "failed_attempts": 2,
      "reclaimed": 0,
      "retried_tasks": 1,
      "protocol_violating": 2,
      "stale": 0,
      "dependency_releases": 0,
      "duration": {
        "average_seconds": 89.0,
        "median_seconds": 30.0,
        "p95_seconds": 189.3
      },
      "queue_wait": {
        "average_seconds": 851.75,
        "median_seconds": 694.5,
        "p95_seconds": 1910.65
      },
      "blocker_classes": {},
      "task_types": {
        "scratch": 3
      }
    },
    {
      "name": "tester",
      "on_disk": true,
      "telemetry_state": "observed_work",
      "assigned_tasks": 2,
      "task_status": {
        "blocked": 1,
        "todo": 1
      },
      "attempts": 1,
      "running_attempts": 0,
      "completed_tasks": 0,
      "blocked_tasks": 1,
      "failed_attempts": 0,
      "reclaimed": 0,
      "retried_tasks": 0,
      "protocol_violating": 0,
      "stale": 0,
      "dependency_releases": 0,
      "duration": {
        "average_seconds": 149.0,
        "median_seconds": 149.0,
        "p95_seconds": 149.0
      },
      "queue_wait": {
        "average_seconds": 1316.0,
        "median_seconds": 1316.0,
        "p95_seconds": 1316.0
      },
      "blocker_classes": {
        "needs_input": 1
      },
      "task_types": {
        "scratch": 2
      }
    }
  ],
  "notes": {
    "attempts_are_task_runs": true,
    "task_counts_are_distinct_task_rows": true,
    "profile_attribution": "task_runs.profile for attempts; tasks.assignee for assignments and lifecycle events",
    "secret_safe": true
  }
} against the live hermesagent board
- local builds/tests were not run per execution contract; CI should run the focused tests