### PR TITLE
fix(auxiliary): never cache availability-probe client stubs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8067,6 +8067,17 @@ def _get_cached_client(
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.
         bound_loop = current_loop
+        if isinstance(client, _AuxProbeClientStub):
+            # Availability probes must never populate the cache — same guard as
+            # _store_cached_client(). A cached stub is handed to the NEXT
+            # resolution for this key, including a real runtime caller, and
+            # raises on first attribute access. Concretely: the second
+            # resolution hits _compat_model() → _is_openrouter_client(stub) →
+            # stub._client → RuntimeError, so check_vision_requirements()
+            # returned False forever after the first probe and vision_analyze
+            # silently disappeared from the tool schema for the life of the
+            # process (long-lived gateway / desktop backend).
+            return client, model or default_model
         with _client_cache_lock:
             if cache_key not in _client_cache:
                 # Safety belt: if the cache has grown beyond the max, evict

--- a/tests/agent/test_aux_probe_stub_cache_exclusion.py
+++ b/tests/agent/test_aux_probe_stub_cache_exclusion.py
@@ -1,0 +1,103 @@
+"""Availability-probe stubs must never enter the auxiliary client cache.
+
+``aux_probe_mode()`` answers "is a client resolvable?" without building a real
+SDK client: it returns an ``_AuxProbeClientStub`` that raises on any attribute
+access, so a leak into a runtime path fails loudly instead of silently sending
+requests nowhere.
+
+``_store_cached_client()`` has always excluded stubs, but ``_get_cached_client``
+writes to ``_client_cache`` directly and lacked the same guard. The cached stub
+was then served to the NEXT resolution for that key:
+
+* a second probe hit ``_compat_model()`` → ``_is_openrouter_client(stub)`` →
+  ``stub._client`` → ``RuntimeError``, which ``check_vision_requirements()``
+  swallowed into ``False``. ``vision_analyze`` therefore dropped off the tool
+  schema after the first probe and stayed off for the life of the process
+  (check_fn results are TTL-cached process-wide, so a long-lived gateway or
+  desktop backend never recovered).
+* a real caller got the non-functional stub instead of a client.
+
+Only slash-bearing model ids reach the ``_compat_model`` branch, which is why
+this surfaced on providers whose model ids are namespaced (NVIDIA's
+``meta/llama-3.2-11b-vision-instruct``).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent.auxiliary_client as aux
+
+_PROBE_BASE_URL = "https://integrate.api.nvidia.com/v1"
+_SLASH_MODEL = "meta/llama-3.2-11b-vision-instruct"
+
+
+@pytest.fixture(autouse=True)
+def _clean_aux_state():
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+    yield
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+
+
+def _stub() -> aux._AuxProbeClientStub:
+    return aux._AuxProbeClientStub(api_key="probe-key", base_url=_PROBE_BASE_URL)
+
+
+def _cached_stub_count() -> int:
+    return sum(
+        1
+        for entry in aux._client_cache.values()
+        if isinstance(entry[0], aux._AuxProbeClientStub)
+    )
+
+
+def test_probe_stub_is_returned_but_not_cached():
+    """The probe still answers "resolvable", yet leaves the cache untouched."""
+    stub = _stub()
+    with patch.object(aux, "resolve_provider_client", return_value=(stub, _SLASH_MODEL)):
+        with aux.aux_probe_mode():
+            client, model = aux._get_cached_client("nvidia", model=_SLASH_MODEL)
+
+    assert client is stub
+    assert model == _SLASH_MODEL
+    assert _cached_stub_count() == 0
+
+
+def test_repeated_probes_stay_resolvable_for_slash_bearing_models():
+    """Every probe resolves; none is served a stub from a previous probe."""
+    built = []
+
+    def _resolve(provider, model, async_mode=False, **kwargs):
+        built.append(provider)
+        return _stub(), _SLASH_MODEL
+
+    with patch.object(aux, "resolve_provider_client", side_effect=_resolve):
+        with aux.aux_probe_mode():
+            for _ in range(3):
+                client, model = aux._get_cached_client("nvidia", model=_SLASH_MODEL)
+                assert client is not None
+                assert model == _SLASH_MODEL
+
+    # A cache hit would have skipped resolution (and raised on the stub).
+    assert len(built) == 3
+    assert _cached_stub_count() == 0
+
+
+def test_runtime_caller_after_a_probe_gets_a_real_client():
+    """A probe must not poison the cache for the real call that follows it."""
+    real = MagicMock(name="real-client")
+
+    def _resolve(provider, model, async_mode=False, **kwargs):
+        if aux._aux_probe_active():
+            return _stub(), _SLASH_MODEL
+        return real, _SLASH_MODEL
+
+    with patch.object(aux, "resolve_provider_client", side_effect=_resolve):
+        with aux.aux_probe_mode():
+            aux._get_cached_client("nvidia", model=_SLASH_MODEL)
+        client, model = aux._get_cached_client("nvidia", model=_SLASH_MODEL)
+
+    assert client is real
+    assert model == _SLASH_MODEL


### PR DESCRIPTION
## Symptom

`vision_analyze` disappears from the tool schema on a long-lived backend
(gateway / desktop `hermes serve`), even though the `vision` toolset is enabled,
the tool is registered, and a vision backend is configured with a valid API key.
On a fresh process the tool is present; after the first availability probe it is
gone for the life of the process. Related symptom when the tool *is* present:
`RuntimeError: _AuxProbeClientStub used as a real client` on a real call.

Reproduction with `auxiliary.vision.provider: nvidia` /
`auxiliary.vision.model: meta/llama-3.2-11b-vision-instruct` (fresh process):

```
check_vision_requirements() #1 -> True
check_vision_requirements() #2 -> False
check_vision_requirements() #3 -> False
```

## Root cause

`aux_probe_mode()` answers "is a client resolvable?" without paying for real SDK
client construction: it returns an `_AuxProbeClientStub` whose `__getattr__`
raises, so a leak into a runtime path fails loudly instead of silently sending
requests nowhere.

`_store_cached_client()` already excludes stubs, with the comment:

> Probe stubs must never enter the cache — a runtime caller would receive a
> non-functional client on the next cache hit.

But `_get_cached_client()` writes to `_client_cache` **directly**
(`agent/auxiliary_client.py`, the `if client is not None:` block after
`resolve_provider_client`) and lacked that guard. The stub therefore enters the
cache and is served to the next resolution for that key:

1. **Second probe** → cache hit → `_compat_model(stub, model, cached_default)`.
   For a slash-bearing model id this calls `_is_openrouter_client(stub)`, which
   reads `stub._client` → `RuntimeError`.
   `check_vision_requirements()` catches it → `False` → the tool is stripped
   from the schema. `check_fn` results are TTL-cached process-wide, so the
   backend never recovers.
2. **Real caller after a probe** → receives the non-functional stub.

Only slash-bearing model ids reach the `_compat_model` branch, which is why this
shows up on providers with namespaced model ids (NVIDIA, and any
`vendor/model` aux config) but not on OpenRouter, where `_is_openrouter_client`
matches the stub's own `base_url` (it is in `__slots__`) before touching
`_client`.

Not vision-specific: any `check_fn` or aux task that probes through
`_get_cached_client` can poison the cache for the same key.

## Fix

One guard in `_get_cached_client`, mirroring `_store_cached_client`: a probe stub
is returned to the caller (so availability still resolves) but never stored.

## Tests

`tests/agent/test_aux_probe_stub_cache_exclusion.py` — three behaviour
contracts, all failing without the guard:

- the probe still answers "resolvable" and leaves the cache free of stubs;
- repeated probes for a slash-bearing model stay resolvable (each re-resolves
  instead of being served a cached stub);
- a real caller following a probe receives the real client.

Verified `RED` before / `GREEN` after via `scripts/run_tests.sh`, plus the live
`check_vision_requirements()` sequence above going `True, True, True`.
