### PR TITLE
fix(desktop): roster naming — display_name in @mentions, local label edit, autocomplete cold-cache warm

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -544,6 +544,24 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(roster.length, 4)
 })
 
+test('roster: display names ride the row; absent when the backend reports none', () => {
+  const local = { id: 'local', kind: 'local' as const, label: 'This device' }
+  const homelab = { id: 'homelab', kind: 'remote' as const, label: 'Homelab', url: 'http://h:1' }
+
+  const roster = buildAgentRoster([
+    { connection: local, profiles: ['default'], displayNames: { default: 'Scout' } },
+    { connection: homelab, profiles: ['default'] }
+  ])
+
+  const byId = new Map(roster.map(a => [a.connectionId, a]))
+
+  assert.equal(byId.get('local')?.displayName, 'Scout')
+  assert.equal(byId.get('homelab')?.displayName, undefined)
+  // Disambiguation still keys off the profile name, not the display name.
+  assert.equal(byId.get('local')?.handle, 'default-this-device')
+  assert.equal(byId.get('homelab')?.handle, 'default-homelab')
+})
+
 test('rememberSshEnumeration: live list wins, cache then seed default', () => {
   assert.deepEqual(rememberSshEnumeration({ profiles: ['bob', 'kai'] }, ['stale'], 'ssh'), {
     profiles: ['bob', 'kai']

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -415,7 +415,7 @@ export interface ConnectionAgents {
   profiles: null | string[]
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
-  /** Profile display names (`hermes profile rename`), keyed by profile name. */
+  /** Profile display names (`hermes profile rename`), keyed by trimmed profile name. */
   displayNames?: Record<string, string>
   /** Stable backend identity from the connection's /api/status (`install_id`).
    * Two connections reporting the same id are the SAME physical install

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -415,6 +415,8 @@ export interface ConnectionAgents {
   profiles: null | string[]
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
+  /** Profile display names (`hermes profile rename`), keyed by profile name. */
+  displayNames?: Record<string, string>
   /** Stable backend identity from the connection's /api/status (`install_id`).
    * Two connections reporting the same id are the SAME physical install
    * registered under two addresses (hostname + Tailscale IP), so the roster
@@ -433,6 +435,8 @@ export interface RosterAgent {
   /** Bare profile name, or `<profile>-<label-slug>` when the profile name
    * exists on more than one registered source (the @name-device rule). */
   handle: string
+  /** Profile display name (`hermes profile rename`), when the backend reports one. */
+  displayName?: string
 }
 
 /**
@@ -534,13 +538,14 @@ export function buildAgentRoster(
 
   let order = 0
 
-  for (const { connection, installId, profiles } of enumerations) {
+  for (const { connection, displayNames, installId, profiles } of enumerations) {
     for (const profile of profiles || []) {
       const name = String(profile || '').trim() || 'default'
       const key = `${connection.id}\0${name}`
 
       if (!identities.has(key)) {
-        identities.set(key, { connection, installId, order, profile: name })
+        const displayName = String(displayNames?.[name] || '').trim()
+        identities.set(key, { connection, installId, order, profile: name, ...(displayName ? { displayName } : {}) })
       }
     }
 
@@ -551,16 +556,19 @@ export function buildAgentRoster(
   // are the SAME physical install registered under two addresses, so their
   // (install, profile) rows are one bot, not two. Connections without an id
   // (older backends, undialed ssh) keep a per-connection key — no collapse.
-  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
+  const backends = new Map<
+    string,
+    { connection: RegistryConnection; displayName?: string; order: number; profile: string }[]
+  >()
 
-  for (const { connection, installId, order: rank, profile } of identities.values()) {
+  for (const { connection, displayName, installId, order: rank, profile } of identities.values()) {
     const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
     const group = backends.get(key)
 
     if (group) {
-      group.push({ connection, order: rank, profile })
+      group.push({ connection, displayName, order: rank, profile })
     } else {
-      backends.set(key, [{ connection, order: rank, profile }])
+      backends.set(key, [{ connection, displayName, order: rank, profile }])
     }
   }
 
@@ -577,14 +585,15 @@ export function buildAgentRoster(
 
   const roster: RosterAgent[] = []
 
-  for (const { connection, profile } of rows) {
+  for (const { connection, displayName, profile } of rows) {
     roster.push({
       connectionId: connection.id,
       connectionKind: connection.kind,
       connectionLabel: connection.label,
       profile,
       targetProfile: connection.remoteProfile || profile,
-      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
+      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1),
+      ...(displayName ? { displayName } : {})
     })
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13257,13 +13257,29 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
             : []
 
+          const displayNames: Record<string, string> = {}
+
+          for (const p of Array.isArray(body?.profiles) ? body.profiles : []) {
+            const name = String(p?.name || '').trim()
+            const displayName = String(p?.display_name || '').trim()
+
+            if (name && displayName) {
+              displayNames[name] = displayName
+            }
+          }
+
           // The root HERMES_HOME is an agent too; enumerations that omit it
           // (older backends list only named profiles) still get a default row.
           if (!profiles.includes('default')) {
             profiles.unshift('default')
           }
 
-          raw = { connection, profiles, ...(installId ? { installId } : {}) }
+          raw = {
+            connection,
+            profiles,
+            ...(Object.keys(displayNames).length ? { displayNames } : {}),
+            ...(installId ? { installId } : {})
+          }
         }
       } catch (error: any) {
         raw = { connection, profiles: null, error: String(error?.message || error) }

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -712,26 +712,25 @@ export function ConnectionsRegistrySection() {
                       {s.makePrimary}
                     </Button>
                   )}
+                  {/* Local entry: label is editable (registry rule), never removable. */}
+                  <Button
+                    aria-label={s.editConnection}
+                    onClick={() => openEditor(editorFromConnection(conn))}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
                   {conn.kind !== 'local' && (
-                    <>
-                      <Button
-                        aria-label={s.editConnection}
-                        onClick={() => openEditor(editorFromConnection(conn))}
-                        size="icon-sm"
-                        variant="ghost"
-                      >
-                        <Pencil className="size-3.5" />
-                      </Button>
-                      <Button
-                        aria-label={s.removeConnection}
-                        disabled={busy}
-                        onClick={() => setRemoveTarget(conn)}
-                        size="icon-sm"
-                        variant="ghost"
-                      >
-                        {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
-                      </Button>
-                    </>
+                    <Button
+                      aria-label={s.removeConnection}
+                      disabled={busy}
+                      onClick={() => setRemoveTarget(conn)}
+                      size="icon-sm"
+                      variant="ghost"
+                    >
+                      {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
+                    </Button>
                   )}
                 </div>
               }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4722,6 +4722,9 @@ function warmUnionRoster() {
 
   warmingRosterFor.add(connectionId)
 
+  // A hung fetch must not block warms for this connection forever.
+  const evict = setTimeout(() => warmingRosterFor.delete(connectionId), 15000)
+
   fetchRoster(connectionId)
     .then(roster => {
       if (Array.isArray(roster?.profiles)) {
@@ -4730,6 +4733,7 @@ function warmUnionRoster() {
     })
     .catch(() => undefined)
     .finally(() => {
+      clearTimeout(evict)
       warmingRosterFor.delete(connectionId)
     })
 }
@@ -14892,7 +14896,8 @@ export default {
 
           const active = focusedMentionProfile()
           const q = (query || '').toLowerCase()
-          const items = []
+          const prefixed = []
+          const rest = []
           const live = {
             name: active,
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
@@ -14908,27 +14913,25 @@ export default {
             // Renamed bots complete on their friendly name — the tag is the
             // renamed slug when one exists, the profile handle otherwise.
             const tag = botMentionTag(profile)
+            const fields = [tag.toLowerCase(), handle.toLowerCase(), display.toLowerCase()]
 
             // Substring, not prefix: "@scout" must find "default-scout".
-            if (
-              q &&
-              !tag.toLowerCase().includes(q) &&
-              !handle.toLowerCase().includes(q) &&
-              !display.toLowerCase().includes(q)
-            ) {
+            // Prefix hits rank first so broad matches can't crowd them out.
+            if (q && !fields.some(field => field.includes(q))) {
               continue
             }
 
             const source = profile.connectionLabel ? ` · ${profile.connectionLabel}` : ''
+            const bucket = !q || fields.some(field => field.startsWith(q)) ? prefixed : rest
 
-            items.push({
+            bucket.push({
               insert: `@${tag}`,
               display: `@${tag}`,
               meta: `Bot · ${display}${source}`
             })
           }
 
-          return items.slice(0, 8)
+          return [...prefixed, ...rest].slice(0, 8)
         }
       }
     })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4592,7 +4592,17 @@ function useRoster() {
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
-    queryFn: async () => {
+    queryFn: () => fetchRoster(activeConnectionId),
+    refetchInterval: 5000,
+    staleTime: 5000,
+    // Remote (SSH) gateways connect slowly and drop on sleep/wake; keep
+    // retrying instead of latching a terminal error card.
+    retry: true,
+    retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
+  })
+}
+
+async function fetchRoster(activeConnectionId) {
       // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
       // against each bot's last local meta write, and a fetch issued before
       // a write can only carry pre-write ui_meta. (Issue time is the
@@ -4647,14 +4657,6 @@ function useRoster() {
       }
 
       return { ...(local && typeof local === 'object' ? local : {}), fetchedAt: issuedAt }
-    },
-    refetchInterval: 5000,
-    staleTime: 5000,
-    // Remote (SSH) gateways connect slowly and drop on sleep/wake; keep
-    // retrying instead of latching a terminal error card.
-    retry: true,
-    retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
-  })
 }
 
 /** Synchronous union-roster read for the composer surfaces (autocomplete
@@ -4701,6 +4703,35 @@ function cachedUnionRoster() {
   }
 
   return null
+}
+
+/** Cold cache (no Bots surface mounted yet): fetch once and seed the query
+ *  cache so the popup answers on the next keystroke. */
+const warmingRosterFor = new Set()
+
+function warmUnionRoster() {
+  if (typeof queryClient === 'undefined' || !queryClient?.setQueryData) {
+    return
+  }
+
+  const connectionId = String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+
+  if (warmingRosterFor.has(connectionId)) {
+    return
+  }
+
+  warmingRosterFor.add(connectionId)
+
+  fetchRoster(connectionId)
+    .then(roster => {
+      if (Array.isArray(roster?.profiles)) {
+        queryClient.setQueryData([...ROSTER_KEY, connectionId], roster)
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      warmingRosterFor.delete(connectionId)
+    })
 }
 
 /** Merge the union agent roster (host.agents) over the active gateway's
@@ -4822,6 +4853,7 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
     profiles.push({
       name: profile,
       handle: agent.handle,
+      ...(agent.displayName ? { display_name: agent.displayName } : {}),
       connectionId,
       connectionKind: agent.connectionKind,
       connectionLabel: agent.connectionLabel,
@@ -5889,7 +5921,14 @@ function displayName(bot, meta) {
   // "Hermes". Annotated active rows carry sourceScoped too, and keying this
   // off sourceScoped renamed the user's main agent to an IP-derived label
   // (community report, Aug 17 2026).
-  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel && !alias && !meta?.title?.trim()) {
+  if (
+    bot?.remoteSource &&
+    (bot.name || '').trim().toLowerCase() === 'default' &&
+    bot.connectionLabel &&
+    !alias &&
+    !meta?.title?.trim() &&
+    !(typeof bot?.display_name === 'string' && bot.display_name.trim())
+  ) {
     return bot.connectionLabel
   }
 
@@ -14846,6 +14885,8 @@ export default {
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
+            warmUnionRoster()
+
             return []
           }
 
@@ -14868,11 +14909,12 @@ export default {
             // renamed slug when one exists, the profile handle otherwise.
             const tag = botMentionTag(profile)
 
+            // Substring, not prefix: "@scout" must find "default-scout".
             if (
               q &&
-              !tag.toLowerCase().startsWith(q) &&
-              !handle.toLowerCase().startsWith(q) &&
-              !display.toLowerCase().startsWith(q)
+              !tag.toLowerCase().includes(q) &&
+              !handle.toLowerCase().includes(q) &&
+              !display.toLowerCase().includes(q)
             ) {
               continue
             }

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-naming-ergonomics.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-naming-ergonomics.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Roster naming ergonomics: cross-connection rows carry display_name from the
+// union roster, the completion filter matches substrings ("@scout" finds
+// "default-laptop"), and a cold roster cache triggers a one-shot warm fetch.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function runtime() {
+  const context = {
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    URL,
+    atom: initial => {
+      let value = initial
+      return { get: () => value, set: next => (value = next), listen: () => () => undefined }
+    },
+    host: {
+      request: async () => ({}),
+      requestProfile: async () => ({}),
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        connectionId: { get: () => 'homelab', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__x = { mergeMultiSourceRoster, displayName, botFriendlyNames, resolveRosterMentions, warmUnionRoster, $botMeta };\n'
+    )
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+  return context.__x
+}
+
+const scoutAgent = {
+  profile: 'default',
+  handle: 'default-laptop',
+  displayName: 'Scout',
+  connectionId: 'local',
+  connectionKind: 'local',
+  connectionLabel: 'Laptop'
+}
+
+test('merge: thin cross-connection rows carry display_name from the union roster', () => {
+  const { mergeMultiSourceRoster } = runtime()
+
+  const merged = mergeMultiSourceRoster(
+    { profiles: [{ name: 'default' }] },
+    { agents: [{ profile: 'default', handle: 'default-homelab', connectionId: 'homelab', connectionKind: 'remote', connectionLabel: 'Homelab' }, scoutAgent] },
+    'homelab'
+  )
+
+  const scout = merged.profiles.find(row => row.connectionId === 'local')
+  assert.equal(scout.display_name, 'Scout')
+  assert.equal(scout.handle, 'default-laptop')
+})
+
+test('display + mentions: renamed remote default reads as its display_name and resolves @scout', () => {
+  const { mergeMultiSourceRoster, displayName, resolveRosterMentions } = runtime()
+
+  const merged = mergeMultiSourceRoster(
+    { profiles: [{ name: 'default' }] },
+    { agents: [scoutAgent] },
+    'homelab'
+  )
+  const scout = merged.profiles.find(row => row.connectionId === 'local')
+
+  assert.equal(displayName(scout, undefined), 'Scout')
+
+  const resolved = resolveRosterMentions('ping @scout please', [scout], { name: 'default', connectionId: 'homelab' })
+  assert.equal(resolved.length, 1)
+  assert.equal(resolved[0].handle, 'default-laptop')
+
+  // The old handle keeps resolving.
+  const byHandle = resolveRosterMentions('ping @default-laptop', [scout], { name: 'default', connectionId: 'homelab' })
+  assert.equal(byHandle.length, 1)
+})
+
+test('display: without a display_name the remote default still reads as its connection label', () => {
+  const { displayName } = runtime()
+
+  const bare = { name: 'default', remoteSource: true, connectionLabel: 'Laptop' }
+  assert.equal(displayName(bare, undefined), 'Laptop')
+})
+
+test('completion filter is substring: "scout" matches handle default-laptop', () => {
+  // The provider closure is not extractable; assert the shipped predicate shape.
+  const provider = source.slice(source.indexOf("id: 'mention-completions'"))
+  assert.match(provider.slice(0, 2000), /includes\(q\)/)
+  assert.doesNotMatch(provider.slice(0, 2000), /startsWith\(q\)/)
+})
+
+test('warmUnionRoster: no-op without a queryClient, never throws', () => {
+  const { warmUnionRoster } = runtime()
+  assert.doesNotThrow(() => warmUnionRoster())
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-naming-ergonomics.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-naming-ergonomics.test.mjs
@@ -96,11 +96,12 @@ test('display: without a display_name the remote default still reads as its conn
   assert.equal(displayName(bare, undefined), 'Laptop')
 })
 
-test('completion filter is substring: "scout" matches handle default-laptop', () => {
-  // The provider closure is not extractable; assert the shipped predicate shape.
+test('completion filter is substring with prefix-first ranking', () => {
+  // The provider closure is not extractable; assert the shipped predicate shape:
+  // membership by includes, ranking by startsWith.
   const provider = source.slice(source.indexOf("id: 'mention-completions'"))
-  assert.match(provider.slice(0, 2000), /includes\(q\)/)
-  assert.doesNotMatch(provider.slice(0, 2000), /startsWith\(q\)/)
+  assert.match(provider.slice(0, 2200), /field\.includes\(q\)/)
+  assert.match(provider.slice(0, 2200), /field\.startsWith\(q\)/)
 })
 
 test('warmUnionRoster: no-op without a queryClient, never throws', () => {


### PR DESCRIPTION
Bot Mode roster naming had three ergonomics gaps on multi-connection desktops:

- `hermes profile rename` never reached @mentions or Bot Mode display for cross-connection agents — `/api/profiles` returns `display_name`, but the Electron union roster dropped it. Now plumbed through (`ConnectionAgents.displayNames` → `RosterAgent.displayName` → thin roster rows), so a renamed agent resolves by its friendly name and reads as it.
- Mention autocomplete filtered by prefix, so typing a rename never matched its `name-device` handle. Now substring.
- The autocomplete answers from the roster query cache, which stays cold until a Bots surface mounts — the popup returned empty forever. A cold-cache keystroke now seeds a one-shot fetch (single-flight per connection).
- Registered gateways: the local row had no edit affordance even though the registry allows label edits (`normalizeConnectionInput`, label-only, id pinned). Pencil now shown; delete stays remote-only.

Tests: 76 vitest (connection-registry), 566 plugin tests incl. new `roster-naming-ergonomics.test.mjs`, tsc clean. Caveat: the display_name plumbing crosses the `/api/profiles` HTTP boundary, which these tests mock — not yet exercised in a built app against a live two-machine topology.
