### PR TITLE
fix(gateway): track fire-and-forget tasks in plugin platforms and pty registry

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -154,6 +154,9 @@ class PtySessionRegistry:
         self._buffer_cap = buffer_cap
         self._read_timeout = read_timeout
         self._sessions: Dict[str, PtySession] = {}
+        # Strong refs to reaped-session close() tasks so the GC cannot reap
+        # them mid-close (the loop keeps only weak references to tasks).
+        self._reaped_close_tasks: set = set()
 
     async def attach_or_spawn(self, key: str, *, spawn: Callable[[], object]
                               ) -> Tuple[PtySession, bool]:
@@ -198,7 +201,12 @@ class PtySessionRegistry:
             raise RegistryFull()
         oldest = min(idle, key=lambda s: s.last_detached_at or 0.0)
         self._sessions.pop(oldest.key, None)
-        asyncio.create_task(oldest.close())
+        # Retain a strong ref: the loop keeps only weak references to tasks,
+        # so an unreferenced close() can be GC-reaped and the PTY leaked.
+        task = asyncio.create_task(oldest.close())
+        self._reaped_close_tasks.add(task)
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._reaped_close_tasks.discard)
 
     async def close_all(self) -> None:
         for key in list(self._sessions):

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1688,7 +1688,13 @@ class _IncomingHandler(
             # eventually causing a disconnect.  _on_message is wrapped so
             # exceptions inside the task surface in logs instead of
             # disappearing into the event loop.
-            asyncio.create_task(self._safe_on_message(chatbot_msg))
+            # Track the task: unreferenced tasks can be GC-reaped before
+            # they run (the loop keeps only weak refs), silently dropping
+            # the inbound message.
+            _msg_task = asyncio.create_task(self._safe_on_message(chatbot_msg))
+            self._adapter._background_tasks.add(_msg_task)
+            if hasattr(_msg_task, "add_done_callback"):
+                _msg_task.add_done_callback(self._adapter._background_tasks.discard)
         except Exception:
             logger.exception(
                 "[%s] Error preparing incoming message", self._adapter.name

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1269,7 +1269,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        asyncio.create_task(_notify())
+        # Track the task so GC cannot reap the fatal-error notification
+        # (the loop keeps only weak references to tasks).
+        notify_task = asyncio.create_task(_notify())
+        self._background_tasks.add(notify_task)
+        if hasattr(notify_task, "add_done_callback"):
+            notify_task.add_done_callback(self._background_tasks.discard)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Discord and start receiving events."""
@@ -5319,9 +5324,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
         # Fire-and-forget: don't block the interaction handler on Telegram I/O.
         try:
-            asyncio.create_task(self._notify_unauthorized_slash(
+            # Retain a strong ref so GC cannot reap the security notice.
+            unauthorized_task = asyncio.create_task(self._notify_unauthorized_slash(
                 user_name, user_id, chan_id, guild_id, command_text, reason,
             ))
+            self._background_tasks.add(unauthorized_task)
+            if hasattr(unauthorized_task, "add_done_callback"):
+                unauthorized_task.add_done_callback(self._background_tasks.discard)
         except Exception as e:
             logger.debug("[Discord] Could not schedule admin notify task: %s", e)
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1044,9 +1044,13 @@ class LineAdapter(BasePlatformAdapter):
         else:
             text = f"[unsupported message type: {msg_type}]"
 
-        # Best-effort typing indicator (DM only).
+        # Best-effort typing indicator (DM only). Track the task so GC
+        # cannot reap it before the indicator fires.
         if chat_type == "dm" and self._client:
-            asyncio.create_task(self._client.loading(chat_id))
+            loading_task = asyncio.create_task(self._client.loading(chat_id))
+            self._background_tasks.add(loading_task)
+            if hasattr(loading_task, "add_done_callback"):
+                loading_task.add_done_callback(self._background_tasks.discard)
 
         source_obj = self.build_source(
             chat_id=chat_id,

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1044,7 +1044,12 @@ class PhotonAdapter(BasePlatformAdapter):
         still running the handoff, so the handoff always reaches the
         reconnect queue.
         """
-        asyncio.create_task(self._notify_fatal_error_logged())
+        # Track: an unreferenced task can be GC-reaped before it runs and
+        # the fatal-error notification silently lost.
+        notify_task = asyncio.create_task(self._notify_fatal_error_logged())
+        self._background_tasks.add(notify_task)
+        if hasattr(notify_task, "add_done_callback"):
+            notify_task.add_done_callback(self._background_tasks.discard)
 
     async def _notify_fatal_error_logged(self) -> None:
         try:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1347,7 +1347,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # Fire-and-forget: a slow bridge /read must not
                                 # delay message dispatch (matches BlueBubbles
                                 # asyncio.create_task pattern for mark_read).
-                                asyncio.create_task(self._send_read_receipt(msg_data))
+                                # Tracked so GC cannot reap it mid-flight.
+                                receipt_task = asyncio.create_task(self._send_read_receipt(msg_data))
+                                self._background_tasks.add(receipt_task)
+                                if hasattr(receipt_task, "add_done_callback"):
+                                    receipt_task.add_done_callback(self._background_tasks.discard)
                                 if event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:


### PR DESCRIPTION
## Problem

Continues the weak-reference hazard fixed for bundled adapters (#94487) and core paths (#94489): unreferenced `asyncio.create_task()` results can be garbage-collected before they run because the event loop holds only weak references to tasks. Seven more untracked sites, all in plugin platforms + the PTY registry:

| Site | Dropped task → failure |
|---|---|
| `dingtalk` SDK callback `_safe_on_message` | **inbound message lost** |
| `discord` gateway-task-exit `_notify()` | fatal-error notification lost (supervisor never learns) |
| `discord` unauthorized-slash admin notify | **security notification lost** |
| `line` DM loading indicator | indicator never fires |
| `photon` fatal-error notify | notification lost |
| `whatsapp` read receipt | receipt never sent |
| `pty_session.PtySessionRegistry._reap_one_idle_or_raise` close() | reaped close → **PTY process leaked** |

## Fix

Each site retains a strong reference with done-callback discard:
- adapters use their existing `_background_tasks` set (same convention as #94487)
- `PtySessionRegistry` gains a `_reaped_close_tasks` set initialized in `__init__`

## Verification

- dingtalk/discord/line/photon/whatsapp targeted suites: 44 passed, 2 skipped
- `tests/test_pty_session.py`: 9/9 pass with the new registry attribute
- syntax-checked all six modified files