### PR TITLE
fix(gateway): stop same-second spawn_tree.save overwrites

### DIFF
--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3438,12 +3438,17 @@ def _(rid, params: dict) -> dict:
     if not isinstance(subagents, list) or not subagents:
         return _err(rid, 4000, "subagents list required")
 
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     started_at = params.get("started_at")
     finished_at = params.get("finished_at") or time.time()
     label = str(params.get("label") or "")
-    ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S")
+    # Microsecond precision: two saves within the same second previously
+    # produced identical filenames and silently overwrote (write_text
+    # truncates). Also avoids deprecated datetime.utcfromtimestamp.
+    ts = datetime.fromtimestamp(float(finished_at), tz=timezone.utc).strftime(
+        "%Y%m%dT%H%M%S%f"
+    )
     fname = f"{ts}.json"
     d = _spawn_tree_session_dir(session_id or "default")
     path = d / fname


### PR DESCRIPTION
## Problem

`spawn_tree.save` named each snapshot with a **second-resolution** timestamp (`%Y%m%dT%H%M%S` + `.json`). Two saves for the same session within the same wall-clock second produced identical filenames, and `path.write_text(...)` silently truncated the first snapshot. Quick subagent fan-outs — exactly the workload this RPC exists for — land multiple saves inside one second.

## Fix

- Timestamps now carry microsecond precision (`%Y%m%dT%H%M%S%f`): still lexicographically sortable, still matches the legacy fallback scanner (which globs `*.json` generically and reads `finished_at` from the payload, not the filename).
- Replaces deprecated `datetime.utcfromtimestamp(...)` with timezone-aware `datetime.fromtimestamp(ts, tz=timezone.utc)` (the old call emits DeprecationWarning under `-W error`).

## Verification

Behavioral check: stamps for `t` and `t+0.0004s` are distinct; module parses clean. No existing tests reference `spawn_tree` (verified) — the reader path is filename-agnostic so no consumers needed updating.