### PR TITLE
fix: preserve venv shebang in launcher after update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -369,6 +369,92 @@ def _editable_install_is_current(git_cmd, cwd, pre_pull_sha: str | None) -> bool
         return False
     return not result.stdout.strip()
 
+
+def _preserve_venv_shebang_in_launcher() -> None:
+    """Preserve venv-pointing shebang in the hermes launcher script after git pull.
+
+    The launcher script in the repository has ``#!/usr/bin/env python3`` so it
+    works for contributors without a Hermes venv. After a user install, the
+    shebang is rewritten to point at the venv Python
+    (``#!/path/to/venv/bin/python3``) so desktop launchers and non-login-shell
+    environments see Hermes packages instead of escaping to the system interpreter.
+
+    ``git pull`` overwrites that file with the repo version, resetting the shebang
+    to the generic ``#!/usr/bin/env python3``. For users launching Hermes from a
+    desktop entry (XDG ``.desktop`` files, Windows Start Menu shortcuts), the
+    PATH-resolution in ``/usr/bin/env`` sees the system Python instead of the venv,
+    and ``import hermes_cli`` fails with ``ModuleNotFoundError`` on first
+    third-party import (e.g. ``dotenv``).
+
+    This function runs immediately after a successful ``git pull``, before the
+    dependency reinstall step. It detects when the running interpreter is inside
+    Hermes' own venv and rewrites the launcher shebang to point at that venv
+    Python explicitly, so the next desktop-launched invocation sees the right
+    environment.
+
+    Best-effort: never raises. A failed rewrite is logged at debug level; the
+    shebang stays generic and desktop launches continue to fail until the user
+    runs ``hermes`` once from a shell (which activates the venv PATH) or manually
+    patches the shebang.
+    """
+    try:
+        launcher = _m().PROJECT_ROOT / "hermes"
+        if not launcher.is_file():
+            # Not a checkout install (PyPI wheel, system package, etc.) — no
+            # launcher script to patch.
+            return
+
+        venv_py = venv_python_path()
+        if not venv_py or not Path(venv_py).is_file():
+            # No venv or venv Python not found — leave the shebang alone.
+            logger.debug(
+                "Skipping launcher shebang rewrite: venv Python not found (venv_python_path=%r)",
+                venv_py,
+            )
+            return
+
+        # Only rewrite if we're actually running from Hermes' venv. If the user
+        # is running ``hermes update`` from a different Python (system, conda,
+        # another venv), respect that choice and don't force the shebang.
+        running_exe = Path(sys.executable).resolve()
+        venv_exe = Path(venv_py).resolve()
+        if running_exe != venv_exe:
+            logger.debug(
+                "Skipping launcher shebang rewrite: running from %s, venv is %s",
+                running_exe,
+                venv_exe,
+            )
+            return
+
+        # Read the current launcher content.
+        try:
+            lines = launcher.read_text(encoding="utf-8").splitlines(keepends=True)
+        except OSError as exc:
+            logger.debug("Could not read launcher script %s: %s", launcher, exc)
+            return
+
+        if not lines or not lines[0].startswith("#!"):
+            # No shebang line — leave it alone.
+            return
+
+        target_shebang = f"#!{venv_exe}\n"
+        if lines[0] == target_shebang:
+            # Already pointing at the venv — nothing to do.
+            return
+
+        # Rewrite the shebang to point at the venv Python.
+        lines[0] = target_shebang
+        try:
+            launcher.write_text("".join(lines), encoding="utf-8")
+            logger.debug("Rewrote launcher shebang to %s", target_shebang.strip())
+        except OSError as exc:
+            logger.debug("Could not rewrite launcher shebang in %s: %s", launcher, exc)
+
+    except Exception as exc:
+        # Never let a shebang rewrite failure block an update.
+        logger.debug("Unexpected error in _preserve_venv_shebang_in_launcher: %s", exc)
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -6716,6 +6802,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
         _m()._record_bytecode_fingerprint()
         _m()._refresh_bootstrap_cache_scripts(branch)
+
+        # Preserve venv shebang in the launcher script if we're running from
+        # the venv. ``git pull`` resets it to ``#!/usr/bin/env python3``, which
+        # breaks desktop-launcher invocations that don't see the venv in PATH.
+        _preserve_venv_shebang_in_launcher()
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -370,7 +370,11 @@ def _editable_install_is_current(git_cmd, cwd, pre_pull_sha: str | None) -> bool
     return not result.stdout.strip()
 
 
-def _preserve_venv_shebang_in_launcher() -> None:
+def _preserve_venv_shebang_in_launcher(
+    *,
+    launcher_path: Path | None = None,
+    venv_py: str | Path | None = None,
+) -> None:
     """Preserve venv-pointing shebang in the hermes launcher script after git pull.
 
     The launcher script in the repository has ``#!/usr/bin/env python3`` so it
@@ -398,13 +402,17 @@ def _preserve_venv_shebang_in_launcher() -> None:
     patches the shebang.
     """
     try:
-        launcher = _m().PROJECT_ROOT / "hermes"
+        launcher = (
+            Path(launcher_path)
+            if launcher_path is not None
+            else _m().PROJECT_ROOT / "hermes"
+        )
         if not launcher.is_file():
             # Not a checkout install (PyPI wheel, system package, etc.) — no
             # launcher script to patch.
             return
 
-        venv_py = venv_python_path()
+        venv_py = venv_py if venv_py is not None else venv_python_path()
         if not venv_py or not Path(venv_py).is_file():
             # No venv or venv Python not found — leave the shebang alone.
             logger.debug(
@@ -426,6 +434,12 @@ def _preserve_venv_shebang_in_launcher() -> None:
             )
             return
 
