### PR TITLE
fix(desktop): coerce bot RPC rejections for React 19 error formatting

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5302,22 +5302,26 @@ function botBackendProfileScope(route, fallbackProfile = 'default') {
 /** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
  * explicit descriptor, including a registered local source. */
 async function requestForBot(bot, method, params = {}) {
-  try {
-    const route = botConnectionRoute(bot)
+  const route = botConnectionRoute(bot)
 
-    if (route) {
-      if (typeof host.requestProfile !== 'function') {
-        throw new Error(`Cannot route ${method} for ${route.connectionId}::${route.profile}`)
-      }
-
-      return await host.requestProfile(route, method, scopedBotParams(route, method, params))
+  if (route) {
+    if (typeof host.requestProfile !== 'function') {
+      throw new Error(`Cannot route ${method} for ${route.connectionId}::${route.profile}`)
     }
 
+    try {
+      return await host.requestProfile(route, method, scopedBotParams(route, method, params))
+    } catch (error) {
+      // React 19 formats query errors with `(error.name || '').trim()`. IPC /
+      // JSON-RPC rejections are often plain objects whose `name` is a number,
+      // which crashes the Routines pane and hides the original failure (#94471).
+      throw asRpcError(error, `Gateway request ${method} failed`)
+    }
+  }
+
+  try {
     return await host.request(method, params)
   } catch (error) {
-    // React 19 formats query errors with `(error.name || '').trim()`. IPC /
-    // JSON-RPC rejections are often plain objects whose `name` is a number,
-    // which crashes the Routines pane and hides the original failure (#94471).
     throw asRpcError(error, `Gateway request ${method} failed`)
   }
 }
@@ -5332,8 +5336,9 @@ async function requestForBot(bot, method, params = {}) {
 function asRpcError(value, fallback) {
   // Duck-type across realms (plugin tests run the source in `vm`, and IPC
   // can deliver Error-like objects whose prototype is not this realm's
-  // Error). React 19 only needs a string `name`; a stack marks a real
-  // exception vs a JSON-RPC payload like `{ name: 32000, message }`.
+  // Error). React 19 only needs a string `name`. Never mutate the rejection:
+  // frozen/sealed objects make `name = 'Error'` a silent no-op in sloppy
+  // mode, so a non-string name always becomes a fresh Error with cause.
   const isObject = value != null && typeof value === 'object'
   const name = isObject ? value.name : undefined
   const message = isObject ? value.message : undefined
@@ -5343,20 +5348,6 @@ function asRpcError(value, fallback) {
 
   if (isObject && hasStringName && (hasStack || hasStringMessage)) {
     return value
-  }
-
-  if (hasStack) {
-    try {
-      value.name = 'Error'
-      if (typeof value.name === 'string') {
-        return value
-      }
-    } catch {
-      void 0
-    }
-    const copy = new Error(hasStringMessage && message ? String(message) : fallback)
-    copy.cause = value
-    return copy
   }
 
   if (isObject) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5302,17 +5302,71 @@ function botBackendProfileScope(route, fallbackProfile = 'default') {
 /** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
  * explicit descriptor, including a registered local source. */
 async function requestForBot(bot, method, params = {}) {
-  const route = botConnectionRoute(bot)
+  try {
+    const route = botConnectionRoute(bot)
 
-  if (route) {
-    if (typeof host.requestProfile !== 'function') {
-      throw new Error(`Cannot route ${method} for ${route.connectionId}::${route.profile}`)
+    if (route) {
+      if (typeof host.requestProfile !== 'function') {
+        throw new Error(`Cannot route ${method} for ${route.connectionId}::${route.profile}`)
+      }
+
+      return await host.requestProfile(route, method, scopedBotParams(route, method, params))
     }
 
-    return host.requestProfile(route, method, scopedBotParams(route, method, params))
+    return await host.request(method, params)
+  } catch (error) {
+    // React 19 formats query errors with `(error.name || '').trim()`. IPC /
+    // JSON-RPC rejections are often plain objects whose `name` is a number,
+    // which crashes the Routines pane and hides the original failure (#94471).
+    throw asRpcError(error, `Gateway request ${method} failed`)
+  }
+}
+
+/** Coerce an IPC/JSON-RPC rejection into an Error with a string `name`.
+ *
+ *  React Query stores whatever the queryFn throws. React 19 then formats it
+ *  with `(e.name || '').trim()`, which throws TypeError when `name` is a
+ *  number (JSON-RPC codes) or another non-string — the Routines pane crash
+ *  in #94471. Real Error instances are returned as-is when already safe.
+ */
+function asRpcError(value, fallback) {
+  // Duck-type across realms (plugin tests run the source in `vm`, and IPC
+  // can deliver Error-like objects whose prototype is not this realm's
+  // Error). React 19 only needs a string `name`; a stack marks a real
+  // exception vs a JSON-RPC payload like `{ name: 32000, message }`.
+  const isObject = value != null && typeof value === 'object'
+  const name = isObject ? value.name : undefined
+  const message = isObject ? value.message : undefined
+  const hasStringName = typeof name === 'string'
+  const hasStringMessage = typeof message === 'string'
+  const hasStack = isObject && typeof value.stack === 'string'
+
+  if (isObject && hasStringName && (hasStack || hasStringMessage)) {
+    return value
   }
 
-  return host.request(method, params)
+  if (hasStack) {
+    try {
+      value.name = 'Error'
+      if (typeof value.name === 'string') {
+        return value
+      }
+    } catch {
+      void 0
+    }
+    const copy = new Error(hasStringMessage && message ? String(message) : fallback)
+    copy.cause = value
+    return copy
+  }
+
+  if (isObject) {
+    const text = hasStringMessage && String(message).trim() ? String(message) : fallback
+    const error = new Error(text)
+    error.cause = value
+    return error
+  }
+
+  return new Error(value == null || value === '' ? fallback : String(value))
 }
 
 /** Stable per-member identity inside a group room. Local members keep their

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// loadRoutines -> requestForBot. A rejected JSON-RPC value that is not an
+// Error (or an Error whose `name` is not a string) used to crash React 19's
+// formatter: `(e.name || '').trim` is not a function. The Routines pane then
+// died instead of showing "Could not load cronjobs" (#94471).
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load(request, requestProfile) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const host = { request, state: { profile: { listen: () => undefined } } }
+  if (requestProfile) {
+    host.requestProfile = requestProfile
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__routines = { asRpcError, loadRoutines, requestForBot };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+function react19Format(error) {
+  return `${(error.name || '').trim()}: ${error.message}`
+}
+
+test('regression: a non-Error cron.manage rejection becomes a string-named Error', async () => {
+  const runtime = load(async () => {
+    const failure = { name: 32000, message: 'cron.manage failed', code: -32603 }
+    throw failure
+  })
+
+  await assert.rejects(
+    () => runtime.__routines.loadRoutines('research'),
+    error => {
+      assert.equal(typeof error.name, 'string')
+      assert.doesNotThrow(() => react19Format(error))
+      assert.match(String(error.message), /cron.manage failed/)
+      assert.equal(error.cause.name, 32000)
+      return true
+    }
+  )
+})
+
+test('regression: Error with a numeric name is coerced before React 19 format', () => {
+  const weird = new Error('down')
+  Object.defineProperty(weird, 'name', { value: 13, configurable: true })
+  const coerced = load(async () => {}).__routines.asRpcError(weird, 'fallback')
+  assert.equal(typeof coerced.name, 'string')
+  assert.doesNotThrow(() => react19Format(coerced))
+  assert.match(String(coerced.message), /down/)
+})
+
+test('regression: a frozen non-string Error name is copied, not mutated in place', () => {
+  const weird = new Error('down')
+  Object.defineProperty(weird, 'name', { value: 13, configurable: false, writable: false })
+  const coerced = load(async () => {}).__routines.asRpcError(weird, 'fallback')
+  assert.notEqual(coerced, weird)
+  assert.equal(typeof coerced.name, 'string')
+  assert.doesNotThrow(() => react19Format(coerced))
+  assert.match(coerced.message, /down/)
+})
+
+test('regression: a real Error passes through unchanged', () => {
+  const original = new Error('gateway rejected the pause')
+  const coerced = load(async () => {}).__routines.asRpcError(original, 'fallback')
+  assert.equal(coerced, original)
+  assert.equal(coerced.name, 'Error')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs
@@ -81,6 +81,20 @@ test('regression: a frozen non-string Error name is copied, not mutated in place
   assert.match(coerced.message, /down/)
 })
 
+test('regression: a sealed Error with a numeric name is copied, not mutated', () => {
+  const weird = new Error('sealed')
+  Object.defineProperty(weird, 'name', { value: 32000, configurable: true, writable: true })
+  Object.seal(weird)
+  const coerced = load(async () => {}).__routines.asRpcError(weird, 'fallback')
+  assert.notEqual(coerced, weird)
+  assert.equal(typeof coerced.name, 'string')
+  assert.doesNotThrow(() => react19Format(coerced))
+  assert.match(String(coerced.message), /sealed/)
+  // Assignment would have succeeded on a sealed writable property; we still
+  // copy so React 19 never sees a numeric name even if mutation is possible.
+  assert.equal(weird.name, 32000)
+})
+
 test('regression: a real Error passes through unchanged', () => {
   const original = new Error('gateway rejected the pause')
   const coerced = load(async () => {}).__routines.asRpcError(original, 'fallback')


### PR DESCRIPTION
## What does this PR do?

The Bot Mode Routines pane crashed with `(e.name || "").trim is not a function` when `cron.manage` rejected. The rejection was not a standard `Error` — JSON-RPC/IPC often delivers a plain object whose `name` is a number (the RPC code). React 19's error formatter then throws on `.trim`, which takes down the pane and hides the original failure.

`requestForBot` now awaits the RPC and coerces the rejection to an object with a string `name` (real Errors pass through; Error-like objects from another realm are duck-typed so plugin tests in `vm` stay honest). The pane can show "Could not load cronjobs" instead of dying in the formatter.

## Related Issue

Fixes #94471

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: `asRpcError` + `requestForBot` try/catch so every bot RPC rejection is React-19-safe
- `apps/desktop/src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs`: numeric `name` on a plain object and on an Error; frozen name; pass-through of a real Error

## How to Test

```text
cd apps/desktop
node --test \
  src/plugins/hermes-bots/tests/routines-rpc-error.test.mjs \
  src/plugins/hermes-bots/tests/routines-pause-failure.test.mjs \
  src/plugins/hermes-bots/tests/routines-error.test.mjs \
  src/plugins/hermes-bots/tests/routines-profile-scope.test.mjs
# 17 pass
```

Not runtime-tested against a live Desktop window (no bot fleet here). The regression is the formatter contract: `(error.name || '').trim()` must not throw.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (error-path unit tests; no visual change on the happy path)
