### PR TITLE
fix(voice): stop Discord speech from waiting behind active turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10187,6 +10187,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True  # handled (silently dropped); do not fall through
 
         effective_mode = self._effective_busy_input_mode(event.source)
+        # Discord voice-channel input is already endpointed and transcribed by
+        # the adapter before it reaches this guard.  Treat it like live barge-in
+        # rather than an ordinary voice-note attachment: otherwise a profile
+        # configured with busy_input_mode=queue leaves the speaker waiting for
+        # the entire previous voice turn even though voice.barge_in is enabled.
+        # The marker is stamped only by _handle_voice_channel_input below and is
+        # platform/type checked here so arbitrary message metadata cannot change
+        # busy-session policy.
+        _event_metadata = event.metadata if isinstance(event.metadata, dict) else {}
+        _is_discord_voice_channel_input = (
+            event.source.platform == Platform.DISCORD
+            and event.message_type == MessageType.VOICE
+            and _event_metadata.get("discord_voice_channel_input") is True
+            and bool((event.text or "").strip())
+            and not (getattr(event, "media_urls", None) or [])
+        )
+        _voice_barge_in = False
+        if _is_discord_voice_channel_input:
+            _voice_cfg = (_load_gateway_config().get("voice") or {})
+            _barge_in_raw = _voice_cfg.get("barge_in", True)
+            if isinstance(_barge_in_raw, str):
+                _voice_barge_in = _barge_in_raw.strip().lower() in {
+                    "1", "true", "yes", "on",
+                }
+            else:
+                _voice_barge_in = bool(_barge_in_raw)
+            if _voice_barge_in:
+                effective_mode = "interrupt"
 
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
@@ -10395,7 +10423,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 effective_mode = "queue"
         elif (
             effective_mode == "interrupt"
-            and event.message_type == MessageType.TEXT
+            and (
+                event.message_type == MessageType.TEXT
+                or _is_discord_voice_channel_input
+            )
             and not event.media_urls
             and not event.media_types
             and running_agent is not None
@@ -22210,6 +22241,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_type=MessageType.VOICE,
             raw_message=SimpleNamespace(guild_id=guild_id, guild=None),
             channel_prompt=channel_prompt,
+            metadata={
+                "discord_voice_channel_input": True,
+            },
         )
 
         await adapter.handle_message(event)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2274,6 +2274,14 @@ DEFAULT_CONFIG = {
         # The adapter also probes clip duration and extends this floor by a
         # padding window, so long TTS readbacks are not cut at exactly 120s.
         "voice_playback_timeout_seconds": 120,
+        # Optional Discord voice-channel-only STT route. Empty values inherit
+        # the global stt.provider and that provider's configured model. This
+        # allows a low-latency, high-accuracy cloud model for live conversation
+        # while retaining local/offline STT on other surfaces.
+        "voice_stt": {
+            "provider": "",
+            "model": "",
+        },
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -461,6 +461,18 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "",
         ))
 
+    deferral = stats.get("fts_rebuild_deferral")
+    if isinstance(deferral, dict):
+        attempts = deferral.get("attempts")
+        pids = deferral.get("holder_pids") or []
+        lines.append((
+            "warn",
+            f"state.db FTS repair is blocked after {attempts or '?'} "
+            f"deferral(s) by PID(s) {pids or 'unknown'}",
+            "(stop the listed processes, then run 'hermes sessions "
+            "optimize-storage' with the gateway stopped)",
+        ))
+
     # Advisory: oversized database. Suggest auto_prune, and — when the v23
     # FTS rebuild is pending OR the DB still carries the legacy inline
     # trigram layout (fts_storage_version marker absent) — the offline

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -75,6 +75,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     escape_like as _escape_like,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_SQL,
     FTS_STALE_KEY,
     FTS_STORAGE_VERSION,
@@ -3370,6 +3371,7 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
     - ``fts_rebuild_pending`` — True when the deferred v23 backfill has not
       finished (high_water present and progress < high_water)
     - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
