### PR TITLE
fix(gateway): stop blocking the event loop during takeover waits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30788,7 +30788,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 if not _pid_exists(existing_pid):
                     old_gateway_exited = True
                     break  # Process is gone
-                time.sleep(0.5)
+                # Async context: a blocking time.sleep here froze the whole
+                # event loop for up to 10s during takeover (adapter
+                # heartbeats, websockets, and cron all stalled).
+                await asyncio.sleep(0.5)
             else:
                 # Still alive after 10s — force kill
                 logger.warning(
@@ -30812,7 +30815,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                         if not _pid_exists(existing_pid):
                             old_gateway_exited = True
                             break
-                        time.sleep(0.25)
+                        await asyncio.sleep(0.25)
                 if not old_gateway_exited:
                     logger.error(
                         "Old gateway (PID %d) still appears alive after SIGKILL; "


### PR DESCRIPTION
## Problem

`start_gateway()` (an `async def` running on the live loop) waited for the replaced gateway process to exit with **blocking `time.sleep()`**:

- up to 20 × 0.5s while waiting for SIGTERM to take effect
- up to 20 × 0.25s confirming the SIGKILL reaped it

Up to **~15 seconds of frozen event loop** during a takeover/replace: every platform-adapter heartbeat, dashboard websocket, cron tick, and HTTP health endpoint stalls. On messaging platforms this surfaces as the bot going unresponsive for the whole window right when a restart was requested.

## Fix

Both wait loops switch to `await asyncio.sleep(...)` with identical iteration counts and totals — takeover timing semantics are unchanged, but the loop stays live throughout. The surrounding `_pid_exists` probes (psutil/ctypes) are quick syscalls and remain synchronous by design.

## Verification

Takeover/replace selection in `tests/gateway`: 11 passed, 2 skipped; module parses clean.