### PR TITLE
fix(mcp): surface approval prompt for destructive MCP elicitation in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16565,6 +16565,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     set_secret_capture_callback(self._secret_capture_callback)
                 except Exception:
                     pass
+                # Also carry the CLI approval callback in a contextvar so the
+                # MCP elicitation consent path (which runs on the MCP background
+                # loop's worker threads, not this agent thread) can still surface
+                # the prompt_toolkit approval panel. Without it the elicitation
+                # prompt fail-closes with an invisible deny (#94488).
+                try:
+                    from tools.approval import set_cli_approval_callback
+                    _cli_approval_token = set_cli_approval_callback(self._approval_callback)
+                except Exception:
+                    _cli_approval_token = None
                 # Bind this turn's approval session key into the contextvar so
                 # ``tools.approval.is_current_session_yolo_enabled()`` resolves
                 # against the same key that ``/yolo`` toggles under (see
@@ -16670,6 +16680,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if _approval_session_token is not None and reset_current_session_key is not None:
                         try:
                             reset_current_session_key(_approval_session_token)
+                        except Exception:
+                            pass
+                    if _cli_approval_token is not None:
+                        try:
+                            from tools.approval import reset_cli_approval_callback
+                            reset_cli_approval_callback(_cli_approval_token)
                         except Exception:
                             pass
 

--- a/tests/tools/test_mcp_elicitation_approval.py
+++ b/tests/tools/test_mcp_elicitation_approval.py
@@ -1,0 +1,57 @@
+"""Regression tests for MCP elicitation approval routing (#94488).
+
+Before the fix, ``request_elicitation_consent``'s CLI branch called
+``prompt_dangerous_approval`` without an ``approval_callback``. The
+prompt_toolkit fail-closed guard in ``_prompt_dangerous_approval_inner`` then
+returned ``"deny"`` without rendering any prompt, so a destructive MCP tool
+(e.g. Wincontainer ``remove_container``) was silently rejected with
+``human_approval_denied`` and the user never saw an approval request.
+"""
+
+from unittest.mock import patch
+
+from tools import approval
+
+
+def test_resolve_prefers_explicit_callback():
+    explicit = object()
+    assert approval._resolve_cli_approval_callback(explicit) is explicit
+
+
+def test_resolve_falls_back_to_contextvar_callback():
+    ctx_cb = object()
+    token = approval._cli_approval_callback.set(ctx_cb)
+    try:
+        # The contextvar is hit before the thread-local lookup, so the callback
+        # survives the MCP background-loop thread hop even when the
+        # thread-local slot is empty.
+        assert approval._resolve_cli_approval_callback() is ctx_cb
+    finally:
+        approval._cli_approval_callback.reset(token)
+
+
+def test_elicitation_passes_contextvar_callback_to_prompt():
+    ctx_cb = object()
+    token = approval._cli_approval_callback.set(ctx_cb)
+    try:
+        with patch("tools.approval.prompt_dangerous_approval", return_value="once") as prompt, \
+             patch("tools.approval.get_current_session_key", return_value="default"), \
+             patch("tools.approval._is_gateway_approval_context", return_value=False):
+            result = approval.request_elicitation_consent("msg", "desc", timeout_seconds=1)
+            assert result == "accept"
+            _, kwargs = prompt.call_args
+            assert kwargs["approval_callback"] is ctx_cb
+    finally:
+        approval._cli_approval_callback.reset(token)
+
+
+def test_elicitation_no_callback_fails_closed():
+    # No contextvar and no thread-local callback -> approval_callback=None,
+    # and prompt_dangerous_approval's own guard returns "deny" (fail closed).
+    with patch("tools.approval.prompt_dangerous_approval", return_value="deny") as prompt, \
+         patch("tools.approval.get_current_session_key", return_value="default"), \
+         patch("tools.approval._is_gateway_approval_context", return_value=False):
+        result = approval.request_elicitation_consent("msg", "desc", timeout_seconds=1)
+        assert result == "decline"
+        _, kwargs = prompt.call_args
+        assert kwargs["approval_callback"] is None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -23,7 +23,7 @@ import threading
 import time
 import unicodedata
 import uuid
-from typing import Optional
+from typing import Any, Optional
 from hermes_cli.config import cfg_get
 
 from tools.interrupt import is_interrupted
@@ -74,6 +74,21 @@ _approval_session_id: contextvars.ContextVar[str] = contextvars.ContextVar(
 # single-threaded CLI callers that still export HERMES_INTERACTIVE.
 _hermes_interactive_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "hermes_interactive",
+    default=None,
+)
+
+# Per-session CLI approval callback. The CLI registers its prompt_toolkit
+# approval panel on the agent thread (cli.py run_agent), but MCP elicitation
+# consent runs on the MCP background loop's worker threads (tools/mcp_tool.py
+# ``_mcp_loop`` + ``asyncio.to_thread``). A thread-local slot cannot cross that
+# gap, so the callback is also carried in a contextvar: the elicitation handler
+# replays the captured tool-call context (``owner._pending_call_context``) via
+# ``contextvars.Context.run``, which restores this value on the worker thread.
+# ``None`` = unset → no interactive panel available → the elicitation consent
+# path fails closed (mirrors ``tools.terminal_tool._callback_tls`` semantics,
+# GHSA-qg5c-hvr5-hjgr, but scoped to the session context instead of a thread).
+_cli_approval_callback: contextvars.ContextVar[Optional[Any]] = contextvars.ContextVar(
+    "cli_approval_callback",
     default=None,
 )
 
