### PR TITLE
fix(process): poll(acknowledge=True) consumes queued completion

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -70,6 +70,33 @@ def _spawn_python_sleep(seconds: float) -> subprocess.Popen:
     )
 
 
+def test_poll_acknowledge_consumes_completion(registry):
+    """#94455: poll(acknowledge=True) on an exited process must consume the
+    queued notify_on_complete completion so the watcher never injects a stale
+    synthetic turn for a result the agent handled inline. Default poll stays
+    read-only (issue #10156 semantics)."""
+    s = _make_session(sid="proc_ack1", exited=True, exit_code=0, output="done")
+    registry._finished[s.id] = s
+
+    # Read-only default: NOT consumed.
+    registry.poll(s.id)
+    assert not registry.is_completion_consumed(s.id)
+
+    # Explicit acknowledgment: consumed.
+    result = registry.poll(s.id, acknowledge=True)
+    assert result["status"] == "exited"
+    assert registry.is_completion_consumed(s.id)
+
+
+def test_poll_acknowledge_running_is_noop(registry):
+    """Acknowledging a still-running poll must not pre-consume anything — the
+    completion only exists once the process has exited."""
+    s = _make_session(sid="proc_ack2", exited=False)
+    registry._running[s.id] = s
+    registry.poll(s.id, acknowledge=True)
+    assert not registry.is_completion_consumed(s.id)
+
+
 def test_kill_started_since_preserves_preexisting_and_foreign_processes(registry):
     old = _make_session(sid="proc_old", task_id="session-a")
     finished = _make_session(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2048,8 +2048,15 @@ class ProcessRegistry:
         )
         self._move_to_finished(session)
 
-    def poll(self, session_id: str) -> dict:
-        """Check status and get new output for a background process."""
+    def poll(self, session_id: str, acknowledge: bool = False) -> dict:
+        """Check status and get new output for a background process.
+
+        ``acknowledge=True`` opts into consuming the completion: when the
+        process has exited, the queued ``notify_on_complete`` notification is
+        marked consumed so the watcher never injects a stale synthetic turn
+        for a result the agent just handled inline (#94455). The default
+        remains fully read-only.
+        """
         from tools.ansi_strip import strip_ansi
 
         session = self.get(session_id)
@@ -2086,6 +2093,11 @@ class ProcessRegistry:
             # without affecting the gateway/tui watchers, which only consult
             # _completion_consumed.
             self._poll_observed.add(session_id)
+            if acknowledge:
+                # Explicit opt-in: the caller states it fully handled the
+                # exited result inline, so the queued completion must not
+                # produce another turn (#94455).
+                self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"
@@ -3222,6 +3234,10 @@ PROCESS_SCHEMA = {
                 "type": "integer",
                 "description": "Line offset for 'log' action (default: last 200 lines)"
             },
+            "acknowledge": {
+                "type": "boolean",
+                "description": "For 'poll' on an exited process: mark the queued notify_on_complete completion as handled so no synthetic completion turn is injected afterwards. Set this when the poll result was fully processed inline."
+            },
             "limit": {
                 "type": "integer",
                 "description": "Max lines to return for 'log' action",
@@ -3286,7 +3302,8 @@ def _handle_process(args, **kw):
         if not session_id:
             return tool_error(f"session_id is required for {action}")
         if action == "poll":
-            return json.dumps(_redact_process_result(process_registry.poll(session_id)), ensure_ascii=False)
+            return json.dumps(_redact_process_result(process_registry.poll(
+                session_id, acknowledge=bool(args.get("acknowledge")))), ensure_ascii=False)
         elif action == "log":
             return json.dumps(_redact_process_result(process_registry.read_log(
                 session_id, offset=args.get("offset"), limit=args.get("limit", 200))), ensure_ascii=False)


### PR DESCRIPTION
Fixes #94455

## Problem

`process(action="poll")` is deliberately read-only (#10156): it records `_poll_observed` but never marks `_completion_consumed`, so after the agent fully handles an exited poll result inline — validates artifacts, performs follow-ups, reports completion to the user — the `notify_on_complete` watcher still injects a **stale synthetic completion turn**. The agent then answers its own already-delivered report with a redundant "already completed" reply (#94455's recorded session: one exited poll, one queued synthetic user row, one assistant reply to it).

The read-only default is intentional (a status check must not silently suppress autonomous delivery), so the fix cannot simply mark consumed inside `poll()`.

## Fix

Explicit opt-in acknowledgment, exactly the supported path the issue asks for:

- `ProcessRegistry.poll(session_id, acknowledge=False)` — new keyword; when the process has exited and `acknowledge=True`, the session is added to `_completion_consumed` (same mechanism `wait()`/`read_log()` use).
- Default behavior unchanged: plain `poll()` remains fully read-only.
- Polling a still-running process with `acknowledge=True` is a no-op (nothing to consume yet).
- `PROCESS_SCHEMA` gains the documented boolean; `_handle_process` passes it through for `action="poll"`.

## Verification

New tests in `tests/tools/test_process_registry.py`:
- `test_poll_acknowledge_consumes_completion`: default poll leaves completion unconsumed; `acknowledge=True` consumes it and still returns the exited result
- `test_poll_acknowledge_running_is_noop`: acknowledging a running poll pre-consumes nothing

Suite: 58 passed / 28 skipped; the 6 failures are pre-existing on clean `main` on this Windows host (POSIX-only `TestTerminateHostPidPosix` cluster) — reproduced with the change stashed.