### PR TITLE
fix(desktop): terminate owned SSH serve backends on quit

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection } from './connection-apply'
+import {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  teardownSshState
+} from './connection-apply'
 
 function deferred() {
   let resolve!: () => void
@@ -83,6 +88,39 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('teardownSshState', () => {
+  it('terminates the owned remote backend before closing its tunnel and SSH transport', async () => {
+    const events: string[] = []
+
+    const ssh = {
+      cancelForward: async () => events.push('forward'),
+      close: async () => events.push('ssh')
+    }
+
+    await teardownSshState(
+      { ssh, ownershipId: 'owner', localPort: 1234, remotePort: 5678 },
+      { cleanupRemote: async () => events.push('remote') }
+    )
+
+    expect(events).toEqual(['remote', 'forward', 'ssh'])
+  })
+
+  it('still closes the SSH transport when remote cleanup fails', async () => {
+    const close = vi.fn(async () => undefined)
+
+    await teardownSshState(
+      { ssh: { cancelForward: vi.fn(async () => undefined), close }, ownershipId: 'owner' },
+      {
+        cleanupRemote: async () => {
+          throw new Error('remote unavailable')
+        }
+      }
+    )
+
+    expect(close).toHaveBeenCalledOnce()
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -54,4 +54,29 @@ async function resolveTerminalConnection(getTarget, ensureBackend) {
   return target
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection }
+async function teardownSshState(state, { cleanupRemote }) {
+  // Remote process first, while the SSH channel can still exec kill.
+  // Then drop the local forward and close the transport. Each step is
+  // best-effort so a failed remote cleanup cannot trap Cmd+Q (#91668).
+  try {
+    await cleanupRemote(state.ssh, state.ownershipId)
+  } catch {
+    // Remote teardown is best-effort; always release the local tunnel and SSH transport.
+  }
+
+  try {
+    if (state.localPort && state.remotePort) {
+      await state.ssh.cancelForward(state.localPort, state.remotePort)
+    }
+  } catch {
+    // Best effort; closing the transport below drops any remaining forwards.
+  }
+
+  try {
+    await state.ssh.close()
+  } catch {
+    // The app must still be able to quit when SSH teardown fails.
+  }
+}
+
+export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, teardownSshState }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9255,7 +9255,17 @@ async function teardownSshConnection(profile) {
       ownershipId: state.ownershipId || sshOwnershipKey(profile)
     },
     {
-      cleanupRemote: state.remotePlatform === 'Windows' ? async () => {} : remoteLifecycle.disconnect
+      cleanupRemote:
+        state.remotePlatform === 'Windows'
+          ? async () => {
+              // connectWindowsRemote does not share POSIX lock/kill. Stay
+              // silent on the kill path, but leave a log so quit is not a
+              // mysterious no-op on Windows remotes.
+              sshRememberLog(
+                '[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply'
+              )
+            }
+          : remoteLifecycle.disconnect
     }
   )
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -77,7 +77,7 @@ import {
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange } from './connection-apply'
+import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -9244,19 +9244,20 @@ async function teardownSshConnection(profile) {
 
   terminalIpc.disposeTerminalSessionsForSshScope(scope)
 
-  try {
-    if (state.localPort && state.remotePort) {
-      await state.ssh.cancelForward(state.localPort, state.remotePort)
+  // Kill the owned remote serve --isolated *before* closing the SSH
+  // transport. Spawn detaches with setsid/nohup, so closing the tunnel
+  // alone leaves the backend at pid 1 holding state.db (#91668).
+  // Windows remotes use a different lifecycle (connectWindowsRemote) and
+  // are left to a follow-up; POSIX is the leak that OOM'd gateways.
+  await teardownSshState(
+    {
+      ...state,
+      ownershipId: state.ownershipId || sshOwnershipKey(profile)
+    },
+    {
+      cleanupRemote: state.remotePlatform === 'Windows' ? async () => {} : remoteLifecycle.disconnect
     }
-  } catch {
-    // best effort
-  }
-
-  try {
-    await state.ssh.close()
-  } catch {
-    // best effort
-  }
+  )
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -9487,6 +9488,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   sshConnections.set(scope, {
     ssh,
     fingerprint,
+    ownershipId: result.ownershipId || sshOwnershipKey(profile),
     localPort: result.localPort,
     remotePort: result.remotePort,
     pid: result.pid,
@@ -15604,6 +15606,12 @@ app.on('before-quit', event => {
     return
   }
 
+  // A prevented first quit leaves the renderer alive while teardown runs.
+  // Seal the SSH coordinator before touching connections so reconnect
+  // callbacks cannot recreate a backend for a registration whose app is
+  // already quitting (#91668).
+  sshBootstrapCoordinator.shutdown()
+
   if (!backendQuitTeardownDone) {
     event.preventDefault()
     void backendShutdown.run().finally(() => {
@@ -15614,7 +15622,6 @@ app.on('before-quit', event => {
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()
-    sshBootstrapCoordinator.cancelAll()
     const scopes = [...sshConnections.keys()]
 
     const pending = Promise.allSettled([
@@ -15622,7 +15629,10 @@ app.on('before-quit', event => {
       ...sshBootstrapCoordinator.promises()
     ])
 
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
+    // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
+    // The previous 4s race could close SSH first and leave serve --isolated
+    // reparented to pid 1.
+    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 6_000))]).then(async () => {
       await sshBootstrapCoordinator.forceCleanupAll()
       sshQuitTeardownDone = true
       app.quit()

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   buildSpawnCommand,
   cleanupStale,
   connect,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
@@ -469,6 +470,29 @@ test.skipIf(process.platform === 'win32')(
     }
   }
 )
+
+test('disconnect reaps the backend recorded for this desktop ownership', async () => {
+  const lock = ownedLock()
+
+  const ssh = fakeSsh([
+    [/cat .*backend\.lock\.json/, JSON.stringify(lock)],
+    [/kill -0 333/, 'ALIVE\n'],
+    [/print\("OWNED"/, 'OWNED\n']
+  ])
+
+  await disconnect(ssh, OWNERSHIP_ID)
+
+  assert.ok(ssh.calls.some(command => /kill 333\b/.test(command)))
+  assert.ok(ssh.calls.some(command => /rm -f .*backend\.lock\.json/.test(command)))
+})
+
+test('disconnect is a no-op when this desktop has no lockfile', async () => {
+  const ssh = fakeSsh([[/cat .*backend\.lock\.json/, '']])
+
+  await disconnect(ssh, OWNERSHIP_ID)
+
+  assert.ok(!ssh.calls.some(command => /\bkill\b/.test(command)))
+})
 
 test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', async () => {
   const notOurs = fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']])

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -518,6 +518,26 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   await removeLockfile(ssh, ownershipId)
 }
 
+// Normal disconnect (quit, connection switch): reuse cleanupStale so we
+// kill only a provably-owned serve --isolated and drop our lockfile.
+// Closing the SSH transport first is not enough — spawn detaches with
+// setsid/nohup, so the backend reparents to pid 1 and keeps state.db
+// open (#91668).
+async function disconnect(ssh, ownershipId) {
+  if (!ssh || !ownershipId) {
+    return
+  }
+
+  const lock = await readLockfile(ssh, ownershipId)
+
+  if (!lock) {
+    return
+  }
+
+  const pidAlive = await remotePidAlive(ssh, lock.pid)
+  await cleanupStale(ssh, ownershipId, lock, pidAlive)
+}
+
 // Detach so the backend survives the SSH channel closing: setsid (Linux)
 // starts a new session; macOS has no setsid, so fall back to nohup (HUP-immune;
 // fd-detachment is already handled by </dev/null + redirect + &).
@@ -960,6 +980,7 @@ export {
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -111,6 +111,29 @@ test('forceCleanupAll runs registered pending resource cleanup', async () => {
   await promise
 })
 
+test('shutdown cancels active bootstraps and permanently rejects respawn attempts', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const gate = deferred()
+
+  const active = coordinator.start('primary', 'old', async lease => {
+    await gate.promise
+    lease.assertCurrent()
+  })
+
+  coordinator.shutdown()
+  gate.resolve()
+
+  await assert.rejects(active, (error: any) => error.kind === 'superseded')
+  let started = 0
+  await assert.rejects(
+    coordinator.start('primary', 'new', async () => {
+      started += 1
+    }),
+    (error: any) => error.kind === 'superseded'
+  )
+  assert.equal(started, 0)
+})
+
 test('cancelAll invalidates every pending scope and exposes promises for quit', async () => {
   const coordinator = createBootstrapCoordinator()
   const gates = [deferred(), deferred()]

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -23,8 +23,16 @@ function createBootstrapCoordinator() {
   const pending = new Map<string, any>()
   const generations = new Map<string, number>()
   const drains = new Map<string, Promise<void>>()
+  let shutdownRequested = false
 
   function start(scope, fingerprint, run) {
+    if (shutdownRequested) {
+      const error: any = new Error('SSH bootstrap was cancelled because Desktop is quitting.')
+      error.kind = 'superseded'
+
+      return Promise.reject(error)
+    }
+
     const current = pending.get(scope)
 
     if (current?.fingerprint === fingerprint) {
@@ -121,6 +129,13 @@ function createBootstrapCoordinator() {
     }
   }
 
+  function shutdown() {
+    // Terminal: reconnect callbacks during a prevented first quit must not
+    // spawn a replacement serve --isolated for an app that is already leaving.
+    shutdownRequested = true
+    cancelAll()
+  }
+
   async function forceCleanupAll() {
     const cleanups = [...active].flatMap(entry => [...entry.forceCleanups])
     await Promise.allSettled(cleanups.map(cleanup => cleanup()))
@@ -130,7 +145,7 @@ function createBootstrapCoordinator() {
     return [...active].map(entry => entry.promise)
   }
 
-  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, start }
+  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, shutdown, start }
 }
 
 export { createBootstrapCoordinator, sshConfigFingerprint }

--- a/apps/desktop/src/components/assistant-ui/thread/timeout-bag.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeout-bag.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createTimeoutBag } from './timeout-bag'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createTimeoutBag', () => {
+  it('runs a scheduled callback', () => {
+    vi.useFakeTimers()
+    const bag = createTimeoutBag()
+    const fn = vi.fn()
+
+    bag.schedule(fn, 200)
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(200)
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
+  it('clearAll prevents a pending callback from running after the owner unmounts', () => {
+    vi.useFakeTimers()
+    const bag = createTimeoutBag()
+    const fn = vi.fn()
+
+    bag.schedule(fn, 200)
+    bag.clearAll()
+    vi.advanceTimersByTime(200)
+    expect(fn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/timeout-bag.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeout-bag.ts
@@ -1,0 +1,37 @@
+/**
+ * Timers that must die with the owner. The edit composer unmounts on
+ * confirm/cancel while `setTimeout` callbacks still hold `setState`. After
+ * jsdom tears `window` down, React 19's scheduler then throws
+ * `window is not defined` and fails the whole vitest run even when every
+ * test passed.
+ */
+function createTimeoutBag(
+  clock: {
+    setTimeout: typeof globalThis.setTimeout
+    clearTimeout: typeof globalThis.clearTimeout
+  } = globalThis
+) {
+  const ids = new Set<ReturnType<typeof clock.setTimeout>>()
+
+  function schedule(fn: () => void, ms: number) {
+    const id = clock.setTimeout(() => {
+      ids.delete(id)
+      fn()
+    }, ms)
+    ids.add(id)
+
+    return id
+  }
+
+  function clearAll() {
+    for (const id of ids) {
+      clock.clearTimeout(id)
+    }
+
+    ids.clear()
+  }
+
+  return { schedule, clearAll }
+}
+
+export { createTimeoutBag }

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/app/chat/hooks/use-composer-actions'
 import { uploadComposerAttachment } from '@/app/session/hooks/use-prompt-actions'
 import { hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
+import { createTimeoutBag } from '@/components/assistant-ui/thread/timeout-bag'
 import {
   StickyHumanMessageContainer,
   StopGlyph,
@@ -96,6 +97,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const initialDraftRef = useRef<string | null>(null)
   const draftRef = useRef(draft)
   const composingRef = useRef(false)
+  const timeoutsRef = useRef(createTimeoutBag())
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
@@ -124,6 +126,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // cleanup so keyboard routing falls back to the visible chat composer.
   useEffect(
     () => () => {
+      timeoutsRef.current.clearAll()
       notifyThreadEditClose()
       releaseActiveComposer('edit')
     },
@@ -341,7 +344,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         draftRef.current = composerPlainText(editor)
         aui.composer().setText(draftRef.current)
         requestEditFocus()
-        starter ? window.setTimeout(refreshTrigger, 0) : closeTrigger()
+        starter ? timeoutsRef.current.schedule(refreshTrigger, 0) : closeTrigger()
       }
 
       // In place first, spanning Chromium's split text nodes (see
@@ -526,7 +529,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       rememberInitialDraft()
       const nextDraft = syncDraftFromEditor(editor)
-      window.setTimeout(refreshTrigger, 0)
+      timeoutsRef.current.schedule(refreshTrigger, 0)
 
       return nextDraft
     },
@@ -602,7 +605,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       // Clear latch after cooldown to allow re-submission. This prevents rapid
       // double-Enter but doesn't require tracking when onEdit settles (which may
       // be synchronous or async, and whose promise we don't have access to).
-      window.setTimeout(() => {
+      timeoutsRef.current.schedule(() => {
         setSubmitting(false)
       }, 200)
     } catch {
@@ -618,7 +621,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         return
       }
 
-      window.setTimeout(() => {
+      timeoutsRef.current.schedule(() => {
         const root = rootRef.current
         const active = document.activeElement
 
@@ -810,7 +813,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
               onBeforeInput={handleBeforeInput}
-              onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onBlur={() => timeoutsRef.current.schedule(closeTrigger, 80)}
               onCompositionEnd={event => {
                 composingRef.current = false
                 flushEditorToDraft(event.currentTarget)


### PR DESCRIPTION
## What does this PR do?

Quitting Desktop after an SSH remote session left `hermes serve --isolated` running on the gateway (reparented to pid 1, lockfile intact, `state.db` held). Spawn detaches with setsid/nohup on purpose so the backend can be reused; that means closing the SSH transport is not cleanup.

`teardownSshConnection` now kills the owned remote process *before* dropping the tunnel, by reading `backend.lock.json` and reusing `cleanupStale` (kill only a provably-ours pid, always drop our lockfile). The bootstrap coordinator gains a terminal `shutdown()` so reconnect callbacks during a prevented first quit cannot spawn a replacement backend. The quit race is 6s because `cleanupStale` waits up to 5s for the pid to exit; the previous 4s window could close SSH first.

Windows remotes still skip remote kill (`connectWindowsRemote`); the reported leak is POSIX. Not exercised against a live SSH host in this PR — unit tests cover disconnect, teardown order, and shutdown-vs-respawn. Related closed attempt: #91691.

`remote-lifecycle.ts` / `main.ts` are also touched by open PRs #89452, #80984, #90181, #93189. This patch is additive (`disconnect`, teardown sequencing, coordinator seal). Happy to rebase if one of those lands first.

## Related Issue

Fixes #91668

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/remote-lifecycle.ts`: `disconnect()` reads the ownership lock and reuses `cleanupStale`
- `apps/desktop/electron/connection-apply.ts`: `teardownSshState` sequences remote cleanup → cancelForward → close, and still closes SSH if remote cleanup throws
- `apps/desktop/electron/main.ts`: store `ownershipId`; quit path calls `disconnect` on POSIX; coordinator `shutdown()`; 6s race
- `apps/desktop/electron/ssh-bootstrap-coordinator.ts`: `shutdown()` cancels in-flight bootstraps and rejects later `start()`
- Tests for disconnect, teardown order, and shutdown-vs-respawn

## How to Test

```text
cd apps/desktop
npx vitest run --project electron \
  electron/connection-apply.test.ts \
  electron/remote-lifecycle.test.ts \
  electron/ssh-bootstrap-coordinator.test.ts
# 91 passed
```

End-to-end on a real POSIX SSH target (Connect → Quit → assert remote pid and `backend.lock.json` are gone) is the remaining confirmation. I do not have that host in this environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (Electron main-process teardown; no UI change)
