### PR TITLE
fix(mcp): _stdio_children_dead returns True for live children — all stdio MCP servers fail after 786f37071

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,7 +2994,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## What

Commit 786f37071 ("psutil.pid_exists for stdio children liveness") inverted the return value of `MCPServerTask._stdio_children_dead()` in `tools/mcp_tool.py`. The docstring contract is *"True when every stdio child we spawned has exited"*, but the new code returns `True` when a child pid **exists** — i.e. when the server is alive and healthy.

## Why it matters

The caller treats `True` as "children are dead" and fails fast, so **every stdio MCP server fails 100% of calls** with:

```
MCP stdio subprocess for '<name>' has exited; failing the call fast instead of waiting 180s
```

while the actual subprocesses spawn and run fine (they start, log, and sit idle — the client just never talks to them). HTTP transports are unaffected. The inversion slipped through partly because the patched loop left an unreachable `return False  # at least one child alive` line below the new early return — this PR removes that dead line, restoring the original semantics: a live pid → `False` (not all dead).

## How to test

1. Configure any stdio `mcp_servers` entry (e.g. `command: qmd, args: [mcp]` or any npx-based server).
2. On main @ 4c1f53be1, call any of its tools → immediate "has exited" error (~0.01s), every call. Spawning the identical command with the identical env standalone works.
3. With this fix, calls succeed again.

Verified on a live multi-profile install (3 stdio servers across 5 profiles): 100% failure before, all serving after, gateway restart only.

## Platforms

Tested on macOS (darwin arm64), v0.20.5, mcp SDK 2.0.0. The `psutil.pid_exists` probe from 786f37071 is retained, so the Windows liveness intent of that commit is preserved — only the inverted return is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)