### PR TITLE
fix(acp): don't hard-interrupt reused agent on idle session cancel

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1697,21 +1697,31 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state and state.cancel_event:
             with state.runtime_lock:
+                was_running = state.is_running
                 if state.is_running and state.current_prompt_text:
                     state.interrupted_prompt_text = state.current_prompt_text
-                # Publish cancellation and hard-stop the agent before another
-                # prompt can acquire this lock and mistake the turn for
-                # redirectable work.
+                # Publish cancellation before another prompt can acquire this lock
+                # and mistake the turn for redirectable work.
                 state.cancel_event.set()
-                try:
-                    if getattr(state, "agent", None):
-                        request_hard_interrupt(state.agent)
-                except Exception:
-                    logger.debug(
-                        "Failed to interrupt ACP session %s",
-                        session_id,
-                        exc_info=True,
-                    )
+                # Only hard-interrupt the agent when a turn is genuinely in
+                # flight. A `session/cancel` that lands on an IDLE session — e.g.
+                # Xcode's "stop and send" firing a cancel notification right
+                # before it submits the next message — would otherwise leave
+                # _interrupt_requested set on the REUSED agent, and the very
+                # next prompt aborts at the session-turn-lease acquire with
+                # "Stopped waiting for another Hermes process on this session"
+                # even though nothing else is running on it. The next prompt
+                # clears cancel_event itself at turn start.
+                if was_running:
+                    try:
+                        if getattr(state, "agent", None):
+                            request_hard_interrupt(state.agent)
+                    except Exception:
+                        logger.debug(
+                            "Failed to interrupt ACP session %s",
+                            session_id,
+                            exc_info=True,
+                        )
             logger.info("Cancelled session %s", session_id)
 
     async def fork_session(

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -4,6 +4,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from acp.schema import TextContentBlock
 
+import acp_adapter.server as server_mod
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
 
@@ -161,6 +162,46 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert observed["lock_held"] is True
     assert state.cancel_event.is_set()
     assert state.interrupted_prompt_text == "original request"
+
+
+@pytest.mark.asyncio
+async def test_acp_cancel_idle_session_does_not_hard_interrupt(monkeypatch):
+    """A cancel on an IDLE session must not poison the reused agent.
+
+    Xcode implemented \"stop and send\": it fires a ``session/cancel``
+    notification right before submitting the next message. That cancel lands
+    on a session whose previous turn already finished (``is_running`` is
+    False). It must still publish ``cancel_event`` (the next prompt clears it
+    itself at turn start), but must NOT call ``request_hard_interrupt`` — if it
+    did, ``_interrupt_requested`` would stay set on the reused agent and the
+    very next turn would abort at the session-turn-lease acquire with the
+    \"Stopped waiting for another Hermes process on this session\" message.
+    """
+    acp_agent, state, _fake, _conn = make_agent_and_state()
+    state.is_running = False
+    state.current_prompt_text = ""
+    calls = []
+    monkeypatch.setattr(server_mod, "request_hard_interrupt", lambda agent: calls.append(agent))
+
+    await acp_agent.cancel(state.session_id)
+
+    assert state.cancel_event.is_set()
+    assert calls == [], "idle cancel must not hard-interrupt the reused agent"
+
+
+@pytest.mark.asyncio
+async def test_acp_cancel_running_session_still_hard_interrupts(monkeypatch):
+    """A cancel on a genuinely running session must still request a hard stop."""
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.is_running = True
+    state.current_prompt_text = "in flight"
+    calls = []
+    monkeypatch.setattr(server_mod, "request_hard_interrupt", lambda agent: calls.append(agent))
+
+    await acp_agent.cancel(state.session_id)
+
+    assert state.cancel_event.is_set()
+    assert calls == [fake], "running cancel must hard-interrupt the agent"
 
 
 


### PR DESCRIPTION
## Summary

Fix a bug in the ACP (Agent Client Protocol) adapter where a `session/cancel` that lands on an **idle** session leaves `_interrupt_requested` set on the reused agent, causing the **very next message** in that session to abort with:

```
Stopped waiting for another Hermes process on this session. Your message was not processed.
```

This was hit with Xcode 27 as the ACP client (Apple's agent integration), but the root cause is client-agnostic — any ACP client that implements the common "stop and send" pattern (send `session/cancel` immediately before submitting the next message) trips it.

## Root cause

In `acp_adapter/server.py`, `cancel()` called `request_hard_interrupt(state.agent)` **unconditionally**, even when no turn was running:

```python
# before
state.cancel_event.set()
try:
    if getattr(state, "agent", None):
        request_hard_interrupt(state.agent)   # <- always fires, even when idle
```

`request_hard_interrupt` sets `_interrupt_requested = True` on the agent. Because the agent is **reused** across every message in an ACP session, that flag stays set. The next turn's `run_conversation` performs a cross-process session-turn-lease acquire whose `should_abort` is literally `_interrupt_requested` (run_agent.py, in the `acquire_session_turn_lease` call), so it aborts immediately and returns the "Stopped waiting for another Hermes process…" message — even though nothing else is actually running on the session.

The `cancel_event` was already being cleared at the next prompt's start, so the cancellation itself was not the problem — only the leaked hard-interrupt flag on the reused agent was.

## The fix

Gate the hard interrupt on whether a turn is actually in flight (`state.is_running`):

```python
# after
was_running = state.is_running
if state.is_running and state.current_prompt_text:
    state.interrupted_prompt_text = state.current_prompt_text
state.cancel_event.set()
if was_running:
    try:
        if getattr(state, "agent", None):
            request_hard_interrupt(state.agent)
    except Exception:
        logger.debug("Failed to interrupt ACP session %s", session_id, exc_info=True)
```

An cancel on an idle session still publishes `cancel_event` (which the next prompt clears at turn start), but no longer poisons the reused agent. Interactive "Stop" on a genuinely running turn still works because `is_running` is `True` then.

## Reproduction (stdio, client-agnostic)

Single `hermes acp` process, one session, two prompts with a cancel notification between them:

```
initialize
session/new
session/prompt  "Reply with exactly the word: first"     -> end_turn (works)
session/cancel                                             <- JSON-RPC NOTIFICATION (no id)
session/prompt  "Reply with exactly the word: second"      -> aborts
```

Observed server log before the fix:

```
acp_adapter.server: Prompt on session <sid>: Reply with exactly the word: first
agent.turn_context: conversation turn: session=<sid> ... history=0 msg='Reply with exactly the word: first'
agent.conversation_loop: Turn ended: reason=text_response(...) ...
acp_adapter.server: Cancelled session <sid>
acp_adapter.server: Prompt on session <sid>: Reply with exactly the word: second
run_agent: session turn lease wait aborted by interrupt: <sid>    <-- the bug
```

And the client-side effect (what Xcode surfaced to the user) was:

```
Stopped waiting for another Hermes process on this session. Your message was not processed.
```

Note: sending `session/cancel` as a **request with an id** returns `Method not found` (the ACP router treats `session/cancel` as a notification-only method), so the cancel has to be sent as a notification — which is exactly what the generated client does.

## Verification

- New regression tests in `tests/acp_adapter/test_acp_commands.py`:
  - `test_acp_cancel_idle_session_does_not_hard_interrupt` — idle cancel must not call `request_hard_interrupt` but must still set `cancel_event`.
  - `test_acp_cancel_running_session_still_hard_interrupts` — running cancel must still request a hard stop.
- `pytest tests/acp_adapter/test_acp_commands.py` → 5 passed (including the two pre-existing cancel tests, which stay green).
- Re-ran the repro after the fix: both prompts complete with `stopReason: end_turn`, no `session turn lease wait aborted by interrupt` in the log.

## Test plan for the maintainer

1. `pytest tests/acp_adapter/test_acp_commands.py`
2. If an Xcode 27 / Zed setup is available: connect, send two messages in the same chat, and confirm the second is not dropped with "Stopped waiting for another Hermes process…".
