### PR TITLE
fix(photon): reap stale sidecar on Windows to prevent EADDRINUSE

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1487,6 +1487,32 @@ class PhotonAdapter(BasePlatformAdapter):
     @staticmethod
     def _find_listener_pids(port: int) -> List[int]:
         """PIDs listening on a local TCP port (empty if none/undeterminable)."""
+        if sys.platform == "win32":
+            # Use psutil on Windows (lsof is not available).
+            try:
+                import psutil
+                pids: List[int] = []
+                for conn in psutil.net_connections(kind="tcp"):
+                    if conn.laddr.port == port and conn.status == "LISTEN" and conn.pid:
+                        pids.append(conn.pid)
+                return pids
+            except Exception:
+                # Fallback: netstat parsing (slower, no deps).
+                try:
+                    out = subprocess.run(  # noqa: S603, S607
+                        ["netstat", "-ano", "-p", "TCP"],
+                        capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5.0, check=False,
+                    )
+                except (OSError, subprocess.TimeoutExpired):
+                    return []
+                pids = []
+                for line in out.stdout.splitlines():
+                    # Lines look like:  TCP    127.0.0.1:8789    0.0.0.0:0    LISTENING    1234
+                    if f":{port}" in line and "LISTENING" in line:
+                        parts = line.split()
+                        if parts and parts[-1].isdigit():
+                            pids.append(int(parts[-1]))
+                return pids
         try:
             out = subprocess.run(  # noqa: S603, S607
                 ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
@@ -1499,6 +1525,16 @@ class PhotonAdapter(BasePlatformAdapter):
     @staticmethod
     def _pid_is_sidecar(pid: int) -> bool:
         """True if ``pid``'s command line is a Photon sidecar process."""
+        if sys.platform == "win32":
+            # Use psutil on Windows (ps is not available).
+            try:
+                import psutil
+                cmdline = " ".join(psutil.Process(pid).cmdline())
+                # Normalize backslashes to forward slashes for cross-platform matching.
+                cmdline = cmdline.replace("\\", "/")
+                return "photon/sidecar/index.mjs" in cmdline
+            except Exception:
+                return False
         try:
             out = subprocess.run(  # noqa: S603, S607
                 ["ps", "-p", str(pid), "-o", "command="],
@@ -1511,11 +1547,23 @@ class PhotonAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _pid_alive(pid: int) -> bool:
+        if sys.platform == "win32":
+            try:
+                import psutil
+                return psutil.pid_exists(pid)
+            except Exception:
+                try:
+                    os.kill(pid, 0)
+                    return True
+                except OSError:
+                    return False
         try:
-            os.kill(pid, 0)  # windows-footgun: ok — only called from _reap_stale_sidecar which win32-guards early
+            os.kill(pid, 0)
             return True
         except OSError:
             return False
+
+
 
     async def _reap_stale_sidecar(self) -> None:
         """Kill an orphaned sidecar squatting our port before spawning ours.
@@ -1528,8 +1576,9 @@ class PhotonAdapter(BasePlatformAdapter):
         orphans that predate it (or survived it). Listeners are verified by
         command line before being signalled.
         """
-        if sys.platform == "win32":  # lsof/ps; orphaning is a POSIX-only path
-            return
+        # On Windows, orphaning IS possible — the stdin-EOF watch helps but
+        # a fast gateway restart can still race the port release. Use psutil
+        # (or netstat fallback) to find and kill stale sidecars.
         try:
             async with httpx.AsyncClient(timeout=2.0, trust_env=False) as client:
                 await client.post(
@@ -1538,8 +1587,8 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
         except httpx.RequestError:
             return  # nothing listening — the normal case
-        # Off the event loop: _find_listener_pids shells out to `lsof`
-        # (timeout=5s) and _pid_is_sidecar runs a `ps` per candidate pid
+        # Off the event loop: _find_listener_pids shells out to `lsof`/psutil
+        # (timeout=5s) and _pid_is_sidecar runs a `ps`/psutil per candidate pid
         # (timeout=5s each), so this inspection can hold the loop for
         # 5 + 5·N seconds. _reap_stale_sidecar is awaited from
         # _start_sidecar, which runs on every reconnect — exactly when a
@@ -1564,8 +1613,12 @@ class PhotonAdapter(BasePlatformAdapter):
                 pid, self._sidecar_port,
             )
             try:
-                os.kill(pid, signal.SIGTERM)
-            except OSError:
+                if sys.platform == "win32":
+                    import psutil
+                    psutil.Process(pid).terminate()
+                else:
+                    os.kill(pid, signal.SIGTERM)
+            except (OSError, Exception):
                 pass
         deadline = time.time() + 3.0
         while time.time() < deadline and any(self._pid_alive(p) for p in stale):
@@ -1573,8 +1626,12 @@ class PhotonAdapter(BasePlatformAdapter):
         for pid in stale:
             if self._pid_alive(pid):
                 try:
-                    os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — unreachable on win32 (early return above)
-                except OSError:
+                    if sys.platform == "win32":
+                        import psutil
+                        psutil.Process(pid).kill()
+                    else:
+                        os.kill(pid, signal.SIGKILL)
+                except (OSError, Exception):
                     pass
         # Give the OS a beat to release the listening socket.
         await asyncio.sleep(0.2)


### PR DESCRIPTION
## Summary

On Windows, `_reap_stale_sidecar()` had an early return for `win32` that skipped reaping entirely, relying on the stdin-EOF watch to prevent orphaned sidecar processes. But a fast gateway restart can still race the port release: the old sidecar hasn't released port 8789 when the new gateway starts, so the new sidecar hits `EADDRINUSE` and crashes, wasting ~30s on a failed first attempt before the reconnection watcher retries.

### What happens without this fix
1. Gateway shuts down → sidecar stdin pipe closes → sidecar begins shutdown
2. New gateway starts quickly (e.g. after `hermes update`) → sidecar hasn't released port 8789 yet
3. New sidecar spawn → `EADDRINUSE` → crash → `✗ photon failed to connect`
4. Reconnection watcher retries ~30s later → stale sidecar is gone → succeeds on attempt 2

### What this patch does
- **Removes the win32 early-return** from `_reap_stale_sidecar` so it actually runs on Windows
- **`_find_listener_pids`** — uses `psutil.net_connections()` (with `netstat -ano` fallback) instead of `lsof`
- **`_pid_is_sidecar`** — uses `psutil.Process.cmdline()` instead of `ps`, with backslash-to-forward-slash normalization so the `photon/sidecar/index.mjs` path match works on Windows
- **`_pid_alive`** — uses `psutil.pid_exists()` instead of `os.kill(pid, 0)`
- **Process termination** — uses `psutil.Process.terminate()` / `.kill()` instead of `SIGTERM` / `SIGKILL` on win32

### Why psutil and not netstat-only
psutil is already a Hermes dependency (used elsewhere in the codebase). It's faster, more reliable, and avoids parsing `netstat` output which varies by Windows locale. The `netstat` fallback is there for robustness only.

## Test Plan
- [x] Verified `_find_listener_pids(8789)` returns correct PID on Windows 11
- [x] Verified `_pid_is_sidecar` correctly identifies a running sidecar process (with backslash path normalization)
- [x] Verified `_pid_alive` works for both live and nonexistent PIDs
- [x] Verified `adapter.py` compiles clean (`py_compile`)
- [ ] Gateway restart with stale sidecar present → reaper kills it → new sidecar starts on first attempt (no EADDRINUSE)

Tested on: Windows 11, Python 3.11.15, psutil 7.2.2