### PR TITLE
fix(agent): keep marker-merged user rows addressable after alternation repair

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -799,6 +799,23 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # bytes previously sent for the pre-merge message) — drop it
                 # so replay can't substitute stale bytes.
                 drop_stale_api_content(prev)
+                # A display-marker row (e.g. a model-switch marker persisted
+                # as role=user on purpose, #48338) merging with a plain user
+                # row must not bury the plain row's addressable identity.
+                # Keeping the marker's display_kind hides the merged pair
+                # from every user-turn index used for rewind/submit
+                # addressing (display rows are excluded), so the plain
+                # row's durable id becomes unresolvable and the client's
+                # next prompt.submit fails closed with the input silently
+                # dropped (#94486). Keep the pair addressable instead:
+                # drop the display classification and carry the plain row's
+                # id. display_kind never reaches providers (stripped from
+                # every outgoing copy), so the merged turn's wire payload
+                # is unchanged.
+                if prev.get("display_kind") and not msg.get("display_kind"):
+                    prev.pop("display_kind", None)
+                    if msg.get("_row_id") is not None:
+                        prev["_row_id"] = msg["_row_id"]
                 repairs += 1
                 continue
         merged.append(msg)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -812,6 +812,14 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # id. display_kind never reaches providers (stripped from
                 # every outgoing copy), so the merged turn's wire payload
                 # is unchanged.
+                #
+                # Deliberate scope: when both rows carry display_kind (two
+                # consecutive model-switch markers) the pair keeps the first
+                # marker's classification and id — no plain row is swallowed
+                # there, so no addressable turn is lost. prev.pop() relies on
+                # prev being the live object already held in merged (never
+                # copied); a refactor that appends a copy instead would
+                # silently drop the repair.
                 if prev.get("display_kind") and not msg.get("display_kind"):
                     prev.pop("display_kind", None)
                     if msg.get("_row_id") is not None:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -69,6 +69,65 @@ def test_repair_preserves_user_content_when_one_side_empty():
     assert messages == [{"role": "user", "content": "real message"}]
 
 