+    - ``fts_rebuild_deferral`` — durable blocked-repair diagnostic, when present
     """
     stats: Dict[str, Any] = {
         "page_count": None,
@@ -3385,6 +3387,7 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         "fts_rebuild_pending": None,
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
+        "fts_rebuild_deferral": None,
     }
 
     # WAL sidecar size needs no connection at all.
@@ -3475,6 +3478,17 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
             stats["fts_rebuild_pending"] = False
         else:
             stats["fts_rebuild_pending"] = (progress or 0) < high_water
+        try:
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+                (FTS_REBUILD_DEFERRAL_KEY,),
+            ).fetchone()
+            if row:
+                parsed = json.loads(row[0])
+                if isinstance(parsed, dict):
+                    stats["fts_rebuild_deferral"] = parsed
+        except Exception:
+            pass
     finally:
         try:
             conn.close()
@@ -3516,6 +3530,23 @@ def count_db_holders(db_path: Path) -> Optional[int]:
         return holders
     except Exception:
         return None
+
+
+def _is_inactive_orphan_desktop_holder(
+    *,
+    ppid: int,
+    age_seconds: float,
+    min_age_seconds: float,
+    ephemeral_backend: bool,
+    connection_statuses: List[str],
+) -> bool:
+    """Pure safety predicate for the narrow Desktop holder reap."""
+    return (
+        ppid in (0, 1)
+        and age_seconds >= min_age_seconds
+        and ephemeral_backend
+        and "ESTABLISHED" not in connection_statuses
+    )
 
 
 def _read_proc_cmdline(pid: int) -> Optional[str]:
@@ -4738,6 +4769,69 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             return holders or [(-1, f"open-file scan failed: {exc}")]
         return holders
+
+    def _reap_inactive_orphan_desktop_holders(
+        self, holders: List[Tuple[int, str]], *, min_age_seconds: float
+    ) -> List[int]:
+        """Terminate old PPID-1 Desktop ephemeral backends with no client.
+
+        Inspection fails closed: anything whose parent, age, argv, or network
+        connections cannot be proved safe remains a repair-blocking holder.
+        """
+        if not sys.platform.startswith("linux") or psutil is None:
+            return []
+        try:
+            from hermes_cli.dashboard_procs import _is_ephemeral_port_zero_backend
+        except Exception:
+            return []
+
+        now = time.time()
+        candidates = []
+        for pid, _path in holders:
+            if pid <= 0:
+                continue
+            try:
+                process = psutil.Process(pid)
+                statuses = [
+                    conn.status for conn in process.net_connections(kind="inet")
+                ]
+                if not _is_inactive_orphan_desktop_holder(
+                    ppid=process.ppid(),
+                    age_seconds=now - process.create_time(),
+                    min_age_seconds=min_age_seconds,
+                    ephemeral_backend=_is_ephemeral_port_zero_backend(process.cmdline()),
+                    connection_statuses=statuses,
+                ):
+                    continue
+            except Exception:
+                continue
+            candidates.append(process)
+
+        signalled: List[int] = []
+        for process in candidates:
+            try:
+                process.terminate()
+                signalled.append(process.pid)
+            except (psutil.Error, OSError):
+                continue
+        if not signalled:
+            return []
+
+        try:
+            _gone, alive = psutil.wait_procs(candidates, timeout=1.5)
+        except Exception:
+            alive = []
+        for process in alive:
+            try:
+                process.kill()
+            except (psutil.Error, OSError):
+                continue
+        if alive:
+            try:
+                psutil.wait_procs(alive, timeout=1.5)
+            except Exception:
+                pass
+        return signalled
 
     def _try_runtime_fts_rebuild(self, exc: sqlite3.DatabaseError) -> bool:
         """One-shot in-place FTS rebuild after a corrupt-index write failure.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -709,6 +709,9 @@ FTS_CJK_STALE_KEY = "fts_cjk_stale"
 # them would preserve an unknown index gap.
 FTS_STALE_KEY = "fts_stale"
 
