### PR TITLE
fix(update): keep launchd gateways online after updates

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4575,8 +4575,8 @@ def _append_launchd_reload_log(message: str) -> None:
         pass
 
 
-def _launchctl_label_supervising_process(label: str) -> bool:
-    """True when launchd both knows ``label`` AND is running a process for it.
+def _launchctl_label_supervising_pid(label: str) -> int | None:
+    """Return the live PID launchd supervises for ``label``, if any.
 
     A bare ``launchctl list <label>`` exit-0 only proves a *definition* is
     registered — it also returns 0 for ``state = not running`` (macOS 26+),
@@ -4601,10 +4601,15 @@ def _launchctl_label_supervising_process(label: str) -> bool:
             text=True, encoding='utf-8', errors='replace',
         )
         if result.returncode != 0:
-            return False
-        return _parse_launchd_pid_from_list_output(result.stdout) is not None
+            return None
+        return _parse_launchd_pid_from_list_output(result.stdout)
     except (subprocess.TimeoutExpired, OSError):
-        return False
+        return None
+
+
+def _launchctl_label_supervising_process(label: str) -> bool:
+    """True when launchd both knows ``label`` AND is running a process for it."""
+    return _launchctl_label_supervising_pid(label) is not None
 
 
 def _retry_launchctl_bootstrap_until_registered(
@@ -5472,9 +5477,10 @@ def wait_for_launchd_gateway_supervision(
     *,
     timeout: float = LAUNCHD_SUPERVISION_VERIFY_TIMEOUT,
     label: str | None = None,
+    old_pid: int | None = None,
     poll_interval: float = 0.5,
 ) -> bool:
-    """Poll launchd until it is supervising a live gateway process.
+    """Poll launchd until it is supervising a fresh gateway process.
 
     :func:`launchd_restart` returns as soon as the restart has been *requested*.
     The ``_request_gateway_self_restart`` branch hands the work to the running
@@ -5484,9 +5490,10 @@ def wait_for_launchd_gateway_supervision(
     first bootstrap (#88848) — nor a ``launchctl bootstrap`` that exits 0
     without registering, which the reporter measured on macOS 26.6.1.
 
-    Judge the outcome the way #80491 taught the helper to judge it: by a live
-    supervised pid, never by an exit code.  :func:`_launchctl_label_supervising_process`
-    is already that predicate, so this only adds the wait.
+    Judge the outcome by a live supervised PID, never by an exit code.  When
+    ``old_pid`` is supplied, the still-running process that accepted the
+    asynchronous restart request does not count as success; launchd must expose
+    a different PID before the handoff is complete.
 
     Returns True immediately when the detached fallback is active.  On a host
     where launchd cannot manage the domain the gateway runs unsupervised *by
@@ -5499,7 +5506,8 @@ def wait_for_launchd_gateway_supervision(
     label = label or get_launchd_label()
     deadline = time.monotonic() + max(timeout, 0.0)
     while True:
-        if _launchctl_label_supervising_process(label):
+        pid = _launchctl_label_supervising_pid(label)
+        if pid is not None and pid != old_pid:
             return True
         if time.monotonic() >= deadline:
             return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5140,6 +5140,43 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
         print("    launchctl kickstart -k gui/$UID/<label>   # macOS (or user/$UID)")
 
 
+def _kickstart_launchd_gateway_and_wait(
+    label: str,
+    *,
+    domain: str | None = None,
+    old_pid: int | None = None,
+    timeout: float = 15.0,
+) -> bool:
+    """Force a launchd job to run and verify a fresh supervised process.
+
+    ``KeepAlive`` can leave a planned exit pended with the label still loaded
+    but no process.  Resolve that label's own domain when the caller does not
+    already have it, then use the same explicit domain for kickstart and PID
+    verification.  A missing domain is left to the existing bootstrap recovery
+    guidance because ``kickstart`` cannot revive a deregistered job.
+    """
+    from hermes_cli.gateway import (
+        _launchd_kickstart,
+        _locate_launchd_gateway_service,
+        _wait_for_launchd_service_pid,
+    )
+
+    if domain is None:
+        domain, observed_pid = _locate_launchd_gateway_service(label)
+        if domain is None:
+            return False
+        if old_pid is None:
+            old_pid = observed_pid
+
+    _launchd_kickstart(label, domain)
+    return _wait_for_launchd_service_pid(
+        label,
+        old_pid=old_pid,
+        timeout=timeout,
+        domain=domain,
+    )
+
+
 def _restart_macos_launchd_gateways(
     restarted_services: list,
     failed_or_stale_units: list,
@@ -5167,7 +5204,7 @@ def _restart_macos_launchd_gateways(
         launchd_restart,
         launchd_gateway_labels_for_install,
         _graceful_restart_via_sigusr1,
-        _launchd_kickstart,
+        _launchctl_label_supervising_pid,
         _launchd_service_registered,
         _locate_launchd_gateway_service,
         _wait_for_launchd_service_pid,
@@ -5187,6 +5224,7 @@ def _restart_macos_launchd_gateways(
         if get_launchd_plist_path().exists() and _launchd_service_registered(
             current_label
         ):
+            old_launchd_pid = _launchctl_label_supervising_pid(current_label)
             try:
                 launchd_restart()
             except subprocess.CalledProcessError as e:
@@ -5212,15 +5250,29 @@ def _restart_macos_launchd_gateways(
                 # because it fails on macOS-26 hosts whose per-user domains
                 # reject service management even though launchd_restart() owns
                 # that fallback.
-                if wait_for_launchd_gateway_supervision(label=current_label):
+                if wait_for_launchd_gateway_supervision(
+                    label=current_label,
+                    old_pid=old_launchd_pid,
+                ):
                     restarted_services.append(current_label)
                 else:
-                    failed_or_stale_units.append(current_label)
                     print(
-                        f"  ✗ {current_label} restarted but launchd is not "
-                        "supervising it.\n"
-                        "    Check logs, then: hermes gateway restart"
+                        f"  ↻ {current_label} has no supervised process; "
+                        "forcing launchd kickstart"
                     )
+                    try:
+                        recovered = _kickstart_launchd_gateway_and_wait(current_label)
+                    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                        recovered = False
+                    if recovered:
+                        restarted_services.append(current_label)
+                    else:
+                        failed_or_stale_units.append(current_label)
+                        print(
+                            f"  ✗ {current_label} restarted but launchd is not "
+                            "supervising it.\n"
+                            "    Check logs, then: hermes gateway restart"
+                        )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
@@ -5252,7 +5304,21 @@ def _restart_macos_launchd_gateways(
                 restarted_services.append(label)
                 continue
             try:
-                _launchd_kickstart(label, domain)
+                restarted = _kickstart_launchd_gateway_and_wait(
+                    label,
+                    domain=domain,
+                    old_pid=old_pid,
+                )
+                if not restarted:
+                    print(
+                        f"  ↻ {label} has no supervised process; retrying "
+                        "launchd kickstart"
+                    )
+                    restarted = _kickstart_launchd_gateway_and_wait(
+                        label,
+                        domain=domain,
+                        old_pid=old_pid,
+                    )
             except subprocess.CalledProcessError as e:
                 stderr = (getattr(e, "stderr", "") or "").strip()
                 failed_or_stale_units.append(label)
@@ -5261,9 +5327,7 @@ def _restart_macos_launchd_gateways(
                     f"    Recover manually: launchctl kickstart -k {domain}/{label}"
                 )
                 continue
-            if _wait_for_launchd_service_pid(
-                label, old_pid=old_pid, timeout=15.0, domain=domain
-            ):
+            if restarted:
                 restarted_services.append(label)
             else:
                 failed_or_stale_units.append(label)

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -306,7 +306,10 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
 
     def fake_wait(label, old_pid, timeout, domain):
         rec.waits.append(f"{domain}/{label}")
-        return (wait_results or {}).get(label, True)
+        result = (wait_results or {}).get(label, True)
+        if isinstance(result, list):
+            return result.pop(0)
+        return result
 
     monkeypatch.setattr(gw, "_wait_for_launchd_service_pid", fake_wait)
     monkeypatch.setattr(
@@ -612,6 +615,36 @@ class TestRestartMacosLaunchdGateways:
 
         assert restarted == ["ai.hermes.gateway"]
         assert failed == ["ai.hermes.gateway-zombie"]
+        assert rec.kickstarts == [
+            f"gui/{UID}/ai.hermes.gateway-zombie",
+            f"gui/{UID}/ai.hermes.gateway-zombie",
+        ]
+
+    def test_pended_sibling_respawn_gets_final_kickstart(self, monkeypatch, tmp_path):
+        """#94540: a second kickstart clears launchd's pended spawn state."""
+        label = "ai.hermes.gateway-pended"
+        rec = _fleet(
+            monkeypatch,
+            tmp_path,
+            current="ai.hermes.gateway",
+            labels=["ai.hermes.gateway", label],
+            located={
+                "ai.hermes.gateway": (f"gui/{UID}", 100),
+                label: (f"gui/{UID}", 200),
+            },
+            wait_results={label: [False, True]},
+        )
+        restarted: list[str] = []
+        failed: list[str] = []
+
+        _restart_macos_launchd_gateways(restarted, failed, drain_budget=0.0)
+
+        assert restarted == ["ai.hermes.gateway", label]
+        assert failed == []
+        assert rec.kickstarts == [
+            f"gui/{UID}/{label}",
+            f"gui/{UID}/{label}",
+        ]
 
 
 class TestWaitForLaunchdServicePid:

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -68,7 +68,7 @@ def _no_detached_fallback(monkeypatch):
 
 
 def _supervision_returning(*results):
-    """Fake ``_launchctl_label_supervising_process`` yielding ``results`` in order.
+    """Fake ``_launchctl_label_supervising_pid`` yielding liveness in order.
 
     The final value repeats, so a test can say "False twenty times, then True
     from then on".
@@ -78,7 +78,8 @@ def _supervision_returning(*results):
 
     def probe(label):
         calls.append(label)
-        return seq[min(len(calls) - 1, len(seq) - 1)]
+        running = seq[min(len(calls) - 1, len(seq) - 1)]
+        return 4242 if running else None
 
     probe.calls = calls
     return probe
@@ -89,7 +90,7 @@ class TestWaitForLaunchdGatewaySupervision:
         """The common case must not cost a single sleep."""
         monkeypatch.setattr(
             gateway_cli,
-            "_launchctl_label_supervising_process",
+            "_launchctl_label_supervising_pid",
             _supervision_returning(True),
         )
 
@@ -108,7 +109,7 @@ class TestWaitForLaunchdGatewaySupervision:
         # 0.5s poll interval: 20 misses is ~10s of throttle, then the pid lands.
         probe = _supervision_returning(*([False] * 20 + [True]))
         monkeypatch.setattr(
-            gateway_cli, "_launchctl_label_supervising_process", probe
+            gateway_cli, "_launchctl_label_supervising_pid", probe
         )
 
         assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
@@ -118,7 +119,7 @@ class TestWaitForLaunchdGatewaySupervision:
         """A job that never comes back must fail, and must fail bounded."""
         probe = _supervision_returning(False)
         monkeypatch.setattr(
-            gateway_cli, "_launchctl_label_supervising_process", probe
+            gateway_cli, "_launchctl_label_supervising_pid", probe
         )
 
         assert (
@@ -144,11 +145,66 @@ class TestWaitForLaunchdGatewaySupervision:
         )
         probe = _supervision_returning(False)
         monkeypatch.setattr(
-            gateway_cli, "_launchctl_label_supervising_process", probe
+            gateway_cli, "_launchctl_label_supervising_pid", probe
         )
 
         assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
         assert probe.calls == []
+
+    def test_old_supervised_pid_does_not_satisfy_restart(self, monkeypatch, clock):
+        pids = iter([111, 111, 222])
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_label_supervising_pid",
+            lambda _label: next(pids),
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(
+            label=LABEL,
+            old_pid=111,
+        ) is True
+        assert sum(clock.slept) == pytest.approx(1.0)
+
+
+class TestKickstartLaunchdGatewayAndWait:
+    def test_resolves_domain_and_verifies_fresh_pid(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_locate_launchd_gateway_service",
+            lambda label: ("gui/501", None),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_kickstart",
+            lambda label, domain: calls.append(("kickstart", label, domain)),
+        )
+
+        def _wait(label, old_pid, timeout, domain):
+            calls.append(("wait", label, old_pid, timeout, domain))
+            return True
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_launchd_service_pid", _wait)
+
+        assert update_cmd._kickstart_launchd_gateway_and_wait(LABEL) is True
+        assert calls == [
+            ("kickstart", LABEL, "gui/501"),
+            ("wait", LABEL, None, 15.0, "gui/501"),
+        ]
+
+    def test_deregistered_job_is_not_kickstarted(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_locate_launchd_gateway_service",
+            lambda label: (None, None),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_kickstart",
+            lambda *_args: pytest.fail("deregistered job cannot be kickstarted"),
+        )
+
+        assert update_cmd._kickstart_launchd_gateway_and_wait(LABEL) is False
 
 
 def _patch_launchd_env(
@@ -158,6 +214,7 @@ def _patch_launchd_env(
     registered=True,
     restart=None,
     supervised=True,
+    recovered=False,
 ):
     """Drive ``_restart_macos_launchd_gateways`` through the invoking profile only.
 
@@ -179,7 +236,18 @@ def _patch_launchd_env(
         gateway_cli, "launchd_gateway_labels_for_install", lambda: [LABEL]
     )
 
-    calls = {"restart": 0, "verify": 0, "label": None}
+    calls = {
+        "restart": 0,
+        "verify": 0,
+        "label": None,
+        "old_pid": None,
+        "recover": 0,
+    }
+    monkeypatch.setattr(
+        gateway_cli,
+        "_launchctl_label_supervising_pid",
+        lambda _label: 111,
+    )
 
     def _restart():
         calls["restart"] += 1
@@ -188,14 +256,22 @@ def _patch_launchd_env(
 
     monkeypatch.setattr(gateway_cli, "launchd_restart", _restart)
 
-    def _verify(*, label=None, **_kw):
+    def _verify(*, label=None, old_pid=None, **_kw):
         calls["verify"] += 1
         calls["label"] = label
+        calls["old_pid"] = old_pid
         return supervised
 
     monkeypatch.setattr(
         gateway_cli, "wait_for_launchd_gateway_supervision", _verify
     )
+
+    def _recover(label, **_kwargs):
+        calls["recover"] += 1
+        calls["recover_label"] = label
+        return recovered
+
+    monkeypatch.setattr(update_cmd, "_kickstart_launchd_gateway_and_wait", _recover)
     return calls
 
 
@@ -224,6 +300,7 @@ class TestInvokingProfileIsVerifiedLikeItsSiblings:
         assert calls["restart"] == 1
         assert calls["verify"] == 1
         assert calls["label"] == LABEL
+        assert calls["old_pid"] == 111
 
     def test_unverified_restart_is_not_reported_as_restarted(
         self, monkeypatch, capsys
@@ -237,7 +314,7 @@ class TestInvokingProfileIsVerifiedLikeItsSiblings:
         reported the gateway as restarted, and exited 0, over a job that was
         deregistered from launchd.
         """
-        _patch_launchd_env(monkeypatch, supervised=False)
+        calls = _patch_launchd_env(monkeypatch, supervised=False)
 
         restarted, failed_or_stale = _run_fleet_restart()
 
@@ -245,7 +322,23 @@ class TestInvokingProfileIsVerifiedLikeItsSiblings:
         # Routed into failed_or_stale_units, which sets
         # gateway_fleet_restart_incomplete and makes the update exit 1.
         assert failed_or_stale == [LABEL]
+        assert calls["recover"] == 1
         assert LABEL in capsys.readouterr().out
+
+    def test_pended_keepalive_respawn_is_recovered_with_kickstart(self, monkeypatch):
+        """#94540: verification must act, not only diagnose the dead service."""
+        calls = _patch_launchd_env(
+            monkeypatch,
+            supervised=False,
+            recovered=True,
+        )
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == [LABEL]
+        assert failed_or_stale == []
+        assert calls["recover"] == 1
+        assert calls["recover_label"] == LABEL
 
     def test_verification_budget_clears_the_respawn_throttle(self):
         """A budget under launchd's ~10s respawn throttle would false-alarm.


### PR DESCRIPTION
## What does this PR do?

Keeps launchd-managed gateways online after `hermes update`. The update path now waits for a replacement launchd PID instead of accepting the still-draining process as success, and it performs a verified `launchctl kickstart -k` recovery when KeepAlive leaves the respawn pended.

### Symptom

After an update on macOS, launchd-managed gateways can start, exit with the planned service-restart code, and remain in `state = not running` with `pended nondemand spawn = inefficient`. Bots remain offline until each service is manually kickstarted.

### Impact

Every affected profile's messaging gateway remains offline after the update. The reported seven-profile installation lost all Telegram and WeChat bot connectivity until manual recovery.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py` / `_restart_macos_launchd_gateways()` after `launchd_restart()` requests an asynchronous service handoff.

**Causal chain:**
1. The running launchd gateway accepts the restart request but remains supervised while it drains.
2. The updater's supervision check sees that old PID and can treat the asynchronous handoff as complete before launchd has replaced it.
3. When the old process later exits with the planned restart code inside launchd's minimum-runtime window, KeepAlive can leave the replacement spawn pended and the gateway stays offline.

**Why it is wrong:** A live pre-restart PID proves only that the request was accepted, not that launchd completed the replacement. The failure path diagnosed missing supervision but did not perform the reporter-proven kickstart recovery.

**Working sibling / contrast:** The existing sibling-profile path already required a fresh PID after kickstart. This change applies the same PID identity contract to the invoking profile and adds one bounded final kickstart for a pended sibling spawn.

**Ruled out:** The service plist remains loaded with unconditional KeepAlive, so this is not a missing service definition or disabled restart policy. Deregistered labels remain on the existing bootstrap recovery path because kickstart cannot revive them.

### Fix

- Preserve the currently supervised launchd PID before requesting restart and require a different PID before recording success.
- Recover a loaded-but-not-running label with a domain-correct `launchctl kickstart -k`, then verify a fresh PID.
- Retry the same bounded recovery once for sibling labels whose first kickstart leaves no supervised process.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - expose the supervised launchd PID and make restart verification reject the old PID.
- `hermes_cli/update_cmd.py` - kickstart and verify pended current-profile and sibling-profile respawns.
- `tests/hermes_cli/test_update_launchd_restart_verification.py` - cover fresh-PID identity and current-profile recovery.
- `tests/hermes_cli/test_update_launchd_fleet_restart.py` - cover bounded sibling kickstart recovery.

## How to Test

1. On macOS with a launchd-managed gateway, run `hermes update` while the gateway is active.
2. Verify `launchctl print gui/$(id -u)/ai.hermes.gateway` reports a new live PID after the restart handoff; repeat for named-profile labels.
3. Automated tests run locally: 33 passed, 29 host-gated tests skipped on Windows and delegated to their OS CI lanes.

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_launchd_restart_verification.py tests/hermes_cli/test_update_launchd_fleet_restart.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_wedged_gateway.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all executed tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the deterministic update path on Windows 11; macOS launchd verification is delegated to the macOS CI/review lane

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config example changes are N/A
- [x] Contributor/architecture guide changes are N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A - automated regression output is listed above.

