### PR TITLE
fix(matrix): guard text-batch flush cancellation; track receipt task

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4323,7 +4323,20 @@ class MatrixAdapter(BasePlatformAdapter):
                 key,
                 len(event.text or ""),
             )
-            await self.handle_message(event)
+            try:
+                await self.handle_message(event)
+            except asyncio.CancelledError:
+                # The event was already popped above: re-buffer it so a
+                # cancellation mid-dispatch cannot lose the message.
+                existing = self._pending_text_batches.get(key)
+                if existing is not None and event.text:
+                    existing.text = f"{event.text}\n{existing.text}"
+                    if event.media_urls:
+                        existing.media_urls[:0] = event.media_urls
+                        existing.media_types[:0] = event.media_types
+                else:
+                    self._pending_text_batches[key] = event
+                raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
@@ -4341,7 +4354,13 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:  # pragma: no cover — defensive
                 logger.debug("Matrix: background read receipt failed: %s", exc)
 
-        asyncio.ensure_future(_send())
+        # Track the task: the loop keeps only weak references, so an
+        # unreferenced ensure_future result can be GC-reaped before the
+        # receipt is sent.
+        task = asyncio.ensure_future(_send())
+        self._background_tasks.add(task)
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(self._background_tasks.discard)
 
     async def send_read_receipt(self, room_id: str, event_id: str) -> bool:
         """Send a read receipt (m.read) for an event."""


### PR DESCRIPTION
## Two related defects in the Matrix adapter

**1. Batched text lost on flush cancellation.** `_flush_text_batch` popped the merged event, then awaited `handle_message` unguarded. The batching timer cancels the prior flush on every new chunk, so a cancellation delivered mid-dispatch (the same CPython timing WeCom documents) silently destroyed the popped event — the user's message vanished with no log. Now re-buffered on `CancelledError` (prepended ahead of newer chunks), mirroring the established Telegram flush pattern from #94533's predecessor design.

**2. Read-receipt task GC-reapable.** `_background_read_receipt` used an unreferenced `asyncio.ensure_future(_send())`; the loop holds tasks only weakly, so the receipt could be reaped before sending. The task is now tracked in the adapter's existing `_background_tasks` set with done-callback discard.

## Verification

Matrix batch/flush selection: 2 passed, 2 skipped (unchanged); module parses clean.