### PR TITLE
fix(agent): do not fuzzy-remap check_fn-gated tool names onto siblings

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3545,6 +3545,29 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         if c and c in agent.valid_tool_names:
             return c
 
+    # A name the registry knows but check_fn gated for this turn is a REAL
+    # tool, not a typo: steps 1-4 normalize spellings of the same tool, but
+    # the fuzzy fallback below selects a *different* one. Within a shared
+    # prefix family (kanban_*, memory_*, ...) the nearest available
+    # neighbour is disproportionately likely to be an adjacent operation on
+    # the same resource — kanban_list, deliberately hidden from dispatcher
+    # workers by _check_kanban_orchestrator_mode, remapped onto kanban_link,
+    # turning a read intent into a dependency-writing call that only failed
+    # because its arguments happen to be required (#94506). Gated means
+    # "not permitted here": fall through to the unknown-tool path so the
+    # model learns the name is unavailable this turn instead of being
+    # silently dispatched to a sibling it never called.
+    try:
+        from tools.registry import registry as _tool_registry
+
+        all_names = set(_tool_registry.get_all_tool_names())
+    except Exception:
+        all_names = None
+    if all_names is not None:
+        for c in cands:
+            if c and c in all_names:
+                return None
+
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
     if matches:

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -125,3 +125,55 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+class TestCheckFnGatedNamesNotFuzzyRemapped:
+    """#94506: a registry-known name hidden by check_fn for this turn must
+    NOT be fuzzy-remapped onto a different available tool. The observed case:
+    kanban_list, deliberately hidden from dispatcher workers, resolved to
+    kanban_link — a dependency-WRITING sibling of a READ intent."""
+
+    @pytest.fixture
+    def gated_repair(self, monkeypatch):
+        """repair() bound to a worker-shaped agent + a registry that knows
+        both the gated tool and the available siblings."""
+        from tools import registry as registry_module
+
+        worker_valid = {"kanban_link", "kanban_create", "kanban_update"}
+        registry_all = {"kanban_list", "kanban_unblock", *worker_valid}
+
+        class _FakeRegistry:
+            def get_all_tool_names(self):
+                return sorted(registry_all)
+
+        fake = _FakeRegistry()
+        monkeypatch.setattr(
+            registry_module, "registry", fake, raising=True
+        )
+
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names=worker_valid)
+        return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+    def test_gated_tool_name_returns_none_not_a_sibling(self, gated_repair):
+        # kanban_list is a real registered tool, hidden from this worker by
+        # check_fn. It must fall through to the unknown-tool path (None),
+        # never be substituted with kanban_link.
+        assert gated_repair("kanban_list") is None
+
+    def test_gated_tool_variant_spelling_also_returns_none(self, gated_repair):
+        # A gated tool reached via a class-like emission must not remap
+        # either — the candidate set still hits the registry-known name.
+        assert gated_repair("KanbanList_tool") is None
+
+    def test_true_typo_still_fuzzy_repairs(self, gated_repair):
+        # A name that is NOT registered anywhere is a genuine typo — the
+        # fuzzy fallback keeps working for it.
+        assert gated_repair("kanban_lynk") == "kanban_link"
+
+    def test_ungated_normalization_unchanged(self, gated_repair):
+        # Available tools keep their fast-path behaviour: exact and
+        # normalized spellings never reach the gate.
+        assert gated_repair("kanban_link") == "kanban_link"
+        assert gated_repair("KanbanLink") == "kanban_link"


### PR DESCRIPTION
## What does this PR do?

`repair_tool_call()`'s step-5 fuzzy fallback (`difflib`, cutoff=0.7) treats a tool name that the registry knows but `check_fn` withheld for this turn as a typo, and substitutes the nearest *available* neighbour. Within a shared prefix family that neighbour is disproportionately an adjacent operation on the same resource — the reported case: a dispatcher-spawned kanban worker calling `kanban_list` (deliberately hidden from workers by `_check_kanban_orchestrator_mode`) had it silently remapped onto `kanban_link` (0.79 similarity). The read intent became a dependency-writing call that only failed because `kanban_link` happens to require arguments; a remap whose arguments validate would silently draw a parent→child edge that blocks the child from promoting to `ready`, stalling the board with no error anywhere (#94506).

The fix: before the fuzzy fallback, consult the full (pre-gating) registry name set. If any spelling candidate produced by this pipeline (steps 1–4 normalize spellings of the same tool) names a real registered tool, the input is a real-but-gated name — fall through to the normal unknown-tool path so the model learns the name is unavailable this turn, instead of being silently dispatched to a sibling it never called.

Steps 1–4 are unchanged: they normalize spellings of the *same* tool. Only step 5's cross-tool substitution is now fenced for gated names. The existing fuzzy path still works for genuine typos (names not registered under any spelling).

Note: the open fuzzy-matching rework #37100 addresses candidate *ranking* for `mcp__`-prefixed names; this gate is orthogonal — even with perfect ranking, a gated native name would still be substituted with some sibling, because the gated name itself is absent from `valid_tool_names`.

## Related Issue

Fixes #94506

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `repair_tool_call()`, before the step-5 fuzzy fallback, check the spelling candidates against the pre-gating registry name set (`registry.get_all_tool_names()`); a hit returns `None` (unknown-tool path) instead of letting the fuzzy match pick an available sibling. Registry access failure degrades to the previous behavior.
- `tests/run_agent/test_repair_tool_call_name.py` — new `TestCheckFnGatedNamesNotFuzzyRemapped` class: gated exact name and class-like variant both return `None` (never a sibling); a genuine typo (`kanban_lynk`) still fuzzy-repairs; available tools keep their fast-path normalization.

## How to Test

1. `pytest tests/run_agent/test_repair_tool_call_name.py -q` — should pass (12 passed; 8 pre-existing + 4 new).
2. Observed result: before the change, `repair("kanban_list")` against a worker whose `valid_tool_names` lacks it but contains `kanban_link` returns `"kanban_link"` (the read→write remap); after the change it returns `None` and the model is told the tool is unknown this turn. `repair("kanban_lynk")` still returns `"kanban_link"` (true typo keeps repairing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction from the issue (before the fix) — a worker's `kanban_list` dispatched as `kanban_link`:

```
tools.registry: check_fn _check_kanban_orchestrator_mode returned False; dependent tools will be unavailable this turn
{"error": "both parent_id and child_id are required"}   ← kanban_link's validation error, not kanban_list's
```

```
>>> difflib.get_close_matches('kanban_list', ['kanban_link'], n=1, cutoff=0.7)
['kanban_link']
```

With the fix, the gated name resolves to `None` and the model receives the unknown-tool error naming what is actually unavailable this turn.
