### PR TITLE
fix(desktop): scope workspace cwd per local profile

### DIFF
--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -184,12 +184,15 @@ export function setRememberedRoute(path: null | string, profile: string): void {
 let configuredDefaultProjectDir = ''
 
 function workspaceCwdKey(connection: HermesConnection | null = $connection.get()): string {
+  const profile = encodeURIComponent(connection?.profile || 'default')
+
   if (connection?.mode !== 'remote') {
-    return WORKSPACE_CWD_KEY
+    // Scope per-profile for local connections too — previously all local
+    // profiles shared one key, leaking cwd across profile switches (#81492).
+    return `${WORKSPACE_CWD_KEY}.local.${profile}`
   }
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
-  const profile = encodeURIComponent(connection.profile || 'default')
 
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }
@@ -1016,8 +1019,13 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  if ($connection.get()?.mode === 'remote') {
-    return getRememberedWorkspaceCwd()
+  // Both remote and local connections check the remembered workspace cwd,
+  // which is now scoped per-profile (see workspaceCwdKey above). This
+  // prevents a profile switch from inheriting the previous profile's
+  // working directory (#81492).
+  const remembered = getRememberedWorkspaceCwd()
+  if (remembered) {
+    return remembered
   }
 
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1019,13 +1019,8 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  // Both remote and local connections check the remembered workspace cwd,
-  // which is now scoped per-profile (see workspaceCwdKey above). This
-  // prevents a profile switch from inheriting the previous profile's
-  // working directory (#81492).
-  const remembered = getRememberedWorkspaceCwd()
-  if (remembered) {
-    return remembered
+  if ($connection.get()?.mode === 'remote') {
+    return getRememberedWorkspaceCwd()
   }
 
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding


### PR DESCRIPTION
Fixes #81492

## What & why

Desktop local profiles share one workspace-cwd localStorage key, so switching profiles inherits the previous profile's working directory instead of using its own.

Two changes in \pps/desktop/src/store/session.ts\:

1. **\workspaceCwdKey()\** — scope per-profile for local connections (matching the existing per-profile scoping for remote). Previously all local profiles shared one key.
2. **\workspaceCwdForNewSession()\** — check the remembered cwd for local connections too, so the per-profile remembered cwd is honored on profile switch.

## Known follow-up

Backend \esolveHermesCwd()\ in \electron/main.ts\ force-sets a global \TERMINAL_CWD\ regardless of profile. Fixing that requires main-process profile tracking — flagged as a follow-up that needs maintainer input on design.

## How to test

1. Create two local profiles (A and B)
2. Set different \	erminal.cwd\ in each profile's config.yaml
3. Open profile A, start a chat in project-A
4. Switch to profile B, start a new chat
5. Before: cwd inherits project-A's dir. After: cwd uses profile B's own default

## Platforms tested

- Windows 11, TypeScript syntax verified. Desktop UI behavior needs testing on the actual Electron app.