### PR TITLE
fix(agent): gate durable prompt restore on managed context

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3387,7 +3387,21 @@ def compress_context(
             )
             from agent.conversation_loop import compute_current_context_fingerprint
 
+            # Kept bytes describe whatever managed inputs they were built
+            # from. Stamp the current digest only when it already matches
+            # the stored pair; otherwise persist NULL so restore self-heals
+            # instead of treating (stale SOUL/context, new digest) as valid.
             prompt_fingerprint = compute_current_context_fingerprint(agent)
+            stored_fp = None
+            session_db = getattr(agent, "_session_db", None)
+            if session_db is not None and getattr(agent, "session_id", None):
+                try:
+                    stored_row = session_db.get_session(agent.session_id) or {}
+                    stored_fp = stored_row.get("system_prompt_fingerprint")
+                except Exception:
+                    stored_fp = None
+            if stored_fp != prompt_fingerprint:
+                prompt_fingerprint = None
         else:
             from agent.conversation_loop import build_prompt_with_fingerprint
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3388,19 +3388,27 @@ def compress_context(
             from agent.conversation_loop import compute_current_context_fingerprint
 
             # Kept bytes describe whatever managed inputs they were built
-            # from. Stamp the current digest only when it already matches
-            # the stored pair; otherwise persist NULL so restore self-heals
-            # instead of treating (stale SOUL/context, new digest) as valid.
+            # from. Stamp the current digest only when the durable row
+            # already stores this same prompt+digest pair; otherwise persist
+            # NULL so restore self-heals. Matching fingerprints alone is
+            # not enough: another writer may have rebuilt (current prompt,
+            # current digest) while this agent still holds stale cache.
             prompt_fingerprint = compute_current_context_fingerprint(agent)
             stored_fp = None
+            stored_prompt = None
             session_db = getattr(agent, "_session_db", None)
             if session_db is not None and getattr(agent, "session_id", None):
                 try:
                     stored_row = session_db.get_session(agent.session_id) or {}
                     stored_fp = stored_row.get("system_prompt_fingerprint")
+                    stored_prompt = stored_row.get("system_prompt")
                 except Exception:
                     stored_fp = None
-            if stored_fp != prompt_fingerprint:
+                    stored_prompt = None
+            if (
+                stored_fp != prompt_fingerprint
+                or stored_prompt != cached_system_prompt
+            ):
                 prompt_fingerprint = None
         else:
             from agent.conversation_loop import build_prompt_with_fingerprint

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3385,8 +3385,15 @@ def compress_context(
                 system_message=system_message,
                 log_label="compression keep-prompt",
             )
+            from agent.conversation_loop import compute_current_context_fingerprint
+
+            prompt_fingerprint = compute_current_context_fingerprint(agent)
         else:
-            new_system_prompt = agent._build_system_prompt(system_message)
+            from agent.conversation_loop import build_prompt_with_fingerprint
+
+            new_system_prompt, prompt_fingerprint = build_prompt_with_fingerprint(
+                agent, system_message
+            )
             agent._cached_system_prompt = new_system_prompt
 
         _session_commit_succeeded = False
@@ -3773,10 +3780,17 @@ def compress_context(
                 # Rotation already published prompt + compacted handoff atomically.
                 if in_place:
                     agent._session_db.update_system_prompt(
-                        agent.session_id, new_system_prompt
+                        agent.session_id,
+                        new_system_prompt,
+                        fingerprint=prompt_fingerprint,
                     )
                     agent._last_flushed_db_idx = 0
                 else:
+                    agent._session_db.update_system_prompt(
+                        agent.session_id,
+                        new_system_prompt,
+                        fingerprint=prompt_fingerprint,
+                    )
                     agent._last_flushed_db_idx = len(compressed)
                     agent._flushed_db_message_session_id = agent.session_id
                     agent._flushed_db_message_ids = {

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -880,7 +880,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
       * ``empty``  — row exists, ``system_prompt`` column is the empty
         string.  Indicates a previous-turn write that ran but stored
         nothing (silent persistence bug).  Always warns.
-      * ``present`` — row exists with a usable prompt → reused verbatim.
+      * ``present`` — row exists with a usable prompt → reused verbatim
+        only when runtime identity AND the managed-context fingerprint
+        both match.
 
     Read or write failures against the session DB log at WARNING (not
     DEBUG) so persistent issues (disk full, schema drift, lock contention)
@@ -891,6 +893,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     """
     stored_prompt = None
     stored_state = "missing"
+    session_row = None
     if conversation_history and agent._session_db:
         try:
             session_row = agent._session_db.get_session(agent.session_id)
@@ -912,109 +915,109 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             )
 
     if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
-        # Bot Chat capability epoch: an eternal bot session must adopt
-        # user-initiated capability changes (skills/toolsets/MCP/SOUL/roster)
-        # on the next message, not at /new or compression. The stored prompt
-        # embeds a fingerprint of the capability surface; a mismatch against
-        # disk is a deliberate, once-per-change rebuild — the /model
-        # exception applied to capabilities. Prompts without the stamp
-        # (every non-Bot-Chat session) never take this branch, and the check
-        # fails closed to "reuse" so a probe failure can't burn cache.
-        _bot_stale = False
-        try:
-            from tools.bot_mode_probe import (
-                BOT_CHAT_TITLE,
-                stored_bot_chat_prompt_needs_upgrade,
-                stored_prompt_capability_stale,
-            )
-
-            _home_for_epoch = None
-            try:
-                from agent.system_prompt import _agent_home
-
-                _home_for_epoch = _agent_home(agent)
-            except Exception:
-                pass
-            _bot_stale = stored_prompt_capability_stale(stored_prompt, _home_for_epoch)
-            if not _bot_stale and getattr(agent, "_bot_mode_protocol", True):
-                # Legacy upgrade: a Bot Chat whose prompt predates the epoch
-                # mechanism (no stamp, no protocol) gets ONE migration
-                # rebuild — otherwise pre-existing bots would never learn
-                # the messaging protocol. Title-gated so ordinary unstamped
-                # sessions (i.e. all of them) never take this path; the
-                # rebuilt prompt carries the stamp, so it cannot re-fire.
-                _t = str(getattr(agent, "_session_title_hint", "") or "").strip()
-                if not _t and agent._session_db and agent.session_id:
-                    try:
-                        _t = str(agent._session_db.get_session_title(agent.session_id) or "").strip()
-                    except Exception:
-                        _t = ""
-                if _t == BOT_CHAT_TITLE:
-                    _bot_stale = stored_bot_chat_prompt_needs_upgrade(stored_prompt, _home_for_epoch)
-        except Exception:
-            _bot_stale = False
-        if _bot_stale:
+        if not _stored_prompt_matches_managed_context(agent, session_row):
+            stored_state = "stale_inputs"
             logger.info(
-                "Bot Chat capability epoch changed for session %s; rebuilding "
-                "system prompt to adopt the new capability surface (one-time "
-                "prefix-cache break).",
+                "Stored system prompt for session %s has stale managed context; "
+                "rebuilding from current SOUL/project inputs.",
                 agent.session_id,
             )
-            agent._session_title_hint = "Bot Chat"
-            # The skills index inside the prompt comes from a two-layer cache
-            # (in-process LRU + disk snapshot) that doesn't watch the skills
-            # dir; a capability refresh must rebuild THROUGH it or a freshly
-            # installed skill stays invisible in the new prompt.
+        else:
+            # Bot Chat capability epoch: an eternal bot session must adopt
+            # user-initiated capability changes (skills/toolsets/MCP/SOUL/roster)
+            # on the next message, not at /new or compression. The stored prompt
+            # embeds a fingerprint of the capability surface; a mismatch against
+            # disk is a deliberate, once-per-change rebuild — the /model
+            # exception applied to capabilities. Prompts without the stamp
+            # (every non-Bot-Chat session) never take this branch, and the check
+            # fails closed to "reuse" so a probe failure can't burn cache.
+            _bot_stale = False
             try:
-                from agent.prompt_builder import clear_skills_system_prompt_cache
+                from tools.bot_mode_probe import (
+                    BOT_CHAT_TITLE,
+                    stored_bot_chat_prompt_needs_upgrade,
+                    stored_prompt_capability_stale,
+                )
 
-                clear_skills_system_prompt_cache(clear_snapshot=True)
-            except Exception:
-                pass
-            agent._cached_system_prompt = agent._build_system_prompt(system_message)
-            agent._bot_capability_refreshed = True
-            # Persist the refreshed prompt so the NEXT turn restores the new
-            # bytes verbatim — the cache break is once per capability change,
-            # never per turn. (on_session_start deliberately not re-fired:
-            # this is a continuation, not a new session.)
-            if agent._session_db:
+                _home_for_epoch = None
                 try:
-                    agent._session_db.update_system_prompt(
-                        agent.session_id, agent._cached_system_prompt
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "Session DB update_system_prompt failed after Bot Chat "
-                        "capability refresh (session=%s): %s. The refresh will "
-                        "re-fire next turn.",
-                        agent.session_id, exc,
-                    )
+                    from agent.system_prompt import _agent_home
+
+                    _home_for_epoch = _agent_home(agent)
+                except Exception:
+                    pass
+                _bot_stale = stored_prompt_capability_stale(stored_prompt, _home_for_epoch)
+                if not _bot_stale and getattr(agent, "_bot_mode_protocol", True):
+                    # Legacy upgrade: a Bot Chat whose prompt predates the epoch
+                    # mechanism (no stamp, no protocol) gets ONE migration
+                    # rebuild — otherwise pre-existing bots would never learn
+                    # the messaging protocol. Title-gated so ordinary unstamped
+                    # sessions (i.e. all of them) never take this path; the
+                    # rebuilt prompt carries the stamp, so it cannot re-fire.
+                    _t = str(getattr(agent, "_session_title_hint", "") or "").strip()
+                    if not _t and agent._session_db and agent.session_id:
+                        try:
+                            _t = str(agent._session_db.get_session_title(agent.session_id) or "").strip()
+                        except Exception:
+                            _t = ""
+                    if _t == BOT_CHAT_TITLE:
+                        _bot_stale = stored_bot_chat_prompt_needs_upgrade(stored_prompt, _home_for_epoch)
+            except Exception:
+                _bot_stale = False
+            if _bot_stale:
+                logger.info(
+                    "Bot Chat capability epoch changed for session %s; rebuilding "
+                    "system prompt to adopt the new capability surface (one-time "
+                    "prefix-cache break).",
+                    agent.session_id,
+                )
+                agent._session_title_hint = "Bot Chat"
+                # The skills index inside the prompt comes from a two-layer cache
+                # (in-process LRU + disk snapshot) that doesn't watch the skills
+                # dir; a capability refresh must rebuild THROUGH it or a freshly
+                # installed skill stays invisible in the new prompt.
+                try:
+                    from agent.prompt_builder import clear_skills_system_prompt_cache
+
+                    clear_skills_system_prompt_cache(clear_snapshot=True)
+                except Exception:
+                    pass
+                prompt, fingerprint = build_prompt_with_fingerprint(agent, system_message)
+                agent._cached_system_prompt = prompt
+                agent._bot_capability_refreshed = True
+                # Persist the refreshed prompt so the NEXT turn restores the new
+                # bytes verbatim — the cache break is once per capability change,
+                # never per turn. (on_session_start deliberately not re-fired:
+                # this is a continuation, not a new session.)
+                _persist_system_prompt_pair(
+                    agent, prompt, fingerprint, context="after Bot Chat capability refresh"
+                )
+                return
+            # Continuing session — reuse the exact system prompt from the
+            # previous turn so the Anthropic cache prefix matches.
+            agent._cached_system_prompt = stored_prompt
+            # Prompt-section callbacks are new-session-only. Recover their frozen
+            # bytes from the persisted full prompt so a later compression rebuild
+            # keeps them without evaluating plugin state in this resumed process.
+            from agent.system_prompt import restore_plugin_prompt_sections
+
+            restore_plugin_prompt_sections(agent, stored_prompt)
+            # Reconstruct the cross-session-stable prefix for the early cache
+            # breakpoint. The static prefix is not persisted (only the full
+            # prompt is), so gateway surfaces that build a fresh AIAgent per
+            # turn would otherwise lose the two-block system layout after the
+            # first turn — flip-flopping the wire shape mid-conversation and
+            # silently degrading to the legacy single-breakpoint layout.
+            #
+            # ``reconstruct_static_prefix`` gates on ``_use_prompt_caching`` (so
+            # non-Anthropic routes skip the rebuild), applies the startswith
+            # safety gate (stored prompt bytes are never rewritten), and
+            # fails open to the legacy cache layout.
+            from agent.system_prompt import reconstruct_static_prefix
+
+            reconstruct_static_prefix(agent, system_message=system_message)
             return
-        # Continuing session — reuse the exact system prompt from the
-        # previous turn so the Anthropic cache prefix matches.
-        agent._cached_system_prompt = stored_prompt
-        # Prompt-section callbacks are new-session-only. Recover their frozen
-        # bytes from the persisted full prompt so a later compression rebuild
-        # keeps them without evaluating plugin state in this resumed process.
-        from agent.system_prompt import restore_plugin_prompt_sections
-
-        restore_plugin_prompt_sections(agent, stored_prompt)
-        # Reconstruct the cross-session-stable prefix for the early cache
-        # breakpoint. The static prefix is not persisted (only the full
-        # prompt is), so gateway surfaces that build a fresh AIAgent per
-        # turn would otherwise lose the two-block system layout after the
-        # first turn — flip-flopping the wire shape mid-conversation and
-        # silently degrading to the legacy single-breakpoint layout.
-        #
-        # ``reconstruct_static_prefix`` gates on ``_use_prompt_caching`` (so
-        # non-Anthropic routes skip the rebuild), applies the startswith
-        # safety gate (stored prompt bytes are never rewritten), and
-        # fails open to the legacy cache layout.
-        from agent.system_prompt import reconstruct_static_prefix
-
-        reconstruct_static_prefix(agent, system_message=system_message)
-        return
-    if stored_prompt:
+    if stored_prompt and stored_state != "stale_inputs":
         stored_state = "stale_runtime"
         logger.info(
             "Stored system prompt for session %s has stale runtime identity; "
@@ -1039,7 +1042,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     # First turn of a new session (or recovering from a broken stored
     # prompt) — build from scratch.
-    agent._cached_system_prompt = agent._build_system_prompt(system_message)
+    prompt, fingerprint = build_prompt_with_fingerprint(agent, system_message)
+    agent._cached_system_prompt = prompt
 
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
@@ -1071,17 +1075,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Persist the system prompt snapshot in SQLite.  Failure here used
     # to log at DEBUG, which silently broke prefix-cache reuse on the
     # gateway path (fresh AIAgent per turn → reads from this row every
-    # subsequent turn).
-    if agent._session_db:
-        try:
-            agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
-        except Exception as exc:
-            logger.warning(
-                "Session DB update_system_prompt failed for session %s: "
-                "%s. Subsequent turns will rebuild the system prompt and "
-                "miss the prefix cache.",
-                agent.session_id, exc,
-            )
+    # subsequent turn). Prompt and fingerprint are paired in one UPDATE.
+    _persist_system_prompt_pair(agent, prompt, fingerprint)
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
@@ -1158,6 +1153,100 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         return False
 
     return True
+
+
+def compute_current_context_fingerprint(agent) -> str | None:
+    """Fingerprint of the agent's current managed prompt inputs, or None.
+
+    None means compute failed — callers must fail open to the pre-existing
+    runtime-identity-only restore check so a fingerprint bug cannot break
+    sessions.
+    """
+    try:
+        from agent.prompt_builder import compute_context_fingerprint
+        from agent.runtime_cwd import resolve_context_cwd
+        from agent.system_prompt import _agent_home
+
+        skip_project = bool(getattr(agent, "skip_context_files", False))
+        include_soul = bool(
+            getattr(agent, "load_soul_identity", False) or not skip_project
+        )
+        ctx_len = None
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is not None:
+            raw_len = getattr(compressor, "context_length", None)
+            if isinstance(raw_len, int) and raw_len > 0:
+                ctx_len = raw_len
+        cwd = None if skip_project else resolve_context_cwd()
+        return compute_context_fingerprint(
+            cwd=str(cwd) if cwd is not None else None,
+            include_soul=include_soul,
+            include_project_context=not skip_project,
+            home_override=_agent_home(agent),
+            context_length=ctx_len,
+            allow_install_tree_fallback=getattr(agent, "platform", None) in ("cli", "tui"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to compute managed-context fingerprint for session %s: %s. "
+            "Failing open to runtime-identity restore.",
+            getattr(agent, "session_id", None),
+            exc,
+        )
+        return None
+
+
+def build_prompt_with_fingerprint(agent, system_message):
+    """Build the system prompt and pair it with a TOCTOU-safe fingerprint.
+
+    The fingerprint is computed before and after the build. If the two
+    disagree (a context file changed mid-build) or either compute fails,
+    the fingerprint is None so the next restore rebuilds instead of
+    tagging a stale prompt with a fresh-looking digest.
+    """
+    pre = compute_current_context_fingerprint(agent)
+    prompt = agent._build_system_prompt(system_message)
+    post = compute_current_context_fingerprint(agent)
+    fingerprint = pre if pre is not None and pre == post else None
+    return prompt, fingerprint
+
+
+def _stored_prompt_matches_managed_context(agent, session_row) -> bool:
+    """Return False when stored managed-context inputs are stale or missing.
+
+    Compute failure fail-opens (True) so a fingerprint bug cannot invalidate
+    prefix cache. A legacy NULL stored fingerprint is a mismatch and
+    self-heals via a one-time rebuild.
+    """
+    current_fp = compute_current_context_fingerprint(agent)
+    if current_fp is None:
+        return True
+    stored_fp = None
+    if session_row:
+        stored_fp = session_row.get("system_prompt_fingerprint")
+    if not stored_fp:
+        return False
+    return stored_fp == current_fp
+
+
+def _persist_system_prompt_pair(agent, prompt, fingerprint, *, context: str = "") -> None:
+    """Atomically persist prompt snapshot + fingerprint; warn on write failure."""
+    if not getattr(agent, "_session_db", None):
+        return
+    suffix = f" {context}" if context else ""
+    try:
+        agent._session_db.update_system_prompt(
+            agent.session_id, prompt, fingerprint=fingerprint
+        )
+    except Exception as exc:
+        logger.warning(
+            "Session DB update_system_prompt failed for session %s%s: "
+            "%s. Subsequent turns will rebuild the system prompt and "
+            "miss the prefix cache.",
+            agent.session_id,
+            suffix,
+            exc,
+        )
 
 
 # The three _get_continuation_prompt variants below, in named-constant form

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -2668,3 +2669,120 @@ def build_context_files_prompt(
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+# =========================================================================
+# Managed-context fingerprint (durable session restore, #68563)
+# =========================================================================
+
+_CONTEXT_FINGERPRINT_VERSION = "v1"
+
+
+def _fingerprint_add(hasher: "hashlib._Hash", key: str, value: str) -> None:
+    """Length-prefix a key/value pair so contents cannot collide across slots."""
+    data = value.encode("utf-8")
+    hasher.update(f"{key}:{len(data)}\n".encode("utf-8"))
+    hasher.update(data)
+    hasher.update(b"\n")
+
+
+def _project_family_presence(cwd_path: Path) -> dict:
+    """Which project-context families exist under *cwd_path*.
+
+    Existence is independent of which family wins first-match-wins loading, so
+    add/remove of a shadowed candidate still changes the digest while editing
+    a shadowed file's content does not.
+    """
+    agents = False
+    for directory in _agents_md_directory_chain(cwd_path):
+        for name in ("AGENTS.override.md", "AGENTS.md", "agents.md"):
+            if (directory / name).exists():
+                agents = True
+                break
+        if agents:
+            break
+    rules_dir = cwd_path / ".cursor" / "rules"
+    cursor = (cwd_path / ".cursorrules").exists() or (
+        rules_dir.is_dir() and any(rules_dir.glob("*.mdc"))
+    )
+    return {
+        "hermes_md": _find_hermes_md(cwd_path) is not None,
+        "agents_md": agents,
+        "claude_md": (cwd_path / "CLAUDE.md").exists() or (cwd_path / "claude.md").exists(),
+        "cursorrules": cursor,
+    }
+
+
+def compute_context_fingerprint(
+    *,
+    cwd: Optional[str] = None,
+    include_soul: bool = True,
+    include_project_context: bool = True,
+    home_override: "Path | None" = None,
+    context_length: Optional[int] = None,
+    allow_install_tree_fallback: bool = False,
+) -> str:
+    """SHA-256 of the managed inputs used to assemble the system prompt.
+
+    The digest is not model-visible. It is stored beside the prompt snapshot
+    so a durable session can reuse byte-stable prefix-cache bytes only while
+    SOUL.md / project context files are unchanged.
+    """
+    hasher = hashlib.sha256()
+    _fingerprint_add(hasher, "version", _CONTEXT_FINGERPRINT_VERSION)
+
+    if include_soul:
+        soul = load_soul_md(context_length, home_override=home_override) or ""
+        _fingerprint_add(hasher, "soul", soul)
+    else:
+        _fingerprint_add(hasher, "soul", "<skipped>")
+
+    if not include_project_context:
+        _fingerprint_add(hasher, "project", "<skipped>")
+        return hasher.hexdigest()
+
+    if cwd is None:
+        cwd_value = os.getcwd()
+        cwd_is_fallback = True
+    else:
+        cwd_value = cwd
+        cwd_is_fallback = False
+    cwd_path = Path(cwd_value).resolve()
+
+    from agent.runtime_cwd import _is_install_tree
+
+    if (
+        cwd_is_fallback
+        and not allow_install_tree_fallback
+        and _is_install_tree(cwd_path)
+    ):
+        _fingerprint_add(hasher, "project", "<install-tree-skipped>")
+        return hasher.hexdigest()
+
+    presence = _project_family_presence(cwd_path)
+    winner = "none"
+    content = ""
+    if presence["hermes_md"]:
+        content = _load_hermes_md(cwd_path, context_length)
+        if content:
+            winner = "hermes_md"
+    if winner == "none" and presence["agents_md"]:
+        content = _load_agents_md(cwd_path, context_length)
+        if content:
+            winner = "agents_md"
+    if winner == "none" and presence["claude_md"]:
+        content = _load_claude_md(cwd_path, context_length)
+        if content:
+            winner = "claude_md"
+    if winner == "none" and presence["cursorrules"]:
+        content = _load_cursorrules(cwd_path, context_length)
+        if content:
+            winner = "cursorrules"
+        else:
+            content = ""
+
+    _fingerprint_add(hasher, "project_winner", winner)
+    _fingerprint_add(hasher, "project_content", content)
+    for family, exists in presence.items():
+        _fingerprint_add(hasher, f"exists:{family}", "1" if exists else "0")
+    return hasher.hexdigest()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7920,15 +7920,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._execute_write(_do)
 
     def update_system_prompt(
-        self, session_id: str, system_prompt: Optional[str]
+        self,
+        session_id: str,
+        system_prompt: Optional[str],
+        fingerprint: Optional[str] = None,
     ) -> None:
-        """Store the full assembled system prompt snapshot."""
+        """Store the assembled system prompt snapshot and its input fingerprint.
+
+        Prompt hash and fingerprint are written in a single UPDATE so a
+        reader cannot observe one without the other. A NULL fingerprint
+        (legacy row, TOCTOU disagreement, or compute failure at persist
+        time) is treated as stale on the next restore and rebuilt once.
+        """
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
+            if system_prompt is None:
+                fingerprint_value = None
+            else:
+                fingerprint_value = fingerprint
             conn.execute(
                 "UPDATE sessions "
-                "SET system_prompt_hash = ?, system_prompt = NULL WHERE id = ?",
-                (system_prompt_hash, session_id),
+                "SET system_prompt_hash = ?, system_prompt = NULL, "
+                "system_prompt_fingerprint = ? WHERE id = ?",
+                (system_prompt_hash, fingerprint_value, session_id),
             )
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
@@ -7977,7 +7991,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 "UPDATE sessions SET "
                 "model = ?, model_config = ?, "
-                "system_prompt = NULL, system_prompt_hash = NULL "
+                "system_prompt = NULL, system_prompt_hash = NULL, "
+                "system_prompt_fingerprint = NULL "
                 "WHERE id = ?",
                 (model, merged, session_id),
             )
@@ -8111,7 +8126,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    model_config = ?,
                    model = COALESCE(?, model),
                    system_prompt = NULL,
-                   system_prompt_hash = NULL
+                   system_prompt_hash = NULL,
+                   system_prompt_fingerprint = NULL
                    WHERE id = ?""",
                 (merged, model, session_id),
             )
@@ -8244,7 +8260,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    billing_base_url = ?,
                    billing_mode = COALESCE(?, billing_mode),
                    system_prompt = NULL,
-                   system_prompt_hash = NULL
+                   system_prompt_hash = NULL,
+                   system_prompt_fingerprint = NULL
                    WHERE id = ?""",
                 (provider, base_url, billing_mode, session_id),
             )

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -381,6 +381,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     model_config TEXT,
     system_prompt TEXT,
     system_prompt_hash TEXT,
+    system_prompt_fingerprint TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,

--- a/tests/agent/test_durable_prompt_context_fingerprint.py
+++ b/tests/agent/test_durable_prompt_context_fingerprint.py
@@ -16,6 +16,7 @@ not done here.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 from agent.conversation_loop import (
@@ -336,3 +337,111 @@ class TestContextFingerprintSemantics:
             include_project_context=True,
         )
         assert first != second
+
+
+class TestKeepPromptCompressionFingerprintPairing:
+    def test_keep_prompt_after_soul_drift_does_not_pair_stale_bytes_with_current_digest(
+        self, tmp_path
+    ):
+        """Keep-prompt compaction after a mid-session SOUL edit must not persist
+        (stale prompt, current digest). That false-valid pair defeats restore.
+
+        Either rebuild from current inputs and persist the matching digest, or
+        keep the old bytes with a NULL fingerprint so the next restore
+        self-heals. Never stamp a new digest onto stale cached prompt bytes.
+        """
+        from agent.conversation_compression import compress_context
+        from run_agent import AIAgent
+
+        _home, token, db = _open_home(tmp_path, CURRENT_SOUL)
+        try:
+            session_id = "keep-prompt-soul-drift"
+            stale_prompt = (
+                "You are Hermes Agent.\n"
+                f"{STALE_SOUL}\n"
+                "Model: test/model\n"
+                "Provider: openrouter"
+            )
+            db.create_session(
+                session_id,
+                source="api",
+                model="test/model",
+                system_prompt=stale_prompt,
+            )
+            conn = db._conn
+            assert conn is not None
+            conn.execute(
+                "UPDATE sessions SET system_prompt_fingerprint = ? WHERE id = ?",
+                ("stale-managed-context-fingerprint", session_id),
+            )
+            conn.commit()
+
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id=session_id,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    load_soul_identity=True,
+                )
+            agent.compression_in_place = True
+            agent._compression_feasibility_checked = True
+            agent._use_prompt_caching = False
+            agent._cached_system_prompt = stale_prompt
+            agent._memory_manager = None
+
+            def _fake_compress(
+                messages, current_tokens=None, focus_topic=None, force=False
+            ):
+                return [
+                    {
+                        "role": "user",
+                        "content": "[CONTEXT COMPACTION] summary of prior turns",
+                    },
+                    {"role": "assistant", "content": "recent reply"},
+                ]
+
+            agent.context_compressor.compress = _fake_compress
+            agent.context_compressor._last_compress_aborted = False
+            agent.context_compressor._last_summary_error = None
+            agent.context_compressor.compression_count = 1
+
+            messages = [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"message {i} " + ("word " * 20),
+                }
+                for i in range(8)
+            ]
+            compress_context(
+                agent, messages, "sys", approx_tokens=100_000, force=True
+            )
+
+            row = db.get_session(session_id) or {}
+            persisted = row.get("system_prompt") or ""
+            persisted_fp = row.get("system_prompt_fingerprint")
+            current_fp = compute_current_context_fingerprint(agent)
+            assert current_fp
+            stale_kept = STALE_SOUL in persisted
+            rebuilt = CURRENT_SOUL in persisted and STALE_SOUL not in persisted
+            assert stale_kept or rebuilt, (
+                "keep-prompt after SOUL drift must keep old bytes or rebuild "
+                f"from current inputs; got {persisted!r}"
+            )
+            if stale_kept:
+                assert persisted_fp is None, (
+                    "kept stale prompt bytes must not be paired with a current "
+                    f"digest (got {persisted_fp!r})"
+                )
+            else:
+                assert persisted_fp == current_fp
+            assert not (
+                STALE_SOUL in persisted and persisted_fp == current_fp
+            ), "never persist (old prompt, new digest)"
+        finally:
+            db.close()
+            reset_hermes_home_override(token)

--- a/tests/agent/test_durable_prompt_context_fingerprint.py
+++ b/tests/agent/test_durable_prompt_context_fingerprint.py
@@ -1,0 +1,338 @@
+"""Managed-context fingerprint for durable-session prompt restore (#68563).
+
+Gateway / OpenAI-compatible API sessions persist ``system_prompt`` and reuse
+it on the next agent start. After HTTP 409 ``session_exists``, a client
+continues that durable row instead of creating a new session. Restore must
+not resurrect a stale SOUL / managed-context snapshot just because Model
+and Provider still match.
+
+Dual-store boundary (#1081, cross-repo): this engine patch rebuilds the
+prompt pair on SOUL/managed-context drift and keeps conversation history
+on the same session id (the #68563 contract). The BFF/UI thread is a
+separate store. ``sessions.system_prompt_fingerprint`` is the observable
+version a BFF can watch to mint a new thread; clearing BFF history is
+not done here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent.conversation_loop import (
+    _restore_or_build_system_prompt,
+    build_prompt_with_fingerprint,
+    compute_current_context_fingerprint,
+)
+from agent.prompt_builder import compute_context_fingerprint, load_soul_md
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_state import SessionDB
+
+
+STALE_SOUL = "STALE SOUL TOKEN unique-old-soul-abc"
+CURRENT_SOUL = "CURRENT SOUL TOKEN unique-new-soul-xyz"
+HISTORY = [{"role": "user", "content": "hello from the durable API session"}]
+
+
+def _agent(session_db, session_id: str, *, home):
+    agent = MagicMock()
+    agent._cached_system_prompt = None
+    agent.session_id = session_id
+    agent.model = "test-model"
+    agent.provider = "openrouter"
+    agent.platform = "api"
+    agent._session_db = session_db
+    agent._use_prompt_caching = False
+    # SOUL-only fingerprint so the worktree's AGENTS.md cannot shadow the test.
+    agent.skip_context_files = True
+    agent.load_soul_identity = True
+    agent._bot_mode_protocol = False
+
+    def _build(_system_message=None):
+        soul = load_soul_md(home_override=home) or ""
+        return (
+            "You are Hermes Agent.\n"
+            f"{soul}\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+
+    agent._build_system_prompt = _build
+    return agent
+
+
+def _open_home(tmp_path, soul: str):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "SOUL.md").write_text(soul + "\n", encoding="utf-8")
+    token = set_hermes_home_override(home)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    return home, token, db
+
+
+class TestApi409StaleSoulResurrection:
+    def test_409_continuation_rebuilds_stale_soul_before_reuse(
+        self, tmp_path
+    ):
+        """Existing durable API session + 409 session_exists must not resurrect
+        a stale SOUL snapshot on the next agent start.
+
+        Reproduction of the 409 continuation class:
+
+        1. A durable API session row already exists with conversation history
+           and a stored system prompt assembled from an older SOUL.md.
+        2. The client POSTs the same session id, receives HTTP 409
+           ``session_exists``, and continues that row rather than minting a
+           new session.
+        3. The next AIAgent start restores via ``_restore_or_build_system_prompt``.
+
+        The helper (not the HTTP handler) is the restore seam. It must rebuild
+        from the current SOUL and atomically replace the stored prompt (and
+        its managed-context fingerprint, once persisted) before any reuse.
+
+        Engine history stays on the same session id. The new fingerprint is
+        the version contract a BFF can observe (#1081); this test does not
+        delete transcript rows or call website code.
+        """
+        home, token, db = _open_home(tmp_path, CURRENT_SOUL)
+        try:
+            session_id = "api-durable-409-session"
+            stale_prompt = (
+                "You are Hermes Agent.\n"
+                f"{STALE_SOUL}\n"
+                "Model: test-model\n"
+                "Provider: openrouter"
+            )
+            db.create_session(
+                session_id,
+                source="api",
+                model="test-model",
+                system_prompt=stale_prompt,
+            )
+            db.append_message(
+                session_id, "user", "hello from the durable API session"
+            )
+            conn = db._conn
+            assert conn is not None
+            conn.execute(
+                "UPDATE sessions SET system_prompt_fingerprint = ? "
+                "WHERE id = ?",
+                ("stale-managed-context-fingerprint", session_id),
+            )
+            conn.commit()
+
+            agent = _agent(db, session_id, home=home)
+            _restore_or_build_system_prompt(agent, None, HISTORY)
+
+            cached = agent._cached_system_prompt or ""
+            assert CURRENT_SOUL in cached
+            assert STALE_SOUL not in cached
+
+            row = db.get_session(session_id) or {}
+            persisted = row.get("system_prompt") or ""
+            assert CURRENT_SOUL in persisted
+            assert STALE_SOUL not in persisted
+            expected_fp = compute_current_context_fingerprint(agent)
+            assert row.get("system_prompt_fingerprint") == expected_fp
+            assert expected_fp != "stale-managed-context-fingerprint"
+            # Same UPDATE wrote hash + fingerprint; raw blob is content-addressed.
+            raw = conn.execute(
+                "SELECT system_prompt, system_prompt_hash, "
+                "system_prompt_fingerprint FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            assert raw["system_prompt"] is None
+            assert raw["system_prompt_hash"]
+            assert raw["system_prompt_fingerprint"] == expected_fp
+            messages = db.get_messages(session_id)
+            assert any(
+                (m.get("content") or "") == "hello from the durable API session"
+                for m in messages
+            )
+        finally:
+            db.close()
+            reset_hermes_home_override(token)
+
+
+class TestHermesHomeFingerprintLifecycle:
+    def test_persist_reuse_soul_edit_rebuild_then_reuse(self, tmp_path):
+        """Real temp HERMES_HOME: persist → byte-stable reuse → SOUL edit
+        rebuilds a new pair → subsequent turn reuses the new pair."""
+        home, token, db = _open_home(tmp_path, CURRENT_SOUL)
+        try:
+            session_id = "e2e-soul-lifecycle"
+            db.create_session(session_id, source="api", model="test-model")
+            agent = _agent(db, session_id, home=home)
+
+            _restore_or_build_system_prompt(agent, None, [])
+            first = agent._cached_system_prompt
+            assert CURRENT_SOUL in first
+            first_fp = (db.get_session(session_id) or {}).get(
+                "system_prompt_fingerprint"
+            )
+            assert first_fp
+
+            agent2 = _agent(db, session_id, home=home)
+            _restore_or_build_system_prompt(agent2, None, HISTORY)
+            assert agent2._cached_system_prompt == first
+            assert agent2._cached_system_prompt.encode("utf-8") == first.encode("utf-8")
+            assert (db.get_session(session_id) or {}).get(
+                "system_prompt_fingerprint"
+            ) == first_fp
+
+            (home / "SOUL.md").write_text("EDITED SOUL TOKEN unique-edit-soul\n")
+            agent3 = _agent(db, session_id, home=home)
+            _restore_or_build_system_prompt(agent3, None, HISTORY)
+            rebuilt = agent3._cached_system_prompt or ""
+            assert "unique-edit-soul" in rebuilt
+            assert CURRENT_SOUL not in rebuilt
+            rebuilt_fp = (db.get_session(session_id) or {}).get(
+                "system_prompt_fingerprint"
+            )
+            assert rebuilt_fp
+            assert rebuilt_fp != first_fp
+
+            agent4 = _agent(db, session_id, home=home)
+            _restore_or_build_system_prompt(agent4, None, HISTORY)
+            assert agent4._cached_system_prompt == rebuilt
+            assert (db.get_session(session_id) or {}).get(
+                "system_prompt_fingerprint"
+            ) == rebuilt_fp
+        finally:
+            db.close()
+            reset_hermes_home_override(token)
+
+    def test_legacy_null_fingerprint_self_heals_once(self, tmp_path):
+        home, token, db = _open_home(tmp_path, CURRENT_SOUL)
+        try:
+            session_id = "legacy-null-fp"
+            prompt = (
+                "You are Hermes Agent.\n"
+                f"{CURRENT_SOUL}\n"
+                "Model: test-model\n"
+                "Provider: openrouter"
+            )
+            db.create_session(
+                session_id, source="api", model="test-model", system_prompt=prompt
+            )
+            conn = db._conn
+            assert conn is not None
+            conn.execute(
+                "UPDATE sessions SET system_prompt_fingerprint = NULL WHERE id = ?",
+                (session_id,),
+            )
+            conn.commit()
+            agent = _agent(db, session_id, home=home)
+            _restore_or_build_system_prompt(agent, None, HISTORY)
+            row = db.get_session(session_id) or {}
+            assert row.get("system_prompt_fingerprint")
+            assert CURRENT_SOUL in (row.get("system_prompt") or "")
+        finally:
+            db.close()
+            reset_hermes_home_override(token)
+
+
+class TestFingerprintFailOpenAndToctou:
+    def test_fingerprint_compute_failure_fails_open_to_runtime_reuse(self):
+        stored = (
+            "You are Hermes Agent.\n"
+            "Model: test-model\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {
+            "system_prompt": stored,
+            "system_prompt_fingerprint": "anything",
+        }
+        agent = MagicMock()
+        agent._cached_system_prompt = None
+        agent.session_id = "fail-open"
+        agent.model = "test-model"
+        agent.provider = "openrouter"
+        agent.platform = "api"
+        agent._session_db = db
+        agent._use_prompt_caching = False
+        agent.skip_context_files = True
+        agent.load_soul_identity = False
+        agent._bot_mode_protocol = False
+        agent._build_system_prompt = MagicMock(return_value="SHOULD_NOT_BUILD")
+
+        with patch(
+            "agent.conversation_loop.compute_current_context_fingerprint",
+            return_value=None,
+        ):
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        db.update_system_prompt.assert_not_called()
+
+    def test_toctou_disagreement_persists_null_fingerprint(self):
+        agent = MagicMock()
+        agent._build_system_prompt = MagicMock(return_value="built")
+        with patch(
+            "agent.conversation_loop.compute_current_context_fingerprint",
+            side_effect=["pre-fp", "post-fp"],
+        ):
+            prompt, fingerprint = build_prompt_with_fingerprint(agent, None)
+        assert prompt == "built"
+        assert fingerprint is None
+
+
+class TestContextFingerprintSemantics:
+    def test_soul_edit_changes_digest(self, tmp_path):
+        home = tmp_path / "h"
+        home.mkdir()
+        (home / "SOUL.md").write_text("alpha\n")
+        token = set_hermes_home_override(home)
+        try:
+            first = compute_context_fingerprint(
+                include_soul=True,
+                include_project_context=False,
+                home_override=home,
+            )
+            (home / "SOUL.md").write_text("beta\n")
+            second = compute_context_fingerprint(
+                include_soul=True,
+                include_project_context=False,
+                home_override=home,
+            )
+            assert first != second
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_shadowed_project_file_edit_does_not_change_digest(self, tmp_path):
+        cwd = tmp_path / "proj"
+        cwd.mkdir()
+        (cwd / ".hermes.md").write_text("winner\n")
+        (cwd / "AGENTS.md").write_text("shadowed-v1\n")
+        first = compute_context_fingerprint(
+            cwd=str(cwd),
+            include_soul=False,
+            include_project_context=True,
+        )
+        (cwd / "AGENTS.md").write_text("shadowed-v2\n")
+        second = compute_context_fingerprint(
+            cwd=str(cwd),
+            include_soul=False,
+            include_project_context=True,
+        )
+        assert first == second
+
+    def test_adding_shadowed_candidate_changes_digest(self, tmp_path):
+        cwd = tmp_path / "proj"
+        cwd.mkdir()
+        (cwd / ".hermes.md").write_text("winner\n")
+        first = compute_context_fingerprint(
+            cwd=str(cwd),
+            include_soul=False,
+            include_project_context=True,
+        )
+        (cwd / "AGENTS.md").write_text("now exists\n")
+        second = compute_context_fingerprint(
+            cwd=str(cwd),
+            include_soul=False,
+            include_project_context=True,
+        )
+        assert first != second

--- a/tests/agent/test_durable_prompt_context_fingerprint.py
+++ b/tests/agent/test_durable_prompt_context_fingerprint.py
@@ -445,3 +445,108 @@ class TestKeepPromptCompressionFingerprintPairing:
         finally:
             db.close()
             reset_hermes_home_override(token)
+
+    def test_keep_prompt_does_not_pair_stale_cache_with_current_digest_when_durable_already_rebuilt(
+        self, tmp_path
+    ):
+        """Another writer already persisted (current prompt, current digest).
+
+        A stale long-lived agent still holding old SOUL bytes in cache must
+        not overwrite that pair with (stale cache, current digest) just
+        because stored_fp already equals the current digest.
+        """
+        from agent.conversation_compression import compress_context
+        from run_agent import AIAgent
+
+        _home, token, db = _open_home(tmp_path, CURRENT_SOUL)
+        try:
+            session_id = "keep-prompt-multi-writer-stale-cache"
+            stale_prompt = (
+                "You are Hermes Agent.\n"
+                f"{STALE_SOUL}\n"
+                "Model: test/model\n"
+                "Provider: openrouter"
+            )
+            current_prompt = (
+                "You are Hermes Agent.\n"
+                f"{CURRENT_SOUL}\n"
+                "Model: test/model\n"
+                "Provider: openrouter"
+            )
+            db.create_session(
+                session_id,
+                source="api",
+                model="test/model",
+                system_prompt=current_prompt,
+            )
+
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id=session_id,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    load_soul_identity=True,
+                )
+            current_fp = compute_current_context_fingerprint(agent)
+            assert current_fp
+            conn = db._conn
+            assert conn is not None
+            conn.execute(
+                "UPDATE sessions SET system_prompt_fingerprint = ? WHERE id = ?",
+                (current_fp, session_id),
+            )
+            conn.commit()
+            stored = db.get_session(session_id) or {}
+            assert CURRENT_SOUL in (stored.get("system_prompt") or "")
+            assert stored.get("system_prompt_fingerprint") == current_fp
+
+            agent.compression_in_place = True
+            agent._compression_feasibility_checked = True
+            agent._use_prompt_caching = False
+            agent._cached_system_prompt = stale_prompt
+            agent._memory_manager = None
+
+            def _fake_compress(
+                messages, current_tokens=None, focus_topic=None, force=False
+            ):
+                return [
+                    {
+                        "role": "user",
+                        "content": "[CONTEXT COMPACTION] summary of prior turns",
+                    },
+                    {"role": "assistant", "content": "recent reply"},
+                ]
+
+            agent.context_compressor.compress = _fake_compress
+            agent.context_compressor._last_compress_aborted = False
+            agent.context_compressor._last_summary_error = None
+            agent.context_compressor.compression_count = 1
+
+            messages = [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"message {i} " + ("word " * 20),
+                }
+                for i in range(8)
+            ]
+            compress_context(
+                agent, messages, "sys", approx_tokens=100_000, force=True
+            )
+
+            row = db.get_session(session_id) or {}
+            persisted = row.get("system_prompt") or ""
+            persisted_fp = row.get("system_prompt_fingerprint")
+            assert current_fp == compute_current_context_fingerprint(agent)
+            assert not (
+                STALE_SOUL in persisted and persisted_fp == current_fp
+            ), (
+                "kept stale prompt bytes must not be paired with a current digest"
+            )
+        finally:
+            db.close()
+            reset_hermes_home_override(token)

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -21,6 +21,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.prompt_builder import compute_context_fingerprint
+
+# Agents in this file skip cwd context files; the resulting fingerprint is
+# constant and lets reuse tests supply a matching stored digest without
+# hashing the live HERMES_HOME SOUL.md.
+_SKIPPED_CONTEXT_FP = compute_context_fingerprint(
+    include_soul=False, include_project_context=False
+)
 
 
 def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
@@ -36,8 +44,18 @@ def _make_agent(session_db=None, prebuilt_prompt: str = "BUILT_PROMPT"):
     # reconstruction is gated on _use_prompt_caching, so default it off
     # for the legacy restore tests (the reconstruction tests enable it).
     agent._use_prompt_caching = False
+    agent.skip_context_files = True
+    agent.load_soul_identity = False
+    agent._bot_mode_protocol = False
     agent._build_system_prompt = MagicMock(return_value=prebuilt_prompt)
     return agent
+
+
+def _row(system_prompt, fingerprint=_SKIPPED_CONTEXT_FP):
+    return {
+        "system_prompt": system_prompt,
+        "system_prompt_fingerprint": fingerprint,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +68,7 @@ class TestStoredPromptReuse:
         """Continuing session with a stored prompt → reuse byte-for-byte."""
         stored = "Stored prompt from turn 1 — byte-identical reuse"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
 
         with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
@@ -66,7 +84,7 @@ class TestStoredPromptReuse:
         """Non-ASCII bytes in the stored prompt are not mangled."""
         stored = "Stored prompt with unicode: ☤ ⚗ ◆ — and emoji 🦊"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
 
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
@@ -88,7 +106,7 @@ class TestStoredPromptReuse:
             "Provider: openrouter"
         )
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(
             session_db=db,
             prebuilt_prompt=(
@@ -109,7 +127,9 @@ class TestStoredPromptReuse:
         )
         agent._build_system_prompt.assert_called_once_with(None)
         db.update_system_prompt.assert_called_once_with(
-            agent.session_id, agent._cached_system_prompt
+            agent.session_id,
+            agent._cached_system_prompt,
+            fingerprint=_SKIPPED_CONTEXT_FP,
         )
         assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
 
@@ -133,7 +153,9 @@ class TestLegitimateFreshBuild:
         agent._build_system_prompt.assert_called_once_with(None)
         assert agent._cached_system_prompt == "BUILT_PROMPT"
         # Persisted to DB
-        db.update_system_prompt.assert_called_once_with(agent.session_id, "BUILT_PROMPT")
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, "BUILT_PROMPT", fingerprint=_SKIPPED_CONTEXT_FP
+        )
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
     def test_no_db_skips_persistence(self):
@@ -210,7 +232,7 @@ class TestPromptStabilityInvariant:
             "Session ID: 20260517_153500_abc123\n"
         )
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
 
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
@@ -241,7 +263,7 @@ class TestStaticPrefixReconstructionOnRestore:
         stable = "STATIC IDENTITY AND GUIDANCE"
         stored = stable + "\n\nper-session context\n\nvolatile tail"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
         agent._use_prompt_caching = True
         agent._cached_system_prompt_static = None
@@ -265,7 +287,7 @@ class TestStaticPrefixReconstructionOnRestore:
         legacy layout, restored bytes still authoritative."""
         stored = "OLD STATIC HEAD\n\nper-session context"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
         agent._use_prompt_caching = True
         agent._cached_system_prompt_static = None
@@ -288,7 +310,7 @@ class TestStaticPrefixReconstructionOnRestore:
         break the byte-identical restore."""
         stored = "Stored prompt — must survive"
         db = MagicMock()
-        db.get_session.return_value = {"system_prompt": stored}
+        db.get_session.return_value = _row(stored)
         agent = _make_agent(session_db=db)
         agent._use_prompt_caching = True
         agent._cached_system_prompt_static = None

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5350,3 +5350,42 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+class TestSystemPromptFingerprintPair:
+    """Prompt snapshot and managed-context fingerprint are one UPDATE (#68563)."""
+
+    def test_update_system_prompt_pairs_fingerprint_atomically(self, db):
+        db.create_session("s-fp", source="api", model="m")
+        db.update_system_prompt("s-fp", "assembled prompt", fingerprint="fp-v1")
+        row = db.get_session("s-fp")
+        assert row["system_prompt"] == "assembled prompt"
+        assert row["system_prompt_fingerprint"] == "fp-v1"
+        raw = db._conn.execute(
+            "SELECT system_prompt, system_prompt_hash, "
+            "system_prompt_fingerprint FROM sessions WHERE id = ?",
+            ("s-fp",),
+        ).fetchone()
+        assert raw["system_prompt"] is None
+        assert raw["system_prompt_hash"]
+        assert raw["system_prompt_fingerprint"] == "fp-v1"
+
+        db.update_system_prompt("s-fp", None)
+        cleared = db.get_session("s-fp")
+        assert cleared["system_prompt"] is None
+        assert cleared["system_prompt_fingerprint"] is None
+
+    def test_schema_declares_fingerprint_column(self, db):
+        cols = {
+            row[1]
+            for row in db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert "system_prompt_fingerprint" in cols
+
+    def test_clearing_prompt_also_clears_fingerprint(self, db):
+        db.create_session("s-fp2", source="api", model="m")
+        db.update_system_prompt("s-fp2", "p", fingerprint="fp")
+        db.update_session_model("s-fp2", "other")
+        row = db.get_session("s-fp2")
+        assert row["system_prompt"] is None
+        assert row["system_prompt_fingerprint"] is None

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9451,7 +9451,7 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
         def update_session_meta(self, _session_id, model_config_json, _model=None):
             self.model_config = model_config_json
 
-        def update_system_prompt(self, _session_id, system_prompt):
+        def update_system_prompt(self, _session_id, system_prompt, fingerprint=None):
             self.system_prompt = system_prompt
 
         def append_message(self, session_id, role, content=None, **_kwargs):
@@ -20830,7 +20830,7 @@ def test_persist_live_session_system_prompt_uses_profile_home(monkeypatch, tmp_p
             return f"System prompt from {home}\n{soul}"
 
     class FakeDB:
-        def update_system_prompt(self, session_id, prompt):
+        def update_system_prompt(self, session_id, prompt, fingerprint=None):
             pass
 
     agent = FakeAgent()
@@ -20868,7 +20868,7 @@ def test_persist_live_session_system_prompt_no_profile_is_unchanged(monkeypatch)
             return "plain prompt"
 
     class FakeDB:
-        def update_system_prompt(self, session_id, prompt):
+        def update_system_prompt(self, session_id, prompt, fingerprint=None):
             pass
 
     agent = FakeAgent()
@@ -20913,7 +20913,7 @@ def test_persist_live_session_system_prompt_restores_pre_existing_override(tmp_p
             return "inner prompt"
 
     class FakeDB:
-        def update_system_prompt(self, session_id, prompt):
+        def update_system_prompt(self, session_id, prompt, fingerprint=None):
             pass
 
     agent = FakeAgent()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -37,7 +37,10 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.compaction_display import project_compaction_message_for_display
 from agent.skill_commands import describe_skill_invocation
-from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from agent.conversation_loop import (
+    INTERRUPT_WAITING_FOR_MODEL_PREFIX,
+    build_prompt_with_fingerprint,
+)
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
     clear_turn_marker,
@@ -4927,9 +4930,13 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
         set_hermes_home_override(profile_home) if profile_home else None
     )
     try:
-        prompt = agent._build_system_prompt(None)
+        prompt, fingerprint = build_prompt_with_fingerprint(agent, None)
         agent._cached_system_prompt = prompt
-        db.update_system_prompt(getattr(agent, "session_id", None) or session_key, prompt)
+        db.update_system_prompt(
+            getattr(agent, "session_id", None) or session_key,
+            prompt,
+            fingerprint=fingerprint,
+        )
     except Exception:
         logger.warning(
             "failed to persist live session system prompt for session %s",


### PR DESCRIPTION
## Summary

- fingerprint the managed system-prompt inputs (SOUL plus project context)
- reuse a durable prompt byte-for-byte only when runtime identity and the managed-context fingerprint both match
- rebuild once on SOUL/context drift or a legacy NULL fingerprint, then atomically pair the prompt hash and fingerprint
- guard build-time TOCTOU by persisting a fingerprint only when pre/post input digests agree
- preserve runtime-only restore behavior when fingerprint computation itself fails

## Incident contract

An existing API session can return HTTP 409 on create and continue the durable row. Before this change, that row could restore a pre-fix SOUL indefinitely. The regression suite exercises that continuation shape with existing history and a stale prompt/fingerprint pair.

The Hermes engine patch intentionally does not clear host-owned browser transcript history. `sessions.system_prompt_fingerprint` provides the durable version signal a BFF can observe; atomic host transcript reset/new-thread lifecycle remains a separate host integration boundary.

## Verification

Canonical focused runs on final commit `7c7e56bd9600e30093ef990a420759133325bd82`:

- `scripts/run_tests.sh tests/agent/test_durable_prompt_context_fingerprint.py tests/agent/test_system_prompt_restore.py tests/test_session_system_prompt_dedup.py tests/agent/test_plugin_prompt_sections.py -q` — 33 passed
- `scripts/run_tests.sh tests/test_hermes_state.py tests/test_tui_gateway_server.py -q -k 'TestSystemPromptFingerprintPair or persist_live_session_system_prompt or switch_model'` — 7 passed
- `git diff origin/main...HEAD --check` — clean
- added-line security scan — no hardcoded-secret, shell-injection, eval/exec, pickle, or formatted-SQL findings

Full touched-file runs expose two unrelated failures that reproduce unchanged on current `origin/main`:

- `TestFTS5Search.test_search_projection_skips_context_enrichment_queries`
- `test_model_options_preserves_canonical_custom_row_after_agent_init`

## Review focus

Please check the restore decision, schema migration, atomic prompt/fingerprint pairing, compression/model-switch persistence, failure-open semantics, and TOCTOU behavior.

Related upstream issue: #68563
