### PR TITLE
fix(cron): microsecond stamps for local delivery and full-output files

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -398,7 +398,10 @@ class DeliveryRouter:
         metadata: Optional[Dict[str, Any]]
     ) -> Dict[str, Any]:
         """Save content to local files."""
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Microsecond precision: a retried or rapidly re-triggered job could
+        # otherwise produce the same second-resolution filename and silently
+        # truncate the earlier delivery.
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         
         if job_id:
             output_path = self.output_dir / job_id / f"{timestamp}.md"
@@ -438,7 +441,9 @@ class DeliveryRouter:
     
     def _save_full_output(self, content: str, job_id: str) -> Path:
         """Save full cron output to disk and return the file path."""
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Microsecond precision prevents same-second double-fires from
+        # silently overwriting the earlier run's full output.
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"


### PR DESCRIPTION
## Problem

Both cron output writers used **second-resolution** filename stamps:

- `_deliver_local()` → `<output_dir>/<job_id>/<YYYYMMDD_HHMMSS>.md`
- `_save_full_output()` → `cron/output/<job_id>_<YYYYMMDD_HHMMSS>.txt`

A retried job, a rapid manual re-trigger, or two scheduled fires landing in the same wall-clock second produced an identical filename, and `write_text` silently truncated the earlier run's saved output. Cron runs are exactly the kind of unattended workload where nobody is watching for this — the file exists, it just contains only the newer run.

## Fix

Both stamps gain `%f` (microseconds): `YYYYMMDD_HHMMSS_%f`, matching the convention already used by `agent/agent_runtime_helpers.py:1956`. Sort order and consumers reading the returned `path` are unchanged; the human-readable `**Timestamp:**` line inside the document still shows second precision.

## Verification

- `tests/gateway/test_delivery.py`: 13/13 pass
- `tests/cron/test_cron_created_delivery.py`: 12/12 pass