### PR TITLE
fix(teams): request supported transcript content format

### DIFF
--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -334,7 +334,12 @@ async def download_transcript_text(
     with tempfile.NamedTemporaryFile(prefix="teams-transcript-", suffix=suffix, delete=False) as handle:
         destination = Path(handle.name)
     try:
-        await client.download_to_file(_transcript_download_path(meeting_ref, transcript), destination)
+        # Graph's transcript /content endpoint rejects JSON content negotiation.
+        await client.download_to_file(
+            _transcript_download_path(meeting_ref, transcript),
+            destination,
+            headers={"Accept": "text/vtt"},
+        )
         text = destination.read_text(encoding=encoding).strip()
     except MicrosoftGraphAPIError as exc:
         raise _wrap_graph_error(

--- a/tests/plugins/test_teams_pipeline_meetings.py
+++ b/tests/plugins/test_teams_pipeline_meetings.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from plugins.teams_pipeline.meetings import resolve_meeting_reference
+from plugins.teams_pipeline.meetings import (
+    download_transcript_text,
+    resolve_meeting_reference,
+)
+from plugins.teams_pipeline.models import MeetingArtifact, TeamsMeetingRef
 
 
 class FakeGraphClient:
@@ -31,5 +37,41 @@ async def test_join_url_can_use_organizer_scoped_graph_lookup():
         (
             "/users/organizer-1/onlineMeetings",
             {"$filter": "JoinWebUrl eq 'https://teams.microsoft.com/meet/code'"},
+        )
+    ]
+
+
+@pytest.mark.anyio
+async def test_transcript_download_requests_graph_vtt_content():
+    class FakeDownloadClient:
+        def __init__(self):
+            self.calls = []
+
+        async def download_to_file(self, path, destination, *, headers=None):
+            self.calls.append((path, headers))
+            Path(destination).write_text(
+                "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n<v Speaker>Hello</v>\n",
+                encoding="utf-8",
+            )
+            return {"content_type": "text/vtt"}
+
+    client = FakeDownloadClient()
+    meeting = TeamsMeetingRef(
+        meeting_id="meeting-1",
+        organizer_user_id="organizer-1",
+    )
+    transcript = MeetingArtifact(
+        artifact_type="transcript",
+        artifact_id="transcript-1",
+        display_name="transcript.vtt",
+    )
+
+    text = await download_transcript_text(client, meeting, transcript)
+
+    assert text.startswith("WEBVTT")
+    assert client.calls == [
+        (
+            "/users/organizer-1/onlineMeetings/meeting-1/transcripts/transcript-1/content",
+            {"Accept": "text/vtt"},
         )
     ]

--- a/tests/tools/test_microsoft_graph_client.py
+++ b/tests/tools/test_microsoft_graph_client.py
@@ -76,6 +76,30 @@ class TestMicrosoftGraphClient:
         assert len(calls) == 2
         assert sleeps == [3.0]
 
+    async def test_download_accepts_stream_content_by_default(self, tmp_path: Path):
+        captured_accept: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_accept.append(request.headers["Accept"])
+            return httpx.Response(
+                200,
+                content=b"recording-bytes",
+                headers={"content-type": "video/mp4"},
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+        destination = tmp_path / "recording.mp4"
+
+        result = await client.download_to_file(
+            "/recordings/recording-1/content", destination
+        )
+
+        assert captured_accept == ["*/*"]
+        assert destination.read_bytes() == b"recording-bytes"
+        assert result["content_type"] == "video/mp4"
 
     async def test_invalid_json_response_raises_client_error(self):
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tools/microsoft_graph_client.py
+++ b/tools/microsoft_graph_client.py
@@ -181,7 +181,7 @@ class MicrosoftGraphClient:
             )
             request_headers = {
                 "Authorization": f"Bearer {token}",
-                "Accept": "application/json",
+                "Accept": "*/*",
                 "User-Agent": self.user_agent,
             }
             if headers:


### PR DESCRIPTION
## Summary
Teams meeting transcript downloads succeed by sending the correct Accept header — Graph /content endpoints reject `application/json`, so the shared Graph downloader default is now `*/*` and transcript retrieval explicitly requests `text/vtt`.

Root cause: `download_to_file` hardcoded `Accept: application/json` for all Graph downloads. Microsoft Graph's transcript `/content` endpoints reject JSON content negotiation with `400 BadRequest: Invalid format 'application/json' specified`. The Teams pipeline could resolve a transcript metadata object but then fail its content download.

Salvage of #94567 by @helix4u — cherry-picked with authorship preserved.

## Changes
- `tools/microsoft_graph_client.py`: `download_to_file` default Accept `application/json` → `*/*` (streaming downloads are binary, not JSON)
- `plugins/teams_pipeline/meetings.py`: `download_transcript_text` passes `headers={"Accept": "text/vtt"}`
- 2 regression tests: default Accept behavior + transcript VTT header verification

## Validation
| | Before | After |
|---|---|---|
| Transcript download | 400 BadRequest | text/vtt content |
| Recording download | Sent application/json (wrong for video) | Sends */* (correct) |
| JSON API endpoints | application/json | application/json (unchanged) |
| Targeted tests (31) | — | 31 passed |

Closes #94567
