### PR TITLE
fix(cli): accept custom models without catalog listings

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6570,7 +6570,7 @@ def validate_requested_model(
             message += f"\n  If this server expects `/v1`, try base URL: `{probe.get('suggested_base_url')}`"
 
         return {
-            "accepted": api_mode == "anthropic_messages",
+            "accepted": api_mode in ("chat_completions", "anthropic_messages"),
             "persist": True,
             "recognized": False,
             "message": message,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6566,6 +6566,12 @@ def validate_requested_model(
                 "\n  Many Anthropic-compatible proxies do not implement the Models API "
                 "(GET /v1/models).  The model name has been accepted without verification."
             )
+        if api_mode == "chat_completions":
+            message += (
+                "\n  The model name was accepted without verification — inference may fail "
+                "if this provider does not serve it.  Check the provider's model catalog "
+                "or model name."
+            )
         if probe.get("suggested_base_url"):
             message += f"\n  If this server expects `/v1`, try base URL: `{probe.get('suggested_base_url')}`"
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -675,3 +675,131 @@ class TestValidateOpenRouterVariantSuffixes:
         assert result["accepted"] is True
         assert result["recognized"] is True
         assert result.get("corrected_model") is None
+
+
+# -- validate — custom endpoint fallback when /models is unreachable (#12220) --
+
+class TestValidateCustomUnreachableFallback:
+    """Issue #12220: when a custom endpoint's /models probe returns None
+    (unreachable or not implemented), accept the requested model for
+    chat_completions exactly as the anthropic_messages fallback already
+    does — rejecting it bricks `/model` switches in the gateway for any
+    custom proxy that doesn't expose a /models listing."""
+
+    def _probe(self, models=None, suggested_base_url=None):
+        return {
+            "models": models,
+            "probed_url": "http://localhost:8000/v1/models",
+            "resolved_base_url": "http://localhost:8000/v1",
+            "suggested_base_url": suggested_base_url,
+            "used_fallback": False,
+        }
+
+    def _validate(self, model, provider, probe, **kw):
+        with patch("hermes_cli.models.probe_api_models", return_value=probe):
+            return validate_requested_model(
+                model,
+                provider,
+                api_key="test-key",
+                base_url="http://localhost:8000/v1",
+                **kw,
+            )
+
+    def test_bare_custom_chat_completions_accepted_when_unreachable(self):
+        result = self._validate(
+            "my-proxy-model", "custom", api_mode="chat_completions",
+            probe=self._probe(None),
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "could not reach" in result["message"]
+
+    def test_named_custom_chat_completions_accepted_when_unreachable(self):
+        result = self._validate(
+            "my-proxy-model", "custom:myproxy", api_mode="chat_completions",
+            probe=self._probe(None),
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "could not reach" in result["message"]
+
+    def test_unreachable_warning_includes_suggested_base_url_hint(self):
+        result = self._validate(
+            "my-proxy-model", "custom", api_mode="chat_completions",
+            probe=self._probe(None, suggested_base_url="http://localhost:8000"),
+        )
+        assert result["accepted"] is True
+        assert "If this server expects `/v1`" in result["message"]
+
+    def test_anthropic_messages_fallback_unchanged(self):
+        result = self._validate(
+            "claude-model", "custom", api_mode="anthropic_messages",
+            probe=self._probe(None),
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "Anthropic-compatible proxies" in result["message"]
+
+    def test_valid_catalog_exact_match_unchanged(self):
+        result = self._validate(
+            "my-model", "custom", api_mode="chat_completions",
+            probe=self._probe(["my-model", "other-model"]),
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_valid_catalog_unknown_model_unchanged(self):
+        result = self._validate(
+            "totally-unrelated", "custom", api_mode="chat_completions",
+            probe=self._probe(["my-model", "other-model"]),
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert result.get("corrected_model") is None
+        assert "was not found" in result["message"]
+        assert "Similar models" not in result["message"]
+
+    def test_valid_catalog_close_match_autocorrected(self):
+        result = self._validate(
+            "my-modelx", "custom", api_mode="chat_completions",
+            probe=self._probe(["my-model", "other-model"]),
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result["corrected_model"] == "my-model"
+        assert "Auto-corrected" in result["message"]
+
+    def test_empty_and_whitespace_unchanged(self):
+        empty = self._validate(
+            "", "custom", api_mode="chat_completions", probe=self._probe(None)
+        )
+        assert empty["accepted"] is False
+        assert "empty" in empty["message"]
+
+        spaced = self._validate(
+            "my model", "custom", api_mode="chat_completions", probe=self._probe(None)
+        )
+        assert spaced["accepted"] is False
+        assert "spaces" in spaced["message"]
+
+    def test_whitespace_only_model_rejected_and_not_persisted(self):
+        result = self._validate(
+            "   ", "custom", api_mode="chat_completions", probe=self._probe(None)
+        )
+        assert result["accepted"] is False
+        assert result["persist"] is False
+        assert "empty" in result["message"]
+
+    @pytest.mark.parametrize("api_mode", [None, "codex_responses"])
+    def test_unreachable_rejects_unsupported_api_mode(self, api_mode):
+        result = self._validate(
+            "my-proxy-model", "custom", api_mode=api_mode,
+            probe=self._probe(None),
+        )
+        assert result["accepted"] is False
+        assert result["recognized"] is False

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -714,6 +714,9 @@ class TestValidateCustomUnreachableFallback:
         assert result["persist"] is True
         assert result["recognized"] is False
         assert "could not reach" in result["message"]
+        assert "accepted without verification" in result["message"]
+        assert "inference may fail" in result["message"]
+        assert "provider's model catalog" in result["message"]
 
     def test_named_custom_chat_completions_accepted_when_unreachable(self):
         result = self._validate(
@@ -724,6 +727,9 @@ class TestValidateCustomUnreachableFallback:
         assert result["persist"] is True
         assert result["recognized"] is False
         assert "could not reach" in result["message"]
+        assert "accepted without verification" in result["message"]
+        assert "inference may fail" in result["message"]
+        assert "provider's model catalog" in result["message"]
 
     def test_unreachable_warning_includes_suggested_base_url_hint(self):
         result = self._validate(
@@ -732,6 +738,9 @@ class TestValidateCustomUnreachableFallback:
         )
         assert result["accepted"] is True
         assert "If this server expects `/v1`" in result["message"]
+        assert "accepted without verification" in result["message"]
+        assert "inference may fail" in result["message"]
+        assert "provider's model catalog" in result["message"]
 
     def test_anthropic_messages_fallback_unchanged(self):
         result = self._validate(


### PR DESCRIPTION
## What does this PR do?

Custom OpenAI-compatible endpoints can serve `/chat/completions` without exposing a usable `/models` catalog. In that case, the validator already warned that Hermes would save the requested model, but `chat_completions` returned `accepted: false` and the model switch stopped.

This change makes that fallback consistent with its warning: explicitly requested models are accepted and persisted as unverified when a custom endpoint catalog cannot be reached. The warning now states that the model name was accepted without verification, inference may fail, and the user should check the provider catalog or model name. Authoritative validation remains unchanged whenever a valid catalog is available.

## Related Issue

Fixes #12220

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Accept unreachable custom-provider catalogs for `chat_completions`, matching the existing verified warning and persistence contract.
- Explicitly warn that the model was accepted without verification, inference may fail, and the provider catalog or model name should be checked.
- Keep missing or unsupported API modes rejected.
- Add regressions for bare and named custom providers, URL hints, catalog matches and misses, correction behavior, invalid input, and the unverified-model warning.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py -q`.
2. Run `python3 -m ruff check hermes_cli/models.py tests/hermes_cli/test_model_validation.py`.
3. Configure a custom `chat_completions` endpoint whose `/models` route returns 404, then switch to a non-empty model with `/model`; the switch should persist with an explicit unverified warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

Focused result: 56 tests passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The change is covered by deterministic unit tests with the model-catalog probe mocked.
