### PR TITLE
fix(sessions): fall back across profiles in get_session_detail

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -16,6 +16,7 @@ import asyncio  # noqa: F401 — used by handlers
 import json
 import logging
 import time  # noqa: F401
+from pathlib import Path
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
@@ -561,26 +562,48 @@ def _lookup_session_in_profile(session_id: str, candidate: Optional[str]):
         db.close()
 
 
+def _profile_has_session_store(candidate: str) -> bool:
+    """True only if ``candidate`` already has a non-empty state.db.
+
+    Read-only opens bootstrap a missing/zero-byte store (see
+    ``_open_session_db_at_path``), so the cross-profile fallback below must
+    skip candidates that fail this check rather than open them — otherwise
+    every configured-but-never-run profile on disk gets a state.db created
+    as a side effect of an unrelated session-id miss.
+    """
+    _, home = _cron_profile_home(candidate)
+    try:
+        return (Path(home) / "state.db").stat().st_size > 0
+    except OSError:
+        return False
+
+
 @manage_router.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
-    resolved_profile = profile
-    session = _lookup_session_in_profile(session_id, profile)
-    if not session and not profile:
-        # Bot sessions live in their own profile's state.db. A request that
-        # omits ?profile= only checked the default profile above, so a bot
-        # chat opened without its owning profile 404s here even though it
-        # exists on disk (cross-profile open asymmetry, #67603 family).
-        # Fall back across the other local profiles; an explicit ?profile=
-        # that misses stays a real 404 rather than guessing elsewhere.
-        from hermes_cli.kanban_db import list_profiles_on_disk
+    def _lookup():
+        resolved_profile = profile
+        session = _lookup_session_in_profile(session_id, profile)
+        if not session and not profile:
+            # Bot sessions live in their own profile's state.db. A request
+            # that omits ?profile= only checked the default profile above,
+            # so a bot chat opened without its owning profile 404s here even
+            # though it exists on disk (cross-profile open asymmetry, #67603
+            # family). Fall back across the other local profiles that
+            # already have a session store; an explicit ?profile= that
+            # misses stays a real 404 rather than guessing elsewhere.
+            from hermes_cli.kanban_db import list_profiles_on_disk
 
-        for name in list_profiles_on_disk():
-            if name == "default":
-                continue  # already tried above via the profile=None lookup
-            session = _lookup_session_in_profile(session_id, name)
-            if session:
-                resolved_profile = name
-                break
+            for name in list_profiles_on_disk():
+                if name == "default":
+                    continue  # already tried above via the profile=None lookup
+                if not _profile_has_session_store(name):
+                    continue
+                candidate_session = _lookup_session_in_profile(session_id, name)
+                if candidate_session:
+                    return candidate_session, name
+        return session, resolved_profile
+
+    session, resolved_profile = await asyncio.to_thread(_lookup)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     # Always stamp the owning profile — the serving profile is known even

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -552,27 +552,50 @@ async def get_session_stats(profile: Optional[str] = None):
         db.close()
 
 
-@manage_router.get("/api/sessions/{session_id}")
-async def get_session_detail(session_id: str, profile: Optional[str] = None):
-    db = _open_session_db_for_profile(profile, read_only=True)
+def _lookup_session_in_profile(session_id: str, candidate: Optional[str]):
+    db = _open_session_db_for_profile(candidate, read_only=True)
     try:
         sid = db.resolve_session_id(session_id)
-        session = db.get_session(sid) if sid else None
-        if not session:
-            raise HTTPException(status_code=404, detail="Session not found")
-        # Always stamp the owning profile — the serving profile is known even
-        # when the request carries no ``?profile=`` (it's this process's own
-        # profile). Stamping only on explicit ``?profile=`` left rows for the
-        # default/primary profile systematically unowned, so multi-profile
-        # clients resolved them to whichever gateway happened to be active
-        # (cross-profile open asymmetry, #67603 family).
-        session["profile"] = (
-            _cron_profile_home(profile)[0] if profile else _cron_default_profile()
-        )
-        session["is_default_profile"] = session["profile"] == "default"
-        return session
+        return db.get_session(sid) if sid else None
     finally:
         db.close()
