### PR TITLE
fix(desktop): ignore IME Enter in Kanban task title

### DIFF
--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -33,6 +33,7 @@ import {
 import { useEffect, useState } from 'react'
 
 import { $boardSlug, BOARDS_KEY, createBoard, fetchBoards, fetchProjects, PROJECTS_KEY, updateBoard } from './api'
+import { shouldSubmitOnEnter } from './ime-enter'
 import type { BoardMeta } from './types'
 import { errText, FIELD_LABEL, useKanban } from './ui'
 
@@ -111,7 +112,7 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
             <Input
               autoFocus
               onChange={event => setName(event.target.value)}
-              onKeyDown={event => event.key === 'Enter' && slug && !project && create.mutate()}
+              onKeyDown={event => shouldSubmitOnEnter(event) && slug && !project && create.mutate()}
               placeholder={k.boardNamePlaceholder}
               value={name}
             />

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -79,6 +79,7 @@ import {
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
+import { shouldSubmitOnEnter } from './ime-enter'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
 import { OrchestrationPanel } from './orchestration'
 import { columnMeta, type KanbanBoard, type KanbanTask, type TaskEstimate } from './types'
@@ -683,7 +684,7 @@ function NewTaskDialog({
             autoFocus
             onChange={event => setTitle(event.target.value)}
             onKeyDown={event => {
-              if (event.key === 'Enter') {
+              if (shouldSubmitOnEnter(event)) {
                 event.preventDefault()
                 void submit()
               }

--- a/apps/desktop/src/plugins/kanban/ime-enter.test.ts
+++ b/apps/desktop/src/plugins/kanban/ime-enter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldSubmitOnEnter } from './ime-enter'
+
+describe('shouldSubmitOnEnter', () => {
+  it('submits a normal Enter keypress', () => {
+    expect(shouldSubmitOnEnter({ key: 'Enter', nativeEvent: {} })).toBe(true)
+  })
+
+  it('does not submit while IME composition is active', () => {
+    expect(shouldSubmitOnEnter({ key: 'Enter', nativeEvent: { isComposing: true } })).toBe(false)
+  })
+
+  it('does not submit Chromium composition-boundary keyCode 229', () => {
+    expect(shouldSubmitOnEnter({ key: 'Enter', nativeEvent: { keyCode: 229 } })).toBe(false)
+  })
+
+  it('does not submit non-Enter keys', () => {
+    expect(shouldSubmitOnEnter({ key: 'Escape', nativeEvent: {} })).toBe(false)
+  })
+})

--- a/apps/desktop/src/plugins/kanban/ime-enter.ts
+++ b/apps/desktop/src/plugins/kanban/ime-enter.ts
@@ -1,0 +1,16 @@
+export interface ImeKeyEvent {
+  key: string
+  nativeEvent: {
+    isComposing?: boolean
+    keyCode?: number
+  }
+}
+
+/**
+ * Enter confirms an IME conversion before it should act as a submit shortcut.
+ * Chromium can report the legacy 229 keyCode around composition boundaries,
+ * so keep that fallback in addition to the standard isComposing signal.
+ */
+export function shouldSubmitOnEnter(event: ImeKeyEvent): boolean {
+  return event.key === 'Enter' && !event.nativeEvent.isComposing && event.nativeEvent.keyCode !== 229
+}


### PR DESCRIPTION
## Summary

Fixes #94542.

The Kanban new-task title treats Enter as a submit shortcut. During Japanese IME composition, Enter is also used to confirm the current conversion, so the dialog could submit before composition finished.

This change:
- ignores Enter while `nativeEvent.isComposing` is true
- also guards Chromium's composition-boundary `keyCode === 229` fallback
- preserves normal Enter-to-submit behavior
- adds focused regression coverage for normal Enter, active composition, keyCode 229, and non-Enter keys

## Testing

Added focused Vitest coverage in `apps/desktop/src/plugins/kanban/ime-enter.test.ts`.