@@ -314,16 +329,38 @@ def _is_gateway_approval_context() -> bool:
 def _resolve_cli_approval_callback(approval_callback=None):
     """Return an interactive CLI approval callback when one is available.
 
-    Prefers an explicitly passed callback, then the per-thread CLI callback
-    registered via ``tools.terminal_tool.set_approval_callback``.
+    Prefers an explicitly passed callback, then the per-context callback
+    carried in ``_cli_approval_callback`` (set on the CLI agent thread and
+    replayed across the MCP thread hop via ``contextvars.Context.run``), then
+    the per-thread CLI callback registered via
+    ``tools.terminal_tool.set_approval_callback``.
     """
     if approval_callback is not None:
         return approval_callback
+    ctx_cb = _cli_approval_callback.get()
+    if ctx_cb is not None:
+        return ctx_cb
     try:
         from tools.terminal_tool import _get_approval_callback
         return _get_approval_callback()
     except Exception:
         return None
+
+
+def set_cli_approval_callback(cb) -> contextvars.Token:
+    """Register the CLI approval callback for the current context.
+
+    Mirrors ``tools.terminal_tool.set_approval_callback`` (thread-local) but
+    carries the callback in ``_cli_approval_callback`` so it survives the
+    thread hop into the MCP elicitation consent path. Returns a
+    ``contextvars.Token``; callers should ``reset()`` it when the session ends.
+    """
+    return _cli_approval_callback.set(cb)
+
+
+def reset_cli_approval_callback(token: contextvars.Token) -> None:
+    """Restore the prior CLI approval callback context."""
+    _cli_approval_callback.reset(token)
 
 
 def _should_fall_through_to_cli_approval(
@@ -5687,13 +5724,18 @@ def request_elicitation_consent(
         return "decline"
 
     # CLI / TUI path. allow_permanent=False because elicitation is a
-    # per-call confirmation — there is no pattern to remember.
+    # per-call confirmation — there is no pattern to remember. Resolve the
+    # CLI approval callback explicitly: without it the prompt_toolkit guard
+    # in _prompt_dangerous_approval_inner fail-closes with an invisible
+    # "deny" on interactive surfaces (#94488).
     try:
+        callback = _resolve_cli_approval_callback()
         choice = prompt_dangerous_approval(
             message,
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            approval_callback=callback,
         )
     except Exception as exc:
         logger.error(


### PR DESCRIPTION
## Problem

Destructive MCP tools (e.g. Wincontainer `remove_container`) are auto-denied with `human_approval_denied` in the CLI — the user never sees an approval prompt. Fixes #94488.

## Root cause

When an MCP server requests confirmation via `elicitation/create` (form mode), Hermes routes it through `request_elicitation_consent` → `prompt_dangerous_approval`. That call omitted `approval_callback`, and the consent flow runs on the MCP background loop's worker threads (`_mcp_loop` + `asyncio.to_thread`), while the CLI registers its prompt_toolkit panel on the agent thread via `tools.terminal_tool.set_approval_callback` (thread-local).

`_prompt_dangerous_approval_inner` has a fail-closed guard: with prompt_toolkit active and no callback on the current thread, it returns `"deny"` immediately without rendering a prompt (the guard exists to avoid the #15216 stdin deadlock). So every form-mode elicitation in an interactive CLI/TUI session was silently declined.

## Fix

Carry the CLI approval callback in a session-scoped contextvar (`_cli_approval_callback`) so it survives the thread hop. The elicitation handler already replays the captured tool-call context (`owner._pending_call_context`) via `contextvars.Context.run`, which restores the contextvar on the worker thread.

- `tools/approval.py`: add `_cli_approval_callback` contextvar + `set_cli_approval_callback()` / `reset_cli_approval_callback()`; extend `_resolve_cli_approval_callback()` to prefer explicit → contextvar → thread-local; pass the resolved callback into `prompt_dangerous_approval` from `request_elicitation_consent`'s CLI branch.
- `cli.py`: `run_agent()` now also registers the callback via `set_cli_approval_callback()` (token reset in the turn's `finally`, mirroring the existing session-key pattern).

The contextvar is session-scoped (not process-global), so it does not reintroduce the cross-session races the thread-local design (GHSA-qg5c-hvr5-hjgr) was protecting against. Fail-closed behavior is preserved when no callback/session exists.

## Tests

Added `tests/tools/test_mcp_elicitation_approval.py` covering:

- resolver priority (explicit → contextvar → thread-local)
- the contextvar callback being passed into `prompt_dangerous_approval`
- the no-callback path still failing closed

Verified: `ruff check` passes on the changed files; new tests pass; existing approval tests unaffected.
