### PR TITLE
fix(cli): stop resolving sys.executable out of the venv in the Linux desktop entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -77,12 +77,16 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly. Do NOT resolve() it: in a
+            # venv, ``venv/bin/python`` is a symlink to the base interpreter
+            # (uv always lays it out this way), and following it escapes the
+            # venv — the entry then dies on the first third-party import
+            # (#94564), silently, since Terminal=false.
+            argv = [sys.executable, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -98,15 +102,19 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    # a system path) would escape the venv when spawned by the DE. Compare
+    # against the unresolved bin dir: the venv python is typically a symlink,
+    # and its resolve()d location (the base interpreter) is outside the venv.
+    # Case-sensitively — Linux paths are, and lowercasing broke the match
+    # for any environment path with uppercase characters.
+    exe_dir = str(Path(sys.executable).parent)
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,10 +107,39 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # The prefix must be sys.executable as-is, NOT its resolve()d target:
+    # in a venv, resolve() follows the python symlink out to the base
+    # interpreter, which has no venv site-packages (#94564).
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+# #94564: uv lays venvs out with ``venv/bin/python`` as a symlink to the
+# managed base interpreter. resolve()ing sys.executable follows that link
+# out of the venv, so the entry ran a python with no venv site-packages →
+# ModuleNotFoundError on the first third-party import, silent again.
+def test_exec_keeps_symlinked_venv_interpreter_unresolved(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    root = _make_project(tmp_path)
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python"
+    venv_python.symlink_to(Path(sys.executable).resolve())
+    monkeypatch.setattr(sys, "executable", str(venv_python))
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):
@@ -135,8 +164,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
-    hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.write_text(f"#!{sys.executable}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])


### PR DESCRIPTION
Fixes #94564

## What & why

On Linux, the `hermes.desktop` entry written by `hermes desktop` silently fails to launch when Hermes runs in a uv-created venv. `resolve_exec_command()` prefixed the Exec line with `Path(sys.executable).resolve()` — but in a uv venv, `venv/bin/python` is a **symlink** to the managed base interpreter, so `resolve()` follows it out of the venv. The entry then runs a python with no venv site-packages and dies on the first third-party import (`ModuleNotFoundError: No module named 'yaml'`), invisibly, since `Terminal=false`. This is the same failure mode #90292 fixed, reintroduced through the symlink.

## Changes

- `resolve_exec_command()`: use `sys.executable` as-is (it is already absolute) in both the interpreter-prefix and `-m hermes_cli.main` fallback paths, instead of its `resolve()`d target.
- `_needs_interpreter()`: compare the shebang against the **unresolved** interpreter bin dir (the resolved one points outside the venv), and do it **case-sensitively** — the previous `.lower()` on the shebang broke the match for any environment path containing uppercase characters (Linux paths are case-sensitive).
- Tests: updated the two tests that asserted the resolved-path behavior, and added a regression test that simulates the uv layout (`venv/bin/python` symlinked to the base interpreter, `sys.executable` monkeypatched to the symlink) asserting the Exec line keeps the symlink path.

## How to test

1. Install Hermes on Linux so it runs from a uv venv (the shell installer's default layout).
2. `hermes desktop` → installs `~/.local/share/applications/hermes.desktop`.
3. Before this fix: the entry's `Exec=` points at `~/.local/share/uv/python/cpython-*/bin/python3.11`, and clicking the menu icon does nothing (run the Exec command in a terminal to see the `ModuleNotFoundError`).
4. After this fix: `Exec=` stays on the venv interpreter (or the shell wrapper), and `gtk-launch hermes` opens the app.

`pytest tests/hermes_cli/test_linux_desktop_entry.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_gui_uninstall.py` → 55 passed, 7 skipped.

## Platforms tested

Linux (GNOME, X11), Python 3.11.16, uv 0.12.5. The module is Linux/BSD-only (`is_supported()` gates it), so no macOS/Windows impact.
