### PR TITLE
fix(cli): import logger in _resume_history_limit_error fail-open path

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -612,6 +612,7 @@ class CLIAgentSetupMixin:
         from hermes_state import (
             SessionExportTooLargeError,
             SessionResumeTooLargeError,
+            logger,
             resolved_max_resume_messages,
         )
 


### PR DESCRIPTION
## Symptom

`_resume_history_limit_error()` in `hermes_cli/cli_agent_setup_mixin.py` is designed to **fail open**: a generic exception from the resume safety guard is logged and resume proceeds. But the method raises `NameError: name 'logger' is not defined` inside its own except handler instead.

Every other method in this mixin lazily imports `logger` from `cli` (per the module's import-cycle contract); this one — lifted verbatim from `cli.py` during the god-file decomposition — missed the import, so the intended fail-open path crashes mid-resume whenever the guard throws (e.g. corrupt/unavailable session DB).

## Fix

One line: add `logger` to the existing lazy `from hermes_state import ...` block (module-level `logging.getLogger(__name__)` there), matching the fail-open logging intent.

## Verification

- Runtime regression check: fake session DB whose `assert_resume_safe` raises → returns `None` and logs warning; previously raised `NameError`.
- `ruff check --select F821` clean on the touched file.