### PR TITLE
fix(mcp): stop fast-failing stdio calls against a live subprocess

### DIFF
--- a/tests/tools/test_mcp_stdio_liveness.py
+++ b/tests/tools/test_mcp_stdio_liveness.py
@@ -1,0 +1,91 @@
+"""Regression tests for MCPServerTask._stdio_children_dead (#81995 follow-up).
+
+The fast-fail path added for #81995 must only trip when EVERY tracked stdio
+child has exited. An inverted branch made the helper return ``True`` (all
+dead) as soon as it saw the first *live* pid, so every stdio MCP call on a
+perfectly healthy server was rejected with::
+
+    MCP stdio subprocess for '<name>' has exited; failing the call fast
+
+and ``_watch_stdio_children`` returned immediately, cancelling in-flight RPCs.
+
+These tests pin the contract in both directions so the branch cannot invert
+again: a live child means "not dead", and only an all-dead set fast-fails.
+"""
+
+import asyncio
+import os
+import subprocess
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _stdio_task(pids):
+    task = MCPServerTask("regression-server")
+    task._config = {"command": "/bin/true", "args": []}  # stdio, not http
+    task._stdio_child_pids = set(pids)
+    return task
+
+
+@pytest.fixture(scope="module")
+def dead_pid() -> int:
+    """A pid that really existed and really exited.
+
+    A synthetic out-of-range constant is not usable here: ``psutil.pid_exists``
+    calls ``os.kill(pid, 0)``, which raises ``OverflowError`` above the platform
+    pid range instead of reporting "gone".
+    """
+    proc = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
+    proc.wait()
+    return proc.pid
+
+
+def test_live_child_is_not_reported_dead():
+    """One live pid must mean 'not dead' — this is the inversion that broke."""
+    task = _stdio_task([os.getpid()])
+    assert task._stdio_children_dead() is False
+
+
+def test_all_dead_children_are_reported_dead(dead_pid):
+    task = _stdio_task([dead_pid])
+    assert task._stdio_children_dead() is True
+
+
+def test_mixed_children_are_not_reported_dead(dead_pid):
+    """A dead sibling must not condemn a still-serving child."""
+    task = _stdio_task([dead_pid, os.getpid()])
+    assert task._stdio_children_dead() is False
+
+
+def test_unknown_pids_do_not_fast_fail():
+    """No captured pids → unknown → never fast-fail."""
+    task = _stdio_task([])
+    assert task._stdio_children_dead() is False
+
+
+def test_http_transport_never_fast_fails(dead_pid):
+    task = MCPServerTask("http-server")
+    task._config = {"url": "https://example.invalid/mcp"}
+    task._stdio_child_pids = {dead_pid}
+    assert task._stdio_children_dead() is False
+
+
+def test_watcher_does_not_resolve_while_child_is_alive():
+    """_watch_stdio_children must keep polling, not cancel a healthy RPC."""
+
+    async def _run():
+        task = _stdio_task([os.getpid()])
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(task._watch_stdio_children(), timeout=0.6)
+
+    asyncio.run(_run())
+
+
+def test_watcher_resolves_once_every_child_is_gone(dead_pid):
+    async def _run():
+        task = _stdio_task([dead_pid])
+        await asyncio.wait_for(task._watch_stdio_children(), timeout=2.0)
+
+    asyncio.run(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,7 +2994,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## Symptom

Every tool call to a stdio MCP server was rejected immediately with:

```
MCP stdio subprocess for 'basic-memory' has exited; failing the call fast instead of waiting 300s
```

…while the subprocess was demonstrably alive. `basic-memory.log` showed the server completing initialization and background sync normally at the exact moment the calls were refused, and `psutil.pid_exists()` on the tracked child returned `True`.

## Root cause

`MCPServerTask._stdio_children_dead()` (`tools/mcp_tool.py`) inverted its bail-out:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True   # alive (signal permission irrelevant for liveness)   <-- wrong value
    return False  # at least one child alive                            <-- unreachable
return True
```

The loop skips dead pids and bails on the first live one — but the bail-out returned `True` ("all children dead"). The correct `return False` sat directly beneath it as dead code, which is why the intent is unambiguous from the source itself.

Two call sites consume this:

- `call_tool_handler` (`tools/mcp_tool.py:~6121`) raises the fast-fail `TimeoutError` above.
- `_watch_stdio_children()` resolves on its first poll, cancelling the in-flight RPC.

So a *healthy* stdio server with at least one tracked child failed 100% of calls. HTTP transports (`_is_http()`) and servers with no captured pids short-circuit earlier and were unaffected — which is why this did not surface universally.

Introduced alongside the #81995 fast-fail path; no test covered the helper.

## Fix

Delete the inverted line. Only an all-dead pid set now reports dead.

## Tests

New `tests/tools/test_mcp_stdio_liveness.py` pins the contract in both directions:

| case | expected |
|---|---|
| one live child | not dead |
| all children exited | dead |
| dead sibling + live child | not dead |
| no captured pids (unknown) | not dead |
| HTTP transport | not dead |
| `_watch_stdio_children` while live | keeps polling |
| `_watch_stdio_children` after all gone | resolves |

Re-introducing the inverted line fails 3 of the 7 (verified locally, not just asserted).

One note on the fixture: the dead pid is obtained by spawning and reaping a real process rather than using an out-of-range sentinel. `psutil.pid_exists()` calls `os.kill(pid, 0)`, which raises `OverflowError` above the platform pid range instead of reporting "gone" — my first attempt with `4_294_967_000` failed for exactly that reason.

## Verification

```
$ uv run --no-sync python -m pytest tests/tools/test_mcp_stdio_liveness.py -q
7 passed

$ uv run --no-sync python -m pytest tests/tools/ -q -k mcp
646 passed, 3 skipped

$ uv run --no-sync ruff check tools/mcp_tool.py tests/tools/test_mcp_stdio_liveness.py
All checks passed!
```

(`tests/tools/test_slack_send_message_media.py` fails to collect on current `main` for unrelated reasons and is excluded from the `-k mcp` run.)

After applying this locally, stdio MCP calls to `basic-memory` succeed again.
