### PR TITLE
fix(kanban): make idempotent creation race-safe

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1049,6 +1049,38 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # Data classes
 # ---------------------------------------------------------------------------
 
+
+class CreateTaskResult(str):
+    """Task id with explicit create-versus-reuse outcome metadata.
+
+    This remains a ``str`` subclass so existing callers can pass the return
+    value directly to SQLite queries, path helpers, and public APIs that have
+    historically consumed ``create_task()`` as a plain task id.
+    """
+
+    created: bool
+
+    def __new__(cls, task_id: str, *, created: bool) -> "CreateTaskResult":
+        value = str.__new__(cls, task_id)
+        value.created = bool(created)
+        return value
+
+    def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, bool]]:
+        return ((str(self),), {"created": self.created})
+
+    @property
+    def task_id(self) -> str:
+        return str(self)
+
+    @property
+    def existing(self) -> bool:
+        return not self.created
+
+    @property
+    def reused(self) -> bool:
+        return self.existing
+
+
 @dataclass
 class Task:
     """In-memory view of a row from the ``tasks`` table."""
@@ -2528,12 +2560,60 @@ def init_db(
     return path
 
 
+def _assert_active_idempotency_keys_unique(
+    conn: sqlite3.Connection,
+    *,
+    columns: Optional[set[str]] = None,
+) -> None:
+    """Refuse ambiguous active idempotency keys before mutating legacy tasks."""
+    if columns is None:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+    if not {"id", "status", "idempotency_key"}.issubset(columns):
+        return
+
+    duplicate_rows = conn.execute(
+        """
+        SELECT idempotency_key, id
+          FROM tasks
+         WHERE idempotency_key IS NOT NULL
+           AND status != 'archived'
+           AND idempotency_key IN (
+               SELECT idempotency_key
+                 FROM tasks
+                WHERE idempotency_key IS NOT NULL
+                  AND status != 'archived'
+                GROUP BY idempotency_key
+               HAVING COUNT(*) > 1
+           )
+         ORDER BY idempotency_key, id
+        """
+    ).fetchall()
+    if not duplicate_rows:
+        return
+
+    duplicates: dict[str, list[str]] = {}
+    for row in duplicate_rows:
+        duplicates.setdefault(row["idempotency_key"], []).append(row["id"])
+    details = "; ".join(
+        f"{key!r}: {', '.join(task_ids)}" for key, task_ids in duplicates.items()
+    )
+    raise ValueError(
+        "cannot enforce active Kanban idempotency-key uniqueness; "
+        f"duplicate non-archived tasks exist ({details}). No tasks were changed."
+    )
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    # Reject legacy ambiguity before any additive ALTER or backfill below so a
+    # failed migration leaves the task table's schema and rows unchanged.
+    _assert_active_idempotency_keys_unique(conn, columns=cols)
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
     if "result" not in cols:
@@ -2690,6 +2770,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
     )
