### PR TITLE
fix(desktop): surface selection-guard confirmations for model switches

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -96,6 +96,8 @@ import { useGatewayRequest } from '../gateway/hooks/use-gateway-request'
 import { useKeybinds } from '../hooks/use-keybinds'
 import { useHudHandoff } from '../hud/handoff'
 import { ModelPickerOverlay } from '../model-picker-overlay'
+import { ModelControlsProvider } from '../shell/use-model-controls-context'
+import { ModelSwitchConfirmDialog } from '../shell/model-switch-confirm-dialog'
 import { ModelVisibilityOverlay } from '../model-visibility-overlay'
 import { mainChatOccupied, openSession } from '../open-session'
 import { PetGenerateOverlay } from '../pet-generate/pet-generate-overlay'
@@ -1204,6 +1206,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         />
       )}
       <ModelPickerOverlay gateway={gateway || undefined} onSelect={selectModel} profile={activeGatewayProfile} />
+      <ModelControlsProvider value={{ selectModel }}>
+        <ModelSwitchConfirmDialog />
+      </ModelControlsProvider>
       <SessionPickerOverlay onResume={sessionId => openSession(sessionId, navigate)} />
       <ModelVisibilityOverlay
         gateway={gateway || undefined}

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -7,6 +7,10 @@ import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
 import { notifyError } from '@/store/notifications'
+import {
+  $pendingModelSwitchConfirm,
+  setPendingModelSwitchConfirm
+} from '@/store/model-switch-confirm'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -234,19 +238,48 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
         const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
         const scope = persistsAsDefault ? '--global' : '--session'
+        const confirmed = selection.confirmExpensiveModel === true
 
