### PR TITLE
fix(teams): request supported transcript content format

### DIFF
--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -334,7 +334,12 @@ async def download_transcript_text(
     with tempfile.NamedTemporaryFile(prefix="teams-transcript-", suffix=suffix, delete=False) as handle:
         destination = Path(handle.name)
     try:
-        await client.download_to_file(_transcript_download_path(meeting_ref, transcript), destination)
+        # Graph's transcript /content endpoint rejects JSON content negotiation.
+        await client.download_to_file(
+            _transcript_download_path(meeting_ref, transcript),
+            destination,
+            headers={"Accept": "text/vtt"},
+        )
         text = destination.read_text(encoding=encoding).strip()
     except MicrosoftGraphAPIError as exc:
         raise _wrap_graph_error(

--- a/tests/plugins/test_teams_pipeline_meetings.py
+++ b/tests/plugins/test_teams_pipeline_meetings.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from plugins.teams_pipeline.meetings import resolve_meeting_reference
+from plugins.teams_pipeline.meetings import (
+    download_transcript_text,
+    resolve_meeting_reference,
+)
+from plugins.teams_pipeline.models import MeetingArtifact, TeamsMeetingRef
 
 
 class FakeGraphClient:
@@ -31,5 +37,41 @@ async def test_join_url_can_use_organizer_scoped_graph_lookup():
         (
             "/users/organizer-1/onlineMeetings",
             {"$filter": "JoinWebUrl eq 'https://teams.microsoft.com/meet/code'"},
+        )
+    ]
+
+
+@pytest.mark.anyio
+async def test_transcript_download_requests_graph_vtt_content():
+    class FakeDownloadClient:
+        def __init__(self):
+            self.calls = []
+
+        async def download_to_file(self, path, destination, *, headers=None):
+            self.calls.append((path, headers))
+            Path(destination).write_text(
+                "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n<v Speaker>Hello</v>\n",
+                encoding="utf-8",
+            )
+            return {"content_type": "text/vtt"}
+
+    client = FakeDownloadClient()
+    meeting = TeamsMeetingRef(
+        meeting_id="meeting-1",
+        organizer_user_id="organizer-1",
+    )
+    transcript = MeetingArtifact(
+        artifact_type="transcript",
+        artifact_id="transcript-1",
+        display_name="transcript.vtt",
+    )
+
+    text = await download_transcript_text(client, meeting, transcript)
+
+    assert text.startswith("WEBVTT")
+    assert client.calls == [
+        (
+            "/users/organizer-1/onlineMeetings/meeting-1/transcripts/transcript-1/content",
+            {"Accept": "text/vtt"},
         )
     ]

--- a/tests/tools/test_microsoft_graph_client.py
+++ b/tests/tools/test_microsoft_graph_client.py
@@ -76,6 +76,30 @@ class TestMicrosoftGraphClient:
         assert len(calls) == 2
         assert sleeps == [3.0]
 
+    async def test_download_accepts_stream_content_by_default(self, tmp_path: Path):
+        captured_accept: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_accept.append(request.headers["Accept"])
+            return httpx.Response(
+                200,
+                content=b"recording-bytes",
+                headers={"content-type": "video/mp4"},
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+        destination = tmp_path / "recording.mp4"
+
+        result = await client.download_to_file(
+            "/recordings/recording-1/content", destination
+        )
+
+        assert captured_accept == ["*/*"]
+        assert destination.read_bytes() == b"recording-bytes"
+        assert result["content_type"] == "video/mp4"
 
     async def test_invalid_json_response_raises_client_error(self):
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tools/microsoft_graph_client.py
+++ b/tools/microsoft_graph_client.py
@@ -181,7 +181,7 @@ class MicrosoftGraphClient:
             )
             request_headers = {
                 "Authorization": f"Bearer {token}",
-                "Accept": "application/json",
+                "Accept": "*/*",
                 "User-Agent": self.user_agent,
             }
             if headers:


### PR DESCRIPTION
## What does this PR do?

Microsoft Graph transcript `/content` endpoints reject `Accept: application/json`; they support transcript stream formats such as `text/vtt`. The shared Graph downloader was applying the JSON accept header to every streamed artifact, so the Teams meeting pipeline could successfully resolve a transcript and then fail its content request with `400 BadRequest: Invalid format 'application/json' specified`.

This changes generic Graph stream downloads to accept arbitrary response content and makes transcript retrieval explicitly request `text/vtt`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Use `Accept: */*` as the default for streamed Microsoft Graph downloads.
- Request `text/vtt` explicitly from Teams transcript content endpoints.
- Add behavioral regressions for generic stream negotiation and the transcript download call path.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_microsoft_graph_client.py tests/plugins/test_teams_pipeline_meetings.py tests/plugins/test_teams_pipeline_plugin.py tests/hermes_cli/test_teams_pipeline_plugin_cli.py tests/gateway/test_teams_pipeline_runtime_wiring.py -q`.
2. Verify a transcript content request sends `Accept: text/vtt`.
3. Verify a generic Graph stream download accepts a non-JSON media response.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Conventional commit message
- [x] Searched existing open and closed PRs and issues
- [x] Focused change with behavioral regressions
- [x] Focused Teams pipeline suite passes: 31 tests
- [x] Ruff checks pass
- [x] Tested on native Windows
- [x] Documentation, config, architecture, and tool schema updates are N/A

## Screenshots / Logs

N/A. The failure is HTTP content negotiation and is covered by request-header regressions.