### PR TITLE
fix(feishu): re-buffer batched text when flush is cancelled mid-dispatch

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3839,7 +3839,26 @@ class FeishuAdapter(BasePlatformAdapter):
             key,
             len(event.text or ""),
         )
-        await self._handle_message_with_guards(event)
+        try:
+            await self._handle_message_with_guards(event)
+        except asyncio.CancelledError:
+            # The event was already popped above: a cancellation mid-dispatch
+            # (the batching timer cancels prior flushes on every new chunk)
+            # would silently lose the user's message. Re-buffer it, prepended
+            # ahead of any newer chunk.
+            existing = self._pending_text_batches.get(key)
+            if existing is not None:
+                existing.text = (
+                    f"{event.text}\n{existing.text}"
+                    if event.text and existing.text
+                    else (existing.text or event.text)
+                )
+                if event.media_urls:
+                    existing.media_urls[:0] = event.media_urls
+                    existing.media_types[:0] = event.media_types
+            else:
+                self._pending_text_batches[key] = event
+            raise
 
     # =========================================================================
     # Message content extraction and resource download


### PR DESCRIPTION
## Problem

`_flush_text_batch_now()` popped the merged event, then `await self._handle_message_with_guards(event)` ran **unguarded**. The batching timer cancels prior flushes on every new chunk (`_schedule_batch_flush`: `prior_task.cancel()`), and CPython delivers that cancellation at the next await — inside the dispatch. A cancel mid-send therefore destroyed the already-popped event: the user's message silently vanished.

Same defect class as WeCom/SimpleX/Matrix; Telegram's flushes already implement the correct re-hold pattern.

## Fix

Wrap the dispatch in try/except CancelledError and re-buffer the popped event into `_pending_text_batches` — prepended ahead of any newer chunk (order-preserving, media lists merged) — then re-raise so cancellation semantics are preserved.

## Verification

Feishu selection: 163 passed / 20 skipped with the change; identical 23 failures reproduce with it stashed (environment-dependent on this Windows host), so none are caused by this edit.