### PR TITLE
fix(title): preserve profile scope in background generation

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Optional
 from agent.auxiliary_client import call_llm
 from agent.context_compressor import LEGACY_SUMMARY_PREFIX
 from agent.message_content import flatten_message_text
+from tools.thread_context import propagate_context_to_thread
 
 logger = logging.getLogger(__name__)
 
@@ -438,7 +439,7 @@ def maybe_auto_title(
         return
     apply_instant_title(session_db, session_id, user_message, title_callback)
     threading.Thread(
-        target=auto_title_session,
+        target=propagate_context_to_thread(auto_title_session),
         args=(session_db, session_id, user_message),
         kwargs=dict(failure_callback=failure_callback, main_runtime=main_runtime, title_callback=title_callback, runtime_validator=runtime_validator),
         daemon=True,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -291,6 +291,38 @@ class TestMaybeAutoTitle:
                 runtime_validator=None,
             )
 
+    def test_background_thread_preserves_profile_secret_scope(self):
+        """The title LLM must resolve credentials from the originating profile."""
+        import threading
+
+        from agent.secret_scope import (
+            current_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        called = threading.Event()
+        seen = []
+
+        def capture_scope(*_args, **_kwargs):
+            seen.append(current_secret_scope())
+            called.set()
+
+        token = set_secret_scope({"FREEMODEL_API_KEY": "profile-key"})
+        try:
+            with patch(
+                "agent.title_generator.auto_title_session",
+                side_effect=capture_scope,
+            ):
+                maybe_auto_title(db, "sess-1", "hello", [])
+                assert called.wait(timeout=10), "auto-title thread never ran"
+        finally:
+            reset_secret_scope(token)
+
+        assert seen == [{"FREEMODEL_API_KEY": "profile-key"}]
+
     def test_writes_instant_title_before_the_model_runs(self, tmp_path):
         """The derived title lands synchronously — no LLM, no waiting."""
         db = SessionDB(tmp_path / "state.db")


### PR DESCRIPTION
## Problem

`maybe_auto_title()` starts title generation in a new `threading.Thread`. Python threads do not inherit `ContextVar` state, so profile-scoped credentials can disappear and the title request can resolve against the wrong/default scope.

## Fix

Wrap the background title target with the existing `propagate_context_to_thread()` helper.

## Tests

- `python -m pytest tests/agent/test_title_generator.py -q -o addopts=` — 37 passed
- `python -m py_compile agent/title_generator.py tests/agent/test_title_generator.py`
- `git diff --check`

## Risk

Low. The thread lifecycle and title-generation behavior are unchanged; only the caller context is copied into the worker.