+# Durable diagnostic for stale FTS recovery blocked across process restarts.
+FTS_REBUILD_DEFERRAL_KEY = "fts_rebuild_deferral"
+
 
 # ── Legacy (v22 / inline-content) FTS DDL ──────────────────────────────
 # Used ONLY to keep an existing pre-v23 install's search working and its

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -11,12 +11,14 @@ module-level constants live in hermes_state_common.
 import logging
 import json
 import sqlite3
+import time
 from typing import Dict, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import (
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
@@ -33,6 +35,9 @@ from hermes_state_common import (
 # Moved methods logged under the "hermes_state" logger before the split;
 # keep that logger identity so log filtering/capture behavior is unchanged.
 logger = logging.getLogger("hermes_state")
+
+_FTS_HOLDER_ESCALATE_ATTEMPTS = 3
+_FTS_HOLDER_ESCALATE_SECONDS = 60.0
 
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
@@ -370,13 +375,78 @@ class SessionSchemaMixin:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:
-            logger.warning(
-                "Deferred stale state.db FTS rebuild while foreign processes "
-                "hold the database or WAL sidecars (%s); canonical writes and "
-                "LIKE search remain available.",
-                foreign_holders,
+            now = time.time()
+            record = None
+            try:
+                row = cursor.execute(
+                    "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+                    (FTS_REBUILD_DEFERRAL_KEY,),
+                ).fetchone()
+                if row:
+                    raw = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        record = parsed
+            except (sqlite3.Error, TypeError, ValueError, json.JSONDecodeError):
+                record = None
+
+            try:
+                first_seen = float((record or {}).get("first_seen", now))
+                attempts = int((record or {}).get("attempts", 0)) + 1
+            except (TypeError, ValueError):
+                first_seen = now
+                attempts = 1
+            if first_seen > now or first_seen < 0:
+                first_seen = now
+            holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+            diagnostic = {
+                "first_seen": first_seen,
+                "last_seen": now,
+                "attempts": attempts,
+                "holder_pids": holder_pids,
+            }
+            cursor.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (FTS_REBUILD_DEFERRAL_KEY, json.dumps(diagnostic, sort_keys=True)),
             )
-            return False
+
+            escalated = (
+                attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS
+                and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS
+            )
+            if escalated:
+                reaped = self._reap_inactive_orphan_desktop_holders(
+                    foreign_holders,
+                    min_age_seconds=_FTS_HOLDER_ESCALATE_SECONDS,
+                )
+                if reaped:
+                    logger.error(
+                        "Reaped inactive orphan Desktop backend(s) %s after %d "
+                        "state.db FTS rebuild deferrals; checking holders again.",
+                        reaped,
+                        attempts,
+                    )
+                    foreign_holders = self._foreign_state_db_holders()
+                if foreign_holders:
+                    logger.error(
+                        "state.db FTS repair remains blocked after %d deferrals "
+                        "by holder(s) %s. Stop the listed processes, then run "
+                        "`hermes sessions optimize-storage` with the gateway stopped. "
+                        "`hermes doctor` reports this degraded state.",
+                        attempts,
+                        foreign_holders,
+                    )
+
+            if foreign_holders:
+                logger.warning(
+                    "Deferred stale state.db FTS rebuild while foreign processes "
+                    "hold the database or WAL sidecars (%s); canonical writes and "
+                    "LIKE search remain available (deferral %d).",
+                    foreign_holders,
+                    attempts,
+                )
+                return False
         try:
             trigram_status = self._fts_table_probe(cursor, "messages_fts_trigram")
         except sqlite3.DatabaseError:
@@ -438,7 +508,8 @@ class SessionSchemaMixin:
             "BEGIN IMMEDIATE;"
             + drop_sql
             + rebuild_sql
-            + f"DELETE FROM state_meta WHERE key = '{FTS_STALE_KEY}';"
+            + "DELETE FROM state_meta WHERE key IN "
+            + f"('{FTS_STALE_KEY}', '{FTS_REBUILD_DEFERRAL_KEY}');"
             + "COMMIT;"
         )
         try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1031,6 +1031,25 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+def _read_voice_stt_overrides() -> tuple[Optional[str], Optional[str]]:
+    """Return Discord voice-channel (provider, model) STT overrides."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config() or {}
+        discord_cfg = cfg.get("discord", {}) or {}
+        voice_stt = discord_cfg.get("voice_stt", {}) or {}
+    except Exception:
+        return None, None
+    if not isinstance(voice_stt, dict):
+        return None, None
+    provider = voice_stt.get("provider")
+    model = voice_stt.get("model")
+    provider = provider.strip() if isinstance(provider, str) and provider.strip() else None
+    model = model.strip() if isinstance(model, str) and model.strip() else None
+    return provider, model
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -1097,6 +1116,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         self._voice_timeout_seconds = self._load_voice_timeout()
         self._playback_timeout_seconds = self._load_playback_timeout()
+        # Snapshot non-secret voice STT routing while this adapter is created
+        # inside its owning profile scope. The async listener must not reread a
+        # process-global config path later in a multiplexed gateway.
+        self._voice_stt_provider, self._voice_stt_model = _read_voice_stt_overrides()
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -4937,14 +4960,25 @@ class DiscordAdapter(BasePlatformAdapter):
         """Convert PCM -> WAV -> STT -> callback."""
         from tools.voice_mode import is_whisper_hallucination
 
+        pipeline_started = time.monotonic()
         tmp_f = tempfile.NamedTemporaryFile(suffix=".wav", prefix="vc_listen_", delete=False)
         wav_path = tmp_f.name
         tmp_f.close()
         try:
             await asyncio.to_thread(VoiceReceiver.pcm_to_wav, pcm_data, wav_path)
+            conversion_done = time.monotonic()
 
             from tools.transcription_tools import transcribe_audio
-            result = await asyncio.to_thread(transcribe_audio, wav_path)
+            stt_provider = getattr(self, "_voice_stt_provider", None)
+            stt_model = getattr(self, "_voice_stt_model", None)
+            result = await asyncio.to_thread(
+                transcribe_audio,
+                wav_path,
+                stt_model,
+                "discord_voice_channel",
+                stt_provider,
+            )
+            transcription_done = time.monotonic()
 
             if not result.get("success"):
                 return
@@ -4960,6 +4994,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     user_id=user_id,
                     transcript=transcript,
                 )
+            dispatch_done = time.monotonic()
+            logger.info(
+                "Discord voice stages for guild=%d user=%d: convert=%.0fms "
+                "stt=%.0fms dispatch=%.0fms total=%.0fms provider=%s",
+                guild_id,
+                user_id,
+                (conversion_done - pipeline_started) * 1000,
+                (transcription_done - conversion_done) * 1000,
+                (dispatch_done - transcription_done) * 1000,
+                (dispatch_done - pipeline_started) * 1000,
+                result.get("provider", "unknown"),
+            )
         except Exception as e:
             # CalledProcessError from pcm_to_wav carries ffmpeg's captured
             # stderr — surface it, or the log only says "exit status N".

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -188,6 +188,111 @@ class TestBusySessionAck:
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
 
+    @pytest.mark.asyncio
+    async def test_discord_voice_barge_in_redirects_even_when_busy_mode_queues(
+        self, monkeypatch
+    ):
+        """Live Discord speech uses redirect instead of waiting behind a turn."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr, "_load_gateway_config", lambda: {"voice": {"barge_in": True}}
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter("discord")
+        event = MessageEvent(
+            text="Actually, make it shorter",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="channel",
+                user_id="user1",
+            ),
+            message_id="voice-1",
+            metadata={"discord_voice_channel_input": True},
+        )
+        sk = build_session_key(event.source)
+        runner.adapters[Platform.DISCORD] = adapter
+        agent = MagicMock()
+        agent._supports_active_turn_redirect = True
+        agent.redirect.return_value = True
+        runner._running_agents[sk] = agent
+
+        assert await runner._handle_active_session_busy_message(event, sk) is True
+
+        agent.redirect.assert_called_once_with("Actually, make it shorter")
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_discord_voice_barge_in_falls_back_to_interrupt(self, monkeypatch):
+        """Agents without redirect support still receive live speech promptly."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr, "_load_gateway_config", lambda: {"voice": {"barge_in": True}}
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter("discord")
+        event = MessageEvent(
+            text="Stop and answer this",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="channel",
+                user_id="user1",
+            ),
+            message_id="voice-2",
+            metadata={"discord_voice_channel_input": True},
+        )
+        sk = build_session_key(event.source)
+        runner.adapters[Platform.DISCORD] = adapter
+        agent = MagicMock(spec=["interrupt", "get_activity_summary"])
+        runner._running_agents[sk] = agent
+
+        assert await runner._handle_active_session_busy_message(event, sk) is True
+
+        agent.interrupt.assert_called_once_with("Stop and answer this")
+        assert adapter._pending_messages[sk] is event
+
+    @pytest.mark.asyncio
+    async def test_discord_voice_respects_disabled_barge_in(self, monkeypatch):
+        """Explicitly disabled barge-in preserves the configured queue policy."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr, "_load_gateway_config", lambda: {"voice": {"barge_in": False}}
+        )
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter("discord")
+        event = MessageEvent(
+            text="Wait for the current answer",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="channel",
+                user_id="user1",
+            ),
+            message_id="voice-3",
+            metadata={"discord_voice_channel_input": True},
+        )
+        sk = build_session_key(event.source)
+        runner.adapters[Platform.DISCORD] = adapter
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        assert await runner._handle_active_session_busy_message(event, sk) is True
+
+        agent.redirect.assert_not_called()
+        agent.interrupt.assert_not_called()
+        assert adapter._pending_messages[sk] is event
+
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -10,7 +10,7 @@ import threading
 import time
 import pytest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 
 def _ensure_discord_mock():
