### PR TITLE
fix(openrouter): keep presets pinned to their configured provider

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3090,9 +3090,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             if profile_extra_body:
                 summary_extra_body.update(profile_extra_body)
-            if provider_preferences and "provider" not in profile_extra_body and (
-                (agent.provider or "").strip().lower() == "openrouter"
-                or agent._is_openrouter_url()
+            if (
+                provider_preferences
+                and not agent.model.startswith("@preset/")
+                and "provider" not in profile_extra_body
+                and (
+                    (agent.provider or "").strip().lower() == "openrouter"
+                    or agent._is_openrouter_url()
+                )
             ):
                 summary_extra_body["provider"] = provider_preferences
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -634,7 +634,7 @@ class ChatCompletionsTransport(ProviderTransport):
         base_url = params.get("base_url")
 
         provider_prefs = params.get("provider_preferences")
-        if provider_prefs and is_openrouter:
+        if provider_prefs and is_openrouter and not model.startswith("@preset/"):
             extra_body["provider"] = provider_prefs
 
         # Pareto Code router plugin — model-gated. Same shape as the

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -11,6 +11,7 @@ from providers.base import ProviderProfile
 logger = logging.getLogger(__name__)
 
 _CACHE: list[str] | None = None
+_PRESET_PROVIDER_ROUTING_WARNED = False
 
 # Anthropic model families that still accept an explicit "disable thinking"
 # request (the manual ``thinking: {type: "disabled"}`` form OpenRouter emits
@@ -115,6 +116,8 @@ class OpenRouterProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
+        global _PRESET_PROVIDER_ROUTING_WARNED
+
         body: dict[str, Any] = {}
         # Top-level session_id → OpenRouter's sticky routing key. Per their
         # prompt-caching docs it is used directly as the routing key instead of
@@ -136,15 +139,25 @@ class OpenRouterProfile(ProviderProfile):
         sticky_key = _cache_scope_from_session_id(get_conversation_context() or session_id)
         if sticky_key:
             body["session_id"] = sticky_key
+        model = context.get("model") or ""
         prefs = context.get("provider_preferences")
         if prefs:
-            body["provider"] = prefs
+            if model.startswith("@preset/"):
+                if not _PRESET_PROVIDER_ROUTING_WARNED:
+                    _PRESET_PROVIDER_ROUTING_WARNED = True
+                    logger.warning(
+                        "Ignoring provider_routing for OpenRouter preset %r because "
+                        "request-level provider preferences replace the preset's "
+                        "server-side provider policy",
+                        model,
+                    )
+            else:
+                body["provider"] = prefs
 
         # Pareto Code router — model-gated. The plugins block is only
         # meaningful for openrouter/pareto-code; sending it on any other
         # model has no documented effect and would be confusing in logs.
         # See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
-        model = (context.get("model") or "")
         if model == "openrouter/pareto-code":
             score = context.get("openrouter_min_coding_score")
             if score is not None and score != "":

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -52,6 +52,27 @@ class TestOpenRouterProfile:
         body = p.build_extra_body(provider_preferences={"allow": ["anthropic"]})
         assert body["provider"] == {"allow": ["anthropic"]}
 
+    def test_preset_logs_ignored_provider_preferences(self, caplog):
+        p = get_provider_profile("openrouter")
+
+        with caplog.at_level("WARNING"):
+            p.build_extra_body(
+                model="@preset/diagnostic-contract",
+                provider_preferences={"data_collection": "deny"},
+            )
+            p.build_extra_body(
+                model="@preset/another-preset",
+                provider_preferences={"sort": "price"},
+            )
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "Ignoring provider_routing for OpenRouter preset"
+            in record.getMessage()
+        ]
+        assert len(messages) == 1
+
     def test_sticky_session_id_normalizes_cron_timestamp(self):
         """Cron re-fires of the same job keep the same sticky routing key."""
         p = get_provider_profile("openrouter")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -111,6 +111,29 @@ class TestOpenRouterParity:
 
         assert "provider" not in kw.get("extra_body", {})
 
