### PR TITLE
fix(gateway): clear stale clarify state on interrupt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21124,7 +21124,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
-            # Auto voice reply: send TTS audio before the text response
+            # Auto voice reply: send TTS audio. Runs as a background task so a
+            # slow local TTS (e.g. Qwen3-TTS on ROCm) never delays the text
+            # reply — the voice message arrives when synthesis finishes.
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
             _stts_adapter = self._adapter_for_source(source)
@@ -21136,7 +21138,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
-                await self._send_voice_reply(event, response)
+                try:
+                    asyncio.ensure_future(self._send_voice_reply(event, response))
+                except Exception as _voice_sched_exc:  # noqa: BLE001
+                    logger.warning("Auto voice reply scheduling failed: %s", _voice_sched_exc)
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -27088,6 +27093,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 await adapter.interrupt_session_activity(session_key, source.chat_id)
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
+        # A control interrupt (/stop, /new, /reset) is a hard conversation
+        # boundary.  Clear pending clarify entries immediately rather than
+        # waiting for the interrupted turn's finalizer: that finalizer may
+        # still be draining while the next user message arrives, causing the
+        # stale clarify interceptor to swallow the new turn.
+        try:
+            from tools.clarify_gateway import clear_session as _clear_clarify_session
+
+            _clear_clarify_session(session_key)
+        except Exception:
+            logger.debug(
+                "Failed to clear pending clarify during session interrupt",
+                exc_info=True,
+            )
         if _iac_state is not None:
             _iac_state.persistent.pending_command_text = None
         if release_running_state:

--- a/tests/gateway/test_tool_response_drop_recovery.py
+++ b/tests/gateway/test_tool_response_drop_recovery.py
@@ -291,6 +291,14 @@ class TestPostStopInterruptSwallow:
         runner._invalidate_session_run_generation = (
             lambda key, reason=None: invalidated.append((key, reason))
         )
+        from tools import clarify_gateway
+
+        cleared_clarify_sessions = []
+        monkeypatch.setattr(
+            clarify_gateway,
+            "clear_session",
+            lambda key: cleared_clarify_sessions.append(key),
+        )
         released = []
         runner._release_running_agent_state = (
             lambda key, **kw: released.append(key)
@@ -314,6 +322,7 @@ class TestPostStopInterruptSwallow:
         )
 
         assert agent.interrupt_reasons == [_INTERRUPT_REASON_STOP]
+        assert cleared_clarify_sessions == [session_key]
         assert released == [session_key]
         assert reaped_event.wait(1)
         assert reaped == [


### PR DESCRIPTION
## Summary
- schedule automatic voice replies in the background so slow TTS does not delay text delivery
- clear pending clarify state at hard session boundaries (`/stop`, `/new`, `/reset`)
- add a regression assertion for stale clarify cleanup

## Verification
- `uv run --extra dev pytest tests/gateway/test_tool_response_drop_recovery.py -q` — 7 passed
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_tool_response_drop_recovery.py` — passed
- `git diff --check` — passed

The change is scoped to gateway delivery/recovery and does not alter the existing QQ voice classification PR.