### PR TITLE
fix(terminal): pass non-interactive sudo probes through instead of piping a password

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -75,6 +75,10 @@ def test_non_interactive_sudo_probe_passes_through_unchanged(monkeypatch):
         "sudo -n true",
         "sudo --non-interactive id",
         "sudo -nv true",
+        "sudo -u janet-admin -n id",
+        "sudo --user janet-admin --non-interactive id",
+        "sudo --user=janet-admin -n id",
+        "sudo -g wheel -n id",
     ):
         transformed, sudo_stdin = terminal_tool._transform_sudo_command(command)
         assert transformed == command
@@ -126,6 +130,39 @@ def test_sudo_flag_like_argument_of_child_command_is_not_non_interactive(monkeyp
     )
 
     assert transformed == "sudo -S -p '' rm -n /tmp/thing"
+    assert sudo_stdin == "testpass\n"
+
+
+def test_non_interactive_sudo_probe_with_option_values_keeps_scanning(monkeypatch):
+    """Option-order cases from #94534 review: an option whose value arrives
+    as a separate token (``-u janet-admin``, ``--user janet-admin``) must
+    not stop the flag scan — sudo still sees a later ``-n``, so the
+    invocation passes through verbatim. Without a ``-n`` the same shapes
+    take the normal rewrite, and the separate value is consumed verbatim
+    even when it looks like a flag (getopt takes the next argv element as
+    the option's argument)."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    for command in (
+        "sudo -u janet-admin -n id",
+        "sudo --user janet-admin --non-interactive id",
+        "sudo -u 'janet admin' -n id",
+    ):
+        transformed, sudo_stdin = terminal_tool._transform_sudo_command(command)
+        assert transformed == command
+        assert sudo_stdin is None
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo -u janet-admin id"
+    )
+    assert transformed == "sudo -S -p '' -u janet-admin id"
+    assert sudo_stdin == "testpass\n"
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo -u -n id"
+    )
+    assert transformed == "sudo -S -p '' -u -n id"
     assert sudo_stdin == "testpass\n"
 
 

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -62,6 +62,73 @@ def test_actual_sudo_command_uses_configured_password(monkeypatch):
     assert sudo_stdin == "testpass\n"
 
 
+def test_non_interactive_sudo_probe_passes_through_unchanged(monkeypatch):
+    """#94534: ``sudo -n`` means "fail immediately if a password would be
+    required" and never reads a piped password — rewriting it to
+    ``sudo -S -p '' -n`` makes the probe always fail with "a password is
+    required" even when one is configured, so the model concludes sudo is
+    broken. -n invocations must pass through with no prompt and no stdin."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    for command in (
+        "sudo -n true",
+        "sudo --non-interactive id",
+        "sudo -nv true",
+    ):
+        transformed, sudo_stdin = terminal_tool._transform_sudo_command(command)
+        assert transformed == command
+        assert sudo_stdin is None
+
+
+def test_non_interactive_sudo_probe_never_prompts_interactively(monkeypatch):
+    """Even with no configured password and an interactive UI available, a
+    ``-n`` probe must not trigger the 45s sudo password prompt (#94534)."""
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt must not run for a -n probe")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+    monkeypatch.setattr(
+        terminal_tool, "_sudo_nopasswd_works", lambda: False
+    )
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo -n true")
+
+    assert transformed == "sudo -n true"
+    assert sudo_stdin is None
+
+
+def test_compound_command_rewrites_only_non_n_sudo_invocations(monkeypatch):
+    """``sudo -n true && sudo apt update`` keeps the probe verbatim while the
+    real invocation takes the normal password-pipe rewrite (#94534)."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo -n true && sudo apt update"
+    )
+
+    assert transformed == "sudo -n true && sudo -S -p '' apt update"
+    assert sudo_stdin == "testpass\n"
+
+
+def test_sudo_flag_like_argument_of_child_command_is_not_non_interactive(monkeypatch):
+    """``-n`` belonging to the command sudo runs, not to sudo itself, must
+    not disable the rewrite."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo rm -n /tmp/thing"
+    )
+
+    assert transformed == "sudo -S -p '' rm -n /tmp/thing"
+    assert sudo_stdin == "testpass\n"
+
+
 def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
     monkeypatch.setenv("SUDO_PASSWORD", "")
     monkeypatch.setenv("HERMES_INTERACTIVE", "1")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -706,6 +706,22 @@ _SUDO_NON_INTERACTIVE_FLAGS = {"-n", "--non-interactive"}
 # ``-nv`` without misreading option+argument shapes (``-un root`` is
 # ``-u`` with user ``n``, not a non-interactive cluster).
 _SUDO_NO_ARG_SHORT_FLAGS = "nvkKlVeisbhEP"
