### PR TITLE
fix(gateway): isolate parent turns from delegated child context

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -70,6 +70,23 @@ def is_delegated_child_context() -> bool:
     return bool(_DELEGATED_CHILD_CONTEXT.get())
 
 
+def reset_inherited_execution_context() -> None:
+    """Start a new top-level turn without an inherited child execution role.
+
+    ``asyncio.create_task`` snapshots the caller's ContextVars.  Gateway
+    completion delivery can therefore create the next parent turn from a
+    callback that still carries a delegated-child or non-dispatcher scope.
+    A new inbound turn is an execution-role boundary, not a nested child, so
+    both task-local markers must be cleared before tools build subprocess envs
+    or apply Kanban ownership guards.
+
+    This intentionally does not touch ``os.environ``.  Process-global state is
+    never an execution-role authority and may be shared by concurrent turns.
+    """
+    _DELEGATED_CHILD_CONTEXT.set(False)
+    _NON_DISPATCHER_OWNED_CONTEXT.set(False)
+
+
 @contextmanager
 def non_dispatcher_owned_context() -> Iterator[None]:
     """Mark in-process execution that does NOT own the dispatcher's Kanban task.
@@ -132,9 +149,15 @@ def is_delegated_child_process_context() -> bool:
 
 def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[str, str]:
     """Return *env* with dispatcher-only Kanban variables removed."""
-    cleaned = dict(env)
-    for key in KANBAN_ENV_KEYS:
-        cleaned.pop(key, None)
+    # Scrub by namespace, not only today's ownership-key tuple.  Dispatcher
+    # additions such as HERMES_KANBAN_ATTACHMENTS_ROOT and goal/branch metadata
+    # must not silently cross into a delegated subprocess merely because this
+    # helper's fixed list was not updated in the same change.
+    cleaned = {
+        key: value
+        for key, value in env.items()
+        if not key.startswith("HERMES_KANBAN_")
+    }
     cleaned[DELEGATED_CHILD_ENV_MARKER] = "1"
     return cleaned
 

--- a/contributors/emails/choimoonyoung3631@gmail.com
+++ b/contributors/emails/choimoonyoung3631@gmail.com
@@ -1,0 +1,1 @@
+moonweave

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16708,6 +16708,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         6. Run agent conversation
         7. Return response
         """
