### PR TITLE
fix(kanban): preserve browser grants for restricted workers

### DIFF
--- a/contributors/emails/choimoonyoung3631@gmail.com
+++ b/contributors/emails/choimoonyoung3631@gmail.com
@@ -1,0 +1,1 @@
+moonweave

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10691,6 +10691,46 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _assert_worker_runtime_capabilities(
+    hermes_home: Optional[str], toolsets: Optional[list[str]]
+) -> None:
+    """Fail before spawn when an explicit browser grant resolves to no schema."""
+    if not hermes_home or not toolsets or "browser" not in toolsets:
+        return
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from model_tools import get_tool_definitions
+
+    token = set_hermes_home_override(hermes_home)
+    try:
+        # Validate only the implementation-sensitive surface.  Including
+        # terminal when granted preserves browser_exec's host-code security
+        # contract; unrelated profile tools must not trigger network/provider
+        # probes merely because the dispatcher is checking browser readiness.
+        probe_toolsets = ["browser"]
+        if "terminal" in toolsets:
+            probe_toolsets.append("terminal")
+        schema = get_tool_definitions(
+            enabled_toolsets=probe_toolsets,
+            quiet_mode=True,
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    names = {
+        item.get("function", {}).get("name", "")
+        for item in schema
+        if isinstance(item, dict)
+    }
+    if not any(name == "browser_exec" or name.startswith("browser_") for name in names):
+        raise RuntimeError(
+            "browser capability unavailable for the assigned Kanban profile: "
+            "the canonical CLI grant includes browser, but no safe browser "
+            "backend produced a worker tool schema. Install/configure the "
+            "browser backend before dispatching this task."
+        )
+
+
 _retagged_workspace_roots: set[str] = set()
 
 
@@ -10883,6 +10923,7 @@ def _default_spawn(
         cmd.extend(["--reasoning", task.reasoning_effort])
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
+        _assert_worker_runtime_capabilities(env.get("HERMES_HOME"), worker_toolsets)
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([
         "chat",

--- a/model_tools.py
+++ b/model_tools.py
@@ -592,6 +592,57 @@ def _compute_tool_definitions(
         ]
         available_tool_names.discard("browser_exec")
 
+        # browser_exec is the Browser Use implementation of the browser
+        # toolset, but it is also arbitrary host-Python execution.  A
+        # least-privilege profile may intentionally grant browser without
+        # terminal/code/file (Web Design QA is the canonical example).  In
+        # that shape, keep the security gate above and expose the constrained
+        # built-in browser actions when their independent local backend probe
+        # passes.  Registry check_fn results cannot express this choice: they
+        # are TTL-cached process-wide while a gateway serves sessions with
+        # different grants, so the fallback belongs at this session-scoped
+        # schema seam.
+        try:
+            from tools.browser_tool import check_builtin_browser_requirements
+
+            builtin_ready = check_builtin_browser_requirements()
+        except Exception:
+            builtin_ready = False
+        if builtin_ready and "browser" in (enabled_toolsets or []):
+            constrained_names = {
+                "browser_navigate",
+                "browser_snapshot",
+                "browser_click",
+                "browser_type",
+                "browser_scroll",
+                "browser_back",
+                "browser_press",
+                "browser_get_images",
+                "browser_console",
+            }
+            if "vision_analyze" in available_tool_names:
+                constrained_names.add("browser_vision")
+            restored = []
+            for name in sorted(constrained_names & tools_to_include):
+                entry = registry.get_entry(name)
+                if entry is None:
+                    continue
+                schema = {**entry.schema, "name": entry.name}
+                if entry.dynamic_schema_overrides is not None:
+                    try:
+                        overrides = entry.dynamic_schema_overrides()
+                        if isinstance(overrides, dict):
+                            schema.update(overrides)
+                    except Exception:
+                        logger.debug(
+                            "browser fallback schema override failed for %s",
+                            name,
+                            exc_info=True,
+                        )
+                restored.append({"type": "function", "function": schema})
+                available_tool_names.add(name)
+            filtered_tools.extend(restored)
+
     # delegate_task's child-restrictions rule names sibling tools (clarify,
     # memory, cronjob). Warning about tools this session doesn't even have
     # teaches ghost vocabulary — filter the list to tools actually present

--- a/tests/fixtures/browser_qa.html
+++ b/tests/fixtures/browser_qa.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hermes Browser QA Fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Hermes Browser QA Fixture</h1>
+      <button type="button">Neutral action</button>
+    </main>
+  </body>
+</html>

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 
 def _make_task(kb, *, assignee: str):
     return kb.Task(
@@ -161,3 +163,119 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+def test_browser_grant_without_terminal_gets_constrained_browser_schema(
+    monkeypatch, tmp_path
+):
+    """Browser Use must not collapse a least-privilege QA profile to no browser.
+
+    ``browser_exec`` is intentionally unavailable without terminal because it
+    executes host Python.  A profile that grants browser but not terminal must
+    fall back to the constrained built-in browser actions instead of losing the
+    entire browser capability.
+    """
+    profile = tmp_path / ".hermes" / "profiles" / "webdesignqa"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli: [browser, web, kanban]\n",
+        encoding="utf-8",
+    )
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from model_tools import _clear_tool_defs_cache, get_tool_definitions
+    from tools import browser_tool, browser_use_cli
+    from tools.registry import invalidate_check_fn_cache
+
+    # Browser Use is the default implementation, while the constrained local
+    # backend is also available for a no-terminal session.
+    monkeypatch.setattr(browser_use_cli, "_find_cli", lambda: ["browser-use"])
+    monkeypatch.setattr(
+        browser_tool, "_find_agent_browser", lambda *_a, **_kw: "agent-browser"
+    )
+    monkeypatch.setattr(browser_tool, "_chromium_installed", lambda: True)
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        toolsets = __import__(
+            "hermes_cli.kanban_db", fromlist=["_resolve_worker_cli_toolsets"]
+        )._resolve_worker_cli_toolsets(str(profile))
+        invalidate_check_fn_cache()
+        _clear_tool_defs_cache()
+        schema = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+    finally:
+        reset_hermes_home_override(token)
+
+    names = {item["function"]["name"] for item in schema}
+    assert {"browser_navigate", "browser_snapshot"} <= names
+    assert "browser_exec" not in names
+    assert "terminal" not in names
+    assert "execute_code" not in names
+    assert not {"read_file", "write_file", "patch"} & names
+
+
+@pytest.mark.parametrize("workspace_kind", ["scratch", "dir"])
+def test_browser_grant_fails_before_spawn_when_no_safe_backend(
+    monkeypatch, tmp_path, workspace_kind
+):
+    """Unavailable browser grants must produce a pre-dispatch capability error."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "webdesignqa"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "platform_toolsets:\n  cli: [browser, web, kanban]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+    from model_tools import _clear_tool_defs_cache
+    from tools import browser_tool, browser_use_cli
+    from tools.registry import invalidate_check_fn_cache
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(browser_use_cli, "_find_cli", lambda: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_find_agent_browser",
+        lambda *_a, **_kw: (_ for _ in ()).throw(FileNotFoundError("unavailable")),
+    )
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *_a, **_kw: pytest.fail("worker must not spawn without browser"),
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _make_task(kb, assignee="webdesignqa")
+    task.workspace_kind = workspace_kind
+
+    with pytest.raises(RuntimeError, match="browser.*unavailable|browser.*capability"):
+        kb._default_spawn(task, str(workspace))
+
+
+def test_running_dispatcher_resolves_profile_toolset_reload(monkeypatch, tmp_path):
+    """A long-lived gateway dispatcher must read the updated profile grant."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "webdesignqa"
+    profile.mkdir(parents=True)
+    config_path = profile / "config.yaml"
+    config_path.write_text(
+        "platform_toolsets:\n  cli: [web, kanban]\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    before = kb._resolve_worker_cli_toolsets(str(profile))
+    assert before is not None and "browser" not in before
+
+    config_path.write_text(
+        "platform_toolsets:\n  cli: [browser, web, kanban]\n", encoding="utf-8"
+    )
+    after = kb._resolve_worker_cli_toolsets(str(profile))
+
+    assert after is not None and "browser" in after

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5877,11 +5877,27 @@ def check_browser_requirements() -> bool:
     Returns:
         True if all requirements are met, False otherwise
     """
-    # Browser Use CLI backend — browser_exec replaces the whole browser_*
-    # surface (including browser_cdp/browser_dialog, whose check_fns funnel
-    # through here), so hide these tools from the model.
+    # Browser Use CLI backend — browser_exec normally replaces the whole
+    # browser_* surface.  Least-privilege sessions that do not grant terminal
+    # cannot receive browser_exec, because it executes host Python; their
+    # schema resolver separately calls check_builtin_browser_requirements()
+    # and exposes only the constrained browser_* actions when this local
+    # backend is available.
     if _is_browser_use_cli_mode():
         return False
+
+    return check_builtin_browser_requirements()
+
+
+def check_builtin_browser_requirements() -> bool:
+    """Check the constrained built-in browser backend independent of mode.
+
+    ``browser.backend=browser-use`` is a schema preference, not proof that the
+    local agent-browser/Chromium implementation is absent.  Keeping this probe
+    separate lets a browser-granted, no-terminal session fall back safely
+    without globally advertising both implementations or weakening the
+    browser_exec host-code gate.
+    """
 
     # Camofox backend — only needs the server URL, no agent-browser CLI
     if _is_camofox_mode():


### PR DESCRIPTION
## What does this PR do?

Preserves the canonical `browser` grant for restricted Kanban workers such as `webdesignqa` without widening their terminal, file, or code-execution capabilities.

When the Browser Use CLI requires terminal access that the profile does not grant, the worker now receives the constrained built-in browser schema if that backend is ready. If no safe browser backend is available, dispatch fails before the worker starts with an explicit capability diagnostic.

## Related Issue

N/A - runtime incident reproduction supplied directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [x] Tests (adding or improving test coverage)

## Changes Made

- Separate built-in browser readiness checks from Browser Use CLI selection in `tools/browser_tool.py`.
- Restore only constrained built-in `browser_*` tools for browser-granted profiles that lack terminal access.
- Add pre-dispatch diagnostics when a canonical browser grant cannot produce a safe browser schema.
- Add schema, unavailable-backend, profile-reload, workspace-kind, and neutral fixture coverage.

## How to Test

1. Run `python -m pytest -q tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/hermes_cli/test_toolset_validation.py tests/test_toolsets.py tests/test_toolset_distributions.py tests/run_agent/test_background_review_toolset_restriction.py tests/tools/test_delegate_composite_toolsets.py`.
2. Confirm all 45 tests pass and the restricted worker schema includes browser tools but excludes terminal, file, and execute-code tools.
3. Run Ruff on the four changed Python paths, `git diff --check`, and gitleaks over `origin/main..HEAD`.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` suite was not run; the six related regression files pass (45 tests).
- [x] I've added tests for my changes.
- [x] Tested on macOS with Python 3 using the repository environment.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no public configuration or user workflow changed.
- [x] `cli-config.yaml.example` update: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no workflow contract changed.
- [x] Cross-platform impact considered: backend readiness and schema filtering use existing platform checks.
- [x] Tool descriptions/schemas update: behavior is reflected in the actual generated schema and tests.

## Screenshots / Logs

Focused regression: 45 passed. A neutral localhost fixture was opened with the built-in browser backend and its heading/button snapshot was captured during validation. Ruff, diff check, and gitleaks passed. No live install, deploy, restart, or migration was performed.
