### PR TITLE
fix(dashboard): keep refs to superseded console commands

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17131,6 +17131,10 @@ async def console_ws(ws: WebSocket) -> None:
     )
 
     active_task: asyncio.Task | None = None
+    # Strong refs to superseded in-flight commands: overwriting active_task
+    # drops the only reference, and the loop holds tasks weakly — a mid-run
+    # GC reap would abort the old command silently (and leak its exception).
+    console_tasks: set = set()
     pending_confirmation: Optional[str] = None
     command_generation = 0
 
@@ -17226,9 +17230,13 @@ async def console_ws(ws: WebSocket) -> None:
         nonlocal active_task, command_generation
         command_generation += 1
         command_id = command_generation
-        active_task = asyncio.create_task(
+        task = asyncio.create_task(
             run_command(line, confirmed=confirmed, command_id=command_id)
         )
+        console_tasks.add(task)
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(console_tasks.discard)
+        active_task = task
 
     try:
         while True:


### PR DESCRIPTION
## Problem

In the dashboard console websocket handler, `start_command()` overwrites `active_task` while a previous command may still be executing. The superscribed task loses its last strong reference — and the event loop holds tasks **only weakly** — so the GC can reap it mid-execution:

- the old command silently stops with its side effects half-applied
- if it raises, the exception is never retrieved ("Task exception was never retrieved" noise, diagnostic lost)

The generation guard (`command_id != command_generation: return`) correctly prevents output interleaving into the new command's stream — but nothing keeps the old task alive while it runs.

## Fix

All in-flight commands are additionally retained in a per-websocket `console_tasks` set with done-callback discard — the same pattern used across the gateway (e.g. `_background_tasks`). `active_task` semantics, generation guards, and result routing are unchanged.

## Verification

`tests/hermes_cli/test_web_server_console_ws.py`: 2/2 pass; module syntax-checked.