### PR TITLE
fix(teams): stop crashing connect with NoneType when the SDK never bound (salvage #93861)

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -58,11 +58,29 @@ except ImportError:
 import importlib.util
 import sys as _sys
 
-try:
-    TEAMS_SDK_AVAILABLE = importlib.util.find_spec("microsoft_teams") is not None
-except ValueError:
-    # Test stubs may inject a module without ``__spec__``.
-    TEAMS_SDK_AVAILABLE = "microsoft_teams" in _sys.modules
+
+def _probe_teams_sdk_available() -> bool:
+    """True when ``microsoft_teams.apps`` is on sys.path, without importing it.
+
+    Sibling packages (microsoft-teams-api / common / cards) also live under
+    the ``microsoft_teams`` namespace, so ``find_spec("microsoft_teams")``
+    alone can be True while ``App`` is still unbound — connect() then
+    called None and logged ``'NoneType' object is not callable``.
+
+    Probe the parent first: ``find_spec("microsoft_teams.apps")`` raises
+    ``ModuleNotFoundError`` on 3.11+ when the parent namespace is absent,
+    which crashed plugin import and unregistered the Teams platform.
+    """
+    try:
+        if importlib.util.find_spec("microsoft_teams") is None:
+            return False
+        return importlib.util.find_spec("microsoft_teams.apps") is not None
+    except (ValueError, ModuleNotFoundError, ImportError):
+        # Test stubs may inject a module without ``__spec__``.
+        return "microsoft_teams.apps" in _sys.modules
+
+
+TEAMS_SDK_AVAILABLE = _probe_teams_sdk_available()
 ClientOptions = None  # type: ignore[assignment,misc]
 App = None  # type: ignore[assignment,misc]
 ActivityContext = None  # type: ignore[assignment,misc]
@@ -779,8 +797,13 @@ class TeamsAdapter(BasePlatformAdapter):
         # Defensive re-check: create_adapter() already ran the installer
         # (ensure_deps_fn) if deps were missing, but connect() can also be
         # reached via reconnect paths — re-run to bind SDK globals.
+        #
+        # Gate on App, not TEAMS_SDK_AVAILABLE. The latter is a find_spec
+        # probe and can be True from the microsoft_teams namespace without
+        # symbols ever being bound (check_teams_requirements returning
+        # False is ignored if we only inspect the flag).
         check_teams_requirements()
-        if not TEAMS_SDK_AVAILABLE:
+        if App is None or ClientOptions is None:
             self._set_fatal_error(
                 "MISSING_SDK",
                 "microsoft-teams-apps could not be installed. "
@@ -858,7 +881,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 f"Teams connection failed: {e}",
                 retryable=True,
             )
-            logger.error("[teams] Failed to connect: %s", e)
+            logger.error("[teams] Failed to connect: %s", e, exc_info=True)
             return False
 
     async def disconnect(self) -> None:

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -4,7 +4,7 @@ import json
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -169,8 +169,18 @@ _ensure_teams_mock()
 _teams_mod = load_plugin_adapter("teams")
 
 _teams_mod.AIOHTTP_AVAILABLE = True
-# SDK import is deferred (#62935); bind mocked symbols the same way connect() does.
-assert _teams_mod.check_teams_requirements() is True
+# SDK import is deferred (#62935); bind mocked symbols the same way connect()
+# does, but skip the real lazy-installer so collection does not pip-install
+# microsoft-teams-apps.
+
+
+def _bind_mock_sdk(feature, importer, target_globals, **kwargs):
+    target_globals.update(importer())
+    return True
+
+
+with patch("tools.lazy_deps.ensure_and_bind", _bind_mock_sdk):
+    assert _teams_mod.check_teams_requirements() is True
 _teams_mod.TEAMS_SDK_AVAILABLE = True
 
 # Ensure SDK symbols that were None (import failed on Python <3.12) are
@@ -349,9 +359,11 @@ class TestTeamsConnect:
     @pytest.mark.anyio
     async def test_connect_fails_without_sdk(self, monkeypatch):
         monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", False)
+        monkeypatch.setattr(_teams_mod, "App", None)
+        monkeypatch.setattr(_teams_mod, "ClientOptions", None)
         # Simulate the SDK being unavailable AND not installable (offline /
         # locked-down env): the lazy-installer can't rebind the globals, so
-        # TEAMS_SDK_AVAILABLE stays False and connect() must fail.
+        # App stays None and connect() must fail without calling it.
         monkeypatch.setattr(
             "tools.lazy_deps.ensure_and_bind",
             lambda *_a, **_k: False,
@@ -361,6 +373,27 @@ class TestTeamsConnect:
         ))
         result = await adapter.connect()
         assert result is False
