### PR TITLE
fix(desktop): do not treat deferred local enumeration as a failure

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -236,6 +236,7 @@ import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-pro
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
   buildRegistryProfileRoutes,
+  isLocalEnumerationFailure,
   localRouteFallbackProfiles,
   registryGatewayWsUrl,
   undialedSshRouteSeeds
@@ -12885,7 +12886,12 @@ ipcMain.handle('hermes:plugin-profile-routes', async (_event, rawProfileNames) =
     : undefined
 
   const localFallbackProfiles = localSource
-    ? localRouteFallbackProfiles(agents, localSource.id, fallbackProfileNames, Boolean(localEnumeration?.error))
+    ? localRouteFallbackProfiles(
+        agents,
+        localSource.id,
+        fallbackProfileNames,
+        isLocalEnumerationFailure(localEnumeration?.error)
+      )
     : []
 
   if (localSource && localFallbackProfiles.length > 0) {

--- a/apps/desktop/electron/plugin-profile-routes.test.ts
+++ b/apps/desktop/electron/plugin-profile-routes.test.ts
@@ -278,6 +278,18 @@ describe('localRouteFallbackProfiles', () => {
   it('does not synthesize local routes after a successful local enumeration', () => {
     expect(localRouteFallbackProfiles([], 'local', ['default'], false)).toEqual([])
   })
+
+  it('does not synthesize local routes for a deferred connect-on-demand enumeration', () => {
+    expect(
+      localRouteFallbackProfiles([], 'local', ['default'], isLocalEnumerationFailure('connect-on-demand'))
+    ).toEqual([])
+  })
+
+  it('synthesizes local routes for a genuine local enumeration error', () => {
+    expect(
+      localRouteFallbackProfiles([], 'local', ['default'], isLocalEnumerationFailure('ECONNREFUSED'))
+    ).toEqual(['default'])
+  })
 })
 
 describe('undialedSshRouteSeeds', () => {

--- a/apps/desktop/electron/plugin-profile-routes.test.ts
+++ b/apps/desktop/electron/plugin-profile-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildOpaqueProfileRoutes,
   buildRegistryProfileRoutes,
+  isLocalEnumerationFailure,
   localRouteFallbackProfiles,
   type ProfileRouteConfig,
   registryGatewayWsUrl,
@@ -250,6 +251,20 @@ describe('buildRegistryProfileRoutes', () => {
     expect(registryGatewayWsUrl({ profile: 'research' }, 'ws://127.0.0.1:5151/api/ws?token=local')).toBe(
       'ws://127.0.0.1:5151/api/ws?token=local'
     )
+  })
+})
+
+describe('isLocalEnumerationFailure', () => {
+  it('does not treat an intentionally deferred local enumeration as a failure', () => {
+    expect(isLocalEnumerationFailure('connect-on-demand')).toBe(false)
+  })
+
+  it('treats any other enumeration error as a failure', () => {
+    expect(isLocalEnumerationFailure('ECONNREFUSED')).toBe(true)
+  })
+
+  it('treats a missing error as no failure', () => {
+    expect(isLocalEnumerationFailure(undefined)).toBe(false)
   })
 })
 

--- a/apps/desktop/electron/plugin-profile-routes.ts
+++ b/apps/desktop/electron/plugin-profile-routes.ts
@@ -53,7 +53,10 @@ interface BuildOpaqueProfileRoutesOptions {
 
 /** A 'connect-on-demand' local enumeration was intentionally deferred, not
  * failed — it must not be treated as a failure or Bot Mode will synthesize
- * cached local rows on remote-only workspaces where local was never dialed. */
+ * cached local rows on remote-only workspaces where local was never dialed.
+ * The sentinel is set by `enumerateRegistryAgentSources` in main.ts when
+ * `shouldDeferLocalEnumeration` (connection-registry.ts) defers the local
+ * source. */
 export function isLocalEnumerationFailure(error?: string): boolean {
   return Boolean(error) && error !== 'connect-on-demand'
 }

--- a/apps/desktop/electron/plugin-profile-routes.ts
+++ b/apps/desktop/electron/plugin-profile-routes.ts
@@ -51,6 +51,13 @@ interface BuildOpaqueProfileRoutesOptions {
   resolveSsh: (config: ProfileRouteConfig) => Promise<EffectiveSshRoute>
 }
 
+/** A 'connect-on-demand' local enumeration was intentionally deferred, not
+ * failed — it must not be treated as a failure or Bot Mode will synthesize
+ * cached local rows on remote-only workspaces where local was never dialed. */
+export function isLocalEnumerationFailure(error?: string): boolean {
+  return Boolean(error) && error !== 'connect-on-demand'
+}
+
 /** Return cached local profile names only when the local roster read failed. */
 export function localRouteFallbackProfiles(
   agents: RegistryProfileRouteAgent[],


### PR DESCRIPTION
## What does this PR do?

When Hermes Desktop's primary connection is a remote/SSH gateway, local
roster enumeration is intentionally deferred (`error: 'connect-on-demand'`)
so Bot Mode doesn't spawn a local backend the user never asked for. The
`hermes:plugin-profile-routes` IPC handler in `apps/desktop/electron/main.ts`
converted that deferral straight to `Boolean(localEnumeration?.error)` and
passed it to `localRouteFallbackProfiles`, which treats *any* truthy error as
a genuine enumeration failure and re-synthesizes cached local profile rows.
The result: Bot Mode shows a stale "This device" section with a cached local
bot even on a remote-only workspace, even though local was never dialed.

This adds `isLocalEnumerationFailure()` in `plugin-profile-routes.ts`, which
treats `'connect-on-demand'` as the intentional deferral it is (not a
failure) and only reports a failure for any other error string. The IPC
handler now calls that instead of blindly booleanizing the error field.

## Related Issue

Fixes #94648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/plugin-profile-routes.ts`: add exported
  `isLocalEnumerationFailure(error?: string)` helper that excludes
  `'connect-on-demand'` from counting as a failure.
- `apps/desktop/electron/main.ts`: use the new helper instead of
  `Boolean(localEnumeration?.error)` when deciding whether to synthesize
  local fallback profile rows.
- `apps/desktop/electron/plugin-profile-routes.test.ts`: add unit tests for
  the new helper.

## How to Test

1. Configure Desktop with an SSH-backed gateway as the primary connection
   and a cached local profile from a previous session.
2. Open Bot Mode.
3. Before the fix: a "This device" section appears with the cached local
   bot even though local enumeration was deferred. After the fix: it does
   not.

Automated proof — reverted only the source fix
(`git checkout HEAD~1 -- apps/desktop/electron/plugin-profile-routes.ts`,
i.e. the state before this commit) with the new tests in place:

```
❯ |electron| electron/plugin-profile-routes.test.ts (18 tests | 3 failed) 13ms
    × does not treat an intentionally deferred local enumeration as a failure
    × treats any other enumeration error as a failure
    × treats a missing error as no failure

 Test Files  1 failed (1)
      Tests  3 failed | 15 passed (18)
```

With the fix restored:

```
$ npx vitest run --project electron plugin-profile-routes.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Full electron test project (main.ts touches this handler, ran the whole
suite to check for regressions):

```
$ npx vitest run --project electron
 Test Files  121 passed | 1 skipped (122)
      Tests  1738 passed | 3 skipped (1741)
```

Also ran, both clean:

```
$ npx tsc -p tsconfig.electron.json --noEmit
$ npx eslint electron/plugin-profile-routes.ts electron/plugin-profile-routes.test.ts electron/main.ts
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] Tested on: logic is platform-independent (pure TS function + unit
      tests); did not have a macOS/SSH desktop environment available to
      manually reproduce the UI end-to-end.

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, architecture, or tool schema changes.

## Disclosure

This PR was prepared with AI assistance (Claude Code), including the root
cause analysis, the fix, and the tests. All test output above was executed
and verified in this session.
