### PR TITLE
fix(computer-use): keep capture working when Cua Driver is frontmost

### DIFF
--- a/tests/tools/test_computer_use_capture_self_window.py
+++ b/tests/tools/test_computer_use_capture_self_window.py
@@ -1,0 +1,58 @@
+"""Capture target selection must never implicitly target Cua Driver itself."""
+
+from tools.computer_use.cua_backend import _select_capture_target
+
+
+def _window(app_name: str, pid: int, window_id: int, z_index: int):
+    return {
+        "app_name": app_name,
+        "pid": pid,
+        "window_id": window_id,
+        "title": "",
+        "off_screen": False,
+        "z_index": z_index,
+    }
+
+
+def test_implicit_capture_skips_frontmost_cua_driver_window():
+    driver = _window("Cua Driver", 55543, 101, 6)
+    app = _window("IB Gateway 10.50", 777, 202, 5)
+
+    target = _select_capture_target(
+        [driver, app], app_requested=False, exact_target=False
+    )
+
+    assert target == app
+
+
+def test_all_self_windows_keep_existing_failure_target():
+    frontmost = _window("Cua Driver", 55543, 101, 6)
+    other = _window("cua-driver", 55543, 102, 5)
+
+    target = _select_capture_target(
+        [frontmost, other], app_requested=False, exact_target=False
+    )
+
+    assert target == frontmost
+
+
+def test_exact_capture_keeps_explicit_cua_driver_target():
+    driver = _window("Cua_Driver", 55543, 101, 6)
+    app = _window("IB Gateway 10.50", 777, 202, 5)
+
+    target = _select_capture_target(
+        [driver, app], app_requested=False, exact_target=True
+    )
+
+    assert target == driver
+
+
+def test_similarly_named_user_app_is_not_treated_as_driver_self():
+    docs = _window("Cua Driver Docs", 888, 303, 7)
+    app = _window("IB Gateway 10.50", 777, 202, 5)
+
+    target = _select_capture_target(
+        [docs, app], app_requested=False, exact_target=False
+    )
+
+    assert target == docs

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -512,6 +512,12 @@ def _is_real_app_window(w: Dict[str, Any]) -> bool:
     )
 
 
+def _is_cua_driver_self_window(w: Dict[str, Any]) -> bool:
+    """Return True for the authorization daemon's own native window."""
+    app_name = str(w.get("app_name", "")).strip().lower()
+    return re.sub(r"[\s_-]+", "", app_name) == "cuadriver"
+
+
 def _select_capture_target(
     windows: List[Dict[str, Any]],
     *,
@@ -522,15 +528,24 @@ def _select_capture_target(
 
     Callers pass windows already sorted by ``z_index`` descending (higher =
     frontmost). When ordering is informative, keep that frontmost contract.
-    For unqualified default captures (no app filter and no exact
-    pid/window_id) on Linux, desktop/shell helper windows (GNOME ``ding``
-    "Desktop Icons", ``@!x,y;BDHF`` backdrop helpers) are skipped first —
-    they are targetable X11 windows but capture as empty. Then, when every
-    remaining candidate shares the same ``z_index`` (tied or unknown, the
-    common Linux/X11 case), prefer ``_NET_ACTIVE_WINDOW`` over list order
-    (#58026). Exact-target captures must not pay for an ``xprop`` probe.
+    Implicit captures skip the authorization daemon's own windows because
+    cua-driver intentionally refuses to capture its own process. If no other
+    on-screen window exists, preserve the old target so the driver reports its
+    normal refusal. Exact pid/window targets remain untouched.
+
+    For unqualified default captures (no app filter and no exact pid/window_id)
+    on Linux, desktop/shell helper windows (GNOME ``ding`` "Desktop Icons",
+    ``@!x,y;BDHF`` backdrop helpers) are skipped first — they are targetable
+    X11 windows but capture as empty. Then, when every remaining candidate
+    shares the same ``z_index`` (tied or unknown, the common Linux/X11 case),
+    prefer ``_NET_ACTIVE_WINDOW`` over list order (#58026). Exact-target
+    captures must not pay for an ``xprop`` probe.
     """
     candidates = [w for w in windows if not w["off_screen"]]
+    if not exact_target:
+        external = [w for w in candidates if not _is_cua_driver_self_window(w)]
+        if external:
+            candidates = external
     pool = candidates
     if not exact_target and not app_requested and sys.platform == "linux":
         real_apps = [w for w in candidates if _is_real_app_window(w)]


### PR DESCRIPTION
## What does this PR do?

Unqualified computer-use captures no longer fail when Cua Driver's authorization window is frontmost. Implicit target selection now skips Cua Driver self-windows while preserving explicit pid/window targeting and the existing driver refusal when no external window exists.

### Symptom

A bare `computer_use(action="capture")` can select Cua Driver's own frontmost window and fail with `Permission denied: Cua Driver refuses operations that target its own authorization process` instead of capturing the next user application.

### Impact

Users cannot take an unqualified capture while the driver's own authorization window is topmost. Explicit pid/window captures continue to work.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:515` / `_select_capture_target()` receives a Cua Driver self-window before user application windows in z-order.

**Causal chain:**
1. An unqualified capture loads and sorts native windows by descending `z_index`.
2. `_select_capture_target()` accepts the first on-screen row without distinguishing the driver's authorization process from a user target.
3. Cua Driver correctly refuses the self-target, so the capture fails before reaching the next real application window.

**Why it is wrong:** The wrapper implicitly chooses a target that the downstream driver intentionally prohibits.

**Working sibling / contrast:** Explicit `pid` and `window_id` captures already bypass implicit discovery and remain unchanged.

**Ruled out:** The capture transport and image parsing are not the cause; the failing row is chosen before `get_window_state` or screenshot response handling begins.

### Fix

Recognize exact normalized Cua Driver application names during implicit selection and prefer the remaining on-screen windows. If all candidates are driver self-windows, retain the previous first target so the driver returns its normal refusal instead of the wrapper raising or selecting an unrelated off-screen window.

## Related Issue

Closes #94527

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - exclude Cua Driver self-windows from implicit target selection only.
- `tests/tools/test_computer_use_capture_self_window.py` - cover frontmost self-window fallback, all-self behavior, explicit targeting, and similarly named user apps.

## How to Test

1. Run the focused cross-platform target-selection regression tests:

```bash
scripts/run_tests.sh tests/tools/test_computer_use_capture_self_window.py tests/tools/test_computer_use_cua_backend_linux.py -q
```

2. Run the broader computer-use tool suite:

```bash
scripts/run_tests.sh tests/tools/test_computer_use*.py -q
```

The focused run passes 7 tests with 2 platform skips on Windows. The broader run passes 295 tests with 2 platform skips; two unrelated failures reproduce identically on unmodified `main` (`test_cli_fallback_reads_screenshot_from_file` on Windows path escaping and `test_linux_default_capture_skips_gnome_shell_helper` on a non-Linux host).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and the function contract is documented inline
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the public tool contract is unchanged

## Screenshots / Logs

N/A - deterministic target-selection regression tests cover the failure without capturing user desktop content.