+
+
+@manage_router.get("/api/sessions/{session_id}")
+async def get_session_detail(session_id: str, profile: Optional[str] = None):
+    resolved_profile = profile
+    session = _lookup_session_in_profile(session_id, profile)
+    if not session and not profile:
+        # Bot sessions live in their own profile's state.db. A request that
+        # omits ?profile= only checked the default profile above, so a bot
+        # chat opened without its owning profile 404s here even though it
+        # exists on disk (cross-profile open asymmetry, #67603 family).
+        # Fall back across the other local profiles; an explicit ?profile=
+        # that misses stays a real 404 rather than guessing elsewhere.
+        from hermes_cli.kanban_db import list_profiles_on_disk
+
+        for name in list_profiles_on_disk():
+            if name == "default":
+                continue  # already tried above via the profile=None lookup
+            session = _lookup_session_in_profile(session_id, name)
+            if session:
+                resolved_profile = name
+                break
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    # Always stamp the owning profile — the serving profile is known even
+    # when the request carries no ``?profile=`` (it's this process's own
+    # profile). Stamping only on explicit ``?profile=`` left rows for the
+    # default/primary profile systematically unowned, so multi-profile
+    # clients resolved them to whichever gateway happened to be active
+    # (cross-profile open asymmetry, #67603 family).
+    session["profile"] = (
+        _cron_profile_home(resolved_profile)[0]
+        if resolved_profile
+        else _cron_default_profile()
+    )
+    session["is_default_profile"] = session["profile"] == "default"
+    return session
 
 
 @manage_router.get("/api/sessions/{session_id}/latest-descendant")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2251,6 +2251,34 @@ class TestWebServerEndpoints:
             "msg 499",
         ]
 
+    def test_get_session_detail_falls_back_across_profiles(self):
+        """A bot session living in a non-default profile's state.db must
+        still resolve when the request omits ?profile= (#94609): the desktop
+        resumes bookmarked/restored session ids without a profile hint, and
+        each profile owns its own state.db.
+        """
+        from hermes_state import SessionDB
+        from hermes_cli import profiles as profiles_mod
+
+        bot_home = profiles_mod.get_profile_dir("basselect")
+        bot_home.mkdir(parents=True)
+        (bot_home / "config.yaml").write_text("")
+        db = SessionDB(db_path=bot_home / "state.db")
+        try:
+            db.create_session(session_id="bot-session-1", source="telegram")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/bot-session-1")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["id"] == "bot-session-1"
+        assert payload["profile"] == "basselect"
+
+        assert self.client.get(
+            "/api/sessions/does-not-exist-anywhere"
+        ).status_code == 404
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2279,6 +2279,32 @@ class TestWebServerEndpoints:
             "/api/sessions/does-not-exist-anywhere"
         ).status_code == 404
 
+    def test_get_session_detail_miss_does_not_bootstrap_other_profiles(self):
+        """A 404 miss must not create a state.db for a configured-but-never-run
+        profile (#94609): the cross-profile fallback loop only has a
+        config.yaml to go on, and read-only opens of a missing/zero-byte
+        store bootstrap it (see ``_open_session_db_at_path``), so the
+        fallback must skip candidates without an existing, non-empty
+        state.db instead of opening every registered profile.
+        """
+        from hermes_cli import profiles as profiles_mod
+
+        bot_home = profiles_mod.get_profile_dir("neverranbot")
+        bot_home.mkdir(parents=True)
+        (bot_home / "config.yaml").write_text("")
+
+        before = sorted(p.name for p in bot_home.iterdir())
+        assert before == ["config.yaml"]
+
+        resp = self.client.get("/api/sessions/does-not-exist-anywhere")
+        assert resp.status_code == 404
+
+        after = sorted(p.name for p in bot_home.iterdir())
+        assert after == before, (
+            f"session-detail miss must not create files under an unrelated "
+            f"never-run profile's home; found {after}"
+        )
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
## What

`GET /api/sessions/{session_id}` (`get_session_detail`) only opens the
requested/default profile's `state.db`. Bot sessions live in their own
profile store (`profiles/<bot>/state.db`), so a desktop resume that omits
`?profile=` — e.g. restoring a bookmarked `/chat?resume=<id>` URL — 404s
even though the session exists on disk under a different profile. This
surfaces to users as `resume failed. session not found`.

