### PR TITLE
fix(cli): resolve session detail across local profile stores

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -43,6 +43,7 @@ _cron_default_profile = late("_cron_default_profile")
 _cron_profile_home = late("_cron_profile_home")
 _import_sessions_for_profile = late("_import_sessions_for_profile")
 _maybe_auto_archive_for_profile = late("_maybe_auto_archive_for_profile")
+_open_matching_session_store = late("_open_matching_session_store")
 _open_session_db_for_profile = late("_open_session_db_for_profile")
 _prune_sessions = late("_prune_sessions")
 _read_session_import_body = late("_read_session_import_body")
@@ -554,22 +555,21 @@ async def get_session_stats(profile: Optional[str] = None):
 
 @manage_router.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
-    db = _open_session_db_for_profile(profile, read_only=True)
+    # Bot chats live in ``profiles/<bot>/state.db``. Desktop resume often
+    # omits ``?profile=``, so the historical single-store open 404'd while
+    # the sibling /messages path (and the sidebar list) still found the
+    # row. Search the requested/current store first, then every other
+    # local profile, and stamp the profile that actually held the row
+    # (#94609).
+    sid, db, owning = _open_matching_session_store(session_id, profile)
+    if db is None:
+        raise HTTPException(status_code=404, detail="Session not found")
     try:
-        sid = db.resolve_session_id(session_id)
-        session = db.get_session(sid) if sid else None
+        session = db.get_session(sid)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        # Always stamp the owning profile — the serving profile is known even
-        # when the request carries no ``?profile=`` (it's this process's own
-        # profile). Stamping only on explicit ``?profile=`` left rows for the
-        # default/primary profile systematically unowned, so multi-profile
-        # clients resolved them to whichever gateway happened to be active
-        # (cross-profile open asymmetry, #67603 family).
-        session["profile"] = (
-            _cron_profile_home(profile)[0] if profile else _cron_default_profile()
-        )
-        session["is_default_profile"] = session["profile"] == "default"
+        session["profile"] = owning
+        session["is_default_profile"] = owning == "default"
         return session
     finally:
         db.close()
@@ -581,7 +581,9 @@ async def get_session_latest_descendant(
     profile: Optional[str] = None,
 ):
     def _lookup():
-        db = _open_session_db_for_profile(profile, read_only=True)
+        _sid, db, _owning = _open_matching_session_store(session_id, profile)
+        if db is None:
+            return None, []
         try:
             return _session_latest_descendant(session_id, db)
         finally:
@@ -614,12 +616,16 @@ async def get_session_messages(
         )
 
     def _read():
-        db = _open_session_db_for_profile(profile, read_only=True)
+        # Same cross-profile fallback as get_session_detail: a bot transcript
+        # must resolve even when the client omitted the owning profile.
+        # On current main this endpoint was still single-store (the issue
+        # text assumed otherwise); keep the two GET-by-id reads aligned.
+        sid, db, _owning = _open_matching_session_store(
+            session_id, profile, resolve_resume=True
+        )
+        if db is None:
+            return None
         try:
-            sid = db.resolve_session_id(session_id)
-            if not sid:
-                return None
-            sid = db.resolve_resume_session_id(sid)
             # Always page this endpoint. An omitted limit used to load an
             # entire transcript, which can be hundreds of thousands of rows
             # for a runaway session and exhaust the dashboard process. Keep

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12502,6 +12502,88 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
     return _open_session_db_at_path(db_path, read_only=read_only)
 
 
