### PR TITLE
fix(gateway): track fire-and-forget adapter tasks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4187,12 +4187,19 @@ class BasePlatformAdapter(ABC):
 
         coro = _run_delete()
         try:
-            asyncio.create_task(coro)
+            task = asyncio.create_task(coro)
         except RuntimeError:
             # No running loop (e.g. unit tests that never reach the async
             # path).  Close the coroutine cleanly so Python doesn't warn
             # about it never being awaited, then drop silently.
             coro.close()
+            return
+        # Retain a reference: the event loop keeps only WEAK references to
+        # tasks, so an unreferenced sleeping delete can be garbage-collected
+        # mid-wait and the ephemeral message silently never deleted.
+        self._background_tasks.add(task)
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
 
     # ── Shared interactive-prompt formatting cores ─────────────────────────
     # Template attrs for ``_format_exec_approval``. Adapters override these to

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1070,6 +1070,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         # Fire-and-forget read receipt
         if self.send_read_receipts and session_chat_id:
-            asyncio.create_task(self.mark_read(session_chat_id))
+            receipt_task = asyncio.create_task(self.mark_read(session_chat_id))
+            self._background_tasks.add(receipt_task)
+            if hasattr(receipt_task, "add_done_callback"):
+                receipt_task.add_done_callback(self._background_tasks.discard)
 
         return web.Response(text="ok")

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -883,7 +883,13 @@ class QQAdapter(BasePlatformAdapter):
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
             }:
-                asyncio.create_task(self._on_message(t, d))
+                # Track the task: the loop holds only weak refs, so an
+                # unreferenced inbound-message task can be reaped by GC
+                # before it runs and the message silently lost.
+                msg_task = asyncio.create_task(self._on_message(t, d))
+                self._background_tasks.add(msg_task)
+                if hasattr(msg_task, "add_done_callback"):
+                    msg_task.add_done_callback(self._background_tasks.discard)
             elif t == "INTERACTION_CREATE":
                 self._create_task(self._on_interaction(d))
             else:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1418,7 +1418,12 @@ class WeixinAdapter(BasePlatformAdapter):
                     _save_sync_buf(self._hermes_home, self._account_id, sync_buf)
 
                 for message in response.get("msgs") or []:
-                    asyncio.create_task(self._process_message_safe(message))
+                    # Track: unreferenced inbound tasks can be GC-reaped
+                    # before running, silently dropping the message.
+                    msg_task = asyncio.create_task(self._process_message_safe(message))
+                    self._background_tasks.add(msg_task)
+                    if hasattr(msg_task, "add_done_callback"):
+                        msg_task.add_done_callback(self._background_tasks.discard)
             except asyncio.CancelledError:
                 break
             except Exception as exc:
@@ -1499,7 +1504,12 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
             self._token_store.set(self._account_id, sender_id, context_token)
-        asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
+        ticket_task = asyncio.create_task(
+            self._maybe_fetch_typing_ticket(sender_id, context_token or None)
+        )
+        self._background_tasks.add(ticket_task)
+        if hasattr(ticket_task, "add_done_callback"):
+            ticket_task.add_done_callback(self._background_tasks.discard)
 
         media_paths: List[str] = []
         media_types: List[str] = []

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3124,6 +3124,9 @@ class ConnectionManager:
         self._consecutive_hb_timeouts: int = 0
         self._reconnect_attempts: int = 0
         self._reconnecting: bool = False
+        # Strong ref so the GC cannot reap the sleeping reconnect task
+        # (the event loop holds only weak references to tasks).
+        self._reconnect_task: Optional[asyncio.Task] = None
         # Debounce buffer for aggregating multi-part inbound messages
         self._inbound_buffer: Dict[str, list] = {}  # key -> [raw_data_frames, ...]
         self._inbound_timers: Dict[str, asyncio.TimerHandle] = {}  # key -> timer
@@ -3662,7 +3665,10 @@ class ConnectionManager:
     def schedule_reconnect(self) -> None:
         """Schedule a reconnect only if running and not already reconnecting."""
         if self._adapter._running and not self._reconnecting:
-            asyncio.create_task(self._reconnect_with_backoff())
+            # Retain the reference: the loop keeps only weak refs to tasks,
+            # so an unreferenced backoff-sleeping reconnect can be GC-reaped
+            # and the adapter silently never reconnects.
+            self._reconnect_task = asyncio.create_task(self._reconnect_with_backoff())
 
     async def _reconnect_with_backoff(self) -> bool:
         """Reconnect with exponential backoff (1s, 2s, 4s, … up to 60s)."""

