### PR TITLE
fix(desktop): New Group Chat bot list no longer clips rows on both sides

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11919,7 +11919,15 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
         jsx(ScrollArea, {
           className: 'max-h-64 min-h-0',
           children: jsx('div', {
-            className: 'grid gap-0.5 pr-2',
+            // `grid-cols-[minmax(0,1fr)]` is load-bearing (same hardening as the
+            // DialogContent body in ui/dialog.tsx): an implicit grid track sizes
+            // to unbreakable content, and every row's second line is a nowrap
+            // `truncate` (`@handle · in “A, B, C…”`). Once bots belong to a group,
+            // that line is long, the implicit track balloons past the dialog, and
+            // the vertical-only ScrollArea clips rows on BOTH sides instead of
+            // truncating them. Pinning the column keeps the track at the dialog
+            // width so `truncate` does its job.
+            className: 'grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-0.5 pr-2',
             children: visible.length
               ? visible.map(bot => {
                   const meta = botRosterMeta(bot, allMeta)

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
@@ -40,3 +40,16 @@ test('source contract: every selected machine is persisted in the durable room r
   assert.match(pluginSource, /room\.members = roomMembers/)
   assert.doesNotMatch(pluginSource, /const remoteMembers = selected/)
 })
+
+test('source contract: bot list pins its grid column so long group lists truncate', () => {
+  // The picker's ScrollArea is vertical-only. An implicit grid track sizes to
+  // unbreakable content — each row's `@handle · in “A, B, C…”` line is a nowrap
+  // truncate — so once bots belong to groups the track outgrows the dialog and
+  // rows clip on BOTH sides instead of truncating (same class as the
+  // DialogContent body fix in ui/dialog.tsx). The column must stay pinned.
+  const dialogBody = pluginSource.slice(
+    pluginSource.indexOf('function CreateGroupChatDialog('),
+    pluginSource.indexOf('// ── threads: the Slack/Discord shape')
+  )
+  assert.match(dialogBody, /className: 'grid w-full min-w-0 grid-cols-\[minmax\(0,1fr\)\] gap-0\.5 pr-2'/)
+})


### PR DESCRIPTION
## Summary

In the **New Group Chat** dialog, once bots belong to a group chat, every bot row in the picker gets clipped on **both sides** — bot names show only their tail (`f Staff`, `s`, `ut`), avatars are cut off past the left edge, and checkboxes are cut off at the right edge.

## Root cause

The picker's bot list sits in `ScrollArea > div.grid.gap-0.5.pr-2` — an **implicit** grid track. CSS grid sizes implicit tracks to unbreakable content, and every row's second line is a nowrap `truncate`:

```
@handle · in “Chief Of Staff, Hermes, Marketing, Engineering, Finance, Research”
```

Before any group exists these lines are short (`@chef`) and the dialog renders fine. Once bots join a group, every member's row carries the long membership string, the implicit track balloons past the dialog width, and the vertical-only Radix ScrollArea silently clips the overflow on both sides instead of letting `truncate` do its job.

This is the same bug class fixed for dialog bodies generally in bdf10471b ("Send Diagnostics dialog no longer clips the link behind a horizontal scrollbar"), which pinned `DialogContent`'s body grid to `minmax(0,1fr)` — but this nested grid inside the group picker was missed by that hardening.

## Fix

Pin the column explicitly and let children shrink/truncate within it:

```diff
-            className: 'grid gap-0.5 pr-2',
+            className: 'grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-0.5 pr-2',
```

## Testing

- Added a source-contract regression test in `create-group-chat.test.mjs` pinning that the picker's list container keeps the explicit `minmax(0,1fr)` column (matching the file's existing contract-test style).
- Full hermes-bots plugin suite: **557/557 pass** (`node --test src/plugins/hermes-bots/tests/*.test.mjs`).