### PR TITLE
docs(gemini): update to use latest gemini models

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -99,7 +99,7 @@ def probe_gemini_tier(
     api_key: str,
     base_url: str = DEFAULT_GEMINI_BASE_URL,
     *,
-    model: str = "gemini-3.6-flash",
+    model: str = "gemini-3.7-flash",
     timeout: float = 10.0,
 ) -> str:
     """Probe a Google AI Studio API key and return its tier.
@@ -1146,7 +1146,7 @@ class GeminiNativeClient:
     def _create_chat_completion(
         self,
         *,
-        model: str = "gemini-3.6-flash",
+        model: str = "gemini-3.7-flash",
         messages: Optional[List[Dict[str, Any]]] = None,
         stream: bool = False,
         tools: Any = None,

--- a/contributors/emails/macd@google.com
+++ b/contributors/emails/macd@google.com
@@ -1,0 +1,1 @@
+markmcd

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -38,7 +38,7 @@ If you prefer direct config editing, use the native Gemini API base URL:
 
 ```yaml
 model:
-  default: gemini-3-flash-preview
+  default: gemini-3.7-flash
   provider: gemini
   base_url: https://generativelanguage.googleapis.com/v1beta
 ```
@@ -49,7 +49,7 @@ After running `hermes model`, your `~/.hermes/config.yaml` will contain:
 
 ```yaml
 model:
-  default: gemini-3-flash-preview
+  default: gemini-3.7-flash
   provider: gemini
   base_url: https://generativelanguage.googleapis.com/v1beta
 ```
@@ -104,20 +104,21 @@ The `hermes model` picker shows Gemini models maintained in Hermes' provider reg
 
 | Model | ID | Notes |
 |-------|----|-------|
-| Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` | Most capable preview model when available |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | Strong reasoning and coding model |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | Recommended default balance of speed and capability |
-| Gemini 3.1 Flash Lite Preview | `gemini-3.1-flash-lite-preview` | Fastest / lowest-cost option when available |
+| Gemini 3.7 Flash | `gemini-3.7-flash` | Recommended default balance of speed, capability, and multimodal understanding |
+| Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` | Most capable reasoning, math, and coding model |
+| Gemini 3.5 Flash Lite | `gemini-3.5-flash-lite` | Fastest and lowest-cost option for lightweight tasks |
+| Gemini 2.5 Flash | `gemini-2.5-flash` | Previous generation fast model with thinking capabilities |
+| Gemini 2.5 Pro | `gemini-2.5-pro` | Previous generation complex reasoning model |
 
 Model availability changes over time. If a model disappears or is not enabled for your key, run `hermes model` again and pick one from the current list.
 
 :::info Model IDs
-Use Gemini's native model IDs such as `gemini-3-flash-preview`, not OpenRouter-style IDs like `google/gemini-3-flash-preview`, when `provider: gemini`.
+Use Gemini's native model IDs such as `gemini-3.7-flash`, not OpenRouter-style IDs like `google/gemini-3.7-flash`, when `provider: gemini`.
 :::
 
 ### Latest Aliases
 
-Google publishes moving aliases for the Pro and Flash Gemini families. `gemini-pro-latest` and `gemini-flash-latest` are useful when you want Google to advance the model automatically without changing your Hermes config.
+Google publishes moving aliases for the Pro and Flash Gemini families. `gemini-pro-latest` and `gemini-flash-latest` are useful when you want Google to advance the model automatically without changing your Hermes config. Note that your usage charges may be affected if newer models introduce different rates.
 
 | Alias | Currently tracks | Notes |
 |-------|------------------|-------|
@@ -131,7 +132,7 @@ model:
   base_url: https://generativelanguage.googleapis.com/v1beta
 ```
 
-If you need strict reproducibility, prefer explicit model IDs such as `gemini-3.1-pro-preview` or `gemini-3-flash-preview`.
+If you need strict reproducibility, prefer explicit model IDs such as `gemini-3.1-pro-preview` or `gemini-3.7-flash`.
 
 ### Gemma via the Gemini API
 
@@ -160,9 +161,9 @@ model:
 Use the `/model` command during a conversation:
 
 ```text
-/model gemini-3-flash-preview
+/model gemini-3.7-flash
 /model gemini-flash-latest
-/model gemini-3-pro-preview
+/model gemini-3.1-pro-preview
 /model gemini-pro-latest
 /model gemma-4-31b-it
 /model gemini-3.1-flash-lite-preview


### PR DESCRIPTION
## What this PR does

Salvage of #94522 by @markmcd — update docs and defaults to use current-gen Gemini models (gemini-3.7-flash, gemini-3.5-flash-lite, etc.).

The original PR was blocked solely by the contributor attribution check (`macd@google.com` was unmapped). This salvage cherry-picks the original commit (preserving authorship) and adds the email mapping.

## Changes

- Update default model IDs in `agent/gemini_native_adapter.py` from `gemini-3.6-flash` to `gemini-3.7-flash`
- Update `website/docs/guides/google-gemini.md` to reference current-gen models (3.7 Flash, 3.5 Flash Lite, 2.5 Flash, 2.5 Pro) in the model table, config examples, and `/model` commands
- Add `contributors/emails/macd@google.com` → `markmcd` mapping so the attribution check passes

## Why salvage

The original PR had all tests/lints passing but was blocked by the contributor attribution CI gate. Cherry-picking preserves @markmcd's authorship in git history.

## Test plan

- [x] All tests and lints pass on the original PR
- [ ] Contributor attribution check passes with the new mapping file
