### PR TITLE
feat(desktop): per-job model switcher in the cron detail panel and sidebar context menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -294,6 +294,13 @@ function CronJobSidebarRow({
       {renderActionItem(kit, { icon: 'watch', key: 'manage', label: c.manage, onSelect: onManage })}
       <kit.Separator />
       {renderActionItem(kit, {
+        icon: 'settings',
+        key: 'change-model',
+        label: c.changeModel,
+        onSelect: onManage
+      })}
+      <kit.Separator />
+      {renderActionItem(kit, {
         icon: 'trash',
         key: 'delete',
         label: t.common.delete,

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -45,6 +45,14 @@ export interface CronEditorSaveValues {
   schedule: string
 }
 
+/** Build the narrow update payload used by the detail-panel model picker. */
+export function cronModelUpdates(provider: string, model: string): CronJobUpdates {
+  return {
+    model: model.trim() || null,
+    provider: provider.trim() || null
+  }
+}
+
 export function parseCronDeliveryTargets(value: string): string[] {
   const targets = value
     .split(',')

--- a/apps/desktop/src/app/cron/cron-model-switcher.test.ts
+++ b/apps/desktop/src/app/cron/cron-model-switcher.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CronJobUpdates } from '@/types/hermes'
+
+import { cronEditorUpdates } from './cron-job-model'
+
+describe('cron model switcher — updateCronJob payload', () => {
+  // The model switcher in CronJobDetail calls updateCronJob directly with
+  // { model, provider } — bypassing the editor form. Verify the payload shape
+  // matches what the API expects (null clears, string pins).
+
+  it('pins a model and provider when both are provided', () => {
+    const updates: CronJobUpdates = {
+      model: 'claude-sonnet-4',
+      provider: 'anthropic'
+    }
+
+    expect(updates.model).toBe('claude-sonnet-4')
+    expect(updates.provider).toBe('anthropic')
+  })
+
+  it('clears a previous pin when model is empty', () => {
+    const updates: CronJobUpdates = {
+      model: null,
+      provider: null
+    }
+
+    expect(updates.model).toBeNull()
+    expect(updates.provider).toBeNull()
+  })
+
+  it('pins a model with an empty provider when only model is selected', () => {
+    const updates: CronJobUpdates = {
+      model: 'gpt-4o',
+      provider: ''
+    }
+
+    // The API normalizes empty-string provider to null/undefined
+    expect(updates.model).toBe('gpt-4o')
+  })
+})
+
+describe('cronEditorUpdates — model switcher integration', () => {
+  it('writes the model override for agent jobs (same path as the switcher)', () => {
+    const updates = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: 'deepseek-chat',
+        name: 'Daily summary',
+        prompt: 'go',
+        provider: 'deepseek',
+        schedule: '0 9 * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(updates.model).toBe('deepseek-chat')
+    expect(updates.provider).toBe('deepseek')
+  })
+
+  it('clears a previous pin when the switcher resets to default', () => {
+    const updates = cronEditorUpdates(
+      { deliver: 'local', model: '', name: 'Daily', prompt: 'go', provider: '', schedule: '0 9 * * *' },
+      { scriptOnlyJob: false }
+    )
+
+    expect(updates.model).toBe(null)
+    expect(updates.provider).toBe(null)
+  })
+
+  it('uses a cheaper model for low-effort jobs and a powerful model for heavy jobs', () => {
+    // Low-effort summarising job
+    const cheapUpdates = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: 'deepseek-chat',
+        name: 'Feed summariser',
+        prompt: 'Summarise the feed',
+        provider: 'deepseek',
+        schedule: '0 * * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(cheapUpdates.model).toBe('deepseek-chat')
+
+    // Heavy reasoning job
+    const heavyUpdates = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: 'claude-sonnet-4',
+        name: 'Weekly analysis',
+        prompt: 'Analyse the week',
+        provider: 'anthropic',
+        schedule: '0 9 * * 1'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(heavyUpdates.model).toBe('claude-sonnet-4')
+  })
+})

--- a/apps/desktop/src/app/cron/cron-model-switcher.test.ts
+++ b/apps/desktop/src/app/cron/cron-model-switcher.test.ts
@@ -1,42 +1,27 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CronJobUpdates } from '@/types/hermes'
-
-import { cronEditorUpdates } from './cron-job-model'
+import { cronEditorUpdates, cronModelUpdates } from './cron-job-model'
 
 describe('cron model switcher — updateCronJob payload', () => {
-  // The model switcher in CronJobDetail calls updateCronJob directly with
-  // { model, provider } — bypassing the editor form. Verify the payload shape
-  // matches what the API expects (null clears, string pins).
-
   it('pins a model and provider when both are provided', () => {
-    const updates: CronJobUpdates = {
-      model: 'claude-sonnet-4',
-      provider: 'anthropic'
-    }
+    const updates = cronModelUpdates('anthropic', 'claude-sonnet-4')
 
     expect(updates.model).toBe('claude-sonnet-4')
     expect(updates.provider).toBe('anthropic')
   })
 
   it('clears a previous pin when model is empty', () => {
-    const updates: CronJobUpdates = {
-      model: null,
-      provider: null
-    }
+    const updates = cronModelUpdates('', '')
 
     expect(updates.model).toBeNull()
     expect(updates.provider).toBeNull()
   })
 
-  it('pins a model with an empty provider when only model is selected', () => {
-    const updates: CronJobUpdates = {
-      model: 'gpt-4o',
-      provider: ''
-    }
+  it('normalizes an empty provider when only a model is selected', () => {
+    const updates = cronModelUpdates('  ', ' gpt-4o ')
 
-    // The API normalizes empty-string provider to null/undefined
     expect(updates.model).toBe('gpt-4o')
+    expect(updates.provider).toBeNull()
   })
 })
 

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -4,8 +4,8 @@ import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { PageLoader } from '@/components/page-loader'
 import { ModelPickerDialog } from '@/components/model-picker'
+import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Codicon } from '@/components/ui/codicon'
@@ -702,9 +702,6 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               busy={busyJobTokens.has(selectedJob.id) || triggeringJobKeys.has(`${profile}:${selectedJob.id}`)}
               c={c}
               job={selectedJob}
-              onOpenSession={onOpenSession}
-              onPauseResume={() => void handlePauseResume(selectedJob)}
-              onTrigger={() => void handleTrigger(selectedJob)}
               onModelChange={async (provider, model) => {
                 const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
                   updateCronJob(selectedJob.id, {
@@ -721,6 +718,9 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
                   notifyError(refreshError, c.failedLoad)
                 }
               }}
+              onOpenSession={onOpenSession}
+              onPauseResume={() => void handlePauseResume(selectedJob)}
+              onTrigger={() => void handleTrigger(selectedJob)}
             />
           ) : query.trim() ? (
             // A search with no selected job: search-flavored copy is right.
@@ -798,18 +798,18 @@ function CronJobDetail({
   busy,
   c,
   job,
+  onModelChange,
   onOpenSession,
   onPauseResume,
-  onTrigger,
-  onModelChange
+  onTrigger
 }: {
   busy: boolean
   c: Translations['cron']
   job: CronJob
+  onModelChange?: (provider: string, model: string) => Promise<void>
   onOpenSession?: (sessionId: string) => void
   onPauseResume: () => void
   onTrigger: () => void
-  onModelChange?: (provider: string, model: string) => Promise<void>
 }) {
   const state = jobState(job)
   const isPaused = state === 'paused'

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -78,6 +78,7 @@ import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, init
 import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
 import {
   cronEditorUpdates,
+  cronModelUpdates,
   jobIsScriptOnly,
   parseCronDeliveryTargets,
   toggleCronDeliveryTarget,
@@ -704,10 +705,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               job={selectedJob}
               onModelChange={async (provider, model) => {
                 const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
-                  updateCronJob(selectedJob.id, {
-                    model: model || null,
-                    provider: provider || null
-                  })
+                  updateCronJob(selectedJob.id, cronModelUpdates(provider, model))
                 )
 
                 if (stale) {
@@ -878,6 +876,7 @@ function CronJobDetail({
           onOpenChange={setModelPickerOpen}
           onSelect={async ({ provider, model }) => {
             setModelBusy(true)
+
             try {
               await onModelChange(provider, model)
               notify({ kind: 'success', title: c.modelUpdated, message: truncate(jobTitle(job), 60) })

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -5,6 +5,7 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
+import { ModelPickerDialog } from '@/components/model-picker'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Codicon } from '@/components/ui/codicon'
@@ -704,6 +705,22 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               onOpenSession={onOpenSession}
               onPauseResume={() => void handlePauseResume(selectedJob)}
               onTrigger={() => void handleTrigger(selectedJob)}
+              onModelChange={async (provider, model) => {
+                const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () =>
+                  updateCronJob(selectedJob.id, {
+                    model: model || null,
+                    provider: provider || null
+                  })
+                )
+
+                if (stale) {
+                  return
+                }
+
+                if (refreshError) {
+                  notifyError(refreshError, c.failedLoad)
+                }
+              }}
             />
           ) : query.trim() ? (
             // A search with no selected job: search-flavored copy is right.
@@ -783,7 +800,8 @@ function CronJobDetail({
   job,
   onOpenSession,
   onPauseResume,
-  onTrigger
+  onTrigger,
+  onModelChange
 }: {
   busy: boolean
   c: Translations['cron']
@@ -791,12 +809,16 @@ function CronJobDetail({
   onOpenSession?: (sessionId: string) => void
   onPauseResume: () => void
   onTrigger: () => void
+  onModelChange?: (provider: string, model: string) => Promise<void>
 }) {
   const state = jobState(job)
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
   const modelOverride = jobModel(job)
+  const providerOverride = jobProvider(job)
+  const [modelPickerOpen, setModelPickerOpen] = useState(false)
+  const [modelBusy, setModelBusy] = useState(false)
 
   return (
     <PanelDetail>
@@ -813,6 +835,11 @@ function CronJobDetail({
             <PanelAction disabled={busy} icon="zap" onClick={onTrigger} primary>
               {c.triggerNow}
             </PanelAction>
+            {onModelChange && !jobIsScriptOnly(job) && (
+              <PanelAction disabled={busy || modelBusy} icon="settings" onClick={() => setModelPickerOpen(true)}>
+                {modelOverride || c.modelSwitcher}
+              </PanelAction>
+            )}
           </div>
         </div>
 
@@ -842,6 +869,27 @@ function CronJobDetail({
       ) : null}
 
       <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+
+      {onModelChange && !jobIsScriptOnly(job) && (
+        <ModelPickerDialog
+          contentClassName="z-[100]"
+          currentModel={modelOverride}
+          currentProvider={providerOverride}
+          onOpenChange={setModelPickerOpen}
+          onSelect={async ({ provider, model }) => {
+            setModelBusy(true)
+            try {
+              await onModelChange(provider, model)
+              notify({ kind: 'success', title: c.modelUpdated, message: truncate(jobTitle(job), 60) })
+            } catch {
+              notifyError(new Error(c.failedUpdate), c.failedUpdate)
+            } finally {
+              setModelBusy(false)
+            }
+          }}
+          open={modelPickerOpen}
+        />
+      )}
     </PanelDetail>
   )
 }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1604,7 +1604,10 @@ export const ar = defineLocale({
     optional: 'اختياري',
     promptScheduleRequired: 'الرسالة والجدول مطلوبان',
     saveChanges: 'حفظ التغييرات',
-    createAction: 'إنشاء'
+    createAction: 'إنشاء',
+    modelSwitcher: 'النموذج',
+    modelUpdated: 'تم تحديث النموذج',
+    changeModel: 'تغيير النموذج'
   },
   artifacts: {
     search: 'بحث',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2045,6 +2045,9 @@ export const en: Translations = {
     scriptOnlyEditHint: 'Script-only job (no AI prompt). Job id:',
     saveChanges: 'Save changes',
     createAction: 'Create cron',
+    modelSwitcher: 'Model',
+    modelUpdated: 'Model updated',
+    changeModel: 'Change model',
     tabs: {
       jobs: 'Jobs',
       blueprints: 'Blueprints'

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1757,6 +1757,9 @@ export const ja = defineLocale({
     scriptOnlyEditHint: 'スクリプトのみのジョブ（AI プロンプトなし）。ジョブ ID:',
     saveChanges: '変更を保存',
     createAction: 'Cron を作成',
+    modelSwitcher: 'モデル',
+    modelUpdated: 'モデルを更新しました',
+    changeModel: 'モデルを変更',
     tabs: {
       jobs: 'ジョブ',
       blueprints: 'ブレーンプリント'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1718,6 +1718,9 @@ export interface Translations {
     scriptOnlyEditHint: string
     saveChanges: string
     createAction: string
+    modelSwitcher: string
+    modelUpdated: string
+    changeModel: string
     tabs: {
       jobs: string
       blueprints: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1694,6 +1694,9 @@ export const zhHant = defineLocale({
     scriptOnlyEditHint: '僅腳本任務（無 AI 提示詞）。任務 ID：',
     saveChanges: '儲存變更',
     createAction: '建立排程工作',
+    modelSwitcher: '模型',
+    modelUpdated: '模型已更新',
+    changeModel: '變更模型',
     tabs: {
       jobs: '工作',
       blueprints: '藍圖'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2227,6 +2227,9 @@ export const zh: Translations = {
     scriptOnlyEditHint: '仅脚本任务（无 AI 提示词）。任务 ID：',
     saveChanges: '保存更改',
     createAction: '创建定时任务',
+    modelSwitcher: '模型',
+    modelUpdated: '模型已更新',
+    changeModel: '更改模型',
     tabs: {
       jobs: '任务',
       blueprints: '蓝图'


### PR DESCRIPTION
## What does this PR do?

Surfaces the existing per-job model/provider override in the **desktop cron UI** — where it was only reachable via the CLI (`hermes cron edit <id> --model … --provider …`) or by hand-editing `jobs.json`.

The backend has supported per-job model pins since the beginning (resolution at fire time: per-job pin → `cron.model` → global default). But the desktop UI never exposed it — meaning users who wanted to route a cheap summarising job to a cheap model and a heavy reasoning job to a powerful model had to drop to the CLI.

### What's new

**CronJobDetail panel** — a model switcher button appears next to the Resume/Trigger action buttons. It opens the same `ModelPickerDialog` the chat composer uses — so users see all their configured providers and actually-available models, with pricing, search, and the same UX they already know. Selecting a model calls `updateCronJob({ model, provider })` immediately; no editor round-trip needed. The button label shows the currently pinned model name, or "Model" when following the default.

**Sidebar right-click context menu** — a "Change model" entry opens the full manage panel where the switcher lives, keeping model configuration in one discoverable place rather than spreading it across the sidebar.

**Script-only jobs** — the switcher is hidden for `no_agent` jobs since they don't run an LLM.

## Related Issue

Closes the "model switcher missing from the desktop cron UI" gap. Related: #89513 (Models pane missing cron config), #89562 (fleet model defaults in UI), #93004 (per-job reasoning effort picker — this PR is the model-axis counterpart).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/cron/index.tsx` — `ModelPickerDialog` in `CronJobDetail`, `onModelChange` handler calls `updateCronJob` with `{ model, provider }`
- `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx` — "Change model" context menu item
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar}.ts` + `types.ts` — `modelSwitcher`, `modelUpdated`, `changeModel` strings
- `apps/desktop/src/app/cron/cron-model-switcher.test.ts` — test coverage for the model switcher payload shape

## How to Test

1. `cd apps/desktop && npx vitest run src/app/cron/` — 38 pass (incl. new tests)
2. `npx tsc -p tsconfig.json --noEmit` — clean
3. Open the Scheduled Jobs panel → select a job → click the "Model" button next to Resume/Trigger → pick a model → verify the job's model pin updates
4. Right-click a cron job in the sidebar → "Change model" opens the manage panel with the switcher

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant tests and they pass (38/38)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys added (surfaces existing `model`/`provider` fields already in `CronJobUpdates`)
- [x] N/A — renderer-only change, no cross-platform impact