### PR TITLE
fix(computer_use): 'screenshot my screen' no longer returns just the wallpaper (salvage #60081)

### DIFF
--- a/contributors/emails/joshuadavidfairbank@gmail.com
+++ b/contributors/emails/joshuadavidfairbank@gmail.com
@@ -1,0 +1,1 @@
+2ndNatureAI

--- a/tests/tools/test_computer_use_fullscreen_capture.py
+++ b/tests/tools/test_computer_use_fullscreen_capture.py
@@ -1,0 +1,240 @@
+"""Full-screen vs desktop-shell capture routing (#60081, wallpaper-only bug).
+
+`capture(app='screen')` previously resolved to the OS shell/desktop window
+(Progman/WorkerW on Windows) via list_windows — the wallpaper + icons layer —
+so "screenshot my screen" always showed a bare desktop no matter what was
+actually displayed. cua-driver's `get_desktop_state` does a real composited
+full-screen grab; the `screen`/`fullscreen`/`all` sentinels now route there,
+while `desktop` keeps the shell-window lane (with clickable elements).
+
+Salvaged from @2ndNatureAI's PR #60081 (enumeration-hang bypass) and extended
+with the sentinel split + no-elements guidance note.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+# 8×8 transparent PNG — decodes cleanly for dimension sniffing.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+    "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeSession:
+    """Records tool calls; serves get_config / set_config / get_desktop_state
+    and (for the desktop-shell path) list_windows / screenshot."""
+
+    def __init__(
+        self,
+        windows: Optional[List[Dict[str, Any]]] = None,
+        desktop_image: Optional[str] = _PNG_B64,
+        capture_scope: str = "window",
+    ):
+        self.calls: List[tuple] = []
+        self._windows = windows or []
+        self._desktop_image = desktop_image
+        self._scope = capture_scope
+        self.capabilities_discovered = True
+
+    def _has_tool(self, name: str) -> bool:
+        return name in {"get_desktop_state", "screenshot", "list_windows"}
+
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
+        self.calls.append((name, dict(args or {})))
+        if name == "get_config":
+            return {
+                "data": "",
+                "images": [],
+                "structuredContent": {"capture_scope": self._scope},
+                "isError": False,
+            }
+        if name == "set_config":
+            self._scope = args["value"]
+            return {"data": "ok", "images": [], "structuredContent": None,
+                    "isError": False}
+        if name == "get_desktop_state":
+            images = [self._desktop_image] if self._desktop_image else []
+            return {
+                "data": "desktop state",
+                "images": images,
+                "image_mime_types": ["image/png"] if images else [],
+                "structuredContent": {"screen_width": 8, "screen_height": 8},
+                "isError": False,
+            }
+        if name == "list_windows":
+            return {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": self._windows},
+                "isError": False,
+            }
+        if name == "screenshot":
+            return {
+                "data": "",
+                "images": [_PNG_B64],
+                "image_mime_types": ["image/png"],
+                "structuredContent": None,
+                "isError": False,
+            }
+        raise AssertionError(f"unexpected tool call: {name}")
+
+    def called(self, name: str) -> List[Dict[str, Any]]:
+        return [a for (n, a) in self.calls if n == name]
+
+
+def _make_backend(session: _FakeSession):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend._session_id = "test-session"
+    return backend
+
+
+class TestFullScreenLane:
+    @pytest.mark.parametrize("sentinel", ["screen", "Screen", "fullscreen",
+                                          "full screen", "all"])
+    def test_screen_sentinels_route_to_get_desktop_state(self, sentinel):
+        session = _FakeSession()
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="som", app=sentinel)
+
+        assert session.called("get_desktop_state"), (
+            f"app={sentinel!r} must use the composited desktop lane"
+        )
+        assert not session.called("list_windows"), (
+            "full-screen capture must not enumerate windows (enumeration "
+            "can hang on Windows — trycua/cua#2110)"
+        )
+        assert cap.png_b64 == _PNG_B64
+        assert cap.elements == []
+        assert cap.app == "screen"
+
+    def test_full_screen_result_carries_interactive_lane_note(self):
+        session = _FakeSession()
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="vision", app="screen")
+
+        assert "no interactable elements" in cap.note
+        assert "capture(app='desktop')" in cap.note
+        assert "capture(app='<AppName>')" in cap.note
+
+    def test_capture_scope_switched_and_restored(self):
+        session = _FakeSession(capture_scope="window")
+        backend = _make_backend(session)
+
+        backend.capture(mode="vision", app="screen")
+
+        set_calls = session.called("set_config")
+        assert {"key": "capture_scope", "value": "desktop",
+                "session": "test-session"} in set_calls
+        assert {"key": "capture_scope", "value": "window",
+                "session": "test-session"} in set_calls
+        assert session._scope == "window", "prior scope must be restored"
+
+    def test_scope_untouched_when_already_desktop(self):
+        session = _FakeSession(capture_scope="desktop")
+        backend = _make_backend(session)
+
+        backend.capture(mode="vision", app="screen")
+
+        assert not session.called("set_config")
+
+    def test_imageless_desktop_state_fails_closed_with_guidance(self):
+        session = _FakeSession(desktop_image=None)
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="vision", app="screen")
+
+        assert cap.png_b64 is None
+        assert "get_desktop_state returned no image" in cap.window_title
+
+    def test_dimensions_come_from_decoded_image(self):
+        session = _FakeSession()
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="vision", app="screen")
+
+        # The 8×8 PNG's real dimensions win over structuredContent.
+        assert (cap.width, cap.height) == (8, 8)
+        assert cap.png_bytes_len == len(base64.b64decode(_PNG_B64))
+
+    def test_exact_pid_window_target_bypasses_full_screen_lane(self):
+        session = _FakeSession()
+        backend = _make_backend(session)
+
+        backend.capture(mode="vision", app="screen", pid=123, window_id=456)
+
+        assert not session.called("get_desktop_state"), (
+            "an exact pid/window target must win over the app sentinel"
+        )
+
+
+class TestDesktopShellLane:
+    _PROGMAN = {
+        "app_name": "Progman",
+        "title": "Program Manager",
+        "pid": 100,
+        "window_id": 1,
+        "off_screen": False,
+        "z_index": 0,
+    }
+
+    def test_desktop_sentinel_keeps_shell_window_lane(self):
+        session = _FakeSession(windows=[self._PROGMAN])
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="vision", app="desktop")
+
+        assert session.called("list_windows"), (
+            "app='desktop' must still resolve the shell window so desktop "
+            "icons stay clickable"
+        )
+        assert not session.called("get_desktop_state")
+        assert backend._active_pid == 100
+        assert cap.note == ""
+
+    def test_desktop_sentinel_without_shell_window_fails_with_guidance(self):
+        session = _FakeSession(windows=[{
+            "app_name": "Notepad", "title": "Untitled", "pid": 7,
+            "window_id": 9, "off_screen": False, "z_index": 1,
+        }])
+        backend = _make_backend(session)
+
+        cap = backend.capture(mode="vision", app="desktop")
+
+        assert cap.png_b64 is None
+        assert "no desktop/shell window found" in cap.window_title
+
+
+class TestNoteInSummary:
+    def test_capture_response_appends_note_line(self, tmp_path, monkeypatch):
+        import hermes_constants
+        from tools.computer_use.backend import CaptureResult
+        from tools.computer_use import tool as cu_tool
+
+        monkeypatch.setattr(hermes_constants, "get_hermes_dir",
+                            lambda *a, **k: tmp_path)
+        monkeypatch.setattr(cu_tool, "_should_route_through_aux_vision",
+                            lambda: False)
+
+        cap = CaptureResult(
+            mode="vision", width=8, height=8, png_b64=_PNG_B64,
+            elements=[], app="screen",
+            window_title="Full screen (composited)",
+            png_bytes_len=len(base64.b64decode(_PNG_B64)),
+            note="full-screen capture has no interactable elements; "
+                 "call capture(app='desktop') for the desktop shell",
+        )
+        result = cu_tool._capture_response(cap)
+
+        text = str(result)
+        assert "full-screen capture has no interactable elements" in text

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -65,6 +65,10 @@ class CaptureResult:
     # When None, downstream consumers fall back to base64-prefix
     # sniffing for back-compat with older drivers.
     image_mime_type: Optional[str] = None
+    # Optional guidance appended to the human-readable summary — used by
+    # capture lanes that intentionally return no elements (e.g. full-screen
+    # composited grabs) to tell the model how to reach an interactive lane.
+    note: str = ""
 
 
 @dataclass

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -178,11 +178,19 @@ _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
 # pid + window_id), and there is no MCP tool that captures the entire virtual
 # desktop or an arbitrary monitor as one image. But the OS shell surfaces
 # themselves (the desktop backdrop and the taskbar/menu-bar) are real windows
-# that show up in `list_windows`, so "show me my screen" / "click the taskbar"
-# is reachable by targeting those windows. When `app` is one of these
-# sentinels, capture() resolves to the desktop/shell window instead of an
-# application window.
-_SCREEN_CAPTURE_SENTINELS = {"screen", "desktop", "fullscreen", "full screen", "all"}
+# that show up in `list_windows`, so "click the taskbar" is reachable by
+# targeting those windows.
+#
+# Two distinct whole-screen intents, two lanes:
+#   * app="screen" (or "fullscreen"/"full screen"/"all") → a real composited
+#     capture of everything currently displayed, via cua-driver's
+#     `get_desktop_state`. Pixels only — no element tree.
+#   * app="desktop" → the OS shell/desktop window (wallpaper + icons) resolved
+#     through list_windows, WITH interactable elements (desktop icons).
+_FULL_SCREEN_SENTINELS = {"screen", "fullscreen", "full screen", "all"}
+_DESKTOP_SHELL_SENTINELS = {"desktop"}
+# Backwards-compatible union — membership means "some whole-screen intent".
+_SCREEN_CAPTURE_SENTINELS = _FULL_SCREEN_SENTINELS | _DESKTOP_SHELL_SENTINELS
 
 # Known shell/desktop window identifiers across platforms. Matched
 # case-insensitively as a substring against both the window's app_name and
@@ -2921,6 +2929,103 @@ class CuaDriverBackend(ComputerUseBackend):
             and app_lower in str(w.get("title", "")).lower()
         ]
 
+    def _capture_full_screen(self, mode: str) -> CaptureResult:
+        """Capture the whole displayed screen via cua-driver's desktop lane.
+
+        Uses `get_desktop_state` — a composited grab of everything currently
+        on screen (like PrtScn) — instead of resolving a single window through
+        `list_windows`. This is what "screenshot my screen" means: previously
+        the `screen` sentinel resolved to the OS shell window (Progman /
+        WorkerW on Windows), which is the wallpaper + icons layer and never
+        shows the windows stacked above it.
+
+        Bonus resilience (2ndNatureAI, #60081): this lane works even when
+        Windows UIA enumeration (`list_windows` / `list_apps`) hangs
+        (trycua/cua#2110/#2113), because it never enumerates.
+
+        Returns pixels only — a composited image has no single accessibility
+        tree, so `elements` is always empty regardless of requested mode. The
+        result carries a `note` telling the model how to reach the
+        interactive lanes.
+        """
+        self._clear_active_target()
+        previous_scope: Optional[str] = None
+        try:
+            cfg = self._session.call_tool(
+                "get_config", {"session": self._session_id}, timeout=10.0,
+            )
+            sc = cfg.get("structuredContent") or {}
+            if isinstance(sc, dict):
+                val = sc.get("capture_scope")
+                if isinstance(val, str):
+                    previous_scope = val
+        except Exception as e:
+            logger.debug("cua-driver get_config before full-screen capture failed: %s", e)
+
+        try:
+            if previous_scope != "desktop":
+                self._session.call_tool(
+                    "set_config",
+                    {"key": "capture_scope", "value": "desktop",
+                     "session": self._session_id},
+                    timeout=10.0,
+                )
+            out = self._call_capture_tool(
+                "get_desktop_state", {"session": self._session_id},
+            )
+        finally:
+            if previous_scope and previous_scope != "desktop":
+                try:
+                    self._session.call_tool(
+                        "set_config",
+                        {"key": "capture_scope", "value": previous_scope,
+                         "session": self._session_id},
+                        timeout=10.0,
+                    )
+                except Exception as e:
+                    logger.debug("cua-driver restore capture_scope failed: %s", e)
+
+        png_b64, image_mime_type = _image_from_tool_result(out)
+        if not png_b64:
+            return self._failed_capture(
+                mode,
+                "<get_desktop_state returned no image; the driver may "
+                "predate the desktop capture lane — try "
+                "capture(app='<AppName>') for a specific window>",
+            )
+        structured = out.get("structuredContent") or {}
+        width = int(structured.get("screenshot_width")
+                    or structured.get("screen_width") or 0)
+        height = int(structured.get("screenshot_height")
+                     or structured.get("screen_height") or 0)
+        png_bytes_len = 0
+        try:
+            raw = base64.b64decode(png_b64, validate=False)
+            png_bytes_len = len(raw)
+            detected_width, detected_height = _image_dimensions_from_bytes(raw)
+            if detected_width and detected_height:
+                width = detected_width
+                height = detected_height
+        except Exception:
+            png_bytes_len = len(png_b64) * 3 // 4
+        return CaptureResult(
+            mode="vision",
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=[],
+            app="screen",
+            window_title="Full screen (composited)",
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+            note=(
+                "full-screen capture has no interactable elements; to act on "
+                "what you see, call capture(app='<AppName>') for that app's "
+                "clickable element list, or capture(app='desktop') for the "
+                "desktop shell (wallpaper icons / taskbar) with elements"
+            ),
+        )
+
     # ── Capture ────────────────────────────────────────────────────
     def capture(
         self,
@@ -2949,6 +3054,19 @@ class CuaDriverBackend(ComputerUseBackend):
             pid = None
         if _is_placeholder_id(window_id):
             window_id = None
+        # Step 0: explicit full-screen capture — a composited grab of
+        # everything displayed, via get_desktop_state. Bypasses window
+        # enumeration entirely (also keeps screenshots working when Windows
+        # UIA enumeration hangs — trycua/cua#2110/#2113, #60081).
+        # app='desktop' intentionally does NOT take this lane: it resolves to
+        # the shell/desktop window below so desktop icons stay clickable.
+        if (
+            pid is None
+            and window_id is None
+            and app
+            and app.strip().lower() in _FULL_SCREEN_SENTINELS
+        ):
+            return self._capture_full_screen(mode)
         # An exact pid/window pair is both the stable capture_after target and
         # the escape hatch when app/window discovery is unavailable on X11.
         if pid is not None or window_id is not None:
@@ -2987,13 +3105,12 @@ class CuaDriverBackend(ComputerUseBackend):
         # returned by list_windows is the localized name (e.g. "計算機"), so
         # `app="Calculator"` legitimately matches no windows on a non-English
         # system and the caller needs to retry with the localized name.
-        if pid is None and window_id is None and app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS:
-            # Whole-screen / desktop request. cua-driver has no virtual-desktop
-            # capture tool, so resolve to the OS shell/desktop window (the
-            # desktop backdrop or the taskbar/menu-bar), which list_windows
-            # does surface. This makes "show me my screen" and "click the
-            # taskbar" work; a single image still can't span multiple monitors
-            # — that's a driver limitation, not a wrapper one.
+        if pid is None and window_id is None and app and app.strip().lower() in _DESKTOP_SHELL_SENTINELS:
+            # Desktop-shell request (app='desktop'): resolve to the OS
+            # shell/desktop window (the desktop backdrop or the
+            # taskbar/menu-bar) via list_windows. Unlike the full-screen lane
+            # above, this carries the shell's interactable elements (desktop
+            # icons), so "click the taskbar" / "open the recycle bin" work.
             def _is_desktop_window(w: Dict[str, Any]) -> bool:
                 haystack = f"{w.get('app_name', '')} {w.get('title', '')}".lower()
                 return any(name in haystack for name in _DESKTOP_WINDOW_NAMES)

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -87,12 +87,12 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "Optional. Limit capture/action to a specific app "
                     "(by name, e.g. 'Safari', or bundle ID, "
                     "'com.apple.Safari'). If omitted, operates on the "
-                    "frontmost app's window. Pass app='screen' (or "
-                    "'desktop') to capture the OS desktop/shell surface — "
-                    "e.g. to see the wallpaper or click the taskbar. Note: "
-                    "capture is per-window; a single image cannot span "
-                    "multiple monitors, so on a multi-screen setup capture "
-                    "one window or display at a time."
+                    "frontmost app's window. Pass app='screen' to capture "
+                    "everything currently displayed (a composited "
+                    "full-screen grab; image only, no clickable elements). "
+                    "Pass app='desktop' to target the OS desktop/shell "
+                    "surface itself (wallpaper, desktop icons, taskbar) "
+                    "with its clickable elements."
                 ),
             },
             "pid": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1218,6 +1218,8 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         summary_lines.append(
             f"  (shareable screenshot saved to {screenshot_path})"
         )
+    if cap.note:
+        summary_lines.append(f"  ({cap.note})")
     if elements_file:
         summary_lines.append(
             f"  (full element tree with untruncated labels saved to "

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -301,6 +301,17 @@ you the saved file's path instead.
 Only the 20 most recent capture files are kept, and screenshots are never
 sent automatically — only when you ask for one.
 
+### Whole screen vs. desktop surface
+
+"Screenshot my screen" captures **everything currently displayed** — a
+composited grab of all visible windows, like pressing PrtScn. This image has
+no clickable elements, so to *act* on something in it the agent re-captures
+the specific app.
+
+Asking for the **desktop** instead targets the OS shell surface itself —
+wallpaper, desktop icons, taskbar — with its clickable elements, so requests
+like "open the Recycle Bin on my desktop" still work.
+
 ## Provider compatibility
 
 | Provider | Vision? | Works? | Notes |


### PR DESCRIPTION
## Summary

"Screenshot my screen" now captures everything actually displayed — instead of always returning the bare wallpaper.

Root cause: the `screen` sentinel resolved to the OS shell window (Progman/WorkerW on Windows) via `list_windows`, which is the wallpaper + desktop-icons layer beneath every real window. cua-driver's `get_desktop_state` does a real composited full-screen grab; we never routed to it.

Reported in Discord (support bundle c27b5485) and reproduced live on Teknium's desktop: 1000 windows open, screenshot shows wallpaper.

## Changes

- `tools/computer_use/cua_backend.py`: `screen`/`fullscreen`/`all` sentinels route to `get_desktop_state` directly, bypassing window enumeration (also keeps captures alive when Windows UIA enumeration hangs — trycua/cua#2110/#2113). `desktop` keeps the shell-window lane so desktop icons/taskbar stay clickable. Salvaged from #60081 by @2ndNatureAI (surgical reapply; their branch predates the capture-routing refactor).
- `tools/computer_use/backend.py` + `tool.py`: full-screen results carry a `note` surfaced in the tool summary — no clickable elements in a composited grab, call `capture(app='<AppName>')` or `capture(app='desktop')` to act.
- `tools/computer_use/schema.py`: `app` description now distinguishes `screen` (composited image) from `desktop` (shell surface with elements).
- `website/docs/user-guide/features/computer-use.md`: "Whole screen vs. desktop surface" section.
- `tests/tools/test_computer_use_fullscreen_capture.py`: 14 regressions — sentinel routing, scope switch/restore, imageless fail-closed, note propagation, desktop lane preserved, pid/window override.

## Validation

| | Before | After |
|---|---|---|
| `capture(app='screen')` | wallpaper + icons (shell window) | composited full-screen image |
| `capture(app='desktop')` | wallpaper + icons | unchanged (with clickable elements) |
| Windows UIA enumeration hung | capture hangs | full-screen capture still works |
| New tests without fix | — | 9/14 fail (sabotage-verified) |
| `tests/tools/test_computer_use*.py` | — | 159 passed |

## Infographic

![Screenshot My Screen — Fixed](https://v3b.fal.media/files/b/0aa7ba6d/349j2DzkVGeFqf1Wn9oJG_2M0Vxosa.png)