+def _session_lookup_targets(
+    profile: Optional[str],
+) -> List[Tuple[Optional[str], Path, bool]]:
+    """Ordered ``(profile_key, db_path, allow_bootstrap)`` stores for an id lookup.
+
+    Desktop Bot Mode resumes often omit ``?profile=`` even though the row
+    lives in ``profiles/<bot>/state.db`` (#94609). Try the requested (or
+    this process's) store first — that path is allowed to bootstrap a
+    missing file, matching the historical single-store open. Every other
+    local profile is a fallback and is opened only when ``state.db``
+    already exists, so a miss does not mint empty databases across the
+    profile tree.
+    """
+    from hermes_cli.profiles import get_profile_dir, list_profile_names
+    from hermes_state import _default_db_path
+
+    targets: List[Tuple[Optional[str], Path, bool]] = []
+    seen: set[str] = set()
+
+    def _add(key: Optional[str], db_path: Path, allow_bootstrap: bool) -> None:
+        try:
+            resolved = str(db_path.expanduser().resolve())
+        except OSError:
+            return
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        targets.append((key, db_path, allow_bootstrap))
+
+    if profile:
+        name, home = _cron_profile_home(profile)
+        _add(name, Path(home) / "state.db", True)
+    else:
+        _add(None, Path(_default_db_path()), True)
+
+    for name in list_profile_names():
+        try:
+            home = get_profile_dir(name)
+        except Exception:
+            continue
+        _add(name, Path(home) / "state.db", False)
+
+    return targets
+
+
+def _open_matching_session_store(
+    session_id: str,
+    profile: Optional[str],
+    *,
+    resolve_resume: bool = False,
+):
+    """Open the first local profile store that actually contains ``session_id``.
+
+    Returns ``(sid, db, owning_profile)``. The caller must close ``db``.
+    Returns ``(None, None, None)`` when no store has the row.
+
+    ``resolve_resume`` follows compression-chain ids the same way
+    ``GET /api/sessions/{id}/messages`` historically did on a single store.
+    """
+    db = None
+    try:
+        for key, db_path, allow_bootstrap in _session_lookup_targets(profile):
+            if not allow_bootstrap and not db_path.is_file():
+                continue
+            db = _open_session_db_at_path(db_path, read_only=True)
+            sid = db.resolve_session_id(session_id)
+            if not sid:
+                db.close()
+                db = None
+                continue
+            if resolve_resume:
+                sid = db.resolve_resume_session_id(sid) or sid
+            owning = key if key is not None else _cron_default_profile()
+            found = db
+            db = None
+            return sid, found, owning
+        return None, None, None
+    finally:
+        if db is not None:
+            db.close()
+
+
 # In-process throttle for the opportunistic auto-archive trigger, keyed by
 # profile. Bounds the config.yaml read to at most once per this window per
 # profile; the actual sweep is throttled far more coarsely by state_meta

