### PR TITLE
fix(signal): use monotonic clock for SSE staleness watchdog

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -400,7 +400,7 @@ class SignalAdapter(BasePlatformAdapter):
                 return False
 
             self._running = True
-            self._last_sse_activity = time.time()
+            self._last_sse_activity = time.monotonic()
             self._sse_task = asyncio.create_task(self._sse_listener())
             self._health_monitor_task = asyncio.create_task(self._health_monitor())
 
@@ -464,7 +464,7 @@ class SignalAdapter(BasePlatformAdapter):
                 ) as response:
                     self._sse_response = response
                     backoff = SSE_RETRY_DELAY_INITIAL  # Reset on successful connection
-                    self._last_sse_activity = time.time()
+                    self._last_sse_activity = time.monotonic()
                     logger.info("Signal SSE: connected")
 
                     buffer = ""
@@ -481,14 +481,14 @@ class SignalAdapter(BasePlatformAdapter):
                             # is alive — update activity so the health monitor
                             # doesn't report false idle warnings.
                             if line.startswith(":"):
-                                self._last_sse_activity = time.time()
+                                self._last_sse_activity = time.monotonic()
                                 continue
                             # Parse SSE data lines
                             if line.startswith("data:"):
                                 data_str = line[5:].strip()
                                 if not data_str:
                                     continue
-                                self._last_sse_activity = time.time()
+                                self._last_sse_activity = time.monotonic()
                                 try:
                                     data = json.loads(data_str)
                                     await self._handle_envelope(data)
@@ -525,7 +525,7 @@ class SignalAdapter(BasePlatformAdapter):
             if not self._running:
                 break
 
-            elapsed = time.time() - self._last_sse_activity
+            elapsed = time.monotonic() - self._last_sse_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
                 logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
                 try:
@@ -535,7 +535,7 @@ class SignalAdapter(BasePlatformAdapter):
                     if resp.status_code == 200:
                         # Daemon is alive but SSE is idle — update activity to
                         # avoid repeated warnings (connection may just be quiet)
-                        self._last_sse_activity = time.time()
+                        self._last_sse_activity = time.monotonic()
                         logger.debug("Signal: daemon healthy, SSE idle")
                     else:
                         logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)


### PR DESCRIPTION
## Problem

`SignalAdapter._health_monitor()` computed SSE idle time as `time.time() - self._last_sse_activity`. Both stamps are **wall-clock**, so a system clock adjustment (NTP step, manual change) or a sleep/wake resync shifts both equally but corrupts the *elapsed* computation:

- **backward jump** → `elapsed` goes negative/small → the stale-connection reconnect is suppressed for up to a full `HEALTH_CHECK_STALE_THRESHOLD` cycle → Signal inbound messages silently stop flowing
- **forward jump** → spurious "SSE idle" warnings and forced reconnects

This is exactly why the codebase uses `time.monotonic()` for interval math elsewhere (e.g. the gateway restart watcher deadline in `gateway/run.py`).

## Fix

Switch the six `_last_sse_activity` stamp/elapsed sites in `signal.py` to `time.monotonic()`. The remaining `time.time()` use in this file (`rpc_id` generation at :983) is intentionally wall-clock and untouched.

## Verification

`tests/gateway/test_signal.py`: 60/60 pass. Binary-safe edit (no encoding or line-ending churn; verified via diff).