+        # Keep the unresolved absolute path for the shebang. On POSIX,
+        # ``venv/bin/python3`` is commonly a symlink to the base interpreter;
+        # resolving it here would point the launcher at the system Python and
+        # lose the venv's site-packages.
+        target_python = Path(venv_py).absolute()
+
         # Read the current launcher content.
         try:
             lines = launcher.read_text(encoding="utf-8").splitlines(keepends=True)
@@ -437,17 +451,32 @@ def _preserve_venv_shebang_in_launcher() -> None:
             # No shebang line — leave it alone.
             return
 
-        target_shebang = f"#!{venv_exe}\n"
+        target_shebang = f"#!{target_python}\n"
+        if len(target_shebang) > 253:
+            logger.warning(
+                "Launcher shebang is longer than Linux's safe limit (%d bytes): %s",
+                len(target_shebang),
+                target_shebang.strip(),
+            )
         if lines[0] == target_shebang:
             # Already pointing at the venv — nothing to do.
             return
 
-        # Rewrite the shebang to point at the venv Python.
+        # Rewrite atomically so an interrupted update cannot leave a truncated
+        # launcher. Preserve the original mode explicitly because write_text()
+        # would otherwise create a replacement using the process umask.
         lines[0] = target_shebang
+        temporary = launcher.with_name(f".{launcher.name}.tmp-{os.getpid()}")
         try:
-            launcher.write_text("".join(lines), encoding="utf-8")
+            temporary.write_text("".join(lines), encoding="utf-8")
+            temporary.chmod(launcher.stat().st_mode & 0o7777)
+            os.replace(temporary, launcher)
             logger.debug("Rewrote launcher shebang to %s", target_shebang.strip())
         except OSError as exc:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
             logger.debug("Could not rewrite launcher shebang in %s: %s", launcher, exc)
 
     except Exception as exc:

--- a/tests/hermes_cli/test_update_launcher_shebang.py
+++ b/tests/hermes_cli/test_update_launcher_shebang.py
@@ -1,0 +1,63 @@
+"""Regression tests for preserving the venv interpreter in the launcher."""
+
+import sys
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX venv symlinks are not representative on Windows",
+)
+def test_shebang_keeps_unresolved_venv_path_when_python_is_symlink(
+    tmp_path, monkeypatch
+):
+    """The shebang must retain the venv path, not the symlink target."""
+    launcher = tmp_path / "hermes"
+    launcher.write_text("#!/usr/bin/env python3\nprint('ok')\n", encoding="utf-8")
+    launcher.chmod(0o755)
+
+    base_python = tmp_path / "base-python"
+    base_python.write_text("", encoding="utf-8")
+    venv_python = tmp_path / "venv" / "bin" / "python3"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base_python)
+
+    monkeypatch.setattr(update_cmd.sys, "executable", str(base_python))
+    update_cmd._preserve_venv_shebang_in_launcher(
+        launcher_path=launcher,
+        venv_py=venv_python,
+    )
+
+    lines = launcher.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == f"#!{venv_python.absolute()}"
+    assert launcher.stat().st_mode & 0o7777 == 0o755
+    assert not list(tmp_path.glob(".hermes.tmp-*"))
+
+
+def test_shebang_rewrite_is_idempotent_and_preserves_mode(tmp_path, monkeypatch):
+    launcher = tmp_path / "hermes"
+    launcher.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    launcher.chmod(0o751)
+    venv_python = tmp_path / "venv" / "bin" / "python3"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(update_cmd.sys, "executable", str(venv_python))
+
+    update_cmd._preserve_venv_shebang_in_launcher(
+        launcher_path=launcher,
+        venv_py=venv_python,
+    )
+    first_content = launcher.read_text(encoding="utf-8")
+    first_mode = launcher.stat().st_mode & 0o7777
+
+    update_cmd._preserve_venv_shebang_in_launcher(
+        launcher_path=launcher,
+        venv_py=venv_python,
+    )
+
+    assert launcher.read_text(encoding="utf-8") == first_content
+    assert launcher.stat().st_mode & 0o7777 == first_mode == 0o751
+    assert not list(tmp_path.glob(".hermes.tmp-*"))


### PR DESCRIPTION
Summary

Fixes desktop launcher failures after hermes update by automatically preserving the venv-pointing shebang in the launcher script.

Problem

After hermes update:
- git pull overwrites the hermes launcher script with the repo version
- Repo version has #!/usr/bin/env python3 (for contributors without venv)
- User installs rewrite this to #!/path/to/venv/bin/python3
- Desktop launchers (XDG .desktop files, Windows shortcuts) fail with ModuleNotFoundError: No module named 'dotenv'
- /usr/bin/env python3 resolves to system Python instead of venv

Solution

- New _preserve_venv_shebang_in_launcher() function runs after git pull
- Detects when running from Hermes' own venv
- Rewrites launcher shebang to point at venv Python explicitly
- Best-effort: never raises, logs failures at debug level
- Runs immediately after bytecode cache clear, before dependency install

Testing

Tested on Linux Mint 22.3:
- ✅ Desktop launcher click → failed before, works after
- ✅ Terminal hermes command → works (unchanged)
- ✅ Update cycle → shebang preserved correctly
- ✅ System Python vs venv Python detection working

Implementation Details

- Only rewrites when sys.executable matches venv Python (respects user choice)
- Preserves existing behavior for contributors and non-venv setups
- No changes needed to installer or desktop entry logic

