### PR TITLE
fix(streaming): stop complete responses from being retried as stream drops

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3952,6 +3952,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         role = "assistant"
         reasoning_parts: list = []
         usage_obj = None
+        provider_finish_consumed = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -4331,8 +4332,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     name = entry["function"]["name"]
                     if name and idx not in tool_gen_notified:
                         tool_gen_notified.add(idx)
-                        _fire_first_delta()
-                        agent._fire_tool_gen_started(name)
+                        if not terminal_chunk_crossed_fence:
+                            _fire_first_delta()
+                            agent._fire_tool_gen_started(name)
                         # Record the partial tool-call name so the outer
                         # stub-builder can surface a user-visible warning
                         # if streaming dies before this tool's arguments
@@ -4342,7 +4344,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # discarding the attempted action.
                         result["partial_tool_names"].append(name)
 
-            if chunk_finish_reason:
+            if chunk_finish_reason is not None:
+                provider_finish_consumed = True
                 finish_reason = chunk_finish_reason
 
             # Usage in the final chunk
@@ -4351,7 +4354,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         _close_managed_stream()
 
-        if _stream_attempt_was_cancelled(stream_attempt_id):
+        if (
+            _stream_attempt_was_cancelled(stream_attempt_id)
+            and not provider_finish_consumed
+        ):
             raise _httpx.RemoteProtocolError(
                 f"stream attempt {stream_attempt_id} was superseded"
             )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3953,6 +3953,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         provider_finish_consumed = False
+        provider_terminal_crossed_fence = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -4091,11 +4092,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _set_request_stream_handle(stream)
         pending_text_parts: list[str] = []
 
-        def _flush_pending_stream_text():
+        def _flush_pending_stream_text(*, suppress_callbacks: bool = False):
             if not pending_text_parts:
                 return
             pending_parts = list(pending_text_parts)
             pending_text_parts.clear()
+            if suppress_callbacks:
+                return
             if not tool_calls_acc:
                 for text in pending_parts:
                     _fire_first_delta()
@@ -4262,7 +4265,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Accumulate tool call deltas — notify display on first name
             delta_tool_calls = getattr(delta, "tool_calls", None)
             if delta_tool_calls:
-                _flush_pending_stream_text()
+                _flush_pending_stream_text(
+                    suppress_callbacks=terminal_chunk_crossed_fence
+                )
                 for tc_delta in delta_tool_calls:
                     raw_index = getattr(tc_delta, "index", None)
                     raw_idx = raw_index if raw_index is not None else 0
@@ -4346,6 +4351,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             if chunk_finish_reason is not None:
                 provider_finish_consumed = True
+                provider_terminal_crossed_fence |= terminal_chunk_crossed_fence
                 finish_reason = chunk_finish_reason
 
             # Usage in the final chunk
@@ -4531,7 +4537,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         if provider_stream_error is not None:
             raise provider_stream_error
-        _flush_pending_stream_text()
+        _flush_pending_stream_text(
+            suppress_callbacks=provider_terminal_crossed_fence
+        )
 
         full_reasoning = "".join(reasoning_parts) or None
         mock_message = SimpleNamespace(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -5118,6 +5118,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _close_request_client_once(
                 "stream_request_complete"
                 if result["response"] is not None
+                and not _stream_attempt_was_cancelled(stream_attempt_id)
                 else "stream_error_cleanup"
             )
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3992,6 +3992,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._check_openrouter_cache_status(response)
             _writer_token["value"] = claim_stream_writer(agent)
 
+        def _stream_chunk_finish_reason(_chunk: Any) -> Any:
+            try:
+                choices = getattr(_chunk, "choices", None)
+                return getattr(choices[0], "finish_reason", None) if choices else None
+            except Exception:
+                return None
+
+        def _stream_writer_is_active() -> bool:
+            token = _writer_token["value"]
+            return token is None or stream_writer_is_current(agent, token)
+
         def _accept_stream_chunk(_chunk: Any) -> bool:
             # A stale-attempt fence can win while Relay is handing an
             # already-received tool-call chunk back to Hermes. Preserve only
@@ -4005,10 +4016,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     provider_tool_in_flight["yes"] = True
             except Exception:
                 pass
+            # A provider terminal chunk cannot add any later output. Preserve
+            # its completion marker even if a concurrent stream just won the
+            # writer fence; dropping it turns a complete response into a false
+            # mid-stream failure.
+            if _stream_chunk_finish_reason(_chunk) is not None:
+                return True
             if not _stream_attempt_is_active(stream_attempt_id):
                 return False
-            token = _writer_token["value"]
-            if token is not None and not stream_writer_is_current(agent, token):
+            if not _stream_writer_is_active():
                 logger.warning(
                     "Streaming attempt superseded by a newer stream; stopping "
                     "consumption to preserve the single-writer invariant "
@@ -4099,6 +4115,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         ):
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
+            chunk_finish_reason = _stream_chunk_finish_reason(chunk)
+            terminal_chunk_crossed_fence = (
+                chunk_finish_reason is not None
+                and (
+                    not _stream_attempt_is_active(stream_attempt_id)
+                    or not _stream_writer_is_active()
+                )
+            )
 
             # Update per-attempt diagnostic counters.  Best-effort —
             # failures are swallowed so the streaming hot path is never
@@ -4142,7 +4166,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         )
                 break
 
