### PR TITLE
fix(memory): rebuild tool routing after provider initialize

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1239,3 +1239,69 @@ class MemoryManager:
                     "Memory provider '%s' initialize failed: %s",
                     provider.name, e,
                 )
+        # Rebuild tool routing table after initialization — providers may
+        # report different schemas after initialize() (e.g. Cortext sets
+        # _available=True).  Without this, tools injected via
+        # inject_memory_provider_tools() are visible in the tool surface but
+        # unroutable in handle_tool_call(), causing "Unknown tool" errors.
+        self._reindex_tool_routing()
+        logger.debug(
+            "Memory tool routing reindexed after init: %s",
+            sorted(self._tool_to_provider),
+        )
+
+    def _reindex_tool_routing(self) -> None:
+        """Rebuild _tool_to_provider from all providers' current schemas.
+
+        Called after initialize_all() so that providers whose
+        get_tool_schemas() returned [] before initialize() (because
+        _available was False) get their tools into the routing table.
+
+        This is a full rebuild, not an additive update: providers that
+        *remove* tools during initialize() have their stale routes cleared.
+        Core tool names are still respected — a provider can never shadow
+        a built-in.  First-provider-wins on name conflicts, matching
+        add_provider() semantics.
+
+        Init-time only; the dict swap is atomic under CPython so concurrent
+        readers of _tool_to_provider see either the old or new table, never
+        a partially-built one.
+        """
+        from toolsets import _HERMES_CORE_TOOLS
+
+        _core_tool_names = set(_HERMES_CORE_TOOLS)
+        new_routing: Dict[str, Any] = {}
+        for provider in self._providers:
+            try:
+                for raw_schema in provider.get_tool_schemas():
+                    schema = normalize_tool_schema(raw_schema)
+                    if schema is None:
+                        continue
+                    tool_name = schema["name"]
+                    if tool_name in _core_tool_names:
+                        logger.warning(
+                            "Memory provider '%s' tool '%s' shadows a "
+                            "reserved core tool name; skipped during reindex.",
+                            provider.name, tool_name,
+                        )
+                        continue
+                    if not tool_name:
+                        continue
+                    if tool_name in new_routing:
+                        logger.warning(
+                            "Memory tool name conflict during reindex: '%s' "
+                            "already routed to %s, ignoring from %s",
+                            tool_name,
+                            new_routing[tool_name].name,
+                            provider.name,
+                        )
+                        continue
+                    new_routing[tool_name] = provider
+            except Exception as exc:
+                logger.warning(
+                    "Memory provider '%s' get_tool_schemas() failed during "
+                    "reindex: %s",
+                    provider.name, exc,
+                )
+                continue
+        self._tool_to_provider = new_routing

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1158,3 +1158,128 @@ class TestTrivialPromptClassifier:
                   "hello world", "ok so what's next", "what's my name",
                   "hey can you check the logs", "continue the migration plan"):
             assert not is_trivial_prompt(t), f"expected non-trivial: {t!r}"
