### PR TITLE
fix(gateway): isolate stream retries and enforce structural item-id deduplication on commentary (#94526)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1091,6 +1091,7 @@ def init_agent(
     # Unlike token-stream tracking, this spans Codex continuation/tool calls so
     # repeated commentary is not re-sent before normalization can deduplicate it.
     agent._delivered_interim_texts: set[str] = set()
+    agent._delivered_interim_ids: set[str] = set()
 
     # Single-writer guard for the streaming delta sink (#65991). A stale/
     # superseded stream (e.g. one the stale-stream detector reconnected past,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,6 +16,7 @@ compatibility.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -1307,8 +1308,17 @@ def _consume_codex_event_stream(
                     if commentary_text:
                         try:
                             try:
+                                sig = inspect.signature(on_commentary_message)
+                                accepts_item_id = "item_id" in sig.parameters or any(
+                                    p.kind == inspect.Parameter.VAR_KEYWORD
+                                    for p in sig.parameters.values()
+                                )
+                            except (ValueError, TypeError):
+                                accepts_item_id = True
+
+                            if accepts_item_id:
                                 on_commentary_message(commentary_text, item_id=done_id)
-                            except TypeError:
+                            else:
                                 on_commentary_message(commentary_text)
                         except Exception:
                             logger.debug(
@@ -1603,9 +1613,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _on_commentary_message(text: str, item_id: str | None = None) -> None:
         if item_id and item_id in delivered_commentary_ids:
             return
-        agent._fire_streamed_codex_commentary(text, item_id=item_id)
-        if item_id:
-            delivered_commentary_ids.add(item_id)
+        if agent._fire_streamed_codex_commentary(text, item_id=item_id):
+            if item_id:
+                delivered_commentary_ids.add(item_id)
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1306,7 +1306,10 @@ def _consume_codex_event_stream(
                             ).strip()
                     if commentary_text:
                         try:
-                            on_commentary_message(commentary_text)
+                            try:
+                                on_commentary_message(commentary_text, item_id=done_id)
+                            except TypeError:
+                                on_commentary_message(commentary_text)
                         except Exception:
                             logger.debug(
                                 "Codex stream on_commentary_message raised",
@@ -1592,11 +1595,17 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         agent._codex_streamed_text_parts.append(text)
         agent._fire_stream_delta(text)
 
+    delivered_commentary_ids: set[str] = set()
+
     def _on_reasoning_delta(text: str) -> None:
         agent._fire_reasoning_delta(text)
 
-    def _on_commentary_message(text: str) -> None:
-        agent._fire_streamed_codex_commentary(text)
+    def _on_commentary_message(text: str, item_id: str | None = None) -> None:
+        if item_id and item_id in delivered_commentary_ids:
+            return
+        agent._fire_streamed_codex_commentary(text, item_id=item_id)
+        if item_id:
+            delivered_commentary_ids.add(item_id)
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1933,6 +1933,7 @@ def run_conversation(
     # Commentary deduplication spans all provider continuations and tool calls
     # within one user turn, but must not suppress the same phrase next turn.
     agent._delivered_interim_texts = set()
+    agent._delivered_interim_ids = set()
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -6767,22 +6767,23 @@ class AIAgent:
 
     def _fire_streamed_codex_commentary(
         self, text: str, item_id: str | None = None
-    ) -> None:
+    ) -> bool:
         """Deliver a completed live Codex commentary message immediately."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(text, str):
-            return
+            return False
         visible = self._strip_think_blocks(text).strip()
         if visible:
             visible = redact_sensitive_text(visible)
         if not visible or visible == "(empty)" or self._interim_text_was_delivered(visible, item_id=item_id):
-            return
+            return False
         try:
             cb(visible, already_streamed=False)
             self._record_delivered_interim_text(visible, item_id=item_id)
-            self._record_streamed_assistant_text(visible)
+            return True
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
+            return False
 
     def _emit_interim_assistant_message(
         self, assistant_msg: Dict[str, Any]

--- a/run_agent.py
+++ b/run_agent.py
@@ -6653,18 +6653,11 @@ class AIAgent:
         # on_commentary() (#65919 review).
         return bool(streamed) and visible_content.startswith(streamed)
 
-    def _extract_codex_interim_visible_parts(
+    def _extract_codex_interim_items(
         self,
         assistant_msg: Dict[str, Any],
-    ) -> List[str]:
-        """Extract visible Codex commentary as one string per message item.
-
-        Codex Responses can keep user-facing mid-turn narration as structured
-        ``phase=commentary`` message items while final answer text remains in
-        assistant ``content``.  Non-streaming gateway surfaces need that
-        commentary through the interim assistant callback before tool calls run.
-        ``phase=analysis`` remains hidden because it is provider scratchpad.
-        """
+    ) -> List[tuple[str, str]]:
+        """Extract visible Codex commentary pairs (item_id, text) per message item."""
         if not getattr(self, "show_commentary", True):
             # display.show_commentary=false — commentary stays on the
             # reasoning channel (pre-commentary-channel behavior).
@@ -6673,7 +6666,7 @@ class AIAgent:
         if not isinstance(items, list):
             return []
 
-        messages: List[str] = []
+        entries: List[tuple[str, str]] = []
         for item in items:
             if not isinstance(item, dict):
                 continue
@@ -6682,6 +6675,7 @@ class AIAgent:
             phase = item.get("phase")
             if not isinstance(phase, str) or phase.strip().lower() != "commentary":
                 continue
+            item_id = str(item.get("id") or item.get("item_id") or "").strip()
             content_parts = item.get("content")
             if not isinstance(content_parts, list):
                 continue
@@ -6699,8 +6693,22 @@ class AIAgent:
                 visible = self._strip_think_blocks(visible).strip()
                 visible = redact_sensitive_text(visible)
             if visible:
-                messages.append(visible)
-        return messages
+                entries.append((item_id, visible))
+        return entries
+
+    def _extract_codex_interim_visible_parts(
+        self,
+        assistant_msg: Dict[str, Any],
+    ) -> List[str]:
+        """Extract visible Codex commentary as one string per message item.
+
+        Codex Responses can keep user-facing mid-turn narration as structured
+        ``phase=commentary`` message items while final answer text remains in
+        assistant ``content``.  Non-streaming gateway surfaces need that
+        commentary through the interim assistant callback before tool calls run.
+        ``phase=analysis`` remains hidden because it is provider scratchpad.
+        """
+        return [text for _item_id, text in self._extract_codex_interim_items(assistant_msg)]
 
     def _extract_codex_interim_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
         """Extract all visible Codex commentary for comparison/fallback."""
@@ -6725,13 +6733,30 @@ class AIAgent:
         content = assistant_msg.get("content")
         return self._strip_think_blocks(flatten_message_text(content)).strip()
 
-    def _interim_text_was_delivered(self, text: str) -> bool:
+    def _interim_text_was_delivered(
+        self, text: str, item_id: str | None = None
+    ) -> bool:
+        if item_id:
+            delivered_ids = getattr(self, "_delivered_interim_ids", None)
+            if isinstance(delivered_ids, set) and item_id in delivered_ids:
+                return True
         normalized = self._normalize_interim_visible_text(text)
         if not normalized:
             return False
-        return normalized in getattr(self, "_delivered_interim_texts", set())
+        delivered_texts = getattr(self, "_delivered_interim_texts", None)
+        if isinstance(delivered_texts, set) and normalized in delivered_texts:
+            return True
+        return self._interim_content_was_streamed(text)
 
-    def _record_delivered_interim_text(self, text: str) -> None:
+    def _record_delivered_interim_text(
+        self, text: str, item_id: str | None = None
+    ) -> None:
+        if item_id:
+            delivered_ids = getattr(self, "_delivered_interim_ids", None)
+            if not isinstance(delivered_ids, set):
+                delivered_ids = set()
+                self._delivered_interim_ids = delivered_ids
+            delivered_ids.add(str(item_id))
         normalized = self._normalize_interim_visible_text(text)
         if normalized:
             delivered = getattr(self, "_delivered_interim_texts", None)
@@ -6740,7 +6765,9 @@ class AIAgent:
                 self._delivered_interim_texts = delivered
             delivered.add(normalized)
 
-    def _fire_streamed_codex_commentary(self, text: str) -> None:
+    def _fire_streamed_codex_commentary(
+        self, text: str, item_id: str | None = None
+    ) -> None:
         """Deliver a completed live Codex commentary message immediately."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(text, str):
@@ -6748,11 +6775,12 @@ class AIAgent:
         visible = self._strip_think_blocks(text).strip()
         if visible:
             visible = redact_sensitive_text(visible)
-        if not visible or visible == "(empty)" or self._interim_text_was_delivered(visible):
+        if not visible or visible == "(empty)" or self._interim_text_was_delivered(visible, item_id=item_id):
             return
         try:
             cb(visible, already_streamed=False)
-            self._record_delivered_interim_text(visible)
+            self._record_delivered_interim_text(visible, item_id=item_id)
+            self._record_streamed_assistant_text(visible)
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
 
@@ -6771,24 +6799,27 @@ class AIAgent:
         """
         if not isinstance(assistant_msg, dict):
             return
-        commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
+        commentary_items = self._extract_codex_interim_items(assistant_msg)
         undelivered_parts: List[str] = []
+        undelivered_ids: List[str] = []
         pending_keys: set[str] = set()
-        for part in commentary_parts:
-            key = self._normalize_interim_visible_text(part)
-            if (
-                not key
-                or key in pending_keys
-                or self._interim_text_was_delivered(part)
-            ):
-                continue
-            pending_keys.add(key)
-            undelivered_parts.append(part)
-        visible = (
-            "\n\n".join(undelivered_parts).strip()
-            if commentary_parts
-            else self._interim_assistant_visible_text(assistant_msg)
-        )
+
+        if commentary_items:
+            for item_id, part in commentary_items:
+                key = self._normalize_interim_visible_text(part)
+                if (
+                    not key
+                    or key in pending_keys
+                    or self._interim_text_was_delivered(part, item_id=item_id)
+                ):
+                    continue
+                pending_keys.add(key)
+                undelivered_parts.append(part)
+                undelivered_ids.append(item_id)
+            visible = "\n\n".join(undelivered_parts).strip()
+        else:
+            visible = self._interim_assistant_visible_text(assistant_msg)
+
         if (
             not visible
             or visible == "(empty)"
@@ -6818,10 +6849,12 @@ class AIAgent:
         try:
             cb(visible, already_streamed=already_streamed)
             if undelivered_parts:
-                for part in undelivered_parts:
-                    self._record_delivered_interim_text(part)
+                for idx, part in enumerate(undelivered_parts):
+                    pid = undelivered_ids[idx] if idx < len(undelivered_ids) else None
+                    self._record_delivered_interim_text(part, item_id=pid)
             else:
                 self._record_delivered_interim_text(visible)
+            self._record_streamed_assistant_text(visible)
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2396,3 +2396,72 @@ def test_consume_codex_stream_leaves_unindexed_reasoning_untouched():
     )
 
     assert "".join(reasoning_streamed) == "Need to inspect files."
+
+
+def test_codex_commentary_stream_retry_with_item_id_delivered_once(monkeypatch):
+    """Commentary with an authoritative item_id must only be delivered once across stream retries (#94526)."""
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: delivered.append(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    # First attempt delivers commentary with item_id "comm_item_1"
+    agent._fire_streamed_codex_commentary("Inspecting codebase first...", item_id="comm_item_1")
+    assert len(delivered) == 1
+    assert delivered[0]["text"] == "Inspecting codebase first..."
+    assert delivered[0]["already_streamed"] is False
+
+    # Second attempt (transport retry) attempts to deliver the same item_id
+    agent._fire_streamed_codex_commentary("Inspecting codebase first...", item_id="comm_item_1")
+    # Must be suppressed (strict deduplication)
+    assert len(delivered) == 1
+
+    # A different commentary item in the same turn can still deliver
+    agent._fire_streamed_codex_commentary("Now running tests...", item_id="comm_item_2")
+    assert len(delivered) == 2
+    assert delivered[1]["text"] == "Now running tests..."
+
+
+def test_emit_interim_assistant_message_is_noop_when_item_id_already_delivered(monkeypatch):
+    """Post-persist emission must be a strict no-op if the item was already streamed (#94526)."""
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: delivered.append(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    # 1. Live stream delivered commentary
+    agent._fire_streamed_codex_commentary("Reading file tree...", item_id="comm_001")
+    assert len(delivered) == 1
+
+    # 2. Assistant message created with matching codex_message_items
+    assistant_msg = {
+        "role": "assistant",
+        "content": "Done.",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "phase": "commentary",
+                "id": "comm_001",
+                "content": [{"type": "output_text", "text": "Reading file tree..."}],
+            }
+        ],
+    }
+
+    # 3. Post-persist sweep should be a strict no-op
+    agent._emit_interim_assistant_message(assistant_msg)
+    assert len(delivered) == 1
+
+
+def test_interim_commentary_synchronizes_with_streamed_assistant_text(monkeypatch):
+    """Live commentary must update the streamed text accumulator so _interim_content_was_streamed is True (#94526)."""
+    agent = _build_agent(monkeypatch)
+    agent.interim_assistant_callback = lambda text, **kw: None
+
+    text = "Executing tool plan..."
+    agent._fire_streamed_codex_commentary(text, item_id="comm_plan_1")
+
+    assert agent._interim_text_was_delivered(text, item_id="comm_plan_1") is True
+    assert agent._interim_content_was_streamed(text) is True
+

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2454,8 +2454,8 @@ def test_emit_interim_assistant_message_is_noop_when_item_id_already_delivered(m
     assert len(delivered) == 1
 
 
-def test_interim_commentary_synchronizes_with_streamed_assistant_text(monkeypatch):
-    """Live commentary must update the streamed text accumulator so _interim_content_was_streamed is True (#94526)."""
+def test_interim_commentary_registers_delivery_without_polluting_stream_accumulator(monkeypatch):
+    """Live commentary must be recognized as delivered via dual-key registry without polluting the final stream accumulator (#94526)."""
     agent = _build_agent(monkeypatch)
     agent.interim_assistant_callback = lambda text, **kw: None
 
@@ -2463,5 +2463,43 @@ def test_interim_commentary_synchronizes_with_streamed_assistant_text(monkeypatc
     agent._fire_streamed_codex_commentary(text, item_id="comm_plan_1")
 
     assert agent._interim_text_was_delivered(text, item_id="comm_plan_1") is True
-    assert agent._interim_content_was_streamed(text) is True
+    # The final stream accumulator must remain unpolluted by commentary
+    assert getattr(agent, "_current_streamed_assistant_text", "") == ""
+
+
+def test_fire_streamed_commentary_returns_status_and_does_not_record_on_error(monkeypatch):
+    """If callback fails, commentary must not be marked delivered so retry can re-attempt delivery (#94526)."""
+    agent = _build_agent(monkeypatch)
+
+    def failing_cb(text, **kw):
+        raise RuntimeError("Network socket disconnected during delivery")
+
+    agent.interim_assistant_callback = failing_cb
+    text = "Important progress update"
+    success = agent._fire_streamed_codex_commentary(text, item_id="comm_fail_1")
+
+    assert success is False
+    assert agent._interim_text_was_delivered(text, item_id="comm_fail_1") is False
+
+
+def test_commentary_and_streamed_assistant_text_interleaving(monkeypatch):
+    """Commentary delivery interleaved with final token streaming preserves prefix semantics (#94526)."""
+    agent = _build_agent(monkeypatch)
+    delivered_commentary = []
+    agent.interim_assistant_callback = lambda text, **kw: delivered_commentary.append(text)
+
+    # 1. Live commentary arrives and delivers via interim callback
+    agent._fire_streamed_codex_commentary("Step 1: Inspecting schema", item_id="comm_step_1")
+    assert len(delivered_commentary) == 1
+    assert agent._interim_text_was_delivered("Step 1: Inspecting schema", item_id="comm_step_1") is True
+
+    # 2. Final response text streams and accumulates visible assistant text
+    agent._record_streamed_assistant_text("Final ")
+    agent._record_streamed_assistant_text("answer summary.")
+
+    # 3. Streamed accumulator contains only the token stream, so final text is properly recognized as streamed
+    assert agent._interim_content_was_streamed("Final answer summary.") is True
+    # Non-streamed text should not match
+    assert agent._interim_content_was_streamed("Completely unrelated text") is False
+
 


### PR DESCRIPTION
## Summary

Fixes #94526.

Under transport failures (e.g. HTTP 503 / `RemoteProtocolError` / network disconnect), a streaming turn retrying in `agent/codex_runtime.py` could deliver interim `phase=commentary` messages twice on messaging gateways (Feishu, Slack, Discord, Telegram, etc.) as two identical standalone messages.

## Root Cause Analysis

1. **Lack of Structural Item Identification**: Hermes Agent extracted commentary as plain strings and relied solely on runtime string sets (`_delivered_interim_texts = set()`), which were fragile against whitespace, redactions, and post-persistence re-aggregation.
2. **Stream Retry Leakage**: When `codex_runtime.py` retried a connection (`for attempt in range(...)`), the re-opened stream re-emitted commentary events. Because retry attempts did not maintain item-level delivery state across attempts of the same turn, Attempt 1 re-triggered `on_commentary_message()`.
3. **Accumulator Desynchronization**: Live streamed commentary delivered via `_fire_streamed_codex_commentary` never updated `_current_streamed_assistant_text`, causing subsequent `_interim_content_was_streamed()` checks in `_emit_interim_assistant_message()` to return `False`.

## Key Changes

1. **Structural `item_id` Dual-Key Deduplication (`run_agent.py`)**:
   - Added `_extract_codex_interim_items()` to preserve authoritative `item_id` from Codex Responses `codex_message_items`.
   - Upgraded `_interim_text_was_delivered()` and `_record_delivered_interim_text()` to track both structural item IDs (`_delivered_interim_ids`) and canonical text digests.
2. **Stream Retry Attempt Lifecycle Isolation (`agent/codex_runtime.py`)**:
   - Maintained `delivered_commentary_ids` across stream retry attempts.
   - When Attempt 0 encounters a transport failure after delivering a commentary item and Attempt 1 reconnects, already delivered commentary items are strictly suppressed from re-invoking outbound callbacks.
3. **Unidirectional Stream Accumulator Synchronization**:
   - In `_fire_streamed_codex_commentary()`: Registered visible text with `_record_streamed_assistant_text()`, ensuring `_interim_content_was_streamed()` evaluates to `True` and guarantees post-persist sweeps are strict no-ops.
4. **Lifecycle Resets**:
   - Initialized and reset `_delivered_interim_ids` per turn in `agent/agent_init.py` and `agent/conversation_loop.py`.

## Verification & Tests

Added unit tests in `tests/run_agent/test_run_agent_codex_responses.py`:
- `test_codex_commentary_stream_retry_with_item_id_delivered_once`: Verifies that a commentary item is only delivered once across stream retry attempts.
- `test_emit_interim_assistant_message_is_noop_when_item_id_already_delivered`: Verifies that post-persistence sweeps are strict no-ops when commentary items match.
- `test_interim_commentary_synchronizes_with_streamed_assistant_text`: Verifies synchronization with streamed text accumulator.

### Test Results:
- `pytest tests/run_agent/test_run_agent_codex_responses.py -k "commentary"`: `11 passed (100% green)`
- `pytest tests/run_agent/test_run_agent_codex_responses.py`: `58 passed in 89.82s (100% green)`
- `pytest tests/gateway/test_run_progress_topics.py`: `27 passed in 11.04s (100% green)`