+    if "status" in cols:
+        # Recheck at the constraint boundary in case a writer bypassed the
+        # cross-process initialization lock while additive migration ran.
+        _assert_active_idempotency_keys_unique(conn, columns=cols)
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency_active_unique "
+            "ON tasks(idempotency_key) "
+            "WHERE idempotency_key IS NOT NULL AND status != 'archived'"
+        )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
@@ -3155,6 +3244,43 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _assert_idempotency_contract_matches(
+    existing: Task,
+    *,
+    idempotency_key: str,
+    title: str,
+    assignee: Optional[str],
+    workspace_kind: str,
+    workspace_path: Optional[str],
+    skills: Optional[list[str]],
+) -> None:
+    expected = {
+        "title": title.strip(),
+        "assignee": assignee,
+        "workspace_kind": workspace_kind,
+        "workspace_path": workspace_path,
+        "skills": tuple(skills or ()),
+    }
+    actual = {
+        "title": existing.title,
+        "assignee": existing.assignee,
+        "workspace_kind": existing.workspace_kind,
+        "workspace_path": existing.workspace_path,
+        "skills": tuple(existing.skills or ()),
+    }
+    mismatches = [
+        f"{field}: expected {expected[field]!r}, existing {actual[field]!r}"
+        for field in expected
+        if expected[field] != actual[field]
+    ]
+    if mismatches:
+        raise ValueError(
+            f"idempotency key {idempotency_key!r} already belongs to task "
+            f"{existing.id!r} with a different semantic contract "
+            f"({'; '.join(mismatches)})"
+        )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3183,19 +3309,21 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
-) -> str:
+) -> CreateTaskResult:
     """Create a new task and optionally link it under parent tasks.
 
-    Returns the new task id.  Status is ``ready`` when there are no
+    Returns a string-compatible task id with explicit ``created`` / ``existing``
+    metadata. Status is ``ready`` when there are no
     parents (or all parents already ``done``), otherwise ``todo``.
     If ``triage=True``, status is forced to ``triage`` regardless of
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
     If ``idempotency_key`` is provided and a non-archived task with the
-    same key already exists, returns the existing task's id instead of
-    creating a duplicate. Useful for retried webhooks / automation that
-    should not double-write.
+    same key and semantic contract already exists, returns the existing task's
+    id instead of creating a duplicate. A mismatch in title, assignee,
+    workspace kind/path, or skills fails closed. Useful for retried webhooks /
+    automation that should not double-write.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3393,21 +3521,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -3430,6 +3543,38 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    def _existing_idempotency_result() -> Optional[CreateTaskResult]:
+        if idempotency_key is None:
+            return None
+        existing_row = conn.execute(
+            "SELECT * FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived'",
+            (idempotency_key,),
+        ).fetchone()
+        if existing_row is None:
+            return None
+        existing_task = Task.from_row(existing_row)
+        expected_workspace_path = workspace_path
+        if (
+            project_obj is not None
+            and workspace_kind == "worktree"
+            and project_repo
+            and expected_workspace_path is None
+        ):
+            expected_workspace_path = os.path.join(
+                project_repo, ".worktrees", existing_task.id
+            )
+        _assert_idempotency_contract_matches(
+            existing_task,
+            idempotency_key=idempotency_key,
+            title=title,
+            assignee=assignee,
+            workspace_kind=workspace_kind,
+            workspace_path=expected_workspace_path,
+            skills=skills_list,
+        )
+        return CreateTaskResult(existing_task.id, created=False)
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -3438,6 +3583,10 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                existing_result = _existing_idempotency_result()
+                if existing_result is not None:
+                    return existing_result
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3555,8 +3704,14 @@ def create_task(
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
-            return task_id
+            return CreateTaskResult(task_id, created=True)
         except sqlite3.IntegrityError:
+            # A writer outside the normal BEGIN IMMEDIATE path may have won the
+            # partial-unique-index race after our lookup. Read back its row and
+            # apply the same semantic-collision guard before reporting reuse.
+            existing_result = _existing_idempotency_result()
+            if existing_result is not None:
+                return existing_result
             if attempt == 1:
                 raise
             # Retry with a fresh id.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -650,7 +650,12 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
-        body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        body: dict[str, Any] = {
+            "task": _task_dict(task) if task else None,
+            "created": task_id.created,
+            "existing": task_id.existing,
+            "reused": task_id.reused,
+        }
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+import pickle
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 import types
 import unittest.mock
@@ -166,9 +168,303 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "idx_events_run" in indexes
 
 
+def test_idempotency_unique_index_migration_rejects_active_duplicates_without_mutation(
+    tmp_path,
+):
+    db_path = tmp_path / "duplicate-idempotency.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                assignee TEXT,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+                idempotency_key TEXT
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO tasks
+                (id, title, status, created_at, workspace_kind, idempotency_key)
+            VALUES (?, ?, 'ready', ?, 'scratch', ?)
+            """,
+            [
+                ("t_duplicate_a", "first", 1, "period-2026-q3"),
+                ("t_duplicate_b", "second", 2, "period-2026-q3"),
+            ],
+        )
+        conn.commit()
+        columns_before = conn.execute("PRAGMA table_info(tasks)").fetchall()
+    finally:
+        conn.close()
+
+    with pytest.raises(ValueError) as exc_info:
+        kb.init_db(db_path)
+
+    message = str(exc_info.value)
+    assert "period-2026-q3" in message
+    assert "t_duplicate_a" in message
+    assert "t_duplicate_b" in message
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT id, idempotency_key, status FROM tasks ORDER BY id"
+        ).fetchall()
+        columns_after = conn.execute("PRAGMA table_info(tasks)").fetchall()
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            )
+        }
+    finally:
+        conn.close()
+
+    assert rows == [
+        ("t_duplicate_a", "period-2026-q3", "ready"),
+        ("t_duplicate_b", "period-2026-q3", "ready"),
+    ]
+    assert columns_after == columns_before
+    assert "idx_tasks_idempotency_active_unique" not in indexes
+
+
+def test_database_enforces_one_active_task_per_idempotency_key(tmp_path):
+    db_path = tmp_path / "idempotency-constraint.db"
+    with kb.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO tasks
+                (id, title, status, created_at, workspace_kind, idempotency_key)
+            VALUES ('t_first', 'first', 'ready', 1, 'scratch', 'shared-key')
+            """
+        )
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO tasks
+                    (id, title, status, created_at, workspace_kind, idempotency_key)
+                VALUES ('t_duplicate', 'duplicate', 'ready', 2, 'scratch', 'shared-key')
+                """
+            )
+
+        conn.execute("UPDATE tasks SET status = 'archived' WHERE id = 't_first'")
+        conn.execute(
+            """
+            INSERT INTO tasks
+                (id, title, status, created_at, workspace_kind, idempotency_key)
+            VALUES ('t_reused', 'reused', 'ready', 3, 'scratch', 'shared-key')
+            """
+        )
+        conn.commit()
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'shared-key' "
+            "AND status != 'archived'"
+        ).fetchone()[0] == 1
+
+
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
+
+def test_idempotent_create_reports_created_then_reused(kanban_home, tmp_path):
+    workspace_path = str(tmp_path / "shared-workspace")
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="periodic assessment",
+            assignee="ops",
+            workspace_kind="dir",
+            workspace_path=workspace_path,
+            skills=["audit"],
+            idempotency_key="assessment-2026-q3",
+        )
+        second = kb.create_task(
+            conn,
+            title="periodic assessment",
+            assignee="ops",
+            workspace_kind="dir",
+            workspace_path=workspace_path,
+            skills=["audit"],
+            idempotency_key="assessment-2026-q3",
+        )
+
+        assert first.task_id == second.task_id
+        assert first.created is True
+        assert first.existing is False
+        assert first.reused is False
+        assert second.created is False
+        assert second.existing is True
+        assert second.reused is True
+        assert str(first) == first.task_id
+        assert [event.kind for event in kb.list_events(conn, first)] == ["created"]
+
+
+def test_create_task_result_pickles_as_a_string_compatible_result():
+    original = kb.CreateTaskResult("t_pickle", created=False)
+
+    restored = pickle.loads(pickle.dumps(original))
+
+    assert restored == "t_pickle"
+    assert isinstance(restored, kb.CreateTaskResult)
+    assert restored.created is False
+    assert restored.reused is True
+
+
+def test_empty_non_null_idempotency_key_is_reused(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="empty key contract",
+            assignee="ops",
+            idempotency_key="",
+        )
+        second = kb.create_task(
+            conn,
+            title="empty key contract",
+            assignee="ops",
+            idempotency_key="",
+        )
+
+        assert first.created is True
+        assert second.reused is True
+        assert first.task_id == second.task_id
+
+
+def test_archived_idempotency_key_may_be_reused(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="periodic assessment",
+            assignee="ops",
+            idempotency_key="assessment-2026-q2",
+        )
+        assert kb.archive_task(conn, first) is True
+
+        second = kb.create_task(
+            conn,
+            title="periodic assessment",
+            assignee="ops",
+            idempotency_key="assessment-2026-q2",
+        )
+
+        assert second.created is True
+        assert second.task_id != first.task_id
+        rows = conn.execute(
+            "SELECT id, status FROM tasks WHERE idempotency_key = ? ORDER BY id",
+            ("assessment-2026-q2",),
+        ).fetchall()
+        assert len(rows) == 2
+        assert sum(row["status"] != "archived" for row in rows) == 1
+        assert [event.kind for event in kb.list_events(conn, second)] == ["created"]
+
+
+def test_simultaneous_idempotent_creators_return_one_created_and_one_reused(
+    kanban_home,
+):
+    release_creators = threading.Barrier(2)
+    # On the regressed implementation the lookup ran before BEGIN IMMEDIATE;
+    # hold both legacy lookups at that exact boundary so the test is reliably
+    # RED there. The fixed path performs its lookup inside the write transaction,
+    # so this trace-only barrier intentionally remains dormant.
+    pre_transaction_lookups = threading.Barrier(2)
+
+    def create_from_independent_connection():
+        conn = kb.connect()
+        try:
+            def synchronize_legacy_lookup(sql):
+                if (
+                    "FROM TASKS WHERE IDEMPOTENCY_KEY" in sql.upper()
+                    and not conn.in_transaction
+                ):
+                    pre_transaction_lookups.wait(timeout=5)
+
+            conn.set_trace_callback(synchronize_legacy_lookup)
+            release_creators.wait(timeout=5)
+            return kb.create_task(
+                conn,
+                title="simultaneous assessment",
+                assignee="ops",
+                skills=["audit"],
+                idempotency_key="assessment-simultaneous-2026-q3",
+            )
+        finally:
+            conn.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(create_from_independent_connection) for _ in range(2)
+        ]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert results[0].task_id == results[1].task_id
+    assert sorted(result.created for result in results) == [False, True]
+    assert sorted(result.reused for result in results) == [False, True]
+
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived'",
+            ("assessment-simultaneous-2026-q3",),
+        ).fetchall()
+        assert [row["id"] for row in rows] == [results[0].task_id]
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ? AND kind = 'created'",
+            (results[0].task_id,),
+        ).fetchone()[0] == 1
+
+
+@pytest.mark.parametrize(
+    ("override", "field"),
+    [
+        ({"title": "different assessment"}, "title"),
+        ({"assignee": "alice"}, "assignee"),
+        ({"workspace_kind": "scratch"}, "workspace_kind"),
+        ({"workspace_path": "/different/workspace"}, "workspace_path"),
+        ({"skills": ["different-skill"]}, "skills"),
+    ],
+)
+def test_idempotent_create_rejects_semantic_mismatch_without_mutation(
+    kanban_home,
+    tmp_path,
+    override,
+    field,
+):
+    workspace_path = str(tmp_path / "shared-workspace")
+    contract = {
+        "title": "periodic assessment",
+        "assignee": "ops",
+        "workspace_kind": "dir",
+        "workspace_path": workspace_path,
+        "skills": ["audit"],
+        "idempotency_key": "assessment-2026-q4",
+    }
+    with kb.connect() as conn:
+        original = kb.create_task(conn, **contract)
+
+        with pytest.raises(ValueError, match=field):
+            kb.create_task(conn, **(contract | override))
+
+        task = kb.get_task(conn, original)
+        assert task is not None
+        assert task.title == contract["title"]
+        assert task.assignee == contract["assignee"]
+        assert task.workspace_kind == contract["workspace_kind"]
+        assert task.workspace_path == contract["workspace_path"]
+        assert task.skills == contract["skills"]
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?",
+            (contract["idempotency_key"],),
+        ).fetchone()[0] == 1
+        assert [event.kind for event in kb.list_events(conn, original)] == ["created"]
 
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -116,6 +116,57 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_api_reports_created_then_reused(client):
+    payload = {
+        "title": "Quarterly assessment",
+        "assignee": "researcher",
+        "workspace_kind": "scratch",
+        "skills": ["audit"],
+        "idempotency_key": "quarterly-assessment-2026-q3",
+    }
+
+    first = client.post("/api/plugins/kanban/tasks", json=payload)
+    second = client.post("/api/plugins/kanban/tasks", json=payload)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    first_body = first.json()
+    second_body = second.json()
+    assert first_body["task"]["id"] == second_body["task"]["id"]
+    assert first_body["created"] is True
+    assert first_body["existing"] is False
+    assert first_body["reused"] is False
+    assert second_body["created"] is False
+    assert second_body["existing"] is True
+    assert second_body["reused"] is True
+
+
+def test_create_task_api_rejects_idempotency_contract_mismatch_without_mutation(client):
+    payload = {
+        "title": "Quarterly assessment",
+        "assignee": "researcher",
+        "workspace_kind": "scratch",
+        "skills": ["audit"],
+        "idempotency_key": "quarterly-assessment-2026-q4",
+    }
+    first = client.post("/api/plugins/kanban/tasks", json=payload)
+
+    mismatch = client.post(
+        "/api/plugins/kanban/tasks",
+        json={**payload, "title": "Different assessment"},
+    )
+
+    assert first.status_code == 200, first.text
+    assert mismatch.status_code == 400, mismatch.text
+    assert "different semantic contract" in mismatch.json()["detail"]
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT title FROM tasks WHERE idempotency_key = ?",
+            (payload["idempotency_key"],),
+        ).fetchall()
+    assert [row["title"] for row in rows] == [payload["title"]]
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,28 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_idempotency_result_is_explicit_and_task_id_stays_compatible(worker_env):
+    from tools import kanban_tools as kt
+
+    args = {
+        "title": "periodic child",
+        "assignee": "peer",
+        "workspace_kind": "scratch",
+        "skills": ["audit"],
+        "idempotency_key": "periodic-child-2026-q3",
+    }
+    first = json.loads(kt._handle_create(args))
+    second = json.loads(kt._handle_create(args))
+
+    assert first["task_id"] == second["task_id"]
+    assert first["created"] is True
+    assert first["existing"] is False
+    assert first["reused"] is False
+    assert second["created"] is False
+    assert second["existing"] is True
+    assert second["reused"] is True
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1466,6 +1466,9 @@ def _handle_create(args: dict, **kw) -> str:
             subscribed = _maybe_auto_subscribe(conn, new_tid)
             return _ok(
                 task_id=new_tid,
+                created=new_tid.created,
+                existing=new_tid.existing,
+                reused=new_tid.reused,
                 status=new_task.status if new_task else None,
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
@@ -2137,7 +2140,8 @@ KANBAN_CREATE_SCHEMA = {
         "orchestrator workers to fan out — decompose work into child "
         "tasks with specific assignees, link them into a pipeline, "
         "then complete your own task. The dispatcher picks up the new "
-        "tasks on its next tick and spawns the assigned profiles."
+        "tasks on its next tick and spawns the assigned profiles. The result "
+        "retains task_id and explicitly reports created, existing, and reused."
     ),
     "parameters": {
         "type": "object",
@@ -2225,8 +2229,9 @@ KANBAN_CREATE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "If a non-archived task with this key already "
-                    "exists, return that task's id instead of creating "
-                    "a duplicate. Useful for retry-safe automation."
+                    "exists with the same title, assignee, workspace, and skills, "
+                    "return that task's id with existing/reused=true instead of "
+                    "creating a duplicate. A semantic mismatch is rejected."
                 ),
             },
             "max_runtime_seconds": {


### PR DESCRIPTION
## Summary
- enforce one active task per non-null idempotency key with a partial SQLite unique index
- fail closed before mutating legacy task tables when duplicate active keys block migration
- preserve string callers while exposing explicit created/existing/reused state across the DB, tool, and dashboard APIs
- reject semantic key collisions and serialize simultaneous creators to one task and one creation event

This is intentionally split from #94194 so unknown-assignee hardening and idempotent-create concurrency remain independently reviewable.

## Test plan
- [x] New regression selection fails on current main (15 failures)
- [x] Affected DB/tool/dashboard suites: 115 passed, 1 expected macOS host skip
- [x] Broad Kanban/dispatcher/API/tool/plugin suites: 475 passed, 2 expected host skips
- [x] Ruff check on all changed Python files
- [x] `git diff --check`
- [x] Independent review passed with no security or logic findings