### PR TITLE
fix(desktop): list Windows SSH bot profiles

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -349,7 +349,12 @@ import {
   getVenvSitePackagesEntries,
   resolveVenvHermesCommand
 } from './windows-hermes-path'
-import { connectWindowsRemote, detectRemotePlatform, helper } from './windows-remote-lifecycle'
+import {
+  connectWindowsRemote,
+  detectRemotePlatform,
+  helper,
+  listRemoteHermesProfiles as listSshRemoteHermesProfiles
+} from './windows-remote-lifecycle'
 import {
   alreadyHasNoSandbox,
   buildNoSandboxRelaunchArgs,
@@ -13090,7 +13095,7 @@ async function probeSshProfileInventory(connection) {
 
   try {
     await ssh.open()
-    const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
+    const profiles = await listSshRemoteHermesProfiles(ssh, sshConfig.remoteHermesPath || '')
 
     if (profiles.length > 0) {
       sshRosterCache.set(connection.id, profiles)

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   detectRemotePlatform,
   encodedPowerShell,
   helperCommand,
+  listRemoteHermesProfiles,
   powerShellCommand,
   psLiteral,
   reusableWindowsLock,
@@ -91,6 +92,53 @@ test('helper command uses the fixed remote Python entry point and quotes path da
   assert.match(script, /-m' 'hermes_cli\.windows_ssh_runtime' 'inspect'/)
   assert.match(script, /Hermes''s/)
   assert.match(script, /C:\\x y\\hermes\.exe/)
+})
+
+test('profile inventory preserves POSIX listing and uses the Windows runtime helper', async () => {
+  const posixCalls: string[] = []
+  const posixProfiles = await listRemoteHermesProfiles(
+    sshWith(async command => {
+      posixCalls.push(command)
+
+      if (command === 'uname -s; uname -m') return 'Linux\nx86_64\n'
+      if (command.startsWith('echo ')) return '/home/test/.hermes\n'
+
+      return 'writer\ndeals\n'
+    })
+  )
+
+  assert.deepEqual(posixProfiles, ['default', 'deals', 'writer'])
+  assert.equal(posixCalls.some(command => command.includes('list-profiles')), false)
+
+  const windowsCalls: string[] = []
+  const windowsProfiles = await listRemoteHermesProfiles(
+    sshWith(async command => {
+      windowsCalls.push(command)
+
+      if (command.startsWith('uname ')) {
+        throw new Error('PowerShell does not recognize uname')
+      }
+
+      const script = Buffer.from(command.split(' ').pop()!, 'base64').toString('utf16le')
+
+      if (script.includes('ConvertTo-Json')) {
+        return JSON.stringify({
+          os: 'Windows',
+          arch: 'AMD64',
+          hermesHome: 'C:\\h',
+          hermesPath: 'C:\\h\\hermes.exe',
+          python: 'C:\\h\\python.exe'
+        })
+      }
+
+      assert.match(script, /hermes_cli\.windows_ssh_runtime' 'list-profiles'/)
+
+      return JSON.stringify(['default', 'deals'])
+    })
+  )
+
+  assert.deepEqual(windowsProfiles, ['default', 'deals'])
+  assert.equal(windowsCalls.length, 3)
 })
 
 test('Windows lock validation is scoped and exact', () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 
+import { listRemoteHermesProfiles as listPosixRemoteHermesProfiles } from './remote-lifecycle'
 import { assertBootstrapNotSuperseded, redactSecrets, SSH_ERROR } from './ssh-connection'
 
 const LOCKFILE_SCHEMA_VERSION = 2
@@ -118,6 +119,22 @@ async function helper(ssh, runtime, operation, args = [], stdinData?) {
   }
 
   return parsed
+}
+
+async function listRemoteHermesProfiles(ssh, explicitHermesPath = '') {
+  const platform: any = await detectRemotePlatform(ssh, explicitHermesPath)
+
+  if (platform.os !== 'Windows') {
+    return listPosixRemoteHermesProfiles(ssh)
+  }
+
+  const profiles = await helper(ssh, platform, 'list-profiles')
+
+  if (!Array.isArray(profiles) || profiles.some(profile => typeof profile !== 'string')) {
+    throw new Error('The remote Windows profile inventory is invalid.')
+  }
+
+  return profiles
 }
 
 function fingerprintToken(token) {
@@ -446,6 +463,7 @@ export {
   encodedPowerShell,
   helper,
   helperCommand,
+  listRemoteHermesProfiles,
   powerShellCommand,
   probeWindowsRemote,
   psLiteral,

--- a/hermes_cli/windows_ssh_runtime.py
+++ b/hermes_cli/windows_ssh_runtime.py
@@ -450,6 +450,13 @@ def inspect_hermes(hermes_path: str) -> dict[str, Any]:
     }
 
 
+def list_profile_names() -> list[str]:
+    """Return the canonical default + named profile inventory."""
+    from hermes_cli.profiles import profiles_to_serve
+
+    return [name for name, _ in profiles_to_serve(multiplex=True)]
+
+
 def dispatch(argv: list[str]) -> Any:
     if not argv:
         raise ValueError("missing operation")
@@ -489,6 +496,8 @@ def dispatch(argv: list[str]) -> Any:
         return spawn_backend(_read_json_stdin())
     if operation == "inspect" and len(argv) == 2:
         return inspect_hermes(argv[1])
+    if operation == "list-profiles" and len(argv) == 1:
+        return list_profile_names()
     if operation == "process-state" and len(argv) == 5:
         return process_state(int(argv[1]), int(argv[2]), argv[3], argv[4])
     if operation == "terminate" and len(argv) == 5:

--- a/tests/hermes_cli/test_windows_ssh_runtime.py
+++ b/tests/hermes_cli/test_windows_ssh_runtime.py
@@ -1,0 +1,10 @@
+from hermes_cli.windows_ssh_runtime import dispatch
+
+
+def test_list_profiles_operation_uses_canonical_profile_inventory(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    (root / "profiles" / "deals").mkdir(parents=True)
+    (root / "profiles" / ".ignored").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    assert dispatch(["list-profiles"]) == ["default", "deals"]


### PR DESCRIPTION
## Summary

- route SSH profile inventory through the platform-aware Windows remote lifecycle
- list Windows profiles with the canonical Hermes profile helper instead of POSIX path validation and ls
- preserve the existing POSIX inventory behavior

## Reproduction

Hermes Desktop connected over SSH to a Windows host whose Hermes home is C:\Users\... repeatedly logs: profile inventory failed: Unsafe remote Hermes home. The shared inventory path validates only POSIX paths, so Connections bots are not discovered and Create on cannot target the Windows machine reliably.

## Tests

- scripts/run_tests.sh tests/hermes_cli/test_windows_ssh_runtime.py
- npm --prefix apps/desktop run test:desktop:platforms -- electron/windows-remote-lifecycle.test.ts
- npm --prefix apps/desktop run typecheck