### PR TITLE
fix(kanban): skip capacity-deferred stranded diagnostics

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1651,12 +1651,56 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
     return _linked_ids(conn, "child_id", "parent_id", task_id)
 
 
-def task_graph_contexts(conn: sqlite3.Connection, task_ids: Iterable[str]) -> dict[str, dict]:
+def task_graph_contexts(
+    conn: sqlite3.Connection, task_ids: Iterable[str]
+) -> dict[str, dict[str, Any]]:
     """Bulk-load compact direct graph state for graph-aware diagnostics."""
     ordered_ids = list(dict.fromkeys(str(task_id) for task_id in task_ids if task_id))
-    contexts = {task_id: {"parents": [], "children": []} for task_id in ordered_ids}
+    contexts: dict[str, dict[str, Any]] = {
+        task_id: {"parents": [], "children": []} for task_id in ordered_ids
+    }
     if not ordered_ids:
         return contexts
+
+    running_rows = conn.execute(
+        "SELECT assignee, COUNT(*) AS count FROM tasks "
+        "WHERE status = 'running' GROUP BY assignee"
+    ).fetchall()
+    running_by_assignee = {
+        (row["assignee"] or ""): int(row["count"])
+        for row in running_rows
+    }
+    try:
+        from hermes_cli.kanban_db_dispatch import count_running_tasks_other_boards
+
+        current_db_path = None
+        for row in conn.execute("PRAGMA database_list").fetchall():
+            if row[1] == "main" and row[2]:
+                current_db_path = Path(row[2])
+                break
+        running_total = sum(running_by_assignee.values()) + count_running_tasks_other_boards(
+            current_db_path=current_db_path
+        )
+    except Exception:
+        running_total = sum(running_by_assignee.values())
+
+    assignee_rows = conn.execute(
+        f"SELECT id, assignee FROM tasks WHERE id IN ({','.join('?' for _ in ordered_ids)})",
+        tuple(ordered_ids),
+    ).fetchall()
+    try:
+        from hermes_cli.profiles import profile_exists
+    except Exception:
+        profile_exists = None  # type: ignore[assignment]
+    for row in assignee_rows:
+        try:
+            profile_exists_for_task = bool(profile_exists and profile_exists(row["assignee"] or ""))
+        except Exception:
+            profile_exists_for_task = False
+        contexts[row["id"]]["assignee_profile_exists"] = profile_exists_for_task
+    for context in contexts.values():
+        context["running_total"] = running_total
+        context["running_by_assignee"] = running_by_assignee
 
     placeholders = ",".join("?" for _ in ordered_ids)
     for bucket, own, other in (("parents", "child_id", "parent_id"), ("children", "parent_id", "child_id")):
@@ -1671,7 +1715,7 @@ def task_graph_contexts(conn: sqlite3.Connection, task_ids: Iterable[str]) -> di
     return contexts
 
 
-def task_graph_context(conn: sqlite3.Connection, task_id: str) -> dict:
+def task_graph_context(conn: sqlite3.Connection, task_id: str) -> dict[str, Any]:
     """Return compact direct parent/child state for one task."""
     return task_graph_contexts(conn, [task_id])[task_id]
 

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1359,7 +1359,11 @@ def count_running_tasks(conn: sqlite3.Connection) -> int:
         return 0
 
 
-def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
+def count_running_tasks_other_boards(
+    board: Optional[str] = None,
+    *,
+    current_db_path: Optional[Path] = None,
+) -> int:
     """Total ``running`` tasks across every board EXCEPT ``board``.
 
     Caps bound the HOST, but each board's tick only sees its own DB; without
@@ -1368,7 +1372,9 @@ def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
     board to one file) yields 0. Fails open per board.
     """
     try:
-        current_path = str(_kb.kanban_db_path(board=board).expanduser().resolve())
+        current_path = str(
+            (current_db_path or _kb.kanban_db_path(board=board)).expanduser().resolve()
+        )
     except Exception:
         current_path = None
     try:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -637,6 +637,23 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     if not assignee.strip():
         return []
 
