### PR TITLE
fix(gateway): re-buffer batched text when flush is cancelled mid-dispatch

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -709,7 +709,26 @@ class SimplexAdapter(BasePlatformAdapter):
                 key,
                 len(event.text or ""),
             )
-            await self.handle_message(event)
+            try:
+                await self.handle_message(event)
+            except asyncio.CancelledError:
+                # The event was already popped above: without re-buffering,
+                # a cancellation mid-dispatch loses the user's message
+                # permanently (the batching timer cancels prior flushes on
+                # every new chunk). Prepend to preserve order.
+                existing = self._pending_text_batches.get(key)
+                if existing is not None:
+                    existing.text = (
+                        f"{event.text}\n{existing.text}"
+                        if event.text and existing.text
+                        else (existing.text or event.text)
+                    )
+                    if event.media_urls:
+                        existing.media_urls[:0] = event.media_urls
+                        existing.media_types[:0] = event.media_types
+                else:
+                    self._pending_text_batches[key] = event
+                raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -675,7 +675,25 @@ class WeComAdapter(BasePlatformAdapter):
                 "[WeCom] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
-            await self.handle_message(event)
+            try:
+                await self.handle_message(event)
+            except asyncio.CancelledError:
+                # The event was already popped above: without re-buffering,
+                # a cancellation mid-dispatch loses the user's message
+                # permanently. Prepend so it precedes any newer chunk.
+                existing = self._pending_text_batches.get(key)
+                if existing is not None:
+                    existing.text = (
+                        f"{event.text}\n{existing.text}"
+                        if event.text and existing.text
+                        else (existing.text or event.text)
+                    )
+                    if event.media_urls:
+                        existing.media_urls[:0] = event.media_urls
+                        existing.media_types[:0] = event.media_types
+                else:
+                    self._pending_text_batches[key] = event
+                raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)


### PR DESCRIPTION
## Problem

WeCom and SimpleX text-batch flushes (`_flush_text_batch`) pop the merged event, then `await self.handle_message(event)` with **no CancelledError guard**. The batching timer cancels the prior flush on every new chunk — and WeCom's own comment documents that CPython delivers the cancellation at "the *next* await (handle_message)" when the sleep already fired.

That is precisely the loss window: the event was popped at :671/:704, cancellation lands inside `handle_message`, propagates, and the buffered user message is **silently lost** — no re-dispatch, no log. The existing WeCom ownership check only prevents the superseding task from seeing an empty batch; it does not save the popped event.

Telegram already solves this exact case in its flushes: on `CancelledError` the event is re-held for later dispatch (`where="text-flush-cancelled"`).

## Fix

Both adapters now wrap `handle_message` in try/except CancelledError:

- on success, nothing changes
- on cancellation, the popped event is re-buffered into `_pending_text_batches` — prepended ahead of any newer chunk (order-preserving merge, media lists included), or restored wholesale if the slot is empty — then re-raised so cancellation semantics are preserved

## Verification

- `tests/gateway/test_wecom.py` + `tests/gateway/test_simplex_plugin.py`: 37/37 pass
- syntax-checked both modules