### PR TITLE
fix(desktop): preview files only on intentional activation

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree-activation.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree-activation.test.tsx
@@ -1,0 +1,104 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-arborist', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+
+  return {
+    Tree: forwardRef(function MockTree(props: { onActivate?: (node: unknown) => void }, ref) {
+      const file = {
+        data: { id: 'C:/repo/file.txt', isDirectory: false },
+        isOpen: false,
+        select: vi.fn()
+      }
+
+      useImperativeHandle(ref, () => ({ focusedNode: file, selectedNodes: [file] }))
+
+      return (
+        <button data-testid="activate-file" onClick={() => props.onActivate?.(file)}>
+          activate
+        </button>
+      )
+    })
+  }
+})
+
+vi.mock('@/hooks/use-resize-observer', () => ({
+  useResizeObserver: (callback: (entries: readonly ResizeObserverEntry[]) => void) => {
+    useEffect(() => callback([]), [callback])
+  }
+}))
+
+vi.mock('../file-actions', () => ({
+  FileEntryContextMenu: ({ children }: { children: unknown }) => children,
+  InlineRenameInput: () => null,
+  isRenameShortcut: () => false
+}))
+
+vi.mock('./dnd-manager', () => ({ getFileTreeDndManager: () => ({}) }))
+
+import { ProjectTree } from './tree'
+
+afterEach(cleanup)
+
+describe('Files panel preview activation contract (#93970)', () => {
+  it('does not open preview on a single Arborist activation', async () => {
+    const preview = vi.fn()
+    const original = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = () => ({ height: 200, width: 300 }) as DOMRect
+
+    try {
+      await act(async () => {
+        render(
+          <ProjectTree
+            collapseNonce={0}
+            cwd="C:/repo"
+            data={[]}
+            onActivateFile={vi.fn()}
+            onActivateFolder={vi.fn()}
+            onLoadChildren={vi.fn()}
+            onNodeOpenChange={vi.fn()}
+            onPreviewFile={preview}
+            openState={{}}
+          />
+        )
+      })
+
+      fireEvent.click(screen.getByTestId('activate-file'))
+      expect(preview).not.toHaveBeenCalled()
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = original
+    }
+  })
+
+  it('keeps Space as the keyboard preview action', async () => {
+    const preview = vi.fn()
+    const original = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = () => ({ height: 200, width: 300 }) as DOMRect
+
+    try {
+      await act(async () => {
+        render(
+          <ProjectTree
+            collapseNonce={0}
+            cwd="C:/repo"
+            data={[]}
+            onActivateFile={vi.fn()}
+            onActivateFolder={vi.fn()}
+            onLoadChildren={vi.fn()}
+            onNodeOpenChange={vi.fn()}
+            onPreviewFile={preview}
+            openState={{}}
+          />
+        )
+      })
+
+      fireEvent.keyDown(screen.getByTestId('activate-file'), { key: ' ' })
+      expect(preview).toHaveBeenCalledOnce()
+      expect(preview).toHaveBeenCalledWith('C:/repo/file.txt')
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = original
+    }
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { useMemo } from 'react'
-import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type TreeApi } from 'react-arborist'
+import { type NodeRendererProps, type RowRendererProps, Tree, type TreeApi } from 'react-arborist'
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { Codicon } from '@/components/ui/codicon'
@@ -146,42 +146,45 @@ export function ProjectTree({
     [revealNode]
   )
 
-  const handleActivate = useCallback(
-    (node: NodeApi<TreeNode>) => {
-      // arborist fires onActivate on click/dblclick/Enter — independent of the
-      // row's own handlers. Suppress it for the row being renamed so the
-      // context-menu "Rename" (and its fall-through) can't open the preview.
-      if (node.data && !node.data.isDirectory && $renamingPath.get() !== node.data.id) {
-        onPreviewFile?.(node.data.id)
+  // Keep keyboard activation explicit now that mouse preview is double-click
+  // only. Capture-phase also lets F2 / Enter beat arborist's own handlers.
+  const handleTreeKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key === ' ' && !$renamingPath.get()) {
+        const node = treeRef.current?.focusedNode
+
+        if (node?.data && !node.data.isDirectory && !node.data.placeholder) {
+          event.preventDefault()
+          event.stopPropagation()
+          node.select()
+          onPreviewFile?.(node.data.id)
+        }
+
+        return
       }
+
+      if (!isRenameShortcut(event) || $renamingPath.get()) {
+        return
+      }
+
+      const node = treeRef.current?.selectedNodes?.[0]
+
+      if (!node?.data || node.data.placeholder) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      beginInlineRename(node.data.id)
     },
     [onPreviewFile]
   )
-
-  // F2 / Enter on the selected row begins an inline rename. Capture-phase so it
-  // beats arborist's own Enter-to-activate; skipped while an edit is in progress
-  // (the editor input owns Enter/Esc then) and for placeholder rows.
-  const handleRenameShortcut = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (!isRenameShortcut(event) || $renamingPath.get()) {
-      return
-    }
-
-    const node = treeRef.current?.selectedNodes?.[0]
-
-    if (!node?.data || node.data.placeholder) {
-      return
-    }
-
-    event.preventDefault()
-    event.stopPropagation()
-    beginInlineRename(node.data.id)
-  }, [])
 
   return (
     <div
       className="min-h-0 flex-1 overflow-hidden"
       data-project-tree=""
-      onKeyDownCapture={handleRenameShortcut}
+      onKeyDownCapture={handleTreeKeyDown}
       ref={containerRef}
     >
       {size.height > 0 && size.width > 0 ? (
@@ -196,7 +199,6 @@ export function ProjectTree({
           indent={INDENT}
           initialOpenState={openState}
           key={`${cwd}:${collapseNonce}`}
-          onActivate={handleActivate}
           onToggle={handleToggle}
           openByDefault={false}
           padding={0}


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop Files panel open file previews only from intentional activation: left-button double-click or the existing Space keyboard action. A single click now selects the file without opening the preview rail, and context-click actions no longer fall through to preview.

The Files tree previously passed React Arborist's generic `onActivate` directly to preview. Arborist invokes that callback from ordinary row clicks as well as keyboard activation, even though the row already has a dedicated double-click preview handler. This PR removes preview from the generic activation channel and preserves Space explicitly for keyboard accessibility.

## Related Issue

Fixes #93970

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/right-sidebar/files/tree.tsx`
  - remove preview from Arborist's generic activation callback
  - keep single-click selection and folder toggling unchanged
  - preserve Space as the accessible keyboard preview action
  - retain Shift attachment and F2/Enter rename behavior
- `apps/desktop/src/app/right-sidebar/files/tree-activation.test.tsx`
  - prove a generic/single-click activation does not preview
  - prove Space still previews the focused file

## How to Test

1. Open a project in Desktop and show the Files panel.
2. Single-click or right-click a file: it must not open the preview rail.
3. Double-click the file: it must open in preview. Focus the file and press Space: it must also preview. Clicking a folder must still toggle it.

Automated validation on Windows 11, exact head `b283a2fca573dbb30387535301df7427d6fedade`:

- focused + adjacent Vitest: **4/4 passed**
- Desktop TypeScript typecheck: **passed**
- Prettier + ESLint + `git diff --check`: **passed**
- production build + dist assertion: **passed**
- real Electron E2E: **5/5 passed** (single click, context click, double click, Space, folder toggle, plus shipped startup baseline)
- full UI run: **5,723 passed**; 8 tests in 3 unrelated files timed out under full-suite load, and all three files passed immediately in isolated reruns (**8/8**, **3/3**, **1/1**)
- independent exact-SHA review: **PASS**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop-only TypeScript change; Desktop gates above were run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — behavior is renderer-level and platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The real Electron E2E exercised the built renderer and isolated Hermes backend. No temporary E2E fixture or local environment link is included in this PR.