+# sudo options whose value arrives as a separate token; the value is
+# consumed verbatim (even when it looks like a flag) so scanning reaches
+# a later ``-n``: ``sudo -u janet-admin -n id``.
+_SUDO_ARG_SHORT_FLAGS = "CcgpRrTtUu"
+_SUDO_ARG_LONG_FLAGS = {
+    "--close-from",
+    "--command-timeout",
+    "--group",
+    "--login-class",
+    "--other-user",
+    "--prompt",
+    "--restart-timeout",
+    "--role",
+    "--type",
+    "--user",
+}
 
 
 def _sudo_invocation_is_non_interactive(command: str, start: int) -> bool:
@@ -715,11 +731,15 @@ def _sudo_invocation_is_non_interactive(command: str, start: int) -> bool:
     (without consuming them) and reports whether one asks sudo to fail
     immediately instead of prompting: ``-n`` / ``--non-interactive``, or a
     merged argument-less short cluster containing ``n`` (e.g. ``-nv``).
-    Stops at the first non-flag token (the command sudo would run), at
-    ``--`` (end of sudo options), or at a shell/line separator.
+    An option whose value comes as a separate token (``-u janet-admin``,
+    ``--user janet-admin``) consumes that token, so scanning continues at
+    the following flag instead of stopping at the value. Stops at the
+    first non-flag token (the command sudo would run), at ``--`` (end of
+    sudo options), or at a shell/line separator.
     """
     i = start
     n = len(command)
+    skip_value = False
     while i < n:
         ch = command[i]
         if ch.isspace():
@@ -730,18 +750,29 @@ def _sudo_invocation_is_non_interactive(command: str, start: int) -> bool:
         if ch in ";|&()":
             return False
         token, next_i = _read_shell_token(command, i)
+        if skip_value:
+            skip_value = False
+            i = next_i
+            continue
         if token == "--":
             return False
         if token.startswith("-"):
             if token in _SUDO_NON_INTERACTIVE_FLAGS:
                 return True
-            body = token[1:]
-            if (
-                len(body) > 1
-                and "n" in body
-                and all(c in _SUDO_NO_ARG_SHORT_FLAGS for c in body)
-            ):
-                return True
+            if token in _SUDO_ARG_LONG_FLAGS:
+                skip_value = True
+            elif not token.startswith("--"):
+                body = token[1:]
+                for pos, c in enumerate(body):
+                    if c == "n":
+                        return True
+                    if c not in _SUDO_NO_ARG_SHORT_FLAGS:
+                        # An argument-taking flag ends the flag part: the
+                        # rest of the cluster is its value (``-un`` is
+                        # user ``n``); a trailing one takes the next token.
+                        if c in _SUDO_ARG_SHORT_FLAGS and pos == len(body) - 1:
+                            skip_value = True
+                        break
         else:
             return False
         i = next_i

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -701,6 +701,53 @@ def _read_shell_token(command: str, start: int) -> tuple[str, int]:
     return command[start:i], i
 
 
+_SUDO_NON_INTERACTIVE_FLAGS = {"-n", "--non-interactive"}
+# Argument-less sudo short options, used to accept merged clusters like
+# ``-nv`` without misreading option+argument shapes (``-un root`` is
+# ``-u`` with user ``n``, not a non-interactive cluster).
+_SUDO_NO_ARG_SHORT_FLAGS = "nvkKlVeisbhEP"
+
+
+def _sudo_invocation_is_non_interactive(command: str, start: int) -> bool:
+    """Whether the sudo invocation whose options begin at *start* uses -n.
+
+    Peeks the flag tokens directly following the ``sudo`` command word
+    (without consuming them) and reports whether one asks sudo to fail
+    immediately instead of prompting: ``-n`` / ``--non-interactive``, or a
+    merged argument-less short cluster containing ``n`` (e.g. ``-nv``).
+    Stops at the first non-flag token (the command sudo would run), at
+    ``--`` (end of sudo options), or at a shell/line separator.
+    """
+    i = start
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch.isspace():
+            if ch == "\n":
+                return False
+            i += 1
+            continue
+        if ch in ";|&()":
+            return False
+        token, next_i = _read_shell_token(command, i)
+        if token == "--":
+            return False
+        if token.startswith("-"):
+            if token in _SUDO_NON_INTERACTIVE_FLAGS:
+                return True
+            body = token[1:]
+            if (
+                len(body) > 1
+                and "n" in body
+                and all(c in _SUDO_NO_ARG_SHORT_FLAGS for c in body)
+            ):
+                return True
+        else:
+            return False
+        i = next_i
+    return False
+
+
 def _rewrite_real_sudo_invocations(command: str) -> tuple[str, int]:
     """Rewrite only real unquoted sudo command words, not plain text mentions.
 
