### PR TITLE
fix(terminal): expand ~ and trim TERMINAL_SSH_KEY before ssh -i

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -161,6 +161,21 @@ class TestTerminalToolConfig:
         from tools.terminal_tool import _get_env_config
         assert _get_env_config()["ssh_persistent"] is False
 
+    def test_ssh_key_tilde_expanded_and_trimmed(self, monkeypatch):
+        """The key path is passed to `ssh -i` via subprocess with no shell,
+        so a leading ~ must be expanded (and stray whitespace stripped)
+        before OpenSSH ever sees it."""
+        monkeypatch.delenv("TERMINAL_SSH_PERSISTENT", raising=False)
+        from tools.terminal_tool import _get_env_config
+
+        monkeypatch.setenv("TERMINAL_SSH_KEY", "  ~/keys/id_ed25519  ")
+        cfg = _get_env_config()
+        assert not cfg["ssh_key"].startswith("~")
+        assert cfg["ssh_key"] == os.path.expanduser("~/keys/id_ed25519")
+
+        monkeypatch.setenv("TERMINAL_SSH_KEY", "")
+        assert _get_env_config()["ssh_key"] == ""
+
 
 class TestSSHPreflight:
     def test_ensure_ssh_available_raises_clear_error_when_missing(self, monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1789,7 +1789,10 @@ def _get_env_config() -> Dict[str, Any]:
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        # expanduser: the key path is passed directly to `ssh -i` via
+        # subprocess (no shell), so a leading ~ would otherwise be handed to
+        # OpenSSH literally and silently fall back to default keys.
+        "ssh_key": os.path.expanduser(os.getenv("TERMINAL_SSH_KEY", "").strip()),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.


### PR DESCRIPTION
## Problem

`TERMINAL_SSH_KEY` is handed to OpenSSH via `subprocess` (`ssh -i <key>`) with **no shell involved**, so tilde expansion never happens. A user setting

```
TERMINAL_SSH_KEY=~/keys/id_ed25519
```

— the natural spelling, and what most docs suggest — sent the literal string `~/keys/id_ed25519` to `ssh -i`. OpenSSH can't find that file, prints a warning to stderr (swallowed by the capture), and **silently falls back to default keys**: auth then fails or authenticates as the wrong identity with zero indication that the configured key was ignored.

## Fix

`_get_env_config()` now applies `os.path.expanduser(...).strip()` to the value at config-build time, so every consumer (`SSHEnvironment.key_path`, scp commands) sees an absolute path.

## Verification

New test in `tests/tools/test_ssh_environment.py`: `"  ~/keys/id_ed25519  "` → expanded absolute path equal to `expanduser("~/keys/id_ed25519")`, empty value stays empty. Suite: 11 passed, 5 skipped (live-host gated).