### PR TITLE
fix(gateway): /kanban must not raise on unbalanced quotes in args

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -482,7 +482,13 @@ class GatewaySlashCommandsMixin:
         if text.startswith("kanban"):
             text = text[len("kanban"):].lstrip()
 
-        tokens = shlex.split(text) if text else []
+        try:
+            tokens = shlex.split(text) if text else []
+        except ValueError:
+            # Unbalanced quote in user-typed args ("/kanban deploy "v2)
+            # must not raise out of the handler — /resume guards its own
+            # shlex.split the same way. Fall back to whitespace splitting.
+            tokens = text.split()
         requested_board = None
         action = None
         i = 0


### PR DESCRIPTION
## Problem

The `/kanban` handler called `shlex.split(text)` bare. Any unbalanced quote in user-typed args — `"/kanban deploy \"v2"`, or a first-token apostrophe like `don't` opening a quote per POSIX parsing — raised `ValueError: No closing quotation` straight out of the slash handler.

Every other `shlex.split` site in the gateway guards this exact failure:

- `/resume` (slash_commands.py:4876-4879): try/except ValueError → parse-error message
- `run.py` profile-arg parser (:9482-9485): try/except → whitespace-split fallback
- `run.py` home-detection (:30618-30621): same fallback

## Fix

Mirror the established fallback: on `ValueError`, split on whitespace so the command still runs (quote-grouping lost, which is the correct degradation for malformed input).

## Verification

Swept all gateway/plugin `shlex.split(` call sites — this was the only unguarded one; module parses clean.