+    # Occupied configured capacity defers a valid profile's task by design;
+    # reporting it as unclaimed would recommend an incorrect reassignment.
+    graph = cfg.get("_graph") or {}
+    kanban_cfg = cfg.get("kanban") or {}
+    running_total = int(graph.get("running_total") or 0)
+    running_by_assignee = graph.get("running_by_assignee") or {}
+    running_on_board = sum(int(count) for count in running_by_assignee.values())
+    max_spawn = _positive_int(kanban_cfg.get("max_spawn"), 0)
+    max_in_progress = _positive_int(kanban_cfg.get("max_in_progress"), 0)
+    max_per_profile = _positive_int(kanban_cfg.get("max_in_progress_per_profile"), 0)
+    if graph.get("assignee_profile_exists") is True and (
+        (max_spawn and running_on_board >= max_spawn)
+        or (max_in_progress and running_total >= max_in_progress)
+        or (max_per_profile and int(running_by_assignee.get(assignee, 0)) >= max_per_profile)
+    ):
+        return []
+
     # Most recent event that put the task into ready; with none (old task /
     # truncated events) fall back to created_at — over-flagging an ancient
     # task beats missing a stranded one.

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -199,6 +199,102 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+@pytest.mark.parametrize(
+    ("kanban_config", "graph"),
+    [
+        (
+            {"max_spawn": 1},
+            {"running_by_assignee": {"demo": 1}, "assignee_profile_exists": True},
+        ),
+        (
+            {"max_in_progress": 1},
+            {"running_total": 1, "assignee_profile_exists": True},
+        ),
+        (
+            {"max_in_progress_per_profile": 1},
+            {"running_by_assignee": {"demo": 1}, "assignee_profile_exists": True},
+        ),
+    ],
+)
+def test_stranded_in_ready_skips_capacity_deferred_tasks(kanban_config, graph):
+    now = 100_000
+    task = _task(status="ready", assignee="demo", claim_lock=None)
+    events = [_event("created", ts=now - 45 * 60)]
+
+    diags = kd.compute_task_diagnostics(
+        task, events, [], now=now, config={"kanban": kanban_config}, graph=graph,
+    )
+
+    assert not [d for d in diags if d.kind == "stranded_in_ready"]
+
+
+def test_stranded_in_ready_warns_for_invalid_profile_at_host_capacity():
+    now = 100_000
+    task = _task(status="ready", assignee="typo", claim_lock=None)
+    events = [_event("created", ts=now - 45 * 60)]
+
+    diags = kd.compute_task_diagnostics(
+        task,
+        events,
+        [],
+        now=now,
+        config={"kanban": {"max_in_progress": 1}},
+        graph={"running_total": 1, "assignee_profile_exists": False},
+    )
+
+    assert [d for d in diags if d.kind == "stranded_in_ready"]
+
+
+def test_stranded_in_ready_warns_when_only_another_board_reaches_max_spawn():
+    now = 100_000
+    task = _task(status="ready", assignee="demo", claim_lock=None)
+    events = [_event("created", ts=now - 45 * 60)]
+
+    diags = kd.compute_task_diagnostics(
+        task,
+        events,
+        [],
+        now=now,
+        config={"kanban": {"max_spawn": 1}},
+        graph={
+            "running_total": 1,
+            "running_by_assignee": {},
+            "assignee_profile_exists": True,
+        },
+    )
+
+    assert [d for d in diags if d.kind == "stranded_in_ready"]
+
+
+def test_task_graph_context_reports_running_capacity(kanban_home):
+    (kanban_home / "profiles" / "demo").mkdir(parents=True)
+    with kbc.connect() as conn:
+        running = kb.create_task(conn, title="running", assignee="demo")
+        queued = kb.create_task(conn, title="queued", assignee="demo")
+        assert kb.claim_task(conn, running) is not None
+
+        context = kb.task_graph_context(conn, queued)
+
+    assert context["running_total"] == 1
+    assert context["running_by_assignee"] == {"demo": 1}
+    assert context["assignee_profile_exists"] is True
+
+
+def test_task_graph_context_counts_running_tasks_on_other_boards(kanban_home):
+    (kanban_home / "profiles" / "demo").mkdir(parents=True)
+    kb.create_board("second")
+    with kbc.connect(board="second") as other:
+        running = kb.create_task(other, title="running", assignee="demo")
+        assert kb.claim_task(other, running) is not None
+
+    with kbc.connect() as conn:
+        queued = kb.create_task(conn, title="queued", assignee="demo")
+        context = kb.task_graph_context(conn, queued)
+
+    assert context["running_total"] == 1
+    assert context["running_by_assignee"] == {}
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #94501. `stranded_in_ready` now recognizes a valid profile task that is deliberately queued behind an occupied configured capacity limit, instead of recommending an incorrect reassignment.

## Related Issue

Fixes #94501

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests only
- [ ] Refactor
- [ ] New skill

## Changes Made

- Add read-only current-board, host-wide, and per-profile running-capacity context to Kanban diagnostics.
- Suppress only valid-profile ready tasks while `max_spawn`, `max_in_progress`, or `max_in_progress_per_profile` is occupied.
- Preserve warnings for invalid profiles and for another board occupying only the host-wide budget.

## How to Test

1. Base: `b0ab2e163a50d4e6c36507eba955a6067fde6abc`; candidate: `cc3690ed72cce63cebf44b7f22b8a110970ede64`.
2. In isolated `HOME`/`HERMES_HOME`, configure `kanban.max_spawn: 1`, run one valid-profile task, age a second valid-profile ready task by 45 minutes, then run `hermes kanban diagnostics --task <id> --json`. Current main reports `stranded_in_ready`; this head returns an empty diagnostics list.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_host_cap.py -q` (23 passed).

## Evidence

- `uv run ruff check hermes_cli/kanban_db.py hermes_cli/kanban_db_dispatch.py hermes_cli/kanban_diagnostics.py tests/hermes_cli/test_kanban_diagnostics.py` passed.
- `python -m compileall` for the three production modules and `git diff --check` passed.
- TruffleHog filesystem scan of the exact commit diff found 0 verified, unknown, or unverified secrets.
- `ty` has 9 existing diagnostics, identical to clean current main for these paths. Ruff format reports the same 4 existing unformatted files on clean current main, so this change does not bulk-reformat unrelated code.
- The final competition sweep found no same-root `max_spawn`/capacity diagnostics PR; the only issue cross-reference is this PR.

## Scope

This does not alter dispatcher capacity, task state, scheduling, or worker selection. It only prevents a false stranded diagnostic when a configured limit is demonstrably occupied. Docker, Nix, and hosted CI still require maintainer approval for fork workflows.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs for this ownership boundary.
- [x] This PR contains only changes related to this fix.
- [ ] I did not run the full `pytest tests/ -q` suite; the focused and adjacent Kanban suites passed.
- [x] I added regression tests for the fix.
- [x] I tested on macOS.

### Documentation & Housekeeping

- [x] Documentation updates are not needed for this internal diagnostics correction.
- [x] `cli-config.yaml.example` is not affected.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not affected.
- [x] Cross-platform impact is limited to SQLite diagnostics logic; no platform-specific behavior changed.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

The JSON CLI before/after result is included in Evidence.