### PR TITLE
fix(cron): stop multiplex ticker recreating archived profile homes

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -638,6 +639,15 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_homes`` is captured once when the ticker starts and never
+        re-scanned. If an admin archives a profile (moves its directory out
+        from under ``profiles/``) while the ticker is running, the stale
+        entry must not keep being ticked — ``ensure_dirs()``'s
+        ``mkdir(parents=True, exist_ok=True)`` on the heartbeat/tick path
+        would otherwise silently recreate the directory the admin just
+        removed (#94590). Re-checking ``home.is_dir()`` every cycle is cheap
+        and self-heals without a restart once the directory is gone.
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -659,6 +669,8 @@ class InProcessCronScheduler(CronScheduler):
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
+            if not Path(home).is_dir():
+                continue  # archived/removed since the ticker captured this list (#94590)
             home_token = set_hermes_home_override(str(home))
             try:
                 with use_cron_store(home):
@@ -683,6 +695,8 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        if not Path(home).is_dir():
+                            continue  # archived/removed since the ticker captured this list (#94590)
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
@@ -706,6 +720,8 @@ class InProcessCronScheduler(CronScheduler):
             # Record per-profile heartbeat after each tick cycle.
             for entry in profile_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
+                if not Path(home).is_dir():
+                    continue  # archived/removed since the ticker captured this list (#94590)
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -703,3 +703,51 @@ def test_multiplex_ticker_does_not_recreate_archived_profile(tmp_path):
     assert not p2.exists(), "archived profile directory must not be recreated by the ticker"
 
 
+def test_multiplex_ticker_resumes_after_profile_unarchived(tmp_path):
+    """Recreating a previously-archived profile's directory must let the
+    ticker resume ticking it on the next cycle (the self-heal behavior
+    ``_start_multiplex``'s docstring claims for the ``is_dir()`` guard, #94590).
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "research"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+
+    profile_homes = [("default", p1), ("research", p2)]
+
+    class _StepStopEvent:
+        def __init__(self, iterations, on_wait):
+            self._remaining = iterations
+            self._on_wait = on_wait
+
+        def is_set(self):
+            return self._remaining <= 0
+
+        def wait(self, timeout=None):
+            self._remaining -= 1
+            self._on_wait()
+            return False
+
+    calls = {"n": 0}
+
+    def _archive_then_unarchive():
+        import shutil
+
+        calls["n"] += 1
+        if calls["n"] == 1:
+            shutil.rmtree(p2)  # iteration 2 must skip "research"
+        elif calls["n"] == 2:
+            (p2 / "cron").mkdir(parents=True, exist_ok=True)  # iteration 3 must resume it
+
+    stop = _StepStopEvent(iterations=3, on_wait=_archive_then_unarchive)
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", return_value=0):
+        prov.start(stop, interval=0, profile_homes=profile_homes)
+
+    assert (p2 / "cron" / "ticker_heartbeat").exists(), \
+        "un-archived profile must be ticked again once its directory reappears"
+
+

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,66 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_does_not_recreate_archived_profile(tmp_path):
+    """A profile home removed after the ticker captured its (fixed) profile_homes
+    list must not be recreated by the next tick's ensure_dirs()/mkdir (#94590).
+
+    ``_start_multiplex`` never re-scans ``profiles/`` — it ticks the same list
+    of homes for as long as the ticker thread lives. If an admin archives a
+    profile (moves its directory away) mid-run, the stale entry's heartbeat
+    write used to mkdir the directory straight back into existence every
+    interval.
+
+    Runs the ticker loop synchronously (no background thread) via a fake
+    stop_event whose ``wait()`` steps one iteration at a time, so the profile
+    can be archived deterministically between iteration 1 and 2 with no race
+    against a live ticker thread.
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "research"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+
+    profile_homes = [("default", p1), ("research", p2)]
+
+    class _StepStopEvent:
+        """Runs exactly `iterations` loop passes, invoking `on_wait` (in the
+        same thread, between passes) where the real code calls
+        stop_event.wait(interval)."""
+
+        def __init__(self, iterations, on_wait):
+            self._remaining = iterations
+            self._on_wait = on_wait
+
+        def is_set(self):
+            return self._remaining <= 0
+
+        def wait(self, timeout=None):
+            self._remaining -= 1
+            self._on_wait()
+            return False
+
+    archived = []
+
+    def _archive_research_once():
+        # Only ever archive once — a second call would silently mask a
+        # recreation the guard failed to prevent during iteration 2.
+        if not archived:
+            archived.append(True)
+            import shutil
+            shutil.rmtree(p2)
+
+    stop = _StepStopEvent(iterations=3, on_wait=_archive_research_once)
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", return_value=0):
+        # Iteration 1 ticks both profiles normally, then on_wait archives
+        # "research" before iteration 2 starts. Iterations 2 and 3 must not
+        # recreate it.
+        prov.start(stop, interval=0, profile_homes=profile_homes)
+
+    assert not p2.exists(), "archived profile directory must not be recreated by the ticker"
+
+


### PR DESCRIPTION
Fixes #94590.

## Root cause

`InProcessCronScheduler._start_multiplex()` (`cron/scheduler_provider.py`)
ticks the `profile_homes` list it was handed once, when the ticker thread
starts (`hermes_cli/web_server.py::_start_desktop_cron_ticker` builds that
list from a single `profiles_to_serve(multiplex=True)` scan and never
refreshes it for the life of the desktop backend).

When an admin archives a profile — `mv profiles/research
profiles/_archived/research-...` — while the ticker thread is already
running, the stale `("research", <path>)` entry stays in that captured
list. Every subsequent tick still does:

```python
with use_cron_store(home):
    record_ticker_heartbeat(success=ok)
```

`record_ticker_heartbeat` → `_atomic_write_epoch` → `ensure_dirs()` calls
`store.cron_dir.mkdir(parents=True, exist_ok=True)`, where `cron_dir = home
/ "cron"`. `mkdir(parents=True)` happily recreates `home` itself if it's
missing — so the very directory the admin just moved away reappears within
one tick interval (60s), containing only `cron/ticker_heartbeat` +
`ticker_last_success`, exactly as reported.

This hits all three places in `_start_multiplex` that walk `profile_homes`:
the initial recovery+heartbeat pass, the per-tick `cron_tick` loop, and the
post-tick heartbeat loop.

## Fix

Before scoping to a profile's home in each of those three loops, skip the
entry if `Path(home).is_dir()` is now `False`. This is a cheap check (no
extra I/O beyond a stat) and self-heals on the very next tick once a
profile directory is gone — no ticker restart required. It does not touch
`profiles_to_serve`/directory scanning at all, since the recreation happens
downstream of that scan, in the ticker's per-iteration store access.

## Test

Added `test_multiplex_ticker_does_not_recreate_archived_profile` in
`tests/cron/test_scheduler_provider.py`. It drives
`InProcessCronScheduler._start_multiplex` synchronously (no background
thread) via a fake `stop_event` whose `wait()` steps one loop iteration at a
time, so a profile's directory can be removed deterministically between
iteration 1 and iteration 2 with no race against a live ticker thread. It
then asserts the archived directory stays gone through two more iterations.

Confirmed the test fails without the fix and passes with it:

```
$ git checkout HEAD -- cron/scheduler_provider.py   # revert only the fix
$ python -m pytest tests/cron/test_scheduler_provider.py -q -k does_not_recreate
...
>       assert not p2.exists(), "archived profile directory must not be recreated by the ticker"
E       AssertionError: archived profile directory must not be recreated by the ticker
E       assert not True
E        +  where True = exists()
1 failed, 30 deselected in 0.24s

$ git checkout cron/scheduler_provider.py           # restore the fix
$ python -m pytest tests/cron/test_scheduler_provider.py -q
...............................                                          [100%]
31 passed in 1.25s
```

Also ran the wider `tests/cron/` suite (939 passed, 4 pre-existing failures
unrelated to this change — confirmed identical on unmodified `main`:
`test_media_send_timeout.py` assertion-count mismatch and
`test_script_claim_heartbeat.py`'s process-group kill guard, both artifacts
of the sandboxed process-group environment this was validated in rather
than this repo's own `scripts/run_tests_parallel.py` isolation).

`ruff check cron/scheduler_provider.py tests/cron/test_scheduler_provider.py`
passes clean.

## AI assistance disclosure

This change was written by an autonomous coding agent (Claude), with the
root cause traced to a specific line (`ensure_dirs()`'s `mkdir(parents=True,
exist_ok=True)`) and the fix/test verified locally as shown above before
pushing.
