### PR TITLE
fix(compression): abort on empty-content summarizer response instead of dropping the middle window

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -110,6 +110,19 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
 
 
+class SummaryEmptyContentError(RuntimeError):
+    """The summarizer returned HTTP 200 with empty/whitespace-only content.
+
+    Raised by the empty-content guard in ``_generate_summary`` so the failure
+    keeps its identity when it reaches the exception handler: it is a
+    degraded-provider signal (same class as #11978's null-body proxies) and
+    must be classified into the network-failure abort carve-out instead of
+    the generic summary-failure path, which commits the destructive
+    static fallback under the stock ``abort_on_summary_failure=False``
+    and permanently drops the middle window (#94448).
+    """
+
+
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
 
 
@@ -5043,8 +5056,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Treat empty content as a failure so it routes through the same
             # main-model fallback + cooldown machinery as a transport error,
             # rather than replacing real context with an empty summary.
+            # SummaryEmptyContentError (not bare RuntimeError) keeps the
+            # degraded-provider identity intact so the exception handler can
+            # classify it into the network-failure abort carve-out (#94448).
             if not content.strip():
-                raise RuntimeError(
+                raise SummaryEmptyContentError(
                     "Context compression LLM returned empty content "
                     f"(provider={self.provider or 'auto'} "
                     f"model={self.summary_model or self.model})"
@@ -5150,6 +5166,17 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # Keep the established field name for caller compatibility;
                 # it now represents the broader terminal access/quota class.
                 self._last_summary_auth_failure = True
+            if isinstance(e, SummaryEmptyContentError):
+                # An HTTP 200 with an empty body is the same degraded-provider
+                # signal as a dropped connection: the transport answered but
+                # the provider failed at the compaction moment (#11978-class
+                # proxies; opencode-go in #94448). Classify it into the
+                # network-failure carve-out so compress() ABORTS and preserves
+                # the session instead of committing the destructive static
+                # fallback under the stock abort_on_summary_failure=false —
+                # retrying once the provider recovers is strictly better than
+                # permanently dropping the middle window (#94448).
+                self._last_summary_network_failure = True
             if _is_json_decode and not _is_model_not_found and not _is_timeout:
                 logger.error(
                     "Context compression failed: auxiliary LLM returned a "

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1127,6 +1127,111 @@ class TestStreamingClosedFallback:
 
 
 
+class TestEmptyContentSummaryFailureAborts:
+    """Regression #94448: an HTTP-200 empty-content summary response from a
+    degraded provider must be classified into the network-failure carve-out
+    (abort) instead of falling into the generic failure path, which commits
+    the destructive Phase-4 fallback under the stock default
+    ``abort_on_summary_failure=False`` and permanently deletes the middle
+    window of the session.
+
+    The empty-content guard (#11978) already refuses to store the empty body;
+    what was missing was the abort classification, so ``compress()`` still
+    dropped every uncompacted turn for a static placeholder marker.
+    """
+
+    def _msgs(self, n=12):
+        msgs = [{"role": "user", "content": "do something"}]
+        for i in range(n - 1):
+            msgs.append({"role": "assistant", "content": f"reply {i}"})
+            msgs.append({"role": "user", "content": f"follow-up {i}"})
+        return msgs
+
+    @staticmethod
+    def _empty_response(content=""):
+        mock = MagicMock()
+        mock.choices = [MagicMock()]
+        mock.choices[0].message.content = content
+        return mock
+
+    def test_generate_summary_flags_network_failure(self):
+        """Empty content raises the guard error; it must be classified
+        as a network-class failure so the abort carve-out fires."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=self._empty_response(),
+        ):
+            result = c._generate_summary(self._msgs())
+        assert result is None
+        assert c._last_summary_network_failure is True
+        assert c._last_summary_auth_failure is False
+        # Transient cooldown engaged so we don't hammer the degraded provider.
+        assert c._summary_failure_cooldown_until > 0
+
+    def test_whitespace_only_content_also_flags_network_failure(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=self._empty_response(content="   \n\t"),
+        ):
+            result = c._generate_summary(self._msgs())
+        assert result is None
+        assert c._last_summary_network_failure is True
+
+    def test_compress_aborts_and_preserves_middle_window(self):
+        """The core contract: with the stock default
+        ``abort_on_summary_failure=False``, an empty-content summarizer
+        response must leave the session UNCHANGED (retryable), never commit
+        the destructive fallback that drops the middle window."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=self._empty_response(),
+        ):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result == msgs  # session preserved unchanged — retry later
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+        assert c._last_summary_dropped_count == 0
+
+    def test_aux_model_empty_content_still_gets_main_retry_before_abort(self):
+        """The one-shot fallback to the main model still runs first — abort
+        only kicks in once the main model also returns empty content."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                summary_model_override="broken-aux-model",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[self._empty_response(), self._empty_response()],
+        ) as mock_call:
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert mock_call.call_count == 2  # aux attempt + main-model retry
+        assert mock_call.call_args_list[0].kwargs.get("model") == "broken-aux-model"
+        assert result == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+
+
 class TestAuxModelFallbackSurfacedToCallers:
     """When summary_model fails but retry-on-main succeeds, compress() must
     expose the aux-model failure via _last_aux_model_failure_{model,error}


### PR DESCRIPTION
## What

An HTTP 200 with an **empty/whitespace-only `content`** from a degraded summarizer provider already fails the empty-content guard (#11978) instead of being stored as a prefix-only summary — but that failure was not classified into either abort-trigger carve-out (`_last_summary_network_failure` / `_last_summary_auth_failure`). Under the stock default `compression.abort_on_summary_failure: false`, it therefore routed through the generic failure path: `compress()` committed the destructive Phase-4 static fallback and **permanently dropped the entire middle window** — in the reported session, 547 messages → 20, ~338K tokens of context gone (`failure_class=summary_generation_failed, fallback_used=true, commit_status=committed`).

Fixes #94448.

## Root cause

1. The empty-content guard in `_generate_summary()` raises a bare `RuntimeError` ("Context compression LLM returned empty content").
2. In the exception handler, nothing matches the abort-trigger classifications: no status code (→ not model-not-found/timeout), not a JSON-decode error, not a streaming-closed connection error, not access/quota.
3. After any main-model retry is exhausted (or unavailable), the generic cooldown path returns `None` with **no flag set**, so `compress()`'s abort guard at `not summary and (abort_on_summary_failure or auth or network)` is False → Phase 4 inserts the deterministic "Recovered from a deterministic fallback…" handoff and drops the middle window.

An empty body over HTTP 200 is exactly the degraded-provider signal class as a dropped connection (#11978's null-body proxies; opencode-go in #94448): the provider was failing at the compaction moment. Retrying once it recovers is strictly better than deleting context.

## Fix

- Raise a dedicated `SummaryEmptyContentError(RuntimeError)` from the empty-content guard so the failure keeps its identity (same message; still a `RuntimeError` for any generic handler).
- Classify it in the exception handler into the existing `_last_summary_network_failure` carve-out — mirroring `_is_streaming_closed` (#29559/#25585) — so `compress()` **aborts**, preserves the messages unchanged, reports `_last_compress_aborted=True` / `_last_summary_fallback_used=False` / `_last_summary_dropped_count=0`, and telemetry records `summary_network_failure`.
- No change to the one-shot fallback-to-main-model behavior: when `summary_model` differs from the main model, the main-model retry still runs first; only if the main model also returns empty does the abort stick. On success, flags are cleared as before.

## Tests

Behavior-contract tests in `tests/agent/test_context_compressor.py::TestEmptyContentSummaryFailureAborts`:

- empty content (and whitespace-only) flags `_last_summary_network_failure` and engages the transient cooldown — fails on `main` (flag stays `False`), passes with the fix;
- the core contract: with `abort_on_summary_failure=False`, `compress()` returns the messages **unchanged** (`result == msgs`) with `_last_compress_aborted=True`, `fallback_used=False`, `dropped_count=0` — on `main` this commits the destructive fallback (`result != msgs`);
- aux-model empty content still gets the one-shot main-model retry before aborting (`call_count == 2`).

Existing suites green: full `test_context_compressor.py` + `test_compression_concurrent_fork.py` (185), compression abort/cooldown/fallback neighbors (58), compaction/boundary/native/micro suites (143). All 4 new tests fail on current `main` without the fix.

## Related

- #11978 / #50297 — introduced the empty-content guard (correct half of the fix); this adds the missing abort classification.
- #70207 / @Drexuxux's #70321 — recovers the summary from the reasoning field; complementary: when there is genuinely no recoverable content, this PR ensures the session is preserved instead of destroyed.
- @nankingjing's #58984 — scopes these same failure flags to their episode; compatible (this PR reuses the existing flag semantics).
- #29559 / #25585 — precedent for the network-failure abort carve-out.

---
Bruno Bza (@BrunoBza)
