### PR TITLE
fix(anthropic): Qwen3.8 family uses adaptive thinking on third-party Messages endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -283,8 +284,16 @@ def _supports_adaptive_thinking(model: str) -> bool:
     Kimi / Moonshot models are the exception: their Anthropic-compatible
     endpoints implement the adaptive contract (``thinking.type="adaptive"``
     + ``output_config.effort``, including ``xhigh`` and ``display``).
+
+    The Qwen3.8 family is the same shape of exception on third-party
+    Anthropic-compatible endpoints: the adaptive contract works with a
+    clean effort dose-response, while the manual ``budget_tokens`` field
+    is rejected outright (HTTP 502 upstream_error at any budget value) —
+    see :func:`_model_name_is_qwen3_8_family`.
     """
     if _model_name_is_kimi_family(model):
+        return True
+    if _model_name_is_qwen3_8_family(model):
         return True
     if not _is_claude_model(model):
         return False
@@ -550,6 +559,34 @@ def _model_name_is_kimi_family(model: str | None) -> bool:
     if m in _KIMI_FAMILY_EXACT_SLUGS:
         return True
     return m.startswith(_KIMI_FAMILY_MODEL_PREFIXES)
+
+
+def _model_name_is_qwen3_8_family(model: str | None) -> bool:
+    """True for Qwen3.8 models (``qwen3.8-max``, ``qwen3.8-plus``, …).
+
+    Third-party Anthropic-compatible endpoints serving the Qwen3.8 family
+    implement the adaptive-thinking contract — ``thinking.type="adaptive"``
+    + ``output_config.effort``, the same shape as Kimi/Moonshot and GLM-5
+    (#91006). Verified live against ``qwen3.8-max`` via a third-party relay
+    (2026-08-25): effort low ≈0.5K thinking chars vs high ≈5.5K (~10x
+    dose-response), while the manual ``budget_tokens`` field fails hard
+    with HTTP 502 upstream_error at any budget value — so the manual path
+    breaks every request when reasoning effort is configured.
+
+    Older Qwen generations (``qwen3-max``, ``qwen2.5``, ``qwq``, …) keep
+    the manual path: no evidence they accept the adaptive contract.
+    """
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    # Strip vendor prefix (e.g. ``qwen/qwen3.8-max`` → ``qwen3.8-max``)
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    # qwen3.8, qwen3.8-max, qwen3.8p2 / qwen-3.8-max (relay spellings) —
+    # but NOT qwen3-max / qwen3.85 / qwen2.5 / qwq.
+    return bool(re.match(r"^qwen-?3\.8(?:[.\-_p]|$)", m))
 
 
 def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> bool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1031,8 +1031,10 @@ class TestBuildAnthropicKwargs:
 
     def test_non_claude_anthropic_models_use_manual_path(self):
         """Non-Claude Anthropic-Messages models (minimax, qwen3, glm) must not
-        be misclassified as adaptive by the default-to-modern rule. Kimi is
-        the deliberate exception — see test_kimi_family_uses_adaptive_path."""
+        be misclassified as adaptive by the default-to-modern rule. Kimi and
+        the Qwen3.8 family are deliberate exceptions — see
+        test_bare_k3_coding_plan_slug_is_kimi_family and
+        test_qwen3_8_family_uses_adaptive_path."""
         from agent.anthropic_adapter import (
             _supports_adaptive_thinking,
             _supports_xhigh_effort,
@@ -1059,6 +1061,78 @@ class TestBuildAnthropicKwargs:
         # Prefix-lookalikes without a separator must not be swept in.
         for m in ("k30", "k3000-chat", "keras-3"):
             assert _model_name_is_kimi_family(m) is False, m
+
+    def test_qwen3_8_family_uses_adaptive_path(self):
+        """Third-party Anthropic-compatible endpoints serving Qwen3.8 honor
+        the adaptive contract (``thinking.type="adaptive"`` +
+        ``output_config.effort``) with a clean effort dose-response, while
+        the manual ``budget_tokens`` field is rejected with HTTP 502
+        upstream_error at any value — so Qwen3.8 must take the adaptive path
+        like Kimi/GLM-5, or every request hard-fails when reasoning effort
+        is configured. Verified live against qwen3.8-max via a third-party
+        relay (2026-08-25): effort low ≈0.5K thinking chars vs high ≈5.5K;
+        budget_tokens=8000 and 16000 → 502 upstream_error ×3 each.
+
+        xhigh stays allowed by default, mirroring the Kimi/GLM-5 treatment
+        (adaptive non-Claude families accept it unless proven otherwise);
+        not separately verified on the relay.
+        """
+        from agent.anthropic_adapter import (
+            _model_name_is_qwen3_8_family,
+            _supports_adaptive_thinking,
+            _supports_xhigh_effort,
+        )
+        for m in ("qwen3.8-max", "qwen3.8", "qwen3.8-plus", "Qwen/qwen3.8-max",
+                  "qwen-3.8-max", "qwen3.8p2"):
+            assert _model_name_is_qwen3_8_family(m) is True, m
+            assert _supports_adaptive_thinking(m) is True, m
+        assert _supports_xhigh_effort("qwen3.8-max") is True
+        # Older Qwen generations and lookalikes stay on the manual budget path.
+        for m in ("qwen3-max", "qwen3-235b-a22b", "qwen2.5-max", "qwq-32b",
+                  "qwen3.85", "qwen30.8"):
+            assert _model_name_is_qwen3_8_family(m) is False, m
+            assert _supports_adaptive_thinking(m) is False, m
+
+    def test_qwen3_8_builds_adaptive_effort_kwargs(self):
+        """build_anthropic_kwargs must emit the adaptive contract for Qwen3.8
+        (never the manual budget_tokens path, which third-party endpoints
+        reject with 502), and must NOT inject the manual-path side effects
+        (temperature=1 forcing, max_tokens bump). Thinking-off stays
+        omission-based like Kimi — no explicit disable on non-Claude."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        base = dict(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+        )
+        kw = build_anthropic_kwargs(
+            model="Qwen/qwen3.8-max",
+            reasoning_config={"enabled": True, "effort": "high"},
+            **base,
+        )
+        assert kw["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kw["output_config"] == {"effort": "high"}
+        assert "budget_tokens" not in kw["thinking"]
+        # Manual-path side effects must not leak into the adaptive path.
+        assert "temperature" not in kw
+        assert kw["max_tokens"] == 1024
+
+        kw_off = build_anthropic_kwargs(
+            model="qwen3.8-max",
+            reasoning_config={"enabled": False},
+            **base,
+        )
+        assert "thinking" not in kw_off
+
+        # Older Qwen keeps the manual path unchanged (regression guard).
+        kw_old = build_anthropic_kwargs(
+            model="qwen3-max",
+            reasoning_config={"enabled": True, "effort": "high"},
+            **base,
+        )
+        assert kw_old["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert kw_old["temperature"] == 1
 
     def test_fast_mode_omitted_for_unsupported_model(self):
         """fast_mode=True on Opus 4.7 must NOT inject speed=fast (API 400s)."""


### PR DESCRIPTION
## Summary

Qwen3.8 models served over third-party Anthropic-compatible endpoints (`api_mode: anthropic_messages`) implement the **adaptive-thinking contract** — `thinking.type="adaptive"` + `output_config.effort`, the same shape as Kimi/Moonshot (#67606) and GLM-5 (#91006).

Hermes classifies them via the generic non-Claude rule (`_supports_adaptive_thinking()` returns False), so reasoning effort goes out as a manual `thinking.type="enabled"` + `budget_tokens` block. On these endpoints that block does not no-op — it fails hard:

- `budget_tokens=8000` → HTTP 502 `upstream_error` (×3 consecutive attempts)
- `budget_tokens=16000` → HTTP 502 `upstream_error`
- no thinking params → works; model thinks natively
- adaptive + `output_config.effort=low/high` → works, ~10× dose-response between levels (verified live against `qwen3.8-max`, 2026-08-25, per #94548)

So any user setting `agent.reasoning_effort` for a qwen3.8 main model on such an endpoint gets hard failures on **every** request.

## Change

Follows the GLM-5 precedent from #91006 (@alindebergASL): add `_model_name_is_qwen3_8_family()` (qwen3.8, qwen3.8-max, vendor-prefixed and relay spellings like `qwen-3.8-max` / `qwen3.8p2`; older generations and lookalikes excluded) and return `True` from `_supports_adaptive_thinking()` for that family.

Deliberate scope decisions:
- **Older Qwen stays manual** (`qwen3-max`, `qwen2.5`, `qwq`) — no evidence those accept the adaptive contract.
- **Thinking-off remains omission-based** for non-Claude families (mirrors Kimi's documented behavior, #13848) — `_accepts_thinking_disable()` stays Claude-gated.
- **xhigh stays allowed by default**, mirroring the Kimi/GLM-5 treatment of adaptive non-Claude families (not separately verified on the relay).
- Not the broader "default unknown aliases to adaptive on third-party endpoints" direction (#66602) — explicit family only.

## Tests (behavior-contract)

- classification table: positive names incl. vendor-prefixed/case variants; negatives keep the manual path (`qwen3-max`, `qwen3-235b-a22b`, `qwen2.5-max`, `qwq-32b`, lookalikes `qwen3.85`/`qwen30.8`)
- `build_anthropic_kwargs` wire shape: emits `{type: adaptive, display: summarized}` + `output_config.effort`, never `budget_tokens`; asserts the manual-path side effects do **not** leak (`temperature=1` forcing, `max_tokens` bump); thinking-off omission; regression guard pinning older-Qwen manual behavior
- both new tests proven RED against current main's adapter before the fix

Local suites: `test_anthropic_adapter.py` 97✓ · thinking-disable/minimax/provider-profiles 56✓ · adapter consumer suites 340✓ · `test_run_agent.py` 280✓

Fixes #94548

---
Bruno Bza (@BrunoBza)
