### PR TITLE
fix(teams): authenticate Bot Framework connector attachment downloads (pasted images 401)

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -893,29 +893,75 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
+    async def _get_botframework_token(self) -> str:
+        """Acquire a Bot Framework bearer token via client credentials.
+
+        Needed to download connector attachments (smba.trafficmanager.net
+        /v3/attachments/...), which -- unlike SharePoint file downloadUrls --
+        are NOT pre-authenticated and return 401 without the bot's own
+        token. Token is cached until ~5 minutes before expiry.
+        """
+        import time
+        import httpx
+
+        cached = getattr(self, "_bf_token_cache", None)
+        if cached and cached[1] > time.time() + 300:
+            return cached[0]
+
+        client_id = self._client_id
+        client_secret = self._client_secret
+        tenant_id = self._tenant_id
+        if not (client_id and client_secret and tenant_id):
+            raise ValueError("Missing TEAMS_CLIENT_ID/SECRET/TENANT_ID for attachment auth")
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "scope": "https://api.botframework.com/.default",
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        token = payload["access_token"]
+        self._bf_token_cache = (token, time.time() + int(payload.get("expires_in", 3600)))
+        return token
+
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
         Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
+        URLs (no extra auth header needed). Bot Framework connector
+        attachment URLs (pasted/inline images on smba.trafficmanager.net /
+        botframework.com hosts) require the bot's bearer token -- detected
+        below and fetched with auth. Validates the URL against the SSRF
+        guard and follows redirects through the shared redirect guard,
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
+        from urllib.parse import urlparse
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        host = (urlparse(url).hostname or "").lower()
+        if host.endswith("trafficmanager.net") or host.endswith("botframework.com"):
+            try:
+                headers["Authorization"] = f"Bearer {await self._get_botframework_token()}"
+            except Exception as e:
+                logger.warning("[teams] Could not acquire Bot Framework token for attachment: %s", e)
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -1019,11 +1065,28 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
-                    if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                    from urllib.parse import urlparse as _urlparse
+                    _host = (_urlparse(content_url).hostname or "").lower()
+                    if _host.endswith("trafficmanager.net") or _host.endswith("botframework.com"):
+                        # Bot Framework connector URL: needs the bot's own
+                        # bearer token; the generic cache helper sends none.
+                        data = await self._fetch_attachment_bytes(content_url)
+                        ext = content_type.split("/")[-1].split(";")[0] or "png"
+                        cached_m = cache_media_bytes(
+                            data,
+                            filename=att_name or f"image.{ext}",
+                            mime_type=content_type,
+                        )
+                        if cached_m:
+                            media_urls.append(cached_m.path)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
+                    else:
+                        cached = await cache_image_from_url(content_url)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue


### PR DESCRIPTION
## What does this PR do?

Fixes silently dropped inline/pasted images in the Microsoft Teams platform adapter.

Teams delivers two different kinds of inbound attachments: file uploads (paperclip) carry **pre-authenticated SharePoint downloadUrls**, while pasted/inline images carry a contentUrl on **`smba.trafficmanager.net`** (Bot Framework connector), which **requires the bot's own bearer token**. The adapter fetches all attachments unauthenticated, so every pasted image fails with `401 Unauthorized` and is dropped — with only a log warning the user never sees:

```
WARNING hermes_plugins.teams_platform.adapter: [teams] Failed to cache image attachment:
Client error '401 Unauthorized' for url 'https://smba.trafficmanager.net/emea/<tenant>/v3/attachments/<id>/views/original'
```

The fix acquires a Bot Framework token via the client-credentials flow (using the adapter's existing `self._client_id/_client_secret/_tenant_id`) and attaches it **only** for Bot Framework hosts (`*.trafficmanager.net` / `*.botframework.com`). SharePoint and all other URLs behave exactly as before; SSRF and redirect guards are unchanged. Token-acquisition failure degrades gracefully (warning + unauthenticated fetch — same behavior as today, no new failure mode).

## Related Issue

No existing issue; found and verified on a live deployment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/teams/adapter.py`:
  - Added `TeamsAdapter._get_botframework_token()` — client-credentials token for scope `https://api.botframework.com/.default`, cached until ~5 min before expiry
  - `_fetch_attachment_bytes()` — sends the bearer token when the attachment host ends with `trafficmanager.net` / `botframework.com`
  - Inbound `image/*` attachments with Bot Framework contentUrls now route through the authenticated `_fetch_attachment_bytes()` + `cache_media_bytes()` instead of the unauthenticated `cache_image_from_url()`

## How to Test

1. Run a Teams bot (personal scope) with `supportsFiles: true` in the app manifest
2. **Paste** an image into the bot chat (Ctrl+V into the compose box — not the paperclip upload) and send
3. Before this fix: gateway log shows the 401 warning above and the agent never receives the image. After: the image caches and is delivered to the agent (verified end-to-end on a live EMEA-tenant deployment, including the token-cache path on subsequent images)
4. Regression check: send a file via the paperclip (SharePoint path) — unchanged behavior

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Docker, linux/amd64), live Microsoft Teams tenant (EMEA)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings of both touched methods updated; no user-facing config or docs change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (every pasted image, silently dropped):

```
2026-08-25 09:04:50,498 WARNING hermes_plugins.teams_platform.adapter: [teams] Failed to cache image attachment: Client error '401 Unauthorized' for url 'https://smba.trafficmanager.net/emea/<tenant>/v3/attachments/0-weu-d5-.../views/original'
```

After: no warning; image cached and delivered to the agent.
