### PR TITLE
fix(background-review): clarify user memory routing

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -446,8 +446,11 @@ _MEMORY_REVIEW_PROMPT = (
     "preferences, or personal details worth remembering?\n"
     "2. Has the user expressed expectations about how you should behave, their work "
     "style, or ways they want you to operate?\n\n"
-    "If something stands out, save it using the memory tool. "
-    "If nothing is worth saving, just say 'Nothing to save.' and stop."
+    "If something stands out, save it using the memory tool with "
+    "target='user' (USER.md), not target='memory' (MEMORY.md). "
+    "Use target='memory' only for durable facts about the operating "
+    "environment, tools, or project configuration. If nothing is worth "
+    "saving, just say 'Nothing to save.' and stop."
 )
 
 _SKILL_REVIEW_PROMPT = (


### PR DESCRIPTION
## What does this PR do?

Clarifies `_MEMORY_REVIEW_PROMPT` so facts about the user — persona,
preferences, personal details, work style, and expectations — are saved
to `USER.md` via `target="user"`.

It also clarifies that `target="memory"` / `MEMORY.md` is for durable
facts about the operating environment, tools, or project configuration.

## Related Issue

No existing issue referenced.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `agent/background_review.py`
- Added explicit `target="user"` guidance for user-profile learnings
- Documented the intended limited use of `target="memory"`

## How to Test

1. Run `python -m py_compile agent\background_review.py`
2. Enable or trigger a memory-only background review after a user expresses a durable preference.
3. Verify that the review uses `target="user"` for the preference rather than the default `target="memory"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (prompt-only clarification; no test added)
- [x] I've tested on my platform: Windows 11; `python -m py_compile agent\background_review.py`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A