### PR TITLE
fix(guard): exempt git commit message + pathspec from gateway lifecycle block

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -345,6 +345,17 @@ _DATA_SINK_EXECUTABLES = frozenset(
 # commit-ish, and top-level `-c` is config injection) and -F/--file (a path we
 # don't want to vouch for) — leaving them visible keeps the guard fail-closed.
 _GIT_MESSAGE_FLAGS = frozenset({"-m", "--message"})
+# Clustered short-flag group ending in a lowercase message `m` whose VALUE is
+# the NEXT token: `-m`, `-am`, `-vam`, ... `git commit -am "msg"` is arguably
+# THE most common real-world commit invocation, so it must be exempted too.
+# Uppercase `-M` is a different flag and stays excluded (the required final
+# char is a lowercase `m`); `--`-prefixed long options never match (second
+# char is `-`, not a letter).
+_GIT_CLUSTERED_MESSAGE_FLAG = re.compile(r"^-[a-zA-Z]*m$")
+# Same cluster with the message glued on (`-mTEXT`, `-amTEXT`): git parses the
+# first `m` as the message flag and the remainder as inert value. group(1) is
+# the flag run up to and including that `m`; group(2) is the value to mask.
+_GIT_ATTACHED_MESSAGE_FLAG = re.compile(r"^(-[a-zA-Z]*?m)(.+)$")
 # Argument shapes that can smuggle execution back INTO a data sink: command
 # and process substitution anywhere, sqlite3 dot-commands (`.shell ...`),
 # psql backslash escapes (`\! ...`). Any hit disables masking for the whole
@@ -642,7 +653,9 @@ def _mask_git_data_positions(segment: list[str]) -> Optional[list[str]]:
     is not git (so the caller leaves it untouched). Unlike the blanket
     data-sink masker, this touches only:
 
-      * the VALUE of ``-m``/``--message`` (``-m X``, ``-mX``, ``--message=X``)
+      * the VALUE of a message flag — plain ``-m``/``--message`` and any
+        clustered short group ending in ``m`` (``-am``, ``-vam``), in both
+        detached (``-am X``) and attached (``-amX``, ``--message=X``) forms
       * every token after a bare ``--`` (pathspec — git never executes a path)
 
     Top-level ``-c key=val`` config, ``-C``/``--reuse-message`` commit-ish
@@ -652,7 +665,14 @@ def _mask_git_data_positions(segment: list[str]) -> Optional[list[str]]:
     relax the plain-regex verdict, never tighten it.
     """
     index = _command_token_index(segment)
-    if index is None or Path(segment[index]).name != "git":
+    if index is None:
+        return None
+    executable = Path(segment[index]).name
+    # Windows git ships as `git.exe` / `git.cmd`; strip the extension so the
+    # exemption applies on Windows checkouts too, not just POSIX `git`.
+    if executable.lower().endswith((".exe", ".cmd")):
+        executable = executable[: executable.rfind(".")]
+    if executable != "git":
         return None
     # A git message/pathspec token carrying a command-substitution marker is a
     # SHELL-level execution vector (`git commit -m "$(systemctl restart
@@ -675,6 +695,13 @@ def _mask_git_data_positions(segment: list[str]) -> Optional[list[str]]:
         if skip_next:
             out.append("arg")
             skip_next = False
+            # If the value we just consumed was a literal ``--``, it was the
+            # message text (`git commit -m -- <pathspec>`), NOT the pathspec
+            # separator. git then treats the remaining tokens as pathspecs, so
+            # flip to separator mode here — masking those inert paths too and
+            # keeping a future reader from mis-tightening this position.
+            if token == "--":
+                after_separator = True
             continue
         if after_separator:
             # Everything past `--` is a pathspec: pure data to git.
@@ -684,24 +711,21 @@ def _mask_git_data_positions(segment: list[str]) -> Optional[list[str]]:
             after_separator = True
             out.append(token)
             continue
-        if token in _GIT_MESSAGE_FLAGS:
-            # Value is the next token (`-m X`, `--message X`).
-            if position + 1 < len(arguments):
-                out.append(token)
-                skip_next = True
-                continue
+        # Clustered/aliased message flag whose VALUE is the NEXT token:
+        # `-m`, `-am`, `-vam`, `--message` (`git commit -am "msg"`).
+        if token in _GIT_MESSAGE_FLAGS or _GIT_CLUSTERED_MESSAGE_FLAG.match(token):
             out.append(token)
+            if position + 1 < len(arguments):
+                skip_next = True
             continue
         if token.startswith("--message="):
             out.append("--message=arg")
             continue
-        if (
-            token.startswith("-m")
-            and not token.startswith("--")
-            and len(token) > 2
-        ):
-            # Attached short form `-mSOME TEXT` (git accepts `-mfoo`).
-            out.append("-marg")
+        attached = _GIT_ATTACHED_MESSAGE_FLAG.match(token)
+        if attached and not token.startswith("--"):
+            # Attached short form with the message glued on: `-mTEXT`,
+            # `-amTEXT`. Keep the flag run, mask only the value.
+            out.append(f"{attached.group(1)}arg")
             continue
         out.append(token)
     return out

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -329,6 +329,22 @@ def _is_cloud_placeholder_path(path: Path) -> bool:
 _DATA_SINK_EXECUTABLES = frozenset(
     {"grep", "egrep", "fgrep", "rg", "ag", "ack", "journalctl", "sqlite3", "psql"}
 )
+# git is NOT a generic data sink: `git -c core.pager='systemctl restart
+# hermes-gateway' log` smuggles a command git will execute, so blanket-masking
+# every git argument (as _DATA_SINK_EXECUTABLES does) would open an execution
+# hole. Instead we mask only the two positions git treats as pure, never-executed
+# data — and which produced the real false positives (a clipping commit landing
+# gateway-ops notes: the message text and the `--`-separated pathspec both carry
+# lifecycle-shaped strings that git never runs). Everything else in a git
+# segment (top-level `-c` config, subcommand flags) stays visible and fails
+# closed to the plain regex, so this exemption can only ever ALLOW, never block.
+#
+# Message-carrying flags whose VALUE is arbitrary user text, not a command:
+#   -m/--message <TEXT>, -m<TEXT>, --message=<TEXT>
+# Deliberately excludes -c/-C/--reuse-message/--reedit-message (those take a
+# commit-ish, and top-level `-c` is config injection) and -F/--file (a path we
+# don't want to vouch for) — leaving them visible keeps the guard fail-closed.
+_GIT_MESSAGE_FLAGS = frozenset({"-m", "--message"})
 # Argument shapes that can smuggle execution back INTO a data sink: command
 # and process substitution anywhere, sqlite3 dot-commands (`.shell ...`),
 # psql backslash escapes (`\! ...`). Any hit disables masking for the whole
@@ -618,6 +634,79 @@ def contains_launchctl_submit_command(command: str) -> bool:
     return False
 
 
+def _mask_git_data_positions(segment: list[str]) -> Optional[list[str]]:
+    """Mask ONLY git's pure-data positions (message text, ``--`` pathspec).
+
+    Returns a new token list with lifecycle-shaped strings that git treats as
+    inert data replaced by ``arg``, or ``None`` when this segment's executable
+    is not git (so the caller leaves it untouched). Unlike the blanket
+    data-sink masker, this touches only:
+
+      * the VALUE of ``-m``/``--message`` (``-m X``, ``-mX``, ``--message=X``)
+      * every token after a bare ``--`` (pathspec — git never executes a path)
+
+    Top-level ``-c key=val`` config, ``-C``/``--reuse-message`` commit-ish
+    refs, ``-F``/``--file`` paths, and the subcommand itself stay visible, so a
+    real ``git -c core.pager='systemctl restart hermes-gateway' log`` execution
+    vector is NOT masked and still fails closed. Masking here can only ever
+    relax the plain-regex verdict, never tighten it.
+    """
+    index = _command_token_index(segment)
+    if index is None or Path(segment[index]).name != "git":
+        return None
+    # A git message/pathspec token carrying a command-substitution marker is a
+    # SHELL-level execution vector (`git commit -m "$(systemctl restart
+    # hermes-gateway)"` runs the substitution before git sees anything), so
+    # masking it would ALLOW a real command. Fail closed: if any token in the
+    # segment carries such a marker, don't mask anything here — leave the
+    # segment to the plain regex verdict. Mirrors the data-sink masker's
+    # _UNSAFE_DATA_ARG_MARKERS guard.
+    if any(
+        marker in token
+        for token in segment[index + 1 :]
+        for marker in _UNSAFE_DATA_ARG_MARKERS
+    ):
+        return list(segment)
+    out = list(segment[: index + 1])
+    arguments = segment[index + 1 :]
+    after_separator = False
+    skip_next = False
+    for position, token in enumerate(arguments):
+        if skip_next:
+            out.append("arg")
+            skip_next = False
+            continue
+        if after_separator:
+            # Everything past `--` is a pathspec: pure data to git.
+            out.append("arg")
+            continue
+        if token == "--":
+            after_separator = True
+            out.append(token)
+            continue
+        if token in _GIT_MESSAGE_FLAGS:
+            # Value is the next token (`-m X`, `--message X`).
+            if position + 1 < len(arguments):
+                out.append(token)
+                skip_next = True
+                continue
+            out.append(token)
+            continue
+        if token.startswith("--message="):
+            out.append("--message=arg")
+            continue
+        if (
+            token.startswith("-m")
+            and not token.startswith("--")
+            and len(token) > 2
+        ):
+            # Attached short form `-mSOME TEXT` (git accepts `-mfoo`).
+            out.append("-marg")
+            continue
+        out.append(token)
+    return out
+
+
 def _mask_data_sink_arguments(text: str) -> str:
     """Replace data-sink executables' arguments with a neutral placeholder.
 
@@ -673,6 +762,12 @@ def _mask_data_sink_arguments(text: str) -> str:
         rebuilt: list[str] = []
         for segment in segments:
             if not segment:
+                continue
+            git_masked = _mask_git_data_positions(segment)
+            if git_masked is not None:
+                if git_masked != segment:
+                    changed = True
+                rebuilt.extend(git_masked)
                 continue
             index = _command_token_index(segment)
             if index is not None and Path(segment[index]).name in _DATA_SINK_EXECUTABLES:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1971,6 +1971,55 @@ class TestLifecycleGuardDataArgumentExemption:
         check_gateway_lifecycle(prompt, str(script))
 
 
+class TestLifecycleGuardGitDataExemption:
+    """git commit messages and ``--`` pathspecs are pure DATA to git — a
+    lifecycle-shaped string there must not block (the real false positive:
+    a knowledge-clipping commit landing gateway-ops notes, whose message or
+    filenames mention `hermes gateway restart`). But git's execution vectors
+    (top-level `-c` config injection, shell command substitution in the
+    message, `-C` commit-ish) must STILL block. #hermes-infra clipping FP.
+    """
+
+    def _scan(self, command, **kwargs):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        return contains_gateway_lifecycle_command_or_referenced_script(
+            command, **kwargs
+        )
+
+    @pytest.mark.parametrize("command", [
+        # Commit MESSAGE carrying a lifecycle-shaped string: git never runs it.
+        'git commit -q -m "how to run hermes gateway restart"',
+        'git commit -m "fix: systemctl restart hermes-gateway crash"',
+        'git commit -m "note: launchctl kickstart ai.hermes.gateway"',
+        # Attached short form and long form.
+        'git commit -m"clip: hermes gateway stop steps"',
+        'git commit --message="hermes gateway restart tips"',
+        # `--` pathspec: filenames are inert data to git.
+        'git add -- "clips/hermes gateway restart guide.md"',
+        'git add -- "01_sources/pkill hermes gateway note.md"',
+        'git commit -m "clip" -- "notes/systemctl restart hermes-gateway.md"',
+    ])
+    def test_git_data_positions_not_blocked(self, command):
+        assert self._scan(command, cwd="/tmp") is False
+
+    @pytest.mark.parametrize("command", [
+        # Top-level `-c` config injection: git executes core.pager.
+        'git -c core.pager="systemctl restart hermes-gateway" log',
+        # Shell command substitution in the message runs BEFORE git.
+        'git commit -m "$(systemctl restart hermes-gateway)"',
+        # A real lifecycle command chained after a benign git commit.
+        'git commit -m "clip"; hermes gateway stop',
+        # Alias definition VALUE is not a message/pathspec — stays visible.
+        'git config alias.x "!hermes gateway restart"',
+        # `-C` takes a commit-ish, not free text — must not be masked.
+        'git commit -C "hermes gateway restart"',
+    ])
+    def test_git_execution_vectors_still_blocked(self, command):
+        assert self._scan(command, cwd="/tmp") is True
+
+
 class TestLifecycleGuardNeverRaises:
     """The guard must return a verdict for every input — binary referenced
     paths, NUL bytes, non-UTF-8, /dev/* nodes, directories, missing files —

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1996,6 +1996,16 @@ class TestLifecycleGuardGitDataExemption:
         # Attached short form and long form.
         'git commit -m"clip: hermes gateway stop steps"',
         'git commit --message="hermes gateway restart tips"',
+        # Clustered short-flag groups ending in `m` (`-am` is THE most common
+        # real commit invocation). Both detached value and glued-on value.
+        'git commit -am "clip: how to run hermes gateway restart"',
+        'git commit -am"clip: hermes gateway restart steps"',
+        'git commit -vam "clip: systemctl restart hermes-gateway"',
+        # Windows git binaries (`git.exe`/`git.cmd`) get the same exemption.
+        'git.exe commit -m "clip: hermes gateway restart"',
+        'git.cmd commit -am "clip: hermes gateway stop"',
+        # `-m` whose VALUE is a literal `--` (message text, not a separator).
+        'git commit -m -- "notes: systemctl restart hermes-gateway"',
         # `--` pathspec: filenames are inert data to git.
         'git add -- "clips/hermes gateway restart guide.md"',
         'git add -- "01_sources/pkill hermes gateway note.md"',
@@ -2015,6 +2025,11 @@ class TestLifecycleGuardGitDataExemption:
         'git config alias.x "!hermes gateway restart"',
         # `-C` takes a commit-ish, not free text — must not be masked.
         'git commit -C "hermes gateway restart"',
+        # Uppercase `-M` in a cluster is NOT a message flag (its value stays
+        # visible) — only a lowercase-`m`-terminated cluster is exempted.
+        'git commit -aM "hermes gateway restart"',
+        # Top-level `-c` visibility wins even alongside a masked message.
+        'git -c core.pager="systemctl restart hermes-gateway" commit -m "benign"',
     ])
     def test_git_execution_vectors_still_blocked(self, command):
         assert self._scan(command, cwd="/tmp") is True


### PR DESCRIPTION
Fixes #94469

## Summary

The in-gateway lifecycle guard (`cron/lifecycle_guard.py`) blocks `git` commands
whose commit message (`-m`/`--message`) or `--` pathspec merely *contains* a
gateway-lifecycle string. git never executes that text, so the block is a false
positive. `_mask_data_sink_arguments` already exempts this class for
grep/rg/sqlite3/psql (`70de958921`); this extends the same idea to git's
provably-inert positions without treating git as a blanket data sink.

## Change

New `_mask_git_data_positions(segment)` masks only:

- the value of `-m` / `--message` (`-m X`, `-mX`, `--message=X`)
- every token after a bare `--` (pathspec)

Wired into `_mask_data_sink_arguments`' per-segment loop ahead of the data-sink
branch. Fails closed on everything that can execute a string:

- top-level `-c key=val` (config injection, e.g. `core.pager`)
- `-C` / `--reuse-message` (commit-ish, not free text)
- `-F` / `--file` (a path we don't vouch for)
- any message/pathspec token carrying a command-substitution marker
  (`$(`, backtick, `<(`, `>(`, `\!`) — the shell runs it before git

Like the existing data-sink masker, this can only relax the verdict, never
tighten it, so no currently-blocked real foot-gun becomes allowed.

## What deliberately did NOT change

- `git` is NOT added to `_DATA_SINK_EXECUTABLES` (that would blanket-mask
  `git -c core.pager=...`, an execution hole).
- No change to the lifecycle regex or any non-git segment handling.

## Tests

- New `TestLifecycleGuardGitDataExemption`: 8 allow + 5 block cases.
- Full guard suite (`tests/hermes_cli/test_gateway_restart_loop.py`): 310 passed.
- Differential execution (same probe, upstream `main` vs this branch):
  `git commit -m "…hermes gateway restart…"` → `True` on main, `False` here;
  `git -c core.pager="…" log` → `True` on both.
- Pre-filing gate: reverting only the source change (keeping the new tests) on
  fresh `origin/main` turns the "not blocked" tests red (7/8), proving they
  exercise the fix.

Base for these runs: `origin/main` at `bc47fcd3f9`.

## Risk

Low, and strictly narrowing exposure to two inert git positions. Every
execution-capable git surface stays blocked.
