### PR TITLE
feat(teams): outbound file sending via FileConsentCard (personal scope)

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -792,6 +792,8 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Outbound file sends awaiting user consent (token -> file details).
+        self._pending_file_sends: Dict[str, Dict[str, Any]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Defensive re-check: create_adapter() already ran the installer
@@ -855,6 +857,10 @@ class TeamsAdapter(BasePlatformAdapter):
                 ctx: ActivityContext[AdaptiveCardInvokeActivity],
             ) -> InvokeResponse[AdaptiveCardActionMessageResponse]:
                 return await self._on_card_action(ctx)
+
+            @self._app.on_file_consent
+            async def _handle_file_consent(ctx):
+                await self._on_file_consent(ctx)
 
             # initialize() calls register_route() on the bridge, which adds
             # POST /api/messages to aiohttp_app automatically
@@ -1470,6 +1476,15 @@ class TeamsAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
+        # Local files go through the Teams file-consent flow (personal scope):
+        # Teams rejects large/base64 data-URI document attachments with 400.
+        if not (file_path.startswith("http://") or file_path.startswith("https://")):
+            return await self._send_file_consent_card(
+                chat_id=chat_id,
+                file_path=file_path.removeprefix("file://"),
+                caption=caption,
+                file_name=file_name,
+            )
         return await self._send_media_attachment(
             chat_id=chat_id,
             source=file_path,
@@ -1477,6 +1492,168 @@ class TeamsAdapter(BasePlatformAdapter):
             caption=caption,
             media_label="document",
         )