-            if not _stream_attempt_is_active(stream_attempt_id):
+            if (
+                not _stream_attempt_is_active(stream_attempt_id)
+                and chunk_finish_reason is None
+            ):
                 _discard_stale_stream_chunk(stream_attempt_id, chunk)
                 continue
 
@@ -4194,14 +4221,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_text,
                 )
                 reasoning_parts.append(reasoning_text)
-                _fire_first_delta()
-                agent._fire_reasoning_delta(reasoning_text)
+                if not terminal_chunk_crossed_fence:
+                    _fire_first_delta()
+                    agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             delta_content = getattr(delta, "content", None)
             if delta_content:
                 content_parts.append(delta_content)
-                if not tool_calls_acc:
+                if not tool_calls_acc and not terminal_chunk_crossed_fence:
                     if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
                         pending_text_parts.append(delta.content)
                         pending_text = "".join(pending_text_parts)
@@ -4223,7 +4251,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # reasoning display.  Non-reasoning text is harmlessly
                 # suppressed by the CLI's _stream_delta when the stream
                 # box is already closed (tool boundary flush).
-                elif agent.stream_delta_callback:
+                elif agent.stream_delta_callback and not terminal_chunk_crossed_fence:
                     try:
                         agent.stream_delta_callback(delta_content)
                         agent._record_streamed_assistant_text(delta_content)
@@ -4314,7 +4342,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # discarding the attempted action.
                         result["partial_tool_names"].append(name)
 
-            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
             if chunk_finish_reason:
                 finish_reason = chunk_finish_reason
 

--- a/tests/run_agent/test_stream_single_writer_65991.py
+++ b/tests/run_agent/test_stream_single_writer_65991.py
@@ -174,6 +174,38 @@ class TestSingleWriterLoop:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_stale_terminal_marker_discards_buffered_text_callbacks(
+        self, _close, mock_create, monkeypatch
+    ):
+        """Buffered text stays in the result without stale UI callbacks."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent = _make_agent()
+        delivered = []
+        first_delta = []
+        agent.stream_delta_callback = delivered.append
+        agent._stream_callback = None
+
+        def stream_gen():
+            yield _chunk(content="data: buffered")
+            time.sleep(0.7)
+            yield _chunk(finish_reason="stop", model="m")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream_gen()
+        mock_create.return_value = mock_client
+
+        response = agent._interruptible_streaming_api_call(
+            {}, on_first_delta=lambda: first_delta.append("fired")
+        )
+
+        assert delivered == []
+        assert first_delta == []
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "data: buffered"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_stale_terminal_tool_call_skips_generation_callback(
         self, _close, mock_create
     ):

--- a/tests/run_agent/test_stream_single_writer_65991.py
+++ b/tests/run_agent/test_stream_single_writer_65991.py
@@ -8,6 +8,7 @@ These tests exercise the real ``AIAgent`` guard helpers and the streaming
 consume-loop, asserting that exactly one writer ever reaches the turn.
 """
 import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -30,8 +31,13 @@ def _make_agent():
     return agent
 
 
