### PR TITLE
fix(ci): restore installer E2E network trust

### DIFF
--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,9 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# Node connects to the proxy's TLS endpoint, not directly to the public
+# upstream. Trust the sandbox CA below; proxy.py separately uses real-ca.pem
+# when it opens and verifies the upstream TLS connection.
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -216,7 +219,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \


### PR DESCRIPTION
## What does this PR do?

Restores the scheduled installer-route E2E by giving Node/npm the certificate authority that signs the sandbox proxy endpoint. The workflow has been permanently red since Node stopped accepting the unrelated public CA bundle for that hop, masking real install and update regressions.

### Symptom

Every scheduled installer-route leg stalls or fails during `npm install`, while the proxy logs thousands of `SSLEOFError: UNEXPECTED_EOF_WHILE_READING` entries. The update-route legs continue to pass.

### Impact

The install and update E2E suite has failed on every scheduled run since 2026-08-13, so it no longer provides a usable regression signal for installer changes.

### Bug Cause

**Trigger:** `scripts/sandbox/stage2-run.sh:219` / the Node trust environment passed into the bubblewrap payload

**Causal chain:**
1. The sandbox proxy terminates npm's TLS connection with a per-host certificate signed by `/work/certs/ca.pem`.
2. The payload instead gives Node `NODE_EXTRA_CA_CERTS=/work/certs/real-ca.pem`, which is the bundle the proxy uses for its separate upstream TLS connection.
3. npm rejects the proxy certificate and closes the connection; the proxy observes the client abort as `SSLEOFError`, retries accumulate, and the installer times out.

**Why it is wrong:** The two TLS hops have different trust anchors. The sandbox client must trust the ephemeral sandbox CA, while the proxy must continue to verify public upstream servers with the real CA bundle.

**Working sibling / contrast:** curl already receives `/work/certs/ca.pem` through `CURL_CA_BUNDLE`, so the non-Node installer downloads complete through the same proxy.

**Ruled out:** Adding retries or disabling TLS verification would only mask the trust mismatch. The proxy already verifies its upstream hop with `real-ca.pem`, so no upstream verification needs to be weakened.

### Fix

Point `NODE_EXTRA_CA_CERTS` at the sandbox CA. Keep `real-ca.pem` scoped to `proxy.py` for upstream verification, preserving certificate validation on both hops.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/sandbox/stage2-run.sh` - give Node/npm the CA that signs the sandbox MITM endpoint and document the two-hop trust boundary.

## How to Test

1. Run `bash -n scripts/sandbox/stage2-run.sh tests/install/install-update-e2e.sh`.
2. Run `tests/install/install-update-e2e.sh --route installer --install-ref v2026.4.23` on an Ubuntu host with the sandbox dependencies.
3. Confirm npm completes and the installer route lands on the target commit without an `SSLEOFError` storm.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant shell syntax checks and they pass
- [x] The existing real-network installer E2E directly covers this change
- [x] I've considered platform impact: this changes only the Linux bubblewrap development sandbox

### Documentation & Housekeeping

- [x] Relevant inline documentation is updated
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A
- [x] Cross-platform impact has been considered
- [x] Tool description and schema changes are N/A

## Screenshots / Logs

The failing scheduled runs and aggregate error signature are linked from #94613. Phase B will verify the installer route in the real sandbox environment.