### PR TITLE
feat(desktop): add explicit multi-select mode for chats

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -127,6 +127,7 @@ import {
 } from '@/store/session'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 import { $unconfirmedPinWrites } from '@/store/session-pin-sync'
+import { clearSessionSelection } from '@/store/session-selection'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
@@ -171,6 +172,7 @@ import {
 } from './projects'
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import { SidebarSelectionActionBar } from './selection-action-bar'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
@@ -449,6 +451,38 @@ export function ChatSidebar({
     window.addEventListener(SESSION_SEARCH_FOCUS_EVENT, onFocus)
 
     return () => window.removeEventListener(SESSION_SEARCH_FOCUS_EVENT, onFocus)
+  }, [])
+
+  // Escape cancels the sidebar's multi-select. Capture phase and
+  // unconditional: selection is a sidebar-wide mode, so it must not depend on
+  // where focus happens to sit, and clearing an inactive selection is a no-op.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        clearSessionSelection()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [])
+
+  // A click on sidebar space that ISN'T a session row or the selection action
+  // bar cancels the selection — the empty area below the list, a section
+  // header, the nav. Row clicks are excluded because they carry their own
+  // selection gestures; the action bar and any open menu/dialog are excluded
+  // so clicking "Archive 7 chats" doesn't also cancel the very thing clicked.
+  const onSidebarPointerDown = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    if (
+      (event.target as HTMLElement).closest(
+        '[data-session-row], [data-row-actions], [data-session-selection-bar], [role="menu"], [role="dialog"], [data-slot="dropdown-menu-trigger"]'
+      )
+    ) {
+      return
+    }
+
+    clearSessionSelection()
   }, [])
 
   // Flash the ⌘N hint full-opacity (no transition) for the press, so hitting
@@ -1465,7 +1499,9 @@ export function ChatSidebar({
         'border-(--sidebar-edge-border) bg-(--ui-sidebar-surface-background) opacity-100'
       )}
       collapsible="none"
+      onPointerDown={onSidebarPointerDown}
     >
+      <SidebarSelectionActionBar />
       <SidebarContent className="gap-0 overflow-hidden bg-transparent px-2.5">
         <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