+def test_repair_marker_user_merge_keeps_plain_row_addressable():
+    """#94486: a display-marker user row (model-switch marker, persisted as
+    role=user on purpose per #48338) merging with the plain user row after it
+    must keep the pair addressable — the merged row drops the display
+    classification and carries the plain row's durable id, so rewind/submit
+    addressing (which indexes non-display user turns) can still resolve it.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "assistant", "content": "reply"},
+        {
+            "role": "user",
+            "display_kind": "model_switch",
+            "_row_id": 12134,
+            "content": "[System: The active model for this chat has changed to ds4.]",
+        },
+        {"role": "user", "_row_id": 12135, "content": "the user's real prompt"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 2
+    merged = messages[1]
+    assert merged["role"] == "user"
+    assert not merged.get("display_kind")
+    assert merged["_row_id"] == 12135
+    assert "the user's real prompt" in merged["content"]
+    assert "[System:" in merged["content"]
+
+
+def test_repair_plain_user_then_marker_stays_addressable():
+    """The mirror shape (plain user, then a display marker) already keeps the
+    plain row's identity; pin that the merge does not resurrect a display
+    classification or swap in the marker's id.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "_row_id": 12134, "content": "the user's real prompt"},
+        {
+            "role": "user",
+            "display_kind": "model_switch",
+            "_row_id": 12135,
+            "content": "[System: The active model for this chat has changed to ds4.]",
+        },
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert messages == [
+        {
+            "role": "user",
+            "_row_id": 12134,
+            "content": "the user's real prompt\n\n[System: The active model for this chat has changed to ds4.]",
+        }
+    ]
+
+
 def test_repair_does_not_rewind_ongoing_dialog_tool_pair():
     """assistant(tool_calls) + tool + user is a VALID pattern (user redirect
     before the model gets its continuation turn). Repair must not touch it —

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6512,6 +6512,100 @@ def test_prompt_submit_row_id_not_found(monkeypatch):
         server._sessions.pop("missing-row-sid", None)
 
 
+def test_prompt_submit_resolves_row_id_absorbed_into_marker_merge(monkeypatch):
+    """#94486: after a mid-session model switch, the marker is persisted as
+    role=user (#48338) and the next real user row merges into it under
+    repair. The merged row must stay addressable (plain row's _row_id kept,
+    display classification dropped) so prompt.submit with
+    truncate_before_row_id resolves instead of failing closed with the
+    user's input silently dropped.
+    """
+    import copy
+
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    verbatim = [
+        {"_row_id": 12131, "role": "user", "content": "first"},
+        {"_row_id": 12133, "role": "assistant", "content": "reply 1"},
+        {
+            "_row_id": 12134,
+            "role": "user",
+            "display_kind": "model_switch",
+            "content": "[System: The active model for this chat has changed to ds4.]",
+        },
+        {"_row_id": 12135, "role": "user", "content": "the dropped prompt"},
+    ]
+    repaired = copy.deepcopy(verbatim)
+    assert repair_message_sequence(None, repaired) == 1
+    # The merged pair survives as ONE addressable user row carrying the
+    # plain row's durable id — this is the property the gateway relies on.
+    assert len(repaired) == 3
+    assert repaired[2]["_row_id"] == 12135
+    assert not repaired[2].get("display_kind")
+
+    replaced = []
+
+    class _FakeDB:
+        def get_messages_as_conversation(
+            self, key, include_ancestors=False, repair_alternation=False,
+            include_row_ids=False, **_kwargs
+        ):
+            assert key == "session-key"
+            assert include_row_ids is True
+            return copy.deepcopy(repaired if repair_alternation else verbatim)
+
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False, **_kwargs):
+            replaced.append((key, list(messages)))
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def _fake_session_db(_session):
+        yield _FakeDB()
+
+    # Live history as it looks after a session restore: the durable
+    # transcript reloaded WITHOUT row-id stamps (restore doesn't request
+    # them), so resolution must go through the durable fallback.
+    live = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": repaired[2]["content"]},
+    ]
+    server._sessions["merged-marker-sid"] = _session(history=list(live))
+    monkeypatch.setattr(server, "_session_db", _fake_session_db)
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "merged-marker-sid",
+                    "text": "new turn",
+                    "truncate_before_row_id": 12135,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None, resp.get("error")
+        # The cut lands before the merged marker+prompt pair: everything the
+        # pair would have buried is kept, the pair itself is replaced by the
+        # freshly submitted turn. (Rows carry _row_id stamps because the
+        # durable fallback healed the live list's missing stamps first.)
+        assert len(replaced) == 1
+        assert replaced[0][0] == "session-key"
+        assert replaced[0][1] == [
+            {"role": "user", "content": "first", "_row_id": 12131},
+            {"role": "assistant", "content": "reply 1", "_row_id": 12133},
+        ]
+        assert len(server._sessions["merged-marker-sid"]["history"]) == 2
+    finally:
+        server._sessions.pop("merged-marker-sid", None)
+
+
 def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
     """truncate_before_row_id must not match string platform IDs."""
     history = [


### PR DESCRIPTION
## What does this PR do?

After a mid-session model switch, the next user prompt can be **silently dropped** (`prompt.submit: target row_id NNN not found ... refusing truncation without fallback`), leaving the conversation appearing frozen with no error in the UI.

Root cause chain:

1. A model-switch marker is persisted as `role=user` **on purpose** (#48338 — strict OpenAI-compatible providers reject non-leading system messages), so the next real user row forms a `user;user` pair in the durable transcript.
2. `repair_message_sequence` Pass 2 merges that pair into the **earlier** (marker) row — keeping the marker's `display_kind` and dropping the plain row's `_row_id` from the repaired view.
3. Every rewind/`prompt.submit` addressing surface (`_history_user_indices`) indexes **non-display** user turns, so the merged pair becomes unaddressable: `truncate_before_row_id` aimed at the plain row fails closed and the submitted input is lost.

The fix keeps the merged pair **addressable**: when a display-marker user row merges with a plain user row, the merged row drops the display classification and carries the plain row's durable id. `display_kind` never reaches providers (it is stripped from every outgoing copy in `conversation_loop`), so the merged turn's wire payload is unchanged.

## Related Issue

Fixes #94486

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `repair_message_sequence` Pass 2, when the surviving row carries a `display_kind` and the absorbed row is a plain user row, pop the display classification and carry the plain row's `_row_id`, so the merged pair stays addressable for rewind/submit targeting (#94486).
- `tests/run_agent/test_message_sequence_repair.py` — two pins: marker→plain merge keeps the plain row's id and drops `display_kind`; plain→marker merge keeps the plain row's identity (mirror shape unchanged).
- `tests/test_tui_gateway_server.py` — end-to-end pin of the issue's exact shape: durable transcript containing `[System: ... model ... has changed]` (marker, role=user) followed by the real user row; live history restored without row-id stamps; `prompt.submit` with `truncate_before_row_id` aimed at the real row now resolves and truncates instead of returning 4018 and dropping the input.

## How to Test

1. `pytest tests/run_agent/test_message_sequence_repair.py -q` — should pass (37 passed; includes the two new pins).
2. `pytest tests/test_tui_gateway_server.py -q -k "merged_marker or row_id or truncate or alternation"` — should pass (30 passed; includes the new end-to-end test).
3. Observed result: before the change, the e2e test's `prompt.submit` returns error 4018 (`target user message is no longer in session history`) and no `replace_messages` call happens; after the change the request succeeds, the durable truncation keeps everything before the merged marker+prompt pair, and the new turn proceeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction from the issue (before the fix):

```
INFO agent.agent_runtime_helpers: Model switched in-place: deepseek-v4-flash (custom) -> deepseek-v4-flash (custom:ds4)
INFO hermes_state: Repaired 2 message-alternation violation(s) while restoring session 20260824_172329_ee80af
WARNING tui_gateway.server: prompt.submit: target row_id 12135 not found for session d3e2e58a (in-memory + durable); refusing truncation without fallback
```

With the fix, the merged marker+prompt row carries `_row_id=12135` and stays in the addressable user-turn index, so the same submit resolves, truncates before the pair, and the turn proceeds.
