### PR TITLE
fix(gateway): give goal kickoff a distinct lifecycle

### DIFF
--- a/gateway/slash_commands_goals.py
+++ b/gateway/slash_commands_goals.py
@@ -62,7 +62,12 @@ class GatewayGoalCommandsMixin:
         if result.clear_pending:
             self._clear_goal_continuations(event, result.clear_pending)
         if result.prompt:
-            self._enqueue_goal_turn(event, result.prompt, label="command enqueue", kickoff=result.kickoff)
+            prompt = (
+                mgr.next_continuation_prompt() or result.prompt
+                if result.kickoff
+                else result.prompt
+            )
+            self._enqueue_goal_turn(event, prompt, label="command enqueue", kickoff=result.kickoff)
         return result.output
 
     def _clear_goal_continuations(self, event: MessageEvent, verb: str) -> None:
@@ -78,8 +83,8 @@ class GatewayGoalCommandsMixin:
     ) -> None:
         """Enqueue *text* as the next turn through the adapter FIFO (the post-turn judge's path).
 
-        A kickoff keeps the triggering message id / channel prompt; a resume continuation carries
-        none. Best-effort: failures only logged.
+        A kickoff is a distinct internal lifecycle; neither kickoff nor resume reuses the
+        triggering message id/channel prompt. Best-effort: failures only logged.
         """
         try:
             adapter, quick_key = self._adapter_and_key_for(event)
@@ -88,8 +93,9 @@ class GatewayGoalCommandsMixin:
                     text=text,
                     message_type=MessageType.TEXT,
                     source=event.source,
-                    message_id=event.message_id if kickoff else None,
-                    channel_prompt=event.channel_prompt if kickoff else None,
+                    message_id=None,
+                    channel_prompt=None,
+                    internal=kickoff,
                 )
                 self._enqueue_fifo(quick_key, turn, adapter)
         except Exception as exc:

--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -205,3 +205,71 @@ async def test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains(hermes_
     assert adapter._pending_messages[adapter_key].text.startswith(
         "[Continuing toward your standing goal]"
     )
+
+
+@pytest.mark.asyncio
+async def test_idle_goal_command_drains_distinct_kickoff_without_user_nudge(hermes_home):
+    """The kickoff must not alias the slash-command ledger identity."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+    import uuid
+
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionEntry
+
+    src = _slack_thread_source()
+    key = build_session_key(src)
+    session_entry = SessionEntry(
+        session_key=key,
+        session_id=f"goal-idle-{uuid.uuid4().hex[:8]}",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="channel",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="x")},
+    )
+    runner._queued_events = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store._generate_session_key.return_value = key
+    adapter = _DrainProbeAdapter()
+    runner.adapters = {Platform.SLACK: adapter}
+
+    platform_ids: set[str] = set()
+    agent_turns: list[MessageEvent] = []
+
+    async def handler(event):
+        if event.message_id:
+            if event.message_id in platform_ids:
+                return None
+            platform_ids.add(event.message_id)
+        if event.get_command() == "goal":
+            return await runner._handle_goal_command(event)
+        agent_turns.append(event)
+        return "goal work started"
+
+    adapter.set_message_handler(handler)
+    await adapter.handle_message(
+        MessageEvent(
+            text="/goal finish this without another message",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="cmd-idle-goal",
+        )
+    )
+    for _ in range(60):
+        if agent_turns and len(adapter.sent) >= 2:
+            break
+        await asyncio.sleep(0.05)
+
+    assert len(agent_turns) == 1
+    assert agent_turns[0].internal is True
+    assert agent_turns[0].message_id is None
+    assert agent_turns[0].channel_prompt is None
+    assert agent_turns[0].text.startswith("[Continuing toward your standing goal]")
+    assert adapter.sent[0].startswith("⊙ Goal set")
+    assert adapter.sent[1] == "goal work started"


### PR DESCRIPTION
## Problem

The synthetic first turn queued by `/goal` reuses the slash command message ID and channel prompt. Platform-ledger deduplication can therefore classify the kickoff as the already-processed command, leaving the goal active without starting work until another user message arrives.

## Fix

Queue the canonical goal continuation as an internal event with no platform message ID or inherited channel prompt. The kickoff is now a separate inbound lifecycle from the command that created it.

## Tests

- `python -m pytest tests/gateway/test_goal_continuation_drain.py tests/gateway/test_goal_max_turns_config.py -q -o addopts=` — 5 passed
- End-to-end regression covers command-ledger dedup and proves the kickoff drains without a user nudge
- `python -m py_compile gateway/slash_commands.py tests/gateway/test_goal_continuation_drain.py`
- `git diff --check`

## Risk

Low. Existing FIFO delivery remains the owner; only synthetic-event provenance and canonical continuation text change.