### PR TITLE
fix(skills): background-review curator patches no longer refused after skill_view (#75618, salvage #73975)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -2,6 +2,7 @@
 
 import json
 from contextlib import contextmanager
+from contextvars import copy_context
 from pathlib import Path
 from unittest.mock import patch
 
@@ -914,6 +915,61 @@ class TestCuratorConsolidationDeleteGuard:
         # Skill must remain active on disk — fail closed, no archive.
         assert (skills_root / "active-skill").exists()
 
+    def test_background_review_read_survives_copied_tool_contexts(
+        self, tmp_path, monkeypatch
+    ):
+        """A view in one tool worker authorizes a patch in the next worker."""
+        from tools.skills_tool import skill_view
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+            viewed = copy_context().run(skill_view, "reviewed")
+            assert json.loads(viewed)["success"] is True
+
+            patched = copy_context().run(
+                skill_manage,
+                action="patch",
+                name="reviewed",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the thing safely.",
+            )
+            assert json.loads(patched)["success"] is True
+
+        _reset_background_review_read_marks()
+
+    def test_background_review_read_marks_stay_isolated_between_reviews(
+        self, tmp_path, monkeypatch
+    ):
+        """Copied tool contexts share only their own review's read marks."""
+        from tools.skills_tool import skill_view
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+            first_review = copy_context()
+            _reset_background_review_read_marks()
+            second_review = copy_context()
+
+            viewed = first_review.run(skill_view, "reviewed")
+            assert json.loads(viewed)["success"] is True
+
+            blocked = second_review.run(
+                skill_manage,
+                action="patch",
+                name="reviewed",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the thing safely.",
+            )
+            result = json.loads(blocked)
+            assert result["success"] is False
+            assert result.get("_read_before_write_required") is True
+
+        _reset_background_review_read_marks()
 
     def test_background_review_support_file_overwrite_requires_that_file_read(self, tmp_path, monkeypatch):
         from tools.skills_tool import skill_view

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -36,6 +36,7 @@ import json
 import logging
 import re
 import shutil
+import threading
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,9 +53,25 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
-)
+class _BackgroundReviewReadMarks:
+    """Read marks shared by copied tool contexts within one review run."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._paths: set[str] = set()
+
+    def add(self, path: str) -> None:
+        with self._lock:
+            self._paths.add(path)
+
+    def contains(self, path: str) -> bool:
+        with self._lock:
+            return path in self._paths
+
+
+_background_review_read_paths: (
+    "_ctxvars.ContextVar[Optional[_BackgroundReviewReadMarks]]"
+) = _ctxvars.ContextVar("background_review_read_paths", default=None)
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +94,11 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    marks = _background_review_read_paths.get()
+    if marks is None:
+        marks = _BackgroundReviewReadMarks()
+        _background_review_read_paths.set(marks)
+    marks.add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +106,13 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    marks = _background_review_read_paths.get()
+    return marks is not None and marks.contains(resolved)
 
 
 def _reset_background_review_read_marks() -> None:
-    """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    """Start a fresh, isolated read set for the current review context."""
+    _background_review_read_paths.set(_BackgroundReviewReadMarks())
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.


### PR DESCRIPTION
## Summary

The background-review curator can patch skills again — previously every `skill_manage` patch/edit from the self-improvement fork was refused with "the current SKILL.md content has not been loaded in this review turn," even immediately after `skill_view` on the same skill, so no skill was ever updated by the curator (creates worked, patches never did).

Root cause: the read-before-write mark was a `ContextVar[frozenset]` re-`.set()` per mark. Tool dispatch runs each call in `contextvars.copy_context().run(...)` on a worker thread (`tools/thread_context.py:propagate_context_to_thread`), so a mark set inside `skill_view`'s private copied context was invisible to `skill_manage`'s worker.

Salvage of #73975 by @zyz619963502zyz (earliest of a 3-PR cluster; authorship preserved). Fixes #75618.

## Changes

- `tools/skill_manager_tool.py`: the ContextVar now holds a **mutable, lock-protected mark store** (`_BackgroundReviewReadMarks`). Copied contexts within one review fork share the same object reference, so marks survive per-call thread dispatch; `_reset_background_review_read_marks()` installs a fresh store, so concurrent review forks stay isolated from each other.
- `tests/tools/test_skill_manager_tool.py`: two regression tests — cross-context mark visibility (fails on main, passes with fix) and cross-fork isolation.

## Validation

| Check | main | with fix |
|---|---|---|
| Mark visible in second copied context (live repro, origin=background_review) | False (bug) | True |
| Cross-fork mark leak | n/a | False (isolated) |
| `tests/tools/test_skill_manager_tool.py` | — | 49/49 pass |

**Live repro:** on `origin/main`, `mark_background_review_skill_read` in one `copy_context()` is invisible to `_background_review_has_read` in a sibling context (the exact production dispatch shape); with the fix, visible within the fork and isolated across forks.

## Cluster

- #73975 — salvaged here (earliest, fork-scoped design, only PR with tests)
- #75661 — duplicate approach, 2 days later (already labeled `duplicate`)
- #83321 — module-global set+lock: fixes visibility but leaks marks across concurrent review forks (multiplex gateway runs multiple profiles per process); no test in diff

## Infographic

![Skill curator can patch skills again](https://v3b.fal.media/files/b/0aa7b8e4/verhQtwr0I5qZN9K3B_yN_IIBKMSpI.png)