+
+    @pytest.mark.anyio
+    async def test_connect_fails_when_namespace_exists_but_app_unbound(self, monkeypatch):
+        """find_spec('microsoft_teams') can be true from sibling packages
+        without microsoft-teams-apps. connect() must not call App() while
+        it is still None — that was ``'NoneType' object is not callable``.
+        """
+        monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "App", None)
+        monkeypatch.setattr(_teams_mod, "ClientOptions", None)
+        monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(
+            "tools.lazy_deps.ensure_and_bind",
+            lambda *_a, **_k: False,
+        )
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        result = await adapter.connect()
+        assert result is False
+        assert adapter._app is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_teams_dotenv_isolation.py
+++ b/tests/gateway/test_teams_dotenv_isolation.py
@@ -115,6 +115,35 @@ def _purge_teams_adapter_modules() -> None:
 
 
 class TestTeamsAdapterImportDoesNotLeakDotenv:
+    def test_adapter_import_without_sdk_does_not_raise(self, monkeypatch):
+        """Plugin import must not crash when microsoft_teams is absent.
+
+        ``find_spec("microsoft_teams.apps")`` raises ModuleNotFoundError on
+        3.11+ if the parent namespace is missing — that unregistered Teams.
+        """
+        for name in list(sys.modules):
+            if name == "microsoft_teams" or name.startswith("microsoft_teams."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+        _purge_teams_adapter_modules()
+
+        import plugins.platforms.teams.adapter as teams_adapter
+
+        # Import must succeed even when the parent namespace is absent
+        # (CI: no microsoft-teams-apps). Symbols stay unbound until connect.
+        assert teams_adapter.App is None
+
+    def test_namespace_without_apps_is_not_sdk_available(self, monkeypatch):
+        """A sibling microsoft_teams package must not count as the Teams SDK."""
+        ns = types.ModuleType("microsoft_teams")
+        ns.__path__ = []  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "microsoft_teams", ns)
+        _purge_teams_adapter_modules()
+
+        import plugins.platforms.teams.adapter as teams_adapter
+
+        assert teams_adapter.App is None
+        assert teams_adapter.TEAMS_SDK_AVAILABLE is False
+
     def test_adapter_import_does_not_load_cwd_dotenv(self, tmp_path, monkeypatch):
         _plant_cwd_dotenv(tmp_path, monkeypatch)
         _install_fake_teams_sdk(monkeypatch)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -1230,12 +1230,19 @@ def ensure_and_bind(
     """
     try:
         ensure(feature, prompt=prompt)
-    except (FeatureUnavailable, Exception):
+    except FeatureUnavailable as exc:
+        logger.warning("%s", exc)
+        return False
+    except Exception as exc:
+        logger.warning("Failed to ensure feature %r: %s", feature, exc)
         return False
 
     try:
         bindings = importer()
-    except ImportError:
+    except ImportError as exc:
+        logger.warning(
+            "Failed to import feature %r after install: %s", feature, exc
+        )
         return False
 
     target_globals.update(bindings)


### PR DESCRIPTION
## Summary
Teams connect() no longer crashes with `'NoneType' object is not callable` when `microsoft_teams` namespace exists from sibling packages but `App` was never bound.

## Root cause
`find_spec("microsoft_teams")` returns True from sibling packages (microsoft-teams-api / common / cards) that share the `microsoft_teams` namespace, without `microsoft-teams-apps` being installed. Connect() gated on this flag, called `App()` while it was still `None`, and crashed.

## Changes
- **adapter.py**: `_probe_teams_sdk_available()` now probes `microsoft_teams.apps` (the real SDK submodule), not just the parent namespace. Also catches `ModuleNotFoundError` on 3.11+ when the parent namespace is absent (previously crashed plugin import).
- **adapter.py**: connect() gates on `App is None or ClientOptions is None` (the actual bound symbols) instead of the `TEAMS_SDK_AVAILABLE` find_spec flag.
- **adapter.py**: `exc_info=True` added to the connect failure logger for traceback visibility.
- **lazy_deps.py**: `ensure_and_bind()` failure paths now log `logger.warning()` with feature name and exception, instead of silently returning `False`.

## Validation
| | Before | After |
|---|---|---|
| connect() with namespace-only | crash: `'NoneType' object is not callable` | returns False with MISSING_SDK |
| plugin import without SDK | crash: `ModuleNotFoundError` (3.11+) | imports cleanly, App stays None |
| ensure_and_bind failure | silent return False | logged warning with context |
| tests | 20 passed, 4 pre-existing failures | 20 passed, 4 pre-existing failures |

## Credit
Cherry-picked from @xxxigm's PR #93861 with authorship preserved via rebase-merge.