--- a/tests/gateway/platforms/test_fire_and_forget_tracking.py
+++ b/tests/gateway/platforms/test_fire_and_forget_tracking.py
@@ -1,0 +1,79 @@
+"""Fire-and-forget tasks must be tracked: the event loop keeps only weak
+references to tasks, so an unreferenced sleeping task can be garbage-collected
+mid-wait. Before the fix, _schedule_ephemeral_delete (and the platform
+adapters' inline create_task calls) could be silently reaped, so ephemeral
+messages were never deleted, inbound WeChat/QQ messages lost, and Yuanbao's
+reconnect never fired.
+"""
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class _MinimalAdapter(BasePlatformAdapter):
+    """Concrete stand-in satisfying the abstract surface."""
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+    async def send(self, chat_id, text, **kwargs):  # noqa: ANN001, ANN003
+        pass
+
+
+def _bare_adapter() -> BasePlatformAdapter:
+    adapter = object.__new__(_MinimalAdapter)
+    adapter._background_tasks = set()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_schedule_ephemeral_delete_tracks_task():
+    adapter = _bare_adapter()
+    deleted = []
+
+    async def fake_delete(chat_id, message_id):
+        deleted.append((chat_id, message_id))
+
+    object.__setattr__(adapter, "delete_message", fake_delete)
+
+    adapter._schedule_ephemeral_delete("chat-1", "msg-9", ttl_seconds=1)
+    assert len(adapter._background_tasks) == 1, (
+        "task must be retained while pending — an unreferenced sleeping task "
+        "can be GC-reaped and the delete silently dropped"
+    )
+    await asyncio.sleep(1.15)
+    assert deleted == [("chat-1", "msg-9")]
+    assert len(adapter._background_tasks) == 0, "done callback must discard"
+
+
+@pytest.mark.asyncio
+async def test_schedule_ephemeral_delete_survives_intermediate_gc_pressure():
+    """Even with GC churn between scheduling and firing, the strong ref in
+    _background_tasks keeps the pending delete alive."""
+    adapter = _bare_adapter()
+    deleted = []
+
+    async def fake_delete(chat_id, message_id):
+        deleted.append(message_id)
+
+    object.__setattr__(adapter, "delete_message", fake_delete)
+    adapter._schedule_ephemeral_delete("c", "m", ttl_seconds=1)
+
+    for _ in range(3):
+        garbage = [{"blob": b"x" * 4096} for _ in range(2000)]
+        await asyncio.sleep(0)
+        del garbage
+        import gc
+        gc.collect()
+
+    assert len(adapter._background_tasks) == 1
+    await asyncio.sleep(1.05)
+    assert deleted == ["m"]


### PR DESCRIPTION
## Problem

`asyncio.create_task()` results that are not referenced anywhere can be **garbage-collected before they run** — the event loop keeps only weak references to tasks (documented in the `create_task` docs: "Save a reference to the result..."). Six adapter sites scheduled exactly such unreferenced tasks, each with a concrete silent failure:

| Site | Dropped task → user-visible failure |
|---|---|
| `base.py` `_schedule_ephemeral_delete` | sleeping TTL delete reaped → ephemeral message **never deleted** |
| `qqbot/adapter.py` GUILD/C2C/GROUP/DIRECT `MESSAGE_CREATE` | `_on_message` reaped → **inbound message lost** |
| `weixin.py` poll loop | `_process_message_safe` reaped → **inbound message lost** |
| `weixin.py` typing-ticket prefetch | stale `context_token` behavior |
| `bluebubbles.py` read receipt | receipt never sent |
| `yuanbao.py` `ConnectionManager.schedule_reconnect` | backoff-sleeping reconnect reaped → **adapter silently dead until restart** |

The codebase already knows this pattern — the same files track sibling tasks via `self._background_tasks` + done-callback discard (e.g. bluebubbles tracks `handle_message` three lines above its untracked `mark_read`). These six sites just predate or missed the convention.

## Fix

Each site now retains a strong reference using its file's existing mechanism: `_background_tasks.add(task)` + `task.add_done_callback(self._background_tasks.discard)` for adapters; a new `ConnectionManager._reconnect_task` attribute for yuanbao. Behavior otherwise unchanged.

## Verification

New `tests/gateway/platforms/test_fire_and_forget_tracking.py` (bare-adapter pattern per repo convention):
- scheduled delete is retained in `_background_tasks` while pending, fires, and is discarded by the done-callback
- strong ref survives deliberate GC churn between scheduling and firing

Suites green: platform tests 8/8, qqbot/weixin/bluebubbles 114/114.