### PR TITLE
fix(skills-guard): stop shell_rc_mod matching attribute access (self.profile)

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -413,6 +413,35 @@ class TestFalsePositiveReductions:
         assert sec
         assert all(fi.severity == "critical" for fi in sec)
 
+    def test_shell_rc_pattern_ignores_attribute_access(self, tmp_path):
+        # ``.profile`` is both a shell startup file and the way every language
+        # spells attribute access. Ordinary code produced one medium finding
+        # per line, burying the findings a reviewer needs to read.
+        code = tmp_path / "provider.py"
+        code.write_text(
+            "self.profile = load_plugin()\n"
+            "assert self.profile.name == 'x'\n"
+            "return user.profile\n"
+        )
+        assert not [
+            fi for fi in scan_file(code, "provider.py")
+            if fi.pattern_id == "shell_rc_mod"
+        ]
+
+        # Real references, in the forms they actually appear in, still flag.
+        sh = tmp_path / "setup.sh"
+        sh.write_text(
+            "echo 'export X=1' >> ~/.profile\n"
+            'cp "$HOME/.profile" /tmp/p\n'
+            "source ./.profile\n"
+            "cat ~/.zshrc ~/.bash_profile\n"
+        )
+        flagged = {
+            fi.line for fi in scan_file(sh, "setup.sh")
+            if fi.pattern_id == "shell_rc_mod"
+        }
+        assert flagged == {1, 2, 3, 4}
+
 
 # ---------------------------------------------------------------------------
 # .skillignore / .clawhubignore support

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -258,7 +258,16 @@ THREAT_PATTERNS = [
     (r'\bcrontab\b',
      "persistence_cron", "medium", "persistence",
      "modifies cron jobs"),
-    (r'\.(bashrc|zshrc|profile|bash_profile|bash_login|zprofile|zlogin)\b',
+    # ``profile`` is split out and anchored: the other names are distinctive
+    # enough that a bare ``.zshrc`` is always the file, but ``.profile`` is
+    # also how every language spells attribute access (``self.profile``,
+    # ``user.profile``), which flooded scans of ordinary code. Requiring a
+    # non-identifier character before the dot keeps real paths (``~/.profile``,
+    # ``"$HOME/.profile"``, ``./.profile``) and drops attribute reads.
+    (r'\.(bashrc|zshrc|bash_profile|bash_login|zprofile|zlogin)\b',
+     "shell_rc_mod", "medium", "persistence",
+     "references shell startup file"),
+    (r'(?<![A-Za-z0-9_])\.profile\b',
      "shell_rc_mod", "medium", "persistence",
      "references shell startup file"),
     (r'authorized_keys',


### PR DESCRIPTION
## Problem

`tools/skills_guard.py` flags shell startup files with

```python
(r'\.(bashrc|zshrc|profile|bash_profile|bash_login|zprofile|zlogin)\b',
 "shell_rc_mod", "medium", "persistence",
 "references shell startup file"),
```

Six of those names are distinctive enough that a dot in front of them means
the file. `profile` is not: it is also how every language spells attribute
access. `self.profile`, `user.profile`, and `request.profile` each produce a
medium `persistence` finding described as "references shell startup file".

The cost is signal rather than blocking — `_determine_verdict` treats
medium/low findings alone as informational, so nothing is refused. But the
scan report is what a user reads before trusting a third-party plugin, and
this pattern can dominate it. A model-provider plugin whose tests exercise a
`profile` object scored **36 of 38 findings** from this one rule; the two that
actually deserved a look were at the bottom of a wall of `self.profile`.

Reproduction:

```python
>>> from tools.skills_guard import scan_file
>>> p = Path("provider.py"); p.write_text("self.profile = load_plugin()\n")
>>> [f.pattern_id for f in scan_file(p, "provider.py")]
['shell_rc_mod']
```

## Fix

Split `profile` into its own table entry, anchored on a non-identifier
character before the dot:

```python
(r'\.(bashrc|zshrc|bash_profile|bash_login|zprofile|zlogin)\b', ...),
(r'(?<![A-Za-z0-9_])\.profile\b', ...),
```

The other six names are untouched. Real references keep matching in the forms
they actually take — `~/.profile`, `"$HOME/.profile"`, `./.profile`, and a bare
`.profile` — because none of those has an identifier character before the dot.
Attribute reads no longer match.

Both entries keep the `shell_rc_mod` id. `scan_file` deduplicates on
`(pattern_id, line)`, so a line mentioning both `.zshrc` and `.profile` still
yields exactly one finding, as before.

This is the only copy of the pattern in the tree, and `tools/plugin_guard.py`
imports `scan_file` from here, so plugin scans inherit the fix.

## Tests

`TestFalsePositiveReductions::test_shell_rc_pattern_ignores_attribute_access`
asserts both directions: three lines of ordinary attribute access produce no
`shell_rc_mod` finding, and four lines of genuine references (append via `>>`,
a quoted `$HOME` path, a relative `source`, and `.zshrc`/`.bash_profile` on one
line) all still flag.

Verified the test fails on `main` and passes with the change.
`tests/tools/test_skills_guard.py` — 32 passed.

## Related

Same family as the `agent_config_mod` false positives in #92021 (and #60709),
but a distinct rule and a much smaller change; not overlapping with #92249 /
#92027 / #88952.