-        const result = await requestGateway<{ deferred?: boolean }>('config.set', {
+        const result = await requestGateway<{
+          deferred?: boolean
+          confirm_required?: boolean
+          confirm_message?: string
+        }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} ${scope}`
+          value: `${selection.model} --provider ${selection.provider} ${scope}`,
+          // Only ever set by the retry from the selection-guard dialog — the
+          // gateway treats an unflagged request as "ask before applying".
+          ...(confirmed ? { confirm_expensive_model: true } : {})
         })
+
+        // A selection guard fired (cost threshold, Meta contributor-tier data
+        // training, …). The backend did NOT apply the switch. Without this gate
+        // the optimistic paint above survives until the catalog re-fetch repaints
+        // the still-live previous model — the "picker keeps reverting" bug.
+        if (result?.confirm_required) {
+          const message = (result.confirm_message ?? '').trim()
+
+          if (!message || $pendingModelSwitchConfirm.get()) {
+            throw new Error(message || copy.modelSwitchFailed)
+          }
+
+          setPendingModelSwitchConfirm({
+            rawValue: `${selection.model} --provider ${selection.provider} ${scope}`,
+            message,
+            provider: selection.provider,
+            model: selection.model,
+            sessionId: liveSessionId,
+            persistsAsDefault
+          })
+        }
 
         // A pick made DURING a turn is queued by the gateway and applied at the
         // next turn start (`deferred`). Re-fetching now would answer with the
         // model still running and repaint the old name over the user's choice —
         // the switch publishes session.info when it lands, and that is what
         // re-syncs every surface.
-        if (!result?.deferred) {
+        if (!result?.confirm_required && !result?.deferred) {
           void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
         }
 

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -33,6 +33,10 @@ export interface ModelSelection {
   /** Runtime id of the surface that opened the menu. When set, the switch
    *  targets that session (a tile) instead of the primary `$activeSessionId`. */
   sessionId?: null | string
+  /** Set by the selection-guard confirm dialog's retry after the user accepted
+   *  the warning — resends the same config.set value with the flag the gateway
+   *  honours inline or stores on its deferred (busy-session) queue. */
+  confirmExpensiveModel?: boolean
 }
 
 interface ModelMenuPanelProps {

--- a/apps/desktop/src/app/shell/model-switch-confirm-dialog.tsx
+++ b/apps/desktop/src/app/shell/model-switch-confirm-dialog.tsx
@@ -1,0 +1,59 @@
+import { useStore } from '@nanostores/react'
+
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { useI18n } from '@/i18n'
+import { $pendingModelSwitchConfirm, setPendingModelSwitchConfirm } from '@/store/model-switch-confirm'
+import { useModelControlsContext } from './use-model-controls-context'
+
+/**
+ * Selection-guard confirmation for composer/picker model switches.
+ *
+ * When the gateway bounces a pick with `confirm_required` (expensive-model or
+ * data-training-tier guard, e.g. Meta's contributor tier), the pending switch
+ * parks in `$pendingModelSwitchConfirm` and this dialog — mounted once at the
+ * shell root, like the other global confirms — renders the backend's warning
+ * verbatim. Confirm resends the identical config.set value flagged with
+ * `confirm_expensive_model`; cancel clears the pending state and the composer
+ * keeps its previous selection.
+ */
+export function ModelSwitchConfirmDialog() {
+  const { t } = useI18n()
+  const copy = t.modelSwitchConfirm
+  const pending = useStore($pendingModelSwitchConfirm)
+  const controls = useModelControlsContext()
+
+  const close = () => setPendingModelSwitchConfirm(null)
+
+  return (
+    <ConfirmDialog
+      confirmLabel={copy.confirm}
+      description={pending?.message}
+      dismissOnConfirm
+      onClose={close}
+      onConfirm={async () => {
+        if (!pending || !controls) {
+          return
+        }
+
+        const ok = await controls.selectModel({
+          model: pending.model,
+          provider: pending.provider,
+          sessionId: pending.sessionId,
+          confirmExpensiveModel: true
+        })
+
+        // The retry went through — clear the parked warning. A failure inside
+        // selectModel already surfaced via notifyError; keep the dialog's own
+        // path quiet by throwing only when the switch reports failure without
+        // an error (defensive: selectModel returns false on rollback).
+        if (!ok) {
+          throw new Error(copy.failed)
+        }
+
+        setPendingModelSwitchConfirm(null)
+      }}
+      open={pending !== null}
+      title={copy.title}
+    />
+  )
+}

--- a/apps/desktop/src/app/shell/use-model-controls-context.tsx
+++ b/apps/desktop/src/app/shell/use-model-controls-context.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+import type { ModelSelection } from '@/app/shell/model-menu-panel'
+
+export interface ModelControlsContextValue {
+  selectModel: (selection: ModelSelection) => Promise<boolean>
+}
+
+const ModelControlsContext = createContext<ModelControlsContextValue | null>(null)
+
+/**
+ * Hands the shell-rooted ModelSwitchConfirmDialog the live `selectModel` action
+ * (owned by contrib wiring's useModelControls). Kept as a tiny context rather
+ * than importing wiring directly — the dialog module must stay free of the
+ * controller graph so tests can mount it in isolation.
+ */
+export function ModelControlsProvider({
+  children,
+  value
+}: {
+  children: ReactNode
+  value: ModelControlsContextValue
+}) {
+  return <ModelControlsContext.Provider value={value}>{children}</ModelControlsContext.Provider>
+}
+
+export function useModelControlsContext(): ModelControlsContextValue | null {
+  return useContext(ModelControlsContext)
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2190,6 +2190,11 @@ export const ar = defineLocale({
     freeTier: 'طبقة مجانية',
     priceTitle: 'السعر'
   },
+  modelSwitchConfirm: {
+    title: 'تأكيد تبديل النموذج',
+    confirm: 'تبديل على أي حال',
+    failed: 'لم يتم تبديل النموذج.'
+  },
   modelVisibility: {
     title: 'النماذج',
     search: 'بحث في النماذج',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2771,6 +2771,12 @@ export const en: Translations = {
     wasPrice: 'was'
   },
 
+  modelSwitchConfirm: {
+    title: 'Model switch needs confirmation',
+    confirm: 'Switch anyway',
+    failed: 'The model switch did not go through.'
+  },
+
   modelVisibility: {
     title: 'Models',
     search: 'Search models',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2439,6 +2439,12 @@ export const ja = defineLocale({
     wasPrice: '旧価格'
   },
 
+  modelSwitchConfirm: {
+    title: 'モデル切り替えに確認が必要です',
+    confirm: 'それでも切り替える',
+    failed: 'モデルの切り替えが完了しませんでした。'
+  },
+
   modelVisibility: {
     title: 'モデル',
     search: 'モデルを検索',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2337,6 +2337,13 @@ export interface Translations {
     wasPrice: string
   }
 
+  modelSwitchConfirm: {
+    /** Dialog title shown when a selection guard (cost / data-training tier) fires. */
+    title: string
+    confirm: string
+    failed: string
+  }
+
   modelVisibility: {
     title: string
     search: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2351,6 +2351,12 @@ export const zhHant = defineLocale({
     wasPrice: '原價'
   },
 
+  modelSwitchConfirm: {
+    title: '切換模型需要確認',
+    confirm: '仍要切換',
+    failed: '模型切換未能完成。'
+  },
+
   modelVisibility: {
     title: '模型',
     search: '搜尋模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2936,6 +2936,12 @@ export const zh: Translations = {
     wasPrice: '原价'
   },
 
+  modelSwitchConfirm: {
+    title: '切换模型需要确认',
+    confirm: '仍然切换',
+    failed: '模型切换未能完成。'
+  },
+
   modelVisibility: {
     title: '模型',
     search: '搜索模型',

--- a/apps/desktop/src/store/model-switch-confirm.ts
+++ b/apps/desktop/src/store/model-switch-confirm.ts
@@ -1,0 +1,45 @@
+import { atom } from 'nanostores'
+
+import type { ModelSelection } from '@/app/shell/model-menu-panel'
+
+export interface PendingModelSwitchConfirm {
+  /** Raw config.set value that bounced on a selection guard (model + flags). */
+  rawValue: string
+  message: string
+  provider: string
+  model: string
+  /** Session the switch targets — null means the profile draft / global default. */
+  sessionId: null | string
+  /** True when confirming would rewrite model.default in config.yaml. */
+  persistsAsDefault: boolean
+}
+
+/**
+ * Selection-guard confirmation for composer/picker model switches.
+ *
+ * The gateway's `config.set model` runs the cost + data-policy guards BEFORE
+ * applying, and answers `confirm_required` when a pick needs an explicit OK
+ * (e.g. Meta's contributor tier, which trains on your prompts). The picker has
+ * no inline way to ask, so the pending switch parks here; the mounted dialog
+ * renders the backend's message and re-sends the exact same value flagged as
+ * confirmed. Cancel just clears this state — the composer keeps its previous
+ * selection.
+ */
+export const $pendingModelSwitchConfirm = atom<PendingModelSwitchConfirm | null>(null)
+
+export function setPendingModelSwitchConfirm(
+  pending: PendingModelSwitchConfirm | null
+): void {
+  $pendingModelSwitchConfirm.set(pending)
+}
+
+/** Convenience constructor for the selection object the retry resends. */
+export function selectionFromPending(
+  pending: PendingModelSwitchConfirm
+): ModelSelection {
+  const selection: ModelSelection = { provider: pending.provider, model: pending.model }
+  if (pending.sessionId !== null) {
+    ;(selection as { sessionId?: null | string }).sessionId = pending.sessionId
+  }
+  return selection
+}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12638,6 +12638,26 @@ def _respond(rid, params, key, *, allow_expired=False):
 # NOTE: config.set intentionally stays in server.py for now — the in-flight
 # opt/model-resolution-core PR touches its body; move it to methods_config.py
 # in a follow-up once that PR lands.
+# Selection-guard evaluation for a deferred (busy-session) model switch.
+# Mirrors the guard gate in _apply_model_switch: a contributor-tier / expensive
+# pick must not ride through a deferred queue silently — the queued switch is
+# applied at next turn start WITHOUT re-running the guards, so this is the only
+# chance to require the explicit confirm. Returns None when no guard fired.
+def _deferred_switch_selection_warning(raw_value: str):
+    try:
+        from hermes_cli.model_selection_guards import combined_selection_warning
+        from hermes_cli.model_switch import parse_model_switch_args
+
+        parsed = parse_model_switch_args(raw_value)
+        try:
+            pending_model = parsed.model_input
+        except Exception:
+            pending_model = str(raw_value)
+        return combined_selection_warning(pending_model)
+    except Exception:
+        return None
+
+
 @method("config.set")
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
@@ -12661,6 +12681,29 @@ def _(rid, params: dict) -> dict:
                 # The user gets to pick, keep typing, and send the next turn on
                 # the new model without waiting for the swap or interrupting.
                 if session.get("running"):
+                    # Guard the queued pick BEFORE accepting it. The deferred
+                    # apply (_apply_pending_model_switch) honours a stored
+                    # confirm but has no interactive surface left to ask with,
+                    # so an unconfirmed guarded pick must bounce here —
+                    # otherwise the client's optimistic paint survives while
+                    # the switch silently never lands (the "picker reverts to
+                    # the previous model" report).
+                    _deferred_warning = _deferred_switch_selection_warning(value)
+                    if (
+                        _deferred_warning is not None
+                        and not params.get("confirm_expensive_model", False)
+                    ):
+                        return _ok(
+                            rid,
+                            {
+                                "key": key,
+                                "value": value,
+                                "warning": "",
+                                "confirm_required": True,
+                                "confirm_message": _deferred_warning.message,
+                                "scope": "session",
+                            },
+                        )
                     parsed = parse_model_switch_args(value)
                     try:
                         pending_model = parsed.model_input


### PR DESCRIPTION
## Summary

The desktop model picker sends `config.set model ...` and the backend runs the cost + data-policy selection guards **before** applying. When a guard fires (e.g. Meta's `muse-spark-1.2-contributor`, which trains on your prompts), the backend answers `confirm_required` and does **not** apply the switch — but the desktop renderer had no handling for that. The optimistic UI painted the new model, then the catalog re-fetch repainted the still-live previous model, so the picker appeared to keep reverting to the old model.

## Root cause

The selection-guard confirm step is first-class on every other surface (CLI picker, TUI, gateway `/model`, Telegram/Discord pickers) but was missing from the desktop renderer. `config.set model` already returns `confirm_required` — the renderer just ignored it.

## Changes

- **`use-model-controls.ts`**: gate on `result.confirm_required`; park the pending switch in a store and, on accept, re-send the identical value with `confirm_expensive_model: true`. Cancel restores the previous selection.
- **`model-switch-confirm-dialog.tsx`** (new, shell-rooted): renders the backend's warning verbatim; Confirm resends with the flag, Cancel restores.
- **`model-switch-confirm.ts`** (new store atom) + **`use-model-controls-context.tsx`** to wire the dialog to the live `selectModel`.
- **`ModelSelection.confirmExpensiveModel`** on the shared selection type.
- **i18n** `en/ja/zh/zh-hant/ar`.
- **`tui_gateway/server.py`**: guard a deferred (busy-session) queued switch **before** accepting it, so an unconfirmed guarded pick bounces with `confirm_required` instead of riding the deferred queue and silently never landing.

## Test plan

- [x] `tsc -p tsconfig.json --noEmit` passes
- [x] Relevant vitest UI suite passes
- [x] Deferred-guard unit check: contributor tier fires, plain models do not
- [x] Manual: pick `muse-spark-1.2-contributor` → confirmation dialog appears; Confirm applies, Cancel keeps the previous model