### PR TITLE
fix(memory): send score_threshold in viking_search so subdirectory memories are returned

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -556,6 +556,15 @@ SEARCH_SCHEMA = {
                 "description": "Viking URI prefix to scope search (e.g. 'viking://resources/docs/').",
             },
             "limit": {"type": "integer", "description": "Max results (default: 10)."},
+            "threshold": {
+                "type": "number",
+                "description": (
+                    "Minimum semantic score for a result (0-1). Default 0 "
+                    "returns everything the index matched, including "
+                    "memories in subdirectories; raise it to keep only "
+                    "strong matches."
+                ),
+            },
         },
         "required": ["query"],
     },
@@ -5051,7 +5060,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not query:
             return tool_error("query is required")
 
-        payload: Dict[str, Any] = {"query": query}
+        # score_threshold=0 matches the automatic recall path
+        # (_post_prefetch_search): without it the search/find endpoint
+        # applies its own narrow default recall, which returns only
+        # top-level memory files and silently drops subdirectory memories
+        # (entities/, events/, preferences/) even when they are vector-
+        # indexed and score highly (#94596).
+        score_threshold = 0.0
+        if args.get("threshold") is not None:
+            try:
+                score_threshold = float(args["threshold"])
+            except (TypeError, ValueError):
+                return tool_error("threshold must be a number")
+        payload: Dict[str, Any] = {
+            "query": query,
+            "score_threshold": score_threshold,
+        }
         mode = args.get("mode", "auto")
         if args.get("scope"):
             payload["target_uri"] = args["scope"]

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -708,6 +708,46 @@ def test_tool_search_sorts_by_raw_score_across_buckets():
     assert result["total"] == 3
 
 
+def test_tool_search_sends_score_threshold_zero_by_default():
+    """#94596: without an explicit score_threshold the search/find endpoint
+    applies its own narrow default recall, which returns only top-level
+    memory files and silently drops subdirectory memories (entities/,
+    events/, preferences/) even when they are vector-indexed and score
+    highly. The tool must send 0 like the automatic recall path
+    (_post_prefetch_search) does, so tool callers see the same recall
+    surface as automatic recall."""
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {"result": {"memories": [], "total": 0}}
+
+    provider._tool_search({"query": "fishingdrill"})
+
+    endpoint, payload = provider._client.post.call_args[0]
+    assert endpoint == "/api/v1/search/find"
+    assert payload["score_threshold"] == 0
+
+
+def test_tool_search_threshold_argument_overrides_default():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {"result": {"memories": [], "total": 0}}
+
+    provider._tool_search({"query": "fishingdrill", "threshold": 0.75})
+
+    _, payload = provider._client.post.call_args[0]
+    assert payload["score_threshold"] == 0.75
+
+
+def test_tool_search_rejects_non_numeric_threshold():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+
+    result = provider._tool_search({"query": "fishingdrill", "threshold": "high"})
+
+    assert "threshold must be a number" in result
+    provider._client.post.assert_not_called()
+
+
 def test_tool_add_resource_rejects_hermes_credential_file_upload(tmp_path, monkeypatch):
     import agent.file_safety as fs
 


### PR DESCRIPTION
## What does this PR do?

The `viking_search` tool built its search payload **without `score_threshold`**, so the OpenViking `search/find` endpoint applied its own narrow default recall: only top-level memory files (`profile.md`, `soul.md`, `identity.md`, `.overview.md`) ever came back, while subdirectory memories (`entities/`, `events/`, `preferences/`) were silently dropped — even when they were vector-indexed and scored highly (the issue reproduces with a 0.96-scoring `entities/…/ext-fishingdrill.md` that the tool never returned). The automatic recall path (`_post_prefetch_search`) already sends `score_threshold: 0` explicitly, which is exactly why automatic recall found records the tool could not (#94596).

The fix sends `score_threshold: 0` by default in `_tool_search`, aligning the tool's recall surface with automatic recall. The change only widens results: existing top-level matches keep coming back and subdirectory matches join them. An optional numeric `threshold` parameter is exposed on the tool schema for callers that want only strong matches; a non-numeric value is rejected with a tool error before any request is made.

## Related Issue

Fixes #94596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py` — `_tool_search` now sends `score_threshold` in the payload (default `0`, mirroring `_post_prefetch_search`), with the new optional `threshold` argument validated as a number; `SEARCH_SCHEMA` documents the parameter.
- `tests/plugins/memory/test_openviking_provider.py` — three regressions: the default payload carries `score_threshold: 0` on the `search/find` endpoint; the `threshold` argument overrides it; a non-numeric threshold returns a tool error without issuing a request.

## How to Test

1. `pytest tests/plugins/memory/ -q -k openviking` — should pass (76 passed, 1 skipped).
2. Observed result: with this PR's source reverted (plain main), the new payload tests fail 3/3 — the tool's request payload has no `score_threshold` key at all; with the change, `provider._tool_search({"query": "..."})` posts `{"query": ..., "score_threshold": 0}` and `{"threshold": 0.75}` is forwarded as `score_threshold: 0.75`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction from the issue (before this fix): the same query returned only top-level files through the tool, while the OpenViking CLI with an explicit threshold returned the subdirectory record:

```
viking_search "fishingdrill 钓鱼演练"
  → profile.md (0.865), soul.md (0.285)          # entities/…/ext-fishingdrill.md missing
ov search "fishingdrill" --threshold 0
  → entities/…/ext-fishingdrill.md (0.960), …    # same index, explicit threshold
```

After this fix the tool sends `score_threshold: 0` like automatic recall and returns the subdirectory matches.
