### PR TITLE
fix(cloud): accept peer messages on OAuth-gated agents

### DIFF
--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -57,4 +57,9 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # the NAS relay's bearer-only callback reaches the verifier instead of a
     # 401 no_cookie. The JWT — not this allowlist — is the security boundary.
     "/api/cron/fire",
+    # Hosted peer-to-peer message ingress carries its own per-agent peer key.
+    # Let that route validate the bearer credential instead of consuming it as
+    # a dashboard OAuth access token (which misreports opaque peer keys as a
+    # Nous auth-provider outage before the message handler can run).
+    "/api/v1/message",
 })

--- a/tests/hermes_cli/test_peer_message_dashboard_auth.py
+++ b/tests/hermes_cli/test_peer_message_dashboard_auth.py
@@ -1,0 +1,38 @@
+"""Dashboard-auth boundary for the hosted peer-message endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+
+def test_peer_message_uses_its_own_bearer_auth() -> None:
+    """The OAuth gate must not consume the peer key before the route does."""
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "scheme": "https",
+        "server": ("agent.example", 443),
+        "client": ("127.0.0.1", 12345),
+        "path": "/api/v1/message",
+        "raw_path": b"/api/v1/message",
+        "query_string": b"",
+        "headers": [(b"authorization", b"Bearer opaque-peer-key")],
+        "app": type("App", (), {"state": type("State", (), {"auth_required": True})()})(),
+    }
+    request = Request(scope)
+    reached_route = False
+
+    async def call_next(_request: Request):
+        nonlocal reached_route
+        reached_route = True
+        return JSONResponse({"detail": "peer verifier owns this request"}, status_code=401)
+
+    response = asyncio.run(gated_auth_middleware(request, call_next))
+
+    assert reached_route is True
+    assert response.status_code == 401

--- a/tests/hermes_cli/test_peer_message_dashboard_auth.py
+++ b/tests/hermes_cli/test_peer_message_dashboard_auth.py
@@ -29,6 +29,7 @@ def test_peer_message_uses_its_own_bearer_auth() -> None:
 
     async def call_next(_request: Request):
         nonlocal reached_route
+        assert _request.headers.get("authorization") == "Bearer opaque-peer-key"
         reached_route = True
         return JSONResponse({"detail": "peer verifier owns this request"}, status_code=401)
 


### PR DESCRIPTION
## What does this PR do?

Hosted agents with dashboard OAuth enabled currently reject peer-key message requests before the peer endpoint can authenticate them. This change lets `/api/v1/message` own its bearer-key verification, preventing valid peer traffic from failing with HTTP 503 `Auth provider 'nous' unreachable` before a turn starts.

### Symptom

A POST to `/api/v1/message` with a peer bearer key returns HTTP 503 with `{"detail":"Auth provider 'nous' unreachable"}` instead of reaching the peer-message handler.

### Impact

Peer and API messages cannot start turns on affected hosted agents. The reported SJC agents remained healthy and connected but could not process inbound work.

### Bug Cause

**Trigger:** `hermes_cli/dashboard_auth/public_paths.py:PUBLIC_API_PATHS` omits `/api/v1/message` while `gated_auth_middleware` treats every other bearer-bearing API request as a dashboard OAuth session.

**Causal chain:**
1. A hosted caller sends its opaque per-agent peer key to `/api/v1/message`.
2. The dashboard OAuth gate consumes that bearer before the independently authenticated peer route runs and asks the Nous session provider to parse it as an OAuth JWT.
3. The provider cannot parse the peer credential as a dashboard token, so the gate returns the misleading 503 and the message handler never runs.

**Why it is wrong:** The peer endpoint has its own bearer credential and verifier. Dashboard session authentication must not preempt an independently authenticated service route.

**Working sibling / contrast:** `/api/cron/fire` already bypasses dashboard session auth so its route-owned NAS JWT verifier remains the security boundary.

**Ruled out:** The live agent's public `/api/status` reported `nous_session_valid: valid`, and the Portal JWKS endpoint returned HTTP 200. An arbitrary opaque bearer reproduced the same 503, showing that the failure is credential misrouting rather than an inference or Portal availability outage.

### Fix

Add the peer-message endpoint to the shared public-path bypass used by both dashboard auth middlewares. The endpoint remains protected by its own peer-key verifier; only the unrelated dashboard OAuth layer is bypassed. A regression test proves an opaque peer bearer reaches the downstream route under an engaged OAuth gate.

## Related Issue

Closes #94558

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/public_paths.py` - route peer-message ingress to its own bearer verifier.
- `tests/hermes_cli/test_peer_message_dashboard_auth.py` - verify the OAuth gate does not consume peer credentials.

## How to Test

1. Send an opaque bearer to the affected hosted endpoint before the fix and observe the dashboard-auth 503.
2. Run the focused dashboard-auth tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_peer_message_dashboard_auth.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_cron_fire_dashboard.py -q
```

3. Confirm all 48 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant inline documentation is updated
- [x] Config example changes are not applicable
- [x] Architecture guide changes are not applicable
- [x] Cross-platform impact was considered; the path-routing behavior is platform-independent
- [x] Tool description and schema changes are not applicable

## Screenshots / Logs

Not applicable; the focused regression suite passes 48 tests.
