### PR TITLE
fix(insights): price bare model names and dated-only snapshot keys

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1089,6 +1089,19 @@ def resolve_billing_route(
             provider_name = inferred_provider
             model = bare_model
 
+    # Sessions often store BARE model names ("claude-opus-4-6") with
+    # billing_provider NULL (#3525). Infer the vendor from unambiguous
+    # family prefixes so /insights can price them instead of routing to
+    # provider="unknown".
+    if not provider_name:
+        lower_model = model.lower()
+        if lower_model.startswith("claude"):
+            provider_name = "anthropic"
+        elif lower_model.startswith(("gpt-", "o1", "o3", "o4-", "chatgpt")):
+            provider_name = "openai"
+        elif lower_model.startswith("gemini"):
+            provider_name = "google"
+
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
@@ -1204,6 +1217,24 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+    # Family fallback (#3525): some snapshot keys exist only under their
+    # documented dated form ("claude-3-5-haiku-20241022") while sessions
+    # store the bare family name ("claude-3-5-haiku") — and vice versa.
+    # Compare with the trailing -YYYYMMDD stripped from BOTH sides so
+    # either spelling prices instead of silently returning $0.00.
+    def _strip_date(name: str) -> str:
+        return re.sub(r"-\d{8}$", "", name)
+
+    stripped_model = _strip_date(model)
+    if stripped_model != model:
+        entry = _OFFICIAL_DOCS_PRICING.get((route.provider, stripped_model))
+        if entry:
+            return entry
+    # Requested name is bare; a snapshot key may still exist ONLY under its
+    # dated form ("claude-3-5-haiku-20241022").
+    for (provider_key, model_key), candidate in _OFFICIAL_DOCS_PRICING.items():
+        if provider_key == route.provider and _strip_date(model_key) == stripped_model:
+            return candidate
     return None
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -105,6 +105,38 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
+def test_bare_model_name_with_null_provider_infers_vendor():
+    """/insights sessions store bare names ("claude-opus-4-6") with
+    billing_provider NULL; resolve_billing_route used to route them to
+    provider="unknown" and price $0.00 (#3525 gap 1)."""
+    from agent.usage_pricing import resolve_billing_route
+
+    assert resolve_billing_route("claude-opus-4-6").provider == "anthropic"
+    assert resolve_billing_route("gpt-4o-mini").provider == "openai"
+    assert resolve_billing_route("gemini-2.5-pro").provider == "google"
+    # Unambiguous-only: private/unknown families must NOT be guessed.
+    assert resolve_billing_route("my-private-model").provider == "unknown"
+
+
+def test_dated_only_snapshot_key_prices_bare_family_name():
+    """/insights gap 2 (#3525): some snapshot keys exist only under their
+    documented dated form (claude-3-5-haiku-20241022); a session storing the
+    bare family name must still price instead of silently returning None."""
+    from agent.usage_pricing import (
+        _lookup_official_docs_pricing,
+        resolve_billing_route,
+    )
+
+    route = resolve_billing_route(
+        "claude-3-5-haiku", provider="anthropic"
+    )
+    entry = _lookup_official_docs_pricing(route)
+    assert entry is not None, "bare family name must hit the dated-only key"
+    # Reverse direction: dated session name against a bare key.
+    route2 = resolve_billing_route("claude-opus-4-6-20250414", provider="anthropic")
+    assert _lookup_official_docs_pricing(route2) is not None
+
+
 
 
 def test_deepseek_deprecated_aliases_price_as_v4_flash():


### PR DESCRIPTION
Fixes #3525

## Problem

`/insights` showed `$0.00` for common sessions due to two independent lookup gaps in `agent/usage_pricing.py`, exactly as diagnosed in the issue:

**Gap 1 — provider inference fails for bare names.** Sessions store `claude-opus-4-6` with `billing_provider=NULL`. `resolve_billing_route()` inferred the vendor only when the name carried a `<vendor>/` prefix; everything else routed to `provider="unknown"` → no pricing.

**Gap 2 — no alias handling against dated snapshot keys.** `_lookup_official_docs_pricing()` matched `(provider, model)` exactly, but several rows exist **only** under their documented dated form (`claude-3-5-haiku-20241022` — there is no bare twin), while sessions record `claude-3-5-haiku`. Reverse case also misses (dated session name, bare key).

## Fix

1. Vendor inferred from unambiguous family prefixes when provider is absent: `claude*`→anthropic, `gpt-*`/`o1*`/`o3*`/`o4-*`/`chatgpt*`→openai, `gemini*`→google. Private families remain `unknown` (no false pricing).
2. After direct + existing normalizers miss, both sides of the comparison get their trailing `-YYYYMMDD` stripped before matching.

## Verification

New tests in `tests/agent/test_usage_pricing.py`:
- vendor inference for claude/gpt/gemini with NULL provider; `my-private-model` stays unknown
- bare family name hits the dated-only key AND dated session name hits a bare key

Suite: 48/48 pass.