### PR TITLE
Fix vision probe clients leaking into runtime cache

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8016,7 +8016,13 @@ def _get_cached_client(
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]
-            if async_mode:
+            if isinstance(cached_client, _AuxProbeClientStub):
+                # Probe clients are non-functional sentinels. Older code could
+                # insert one through this function's inline cache path, bypassing
+                # _store_cached_client's guard. Drop any poisoned entry and build
+                # a real runtime client below.
+                del _client_cache[cache_key]
+            elif async_mode:
                 # Validate: the cached client must be bound to the CURRENT,
                 # OPEN loop.  If the loop changed or was closed, the httpx
                 # transport inside is dead — force-close and replace.
@@ -8063,7 +8069,7 @@ def _get_cached_client(
         is_vision=is_vision,
         task=task,
     )
-    if client is not None:
+    if client is not None and not isinstance(client, _AuxProbeClientStub):
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.
         bound_loop = current_loop

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -34,6 +34,88 @@ class TestAuxProbeMode:
         with aux._client_cache_lock:
             assert key not in aux._client_cache
 
+    def test_get_cached_client_probe_does_not_poison_runtime_cache(self):
+        import agent.auxiliary_client as aux
+
+        provider = "custom:vision-test"
+        model = "vendor/vision-model"
+        runtime_client = object()
+
+        def fake_resolver(*args, **kwargs):
+            if aux._aux_probe_active():
+                return aux._AuxProbeClientStub(
+                    base_url="https://vision.invalid/v1"
+                ), model
+            return runtime_client, model
+
+        with aux._client_cache_lock:
+            aux._client_cache.clear()
+        try:
+            with patch.object(
+                aux, "resolve_provider_client", side_effect=fake_resolver
+            ):
+                with aux.aux_probe_mode():
+                    probe_client, probe_model = aux._get_cached_client(
+                        provider,
+                        model,
+                        is_vision=True,
+                    )
+
+                assert isinstance(probe_client, aux._AuxProbeClientStub)
+                assert probe_model == model
+                with aux._client_cache_lock:
+                    assert not aux._client_cache
+
+                client, resolved_model = aux._get_cached_client(
+                    provider,
+                    model,
+                    is_vision=True,
+                )
+
+            assert client is runtime_client
+            assert resolved_model == model
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.clear()
+
+    def test_get_cached_client_discards_stale_probe_stub(self):
+        import agent.auxiliary_client as aux
+
+        provider = "custom:vision-test"
+        model = "vendor/vision-model"
+        runtime_client = object()
+        cache_key = aux._client_cache_key(
+            provider,
+            async_mode=False,
+            is_vision=True,
+            model=model,
+        )
+
+        with aux._client_cache_lock:
+            aux._client_cache.clear()
+            aux._client_cache[cache_key] = (
+                aux._AuxProbeClientStub(base_url="https://vision.invalid/v1"),
+                model,
+                None,
+            )
+        try:
+            with patch.object(
+                aux,
+                "resolve_provider_client",
+                return_value=(runtime_client, model),
+            ):
+                client, resolved_model = aux._get_cached_client(
+                    provider,
+                    model,
+                    is_vision=True,
+                )
+
+            assert client is runtime_client
+            assert resolved_model == model
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.clear()
+
     def test_probe_stub_raises_on_runtime_use(self):
         import agent.auxiliary_client as aux
 


### PR DESCRIPTION
## Summary
- prevent availability-probe stubs from entering the shared auxiliary client cache
- discard legacy poisoned cache entries before building a real runtime client
- add regression coverage for repeated vision checks and slash-bearing custom model IDs

## Root cause
aux_probe_mode deliberately returns an _AuxProbeClientStub during tool availability checks. _store_cached_client rejects these stubs, but _get_cached_client maintained a second inline insertion path that bypassed that guard. The first vision check could therefore poison the cache; the next check or runtime call reached _compat_model and failed with _AuxProbeClientStub used as a real client.

## Verification
- failure-first regression reproduced on current main
- scripts/run_tests.sh on six relevant files: 262 passed
- ruff check and git diff --check pass
- isolated OpenAI-compatible multimodal endpoint E2E: two availability probes, zero cached probe stubs, runtime image request succeeds

## Notes
The full suite was not clean in the local partial dev environment because optional ACP, Anthropic, and Slack dependencies were absent. The relevant suites passed, and the one observed vision-routing failure reproduced on an untouched main worktree.