The handler's own comment already documents the general failure family
this belongs to ("cross-profile open asymmetry, #67603 family").

## Fix

On a miss with no explicit `?profile=`, fall back across the other local
profiles (`hermes_cli.kanban_db.list_profiles_on_disk()`) before returning
404, and stamp the response with whichever profile actually owned the row.
An explicit `?profile=` that misses is left as a real 404 — it shouldn't
silently resolve to a different profile than the caller asked for.

## Review follow-up

A reviewer caught a real side effect in the first version of this fix:
`_open_session_db_for_profile(candidate, read_only=True)` routes through
`_open_session_db_at_path`, whose read-only path bootstraps *any*
missing/zero-byte `state.db` before probing it. The fallback loop called
this for every name `list_profiles_on_disk()` returned — i.e. every
profile with a `config.yaml`, whether or not it had ever run — so a plain
404 for an unrelated session id was silently creating a brand-new
`state.db` (plus `.fts_rebuild.lock`) for every configured-but-never-run
profile on the box.

Fixed by adding `_profile_has_session_store()`, which checks that a
candidate's `state.db` already exists and is non-empty *before* opening
it, and skips candidates that would otherwise be bootstrapped. Also moved
the whole lookup (now including the fallback loop) into
`asyncio.to_thread`, matching the sibling endpoints
(`get_session_messages`, `get_session_latest_descendant`) that already do
this — the reviewer flagged that N sequential synchronous sqlite opens on
a miss (now potentially N first-time schema creations) ran directly on
the event loop.

Added `test_get_session_detail_miss_does_not_bootstrap_other_profiles`,
which reproduces the reviewer's repro directly: creates a profile with
only `config.yaml` (no `state.db`), hits a 404 miss with no `?profile=`,
and asserts no files were created under that profile's home.

## Note for reviewers

Issue #94609 states that the sibling endpoint `get_session_messages`
"already implements" this same cross-profile fallback, quoting a comment
to that effect. I could not find that fallback or comment anywhere in
`hermes_cli/web_routers/sessions.py` on current `main` — `get_session_messages`
opens only the requested/default profile's db, same as `get_session_detail`
did before this change. I've scoped this fix to `get_session_detail` only,
per the issue's actual repro and suggested fix, rather than "mirroring" code
that doesn't exist. Happy to extend the same fallback to `get_session_messages`
in a follow-up if that's wanted — didn't want to expand this PR's blast radius
without confirming that's desired.

## Test plan

Two tests in `tests/hermes_cli/test_web_server.py`:

- `test_get_session_detail_falls_back_across_profiles`: creates a session
  in a non-default profile's `state.db`, requests it with no `?profile=`,
  and asserts a 200 with `profile` stamped as the owning profile (plus a
  sanity check that a truly nonexistent id still 404s).
- `test_get_session_detail_miss_does_not_bootstrap_other_profiles`:
  creates a profile with only `config.yaml` (no `state.db`), hits a 404
  miss with no `?profile=`, and asserts no files were created under that
  profile's home — the regression test for the reviewer's finding above.

```
$ python -m pytest tests/hermes_cli/test_web_server.py -q
169 passed, 1 skipped in 15.69s
```

Fail-on-current-fix check (`git checkout HEAD~1 -- hermes_cli/web_routers/sessions.py`,
keeping the new tests): `test_get_session_detail_miss_does_not_bootstrap_other_profiles`
fails, showing `state.db` and `state.db.fts_rebuild.lock` created under the
untouched profile's home — reproducing the reviewer's exact repro.
Restoring the fix (`git checkout HEAD -- hermes_cli/web_routers/sessions.py`)
makes the full suite pass again (169 passed, 1 skipped).

Also ran:
```
$ ruff check hermes_cli/web_routers/sessions.py tests/hermes_cli/test_web_server.py
All checks passed!
$ python scripts/check-windows-footguns.py hermes_cli/web_routers/sessions.py
✓ No Windows footguns found (1 file(s) scanned).
```

## Disclosure

This PR was drafted by an AI coding agent (Claude), with the fix scoped
and verified against current `main` rather than the issue's (inaccurate)
description of existing behavior, as noted above.
