### PR TITLE
fix(gateway): use asyncio.get_running_loop() in remaining async sites

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28901,7 +28901,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from gateway.streaming_tts_consumer import StreamingTTSConsumer
                 from tools.tts_tool import _load_tts_config
                 _tts_cfg = _load_tts_config()
-                _gateway_loop = self._gateway_loop or asyncio.get_event_loop()
+                _gateway_loop = self._gateway_loop or asyncio.get_running_loop()
                 _stts_consumer = StreamingTTSConsumer(
                     adapter=_stts_adapter,
                     chat_id=source.chat_id,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11623,7 +11623,7 @@ async def _start_device_code_flow(
                     code_challenge=challenge,
                     state=state,
                 )
-        device_data = await asyncio.get_event_loop().run_in_executor(
+        device_data = await asyncio.get_running_loop().run_in_executor(
             None, _do_minimax_request
         )
         sid, sess = _new_oauth_session("minimax-oauth", "device_code", profile=profile)

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -767,7 +767,7 @@ class SimplexAdapter(BasePlatformAdapter):
         corr_id = self._make_corr_id()
         payload = json.dumps({"corrId": corr_id, "cmd": command})
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut: asyncio.Future = loop.create_future()
         self._pending_responses[corr_id] = fut
 


### PR DESCRIPTION
## Problem

Final three `asyncio.get_event_loop()` call sites inside `async def` bodies (completes the sweep started by #94600 for photon; `agent/lsp/client.py` is deliberately excluded as it's covered by open #27389):

- `plugins/platforms/simplex/adapter.py` `_send_command`: response future creation
- `gateway/run.py` `_run_agent_inner`: TTS-consumer loop fallback (`self._gateway_loop or get_event_loop()`)
- `hermes_cli/web_server.py` `_start_device_code_flow`: `run_in_executor` hop

Deprecated since 3.10/3.12; warns under `-W error::DeprecationWarning`; can mis-resolve under nested loops. All three execute on the live loop, so the running-loop accessor is behavior-identical.

## Verification

SimpleX suite: 16/16 pass; all modules syntax-checked.