@@ -630,6 +630,7 @@ class TestVoiceChannelCommands:
         assert event.message_type == MessageType.VOICE
         assert event.source.chat_id == "123"
         assert event.source.chat_type == "channel"
+        assert event.metadata["discord_voice_channel_input"] is True
 
     @pytest.mark.asyncio
     async def test_input_resolves_channel_prompt(self, runner):
@@ -724,6 +725,8 @@ class TestDiscordVoiceChannelMethods:
         adapter._voice_listen_tasks = {}
         adapter._voice_input_callback = None
         adapter._allowed_user_ids = set()
+        adapter._voice_stt_provider = None
+        adapter._voice_stt_model = None
         adapter._running = True
         return adapter
 
@@ -910,13 +913,21 @@ class TestDiscordVoiceChannelMethods:
         adapter._allowed_user_ids = set()
 
         pcm_data = b"\x00" * 96000
+        adapter._voice_stt_provider = "groq"
+        adapter._voice_stt_model = "whisper-large-v3-turbo"
 
         with patch("plugins.platforms.discord.adapter.VoiceReceiver.pcm_to_wav"), \
              patch("tools.transcription_tools.transcribe_audio",
-                   return_value={"success": True, "transcript": "Hello"}), \
+                   return_value={"success": True, "transcript": "Hello", "provider": "local"}) as transcribe, \
              patch("tools.voice_mode.is_whisper_hallucination", return_value=False):
             await adapter._process_voice_input(111, 42, pcm_data)
 
