### PR TITLE
fix(delegate): report non-retryable child failures accurately

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -667,6 +667,98 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_non_retryable_client_error_marks_status_failed(self):
+        """Regression (#82599): a child that aborted on a non-retryable
+        client error (HTTP 401, billing wall, ...) returns a NON-empty error
+        string as final_response with failed=True (see conversation_loop's
+        terminal abort paths). That error text must be reported as a failed
+        delegation, not dressed up as status=completed."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "glm-5.2"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "HTTP 401: token expired or incorrect",
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 401: token expired or incorrect",
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Reply with exactly: PING", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "failed")
+            self.assertEqual(entry["exit_reason"], "error")
+            # A hard abort is not truncation.
+            self.assertIs(entry["truncated"], False)
+            # The underlying error must reach the parent verbatim.
+            self.assertEqual(entry["error"], "HTTP 401: token expired or incorrect")
+
+    def test_interrupted_takes_precedence_over_failed(self):
+        """An explicit stop remains interrupted even if the child also marks
+        its terminal result failed; this preserves the existing status contract."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "glm-5.2"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "Stopped after a provider error",
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "interrupted": True,
+                "failed": True,
+                "error": "HTTP 401: token expired or incorrect",
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Stop cleanly", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "interrupted")
+            self.assertEqual(entry["exit_reason"], "interrupted")
+            self.assertIs(entry["truncated"], False)
+            self.assertNotIn("error", entry)
+
+    def test_budget_exhausted_with_summary_stays_completed(self):
+        """Contract guard for the fix above: completed=False alone does NOT
+        mean failure. A child that exhausted its iteration budget but still
+        produced a genuine summary stays status=completed with
+        exit_reason=max_iterations + truncated=True — only results explicitly
+        marked failed=True flip to failed."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 100
+            mock_child.session_completion_tokens = 50
+            mock_child.run_conversation.return_value = {
+                "final_response": "Refactored 3 of 5 modules before running out of budget",
+                "messages": [],
+                "api_calls": 10,
+                "completed": False,
+                "interrupted": False,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Refactor modules", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["exit_reason"], "max_iterations")
+            self.assertIs(entry["truncated"], True)
+            self.assertNotIn("error", entry)
+
 
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3047,8 +3047,19 @@ def _run_single_child(
         # it instead of silently accepting zero-content "success".
         _empty_sentinel = summary.strip() == "(empty)"
 
+        # The conversation loop's terminal abort paths (non-retryable client
+        # errors like HTTP 401, billing walls, content-policy blocks, ...)
+        # return the error text as final_response and mark the result with
+        # ``failed=True`` (#82599). That error string must not read as usable
+        # output: report the delegation as failed. Note ``completed=False``
+        # alone does NOT mean failure — an iteration-budget-exhausted child
+        # still returns a genuine summary and stays "completed"+truncated.
+        _child_failed = bool(result.get("failed"))
+
         if interrupted:
             status = "interrupted"
+        elif _child_failed:
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -3098,6 +3109,12 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif _child_failed:
+            # Terminal abort (non-retryable client error, billing wall, ...).
+            # Same vocabulary as the timeout/exception entry above; keeps
+            # ``truncated`` False and stops the transcript from reporting a
+            # contradictory exit_reason=max_iterations on a 1-call task.
+            exit_reason = "error"
         elif completed:
             exit_reason = "completed"
         else:


### PR DESCRIPTION
## What does this PR do?

A child that terminates on a non-retryable client error returns both a non-empty error summary and `failed=True`. `delegate_task` previously treated any non-empty summary as usable output, so errors such as HTTP 401 were reported as `status=completed`, `exit_reason=max_iterations`, and `truncated=true`.

This change makes the child's explicit `failed` flag authoritative before the usable-summary branch. Hard failures now surface as `failed/error` without being described as iteration truncation. A child that genuinely exhausts its iteration budget but returns a useful summary remains `completed/max_iterations/truncated`, and an explicit interruption retains precedence.

This is a current-main restack of the focused work from #91940, preserving Chen Jin's original authorship and adding an interruption-precedence contract test.

## Related Issue

Fixes #82599

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: classify `failed=True` child results as `status=failed` with `exit_reason=error` before considering a non-empty summary successful.
- `tests/tools/test_delegate.py`: cover non-retryable failure propagation, iteration-budget summaries, and `interrupted` versus `failed` precedence.

## How to Test

1. Run the focused regression and adjacent delegation suites:

   ```bash
   HERMES_PYTHON="$(python -c 'import sys; print(sys.executable)')" \
     scripts/run_tests.sh \
       tests/tools/test_delegate.py \
       tests/tools/test_async_delegation.py \
       tests/tools/test_delegate_subagent_timeout_diagnostic.py \
       tests/run_agent/test_nonretryable_error_html_summary.py -q
   ```

   Observed: **101 passed, 0 failed** across four per-file subprocess suites.

2. Exercise the real HTTP path with a local OpenAI-compatible endpoint returning HTTP 401:

   ```text
   HTTP 401 → OpenAI SDK → AIAgent.run_conversation → delegate_task
   ```

   Current `main` reports:

   ```text
   status=completed, exit_reason=max_iterations, truncated=true
   ```

   This branch reports:

   ```text
   status=failed, exit_reason=error, truncated=false
   error=HTTP 401: token expired or incorrect
   ```

3. `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
4. `git diff --check origin/main`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run; the four affected/adjacent suites pass 101/101 via the CI-parity wrapper
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or command changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the change is platform-neutral result classification
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the existing result shape and status vocabulary are unchanged

## Screenshots / Logs

N/A — deterministic result-shape regression with automated and HTTP-path verification.
