### PR TITLE
fix(desktop): prefer sibling venv python in .desktop Exec when sys.executable is base python

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -76,9 +76,16 @@ def resolve_exec_command() -> str:
             # installer's bash wrapper). Launched from the .desktop entry that
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # Prefer the venv interpreter that lives next to the repo script;
+            # sys.executable is only correct when Hermes itself runs from the
+            # venv (desktop-update/relaunch paths can run the BASE python
+            # that created the venv, which has no third-party imports).
+            sibling_venv = resolved.parent / "venv" / "bin" / "python"
+            interpreter = (
+                sibling_venv if sibling_venv.is_file()
+                else Path(sys.executable).resolve()
+            )
+            argv = [str(interpreter), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:


### PR DESCRIPTION
## Summary
- `resolve_exec_command()` in `hermes_cli/linux_desktop_entry.py` prefixed `sys.executable` when the resolved `hermes` launcher needs an interpreter (non-venv shebang, per #90292).
- In desktop-update/relaunch launch paths `sys.executable` can be the uv BASE python that created the venv — it has no third-party packages. The generated `hermes.desktop` `Exec=` line then died silently (`Terminal=false`) with `ModuleNotFoundError: No module named 'yaml'` when launched from the dock/launcher.
- Fix: prefer the venv interpreter that lives next to the repo script (`<repo>/venv/bin/python`) before falling back to `sys.executable`.

## Reproduction
1. Install via shell installer (bash wrapper in `~/.local/bin/hermes` exec-ing venv python with the repo `hermes` script, whose shebang is `#!/usr/bin/env python3`).
2. Let the desktop app (re)generate the launcher entry from a context where `sys.executable` is the uv base python (observed via `hermes desktop` relaunch/desktop-update path).
3. Resulting entry: `Exec=/home/user/.local/share/uv/python/cpython-3.11.../python3.11 /home/user/.hermes/hermes-agent/hermes desktop`
4. Click the dock icon → instant crash, no window (verified on Ubuntu 26.04 arm64; same class as #90292).

## Test plan
- [x] Re-ran `install_desktop_entry()` after the patch: entry now resolves to the venv interpreter path and `desktop-file-validate` passes.
- [x] Launched via the regenerated dock entry — desktop app starts and backend becomes ready.
- [ ] Existing tests for `linux_desktop_entry` pass (not run locally: full suite).