### PR TITLE
fix(agent): accept marker-only finish_reason chunks after stream supersession

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4005,6 +4005,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     provider_tool_in_flight["yes"] = True
             except Exception:
                 pass
+            # Payload-empty terminal chunk: the provider completed the
+            # stream (`finish_reason` set, no further writable delta). The
+            # attempt/writer fence exists to stop a superseded stream from
+            # writing *more* text. Fending this marker-only chunk discards
+            # the only completion signal, which the drop-guard then
+            # mislabels as a mid-stream drop. A finish chunk that still
+            # carries content/tool_calls remains gated.
+            try:
+                _choices = getattr(_chunk, "choices", None)
+                if _choices:
+                    _choice = _choices[0]
+                    if getattr(_choice, "finish_reason", None):
+                        _delta = getattr(_choice, "delta", None)
+                        _has_write = bool(
+                            getattr(_delta, "content", None)
+                            or getattr(_delta, "tool_calls", None)
+                            or getattr(_delta, "reasoning_content", None)
+                            or getattr(_delta, "reasoning", None)
+                        )
+                        if not _has_write:
+                            return True
+            except Exception:
+                pass
             if not _stream_attempt_is_active(stream_attempt_id):
                 return False
             token = _writer_token["value"]

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -91,6 +91,95 @@ class TestPartialStreamStubFinishReason:
         assert response.choices[0].message.tool_calls is None
 
 
+class TestTerminalChunkFenceException:
+    """A superseded writer must still accept the provider's terminal
+    finish_reason chunk. Fending that chunk leaves finish_reason None
+    after real text was delivered, which the drop-guard mislabels as a
+    mid-stream drop even though the provider completed the stream.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_superseded_writer_accepts_finish_reason_chunk(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent_box = {}
+
+        class SupersedeBeforeFinish:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                yield _make_stream_chunk(content="Long prose that is complete.")
+                agent_box["agent"]._claim_stream_writer()
+                # Marker-only terminal chunk (empty delta), as vLLM emits.
+                yield _make_stream_chunk(finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SupersedeBeforeFinish()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent_box["agent"] = agent
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "Long prose that is complete."
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_superseded_writer_still_fences_further_content(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent_box = {}
+
+        class SupersedeBeforeMoreText:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                yield _make_stream_chunk(content="kept ")
+                agent_box["agent"]._claim_stream_writer()
+                # A False accept_chunk ends consumption; this text must
+                # never reach the accumulator, and the later finish chunk
+                # is never seen (the fence still stops *further* content).
+                yield _make_stream_chunk(content="must-not-append")
+                yield _make_stream_chunk(finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SupersedeBeforeMoreText()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent_box["agent"] = agent
+        response = agent._interruptible_streaming_api_call({})
+
+        content = response.choices[0].message.content or ""
+        assert "must-not-append" not in content
+        assert "kept" in content
+        assert response.id == PARTIAL_STREAM_STUB_ID
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_genuine_truncation_without_finish_still_drops(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _truncated():
+            yield _make_stream_chunk(content="cut off with no terminal chunk")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _truncated()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
 
 # ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
 


### PR DESCRIPTION
## What does this PR do?

Hermes can log a false mid-stream drop on a response that already completed. When a concurrent turn or retry supersedes the stream writer just before the provider's marker-only terminal chunk arrives (`finish_reason` set, empty delta), `_accept_stream_chunk` treats that chunk as fenced. The consume loop then stops with text delivered and `finish_reason is None`, and the drop-guard mislabels the turn as a provider cut, retries it, and can discard the tail in the CLI.

This change lets a payload-empty finish chunk through the attempt/writer fence so the completion marker is recorded. Content, tool-call, and reasoning deltas stay gated. A finish chunk that still carries writable delta stays fenced (single-writer). A stream that never sends `finish_reason` is still treated as a drop.

## Related Issue

Fixes #94614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: in `_accept_stream_chunk`, accept a `finish_reason` chunk with no writable delta before the attempt/writer checks.
- `tests/run_agent/test_partial_stream_finish_reason.py`: add `TestTerminalChunkFenceException` — superseded writer still completes on a marker-only stop chunk; further content stays fenced; genuine truncation without `finish_reason` still returns the partial-stream stub.

## How to Test

1. Confirm the failure class: stream text, then supersede the writer (`agent._claim_stream_writer()`), then yield a marker-only `finish_reason="stop"` chunk. Before this change, `_interruptible_streaming_api_call` returns `partial-stream-stub` / `finish_reason=length` and logs `Stream ended with no finish_reason after delivering text with no tool calls; treating as a mid-stream drop.`
2. After the change, the same stream completes with `finish_reason=stop` and is not a stub.
3. Run:

```
scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_stream_single_writer_65991.py -q
```

Expected: all tests in those files pass, including `test_superseded_writer_accepts_finish_reason_chunk` and `test_consume_loop_stops_when_superseded_mid_stream`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (writer superseded immediately before a marker-only `finish_reason=stop` chunk):

```
WARNING agent.chat_completion_helpers: Streaming attempt superseded by a newer stream; stopping consumption to preserve the single-writer invariant (model=unknown).
WARNING agent.chat_completion_helpers: Stream ended with no finish_reason after delivering text with no tool calls; treating as a mid-stream drop.
id=partial-stream-stub finish=length is_stub=True
```

After:

```
id=stream-… finish=stop is_stub=False
no mid-stream drop warning
```

Test run:

```
=== Summary: 2 files, 27 tests passed, 0 failed ===
tests/run_agent/test_partial_stream_finish_reason.py (20 passed)
tests/run_agent/test_stream_single_writer_65991.py (7 passed)
```