-def _chunk(content=None, finish_reason=None, model=None):
-    delta = SimpleNamespace(content=content, tool_calls=None, reasoning_content=None, reasoning=None)
+def _chunk(content=None, finish_reason=None, model=None, tool_calls=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
     choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
     return SimpleNamespace(choices=[choice], model=model, usage=None)
 
@@ -137,6 +143,75 @@ class TestSingleWriterLoop:
         assert "-stale-tail" not in "".join(delivered)
         assert response.choices[0].finish_reason == "stop"
         assert response.choices[0].message.content == "first-stale-tail"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_terminal_marker_survives_stale_watchdog_cancellation(
+        self, _close, mock_create, monkeypatch
+    ):
+        """A terminal chunk already in flight wins over watchdog cancellation."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.05")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent = _make_agent()
+        delivered = []
+        agent.stream_delta_callback = delivered.append
+        agent._stream_callback = None
+
+        def stream_gen():
+            yield _chunk(content="first")
+            time.sleep(0.7)
+            yield _chunk(content="-tail", finish_reason="stop", model="m")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream_gen()
+        mock_create.return_value = mock_client
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert delivered == ["first"]
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "first-tail"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_stale_terminal_tool_call_skips_generation_callback(
+        self, _close, mock_create
+    ):
+        """A stale terminal tool call is returned without stale UI callbacks."""
+        agent = _make_agent()
+        delivered = []
+        tool_gen_callbacks = []
+        agent.stream_delta_callback = delivered.append
+        agent.tool_gen_callback = tool_gen_callbacks.append
+        agent._stream_callback = None
+        tool_delta = SimpleNamespace(
+            index=0,
+            id="call-1",
+            function=SimpleNamespace(name="dangerous_tool", arguments="{}"),
+            extra_content=None,
+        )
+
+        def stream_gen():
+            yield _chunk(content="first")
+            agent._claim_stream_writer()
+            yield _chunk(
+                finish_reason="tool_calls",
+                model="m",
+                tool_calls=[tool_delta],
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream_gen()
+        mock_create.return_value = mock_client
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert delivered == ["first"]
+        assert tool_gen_callbacks == []
+        assert response.choices[0].finish_reason == "tool_calls"
+        assert [
+            tool.function.name for tool in response.choices[0].message.tool_calls
+        ] == ["dangerous_tool"]
 
     def test_chat_parser_failure_closes_managed_stream(self):
         agent = _make_agent()

--- a/tests/run_agent/test_stream_single_writer_65991.py
+++ b/tests/run_agent/test_stream_single_writer_65991.py
@@ -115,8 +115,7 @@ class TestSingleWriterLoop:
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_consume_loop_stops_when_superseded_mid_stream(self, _close, mock_create):
-        """The real streaming loop bails out the moment a newer attempt claims
-        the sink, so a superseded stream cannot interleave into the turn."""
+        """A stale writer cannot emit deltas, but its terminal marker survives."""
         agent = _make_agent()
         delivered = []
         agent.stream_delta_callback = lambda t: delivered.append(t)
@@ -132,10 +131,12 @@ class TestSingleWriterLoop:
         mock_client.chat.completions.create.return_value = stream_gen()
         mock_create.return_value = mock_client
 
-        agent._interruptible_streaming_api_call({})
+        response = agent._interruptible_streaming_api_call({})
 
         assert "".join(delivered) == "first"
         assert "-stale-tail" not in "".join(delivered)
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "first-stale-tail"
 
     def test_chat_parser_failure_closes_managed_stream(self):
         agent = _make_agent()


### PR DESCRIPTION
## What does this PR do?

Hermes no longer misclassifies a completed OpenAI-compatible response as a mid-stream drop when the terminal chunk arrives just after another stream wins the attempt or single-writer fence. The stream keeps its provider finish marker and final response content without allowing the superseded writer to emit stale deltas into the live output.

### Symptom

A complete stream can log `Stream ended with no finish_reason after delivering text with no tool calls; treating as a mid-stream drop.` even though the provider sent a final `finish_reason=stop` chunk. Hermes then returns a partial-stream stub and may retry or discard the visible response tail.

### Impact

Users of OpenAI-compatible streaming providers, including local vLLM deployments, can see false retries and lose the tail of otherwise complete long responses when the terminal chunk races with the stream fence.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py:3995` / `_accept_stream_chunk` rejects a terminal chunk after the attempt or writer fence changes.

**Causal chain:**
1. The provider sends response text and then a final chunk carrying both the remaining text and `finish_reason=stop`.
2. A concurrent stream updates the attempt or writer fence before Hermes accepts that final chunk.
3. Relay ends consumption without exposing the terminal chunk, so Hermes sees accumulated text with no finish reason and returns a partial-stream stub.

**Why it is wrong:** The fence protects the live delta sink from later stale output, but a finish-bearing chunk is terminal and cannot be followed by additional provider output. Rejecting it destroys completion metadata rather than protecting the sink.

**Working sibling / contrast:** Non-terminal chunks still pass through the existing attempt and writer checks, and terminal chunks from the current writer retain the existing callback path.

**Ruled out:** The regression test uses a fully consumed in-process provider generator, so no SDK, network, TCP, or SSE truncation is involved. The failure occurs only when Hermes rejects the finish-bearing chunk.

### Fix

Detect finish-bearing chunks before applying the Relay acceptance fence, preserve them through the downstream stale-attempt check, and suppress their callbacks only when they crossed a stale writer or attempt fence. This keeps the complete response and finish marker while preserving the single-writer output invariant.

## Related Issue

Closes #94614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - preserve terminal chunks across stream fences while suppressing stale callbacks.
- `tests/run_agent/test_stream_single_writer_65991.py` - verify the terminal marker and final content survive without emitting stale deltas.

## How to Test

1. Run the single-writer regression suite.
2. Run the partial-stream finish-reason suite to confirm genuine truncation behavior is unchanged.

```bash
scripts/run_tests.sh tests/run_agent/test_stream_single_writer_65991.py -q
scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py -q
```

Local result: 24 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - no user-facing configuration or API changes
- [x] `cli-config.yaml.example`: N/A - no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no workflow changes
- [x] Cross-platform impact considered - the change is provider-object logic with no OS-specific behavior
- [x] Tool descriptions/schemas: N/A - no tool schema changes

## Screenshots / Logs

N/A - automated regression coverage exercises the stream race deterministically.
