### PR TITLE
fix(telegram): wait for reconnect before failing send as Not connected

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -599,6 +599,14 @@ class TelegramAdapter(BasePlatformAdapter):
     # Bounds memory during extended outages; oldest events are dropped first.
     HELD_INBOUND_MAX = 64
     _GENERAL_TOPIC_THREAD_ID = "1"
+    # send() can race a disconnect/reconnect window: the final reply is
+    # generated, Telegram drops, and send() used to fail immediately with
+    # "Not connected" (retryable=False). The delivery ledger then held the
+    # answer until the next gateway boot — hours later. Wait briefly for
+    # _bot (or a replacement adapter the reconnect watcher just installed)
+    # so a 10–20s blip delivers now. Same idea as QQBot._wait_for_reconnection.
+    _RECONNECT_WAIT_SECONDS = 15.0
+    _RECONNECT_POLL_INTERVAL = 0.5
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
     # finalize=True path.  Without this flag, stream_consumer._send_or_edit
@@ -895,6 +903,53 @@ class TelegramAdapter(BasePlatformAdapter):
         if not getattr(self, "_fatal_error_code", None):
             return False
         return not bool(getattr(self, "_fatal_error_retryable", True))
+
+    def _replacement_telegram_adapter(self) -> Optional["TelegramAdapter"]:
+        """Return the live Telegram adapter if the reconnect watcher replaced us.
+
+        The background reconnect watcher builds a *new* adapter and puts it in
+        ``runner.adapters``. An in-flight ``send()`` still holds the old
+        instance whose ``_bot`` stays None. Waiting only on ``self._bot``
+        would miss that replacement and still drop the final reply.
+        """
+        runner = getattr(self, "gateway_runner", None)
+        adapters = getattr(runner, "adapters", None) or {}
+        live = adapters.get(self.platform)
+        if live is not None and live is not self and getattr(live, "_bot", None):
+            return live
+        return None
+
+    async def _wait_for_reconnection(self) -> bool:
+        """Wait for ``_bot`` or a replacement adapter after a transient drop.
+
+        Returns True if sending can proceed (this instance or a replacement
+        is connected). Returns False if still disconnected when the wait
+        expires, or if the failure is permanently fatal.
+        """
+        if self._bot or self._replacement_telegram_adapter() is not None:
+            return True
+        if self._is_permanent_fatal():
+            return False
+        wait_s = float(getattr(self, "_RECONNECT_WAIT_SECONDS", 15.0))
+        poll_s = float(getattr(self, "_RECONNECT_POLL_INTERVAL", 0.5))
+        logger.info(
+            "[%s] Not connected — waiting for reconnection (up to %.0fs)",
+            self.name, wait_s,
+        )
+        waited = 0.0
+        while waited < wait_s:
+            await asyncio.sleep(poll_s)
+            waited += poll_s
+            if self._is_permanent_fatal():
+                return False
+            if self._bot or self._replacement_telegram_adapter() is not None:
+                logger.info("[%s] Reconnected after %.1fs", self.name, waited)
+                return True
+        logger.warning(
+            "[%s] Still not connected after %.0fs",
+            self.name, wait_s,
+        )
+        return False
 
     def _should_drop_delayed_delivery(self) -> bool:
         """True once teardown/fatal-error started — delayed flushes must not dispatch.
@@ -5204,7 +5259,20 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a message to a Telegram chat."""
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            live = self._replacement_telegram_adapter()
+            if live is not None:
+                return await live.send(chat_id, content, reply_to, metadata)
+            if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+                return SendResult(
+                    success=False,
+                    error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            live = self._replacement_telegram_adapter()
+            if not self._bot and live is not None:
+                return await live.send(chat_id, content, reply_to, metadata)
+            if not self._bot:
+                return SendResult(success=False, error="Not connected", retryable=True)
 
         # getattr() — tests build adapters via object.__new__() (no __init__).
         if getattr(self, "_send_path_degraded", False):

--- a/tests/gateway/test_telegram_send_reconnect_wait.py
+++ b/tests/gateway/test_telegram_send_reconnect_wait.py
@@ -1,0 +1,123 @@
+"""Telegram send() must wait for reconnect instead of dropping the final reply.
+
+A network blip can disconnect Telegram while the agent is sending its final
+response. send() used to return "Not connected" immediately (retryable=False),
+so the delivery ledger held the answer until the next gateway boot — hours
+later. QQBot already waits; these tests pin the same contract on Telegram,
+including the reconnect-watcher case that *replaces* the adapter object.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._rich_send_disabled = True
+    adapter.send_typing = AsyncMock()
+    adapter._RECONNECT_WAIT_SECONDS = 0.6
+    adapter._RECONNECT_POLL_INTERVAL = 0.05
+    return adapter
+
+
+def _connected_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_send_waits_and_succeeds_when_bot_returns():
+    adapter = _make_adapter()
+    adapter._bot = None
+
+    async def restore_bot() -> None:
+        await asyncio.sleep(0.12)
+        adapter._bot = _connected_bot()
+
+    asyncio.get_running_loop().create_task(restore_bot())
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "42"
+    adapter._bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_delegates_to_replacement_adapter_installed_mid_wait():
+    old = _make_adapter()
+    old._bot = None
+
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    live._RECONNECT_WAIT_SECONDS = 0.01
+
+    runner = MagicMock()
+    runner.adapters = {}
+    old.gateway_runner = runner
+
+    async def install_replacement() -> None:
+        await asyncio.sleep(0.12)
+        runner.adapters[old.platform] = live
+
+    asyncio.get_running_loop().create_task(install_replacement())
+    result = await old.send("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "42"
+    live._bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_delegates_immediately_when_replacement_already_live():
+    old = _make_adapter()
+    old._bot = None
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    runner = MagicMock()
+    runner.adapters = {old.platform: live}
+    old.gateway_runner = runner
+    old._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait when replacement is already live")
+    )
+
+    result = await old.send("123", "hello")
+
+    assert result.success is True
+    live._bot.send_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_timeout_is_retryable_not_connected():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._RECONNECT_WAIT_SECONDS = 0.15
+    adapter._RECONNECT_POLL_INTERVAL = 0.05
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_send_permanent_fatal_fails_immediately_without_wait():
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._set_fatal_error("telegram_auth_error", "invalid token", retryable=False)
+    adapter._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait on permanent fatal")
+    )
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is False


### PR DESCRIPTION
## Summary
Telegram `send()` now waits up to 15s for reconnection (or a replacement adapter) instead of failing immediately with a non-retryable "Not connected", so a brief network blip during the final reply delivers now instead of sitting in the delivery ledger until the next gateway boot.

Root cause: when Telegram dropped during a final-reply `send()`, the method returned `SendResult(success=False, error="Not connected")` with `retryable=False` (the default). The delivery ledger held the answer until the next gateway restart — often hours later.

## Changes
- `plugins/platforms/telegram/adapter.py`: add `_wait_for_reconnection()` (polls `_bot` / replacement adapter for up to 15s) and `_replacement_telegram_adapter()` (resolves a replacement adapter installed by the reconnect watcher mid-wait). `send()` now checks for a live replacement, waits if needed, and delegates to the replacement if one appears. Permanent-fatal errors still fail closed without waiting. Timeout returns `retryable=True`.
- `tests/gateway/test_telegram_send_reconnect_wait.py`: 5 tests — bot returns mid-wait, replacement installed mid-wait, replacement already live, timeout is retryable, permanent fatal fails immediately without waiting.

## Validation
| | Before | After |
|---|---|---|
| Final reply during 10s blip | Held in ledger until restart | Delivered after reconnect |
| Permanent fatal (bad token) | Fails immediately | Fails immediately (no wait) |
| Timeout after 15s | Non-retryable | Retryable |

- 12 tests pass (send reconnect wait + send path health + final delivery)
- 198 Telegram adapter tests pass (0 regressions)
- E2E verified: timeout→retryable, replacement-already-live→delegates, bot-returns-during-wait→succeeds, replacement-mid-wait→delegates, permanent-fatal→no-wait

Salvaged from #93908 by @xxxigm — cherry-picked with authorship preserved.

Closes #93908
