### PR TITLE
fix(kanban): classify capacity deferrals as healthy

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1728,10 +1728,11 @@ class GatewayKanbanWatchersMixin:
                     if _ad_enabled:
                         await _to_thread_process_service(_auto_decompose_tick, _ad_per_tick)
                     results = await _to_thread_process_service(_tick_once)
-                    any_spawned = False
+                    dispatch_results = []
                     for slug, res in (results or []):
+                        if res is not None:
+                            dispatch_results.append(res)
                         if res is not None and getattr(res, "spawned", None):
-                            any_spawned = True
                             # Quiet by default — only log when something actually
                             # happened, so an idle gateway stays silent.
                             logger.info(
@@ -1747,7 +1748,7 @@ class GatewayKanbanWatchersMixin:
                             )
                     # Health telemetry (aggregate across boards)
                     ready_pending = await _to_thread_process_service(_ready_nonempty)
-                    if ready_pending and not any_spawned:
+                    if _kb.dispatch_health_bad_tick(ready_pending, dispatch_results):
                         bad_ticks += 1
                     else:
                         bad_ticks = 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2675,6 +2675,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "timed_out": res.timed_out,
             "stale": res.stale,
             "auto_blocked": res.auto_blocked,
+            "spawn_failed": res.spawn_failed,
+            "capacity_limited": res.capacity_limited,
             "promoted": res.promoted,
             "spawned": [
                 {"task_id": tid, "assignee": who, "workspace": ws}
@@ -2702,6 +2704,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
+    print(f"Spawn failed: {len(res.spawn_failed)}")
+    if res.spawn_failed:
+        print(f"  {', '.join(res.spawn_failed)}")
+    if res.capacity_limited:
+        print(f"Deferred (capacity): {res.capacity_limited}")
     print(f"Promoted:     {res.promoted}")
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
@@ -2797,8 +2804,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 
     def _on_tick(res):
         ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
-        spawned_any = bool(res.spawned)
-        if ready_pending and not spawned_any:
+        if kb.dispatch_health_bad_tick(ready_pending, [res]):
             health_state["bad_ticks"] += 1
         else:
             health_state["bad_ticks"] = 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -331,6 +331,7 @@ def _fire_dispatch_tick_hook(
             outcome = "skipped_locked"
         elif not any((
             result.spawned,
+            result.spawn_failed,
             result.reclaimed,
             result.promoted,
             result.reconciled_orphans,
@@ -344,6 +345,7 @@ def _fire_dispatch_tick_hook(
             result.skipped_per_profile_capped,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
+            result.capacity_limited,
         )):
             outcome = "idle"
         invoke_hook(
@@ -8025,6 +8027,11 @@ class DispatchResult:
     dead/gone worker). See the reconciliation pass for details."""
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
+    spawn_failed: list[str] = field(default_factory=list)
+    """Task ids whose worker could not be launched this tick.
+    Unlike ``auto_blocked``, this records the first failed attempt too so
+    dispatcher health telemetry cannot mistake a real launch failure for an
+    expected capacity deferral."""
     skipped_unassigned: list[str] = field(default_factory=list)
     """Ready task ids skipped because they have no assignee at all.
     Operator-actionable — usually a misfiled task waiting for routing."""
@@ -8082,6 +8089,39 @@ class DispatchResult:
     spawned. ``None`` when memory was fine/unknown and the guard imposed
     no restriction. Reclaim/promotion bookkeeping still ran either way;
     deferred tasks stay queued for the next tick."""
+    capacity_limited: Optional[str] = None
+    """Configured concurrency cap that intentionally deferred this tick:
+    ``"max_spawn"`` for the board-local cap or ``"max_in_progress"`` for
+    the host-wide cap. ``None`` means neither cap stopped dispatch."""
+
+
+def dispatch_health_bad_tick(
+    ready_pending: bool,
+    results: Iterable[Optional[DispatchResult]],
+) -> bool:
+    """Return whether a no-spawn tick is unexpectedly stuck.
+
+    Capacity, locking, memory pressure, respawn guards, and per-profile caps
+    are deliberate deferrals. A recorded spawn failure always wins over those
+    signals so a mixed tick still alerts the operator.
+    """
+    if not ready_pending:
+        return False
+    observed = [result for result in results if result is not None]
+    if any(result.spawned for result in observed):
+        return False
+    if any(result.spawn_failed for result in observed):
+        return True
+    return not (observed and all(
+        result.capacity_limited
+        or result.skipped_locked
+        or result.memory_pressure
+        or result.respawn_guarded
+        or result.rate_limited
+        or result.skipped_per_profile_capped
+        or result.skipped_nonspawnable
+        for result in observed
+    ))
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -9988,6 +10028,7 @@ def _dispatch_once_locked(
     # budget so the total number of new workers stays bounded.
     if max_spawn is not None:
         if running_count >= max_spawn:
+            result.capacity_limited = "max_spawn"
             return result
         spawn_budget = max_spawn - running_count
 
@@ -10004,6 +10045,7 @@ def _dispatch_once_locked(
     if max_in_progress is not None:
         total_running = running_count + count_running_tasks_other_boards(board)
         if total_running >= max_in_progress:
+            result.capacity_limited = "max_in_progress"
             return result
         remaining = max_in_progress - total_running
         if spawn_budget is None or spawn_budget > remaining:
@@ -10237,6 +10279,7 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            result.spawn_failed.append(claimed.id)
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
@@ -10289,6 +10332,7 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
+            result.spawn_failed.append(claimed.id)
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
@@ -10364,6 +10408,7 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            result.spawn_failed.append(claimed.id)
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
@@ -10409,6 +10454,7 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
+            result.spawn_failed.append(claimed.id)
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -151,6 +151,41 @@ def test_max_in_progress_counts_other_boards(
     # Host budget (2) already consumed by the second board → nothing spawns.
     assert not spawns
     assert not res.spawned
+    assert res.capacity_limited == "max_in_progress"
+
+
+def test_dispatch_health_capacity_deferral_is_not_stuck():
+    result = kb.DispatchResult(capacity_limited="max_in_progress")
+
+    assert not kb.dispatch_health_bad_tick(True, [result])
+
+
+def test_dispatch_health_spawn_failure_still_warns_when_capacity_is_mixed():
+    failed = kb.DispatchResult(spawn_failed=["t_failed"])
+    deferred = kb.DispatchResult(capacity_limited="max_spawn")
+
+    assert kb.dispatch_health_bad_tick(True, [deferred, failed])
+
+
+def test_one_deferred_board_does_not_mask_an_unsignaled_board():
+    deferred = kb.DispatchResult(capacity_limited="max_spawn")
+    unsignaled = kb.DispatchResult()
+
+    assert kb.dispatch_health_bad_tick(True, [deferred, unsignaled])
+
+
+def test_dispatch_records_first_spawn_failure(
+    kanban_home, all_assignees_spawnable,
+):
+    def fail_to_spawn(task, workspace, board=None):
+        raise OSError("worker executable missing")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="launch me", assignee="alice")
+        result = kb.dispatch_once(conn, spawn_fn=fail_to_spawn)
+
+    assert result.spawn_failed == [task_id]
+    assert kb.dispatch_health_bad_tick(True, [result])
 
 
 def test_max_in_progress_partial_budget_across_boards(

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -55,6 +55,7 @@ def test_cap_2_balances_two_profiles(isolated_kanban_home_with_profiles):
     assert spawn_assignees.count("beta") == 2
     assert capped_assignees.count("alpha") == 3
     assert capped_assignees.count("beta") == 1
+    assert not kb.dispatch_health_bad_tick(True, [res])
 
 
 
@@ -96,5 +97,4 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert len(res2.spawned) == 1
     assert len(res2.skipped_per_profile_capped) == 1
     assert res2.spawned[0][0] != spawned_id  # different task this time
-
 


### PR DESCRIPTION
## Summary

- classify board, host, per-profile, memory, lock, and respawn deferrals as expected dispatcher idle states
- surface first-attempt `spawn_failed` results so a real launch failure still wins over a mixed deferral tick
- apply the same health predicate to the gateway watcher and standalone daemon
- expose capacity and spawn-failure reasons in CLI/JSON output

## Root cause

A live single-slot deployment repeatedly logged `kanban dispatcher stuck` while its sole worker was healthy and processing. With both `max_spawn=1` and `max_in_progress=1`, `dispatch_once()` returns at the board-local `max_spawn` guard before reaching the host-cap guard. That means a host-only saturation signal (as proposed in #93753) does not cover the observed configuration.

This change records the exact capacity gate that deferred dispatch and centralizes the health decision. A recorded spawn failure is explicit and remains actionable even when a different board is capacity-limited.

Fixes #46800.

## Verification

- `scripts/run_tests.sh tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_host_cap.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_core_functionality.py tests/gateway/test_kanban_reconcile_orphans.py -q` — 50 passed, 1 skipped
- `uvx ruff check` on all changed Python files — passed
- diff-scoped security review — no new secret, money/signing, command-injection, or SQL-interpolation path

## Risk

Dispatch scheduling, claims, concurrency limits, and worker lifecycle are unchanged. This only improves result telemetry and warning classification.