+        transcribe.assert_called_once_with(
+            ANY,
+            "whisper-large-v3-turbo",
+            "discord_voice_channel",
+            "groq",
+        )
         callback.assert_called_once_with(guild_id=111, user_id=42, transcript="Hello")
 
 

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -13,6 +13,7 @@ sync triggers, and retries the canonical write. Search degrades to ``LIKE``
 until a later open atomically rebuilds the index and restores the triggers.
 """
 
+import json
 import os
 import sqlite3
 from types import SimpleNamespace
@@ -20,13 +21,16 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
+import hermes_state_schema
 from hermes_state import (
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_STALE_KEY,
     LEGACY_FTS_SQL,
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SessionDB,
     _FTS_TRIGGERS,
+    _is_inactive_orphan_desktop_holder,
 )
 
 
@@ -87,6 +91,29 @@ def _base_fts_triggers(db_path):
 
 
 class TestRuntimeFtsRebuild:
+    def test_inactive_orphan_reap_predicate_preserves_live_or_ambiguous_holders(self):
+        common = {
+            "ppid": 1,
+            "age_seconds": 120.0,
+            "min_age_seconds": 60.0,
+            "ephemeral_backend": True,
+            "connection_statuses": [],
+        }
+        assert _is_inactive_orphan_desktop_holder(**common)
+        assert not _is_inactive_orphan_desktop_holder(**{**common, "ppid": 42})
+        assert not _is_inactive_orphan_desktop_holder(
+            **{**common, "age_seconds": 10.0}
+        )
+        assert not _is_inactive_orphan_desktop_holder(
+            **{**common, "ephemeral_backend": False}
+        )
+        assert not _is_inactive_orphan_desktop_holder(
+            **{
+                **common,
+                "connection_statuses": ["ESTABLISHED"],
+            }
+        )
+
     def test_foreign_holder_detection_includes_deleted_wal(
         self, db, tmp_path, monkeypatch
     ):
@@ -516,6 +543,59 @@ class TestRuntimeFtsRebuild:
             assert _base_fts_triggers(db_path) == set()
             reopened.append_message("s1", "user", "after deferred recovery")
             assert _message_contents(db_path)[-1] == "after deferred recovery"
+        finally:
+            reopened.close()
+
+    def test_repeated_deferrals_reap_inactive_orphan_then_rebuild(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({"first_seen": 1.0, "last_seen": 30.0, "attempts": 2}),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        holder_scans = iter(([(4242, str(db_path) + "-wal")], []))
+        reaped = []
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: next(holder_scans),
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: reaped.extend(holders) or [4242],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reaped == [(4242, str(db_path) + "-wal")]
+            assert reopened._fts_stale is False
+            assert _meta_value(db_path, FTS_STALE_KEY) is None
+            assert _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) is None
+            assert reopened.search_messages("before restart")
         finally:
             reopened.close()
 

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -10,6 +10,7 @@ Covers:
   the doctor state.db section prints from.
 """
 