@@ -1607,6 +1643,7 @@ export function ChatSidebar({
                 open
                 pinned={false}
                 rootClassName="min-h-32 flex-1 overflow-hidden p-0"
+                selectionScope="search-results"
                 sessions={searchResults}
                 showProfileTags={showAllProfiles}
               />
@@ -1630,6 +1667,7 @@ export function ChatSidebar({
                 open={pinsOpen}
                 pinned
                 rootClassName="shrink-0 p-0 pb-1"
+                selectionScope="pinned"
                 sessions={pinnedSessions}
                 showProfileTags={showAllProfiles}
                 sortable={pinnedSessions.length > 1}
@@ -1819,6 +1857,11 @@ export function ChatSidebar({
                   'min-h-32 flex-1 overflow-hidden p-0',
                   !recentsVirtualizes && 'compact:min-h-0 compact:flex-none compact:overflow-visible'
                 )}
+                // Stable regardless of the (possibly translated, project-name-
+                // swapping) `sessionsLabel` — the default `label` fallback
+                // would otherwise re-key this section's range-selection scope
+                // on every locale switch or project entry/exit.
+                selectionScope="sessions"
                 sessions={displayAgentSessions}
                 sortable={!showAllProfiles && agentSessions.length > 1}
               />
@@ -1865,6 +1908,10 @@ export function ChatSidebar({
                     open={messagingOpenIds.includes(group.sourceId)}
                     pinned={false}
                     rootClassName="shrink-0 p-0"
+                    // The stable source id, not the (possibly shared or
+                    // translated) display `label` — two platforms rendering
+                    // the same label text must not share one ⇧-click range.
+                    selectionScope={group.sourceId}
                     sessions={shownSessions}
                   />
                 )

--- a/apps/desktop/src/app/chat/sidebar/selection-action-bar.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/selection-action-bar.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearSessionSelection,
+  enterSelectionMode,
+  registerBulkSessionActions,
+  toggleSessionSelection
+} from '@/store/session-selection'
+
+import { SidebarSelectionActionBar } from './selection-action-bar'
+
+afterEach(() => {
+  cleanup()
+  clearSessionSelection()
+  registerBulkSessionActions(null)
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        selection: {
+          archive: 'Archive',
+          cancel: 'Cancel',
+          count: (n: number) => `${n} selected`,
+          delete: 'Delete',
+          deleteDesc: (n: number) => `This will delete ${n} chats.`,
+          deleteTitle: (n: number) => `Delete ${n} chats?`
+        }
+      },
+      common: { cancel: 'Cancel', confirm: 'Confirm', delete: 'Delete', done: 'Done', loading: 'Loading…' }
+    }
+  })
+}))
+
+describe('SidebarSelectionActionBar', () => {
+  it('renders nothing when selection mode is inactive', () => {
+    const { container } = render(<SidebarSelectionActionBar />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows the selected count and calls bulk archive with the selection', () => {
+    const archive = vi.fn()
+    registerBulkSessionActions({ archive, remove: vi.fn() })
+    enterSelectionMode('a')
+    toggleSessionSelection('test', 'b')
+
+    render(<SidebarSelectionActionBar />)
+
+    expect(screen.getByText('2 selected')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archive' }))
+    expect(archive).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('gates delete behind a confirm dialog naming the count', async () => {
+    const remove = vi.fn()
+    registerBulkSessionActions({ archive: vi.fn(), remove })
+    enterSelectionMode('a')
+    toggleSessionSelection('test', 'b')
+
+    render(<SidebarSelectionActionBar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Delete 2 chats?')).toBeTruthy()
+    expect(remove).not.toHaveBeenCalled()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+    expect(remove).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('clears the selection on Cancel', () => {
+    registerBulkSessionActions({ archive: vi.fn(), remove: vi.fn() })
+    enterSelectionMode('a')
+
+    render(<SidebarSelectionActionBar />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByText('1 selected')).toBeNull()
+  })
+
+  it('disables Archive and Delete while no bulk actions are registered', () => {
+    enterSelectionMode('a')
+
+    render(<SidebarSelectionActionBar />)
+
+    expect(screen.getByRole('button', { name: 'Archive' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Delete' }).hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/selection-action-bar.tsx
+++ b/apps/desktop/src/app/chat/sidebar/selection-action-bar.tsx
@@ -1,0 +1,65 @@
+import { useStore } from '@nanostores/react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { useI18n } from '@/i18n'
+import {
+  $bulkSessionActions,
+  $selectedSessionIds,
+  $selectionModeActive,
+  clearSessionSelection
+} from '@/store/session-selection'
+
+// The sidebar's compact bar for the explicit multi-select mode (entered via a
+// row's "Select chats" menu item). Always mounted at a fixed spot in the
+// sidebar; it paints nothing until selection mode is active, which keeps the
+// mount point stable rather than conditional in the parent.
+export function SidebarSelectionActionBar() {
+  const { t } = useI18n()
+  const s = t.sidebar.selection
+  const active = useStore($selectionModeActive)
+  const selectedIds = useStore($selectedSessionIds)
+  const bulkActions = useStore($bulkSessionActions)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  if (!active) {
+    return null
+  }
+
+  const count = selectedIds.length
+  const disabled = !bulkActions || count === 0
+
+  return (
+    // data-session-selection-bar: the sidebar's click-out-to-cancel handler
+    // excludes this element, so clicking Archive/Delete/Cancel never also
+    // fires the click-out that would cancel the very action being clicked.
+    <div className="flex shrink-0 items-center gap-2 px-2 py-1.5" data-session-selection-bar="">
+      <span className="min-w-0 flex-1 truncate text-xs text-(--ui-text-secondary)">{s.count(count)}</span>
+      <Button
+        disabled={disabled}
+        onClick={() => bulkActions?.archive(selectedIds)}
+        size="xs"
+        type="button"
+        variant="secondary"
+      >
+        {s.archive}
+      </Button>
+      <Button disabled={disabled} onClick={() => setDeleteOpen(true)} size="xs" type="button" variant="destructive">
+        {s.delete}
+      </Button>
+      <Button onClick={clearSessionSelection} size="xs" type="button" variant="text">
+        {s.cancel}
+      </Button>
+      <ConfirmDialog
+        confirmLabel={s.delete}
+        description={s.deleteDesc(count)}
+        destructive
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => bulkActions?.remove(selectedIds)}
+        open={deleteOpen}
+        title={s.deleteTitle(count)}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { enterSelectionMode } from '@/store/session-selection'
+
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
@@ -61,6 +63,7 @@ vi.mock('@/i18n', () => ({
           renameFailed: 'Rename failed',
           renameTitle: 'Rename session',
           renamed: 'Renamed',
+          selectChats: 'Select chats',
           sessionActions: 'Session actions',
           unpin: 'Unpin',
           untitledPlaceholder: 'Untitled'
@@ -98,6 +101,7 @@ vi.mock('@/store/session-color', () => ({
   $sessionColorOverrides: atom<Record<string, string>>({}),
   setSessionColorOverride: vi.fn()
 }))
+vi.mock('@/store/session-selection', () => ({ enterSelectionMode: vi.fn() }))
 vi.mock('@/store/session-states', () => ({
   $sessionTiles: atom<unknown[]>([]),
   openSessionTile: vi.fn()
@@ -284,5 +288,43 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})
+
+// The entry point into the sidebar's explicit multi-select mode: both the
+// kebab dropdown and the row's right-click context menu route through the
+// same useSessionActions items, so one test per surface is enough to prove
+// the wiring rather than the shared logic twice.
+describe('SessionActionsMenu "Select chats"', () => {
+  afterEach(() => {
+    vi.mocked(enterSelectionMode).mockClear()
+  })
+
+  it('enters selection mode with this row selected from the kebab menu', async () => {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Select chats' }))
+
+    expect(enterSelectionMode).toHaveBeenCalledWith('s1')
+  })
+
+  it('enters selection mode with this row selected from the right-click menu', async () => {
+    render(
+      <SessionContextMenu sessionId="s2" title="Another session">
+        <button aria-label="Session row" type="button">
+          Row
+        </button>
+      </SessionContextMenu>
+    )
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Session row' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Select chats' }))
+
+    expect(enterSelectionMode).toHaveBeenCalledWith('s2')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,6 +44,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
+import { enterSelectionMode } from '@/store/session-selection'
 import { $sessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
@@ -423,6 +424,21 @@ function useSessionActions({
         ]
       : []
 
+  // Entry point into the sidebar's explicit multi-select mode. Its own group
+  // (not folded into workItems/dangerItems) since it changes what every OTHER
+  // row's click does, not just this one.
+  const selectionItems: ActionItemSpec[] = [
+    spec({
+      disabled: !sessionId,
+      icon: 'checklist',
+      label: r.selectChats,
+      onSelect: () => {
+        triggerHaptic('selection')
+        enterSelectionMode(sessionId)
+      }
+    })
+  ]
+
   // DANGER — put it away / destroy it (delete stays last, destructive-red).
   const dangerItems: ActionItemSpec[] = [
     spec({
@@ -479,6 +495,8 @@ function useSessionActions({
         onCopyError={err => notifyError(err, r.copyIdFailed)}
         text={sessionId}
       />
+      <kit.Separator />
+      {selectionItems.map(item => renderActionItem(kit, item))}
       <kit.Separator />
       {workItems.map(item => renderActionItem(kit, item))}
       <kit.Sub>

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -9,6 +9,12 @@ import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
 import type * as SessionStore from '@/store/session'
+import {
+  $selectedSessionIds,
+  clearSessionSelection,
+  enterSelectionMode,
+  registerSessionRowOrder
+} from '@/store/session-selection'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
@@ -422,5 +428,100 @@ describe('Inbox-style session card', () => {
 
     expect(workspace.className).toMatch(/\btruncate\b/)
     expect(screen.getByText('133 messages')).toBeTruthy()
+  })
+})
+
+// Explicit selection mode: outside it, every existing click gesture (plain
+// resume, ⇧ pin, ⌘/⌃ new tab, ⌘/⌃+⇧ new window, ⌥+⇧ archive) is untouched —
+// that's what session-row-gesture.test.ts and its unmodified callers already
+// prove. This block only covers the NEW behavior that only exists once
+// selection mode is active, and the one seam where entering it changes a
+// plain click's meaning outside the row's own onClick.
+describe('SidebarSessionRow selection mode', () => {
+  afterEach(() => {
+    clearSessionSelection()
+  })
+
+  const rowFor = (title: string) => screen.getByText(title)
+
+  it('leaves a plain click alone (resume) when selection mode is off', () => {
+    const onResume = vi.fn()
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={onResume}
+        onToggleUnread={noop}
+        session={makeSession({ id: 'b', title: 'Off' })}
+        unread={false}
+      />
+    )
+
+    fireEvent.click(rowFor('Off'))
+
+    expect(onResume).toHaveBeenCalledOnce()
+    expect($selectedSessionIds.get()).toEqual([])
+  })
+
+  it('toggles this row on a plain click while selection mode is active', () => {
+    enterSelectionMode('anchor')
+    renderRow(makeSession({ id: 'b', title: 'Toggle me' }))
+
+    fireEvent.click(rowFor('Toggle me'))
+    expect($selectedSessionIds.get()).toEqual(['anchor', 'b'])
+
+    fireEvent.click(rowFor('Toggle me'))
+    expect($selectedSessionIds.get()).toEqual(['anchor'])
+  })
+
+  it('selects a contiguous range on ⇧-click while selection mode is active', () => {
+    registerSessionRowOrder('sessions', ['a', 'b', 'c', 'd'])
+    enterSelectionMode('a')
+    renderRow(makeSession({ id: 'c', title: 'Range end' }))
+
+    fireEvent.click(rowFor('Range end'), { shiftKey: true })
+
+    expect($selectedSessionIds.get()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not fire the existing modifier gestures while selection mode is active', () => {
+    const onArchive = vi.fn()
+    const onPin = vi.fn()
+    enterSelectionMode('anchor')
+
+    render(
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        onArchive={onArchive}
+        onDelete={noop}
+        onPin={onPin}
+        onResume={noop}
+        onToggleUnread={noop}
+        session={makeSession({ id: 'b', title: 'No archive here' })}
+        unread={false}
+      />
+    )
+
+    // ⌥+⇧ archives outside selection mode (session-row-gesture.test.ts); inside
+    // it, every click is a selection gesture instead.
+    fireEvent.click(rowFor('No archive here'), { altKey: true, shiftKey: true })
+
+    expect(onArchive).not.toHaveBeenCalled()
+    expect(onPin).not.toHaveBeenCalled()
+    expect($selectedSessionIds.get()).toEqual(['anchor', 'b'])
+  })
+
+  it('toggles this specific row regardless of ctrl/cmd, since the modifier gestures are suppressed', () => {
+    enterSelectionMode('anchor')
+    renderRow(makeSession({ id: 'b', title: 'Ctrl click' }))
+
+    fireEvent.click(rowFor('Ctrl click'), { ctrlKey: true })
+
+    expect($selectedSessionIds.get()).toEqual(['anchor', 'b'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -30,6 +30,12 @@ import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
+import {
+  $selectedSessionIds,
+  $selectionModeActive,
+  selectSessionRange,
+  toggleSessionSelection
+} from '@/store/session-selection'
 import { $openStoredSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 import { $todoProgressBySession } from '@/store/todos'
@@ -77,6 +83,10 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
    *  model · size footer. The flat recents list opts in via the filter menu;
    *  dense tree surfaces (projects, messaging, pins) keep the one-line row. */
   card?: boolean
+  /** Which list this row belongs to, for ⇧-click range selection. Ranges never
+   *  cross a scope boundary — see `selectSessionRange`. Surfaces that don't
+   *  register a row order (project lanes) still get a plain-click toggle. */
+  selectionScope?: string
 }
 
 const AGE_KEY = { day: 'ageDay', hour: 'ageHour', minute: 'ageMin' } as const
@@ -137,6 +147,7 @@ function SidebarSessionRowImpl({
   dragHandleProps,
   showProfile = false,
   card = false,
+  selectionScope = 'sessions',
   className,
   style,
   ref,
@@ -163,6 +174,10 @@ function SidebarSessionRowImpl({
   // rather than threaded as props: the subscription re-renders past the memo
   // below, and a toggle should repaint every row at once anyway.
   const rowMeta = useStore($sidebarRowMeta)
+  // Explicit sidebar multi-select. A selector, not a plain useStore: the row
+  // repaints when ITS OWN membership flips, not on every other row's toggle.
+  const selectionModeActive = useStore($selectionModeActive)
+  const isMultiSelected = useStoreSelector($selectedSessionIds, ids => ids.includes(session.id))
   // Pinned metadata occupies the actions slot and swaps out for the kebab on
   // hover, so the row reserves the same width either way and never reflows.
   const pinnedAge = rowMeta.includes('updated')
@@ -358,6 +373,9 @@ function SidebarSessionRowImpl({
           !card && density !== 'compact' && 'min-h-[2.75rem]',
           !card && density === 'detailed' && 'min-h-[3.875rem]',
           isSelected && 'bg-(--ui-row-active-background)',
+          // Multi-selected: the active band plus an inset ring, so a
+          // selection of many rows never reads as many open sessions.
+          isMultiSelected && 'bg-(--ui-row-active-background) inset-ring-1 inset-ring-(--ui-accent)',
           // Open in another pane: the SAME band, just weaker. Its own mixed
           // token rather than row opacity — dimming the whole row would take
           // the title and the status dot down with it.
@@ -370,6 +388,7 @@ function SidebarSessionRowImpl({
           className
         )}
         data-glass-opaque={dragging ? '' : undefined}
+        data-session-row=""
         data-working={liveTurn ? 'true' : undefined}
         // The row runs BOTH drags off one press, and each declines outside its
         // own region — so no timing/arbitration rule is needed and neither can
@@ -425,6 +444,27 @@ function SidebarSessionRowImpl({
             openSession(session.id, () => undefined, 'tab')
           })}
           onClick={event => {
+            // Explicit multi-select mode (entered via a row's "Select chats"
+            // menu item) takes over the click entirely: a plain click toggles
+            // just this row, ⇧-click extends the range from the last touched
+            // row. None of the modifier gestures below fire while it's
+            // active — they're one right-click away in the row's menu, and
+            // reusing their modifiers for selection would be the same
+            // ambiguity this mode exists to avoid.
+            if (selectionModeActive) {
+              event.preventDefault()
+              event.stopPropagation()
+              triggerHaptic('selection')
+
+              if (event.shiftKey) {
+                selectSessionRange(selectionScope, session.id)
+              } else {
+                toggleSessionSelection(selectionScope, session.id)
+              }
+
+              return
+            }
+
             // Modifier-click gestures on a row (see `resolveSessionRowClick`):
             //   ⇧          → pin / unpin
             //   ⌘/⌃        → open in a new tab (stack into main)
@@ -624,6 +664,7 @@ function rowPropsEqual(a: SidebarSessionRowProps, b: SidebarSessionRowProps): bo
     a.dragging === b.dragging &&
     a.showProfile === b.showProfile &&
     a.card === b.card &&
+    a.selectionScope === b.selectionScope &&
     a.dragHandleProps === b.dragHandleProps &&
     a.className === b.className &&
     a.style === b.style

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -3,11 +3,17 @@ import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import { forgetSessionRowOrder, registerSessionRowOrder } from '@/store/session-selection'
 
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
 
 afterEach(cleanup)
+
+vi.mock('@/store/session-selection', () => ({
+  forgetSessionRowOrder: vi.fn(),
+  registerSessionRowOrder: vi.fn()
+}))
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -36,10 +42,20 @@ vi.mock('./virtual-session-list', () => ({
   }
 }))
 
+const mockSessionRowPropsHistory: Array<{ selectionScope?: string; session: SessionInfo }> = []
+
+vi.mock('./projects', () => ({
+  EnteredProjectContent: () => null,
+  ProjectOverviewRow: () => null,
+  SidebarWorkspaceGroup: () => <div data-testid="workspace-group" />
+}))
+
 vi.mock('./session-row', () => ({
-  SidebarSessionRow: ({ session }: { session: SessionInfo }) => (
-    <div data-testid={`session-row-${session.id}`}>{session.id}</div>
-  )
+  SidebarSessionRow: (props: { selectionScope?: string; session: SessionInfo }) => {
+    mockSessionRowPropsHistory.push(props)
+
+    return <div data-testid={`session-row-${props.session.id}`}>{props.session.id}</div>
+  }
 }))
 
 function makeSession(id: string, startedAt = 1000): SessionInfo {
@@ -180,5 +196,94 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const thirdRowsRef = mockVirtualListPropsHistory[2].rows
     expect(thirdRowsRef).not.toBe(secondRowsRef)
+  })
+})
+
+// ⇧-click range selection walks the DATA order the section publishes, not DOM
+// order (virtualization only mounts a window) — see `selectSessionRange`.
+describe('SidebarSessionsSection selection scope', () => {
+  afterEach(() => {
+    vi.mocked(registerSessionRowOrder).mockClear()
+    vi.mocked(forgetSessionRowOrder).mockClear()
+  })
+
+  it("defaults the selection scope to the section's own label and publishes the row order", () => {
+    mockSessionRowPropsHistory.length = 0
+    const sessions = generateSessions(3)
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Pinned"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open={true}
+        pinned={false}
+        sessions={sessions}
+      />
+    )
+
+    expect(registerSessionRowOrder).toHaveBeenCalledWith('Pinned', ['session-1', 'session-2', 'session-3'])
+    expect(mockSessionRowPropsHistory.every(props => props.selectionScope === 'Pinned')).toBe(true)
+  })
+
+  it('does not publish one range across separate grouped lanes', () => {
+    const groups = [
+      { id: 'lane-a', label: 'Lane A', path: null, sessions: generateSessions(2) },
+      {
+        id: 'lane-b',
+        label: 'Lane B',
+        path: null,
+        sessions: generateSessions(2).map(session => ({ ...session, id: `b-${session.id}` }))
+      }
+    ]
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        groups={groups}
+        label="Projects"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open={true}
+        pinned={false}
+        sessions={[]}
+      />
+    )
+
+    expect(registerSessionRowOrder).not.toHaveBeenCalled()
+  })
+
+  it('forgets the row order on unmount', () => {
+    const { unmount } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Pinned"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        onToggleUnread={noop}
+        open={true}
+        pinned={false}
+        sessions={generateSessions(2)}
+      />
+    )
+
+    unmount()
+
+    expect(forgetSessionRowOrder).toHaveBeenCalledWith('Pinned')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,7 +1,7 @@
 import type { useSensors } from '@dnd-kit/core'
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -20,6 +20,7 @@ import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
+import { forgetSessionRowOrder, registerSessionRowOrder } from '@/store/session-selection'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import { orderRowsWithinGroups, reorderableRowIds } from './order'
@@ -169,6 +170,10 @@ interface SidebarSessionsSectionProps {
   // grouping is active — the flat recents list opts in; dense tree surfaces
   // (pinned, projects, messaging) keep the one-line row.
   card?: boolean
+  // Range-selection scope for this section's rows (⇧-click). Defaults to the
+  // section label, which is already unique per sidebar section; ranges never
+  // span two scopes, so each list selects on its own.
+  selectionScope?: string
 }
 
 export function SidebarSessionsSection({
@@ -212,7 +217,8 @@ export function SidebarSessionsSection({
   dndSensors,
   showProfileTags = false,
   grouping = 'none',
-  card = false
+  card = false,
+  selectionScope
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
@@ -238,6 +244,7 @@ export function SidebarSessionsSection({
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
   const sessionsDraggable = sortable && !!onReorderSessions
+  const scope = selectionScope ?? label
 
   // Only Pinned arrives pre-ordered as a flat sequence. Recents keeps its
   // recency sort — the drag order is layered on per date group below, so the
@@ -261,6 +268,7 @@ export function SidebarSessionsSection({
         onToggleUnread: () => onToggleUnread(session.id),
         onResume: () => onResumeSession(session.id),
         reorderable: draggable && !branchStem,
+        selectionScope: scope,
         session,
         showProfile: showProfileTags,
         unread: session.unread === true
@@ -282,6 +290,7 @@ export function SidebarSessionsSection({
       onTogglePin,
       onToggleUnread,
       pinned,
+      scope,
       showProfileTags
     ]
   )
@@ -357,6 +366,28 @@ export function SidebarSessionsSection({
   // session order made a drop compute its target index against a list the user
   // wasn't looking at — the drag that landed a row in the wrong slot.
   const sortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
+
+  // Publish the row order ⇧-click ranges over. The DATA order, not the mounted
+  // order: virtualization renders a window, and a range from a row scrolled out
+  // of view must still cover everything between the two ends. Grouped sections
+  // (profile/project lanes) and project lanes both publish nothing: a shared
+  // order across lanes would let a range spill from one lane into the next, so
+  // ⇧-click there degrades to selecting just the clicked row (the row-menu
+  // entry point still works everywhere).
+  const selectionOrderIds = useMemo(
+    () => (groups?.length ? null : flatRows.flatMap(row => (row.kind === 'session' ? [row.entry.session.id] : []))),
+    [flatRows, groups]
+  )
+
+  useEffect(() => {
+    if (selectionOrderIds === null) {
+      return
+    }
+
+    registerSessionRowOrder(scope, selectionOrderIds)
+
+    return () => forgetSessionRowOrder(scope)
+  }, [scope, selectionOrderIds])
 
   // Pinned never virtualizes. Virtualization needs a bounded viewport to
   // measure against, and Pinned deliberately has none — however many chats you
@@ -468,6 +499,7 @@ export function SidebarSessionsSection({
         onToggleUnread={onToggleUnread}
         pinned={pinned}
         rows={flatRows}
+        selectionScope={scope}
         showProfileTags={showProfileTags}
         sortable={sessionsDraggable}
       />
@@ -520,6 +552,7 @@ export function SidebarSessionsSection({
 
 interface SortableSessionRowProps {
   session: SessionInfo
+  selectionScope?: string
   isPinned: boolean
   isSelected: boolean
   unread: boolean

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -30,6 +30,7 @@ interface SessionRowCommonProps {
   onToggleUnread: () => void
   onResume: () => void
   reorderable?: boolean
+  selectionScope?: string
   showProfile?: boolean
 }
 
@@ -48,6 +49,8 @@ export interface VirtualSessionListProps {
   onTogglePin: (sessionId: string) => void
   onToggleUnread: (sessionId: string) => void
   pinned: boolean
+  /** Range-selection scope, forwarded to every row (see `selectSessionRange`). */
+  selectionScope?: string
   showProfileTags?: boolean
   sortable: boolean
 }
@@ -72,6 +75,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   onTogglePin,
   onToggleUnread,
   pinned,
+  selectionScope,
   showProfileTags = false,
   sortable
 }) => {
@@ -151,6 +155,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       onToggleUnread: () => onToggleUnread(session.id),
       onResume: () => onResumeSession(session.id),
       reorderable,
+      selectionScope,
       showProfile: showProfileTags,
       unread: session.unread === true
     }

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -80,6 +80,7 @@ import {
   setMessages
 } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
+import { registerBulkSessionActions } from '@/store/session-selection'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
@@ -547,11 +548,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   const {
     archiveSession,
+    archiveSessions,
     branchCurrentSession,
     branchStoredSession,
     createBackendSessionForSend,
     openNewSessionTile,
     removeSession,
+    removeSessions,
     resumeSession,
     selectSidebarItem,
     startFreshSessionDraft
@@ -574,6 +577,19 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     syncSessionStateToView,
     updateSessionState
   })
+
+  // The sidebar's multi-select verbs. Published through the store rather than
+  // threaded down: the row menu that offers them is several prop layers below,
+  // and they act on the STORE's selection, not on the row they were invoked
+  // from.
+  useEffect(() => {
+    registerBulkSessionActions({
+      archive: ids => void archiveSessions(ids),
+      remove: ids => void removeSessions(ids)
+    })
+
+    return () => registerBulkSessionActions(null)
+  }, [archiveSessions, removeSessions])
 
   // A profile switch/create drops to a fresh new-session draft so the
   // previously open session doesn't bleed across contexts. Skip initial value.
@@ -1246,7 +1262,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           <CommandCenterView
             initialSection={commandCenterInitialSection}
             onClose={closeOverlayToPreviousRoute}
-            onDeleteSession={removeSession}
+            onDeleteSession={async sessionId => {
+              await removeSession(sessionId)
+            }}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
             onOpenSession={sessionId => openSession(sessionId, navigate)}
           />

--- a/apps/desktop/src/app/session/hooks/use-session-actions/bulk-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/bulk-session-actions.test.tsx
@@ -1,0 +1,280 @@
+// Bulk archive/delete for the sidebar's multi-selection: each row runs the
+// same single-row path (optimistic eviction, per-row rollback) as a manual
+// archive/delete, but bounded to at most 6 in flight at once so a big
+// selection doesn't open one socket per row nor sit serially for minutes.
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteSession, type SessionInfo, setSessionArchived } from '@/hermes'
+import { $pinnedSessionIds } from '@/store/layout'
+import { notify } from '@/store/notifications'
+import { setSessions } from '@/store/session'
+import { $selectedSessionIds, $selectionModeActive, enterSelectionMode, toggleSessionSelection } from '@/store/session-selection'
+
+import type { ClientSessionState } from '../../../types'
+
+import { useSessionActions } from './index'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: vi.fn(),
+  getSession: vi.fn(),
+  getAllSessionMessages: vi.fn(),
+  getLatestSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureGatewayProfile: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/store/notifications', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+function session(id: string, overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: false,
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: 1,
+    title: id,
+    tool_call_count: 0,
+    ...overrides
+  } as SessionInfo
+}
+
+type Handle = Pick<ReturnType<typeof useSessionActions>, 'archiveSession' | 'archiveSessions' | 'removeSession'>
+
+function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn().mockResolvedValue(undefined),
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady({ archiveSession: actions.archiveSession, archiveSessions: actions.archiveSessions, removeSession: actions.removeSession })
+  }, [actions, onReady])
+
+  return null
+}
+
+async function mountHarness(): Promise<Handle> {
+  let handle: Handle | undefined
+  render(<Harness onReady={h => (handle = h)} />)
+  await waitFor(() => expect(handle).toBeDefined())
+
+  return handle as Handle
+}
+
+// A controllable "socket": each call parks itself until the test releases it,
+// so the assertions can inspect exactly how many are in flight at once.
+function deferredGate() {
+  const inFlight = new Set<string>()
+  let maxInFlight = 0
+  const releasers = new Map<string, () => void>()
+
+  const call = vi.fn((id: string) => {
+    inFlight.add(id)
+    maxInFlight = Math.max(maxInFlight, inFlight.size)
+
+    return new Promise<{ ok: true }>(resolve => {
+      releasers.set(id, () => {
+        inFlight.delete(id)
+        resolve({ ok: true })
+      })
+    })
+  })
+
+  return {
+    call,
+    getMaxInFlight: () => maxInFlight,
+    inFlight,
+    release: (id: string) => releasers.get(id)?.()
+  }
+}
+
+describe('archiveSessions concurrency + rollback', () => {
+  beforeEach(() => {
+    setSessions([])
+    $pinnedSessionIds.set([])
+    vi.mocked(setSessionArchived).mockReset()
+    vi.mocked(notify).mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $pinnedSessionIds.set([])
+  })
+
+  it('never runs more than 6 archive calls at once for a larger selection', async () => {
+    const ids = Array.from({ length: 10 }, (_, i) => `s${i}`)
+    setSessions(ids.map(id => session(id)))
+
+    const gate = deferredGate()
+    vi.mocked(setSessionArchived).mockImplementation((id: string) => gate.call(id))
+
+    const handle = await mountHarness()
+    const bulk = handle.archiveSessions(ids)
+
+    // Let the worker pool's microtasks run and claim their first ids.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(gate.inFlight.size).toBe(6)
+
+    // Release them in waves; the pool should never exceed the cap even as
+    // finished workers pick up the next id.
+    while (gate.inFlight.size > 0) {
+      const next = [...gate.inFlight]
+      await act(async () => {
+        for (const id of next) {
+          gate.release(id)
+        }
+
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(gate.getMaxInFlight()).toBeLessThanOrEqual(6)
+    }
+
+    await bulk
+    expect(gate.call).toHaveBeenCalledTimes(10)
+  })
+
+  it('rolls back only the failed row and reports one summary error toast', async () => {
+    setSessions([session('ok-1'), session('fails'), session('ok-2')])
+    $pinnedSessionIds.set(['fails'])
+
+    vi.mocked(setSessionArchived).mockImplementation((id: string) =>
+      id === 'fails' ? Promise.reject(new Error('backend down')) : Promise.resolve({ ok: true })
+    )
+
+    const handle = await mountHarness()
+    await act(() => handle.archiveSessions(['ok-1', 'fails', 'ok-2']))
+
+    // The failed row's session AND its pin come back; the two that succeeded
+    // stay gone.
+    expect($pinnedSessionIds.get()).toEqual(['fails'])
+
+    // One summary toast for the whole selection, not one per row.
+    const errorToasts = vi.mocked(notify).mock.calls.filter(([opts]) => opts.kind === 'error')
+    expect(errorToasts).toHaveLength(1)
+  })
+})
+
+// A row-menu archive/delete while selection mode is active runs OUTSIDE
+// `runBulk` (which only clears/prunes for the multi-select bar's own bulk
+// verbs), so the single-row path must prune the removed id itself or a
+// "0 selected" action bar lingers with a dead id inside it.
+describe('single-row archive/delete selection pruning', () => {
+  beforeEach(() => {
+    setSessions([])
+    vi.mocked(setSessionArchived).mockReset()
+    vi.mocked(deleteSession).mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $selectedSessionIds.set([])
+    $selectionModeActive.set(false)
+  })
+
+  it('prunes the archived row from the selection but keeps the rest selected', async () => {
+    setSessions([session('ok-1'), session('ok-2')])
+    vi.mocked(setSessionArchived).mockResolvedValue({ ok: true } as never)
+    enterSelectionMode('ok-1')
+    toggleSessionSelection('test', 'ok-2')
+
+    const handle = await mountHarness()
+    await act(() => handle.archiveSession('ok-1'))
+
+    expect($selectedSessionIds.get()).toEqual(['ok-2'])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+
+  it('exits selection mode when the archived row was the only one selected', async () => {
+    setSessions([session('solo')])
+    vi.mocked(setSessionArchived).mockResolvedValue({ ok: true } as never)
+    enterSelectionMode('solo')
+
+    const handle = await mountHarness()
+    await act(() => handle.archiveSession('solo'))
+
+    expect($selectedSessionIds.get()).toEqual([])
+    expect($selectionModeActive.get()).toBe(false)
+  })
+
+  it('leaves the selection untouched when the archive fails and the row is restored', async () => {
+    setSessions([session('fails')])
+    vi.mocked(setSessionArchived).mockRejectedValue(new Error('backend down'))
+    enterSelectionMode('fails')
+
+    const handle = await mountHarness()
+    await act(() => handle.archiveSession('fails', { quiet: true }))
+
+    expect($selectedSessionIds.get()).toEqual(['fails'])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+
+  it('prunes the deleted row from the selection on a successful single-row delete', async () => {
+    setSessions([session('ok-1'), session('ok-2')])
+    vi.mocked(deleteSession).mockResolvedValue(undefined as never)
+    enterSelectionMode('ok-1')
+    toggleSessionSelection('test', 'ok-2')
+
+    const handle = await mountHarness()
+    await act(() => handle.removeSession('ok-1'))
+
+    expect($selectedSessionIds.get()).toEqual(['ok-2'])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+
+  it('leaves the selection untouched when the delete fails and the row is restored', async () => {
+    setSessions([session('fails')])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('backend down'))
+    enterSelectionMode('fails')
+
+    const handle = await mountHarness()
+    await act(() => handle.removeSession('fails', { quiet: true }))
+
+    expect($selectedSessionIds.get()).toEqual(['fails'])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -24,7 +24,7 @@ import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
-import { $pinnedSessionIds } from '@/store/layout'
+import { dropSessionPins, restoreSessionPins } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -88,6 +88,7 @@ import {
   type SessionOwnerScope,
   type SessionProfileRoute
 } from '@/store/session-request-router'
+import { clearSessionSelection, pruneSessionSelection } from '@/store/session-selection'
 import {
   $sessionTiles,
   closeSessionTile,
@@ -100,7 +101,7 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
-import { $archivedSessions } from '@/store/sidebar-archive'
+import { $archivedSessions, dropArchivedSession, restoreArchivedSession } from '@/store/sidebar-archive'
 import { dropTranscriptTail, loadTranscriptTail, saveTranscriptTail } from '@/store/transcript-tail-cache'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
@@ -134,6 +135,11 @@ import {
   toBranchMessages,
   upsertOptimisticSession
 } from './utils'
+
+// How many rows of a bulk archive/delete may have their RPC in flight at once.
+// Enough that a normal selection finishes in one wave, low enough that
+// selecting a hundred rows doesn't open a hundred sockets against the backend.
+const BULK_SESSION_CONCURRENCY = 6
 
 interface SessionActionsOptions {
   activeSessionId: string | null
@@ -1920,8 +1926,12 @@ export function useSessionActions({
     [copy, forkBranch]
   )
 
+  // `quiet` suppresses this row's own toast so a BULK delete can report once
+  // for the whole selection (see `removeSessions`); the boolean return is what
+  // the bulk caller counts, because the per-row failure is handled here and
+  // never rejects.
   const removeSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, opts?: { quiet?: boolean }): Promise<boolean> => {
       clearNotifications()
 
       // The row may live in the main list OR the archived view's own store
@@ -1936,7 +1946,6 @@ export function useSessionActions({
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
-      const previousPinned = $pinnedSessionIds.get()
 
       const removedOwner: SessionOwnerScope = removed?.connection_id
         ? {
@@ -1945,21 +1954,20 @@ export function useSessionActions({
           }
         : removed?.profile
 
-      const previousArchived = $archivedSessions.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-      $archivedSessions.set(previousArchived.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      const droppedArchived = dropArchivedSession(storedSessionId)
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
       // the delete RPC is in flight, so a racing refresh can't flash it back.
       tombstoneSessions(removedIds)
       beginSessionMutation(removedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
+      const droppedPins = dropSessionPins([storedSessionId, removedPinId])
 
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
@@ -1997,16 +2005,24 @@ export function useSessionActions({
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
+
+        // A row menu's own archive/delete runs outside `runBulk`, so nothing
+        // else drops this id from an active selection — left alone, a
+        // one-row selection deletes down to a dead id and a "0 selected"
+        // action bar.
+        pruneSessionSelection(removedIds.filter((id): id is string => Boolean(id)))
+
+        return true
       } catch (err) {
         if (removedFromMain) {
           setSessions(prev => [removedFromMain, ...prev])
         }
 
         // Restore the archived-view row too (no-op when it wasn't archived).
-        $archivedSessions.set(previousArchived)
+        restoreArchivedSession(droppedArchived)
 
         untombstoneSessions(removedIds)
-        $pinnedSessionIds.set(previousPinned)
+        restoreSessionPins(droppedPins)
 
         if (wasSelected) {
           setFreshDraftReady(false)
@@ -2027,7 +2043,13 @@ export function useSessionActions({
           }
         }
 
-        notifyError(err, copy.deleteFailed)
+        if (opts?.quiet) {
+          console.warn('delete failed', err)
+        } else {
+          notifyError(err, copy.deleteFailed)
+        }
+
+        return false
       } finally {
         // Release the tombstone to the normal projects.tree prune now the RPC has
         // settled (kept on success — the backend has deleted it; cleared on the
@@ -2049,13 +2071,13 @@ export function useSessionActions({
     ]
   )
 
+  // Same `quiet`/boolean-return contract as removeSession, for `archiveSessions`.
   const archiveSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, opts?: { quiet?: boolean }): Promise<boolean> => {
       clearNotifications()
 
       const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
       const wasSelected = selectedStoredSessionId === storedSessionId
-      const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
@@ -2065,7 +2087,7 @@ export function useSessionActions({
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
+      const droppedPins = dropSessionPins([storedSessionId, archivedPinId])
 
       if (wasSelected) {
         startFreshSessionDraft(true)
@@ -2086,15 +2108,31 @@ export function useSessionActions({
           dropSessionState(tiledRuntimeId)
         }
 
-        notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
+        // See the matching comment in `removeSession` — a row menu's own
+        // archive runs outside `runBulk`, so nothing else prunes this id out
+        // of an active selection.
+        pruneSessionSelection(archivedIds.filter((id): id is string => Boolean(id)))
+
+        if (!opts?.quiet) {
+          notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
+        }
+
+        return true
       } catch (err) {
         if (archived) {
           setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
         }
 
         untombstoneSessions(archivedIds)
-        $pinnedSessionIds.set(previousPinned)
-        notifyError(err, copy.archiveFailed)
+        restoreSessionPins(droppedPins)
+
+        if (opts?.quiet) {
+          console.warn('archive failed', err)
+        } else {
+          notifyError(err, copy.archiveFailed)
+        }
+
+        return false
       } finally {
         endSessionMutation(archivedIds)
       }
@@ -2102,8 +2140,87 @@ export function useSessionActions({
     [copy, runtimeIdByStoredSessionIdRef, selectedStoredSessionId, sessionStateByRuntimeIdRef, startFreshSessionDraft]
   )
 
+  // Bulk verbs for the sidebar's multi-selection. Each id runs the SAME
+  // single-row path above (optimistic eviction, tombstone, per-row rollback),
+  // so one failure inside a selection of twenty costs only its own row — and
+  // one summary toast replaces twenty.
+  //
+  // Bounded-concurrent, not sequential: each row is one request on the normal
+  // fetch timeout, so a strictly serial loop over ten selected rows could sit
+  // for minutes against an alive-but-busy backend with no progress and no
+  // cancel. Running rows together is only safe because `dropSessionPins` /
+  // `dropArchivedSession` (and their restores) are read-modify-write against
+  // the CURRENT store value rather than a snapshot the caller holds across an
+  // await — a caller holding a pre-await snapshot would let one row's write
+  // clobber a concurrent sibling's.
+  const runBulk = useCallback(
+    async (
+      sessionIds: readonly string[],
+      run: (sessionId: string) => Promise<boolean>,
+      messages: { done: (count: number) => string; failed: (count: number) => string }
+    ) => {
+      const ids = [...new Set(sessionIds)]
+
+      if (ids.length === 0) {
+        return
+      }
+
+      // Selection is consumed up front: the rows are leaving the list, and a
+      // stale selection would keep offering bulk verbs for ids that are gone.
+      clearSessionSelection()
+
+      let failed = 0
+      let cursor = 0
+
+      // Hand-rolled worker pool: each worker claims the next id and runs it to
+      // completion. `cursor++` is safe without a lock — nothing awaits between
+      // the read and the increment.
+      const worker = async (): Promise<void> => {
+        while (cursor < ids.length) {
+          const id = ids[cursor++]
+
+          if (!(await run(id))) {
+            failed += 1
+          }
+        }
+      }
+
+      await Promise.all(Array.from({ length: Math.min(BULK_SESSION_CONCURRENCY, ids.length) }, worker))
+
+      pruneSessionSelection(ids)
+
+      if (failed > 0) {
+        notify({ kind: 'error', message: messages.failed(failed) })
+
+        return
+      }
+
+      notify({ durationMs: 2_000, kind: 'success', message: messages.done(ids.length) })
+    },
+    []
+  )
+
+  const archiveSessions = useCallback(
+    (sessionIds: readonly string[]) =>
+      runBulk(sessionIds, id => archiveSession(id, { quiet: true }), {
+        done: copy.archivedMany,
+        failed: copy.archiveFailedMany
+      }),
+    [archiveSession, copy, runBulk]
+  )
+
+  const removeSessions = useCallback(
+    (sessionIds: readonly string[]) =>
+      runBulk(sessionIds, id => removeSession(id, { quiet: true }), {
+        done: copy.deletedMany,
+        failed: copy.deleteFailedMany
+      }),
+    [copy, removeSession, runBulk]
+  )
+
   return {
     archiveSession,
+    archiveSessions,
     branchCurrentSession,
     branchStoredSession,
     closeSettings,
@@ -2111,6 +2228,7 @@ export function useSessionActions({
     openNewSessionTile,
     openSettings,
     removeSession,
+    removeSessions,
     resumeSession,
     selectSidebarItem,
     startFreshSessionDraft

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2241,6 +2241,7 @@ export const en: Translations = {
       branchFrom: 'Branch',
       rename: 'Rename',
       archive: 'Archive',
+      selectChats: 'Select chats',
       newWindow: 'New window',
       openInTerminal: 'Open in terminal',
       hideTabBar: 'Hide tab bar',
@@ -2279,6 +2280,14 @@ export const en: Translations = {
       thisWeek: 'Earlier this week',
       lastWeek: 'Last week',
       thisMonth: 'Earlier this month'
+    },
+    selection: {
+      count: n => `${n} selected`,
+      archive: 'Archive',
+      delete: 'Delete',
+      cancel: 'Cancel',
+      deleteTitle: n => `Delete ${n} chats?`,
+      deleteDesc: n => `This will permanently delete ${n} chats. This cannot be undone.`
     },
     statusDivider: {
       working: 'Working',
@@ -3385,6 +3394,10 @@ export const en: Translations = {
     deleteFailed: 'Delete failed',
     archived: 'Archived',
     archiveFailed: 'Archive failed',
+    archivedMany: count => `Archived ${count} chats`,
+    archiveFailedMany: count => `Could not archive ${count} chats`,
+    deletedMany: count => `Deleted ${count} chats`,
+    deleteFailedMany: count => `Could not delete ${count} chats`,
     cwdChangeFailed: 'Working directory change failed',
     cwdStagedTitle: 'Working directory staged',
     cwdStagedMessage: 'Restart the desktop backend to apply cwd changes to this active session.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1946,6 +1946,7 @@ export const ja = defineLocale({
       branchFrom: '分岐',
       rename: '名前を変更',
       archive: 'アーカイブ',
+      selectChats: 'チャットを選択',
       newWindow: '新しいウィンドウ',
       openInTerminal: 'ターミナルで開く',
       copyIdFailed: 'セッション ID をコピーできませんでした',
@@ -1980,6 +1981,14 @@ export const ja = defineLocale({
       thisWeek: '今週',
       lastWeek: '先週',
       thisMonth: '今月'
+    },
+    selection: {
+      count: n => `${n} 件選択中`,
+      archive: 'アーカイブ',
+      delete: '削除',
+      cancel: 'キャンセル',
+      deleteTitle: n => `${n} 件のチャットを削除しますか？`,
+      deleteDesc: n => `${n} 件のチャットを完全に削除します。この操作は元に戻せません。`
     },
     statusDivider: {
       working: '実行中',
@@ -3033,6 +3042,10 @@ export const ja = defineLocale({
     deleteFailed: '削除に失敗しました',
     archived: 'アーカイブしました',
     archiveFailed: 'アーカイブに失敗しました',
+    archivedMany: count => `${count} 件のチャットをアーカイブしました`,
+    archiveFailedMany: count => `${count} 件のチャットのアーカイブに失敗しました`,
+    deletedMany: count => `${count} 件のチャットを削除しました`,
+    deleteFailedMany: count => `${count} 件のチャットの削除に失敗しました`,
     cwdChangeFailed: '作業ディレクトリの変更に失敗しました',
     cwdStagedTitle: '作業ディレクトリがステージングされました',
     cwdStagedMessage:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1904,6 +1904,7 @@ export interface Translations {
       branchFrom: string
       rename: string
       archive: string
+      selectChats: string
       newWindow: string
       openInTerminal: string
       hideTabBar: string
@@ -1942,6 +1943,16 @@ export interface Translations {
       thisWeek: string
       lastWeek: string
       thisMonth: string
+    }
+    // The sidebar's compact action bar, shown while multi-select mode is
+    // active (entered via a row's "Select chats" menu item).
+    selection: {
+      count: (n: number) => string
+      archive: string
+      delete: string
+      cancel: string
+      deleteTitle: (n: number) => string
+      deleteDesc: (n: number) => string
     }
     statusDivider: {
       working: string
@@ -2906,6 +2917,10 @@ export interface Translations {
     deleteFailed: string
     archived: string
     archiveFailed: string
+    archivedMany: (count: number) => string
+    archiveFailedMany: (count: number) => string
+    deletedMany: (count: number) => string
+    deleteFailedMany: (count: number) => string
     cwdChangeFailed: string
     cwdStagedTitle: string
     cwdStagedMessage: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1879,6 +1879,7 @@ export const zhHant = defineLocale({
       branchFrom: '分支',
       rename: '重新命名',
       archive: '封存',
+      selectChats: '選取聊天',
       newWindow: '新視窗',
       openInTerminal: '在終端機中開啟',
       copyIdFailed: '無法複製工作階段 ID',
@@ -1913,6 +1914,14 @@ export const zhHant = defineLocale({
       thisWeek: '本週',
       lastWeek: '上週',
       thisMonth: '本月'
+    },
+    selection: {
+      count: n => `已選取 ${n} 個`,
+      archive: '封存',
+      delete: '刪除',
+      cancel: '取消',
+      deleteTitle: n => `刪除 ${n} 個會話？`,
+      deleteDesc: n => `這將永久刪除 ${n} 個會話，且無法復原。`
     },
     statusDivider: {
       working: '進行中',
@@ -2907,6 +2916,10 @@ export const zhHant = defineLocale({
     deleteFailed: '刪除失敗',
     archived: '已封存',
     archiveFailed: '封存失敗',
+    archivedMany: count => `已封存 ${count} 個會話`,
+    archiveFailedMany: count => `${count} 個會話封存失敗`,
+    deletedMany: count => `已刪除 ${count} 個會話`,
+    deleteFailedMany: count => `${count} 個會話刪除失敗`,
     cwdChangeFailed: '工作目錄變更失敗',
     cwdStagedTitle: '工作目錄已暫存',
     cwdStagedMessage: '重新啟動桌面後端後，工作目錄變更才會套用至此作用中工作階段。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2420,6 +2420,7 @@ export const zh: Translations = {
       branchFrom: '分支',
       rename: '重命名',
       archive: '归档',
+      selectChats: '选择聊天',
       newWindow: '新窗口',
       openInTerminal: '在终端中打开',
       hideTabBar: '隐藏标签栏',
@@ -2459,6 +2460,14 @@ export const zh: Translations = {
       thisWeek: '本周',
       lastWeek: '上周',
       thisMonth: '本月'
+    },
+    selection: {
+      count: n => `已选择 ${n} 个`,
+      archive: '归档',
+      delete: '删除',
+      cancel: '取消',
+      deleteTitle: n => `删除 ${n} 个会话？`,
+      deleteDesc: n => `这将永久删除 ${n} 个会话，且无法撤销。`
     },
     statusDivider: {
       working: '进行中',
@@ -3529,6 +3538,10 @@ export const zh: Translations = {
     deleteFailed: '删除失败',
     archived: '已归档',
     archiveFailed: '归档失败',
+    archivedMany: count => `已归档 ${count} 个会话`,
+    archiveFailedMany: count => `${count} 个会话归档失败`,
+    deletedMany: count => `已删除 ${count} 个会话`,
+    deleteFailedMany: count => `${count} 个会话删除失败`,
     cwdChangeFailed: '工作目录更改失败',
     cwdStagedTitle: '工作目录已暂存',
     cwdStagedMessage: '重启桌面后端后，工作目录更改才会应用到当前活跃会话。',

--- a/apps/desktop/src/store/layout-bulk-pin-drop.test.ts
+++ b/apps/desktop/src/store/layout-bulk-pin-drop.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { $pinnedSessionIds, dropSessionPins, restoreSessionPins } from './layout'
+
+beforeEach(() => {
+  $pinnedSessionIds.set([])
+})
+
+/** Pull just the ids off a batch of rollback tokens, in the order returned —
+ *  the frozen `rankById` map is an implementation detail callers never
+ *  compare directly. */
+function ids(tokens: ReturnType<typeof dropSessionPins>): string[] {
+  return tokens.map(token => token.id)
+}
+
+describe('dropSessionPins', () => {
+  it('drops every named pin in one write and reports one token per removed id', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c', 'd'])
+
+    const dropped = dropSessionPins(['b', 'd'])
+
+    expect(ids(dropped)).toEqual(['b', 'd'])
+    expect(dropped.every(token => token.rankById.get(token.id) === (token.id === 'b' ? 1 : 3))).toBe(true)
+    expect($pinnedSessionIds.get()).toEqual(['a', 'c'])
+  })
+
+  it('ignores blank and unpinned ids without touching the list', () => {
+    $pinnedSessionIds.set(['a'])
+
+    expect(dropSessionPins([null, undefined, '  ', 'stranger'])).toEqual([])
+    expect($pinnedSessionIds.get()).toEqual(['a'])
+  })
+
+  it('collapses a stored id and its lineage-root pin id to one removal each', () => {
+    // archiveSession/removeSession pass both, because a compressed session's
+    // pin is keyed on the lineage root while the row carries the live tip.
+    $pinnedSessionIds.set(['root', 'other'])
+
+    expect(ids(dropSessionPins(['tip', 'root']))).toEqual(['root'])
+    expect($pinnedSessionIds.get()).toEqual(['other'])
+  })
+})
+
+describe('restoreSessionPins', () => {
+  it('puts a rolled-back pin back at the index it held', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    const dropped = dropSessionPins(['b'])
+
+    restoreSessionPins(dropped)
+
+    expect($pinnedSessionIds.get()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not resurrect a sibling row un-pinned while its RPC was in flight', () => {
+    // The whole point of the read-modify-write pair: two bulk rows overlap, the
+    // first fails and rolls back, and the second's un-pin must survive it. A
+    // caller that wrote back a whole pre-await snapshot would undo both.
+    $pinnedSessionIds.set(['keep', 'fails', 'succeeds'])
+
+    const failing = dropSessionPins(['fails'])
+
+    dropSessionPins(['succeeds'])
+    restoreSessionPins(failing)
+
+    expect($pinnedSessionIds.get()).toEqual(['keep', 'fails'])
+  })
+
+  it('preserves original order when two overlapping rows both roll back', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    const first = dropSessionPins(['a'])
+    const second = dropSessionPins(['b'])
+
+    // RPC completion order is not deterministic. The earlier row can fail and
+    // restore before the later row, even though both drops happened in order.
+    restoreSessionPins(first)
+    restoreSessionPins(second)
+
+    expect($pinnedSessionIds.get()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('preserves order across mixed success and failure completion orders', () => {
+    for (const restoreOrder of [
+      ['a', 'c'],
+      ['c', 'a']
+    ]) {
+      $pinnedSessionIds.set(['a', 'b', 'c', 'd'])
+
+      const dropped = new Map([
+        ['a', dropSessionPins(['a'])],
+        ['b', dropSessionPins(['b'])],
+        ['c', dropSessionPins(['c'])]
+      ])
+
+      // b succeeds and stays removed. a and c fail in either RPC completion
+      // order, and both must return around the surviving d without swapping.
+      for (const id of restoreOrder) {
+        restoreSessionPins(dropped.get(id) ?? [])
+      }
+
+      expect($pinnedSessionIds.get()).toEqual(['a', 'c', 'd'])
+    }
+  })
+
+  it('clamps to the end when a concurrent row shortened the list', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    const failing = dropSessionPins(['c'])
+
+    dropSessionPins(['a'])
+    restoreSessionPins(failing)
+
+    expect($pinnedSessionIds.get()).toEqual(['b', 'c'])
+  })
+
+  it('is a no-op for an empty rollback', () => {
+    $pinnedSessionIds.set(['a'])
+    restoreSessionPins([])
+
+    expect($pinnedSessionIds.get()).toEqual(['a'])
+  })
+
+  it('is idempotent: restoring the same token twice only inserts it once', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    const dropped = dropSessionPins(['b'])
+
+    restoreSessionPins(dropped)
+    restoreSessionPins(dropped)
+
+    expect($pinnedSessionIds.get()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('leaves a newly pinned unknown id in its current position on restore', () => {
+    $pinnedSessionIds.set(['a', 'b', 'c'])
+    const dropped = dropSessionPins(['b'])
+
+    // A pin the frozen snapshot never saw arrives while the rollback is
+    // still in flight.
+    $pinnedSessionIds.set(['a', 'new', 'c'])
+    restoreSessionPins(dropped)
+
+    expect($pinnedSessionIds.get()).toEqual(['a', 'new', 'b', 'c'])
+  })
+
+  describe('deterministic matrix over drop/failure subsets and restore order', () => {
+    const ORIGINAL = ['a', 'b', 'c', 'd']
+
+    // Every subset of `set`, smallest first — bounded to sets of size <= 3 by
+    // the callers below, so this never blows up.
+    function powerset(set: string[]): string[][] {
+      return set.reduce<string[][]>((acc, id) => acc.concat(acc.map(s => [...s, id])), [[]])
+    }
+
+    // At most 2 orderings of `ids`: as-is and reversed. A full permutation
+    // set would be exhaustive rather than small once `ids` grows past 2.
+    function ordersOf(ids: string[]): string[][] {
+      return ids.length <= 1 ? [ids] : [ids, [...ids].reverse()]
+    }
+
+    function check(dropped: string[], failed: string[], restoreOrder: string[]) {
+      $pinnedSessionIds.set(ORIGINAL)
+
+      const tokens = new Map(dropped.map(id => [id, dropSessionPins([id])]))
+
+      for (const id of restoreOrder) {
+        restoreSessionPins(tokens.get(id) ?? [])
+      }
+
+      const succeeded = new Set(dropped.filter(id => !failed.includes(id)))
+
+      expect($pinnedSessionIds.get()).toEqual(ORIGINAL.filter(id => !succeeded.has(id)))
+    }
+
+    // Representative drop sets (single, adjacent pair, gapped pair, run of
+    // three) get every failure subset and both restore orders; the full
+    // 4-id drop only needs the all-fail / all-succeed extremes, since the
+    // mixed-order case above already covers a gapped 4-id scenario.
+    for (const dropped of [['a'], ['a', 'b'], ['b', 'd'], ['a', 'b', 'c']]) {
+      for (const failed of powerset(dropped)) {
+        for (const restoreOrder of ordersOf(failed)) {
+          it(`drop ${JSON.stringify(dropped)}, fail ${JSON.stringify(failed)}, restore ${JSON.stringify(restoreOrder)}`, () => {
+            check(dropped, failed, restoreOrder)
+          })
+        }
+      }
+    }
+
+    for (const failed of [[], ORIGINAL]) {
+      for (const restoreOrder of ordersOf(failed)) {
+        it(`drop all 4, fail ${JSON.stringify(failed)}, restore ${JSON.stringify(restoreOrder)}`, () => {
+          check(ORIGINAL, failed, restoreOrder)
+        })
+      }
+    }
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -731,6 +731,87 @@ export function unpinSession(sessionId: string) {
   )
 }
 
+// A rollback token for one dropped pin. `rankById` is a snapshot of the pin
+// order at drop time, shared by every pin dropped in the same write — it lets
+// `restoreSessionPins` re-derive relative order without an absolute index,
+// which breaks the moment a sibling pin's successful removal shifts everyone
+// after it (#mixed-completion-order).
+export interface SessionPinRollback {
+  id: string
+  rankById: ReadonlyMap<string, number>
+}
+
+// Drop several pins in ONE read-modify-write, returning what `restoreSessionPins`
+// needs to undo it. Deliberately reads the CURRENT list rather than taking a
+// snapshot the caller holds across an await: two bulk rows unpinning in parallel
+// would each write back their own pre-await snapshot, so the later write
+// resurrects the pin the earlier one dropped. That clobber is why a bulk
+// archive/delete cannot run its rows sequentially and still finish in bounded
+// time.
+export function dropSessionPins(sessionIds: Array<null | string | undefined>): SessionPinRollback[] {
+  const doomed = new Set(sessionIds.map(id => id?.trim()).filter((id): id is string => Boolean(id)))
+
+  if (!doomed.size) {
+    return []
+  }
+
+  const current = $pinnedSessionIds.get()
+  const rankById: ReadonlyMap<string, number> = new Map(current.map((id, index) => [id, index]))
+  const removed: string[] = []
+
+  const next = current.filter(id => {
+    if (!doomed.has(id)) {
+      return true
+    }
+
+    removed.push(id)
+
+    return false
+  })
+
+  if (removed.length) {
+    setOrderIds($pinnedSessionIds, next)
+  }
+
+  return removed.map(id => ({ id, rankById }))
+}
+
+// Undo `dropSessionPins` on a failed mutation. Each token merges back before
+// the first live pin whose rank (in that token's frozen snapshot) is greater
+// than the token's own — a live pin the snapshot never saw (newly pinned
+// mid-flight) has no rank to compare and is skipped over, leaving it exactly
+// where it already sits. Idempotent: a token whose id is already live is
+// left alone, so restoring the same rollback twice is a no-op the second time.
+export function restoreSessionPins(tokens: readonly SessionPinRollback[]): void {
+  if (!tokens.length) {
+    return
+  }
+
+  let next = $pinnedSessionIds.get()
+
+  for (const token of tokens) {
+    if (next.includes(token.id)) {
+      continue
+    }
+
+    const rank = token.rankById.get(token.id) ?? Infinity
+
+    let insertAt = next.findIndex(id => {
+      const liveRank = token.rankById.get(id)
+
+      return liveRank !== undefined && liveRank > rank
+    })
+
+    if (insertAt === -1) {
+      insertAt = next.length
+    }
+
+    next = [...next.slice(0, insertAt), token.id, ...next.slice(insertAt)]
+  }
+
+  setOrderIds($pinnedSessionIds, next)
+}
+
 // Apply a new pinned order from a drag. The dragged list only holds the pins
 // that currently RESOLVE to a loaded row, so this is a permutation of a subset:
 // re-slot the ids it names into the positions they already occupied, leaving

--- a/apps/desktop/src/store/session-selection.test.ts
+++ b/apps/desktop/src/store/session-selection.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $bulkSessionActions,
+  $selectedSessionIds,
+  $selectionModeActive,
+  clearSessionSelection,
+  enterSelectionMode,
+  forgetSessionRowOrder,
+  pruneSessionSelection,
+  registerBulkSessionActions,
+  registerSessionRowOrder,
+  selectSessionRange,
+  toggleSessionSelection
+} from './session-selection'
+
+beforeEach(() => {
+  clearSessionSelection()
+  registerBulkSessionActions(null)
+  forgetSessionRowOrder('test')
+})
+
+describe('enterSelectionMode', () => {
+  it('turns selection mode on with exactly the given row selected', () => {
+    enterSelectionMode('a')
+
+    expect($selectionModeActive.get()).toBe(true)
+    expect($selectedSessionIds.get()).toEqual(['a'])
+  })
+})
+
+describe('toggleSessionSelection', () => {
+  it('adds the row on first toggle and removes it on the second', () => {
+    toggleSessionSelection('test', 'a')
+    expect($selectedSessionIds.get()).toEqual(['a'])
+
+    toggleSessionSelection('test', 'a')
+    expect($selectedSessionIds.get()).toEqual([])
+  })
+
+  it('does not force selection mode off when a toggle empties the selection', () => {
+    enterSelectionMode('a')
+    toggleSessionSelection('test', 'a')
+
+    expect($selectedSessionIds.get()).toEqual([])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+})
+
+describe('selectSessionRange', () => {
+  it('selects everything between the anchor and the target, in row order', () => {
+    registerSessionRowOrder('test', ['a', 'b', 'c', 'd'])
+    toggleSessionSelection('test', 'a')
+
+    selectSessionRange('test', 'd')
+
+    expect($selectedSessionIds.get()).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('ranges backward from the anchor just as well', () => {
+    registerSessionRowOrder('test', ['a', 'b', 'c', 'd'])
+    toggleSessionSelection('test', 'd')
+
+    selectSessionRange('test', 'b')
+
+    expect($selectedSessionIds.get()).toEqual(['b', 'c', 'd'])
+  })
+
+  it('falls back to a plain toggle when the scope has no registered order', () => {
+    toggleSessionSelection('unregistered', 'a')
+
+    selectSessionRange('unregistered', 'b')
+
+    expect($selectedSessionIds.get()).toEqual(['a', 'b'])
+  })
+
+  it('falls back to a plain toggle when there is no anchor yet', () => {
+    registerSessionRowOrder('test', ['a', 'b', 'c'])
+
+    selectSessionRange('test', 'b')
+
+    expect($selectedSessionIds.get()).toEqual(['b'])
+  })
+})
+
+describe('clearSessionSelection', () => {
+  it('empties the selection and turns selection mode off', () => {
+    enterSelectionMode('a')
+    clearSessionSelection()
+
+    expect($selectedSessionIds.get()).toEqual([])
+    expect($selectionModeActive.get()).toBe(false)
+  })
+
+  it('drops the anchor too, so a later range starts fresh', () => {
+    registerSessionRowOrder('test', ['a', 'b', 'c'])
+    toggleSessionSelection('test', 'a')
+    clearSessionSelection()
+
+    selectSessionRange('test', 'c')
+
+    // No anchor survives the clear, so this ranges-via-toggle onto just 'c'.
+    expect($selectedSessionIds.get()).toEqual(['c'])
+  })
+})
+
+describe('pruneSessionSelection', () => {
+  it('drops only the named ids, leaving mode and the rest of the selection alone', () => {
+    enterSelectionMode('a')
+    toggleSessionSelection('test', 'b')
+    toggleSessionSelection('test', 'c')
+
+    pruneSessionSelection(['b'])
+
+    expect($selectedSessionIds.get()).toEqual(['a', 'c'])
+    expect($selectionModeActive.get()).toBe(true)
+  })
+})
+
+describe('registerBulkSessionActions', () => {
+  it('publishes and clears the bulk actions handle', () => {
+    const actions = { archive: vi.fn(), remove: vi.fn() }
+    registerBulkSessionActions(actions)
+
+    expect($bulkSessionActions.get()).toBe(actions)
+
+    registerBulkSessionActions(null)
+    expect($bulkSessionActions.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/session-selection.ts
+++ b/apps/desktop/src/store/session-selection.ts
@@ -1,0 +1,103 @@
+import { atom } from 'nanostores'
+
+// Explicit sidebar multi-select mode. Off by default: every existing row
+// gesture (shift-click pin, alt+shift archive, ctrl/cmd-click new tab,
+// ctrl/cmd+shift new window) keeps working unchanged until the user opts in
+// via a row's "Select chats" menu item. Only while this is true do plain and
+// shift clicks turn into selection toggles/ranges instead.
+export const $selectionModeActive = atom(false)
+
+export const $selectedSessionIds = atom<string[]>([])
+
+export interface BulkSessionActions {
+  archive: (sessionIds: string[]) => void
+  remove: (sessionIds: string[]) => void
+}
+
+// Published by the wiring layer (ContribWiring) so the action bar — several
+// prop layers away from where sessions are archived/removed — can call the
+// real bulk verbs without threading them down.
+export const $bulkSessionActions = atom<BulkSessionActions | null>(null)
+
+export function registerBulkSessionActions(actions: BulkSessionActions | null): void {
+  $bulkSessionActions.set(actions)
+}
+
+// The DATA order each scope's rows render in, published by the section that
+// owns them (see sessions-section.tsx). Range selection walks this order, not
+// DOM order — virtualization only mounts a window, and a range spanning a
+// scrolled-out row must still cover everything between its two ends. A plain
+// module map, not a store: nothing needs to render off it.
+const rowOrderByScope = new Map<string, string[]>()
+
+// The last row touched by an explicit click (enter, toggle, or the target end
+// of a previous range) — the anchor a following shift-click ranges from.
+let anchorId: string | null = null
+
+export function registerSessionRowOrder(scope: string, ids: string[]): void {
+  rowOrderByScope.set(scope, ids)
+}
+
+export function forgetSessionRowOrder(scope: string): void {
+  rowOrderByScope.delete(scope)
+}
+
+/** Row-menu entry point: start selection mode with exactly this row selected. */
+export function enterSelectionMode(sessionId: string): void {
+  anchorId = sessionId
+  $selectedSessionIds.set([sessionId])
+  $selectionModeActive.set(true)
+}
+
+/** Plain click while selection mode is active: add/remove just this row. */
+export function toggleSessionSelection(scope: string, sessionId: string): void {
+  void scope
+  const current = $selectedSessionIds.get()
+
+  anchorId = sessionId
+  $selectedSessionIds.set(
+    current.includes(sessionId) ? current.filter(id => id !== sessionId) : [...current, sessionId]
+  )
+}
+
+/** Shift-click while selection mode is active: the contiguous range from the
+ *  anchor to this row, within the row's own scope. Falls back to a plain
+ *  toggle when there's no anchor or no registered order for the scope (e.g. a
+ *  project lane that never published one), rather than doing nothing. */
+export function selectSessionRange(scope: string, sessionId: string): void {
+  const order = rowOrderByScope.get(scope)
+
+  if (!order || !anchorId || !order.includes(anchorId) || !order.includes(sessionId)) {
+    toggleSessionSelection(scope, sessionId)
+
+    return
+  }
+
+  const anchorIndex = order.indexOf(anchorId)
+  const targetIndex = order.indexOf(sessionId)
+  const [start, end] = anchorIndex <= targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex]
+
+  $selectedSessionIds.set(order.slice(start, end + 1))
+}
+
+/** Escape, click-out, or a bulk verb finishing: exit selection mode entirely. */
+export function clearSessionSelection(): void {
+  anchorId = null
+  $selectedSessionIds.set([])
+  $selectionModeActive.set(false)
+}
+
+/** Drop specific ids from the selection (rows that just left the list),
+ *  exiting selection mode only if that emptied it — an archive/delete from a
+ *  single row's own menu runs outside a bulk verb, so nothing else clears the
+ *  "0 selected" action bar a lone removed row would otherwise leave behind. */
+export function pruneSessionSelection(removedIds: readonly string[]): void {
+  const removed = new Set(removedIds)
+  const next = $selectedSessionIds.get().filter(id => !removed.has(id))
+
+  $selectedSessionIds.set(next)
+
+  if (next.length === 0) {
+    $selectionModeActive.set(false)
+  }
+}

--- a/apps/desktop/src/store/sidebar-archive-drop.test.ts
+++ b/apps/desktop/src/store/sidebar-archive-drop.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { $archivedSessions, dropArchivedSession, restoreArchivedSession } from './sidebar-archive'
+
+const row = (id: string): SessionInfo => ({ id }) as SessionInfo
+
+beforeEach(() => {
+  $archivedSessions.set([])
+})
+
+describe('dropArchivedSession', () => {
+  it('evicts the row and reports the index it held', () => {
+    $archivedSessions.set([row('a'), row('b'), row('c')])
+
+    expect(dropArchivedSession('b')).toMatchObject({ index: 1, session: { id: 'b' } })
+    expect($archivedSessions.get().map(s => s.id)).toEqual(['a', 'c'])
+  })
+
+  it('returns null for a row the archived view never held', () => {
+    $archivedSessions.set([row('a')])
+
+    expect(dropArchivedSession('stranger')).toBeNull()
+    expect($archivedSessions.get().map(s => s.id)).toEqual(['a'])
+  })
+})
+
+describe('restoreArchivedSession', () => {
+  it('puts a rolled-back row back where it was', () => {
+    $archivedSessions.set([row('a'), row('b'), row('c')])
+    restoreArchivedSession(dropArchivedSession('b'))
+
+    expect($archivedSessions.get().map(s => s.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not resurrect a sibling deleted while its RPC was in flight', () => {
+    // Same contract as restoreSessionPins: a whole-snapshot restore would undo
+    // a parallel row's eviction as well as its own.
+    $archivedSessions.set([row('keep'), row('fails'), row('succeeds')])
+
+    const failing = dropArchivedSession('fails')
+
+    dropArchivedSession('succeeds')
+    restoreArchivedSession(failing)
+
+    expect($archivedSessions.get().map(s => s.id)).toEqual(['keep', 'fails'])
+  })
+
+  it('is a no-op for null and for a row already back in the list', () => {
+    $archivedSessions.set([row('a')])
+    restoreArchivedSession(null)
+    restoreArchivedSession({ index: 0, session: row('a') })
+
+    expect($archivedSessions.get().map(s => s.id)).toEqual(['a'])
+  })
+})

--- a/apps/desktop/src/store/sidebar-archive.ts
+++ b/apps/desktop/src/store/sidebar-archive.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { listAllProfileSessions, type SessionInfo } from '@/hermes'
 
-import { $sessions } from './session'
+import { $sessions, sessionMatchesStoredId } from './session'
 
 // Archived rows are excluded from the sessions query, so the Archived view has
 // to fetch its own set. Capped: it's a lookup surface, not a feed.
@@ -10,6 +10,43 @@ const ARCHIVED_FETCH_LIMIT = 200
 
 export const $archivedSessions = atom<SessionInfo[]>([])
 export const $archivedSessionsLoading = atom(false)
+
+/** Evict one row from the Archived view in a read-modify-write, returning it (and
+ *  the index it held) for rollback. Same reason as `dropSessionPins`: a bulk
+ *  delete runs its rows concurrently, and a caller that wrote back a whole
+ *  pre-await snapshot would resurrect the rows its siblings had already removed. */
+export function dropArchivedSession(storedSessionId: string): null | { index: number; session: SessionInfo } {
+  const current = $archivedSessions.get()
+  const index = current.findIndex(session => sessionMatchesStoredId(session, storedSessionId))
+
+  if (index < 0) {
+    return null
+  }
+
+  const session = current[index]
+
+  $archivedSessions.set([...current.slice(0, index), ...current.slice(index + 1)])
+
+  return { index, session }
+}
+
+/** Undo `dropArchivedSession`, back at the index it held (clamped — a concurrent
+ *  row may have shortened the list since). No-op when the row was never there. */
+export function restoreArchivedSession(entry: null | { index: number; session: SessionInfo }): void {
+  if (!entry) {
+    return
+  }
+
+  const current = $archivedSessions.get()
+
+  if (current.some(session => session.id === entry.session.id)) {
+    return
+  }
+
+  const at = Math.min(entry.index, current.length)
+
+  $archivedSessions.set([...current.slice(0, at), entry.session, ...current.slice(at)])
+}
 
 export async function loadArchivedSessions(): Promise<void> {
   if ($archivedSessionsLoading.get()) {


### PR DESCRIPTION
## Summary

Adds an explicit multi-select mode to the Desktop chat sidebar.

Open a chat’s menu and choose **Select chats**. From there, normal clicks toggle individual chats and Shift-click selects a range inside the same flat list. A compact action bar lets you archive or delete the selection, or cancel the mode.

This deliberately keeps the existing shortcuts intact. Outside selection mode:

- Shift-click still pins a chat
- Alt+Shift-click still archives it
- Ctrl/Cmd+Shift-click still opens it in a new window

## Why

Bulk actions were possible only as an all-or-nothing operation. This gives users a controlled way to act on a specific set of chats without turning checkboxes into permanent sidebar chrome or replacing existing gestures.

It implements the row-selection workflow requested in #48843. It is narrower than #39376’s Archive All flow and avoids the modifier-key regression that affected the closed #68054 attempt.

## What changed

- Adds **Select chats** to the row menu
- Supports click-to-toggle and Shift-click ranges while selection mode is active
- Keeps ranges scoped to one stable flat list; grouped project/profile lanes do not share a range
- Adds Archive, Delete, and Cancel actions with delete confirmation
- Runs bulk mutations with a concurrency cap of 6
- Preserves optimistic per-row rollback and reports one aggregate failure summary
- Prunes stale selections after successful single-row archive/delete actions
- Preserves pin order across arbitrary success/failure completion order using frozen rank-map rollback tokens
- Adds English, Japanese, Simplified Chinese, and Traditional Chinese copy

## Verification

- [x] Desktop Vitest suite: 722 files passed, 1 skipped; 7,540 tests passed, 3 skipped
- [x] Renderer, Electron, and E2E TypeScript checks
- [x] ESLint: 0 errors
- [x] Production Desktop build
- [x] `git diff --check`
- [x] Mock Electron flow: create a session, choose **Select chats**, enter selection mode, and confirm Archive/Delete/Cancel controls
- [x] Deterministic rollback matrix covering drop subsets, failure subsets, and completion order

Fixes #48843