+        # A gateway message is always a fresh top-level execution role.  The
+        # adapter creates its processing task with asyncio.create_task(), which
+        # snapshots the caller's ContextVars; a synthetic background-delegation
+        # completion can otherwise make the next parent turn inherit the child
+        # marker and materialize HERMES_DELEGATED_CHILD_CONTEXT=1 into every
+        # terminal/execute_code subprocess it starts.
+        try:
+            from agent.delegation_context import reset_inherited_execution_context
+
+            reset_inherited_execution_context()
+        except Exception:
+            logger.debug(
+                "reset_inherited_execution_context failed at handler entry",
+                exc_info=True,
+            )
+
         source = event.source
 
         # 🔴 Cross-session leak guard. This handler runs inside a per-message

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -27,6 +27,7 @@ session a few steps later.
 """
 import asyncio
 from contextvars import copy_context
+from typing import Any, cast
 
 import pytest
 
@@ -148,6 +149,57 @@ def test_reset_session_vars_closes_inheritance_leak():
     assert captured["bound"]["HERMES_SESSION_KEY"] == FOREIGN["session_key"]
 
 
+def test_gateway_reentry_drops_inherited_delegated_child_context():
+    """A synthetic completion turn must start as a top-level parent turn.
+
+    ``BasePlatformAdapter.handle_message`` creates the gateway processing task
+    with ``asyncio.create_task``, which snapshots the caller's ContextVars.  A
+    background delegation completion can therefore re-enter from a context
+    that still carries the delegated-child marker.  The real gateway handler
+    must clear that inherited execution role before any parent tool can build a
+    subprocess environment.
+    """
+    from types import SimpleNamespace
+
+    from agent.delegation_context import delegated_child_context
+    from gateway.run import GatewayRunner
+    from tools.environments.local import _make_run_env
+
+    captured = {}
+
+    class ReentrySource:
+        @property
+        def profile(self):
+            captured["subprocess_marker"] = _make_run_env({}).get(
+                "HERMES_DELEGATED_CHILD_CONTEXT"
+            )
+            return None
+
+        @property
+        def profile_route_rejected(self):
+            # Stop immediately after the handler-entry reset seam.  This keeps
+            # the test focused on the actual gateway boundary without building
+            # an agent or touching a live platform/session.
+            return True
+
+    runner = SimpleNamespace(config=SimpleNamespace(multiplex_profiles=True))
+    event = SimpleNamespace(source=ReentrySource())
+
+    async def _reenter():
+        await GatewayRunner._handle_message(
+            cast(Any, runner),
+            cast(Any, event),
+        )
+
+    async def _spawn_reentry():
+        await asyncio.create_task(_reenter())
+
+    with delegated_child_context("child-session"):
+        asyncio.run(_spawn_reentry())
+
+    assert captured["subprocess_marker"] is None
+
+
 # ---------------------------------------------------------------------------
 # Async-delivery capability inheritance (the sibling var outside _VAR_MAP)
 # ---------------------------------------------------------------------------
@@ -198,5 +250,3 @@ def test_reset_session_vars_closes_async_delivery_leak():
         "After reset, async delivery must default to supported; "
         f"got {captured['window']!r}"
     )
-
-

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -5,6 +5,8 @@ import json
 import os
 import shlex
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -296,3 +298,217 @@ def test_child_attempting_default_complete_does_not_finish_parent_or_delete_work
     assert task.status == "running"
     assert run.status == "running"
     assert workspace.is_dir()
+
+
+@pytest.mark.parametrize("outcome", ["success", "exception"])
+def test_parent_can_mutate_kanban_while_background_child_is_active_and_after_cleanup(
+    monkeypatch,
+    tmp_path,
+    outcome,
+):
+    """Exercise the real child runner, subprocess env builder, and DB guard."""
+    kb, tid, _workspace, _attachments_root = _make_running_kanban_task(
+        monkeypatch, tmp_path
+    )
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    from gateway.session_context import get_session_env
+    from tools import delegate_tool
+    from tools.environments.local import _make_run_env
+
+    entered = threading.Event()
+    release = threading.Event()
+    observed = {}
+
+    class Parent:
+        _current_task_id = tid
+
+        def _touch_activity(self, _desc):
+            return None
+
+    class Child:
+        tool_progress_callback = None
+        _delegate_saved_tool_names = []
+        _credential_pool = None
+        _subagent_id = f"sa-{outcome}"
+        _delegate_depth = 1
+        _parent_subagent_id = None
+        session_id = f"child-{outcome}"
+        model = "test-model"
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_estimated_cost_usd = 0.0
+        session_reasoning_tokens = 0
+
+        def get_activity_summary(self):
+            return {
+                "api_call_count": 0,
+                "max_iterations": 1,
+                "current_tool": "terminal",
+            }
+
+        def run_conversation(self, user_message, task_id, **_kwargs):
+            child_env = _make_run_env({})
+            observed["child_marker"] = child_env.get(
+                "HERMES_DELEGATED_CHILD_CONTEXT"
+            )
+            observed["child_session"] = get_session_env("HERMES_SESSION_ID", "")
+            observed["child_kanban_keys"] = {
+                key for key in child_env if key.startswith("HERMES_KANBAN_")
+            }
+            conn = kb.connect()
+            try:
+                with pytest.raises(PermissionError):
+                    kb.add_comment(conn, tid, "child", "must be rejected")
+            finally:
+                conn.close()
+            entered.set()
+            assert release.wait(5)
+            if outcome == "exception":
+                raise RuntimeError("controlled child failure")
+            return {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 0,
+                "messages": [],
+            }
+
+        def close(self):
+            return None
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            delegate_tool._run_single_child,
+            0,
+            "hold at barrier",
+            Child(),
+            Parent(),
+        )
+        assert entered.wait(5)
+
+        parent_env = _make_run_env({})
+        assert parent_env.get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+        conn = kb.connect()
+        try:
+            kb.add_comment(conn, tid, "parent", "allowed while child active")
+        finally:
+            conn.close()
+
+        release.set()
+        result = future.result(timeout=10)
+
+    assert observed["child_marker"] == "1"
+    assert observed["child_session"] == f"child-{outcome}"
+    assert observed["child_kanban_keys"] == set()
+    assert result["status"] == ("completed" if outcome == "success" else "error")
+    assert _make_run_env({}).get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, tid, "parent", "allowed after child cleanup")
+        comments = kb.list_comments(conn, tid)
+    finally:
+        conn.close()
+    assert [comment.author for comment in comments] == ["parent", "parent"]
+
+
+def test_concurrent_children_keep_marker_and_session_identity_isolated(monkeypatch):
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    from agent.delegation_context import delegated_child_context
+    from gateway.session_context import get_session_env
+    from tools.environments.local import _make_run_env
+
+    barrier = threading.Barrier(2)
+
+    def inspect_child(session_id):
+        with delegated_child_context(session_id):
+            barrier.wait(timeout=5)
+            return (
+                _make_run_env({}).get("HERMES_DELEGATED_CHILD_CONTEXT"),
+                get_session_env("HERMES_SESSION_ID", ""),
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        a = executor.submit(inspect_child, "child-a")
+        b = executor.submit(inspect_child, "child-b")
+        assert a.result(timeout=10) == ("1", "child-a")
+        assert b.result(timeout=10) == ("1", "child-b")
+
+    assert _make_run_env({}).get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+
+
+def test_child_timeout_hard_interrupt_does_not_mark_parent(monkeypatch, tmp_path):
+    kb, tid, _workspace, _attachments_root = _make_running_kanban_task(
+        monkeypatch, tmp_path
+    )
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    from tools import delegate_tool
+    from tools.environments.local import _make_run_env
+
+    entered = threading.Event()
+    interrupted = threading.Event()
+    observed = {}
+
+    class Parent:
+        _current_task_id = tid
+
+        def _touch_activity(self, _desc):
+            return None
+
+    class Child:
+        tool_progress_callback = None
+        _delegate_saved_tool_names = []
+        _credential_pool = None
+        _subagent_id = "sa-timeout"
+        _delegate_depth = 1
+        _parent_subagent_id = None
+        session_id = "child-timeout"
+        model = "test-model"
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_estimated_cost_usd = 0.0
+        session_reasoning_tokens = 0
+
+        def get_activity_summary(self):
+            return {"api_call_count": 0, "max_iterations": 1, "current_tool": None}
+
+        def run_conversation(self, **_kwargs):
+            observed["child_marker"] = _make_run_env({}).get(
+                "HERMES_DELEGATED_CHILD_CONTEXT"
+            )
+            entered.set()
+            assert interrupted.wait(5)
+            return {
+                "final_response": "interrupted",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 0,
+                "messages": [],
+            }
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.05)
+
+    def hard_interrupt(_child, *_args, **_kwargs):
+        interrupted.set()
+        return True
+
+    monkeypatch.setattr(delegate_tool, "request_hard_interrupt", hard_interrupt)
+
+    result = delegate_tool._run_single_child(
+        0, "timeout at barrier", Child(), Parent()
+    )
+
+    assert entered.is_set()
+    assert observed["child_marker"] == "1"
+    assert result["status"] == "timeout"
+    assert _make_run_env({}).get("HERMES_DELEGATED_CHILD_CONTEXT") is None
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, tid, "parent", "allowed after timeout interrupt")
+    finally:
+        conn.close()


### PR DESCRIPTION
## What does this PR do?

Prevents a background `delegate_task` child context from being inherited by later top-level gateway turns. A long-lived parent conversation can therefore continue to mutate Kanban while its delegated child remains correctly restricted.

The fix resets inherited execution `ContextVar` values at the gateway message boundary. It does not mutate process-global environment state, weaken the child Kanban guard, rebuild the parent toolset, or change prompt/session behavior.

## Related Issue

N/A - runtime incident reproduction supplied directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add an explicit top-level execution-context reset helper in `agent/delegation_context.py`.
- Apply the reset when gateway message handling enters a new parent turn.
- Scrub all inherited `HERMES_KANBAN_*` ownership variables from child subprocess environments.
- Add gateway/background integration coverage for active children, completion, exception, timeout/interruption, concurrent children, subprocess markers, Kanban mutation isolation, and result re-entry.

## How to Test

1. Run `python -m pytest -q tests/tools/test_delegate_kanban_isolation.py tests/tools/test_async_delegation.py tests/tools/test_delegate_apiserver_background.py tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_delegation_session_id_leak.py tests/gateway/test_session_context_inheritance.py`.
2. Confirm all 51 tests pass, including parent Kanban mutation while a child is active and child mutation denial.
3. Run Ruff on the four changed Python paths, `git diff --check`, and gitleaks over `origin/main..HEAD`.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` suite was not run; the six related regression files pass (51 tests).
- [x] I've added tests for my changes.
- [x] Tested on macOS with Python 3 using the repository environment.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no public configuration or user workflow changed.
- [x] `cli-config.yaml.example` update: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no workflow contract changed.
- [x] Cross-platform impact considered: `ContextVar` and environment-copy behavior remains platform-neutral.
- [x] Tool descriptions/schemas update: N/A.

## Screenshots / Logs

Focused regression: 51 passed. Ruff, diff check, and gitleaks passed. No live install, deploy, restart, or migration was performed.