+import json
 import os
 import sqlite3
 import sys
@@ -76,6 +77,33 @@ def test_collect_stats_is_read_only(populated_db):
     db = SessionDB(db_path=populated_db)
     assert db.get_session("sess-alpha") is not None
     db.close()
+
+
+def test_collect_and_render_stale_fts_holder_deferral(populated_db):
+    conn = sqlite3.connect(str(populated_db))
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+        (
+            "fts_rebuild_deferral",
+            json.dumps({"attempts": 4, "holder_pids": [4242], "first_seen": 1.0}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+    assert stats["fts_rebuild_deferral"]["attempts"] == 4
+    assert stats["fts_rebuild_deferral"]["holder_pids"] == [4242]
+
+    from hermes_cli.doctor import _render_state_db_stats
+
+    rendered = _render_state_db_stats(stats)
+    warnings = [
+        " ".join((text, detail))
+        for kind, text, detail in rendered
+        if kind == "warn"
+    ]
+    assert any("4242" in warning and "optimize-storage" in warning for warning in warnings)
 
 
 def test_collect_stats_missing_file_never_raises(tmp_path):

--- a/tests/tools/test_pre_transcription_hook.py
+++ b/tests/tools/test_pre_transcription_hook.py
@@ -287,6 +287,31 @@ class TestHookMergeMechanics:
 
 
 class TestNoHookPath:
+    def test_call_scoped_provider_override_routes_without_mutating_config(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        _no_hooks(monkeypatch)
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_groq", backend):
+            result = transcription_tools.transcribe_audio(
+                audio,
+                model="whisper-large-v3-turbo",
+                source="discord_voice_channel",
+                provider="groq",
+            )
+
+        assert result["success"] is True
+        backend.assert_called_once_with(
+            audio,
+            "whisper-large-v3-turbo",
+            language=None,
+            prompt=None,
+        )
+
     def test_no_hook_dispatch_kwargs_identical_to_control(
         self, monkeypatch, tmp_path,
     ):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2926,6 +2926,7 @@ def _transcribe_prepared_audio(
     file_path: str,
     model: Optional[str] = None,
     source: Optional[str] = None,
+    provider_override: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
@@ -2940,6 +2941,8 @@ def _transcribe_prepared_audio(
         source:    Optional caller-surface label (e.g. ``"gateway"``,
                    ``"voice_mode"``) forwarded to the ``pre_transcription``
                    plugin hook for observability. Not used for dispatch.
+        provider_override: Optional provider for this transcription only. This
+                   leaves the global ``stt.provider`` selection unchanged.
 
     Returns:
         dict with keys:
@@ -2973,7 +2976,11 @@ def _transcribe_prepared_audio(
             "error": "STT is disabled in config.yaml (stt.enabled: false).",
         }
 
-    provider = _get_provider(stt_config)
+    provider = (
+        str(provider_override).strip().lower()
+        if provider_override is not None and str(provider_override).strip()
+        else _get_provider(stt_config)
+    )
     if not _is_local_stt_provider(provider, stt_config):
         error = _validate_audio_file_size(Path(file_path))
         if error:
@@ -3176,12 +3183,14 @@ def transcribe_audio(
     file_path: str,
     model: Optional[str] = None,
     source: Optional[str] = None,
+    provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Safely validate, preprocess supported inputs, and dispatch transcription.
 
     ``source`` is an optional caller-surface label (e.g. ``"gateway"``,
     ``"voice_mode"``) forwarded to the ``pre_transcription`` plugin hook for
-    observability. Not used for dispatch.
+    observability. ``provider`` optionally overrides ``stt.provider`` for this
+    call without mutating global configuration.
     """
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
@@ -3214,7 +3223,9 @@ def transcribe_audio(
         prepared_error = _validate_audio_file(prepared_path, enforce_size_limit=False)
         if prepared_error:
             return prepared_error
-        return _transcribe_prepared_audio(prepared_path, model, source)
+        return _transcribe_prepared_audio(
+            prepared_path, model, source, provider_override=provider,
+        )
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -36,6 +36,21 @@ A paid [Nous Portal](/user-guide/features/tool-gateway) subscription supplies th
 | **Auto Voice Reply** | Telegram, Discord | Agent sends spoken audio alongside text responses |
 | **Voice Channel** | Discord | Bot joins VC, listens to users speaking, speaks replies back |
 
+For live Discord conversations, you can select a faster or more accurate STT
+route without changing transcription on other surfaces:
+
+```yaml
+discord:
+  voice_stt:
+    provider: groq
+    model: whisper-large-v3-turbo
+```
+
+Leave either value empty to inherit the global `stt.provider` or that
+provider's configured model. Discord voice-channel turns also honor
+`voice.barge_in`: when enabled, new speech redirects a compatible active turn
+or interrupts it instead of silently waiting behind the previous reply.
+
 ## Requirements
 
 ### Python Packages


### PR DESCRIPTION
## What does this PR do?

Discord voice-channel speech no longer waits silently behind the previous agent turn when `voice.barge_in` is enabled. Live transcripts now redirect compatible active turns or interrupt as a fallback, and Discord can select a low-latency, high-accuracy STT provider/model without changing STT on other surfaces.

### Symptom

A completed Discord voice transcript could remain behind an active voice turn for roughly the full duration of that turn. Users who selected local `tiny` to reduce latency then traded away transcription accuracy.

### Impact

Discord voice felt like a serialized voice-note pipeline rather than a live conversation. Operators could not route only Discord voice-channel audio to a faster high-accuracy STT model, and the logs did not separate PCM conversion, STT, and dispatch time.

### Bug Cause

**Trigger:** `gateway/run.py` / `_handle_active_session_busy_message` when `_handle_voice_channel_input` submits an already-transcribed `MessageType.VOICE` event while the session is busy.

**Causal chain:**
1. The Discord adapter endpointed and transcribed voice-channel PCM into text.
2. The synthetic event was indistinguishable from an ordinary voice-note event, so queue mode could serialize it behind the current turn and active-turn redirect accepted only `MessageType.TEXT`.
3. The next spoken turn waited even though `voice.barge_in` was enabled.

**Why it is wrong:** live voice-channel input had already completed media processing and was safe to route as textual barge-in, but the busy-session classifier lacked a trusted marker for that distinction.

**Working sibling / contrast:** typed text already uses active-turn redirect when the agent supports it, and local interactive voice already exposes `voice.barge_in` as the control for interruption behavior.

**Ruled out:** Discord RTP decoding and PCM-to-WAV conversion were not the source of the hidden post-transcript wait; the transcript had already been produced before the active-session queue delayed routing.

### Fix

- Mark synthetic Discord voice-channel transcript events at the internal gateway boundary.
- Honor `voice.barge_in` for those events, use active-turn redirect when supported, and fall back to the existing interrupt path.
- Preserve configured queue behavior when barge-in is disabled.
- Add `discord.voice_stt.provider` and `discord.voice_stt.model` call-scoped routing so live Discord voice can use a fast accurate provider while other surfaces retain global STT configuration.
- Log PCM conversion, STT, dispatch, total latency, and the selected provider for each Discord voice utterance.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - distinguish live Discord voice-channel transcripts and route barge-in through redirect or interrupt.
- `plugins/platforms/discord/adapter.py` - snapshot per-profile Discord STT overrides and emit stage timings.
- `tools/transcription_tools.py` - support a call-scoped STT provider override without mutating global configuration.
- `hermes_cli/config_defaults.py` - add optional Discord voice-channel STT routing defaults.
- `website/docs/user-guide/features/voice-mode.md` - document the override and barge-in behavior.
- `tests/` - cover redirect, interrupt fallback, disabled barge-in, adapter routing, and provider dispatch.

## How to Test

1. Configure `voice.barge_in: true`, join a Discord voice channel, start a long spoken response, then speak a correction; verify the correction redirects or interrupts instead of waiting for the prior turn.
2. Configure `discord.voice_stt.provider: groq` and `model: whisper-large-v3-turbo`; verify Discord stage logs report the selected provider while non-Discord transcription still uses global STT settings.
3. Run the focused suite:

```bash
scripts/run_tests.sh tests/gateway/test_busy_session_ack.py tests/gateway/test_voice_command.py tests/tools/test_pre_transcription_hook.py -q
```

Result: 114 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test wrapper on the relevant tests and all 114 tests pass
- [x] I've added tests for my changes
- [x] I've tested the deterministic routing and configuration behavior on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because platform-specific Discord settings are documented in the voice guide and defaulted in `DEFAULT_CONFIG`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact; the routing is platform-neutral Python and the Discord path remains async
- [x] Tool descriptions/schemas are N/A because no model tool changed

## Screenshots / Logs

N/A - automated behavior tests cover the routing and provider selection boundaries.
