### PR TITLE
fix(core): retain fire-and-forget tasks in run/browser/lsp paths

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -212,6 +212,10 @@ class LSPClient:
         # Request/response correlation
         self._next_id: int = 0
         self._pending: Dict[int, asyncio.Future] = {}
+        # Strong refs to fire-and-forget dispatch tasks: the loop keeps only
+        # weak references to tasks, so an unreferenced dispatcher can be
+        # GC-reaped and the server's request never answered.
+        self._spawned_tasks: set = set()
 
         # Server-side request handlers (server → client requests).
         # Kept small and explicit; everything else returns method-not-found.
@@ -376,7 +380,10 @@ class LSPClient:
                 if kind == "response":
                     self._dispatch_response(key, msg)
                 elif kind == "request":
-                    asyncio.create_task(self._dispatch_request(key, msg))
+                    dispatch_task = asyncio.create_task(self._dispatch_request(key, msg))
+                    self._spawned_tasks.add(dispatch_task)
+                    if hasattr(dispatch_task, "add_done_callback"):
+                        dispatch_task.add_done_callback(self._spawned_tasks.discard)
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
                 else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20647,7 +20647,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watchers = process_registry.pending_watchers
                 process_registry.pending_watchers = []
                 for i, watcher in enumerate(watchers):
-                    asyncio.create_task(self._run_process_watcher(watcher))
+                    # Retain a strong ref: the loop holds only weak refs to
+                    # tasks, so an unreferenced watcher can be GC-reaped and
+                    # its notify_on_complete completion silently lost.
+                    _watcher_task = asyncio.create_task(self._run_process_watcher(watcher))
+                    if not hasattr(self, "_background_tasks"):
+                        self._background_tasks = set()
+                    self._background_tasks.add(_watcher_task)
+                    if hasattr(_watcher_task, "add_done_callback"):
+                        _watcher_task.add_done_callback(self._background_tasks.discard)
                     if i % 100 == 99:
                         await asyncio.sleep(0)
             except Exception as e:
@@ -31018,7 +31026,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
             except Exception as _e:
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
-        asyncio.create_task(runner.stop())
+        # Retain the task: an unreferenced stop() can be GC-reaped before it
+        # finishes, leaving the gateway half-shutdown with no recovery.
+        _stop_task = asyncio.create_task(runner.stop())
+        if not hasattr(runner, "_background_tasks"):
+            runner._background_tasks = set()
+        runner._background_tasks.add(_stop_task)
+        if hasattr(_stop_task, "add_done_callback"):
+            _stop_task.add_done_callback(runner._background_tasks.discard)
 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -328,6 +328,9 @@ class CDPSupervisor:
         self._frames: Dict[str, FrameInfo] = {}
         self._console_events: List[ConsoleEvent] = []
         self._active = False
+        # Strong refs to fire-and-forget tasks: the event loop keeps only
+        # weak references, so unreferenced tasks can be GC-reaped mid-wait.
+        self._spawned_tasks: set = set()
 
         # Supervisor loop machinery — populated in start().
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -923,17 +926,23 @@ class CDPSupervisor:
             # re-archive it as "remote".
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            dismiss_task = asyncio.create_task(
                 self._auto_handle_dialog(dialog, accept=False, prompt_text="")
             )
+            self._spawned_tasks.add(dismiss_task)
+            if hasattr(dismiss_task, "add_done_callback"):
+                dismiss_task.add_done_callback(self._spawned_tasks.discard)
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            accept_task = asyncio.create_task(
                 self._auto_handle_dialog(
                     dialog, accept=True, prompt_text=dialog.default_prompt
                 )
             )
+            self._spawned_tasks.add(accept_task)
+            if hasattr(accept_task, "add_done_callback"):
+                accept_task.add_done_callback(self._spawned_tasks.discard)
         else:
             # must_respond → add to pending and arm watchdog.
             with self._state_lock:
@@ -1143,17 +1152,23 @@ class CDPSupervisor:
         if self.dialog_policy == DIALOG_POLICY_AUTO_DISMISS:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            dismiss_task = asyncio.create_task(
                 self._fulfill_bridge_request(dialog, accept=False, prompt_text="")
             )
+            self._spawned_tasks.add(dismiss_task)
+            if hasattr(dismiss_task, "add_done_callback"):
+                dismiss_task.add_done_callback(self._spawned_tasks.discard)
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            accept_task = asyncio.create_task(
                 self._fulfill_bridge_request(
                     dialog, accept=True, prompt_text=default_prompt
                 )
             )
+            self._spawned_tasks.add(accept_task)
+            if hasattr(accept_task, "add_done_callback"):
+                accept_task.add_done_callback(self._spawned_tasks.discard)
         else:
             # must_respond — add to pending + arm watchdog.
             with self._state_lock:
@@ -1297,7 +1312,10 @@ class CDPSupervisor:
         # Enable domains on the child off-loop so the reader keeps pumping.
         # Awaiting the CDP replies here would deadlock because only the
         # reader can resolve those replies' Futures.
-        asyncio.create_task(self._enable_child_domains(sid))
+        enable_task = asyncio.create_task(self._enable_child_domains(sid))
+        self._spawned_tasks.add(enable_task)
+        if hasattr(enable_task, "add_done_callback"):
+            enable_task.add_done_callback(self._spawned_tasks.discard)
 
     async def _enable_child_domains(self, sid: str) -> None:
         """Enable Page+Runtime (+nested setAutoAttach) on a child CDP session.


### PR DESCRIPTION
## Problem

Same weak-reference hazard as #94487 (platform adapters), in core/tooling paths: unreferenced `asyncio.create_task()` results can be garbage-collected before completion because the event loop holds only weak references to tasks.

| Site | Dropped task → failure |
|---|---|
| `gateway/run.py` pending process-watchers drain | reaped watcher → its `notify_on_complete` completion is silently lost |
| `gateway/run.py` shutdown path `runner.stop()` | reaped stop → gateway left half-shutdown with no recovery |
| `browser_supervisor.py` auto-dismiss / auto-accept dialog handlers | dialogs pile up unhandled |
| `browser_supervisor.py` `_enable_child_domains` | child CDP session futures never resolve → hang paths |
| `agent/lsp/client.py` server→client request dispatcher | request never answered; caller's future hangs until timeout |

## Fix

Each site retains a strong reference with done-callback discard:

- `run.py` sites mirror run.py's own established lazy-`hasattr(self, "_background_tasks")` idiom (:25836-25840)
- `BrowserSupervisor` gains a `_spawned_tasks` set (initialized in `__init__`) used by all four spawn points
- `LspClient` gains `_spawned_tasks` alongside `_pending`

## Verification

- `ast.parse` on all three modified modules
- `tests/agent/lsp`: 65 passed; the 2 failures are environmental and pre-exist with the change stashed (npm-install network test + POSIX tilde expansion on Windows)
- `tests/tools/test_browser_supervisor.py`: collects cleanly (7 windows-gated tests deselected on this host, unchanged)