### PR TITLE
fix(gateway): track remaining fire-and-forget loop tasks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -204,6 +204,11 @@ def _browser_controller_ws_sender(ws, loop, *, wait_timeout: float = 10.0):
     own deadline/cancel path decide; a real send exception still propagates.
     """
 
+    # Strong refs to on-loop fire-and-forget frame pushes: the loop keeps
+    # tasks only weakly, so an unreferenced send can be GC-reaped and the
+    # frame silently dropped.
+    _spawned_sends: set = set()
+
     def send(frame: dict) -> None:
         if ws.closed:
             raise ConnectionError("browser-control websocket is closed")
@@ -212,7 +217,10 @@ def _browser_controller_ws_sender(ws, loop, *, wait_timeout: float = 10.0):
         except RuntimeError:
             on_loop = False
         if on_loop:
-            loop.create_task(ws.send_json(frame))
+            task = loop.create_task(ws.send_json(frame))
+            _spawned_sends.add(task)
+            if hasattr(task, "add_done_callback"):
+                task.add_done_callback(_spawned_sends.discard)
             return
         future = asyncio.run_coroutine_threadsafe(ws.send_json(frame), loop)
         try:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1442,7 +1442,15 @@ class SlackAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
-        loop.create_task(self._restart_socket_mode("socket task exited"))
+        # Track the task: the loop keeps only weak references, so an
+        # unreferenced reconnect can be GC-reaped and Slack would stay
+        # disconnected until process restart.
+        restart_task = loop.create_task(
+            self._restart_socket_mode("socket task exited")
+        )
+        self._background_tasks.add(restart_task)
+        if hasattr(restart_task, "add_done_callback"):
+            restart_task.add_done_callback(self._background_tasks.discard)
 
     def _describe_slack_api_error(
         self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -106,6 +106,10 @@ class WSTransport:
         self.auth_identity = auth_identity
         self._closed = False
         self._last_inbound_at = time.monotonic()
+        # Strong refs to fire-and-forget flush tasks: the loop keeps only
+        # weak references, so an unreferenced batch send can be GC-reaped
+        # before the tokens reach the wire.
+        self._spawned_tasks: set = set()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -176,7 +180,10 @@ class WSTransport:
             self._pending_tokens = []
             if on_loop:
                 # Fire-and-forget — don't block the loop waiting on itself.
-                self._loop.create_task(self._safe_send_many(batch))
+                task = self._loop.create_task(self._safe_send_many(batch))
+                self._spawned_tasks.add(task)
+                if hasattr(task, "add_done_callback"):
+                    task.add_done_callback(self._spawned_tasks.discard)
                 return True
             fut = safe_schedule_threadsafe(
                 self._safe_send_many(batch), self._loop
@@ -231,7 +238,10 @@ class WSTransport:
                 return
             batch = self._pending_tokens
             self._pending_tokens = []
-            self._loop.create_task(self._safe_send_many(batch))
+            task = self._loop.create_task(self._safe_send_many(batch))
+            self._spawned_tasks.add(task)
+            if hasattr(task, "add_done_callback"):
+                task.add_done_callback(self._spawned_tasks.discard)
 
     async def write_async(self, obj: dict) -> bool:
         """Send from the owning event loop. Awaits until the frame is on the wire."""


### PR DESCRIPTION
## Problem

Three more unreferenced task spawns — the event loop holds tasks only **weakly**, so each could be GC-reaped before completing:

| Site | Dropped task → failure |
|---|---|
| `slack` socket-mode watchdog (:1445) | reaped reconnect → **Slack stays disconnected until process restart** |
| `tui_gateway/ws.py` token-batch sends (on-loop + timer flush) | reaped send → batched tokens silently dropped |
| `api_server._browser_controller_ws_sender` on-loop push | reaped send → browser-control frame silently dropped |

Same weak-reference hazard as #94487/#94489/#94494/#94529; these are the remaining sites found by a receiver-aware sweep (`loop.create_task(...)` alias form, which the earlier `asyncio.create_task` greps missed).

## Fix

Each retains a strong reference in a spawned-tasks set with done-callback discard:

- Slack: existing `_background_tasks`
- `WSTransport`: new `_spawned_tasks` set (init in `__init__`, both spawn paths)
- `_browser_controller_ws_sender`: closure-scoped `_spawned_sends` set (per-socket lifetime)

## Verification

`tests/gateway/test_slack.py` + `tests/tui_gateway/test_ws_keepalive.py`: 167/167 pass; all three modules syntax-checked.