### PR TITLE
fix(gateway): detach restart watcher stdin on every spawn path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11561,6 +11561,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     watcher_argv,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL,
                     env=watcher_env,
                     **windows_detach_popen_kwargs(),
                 )
@@ -11570,6 +11571,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         watcher_argv,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
+                        stdin=subprocess.DEVNULL,
                         env=watcher_env,
                         creationflags=windows_detach_flags_without_breakaway(),
                     )
@@ -11615,6 +11617,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 [setsid_bin, "bash", "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
                 env=watcher_env,
                 start_new_session=True,
             )
@@ -11623,6 +11626,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ["bash", "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
                 env=watcher_env,
                 start_new_session=True,
             )


### PR DESCRIPTION
## Problem

All four detached restart-watcher spawns (`gateway/run.py` — Windows primary, Windows no-breakaway retry, POSIX `setsid`, POSIX plain-bash fallback) redirected `stdout`/`stderr` to `DEVNULL` but left **`stdin` inherited** from the gateway process.

A detached watcher holding the gateway's console input handle isn't fully detached: the originating terminal session stays pinned (notably on Windows where the child keeps the console's input handle alive), and any read in the child would block forever against an abandoned tty.

## Fix

`stdin=subprocess.DEVNULL` added to all four spawn paths — matching the repo's own detachment discipline used by `_spawn_detached` in `hermes_cli/gateway_windows.py`.

## Verification

Gateway restart selection: 106 passed / 2 skipped; module parses clean.