### PR TITLE
fix(gateway): transient foreign-holder skip must not burn the FTS rebuild attempt

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3938,7 +3938,6 @@ class SessionStore:
         """
         if self._fts_rebuild_attempted:
             return False
-        self._fts_rebuild_attempted = True
         db = self._db
         if db is None or not hasattr(db, "rebuild_fts"):
             return False
@@ -3954,7 +3953,12 @@ class SessionStore:
                     "transcript writes remain available.",
                     foreign_holders,
                 )
+                # Transient condition (e.g. `sessions optimize-storage` ran
+                # concurrently): do NOT burn the once-per-lifetime attempt,
+                # or a long-running gateway whose startup raced one reader
+                # would never rebuild the index.
                 return False
+        self._fts_rebuild_attempted = True
         try:
             rebuilt = db.rebuild_fts()
         except Exception as exc:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1588,6 +1588,69 @@ class TestGatewaySessionDbRecovery:
         assert len(pending) <= store._MAX_PENDING_PER_SESSION
 
 
+class TestRebuildFtsOnceTransientSkip:
+    """_rebuild_fts_once: the once-per-lifetime guard must only burn on an
+    actually-executed attempt. A foreign-holder skip is transient (e.g.
+    `hermes sessions optimize-storage` raced startup) — if it consumed the
+    flag, a long-running gateway whose startup hit one reader would never
+    rebuild a stale index."""
+
+    def _store(self, db):
+        import threading
+
+        store = object.__new__(SessionStore)
+        store._db = db
+        store._lock = threading.RLock()
+        store._entries = {}
+        store._loaded = True
+        store._save = lambda: None
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        store._fts_rebuild_attempted = False
+        return store
+
+    def test_transient_foreign_holder_skip_allows_later_retry(self):
+        rebuild_calls = []
+
+        class FakeDb:
+            def _foreign_state_db_holders(self):
+                return self.holders
+
+            def rebuild_fts(self):
+                rebuild_calls.append(1)
+                return 1
+
+        db = FakeDb()
+        db.holders = ["pid-123 (other process)"]
+        store = self._store(db)
+
+        assert store._rebuild_fts_once() is False
+        assert store._fts_rebuild_attempted is False, (
+            "transient skip must not consume the attempt"
+        )
+        assert rebuild_calls == []
+
+        db.holders = []
+        assert store._rebuild_fts_once() is True
+        assert rebuild_calls == [1]
+        assert store._fts_rebuild_attempted is True
+
+    def test_second_call_after_success_is_noop(self):
+        class FakeDb:
+            def __init__(self):
+                self.holders = []
+
+            def rebuild_fts(self):
+                return 1
+
+        db = FakeDb()
+        store = self._store(db)
+
+        assert store._rebuild_fts_once() is True
+        assert store._rebuild_fts_once() is False
+
+
 class TestGatewayRoutingTable:
     """state.db gateway_routing table is the primary routing index (#9006 follow-up)."""
 


### PR DESCRIPTION
## Problem

`SessionStore._rebuild_fts_once()` set `_fts_rebuild_attempted = True` **before** the foreign-holder preflight. That preflight is a *transient* condition — any concurrent process holding `state.db`/WAL sidecars open (e.g. `hermes sessions optimize-storage`, a CLI export, a second dashboard) triggers it.

Consequence: a gateway whose startup raced exactly one such reader skipped the rebuild, consumed its once-per-store-lifetime attempt, and **never retried for the life of the process** (days). The FTS index stayed stale — search silently missed messages written before/during the corruption window.

## Fix

Move the flag assignment after the foreign-holder check, so only an actually-executed rebuild consumes the attempt. Deterministic-failure behavior (exception path) is unchanged to avoid retry storms against a genuinely corrupt table.

## Verification

New `TestRebuildFtsOnceTransientSkip` in `tests/gateway/test_session.py`:
- foreign-holder skip returns False **without** consuming the flag or calling `rebuild_fts`; a subsequent clean call performs the rebuild and sets the flag
- post-success calls remain no-ops

Full file: 67/67 pass.