### PR TITLE
fix(gateway): drop dangling colon in _split_host_port hostname

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -357,6 +357,11 @@ def _split_host_port(value: str) -> tuple[str, int | None]:
         host, _, maybe_port = raw.rpartition(":")
         if maybe_port.isdigit():
             return host.lower().rstrip("."), int(maybe_port)
+        if host:
+            # "host:" with an empty port segment: the dangling separator
+            # previously flowed into the hostname ("example.com:") and
+            # produced malformed URLs / ssh targets downstream.
+            return host.lower().rstrip("."), None
     return raw.lower().strip("[]").rstrip("."), None
 
 


### PR DESCRIPTION
## Problem

`_split_host_port("example.com:")` — an endpoint configured with an empty port segment — fell through the `count(":") == 1` branch (empty string isn't `.isdigit()`) into the no-port fall-through, which returns the **raw** input. The trailing colon stayed inside the hostname: `_split_host_port` returned `"example.com:"`, and every downstream consumer that builds URLs (`http://example.com:/...`) or passes the value to ssh/HTTP produced malformed targets with confusing connection errors.

## Fix

When the port segment is empty but a host part exists, return the host with the dangling separator removed (`host.lower().rstrip(".")`). All other shapes unchanged (verified): `host:8080`, `[::1]:443`, bare IPv6, plain hostnames.

## Verification

Behavioral table over six input shapes — all pass, including the two previously broken `host:` forms.