+
+
+# ---------------------------------------------------------------------------
+# Routing reindex after initialize_all() — regression tests
+# ---------------------------------------------------------------------------
+
+
+class DeferredSchemaProvider(FakeMemoryProvider):
+    """Provider whose schemas appear only after initialize()."""
+
+    def __init__(self, name="deferred", tools_after_init=None):
+        super().__init__(name=name, available=True, tools=[])
+        self._tools_after_init = tools_after_init or [
+            {"name": "late_tool", "description": "Appears after init",
+             "parameters": {"type": "object", "properties": {}}},
+        ]
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized = True
+        self._tools = list(self._tools_after_init)
+
+
+class ShrinkingSchemaProvider(FakeMemoryProvider):
+    """Provider that removes all tools during initialize()."""
+
+    def __init__(self, name="shrinking"):
+        super().__init__(name=name, available=True, tools=[
+            {"name": "early_tool", "description": "Goes away after init",
+             "parameters": {"type": "object", "properties": {}}},
+        ])
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized = True
+        self._tools = []
+
+
+class GeneratorBoomProvider(FakeMemoryProvider):
+    """Provider whose get_tool_schemas() yields then raises mid-iteration."""
+
+    def __init__(self, name="boom"):
+        super().__init__(name=name, available=True, tools=[])
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized = True
+
+    def get_tool_schemas(self):
+        yield {"name": "before_boom", "description": "partial",
+               "parameters": {"type": "object", "properties": {}}}
+        raise RuntimeError("iteration boom")
+
+
+class TestRoutingReindex:
+    """Regression: tools advertised after initialize() must be routable."""
+
+    def test_deferred_schemas_become_routable(self):
+        """Provider whose schemas appear only after initialize() must
+        have its tools in the routing table after initialize_all().
+        """
+        mgr = MemoryManager()
+        p = DeferredSchemaProvider()
+        mgr.add_provider(p)
+        # Before init: no tools in routing table
+        assert not mgr.has_tool("late_tool")
+        mgr.initialize_all("test-session")
+        assert mgr.has_tool("late_tool")
+        result = mgr.handle_tool_call("late_tool", {})
+        assert json.loads(result)["handled"] == "late_tool"
+
+    def test_stale_routes_removed_after_rebuild(self):
+        """Provider that removes tools during initialize() must not
+        leave stale routes in the routing table.
+        """
+        mgr = MemoryManager()
+        p = ShrinkingSchemaProvider()
+        mgr.add_provider(p)
+        # Before init: early_tool is routed
+        assert mgr.has_tool("early_tool")
+        mgr.initialize_all("test-session")
+        # After init: early_tool must be gone (true rebuild, not additive)
+        assert not mgr.has_tool("early_tool")
+
+    def test_generator_exception_does_not_crash_reindex(self):
+        """A provider whose get_tool_schemas() raises mid-iteration must
+        not crash _reindex_tool_routing; other providers remain routable.
+        """
+        mgr = MemoryManager()
+        good = FakeMemoryProvider(
+            "good", tools=[{"name": "good_tool", "description": "ok",
+                            "parameters": {}}]
+        )
+        boom = GeneratorBoomProvider()
+        mgr.add_provider(good)
+        mgr.add_provider(boom)
+        mgr.initialize_all("test-session")
+        # good_tool must still be routable despite boom's failure
+        assert mgr.has_tool("good_tool")
+
+    def test_core_tool_shadowing_still_enforced(self):
+        """A provider that advertises a reserved core tool name after
+        initialize() must not shadow the built-in.
+        """
+        from toolsets import _HERMES_CORE_TOOLS
+        core_name = next(iter(_HERMES_CORE_TOOLS))
+        p = DeferredSchemaProvider(
+            tools_after_init=[{"name": core_name, "description": "shadow",
+                               "parameters": {}}]
+        )
+        mgr = MemoryManager()
+        mgr.add_provider(p)
+        mgr.initialize_all("test-session")
+        assert not mgr.has_tool(core_name)
+
+    def test_first_provider_wins_on_conflict(self):
+        """When two providers advertise the same tool name, the first
+        registered provider wins after reindex.
+        """
+        tool_schema = {"name": "shared", "description": "shared",
+                        "parameters": {}}
+        p1 = FakeMemoryProvider("first", tools=[tool_schema])
+        p2 = FakeMemoryProvider("second", tools=[tool_schema])
+        mgr = MemoryManager()
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+        mgr.initialize_all("test-session")
+        assert mgr._tool_to_provider["shared"] is p1


### PR DESCRIPTION
## Problem

External memory provider tools (e.g. `cortext_recall`, `cortext_remember`) are advertised to the model but return `Unknown tool` when called. This affects all gateway sessions (Signal, Discord, Telegram).

## Root Cause

`MemoryManager.add_provider()` builds the `_tool_to_provider` routing table from `provider.get_tool_schemas()` at registration time. However, providers whose `get_tool_schemas()` returns `[]` before `initialize()` (because `_available` is `False` until the binary/DB is verified) never get their tools into the routing table.

Later, `inject_memory_provider_tools()` calls `get_all_tool_schemas()` which returns the schemas (since `_available` is now `True`), so the tools appear in `agent.tools`. But `handle_tool_call()` looks up `_tool_to_provider` — which is still empty — and returns `Unknown tool`.

The execution order in `agent_init.py`:
1. `add_provider()` — builds routing table (empty, schemas not yet available)
2. `initialize_all()` — sets `_available = True`
3. `inject_memory_provider_tools()` — injects schemas into tool surface
4. `handle_tool_call()` — looks up routing table (still empty)

## Fix

Add `_reindex_tool_routing()` called at the end of `initialize_all()`. It does a **full rebuild** of `_tool_to_provider` from all providers' current schemas:

- Providers that gain tools during `initialize()` get their tools routed
- Providers that remove tools during `initialize()` have stale routes cleared
- Core tool shadowing is still enforced
- First-provider-wins on name conflicts (matching `add_provider()` semantics)
- Generator exceptions during schema iteration are caught per-provider
- The dict swap (`self._tool_to_provider = new_routing`) is atomic under CPython

## Tests

5 regression tests in `tests/agent/test_memory_provider.py`:

- `test_deferred_schemas_become_routable` — provider with empty schemas before init, tools after init
- `test_stale_routes_removed_after_rebuild` — provider that removes tools during init (true rebuild, not additive)
- `test_generator_exception_does_not_crash_reindex` — provider that raises mid-iteration, other providers remain routable
- `test_core_tool_shadowing_still_enforced` — reserved core tool names rejected during reindex
- `test_first_provider_wins_on_conflict` — duplicate tool names, first provider wins

All 63 existing tests in `test_memory_provider.py` still pass (no regressions).