### PR TITLE
fix(cli): stop prefixing uv base python on desktop entry Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -76,13 +76,13 @@ def resolve_exec_command() -> str:
             # installer's bash wrapper). Launched from the .desktop entry that
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # sys.executable, unresolved: resolving escapes the venv's symlinked
+            # python (uv venvs) and loses hermes_cli.
+            argv = [str(Path(sys.executable)), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(Path(sys.executable)), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -103,11 +103,10 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
-    # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # Only `env python` resolves through PATH and can escape the venv; an
+    # absolute shebang already names the interpreter that owns the script.
+    interp = shebang[2:].strip().split()[0]
+    return interp == "env" or interp.endswith("/env")
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +135,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -147,6 +147,39 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_prefixes_unresolved_symlinked_interpreter(tmp_path, xdg_home, monkeypatch):
+    """A uv venv symlinks its python to the base interpreter. The prefix must
+    use the UNRESOLVED symlink path — resolving lands on the base python, which
+    lacks the venv's site-packages (the #90292 regression)."""
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    base_python = tmp_path / "base" / "python"
+    base_python.parent.mkdir()
+    base_python.write_text("")
+    base_python.chmod(0o755)
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base_python)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    assert entry is not None
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    first = exec_line.split(" ")[0].strip('"')
+    assert first == str(venv_python)
+    assert first != str(base_python.resolve())
+    assert str(hermes_bin) in exec_line
+    assert exec_line.endswith("desktop")
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Problem

The desktop entry's `Exec` line is regenerated as

```
<uv-python> .../venv/bin/hermes desktop
```

during `hermes update`, which fails with `ModuleNotFoundError: No module named 'hermes_cli'` — silently, since `Terminal=false`.

## Root cause

`resolve_exec_command()` / `_needs_interpreter()` resolved `sys.executable` through the venv's symlinked python (uv venvs) and compared that directory against the console script's shebang, wrongly treating the venv script as escaping the venv.

## Fix

Only `env python` shebangs escape the venv under the desktop environment; an absolute shebang already names the script's own interpreter. The prefix and `-m` fallback now use unresolved `sys.executable`.

Fixes #90292

/cc @1mems @teknium1
