### PR TITLE
fix(sandbox): point NODE_EXTRA_CA_CERTS at the sandbox CA so npm works behind the MITM

### DIFF
--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,20 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# CA trust inside the sandbox is asymmetric across runtimes, by design of
+# their stores:
+#   * curl / Python / git honor the env vars below pointing at ca.pem -- the
+#     sandbox CA whose private key proxy.py uses to mint per-host leaf certs.
+#   * Node.js ignores SSL_CERT_FILE/CURL_CA_BUNDLE entirely (unless built or
+#     run with --use-openssl-ca): it carries a bundled Mozilla store and only
+#     ADDS NODE_EXTRA_CA_CERTS to it. So Node must be handed ca.pem itself --
+#     every proxied TLS connection terminates in one of those minted certs.
+#     Pointing this at real-ca.pem (the public roots) instead made npm reject
+#     every handshake with an SSLEOFError storm in proxy.log, which the
+#     installer treats as fatal since #85297 -- the install-update E2E's
+#     `installer` legs failed on exactly that. A Node process that bypasses
+#     the proxy with a raw socket still trusts its bundled store, so real
+#     upstream CAs are not lost by this.
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -216,7 +230,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \


### PR DESCRIPTION
## What does this PR do?

Inside the dev sandbox every TLS connection is terminated by `scripts/sandbox/proxy.py`, which mints per-host leaf certs from the sandbox's own CA (`ca.pem`). curl, Python and git honor `CURL_CA_BUNDLE`/`SSL_CERT_FILE`/`GIT_SSL_CAINFO` pointing at that CA — but Node.js ignores those variables and only *adds* `NODE_EXTRA_CA_CERTS` to its bundled Mozilla store. Stage 2 pointed that variable at `real-ca.pem` (the public roots), so npm rejected every intercepted handshake. The result is an `SSLEOFError` storm in the sandbox `proxy.log`, and since #85297 made `npm install` failure fatal in `install.sh`, every `installer` leg of the Install & Update E2E fails while every `update` leg passes (that route never runs npm).

The fix points `NODE_EXTRA_CA_CERTS` at `ca.pem`. This mirrors what the docker/iron-proxy egress path already does (`tools/environments/docker.py` sets both `NODE_EXTRA_CA_CERTS` and `--use-openssl-ca`; see the "Node.js asymmetric CA caveat" docs). A Node process that bypasses the proxy with a raw socket still trusts its bundled store, so nothing loses real upstream trust.

## Related Issue

No existing issue or PR found (searched issues and PRs for `NODE_EXTRA_CA_CERTS`, sandbox/npm/SSLEOFError).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/sandbox/stage2-run.sh`: `--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem` → `/work/certs/ca.pem`, plus a comment explaining the runtime asymmetry so it doesn't get "fixed" back.

## How to Test

1. Dispatch **Install & Update E2E** with route `installer` on a repo without this change: each `installer (v…)` leg fails in ~8 min at "Run install + update E2E"; the uploaded installer logs show hundreds of `proxy request failed: SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] …')` lines followed by `✗ npm install failed or timed out`. Example: [run #76 job](https://github.com/NousResearch/hermes-agent/actions/runs/32768468051), [fork run #17](https://github.com/Isakzvegelj/hermes-agent/actions/runs/32770151870/job/97568486960).
2. With this change, the same legs complete: npm resolves through the MITM, `Installation Complete!` reports, HEAD lands on fake main, and `hermes runs after installer re-run`.
3. The scheduled twice-daily workflow on [my fork](https://github.com/Isakzvegelj/hermes-agent/actions/workflows/install-e2e.yml) validates all matrix legs against this commit (`8fef526e`) on the next run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: shell-only change to sandbox asset wiring; there is no unit harness for `stage2-run.sh`. Validation path is the E2E workflow itself (step 2 above); happy to add a string-level regression test if preferred.
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — offered above
- [x] I've tested on my platform: Ubuntu 24.04 (GitHub runner image where the failures reproduce)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (rationale captured as a code comment beside the setting)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (dev-sandbox is Linux-only)
