### PR TITLE
fix(photon): use asyncio.get_running_loop() in async contexts

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -946,10 +946,10 @@ class PhotonAdapter(BasePlatformAdapter):
 
         # Start consuming the inbound gRPC stream from the sidecar.
         self._inbound_running = True
-        self._inbound_task = asyncio.get_event_loop().create_task(
+        self._inbound_task = asyncio.get_running_loop().create_task(
             self._inbound_loop()
         )
-        self._sidecar_health_task = asyncio.get_event_loop().create_task(
+        self._sidecar_health_task = asyncio.get_running_loop().create_task(
             self._monitor_sidecar_health()
         )
 
@@ -959,7 +959,7 @@ class PhotonAdapter(BasePlatformAdapter):
         if self._probe_enabled and self._autostart_sidecar:
             self._respawn_lock = asyncio.Lock()
             self._watchdog_running = True
-            self._watchdog_task = asyncio.get_event_loop().create_task(
+            self._watchdog_task = asyncio.get_running_loop().create_task(
                 self._presence_watchdog()
             )
 
@@ -1699,7 +1699,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 retryable=False,
             ) from exc
         # Pump sidecar stderr/stdout into our logger so users see crashes.
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self._sidecar_supervisor_task = loop.create_task(
             self._supervise_sidecar(self._sidecar_proc)
         )
@@ -1743,7 +1743,7 @@ class PhotonAdapter(BasePlatformAdapter):
         if proc.stdout is None:  # subprocess was launched without stdout=PIPE
             return
         stdout = proc.stdout
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             while True:
                 line = await loop.run_in_executor(None, stdout.readline)


### PR DESCRIPTION
## Problem

Five call sites inside `async def` bodies use `asyncio.get_event_loop()`:

- `connect()`: inbound-loop task, sidecar-health task, presence-watchdog task
- `_start_sidecar()` / `_supervise_sidecar()`: supervisor task + loop handle

`get_event_loop()` inside coroutines is **deprecated since 3.10/3.12** (DeprecationWarning under `-W error::DeprecationWarning`, slated to raise in future Python) and can resolve a *different* loop than the running one when loops nest across threads. Every one of these sites executes on the live loop, so the canonical accessor is behavior-identical today and forward-safe.

Note: `agent/lsp/client.py` has its own pending replacement in open PR #27389 — that file is deliberately untouched here.

## Verification

Photon selection: 143 passed / 6 skipped; the single `test_dir_writable_probe` failure is pre-existing on clean `main` on this Windows host (reproduced with the change stashed). Module parses clean.