### PR TITLE
feat(cli): add `hermes project delete` for hard-deleting projects

### DIFF
--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -313,7 +313,11 @@ def _cmd_restore(args, conn, proj) -> int:
 @_with_project
 def _cmd_delete(args, conn, proj) -> int:
     if not args.yes:
-        answer = input(f"Permanently delete project '{proj.slug}'? [y/N]: ").strip().lower()
+        try:
+            answer = input(f"Permanently delete project '{proj.slug}'? [y/N]: ").strip().lower()
+        except EOFError:
+            print("Aborted: no input available; pass --yes to delete non-interactively.")
+            return 1
         if answer not in ("y", "yes"):
             print("Aborted.")
             return 1

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -95,6 +95,12 @@ def build_parser(
     p_restore = sub.add_parser("restore", help="Restore an archived project")
     p_restore.add_argument("project", help="Project id or slug")
 
+    p_delete = sub.add_parser("delete", help="Permanently delete a project")
+    p_delete.add_argument("project", help="Project id or slug")
+    p_delete.add_argument(
+        "--yes", action="store_true", help="Skip the confirmation prompt"
+    )
+
     p_bind = sub.add_parser("bind-board", help="Bind a kanban board to a project")
     p_bind.add_argument("project", help="Project id or slug")
     p_bind.add_argument(
@@ -132,6 +138,7 @@ def projects_command(args: argparse.Namespace) -> int:
         "use": _cmd_use,
         "archive": _cmd_archive,
         "restore": _cmd_restore,
+        "delete": _cmd_delete,
         "bind-board": _cmd_bind_board,
     }
     handler = handlers.get(action)
@@ -300,6 +307,18 @@ def _cmd_archive(args, conn, proj) -> int:
 def _cmd_restore(args, conn, proj) -> int:
     pdb.restore_project(conn, proj.id)
     print(f"Restored {proj.slug}")
+    return 0
+
+
+@_with_project
+def _cmd_delete(args, conn, proj) -> int:
+    if not args.yes:
+        answer = input(f"Permanently delete project '{proj.slug}'? [y/N]: ").strip().lower()
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+    pdb.delete_project(conn, proj.id)
+    print(f"Deleted {proj.slug}")
     return 0
 
 

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -57,5 +57,27 @@ def test_rename_and_archive(tmp_path):
         assert len(pdb.list_projects(conn)) == 1
 
 
+def test_delete_requires_confirmation(monkeypatch, tmp_path):
+    _run(["create", "Throwaway", str(tmp_path)])
+
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    assert _run(["delete", "throwaway"]) == 1
+    with pdb.connect_closing() as conn:
+        assert len(pdb.list_projects(conn)) == 1
+
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert _run(["delete", "throwaway"]) == 0
+    with pdb.connect_closing() as conn:
+        assert pdb.list_projects(conn, include_archived=True) == []
+
+
+def test_delete_yes_flag_skips_prompt(tmp_path):
+    _run(["create", "Scratch", str(tmp_path)])
+
+    assert _run(["delete", "scratch", "--yes"]) == 0
+    with pdb.connect_closing() as conn:
+        assert pdb.list_projects(conn, include_archived=True) == []
+
+
 
 

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -79,5 +79,18 @@ def test_delete_yes_flag_skips_prompt(tmp_path):
         assert pdb.list_projects(conn, include_archived=True) == []
 
 
+def test_delete_without_yes_in_non_interactive_env(monkeypatch, tmp_path, capsys):
+    _run(["create", "Headless", str(tmp_path)])
+
+    def _raise_eof(_):
+        raise EOFError()
+
+    monkeypatch.setattr("builtins.input", _raise_eof)
+    assert _run(["delete", "headless"]) == 1
+    assert "Aborted" in capsys.readouterr().out
+    with pdb.connect_closing() as conn:
+        assert len(pdb.list_projects(conn)) == 1
+
+
 
 


### PR DESCRIPTION
Fixes part of #94643

## Problem

#94643 asks for a full Project Manager UI in the Desktop sidebar. Most of
that already exists in `apps/desktop/src/app/chat/sidebar/projects/`: the
sidebar lists projects, and the per-project kebab/right-click menu already
covers switch (`set-active`), rename, add-folder, appearance, and a hard
delete with a confirm dialog (`ProjectMenu` / `ProjectContextMenu` in
`project-menu.tsx`, backed by `deleteProject()` in `store/projects.ts` and
the `projects.delete` gateway RPC).

The issue's own "Technical notes" flag one concrete, narrow gap correctly:

> Backend commands already exist except `delete` (only `archive`/`restore`)

That's true at the CLI layer specifically. `hermes_cli/projects_db.py`
already has `delete_project()`, and the gateway already exposes it via the
`projects.delete` RPC (used by the desktop UI's delete action) — but
`hermes_cli/projects_cmd.py` (the `hermes project ...` CLI) only wires up
`archive`/`restore`, not `delete`. There is no way to hard-delete a project
from the CLI, even though every other layer supports it.

The rest of the issue (an archived-projects view + restore surface in the
sidebar, orphaned-project ❌/✅ detection, a create-project modal with a
path picker, and a `Cmd/Ctrl+Shift+P` fuzzy project switcher) is a set of
separate, larger UI/UX features that each need their own design decisions
and are out of scope for this change.

## Fix

Add a `hermes project delete <slug>` subcommand to `hermes_cli/projects_cmd.py`,
mirroring the existing `archive`/`restore` subcommands:

- Resolves the project via the existing `_with_project` decorator (same
  not-found handling as every other project subcommand).
- Prompts for confirmation (`Permanently delete project '<slug>'? [y/N]`)
  since deletion is irreversible, matching the issue's explicit ask for
  "Delete (hard delete **with confirmation**)".
- `--yes` skips the prompt for scripted/non-interactive use.
- Delegates to the already-existing `projects_db.delete_project()`.

No changes to the gateway RPC, the DB layer, or the desktop UI — all three
already supported this operation; only the CLI entry point was missing.

## Testing

Added `test_delete_requires_confirmation` and `test_delete_yes_flag_skips_prompt`
to `tests/hermes_cli/test_projects_cli.py`, following the existing
`test_rename_and_archive` pattern.

Confirmed the new tests fail without the fix:

```
$ git checkout HEAD~1 -- hermes_cli/projects_cmd.py
$ python -m pytest tests/hermes_cli/test_projects_cli.py -v
...
tests/hermes_cli/test_projects_cli.py::test_delete_requires_confirmation FAILED
tests/hermes_cli/test_projects_cli.py::test_delete_yes_flag_skips_prompt FAILED
...
__main__.py project: error: argument project_action: invalid choice: 'delete'
(choose from create, list, ls, show, add-folder, remove-folder, rename,
set-primary, use, archive, restore, bind-board)
2 failed, 2 passed in 1.03s
```

And pass with the fix restored:

```
$ git checkout HEAD -- hermes_cli/projects_cmd.py
$ python -m pytest tests/hermes_cli/test_projects_cli.py -v
tests/hermes_cli/test_projects_cli.py::test_create_list_show PASSED
tests/hermes_cli/test_projects_cli.py::test_rename_and_archive PASSED
tests/hermes_cli/test_projects_cli.py::test_delete_requires_confirmation PASSED
tests/hermes_cli/test_projects_cli.py::test_delete_yes_flag_skips_prompt PASSED
4 passed in 0.50s
```

Also ran the related gateway RPC suite to confirm no regressions:

```
$ python -m pytest tests/hermes_cli/test_projects_cli.py tests/tui_gateway/test_projects_rpc.py -q
35 passed in 3.16s
```

`ruff check hermes_cli/projects_cmd.py tests/hermes_cli/test_projects_cli.py`
passes clean.

## AI assistance disclosure

This PR was drafted by an autonomous coding agent (Claude), including the
investigation into which parts of #94643 were already implemented, the
fix, and the tests above. All commands and output shown were actually run
against this branch.