+    def test_legacy_preset_keeps_server_side_provider_policy(self, transport):
+        kw = transport.build_kwargs(
+            model="@preset/hermes-primary",
+            messages=_simple_messages(),
+            tools=None,
+            is_openrouter=True,
+            provider_preferences={"data_collection": "deny"},
+        )
+
+        assert "provider" not in kw.get("extra_body", {})
+
+    def test_legacy_regular_model_keeps_provider_preferences(self, transport):
+        prefs = {"data_collection": "deny"}
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=_simple_messages(),
+            tools=None,
+            is_openrouter=True,
+            provider_preferences=prefs,
+        )
+
+        assert kw["extra_body"]["provider"] == prefs
+
 
 
 

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -100,6 +100,17 @@ class TestOpenRouterParity:
         )
         assert kw["extra_body"]["provider"] == prefs
 
+    def test_preset_keeps_server_side_provider_policy(self, transport):
+        kw = transport.build_kwargs(
+            model="@preset/hermes-primary",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("openrouter"),
+            provider_preferences={"data_collection": "deny"},
+        )
+
+        assert "provider" not in kw.get("extra_body", {})
+
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2751,6 +2751,38 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_preserves_openrouter_preset_provider_policy(self, agent):
+        agent.provider = "openrouter"
+        agent.model = "@preset/hermes-primary"
+        agent.provider_data_collection = "deny"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert "provider" not in kwargs.get("extra_body", {})
+
+    def test_summary_keeps_provider_preferences_for_regular_openrouter_model(self, agent):
+        agent.provider = "openrouter"
+        agent.model = "anthropic/claude-sonnet-4.6"
+        agent.provider_data_collection = "deny"
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            60,
+        )
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"] == {"data_collection": "deny"}
+
     def test_summary_request_removes_orphan_tool_result(self, agent):
         """Regression: max-iterations summary request must NOT contain
         orphan tool results (tool_call_id with no matching assistant tool_call)."""


### PR DESCRIPTION
## What does this PR do?

OpenRouter presets now keep their server-side provider policy when Hermes also has `provider_routing` preferences configured. Hermes omits the request-level `provider` object for `@preset/...` models because OpenRouter treats that object as a replacement, not an intersection, and logs one warning explaining why the local preferences were ignored.

### Symptom

A preset pinned to one provider can silently route through an unpinned reseller when a leftover `provider_routing` block adds request-level preferences such as `data_collection: deny`.

### Impact

Users relying on an OpenRouter preset's `only` and `allow_fallbacks` policy can receive responses from a provider outside that preset policy without a Hermes diagnostic.

### Bug Cause

**Trigger:** `plugins/model-providers/openrouter/__init__.py:OpenRouterProfile.build_extra_body` when the model starts with `@preset/` and `provider_preferences` is non-empty.

**Causal chain:**
1. Hermes builds request-level preferences from `config.yaml` `provider_routing`.
2. `OpenRouterProfile.build_extra_body` unconditionally emits those preferences as `extra_body.provider`, including for preset model references.
3. OpenRouter replaces the preset's server-side provider policy with the request-level object, allowing routing outside the preset pin.

**Why it is wrong:** Hermes presented presets and local routing preferences as composable configuration, but OpenRouter gives the request-level object precedence rather than intersecting it with the preset policy.

**Working sibling / contrast:** Ordinary OpenRouter model IDs have no hidden preset policy, so they continue to receive the configured request-level provider preferences.

**Ruled out:** The preset itself is not malformed; the issue's direct control request without a request-level `provider` object constrains routing to the pinned endpoint.

### Fix

Treat `@preset/...` provider policy as authoritative: omit `extra_body.provider` for preset models while preserving existing behavior for ordinary models. Emit a once-per-process warning so users can diagnose why `provider_routing` was not applied.

## Related Issue

Closes #94589

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/openrouter/__init__.py` - preserve preset provider policy and warn when request-level preferences are ignored.
- `tests/providers/test_transport_parity.py` - cover the full transport payload contract for preset models.
- `tests/providers/test_provider_profiles.py` - cover the once-per-process diagnostic.

## How to Test

1. Run the provider profile and transport contract tests:

```bash
scripts/run_tests.sh tests/providers/test_provider_profiles.py tests/providers/test_transport_parity.py -q
```

2. Confirm all 28 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant provider tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior is diagnosed at runtime and covered by tests
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the change is pure request construction
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - automated request-payload contracts cover the regression.
