### PR TITLE
fix(gateway): microsecond stamps for conversation saves and profile exports

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -24,6 +24,7 @@ import sys  # noqa: F401
 import threading
 import time  # noqa: F401
 from collections import OrderedDict
+from datetime import datetime
 from pathlib import Path  # noqa: F401
 from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
 
@@ -1179,7 +1180,8 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
             staging.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"Could not create export directory: {exc}")
-        stamp = time.strftime("%Y%m%d-%H%M%S")
+        # Microseconds so two rapid exports can't overwrite the archive.
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S_%f")
         output = str(staging / f"{profiles_mod.normalize_profile_name(name)}-{stamp}.tar.gz")
 
     loop = asyncio.get_running_loop()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3057,7 +3057,8 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         return _err(rid, 5011, f"failed to create save directory {saved_dir}: {e}")
 
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Microseconds so two rapid saves can't silently overwrite each other.
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     path = saved_dir / f"hermes_conversation_{timestamp}.json"
 
     with session["history_lock"]:


### PR DESCRIPTION
## Problem

Two export writers used **second-resolution** filenames, so two rapid invocations silently overwrote the earlier artifact:

- `spawn_tree`-adjacent dashboard save (`tui_gateway/methods_session.py:3060`): `hermes_conversation_<YYYYMMDD_HHMMSS>.json` — a double-clicked save button (or save on two chats within a second) truncated the first snapshot via `write_text`.
- `POST /api/profiles/<name>/export` (`hermes_cli/web_routers/profiles.py:1182`): `<profile>-<YYYYMMDD-HHMMSS>.tar.gz` — same overwrite for rapid exports.

## Fix

Both stamps gain `%f` microseconds, matching the convention already used across the repo (cron delivery #94505, `agent_runtime_helpers`). Prefixes and extensions unchanged, so any prefix-globbing consumers keep working.

## Verification

Syntax-checked both modules; gateway suite selection passes (2 skipped as before).