@@ -751,8 +798,19 @@ def _rewrite_real_sudo_invocations(command: str) -> tuple[str, int]:
 
         token, next_i = _read_shell_token(command, i)
         if command_start and token == "sudo":
-            out.append("sudo -S -p ''")
-            sudo_count += 1
+            if _sudo_invocation_is_non_interactive(command, next_i):
+                # ``sudo -n`` means "fail immediately if a password would
+                # be required" — it never reads a piped password, so the
+                # ``-S`` rewrite + stdin injection destroys the probe's
+                # meaning (``sudo -S -p '' -n true`` always fails with
+                # "a password is required", making the model conclude sudo
+                # is broken). Pass -n invocations through verbatim; the
+                # model can retry the real command without -n, which then
+                # takes the normal prompt/inject path (#94534).
+                out.append(token)
+            else:
+                out.append("sudo -S -p ''")
+                sudo_count += 1
         else:
             out.append(token)
 


### PR DESCRIPTION
## What does this PR do?

`_rewrite_real_sudo_invocations` rewrote **every** command-position `sudo` word to `sudo -S -p ''` and counted it for password-line injection — including model-authored non-interactive probes. `sudo -n` means "fail immediately if a password would be required" and never reads a piped password, so the rewritten `sudo -S -p '' -n true` always fails with `sudo: a password is required` (even with `SUDO_PASSWORD` configured), making the model conclude sudo is broken when a plain `sudo apt update` would have worked. The Hermes-side 45s password prompt was also wasted on a probe whose entire meaning is "do not prompt" (#94534).

The fix peeks the flag tokens directly following each `sudo` command word: when the invocation opts into non-interactive mode (`-n` / `--non-interactive`, or an argument-less short cluster containing `n` such as `-nv`), it is kept verbatim and excluded from the injection count. Compound commands rewrite only their non-`-n` invocations — `sudo -n true && sudo apt update` keeps the probe intact while `sudo apt update` still takes the normal password-pipe path. With `sudo_count` reaching zero for a pure `-n` command, the existing no-password fast path applies, so probes never prompt.

Merged-cluster detection uses an argument-less short-option alphabet so option+argument shapes are not misread (`-un root` is `-u` with user `n`, not a non-interactive cluster); a `-n` belonging to the command sudo runs (`sudo rm -n /tmp/thing`) is not treated as sudo's own flag because the peek stops at the first non-flag token.

## Related Issue

Fixes #94534

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` — new `_sudo_invocation_is_non_interactive()` peek helper (flags after the `sudo` word, up to the first non-flag token / `--` / shell separator); `_rewrite_real_sudo_invocations` keeps non-interactive invocations verbatim and skips their injection count.
- `tests/tools/test_terminal_tool.py` — four regressions: the three probe shapes from the issue pass through unchanged with no stdin; a `-n` probe never triggers the interactive prompt; a compound command rewrites only the non-`-n` invocation; a child-command `-n` does not disable the rewrite.

## How to Test

1. `pytest tests/tools/test_terminal_tool.py tests/tools/test_subagent_sudo_prompt.py tests/tools/test_terminal_none_command_guard.py -q` — should pass (23 passed).
2. Observed result: with the PR's source reverted (plain main) the new probe tests fail 3/4 — `sudo -n true` comes back as `sudo -S -p '' -n true` with `sudo_stdin` set to the configured password; with this change `transformed == "sudo -n true"` and `sudo_stdin is None`, and `sudo -n true && sudo apt update` → `sudo -n true && sudo -S -p '' apt update` with stdin only for the real invocation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Unit repro from the issue (against plain main, before this fix):

```python
transformed, sudo_stdin = tt._transform_sudo_command("sudo -n true")
# transformed == "sudo -S -p '' -n true"   ← -n refuses the piped password
# sudo_stdin == "hunter2\n"                ← the configured password never helps
```

After this fix the same call returns `("sudo -n true", None)`: the probe keeps sudo's own semantics, succeeding under NOPASSWD and failing with sudo's own `sudo: a password is required` otherwise, letting the model retry the real command without `-n`.