+
+    async def _send_file_consent_card(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+    ) -> SendResult:
+        """Offer a file via FileConsentCard; upload happens on user accept.
+
+        Teams personal-scope bots cannot attach file bytes directly: the
+        bot offers the file, the user clicks Accept, Teams returns a
+        pre-authorised OneDrive upload URL, and _on_file_consent uploads
+        the bytes there. The file lands in the user's OneDrive
+        ("Microsoft Teams Chat Files").
+        """
+        import os as _os
+        import uuid as _uuid
+
+        if not self._app:
+            return SendResult(success=False, error="Teams app not initialized")
+        try:
+            size = _os.path.getsize(file_path)
+        except OSError as e:
+            return SendResult(success=False, error=f"Cannot read file: {e}")
+
+        filename = file_name or _os.path.basename(file_path)
+        token = _uuid.uuid4().hex
+        self._pending_file_sends[token] = {
+            "path": file_path,
+            "filename": filename,
+            "chat_id": chat_id,
+        }
+        # Cap pending map (drop oldest) so declined/ignored cards don't leak.
+        while len(self._pending_file_sends) > 50:
+            self._pending_file_sends.pop(next(iter(self._pending_file_sends)))
+
+        try:
+            from microsoft_teams.api import Attachment, MessageActivityInput
+
+            consent_content = {
+                "description": caption or f"Hermes wants to send you '{filename}'",
+                "sizeInBytes": size,
+                "acceptContext": {"hermes_file_token": token},
+                "declineContext": {"hermes_file_token": token},
+            }
+            attachment = Attachment(
+                content_type="application/vnd.microsoft.teams.card.file.consent",
+                name=filename,
+                content=consent_content,
+            )
+            activity = MessageActivityInput().add_attachments(attachment)
+            conv_ref = self._conv_refs.get(chat_id)
+            if conv_ref:
+                result = await self._app.activity_sender.send(activity, conv_ref)
+            else:
+                result = await self._app.send(chat_id, activity)
+            card_id = getattr(result, "id", None)
+            if token in self._pending_file_sends:
+                self._pending_file_sends[token]["card_activity_id"] = card_id
+            return SendResult(success=True, message_id=card_id)
+        except Exception as e:
+            self._pending_file_sends.pop(token, None)
+            logger.error("[teams] send file consent card failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e), retryable=True)
+
+    async def _on_file_consent(self, ctx) -> None:
+        """Handle fileConsent/invoke: upload on accept, clean up on decline."""
+        import httpx
+
+        activity = ctx.activity
+        value = activity.value  # FileConsentCardResponse
+        action = getattr(value, "action", None)
+        context = getattr(value, "context", None) or {}
+        if not isinstance(context, dict):
+            context = getattr(context, "__dict__", {}) or {}
+        token = context.get("hermes_file_token") or context.get("hermesFileToken")
+        pending = self._pending_file_sends.pop(token, None) if token else None
+
+        conv = getattr(activity, "conversation", None)
+        chat_id = getattr(conv, "id", None) or (pending or {}).get("chat_id")
+
+        async def _say(text: str) -> None:
+            if chat_id and self._app:
+                try:
+                    await self._app.send(chat_id, text)
+                except Exception:
+                    logger.warning("[teams] file-consent notify failed", exc_info=True)
+
+        async def _remove_card() -> None:
+            """Delete the consent-card message so the chat shows only the outcome.
+
+            The FileConsentCard does not auto-update after the invoke; the
+            documented pattern is for the bot to delete it (Teams samples do
+            the same). Best-effort: a failure just leaves the stale card.
+            """
+            card_id = (pending or {}).get("card_activity_id")
+            if card_id and chat_id and self._app:
+                try:
+                    await self._app.api.conversations.delete_activity(chat_id, card_id)
+                except Exception:
+                    logger.warning("[teams] could not delete consent card", exc_info=True)
+
+        if action != "accept":
+            logger.info("[teams] file consent declined (token=%s)", token)
+            await _remove_card()
+            if pending:
+                await _say(f"Ok — '{pending['filename']}' blev ikke sendt.")
+            return
+
+        if not pending:
+            await _say("⚠️ This file offer has expired — please ask for the file again.")
+            return
+
+        upload_info = getattr(value, "upload_info", None)
+        upload_url = getattr(upload_info, "upload_url", None) if upload_info else None
+        if not upload_url:
+            await _say("⚠️ Teams did not provide an upload URL — file not sent.")
+            return
+
+        await _remove_card()
+
+        try:
+            with open(pending["path"], "rb") as f:
+                data = f.read()
+            total = len(data)
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.put(
+                    upload_url,
+                    content=data,
+                    headers={
+                        "Content-Length": str(total),
+                        "Content-Range": f"bytes 0-{total - 1}/{total}",
+                    },
+                )
+                resp.raise_for_status()
+
+            # Confirm with a file info card so the chat shows a real file chip.
+            from microsoft_teams.api import Attachment, MessageActivityInput
+
+            info = Attachment(
+                content_type="application/vnd.microsoft.teams.card.file.info",
+                content_url=getattr(upload_info, "content_url", None),
+                name=getattr(upload_info, "name", None) or pending["filename"],
+                content={
+                    "uniqueId": getattr(upload_info, "unique_id", None),
+                    "fileType": getattr(upload_info, "file_type", None),
+                },
+            )
+            activity_out = MessageActivityInput().add_attachments(info)
+            conv_ref = self._conv_refs.get(chat_id) if chat_id else None
+            if conv_ref and self._app:
+                await self._app.activity_sender.send(activity_out, conv_ref)
+            elif chat_id and self._app:
+                await self._app.send(chat_id, activity_out)
+            logger.info(
+                "[teams] file '%s' uploaded via consent flow (%d bytes)",
+                pending["filename"], total,
+            )
+        except Exception as e:
+            logger.error("[teams] file upload failed: %s", e, exc_info=True)
+            await _say(f"⚠️ Upload of '{pending['filename']}' failed: {e}")
 
     async def get_chat_info(self, chat_id: str) -> dict:
         return {"name": chat_id, "type": "unknown", "chat_id": chat_id}

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -893,29 +893,75 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
+    async def _get_botframework_token(self) -> str:
+        """Acquire a Bot Framework bearer token via client credentials.
+
+        Needed to download connector attachments (smba.trafficmanager.net
+        /v3/attachments/...), which -- unlike SharePoint file downloadUrls --
+        are NOT pre-authenticated and return 401 without the bot's own
+        token. Token is cached until ~5 minutes before expiry.
+        """
+        import time
+        import httpx
+
+        cached = getattr(self, "_bf_token_cache", None)
+        if cached and cached[1] > time.time() + 300:
+            return cached[0]
+
+        client_id = self._client_id
+        client_secret = self._client_secret
+        tenant_id = self._tenant_id
+        if not (client_id and client_secret and tenant_id):
+            raise ValueError("Missing TEAMS_CLIENT_ID/SECRET/TENANT_ID for attachment auth")
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "scope": "https://api.botframework.com/.default",
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        token = payload["access_token"]
+        self._bf_token_cache = (token, time.time() + int(payload.get("expires_in", 3600)))
+        return token
+
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
         Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
+        URLs (no extra auth header needed). Bot Framework connector
+        attachment URLs (pasted/inline images on smba.trafficmanager.net /
+        botframework.com hosts) require the bot's bearer token -- detected
+        below and fetched with auth. Validates the URL against the SSRF
+        guard and follows redirects through the shared redirect guard,
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
+        from urllib.parse import urlparse
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        host = (urlparse(url).hostname or "").lower()
+        if host.endswith("trafficmanager.net") or host.endswith("botframework.com"):
+            try:
+                headers["Authorization"] = f"Bearer {await self._get_botframework_token()}"
+            except Exception as e:
+                logger.warning("[teams] Could not acquire Bot Framework token for attachment: %s", e)
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -1019,11 +1065,28 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
-                    if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                    from urllib.parse import urlparse as _urlparse
+                    _host = (_urlparse(content_url).hostname or "").lower()
+                    if _host.endswith("trafficmanager.net") or _host.endswith("botframework.com"):
+                        # Bot Framework connector URL: needs the bot's own
+                        # bearer token; the generic cache helper sends none.
+                        data = await self._fetch_attachment_bytes(content_url)
+                        ext = content_type.split("/")[-1].split(";")[0] or "png"
+                        cached_m = cache_media_bytes(
+                            data,
+                            filename=att_name or f"image.{ext}",
+                            mime_type=content_type,
+                        )
+                        if cached_m:
+                            media_urls.append(cached_m.path)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
+                    else:
+                        cached = await cache_image_from_url(content_url)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue


### PR DESCRIPTION
## What does this PR do?

Adds **outbound file sending** to the Microsoft Teams platform adapter via the documented file-consent flow.

Teams personal-scope bots cannot attach document bytes directly — the existing base64 data-URI path in `_send_media_attachment` is rejected by Teams with HTTP 400, so `send_document()` effectively never worked for local files. With this PR, sending a local file shows the user a native **file consent card** (filename, size, description); on **Accept**, the adapter uploads the bytes to the Teams-provided pre-authorised OneDrive `uploadUrl` and posts a file-info chip, so the chat shows a real, clickable file card. On **Decline**, the offer is cancelled with a short confirmation. The consent card itself is deleted after accept/decline (consent cards do not auto-update after the invoke; deleting is the pattern used by Microsoft's Teams sample bots), keeping the chat tidy.

**No new permissions required:** the flow is pure Bot Framework — no Microsoft Graph scopes. The file lands in the receiving user's own OneDrive (Apps folder), covered by their retention policies, and upload URLs are single-use and pre-authorised by Teams.

> **Note:** this branch is stacked on #94547 (inbound attachment-auth fix) and includes its commit. If #94547 merges first, this PR reduces to the single feature commit. Happy to rebase either way.

## Related Issue

No existing issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/teams/adapter.py`:
  - `send_document()` — local paths route through the new consent flow; remote http(s) URLs keep the existing attach-by-reference path
  - New `_send_file_consent_card()` — sends an `application/vnd.microsoft.teams.card.file.consent` attachment; pending offers correlated via a uuid token in `acceptContext`/`declineContext`, capped at 50 entries so ignored cards cannot leak memory
  - New `_on_file_consent()` — handles `fileConsent/invoke`: uploads on accept (Content-Range PUT to the `uploadUrl`), posts an `application/vnd.microsoft.teams.card.file.info` chip, deletes the consent card, and confirms declines
  - Handler registered via the SDK's existing `@app.on_file_consent` route in `connect()`

## How to Test

1. Run a Teams bot (personal scope) with `supportsFiles: true` in the app manifest
2. Have the agent send a local file (e.g. deliver a `MEDIA:<path>` attachment on the Teams platform)
3. A consent card appears in the chat → click **Accept**: the card disappears and is replaced by a clickable file chip; the file is in your OneDrive under Apps
4. Repeat and click **Decline**: the card disappears and a short cancellation note is posted
5. Regression: sending a remote `https://` document URL still uses the plain attachment path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits — the one extra commit is the stacked #94547 fix, see note above)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Docker, linux/amd64), live Microsoft Teams tenant (EMEA)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on all new methods; no config/docs changes needed (no new keys, feature activates transparently for document sends)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verified live: consent card → Accept → card removed → file chip in chat → file readable from OneDrive. Decline path: card removed → "not sent" confirmation. Gateway log on success:

```
INFO hermes_plugins.teams_platform.adapter: [teams] file 'teams-file-test.md' uploaded via consent flow (474 bytes)
```