--- a/tests/hermes_cli/test_session_cross_profile_lookup.py
+++ b/tests/hermes_cli/test_session_cross_profile_lookup.py
@@ -1,0 +1,143 @@
+"""GET /api/sessions/{id} must find rows that live in another profile store.
+
+Bot chats are written to ``profiles/<bot>/state.db``. Desktop resume often
+omits ``?profile=``, so a single-store open 404s even though the sidebar
+already listed the session (#94609). These tests pin the fallback: metadata
+and messages resolve without the query param, stamp the owning profile, a
+missing id still 404s, and a miss must not bootstrap empty ``state.db``
+files in unrelated profile directories.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    from hermes_cli import profiles
+    from hermes_constants import get_hermes_home
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    bot_home = profiles_root / "basselect"
+    empty_home = profiles_root / "emptybot"
+    for home in (default_home, bot_home, empty_home):
+        home.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {
+        "default": default_home,
+        "basselect": bot_home,
+        "emptybot": empty_home,
+    }
+
+
+@pytest.fixture
+def client(monkeypatch, isolated_profiles):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_cli.web_server import _SESSION_HEADER_NAME, _SESSION_TOKEN, app
+    from hermes_constants import get_hermes_home
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    auth = TestClient(app)
+    auth.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return auth
+
+
+def _seed_session(db_path, session_id, source, content):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session(session_id, source=source)
+        db.append_message(session_id, role="user", content=content)
+    finally:
+        db.close()
+
+
+class TestSessionCrossProfileLookup:
+    def test_detail_finds_bot_session_without_profile_query(self, client, isolated_profiles):
+        _seed_session(
+            isolated_profiles["basselect"] / "state.db",
+            "sess-bot-1",
+            "telegram",
+            "hello from bot",
+        )
+        _seed_session(
+            isolated_profiles["default"] / "state.db",
+            "sess-default",
+            "cli",
+            "hello from default",
+        )
+
+        resp = client.get("/api/sessions/sess-bot-1")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == "sess-bot-1"
+        assert body["profile"] == "basselect"
+        assert body["is_default_profile"] is False
+
+        default_resp = client.get("/api/sessions/sess-default")
+        assert default_resp.status_code == 200, default_resp.text
+        default_body = default_resp.json()
+        assert default_body["id"] == "sess-default"
+        assert default_body["profile"] == "default"
+        assert default_body["is_default_profile"] is True
+
+    def test_messages_find_bot_session_without_profile_query(self, client, isolated_profiles):
+        _seed_session(
+            isolated_profiles["basselect"] / "state.db",
+            "sess-bot-2",
+            "telegram",
+            "transcript lives here",
+        )
+
+        resp = client.get("/api/sessions/sess-bot-2/messages")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["session_id"] == "sess-bot-2"
+        texts = [row.get("content") for row in body["messages"]]
+        assert "transcript lives here" in texts
+
+    def test_explicit_profile_still_resolves_and_unknown_id_404s(
+        self, client, isolated_profiles
+    ):
+        _seed_session(
+            isolated_profiles["basselect"] / "state.db",
+            "sess-bot-3",
+            "telegram",
+            "owned by basselect",
+        )
+
+        resp = client.get("/api/sessions/sess-bot-3", params={"profile": "basselect"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["profile"] == "basselect"
+
+        missing = client.get("/api/sessions/does-not-exist")
+        assert missing.status_code == 404
+        assert missing.json()["detail"] == "Session not found"
+
+        missing_messages = client.get("/api/sessions/does-not-exist/messages")
+        assert missing_messages.status_code == 404
+
+    def test_fallback_does_not_bootstrap_empty_profile_stores(
+        self, client, isolated_profiles
+    ):
+        empty_db = isolated_profiles["emptybot"] / "state.db"
+        assert not empty_db.exists()
+
+        _seed_session(
+            isolated_profiles["basselect"] / "state.db",
+            "sess-bot-4",
+            "telegram",
+            "do not mint emptybot",
+        )
+
+        resp = client.get("/api/sessions/sess-bot-4")
+        assert resp.status_code == 200, resp.text
+        assert not empty_db.exists()

--- a/tests/test_web_server_sessiondb_eventloop.py
+++ b/tests/test_web_server_sessiondb_eventloop.py
@@ -61,13 +61,17 @@ def test_sessiondb_handlers_open_connections_inside_executor_helpers():
             for arg in node.args[:1]
             if isinstance(arg, ast.Name)
         }
+        session_db_openers = {
+            "_open_session_db_for_profile",
+            "_open_matching_session_store",
+        }
         db_open_owners = {
             helper_name
             for helper_name, helper in helpers.items()
             if helper_name in offloaded
             and any(
                 isinstance(node, ast.Call)
-                and _call_name(node) == "_open_session_db_for_profile"
+                and _call_name(node) in session_db_openers
                 for node in ast.walk(helper)
             )
         }


### PR DESCRIPTION
## What does this PR do?

`GET /api/sessions/{id}` opened only the requested (or process) profile store. Bot chats live in `profiles/<bot>/state.db`, so a Desktop resume that omits `?profile=` 404'd with `resume failed. session not found` while the sidebar already listed the row.

On current main the sibling `GET /api/sessions/{id}/messages` is also single-store (the issue text assumed it already fell back). This adds a shared lookup: requested/current store first, then every other local profile that already has a `state.db`. The owning profile stamped on the row is the store that held it. `/messages` and `/latest-descendant` use the same helper so the GET-by-id family stays aligned. Fallback opens skip missing files so a miss does not mint empty databases across the profile tree.

## Related Issue

Fixes #94609

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: `_session_lookup_targets` / `_open_matching_session_store` — ordered cross-profile id lookup, bootstrap only the requested store
- `hermes_cli/web_routers/sessions.py`: detail, messages, and latest-descendant use the helper and stamp the profile that held the row
- `tests/hermes_cli/test_session_cross_profile_lookup.py`: bot session resolves without `?profile=`; unknown id 404s; empty profile dirs are not bootstrapped
- `tests/test_web_server_sessiondb_eventloop.py`: offloaded handlers may open via `_open_matching_session_store`

## How to Test

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_session_cross_profile_lookup.py \
  tests/test_web_server_sessiondb_eventloop.py \
  tests/hermes_cli/test_web_server.py -k 'get_session_messages or latest_descendant'
# 16 passed
```

1. Seed a session in `profiles/<bot>/state.db`.
2. `GET /api/sessions/{id}` without `?profile=` returns 200 and `"profile": "<bot>"`.
3. `GET /api/sessions/{id}/messages` without `?profile=` returns the transcript.
4. An unknown id still 404s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (API behavior; no UI change)
