### PR TITLE
feat(plugins): add Alibaba Cloud Token Plan model provider profiles

### DIFF
--- a/plugins/model-providers/alibaba-token-plan/__init__.py
+++ b/plugins/model-providers/alibaba-token-plan/__init__.py
@@ -1,0 +1,42 @@
+"""Alibaba Cloud Token Plan (Model Studio flat-token tier) provider profiles.
+
+Token Plan is a separate purchase tier from both standard DashScope and the
+Coding Plan, with its own dedicated endpoints and API key
+(``ALIBABA_TOKEN_PLAN_API_KEY``). Both regional endpoints speak the
+OpenAI-compatible chat-completions protocol:
+
+  - ``alibaba-token-plan``    → token-plan.ap-southeast-1.maas.aliyuncs.com (international)
+  - ``alibaba-token-plan-cn`` → token-plan.cn-beijing.maas.aliyuncs.com (mainland China)
+
+Profile names match the models.dev catalog keys exactly so model metadata
+lines up and ``model.provider: alibaba-token-plan-cn`` resolves at runtime
+instead of failing with "Unknown provider" (#73265).
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+alibaba_token_plan = ProviderProfile(
+    name="alibaba-token-plan",
+    aliases=("dashscope-token-plan",),
+    display_name="Alibaba Cloud (Token Plan)",
+    description="Alibaba Cloud Model Studio Token Plan (flat-token tier)",
+    signup_url="https://help.aliyun.com/zh/model-studio/",
+    env_vars=("ALIBABA_TOKEN_PLAN_API_KEY", "ALIBABA_TOKEN_PLAN_BASE_URL"),
+    base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    auth_type="api_key",
+)
+
+alibaba_token_plan_cn = ProviderProfile(
+    name="alibaba-token-plan-cn",
+    aliases=("dashscope-token-plan-cn",),
+    display_name="Alibaba Cloud (Token Plan, China)",
+    description="Alibaba Cloud Model Studio Token Plan, mainland-China endpoint",
+    signup_url="https://help.aliyun.com/zh/model-studio/",
+    env_vars=("ALIBABA_TOKEN_PLAN_API_KEY", "ALIBABA_TOKEN_PLAN_CN_BASE_URL"),
+    base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    auth_type="api_key",
+)
+
+register_provider(alibaba_token_plan)
+register_provider(alibaba_token_plan_cn)

--- a/plugins/model-providers/alibaba-token-plan/plugin.yaml
+++ b/plugins/model-providers/alibaba-token-plan/plugin.yaml
@@ -1,0 +1,5 @@
+name: alibaba-token-plan-provider
+kind: model-provider
+version: 1.0.0
+description: Alibaba Cloud Model Studio Token Plan (international + China endpoints)
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds `alibaba-token-plan` and `alibaba-token-plan-cn` provider profiles for Alibaba Cloud Model Studio's flat-token **Token Plan** tier (a separate purchase tier from standard DashScope and the Coding Plan, with its own dedicated endpoints and API key `ALIBABA_TOKEN_PLAN_API_KEY`).

## Changes

- `plugins/model-providers/alibaba-token-plan/plugin.yaml` — provider manifest (kind: model-provider)
- `plugins/model-providers/alibaba-token-plan/__init__.py` — registers two `ProviderProfile`s:
  - `alibaba-token-plan` → `token-plan.ap-southeast-1.maas.aliyuncs.com` (international)
  - `alibaba-token-plan-cn` → `token-plan.cn-beijing.maas.aliyuncs.com` (mainland China)

Both regional endpoints speak the OpenAI-compatible chat-completions protocol.

## Why

Profile names match the models.dev catalog keys exactly, so model metadata lines up and `model.provider: alibaba-token-plan-cn` resolves at runtime instead of failing with "Unknown provider" (#73265).

## Test Plan

- `python -c "import ast; ast.parse(...)"` — syntax valid
- Provider registration follows the same pattern as the existing `alibaba-coding-plan` provider