### PR TITLE
fix(desktop): profile-rail fresh chats keep one exact session owner from create through every later RPC

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -10,7 +10,7 @@ import type { SessionResumeResponse } from '@/types/hermes'
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
 import { singleFlightSessionResume } from '../../session/hooks/use-prompt-actions/single-flight-resume'
 import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
-import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
+import { resolveSessionOwner } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
 import type { GatewayRequester } from '../types'
 
@@ -74,11 +74,14 @@ export function useSessionTileDelegate({
       }
     }
 
+    // Same ladder as the window's session-RPC dispatcher: tile route → the
+    // row's owner (exact when connection-tagged, else the hint / profile) →
+    // the async cross-profile probe (exact when the resolved row is tagged).
     const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
       const owner =
         sessionTileOwnerRoute(storedSessionId) ??
         knownSessionOwner($sessions.get(), storedSessionId) ??
-        (await resolveSessionProfile(storedSessionId))
+        (await resolveSessionOwner(storedSessionId))
 
       return owner
     }

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => (
 }))
 
 const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
+const { $connectionsRegistry } = await import('@/store/connection-registry-state')
 const { $profiles } = await import('@/store/profile')
 const { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } = await import('@/store/session')
 const { isSessionOwnerResolutionError } = await import('@/store/session-owner-resolution')
@@ -50,11 +51,13 @@ function dispatcher(ambientRequest = vi.fn(async () => ({ ambient: true }))) {
 
 beforeEach(() => {
   gatewayMocks.activeConnectionId = 'local'
+  $connectionsRegistry.set({ connections: [{ id: 'local' }] } as never)
   $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
   probe.resolveSessionOwner.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
+  $connectionsRegistry.set(null)
   setSessions([])
   $sessionTiles.set([])
   $profiles.set([])
@@ -88,6 +91,7 @@ describe('createSessionRpcDispatcher: fail closed', () => {
 
   it('keeps the legacy single-backend Desktop on the ambient socket: no registry source, one profile', async () => {
     gatewayMocks.activeConnectionId = null
+    $connectionsRegistry.set(null)
     $profiles.set([{ name: 'default' }] as never)
     const { ambientRequest, request } = dispatcher()
 
@@ -97,12 +101,14 @@ describe('createSessionRpcDispatcher: fail closed', () => {
 
   it('fails closed as soon as there is somewhere to misroute to: a second profile, or a live registry source', async () => {
     gatewayMocks.activeConnectionId = null
+    $connectionsRegistry.set(null)
     $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
     await expect(dispatcher().request('session.resume', { session_id: 'stored-x' })).rejects.toSatisfy(
       isSessionOwnerResolutionError
     )
 
     gatewayMocks.activeConnectionId = 'local'
+    $connectionsRegistry.set({ connections: [{ id: 'local' }] } as never)
     $profiles.set([{ name: 'default' }] as never)
     await expect(dispatcher().request('session.resume', { session_id: 'stored-x' })).rejects.toSatisfy(
       isSessionOwnerResolutionError

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Fail-closed owner resolution for the window's ONE session-scoped RPC
+// dispatcher. A request that names a session whose owner NO rung can name
+// (tile route → exact hint → connection-tagged / profiled row → REST probe)
+// must not ride the ambient presentation socket: "active" has no routing
+// authority, and the fallback turned missing ownership metadata into a
+// misleading backend "session not found". The single exception is the legacy
+// single-backend Desktop (no registry source, ≤1 profile), where the ambient
+// gateway IS the owner by construction.
+
+const gatewayMocks = vi.hoisted(() => ({
+  activeConnectionId: null as null | string,
+  requestGatewayForAgent: vi.fn(async () => ({ routed: true })),
+  requestGatewayForProfile: vi.fn(async () => ({ profiled: true }))
+}))
+
+vi.mock('@/store/gateway', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  activeGatewayConnectionId: () => gatewayMocks.activeConnectionId,
+  requestGatewayForAgent: gatewayMocks.requestGatewayForAgent,
+  requestGatewayForProfile: gatewayMocks.requestGatewayForProfile
+}))
+
+const probe = vi.hoisted(() => ({ resolveSessionOwner: vi.fn(async () => undefined as unknown) }))
+
+vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  resolveSessionOwner: probe.resolveSessionOwner
+}))
+
+const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
+const { $profiles } = await import('@/store/profile')
+const { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } = await import('@/store/session')
+const { isSessionOwnerResolutionError } = await import('@/store/session-owner-resolution')
+const { $sessionTiles } = await import('@/store/session-states')
+const { makeSessionInfo } = await import('@/test/session-info')
+
+function dispatcher(ambientRequest = vi.fn(async () => ({ ambient: true }))) {
+  return {
+    ambientRequest,
+    request: createSessionRpcDispatcher({
+      ambientRequest: ambientRequest as never,
+      runtimeIdByStoredSessionIdRef: { current: new Map([['stored-omar', 'rt-omar']]) },
+      selectedStoredSessionIdRef: { current: null },
+      sessionStateByRuntimeIdRef: { current: new Map() }
+    })
+  }
+}
+
+beforeEach(() => {
+  gatewayMocks.activeConnectionId = 'local'
+  $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+  probe.resolveSessionOwner.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  setSessions([])
+  $sessionTiles.set([])
+  $profiles.set([])
+  _resetSessionOwnerHintsForTests({ storage: true })
+  vi.clearAllMocks()
+})
+
+describe('createSessionRpcDispatcher: fail closed', () => {
+  it('rejects with an explicit owner-resolution error instead of riding the ambient socket', async () => {
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(request('prompt.submit', { session_id: 'rt-orphan', text: 'hi' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+    await expect(request('prompt.submit', { session_id: 'rt-orphan', text: 'hi' })).rejects.toThrow(
+      /owner could not be resolved for "rt-orphan" \(prompt.submit\)/
+    )
+
+    expect(probe.resolveSessionOwner).toHaveBeenCalledWith('rt-orphan')
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(gatewayMocks.requestGatewayForAgent).not.toHaveBeenCalled()
+    expect(gatewayMocks.requestGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('still lets a request with NO session (ambient chrome) reach the ambient socket', async () => {
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(request('config.get', {})).resolves.toEqual({ ambient: true })
+    expect(ambientRequest).toHaveBeenCalledWith('config.get', {})
+  })
+
+  it('keeps the legacy single-backend Desktop on the ambient socket: no registry source, one profile', async () => {
+    gatewayMocks.activeConnectionId = null
+    $profiles.set([{ name: 'default' }] as never)
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(request('session.resume', { session_id: 'stored-legacy' })).resolves.toEqual({ ambient: true })
+    expect(ambientRequest).toHaveBeenCalledWith('session.resume', { session_id: 'stored-legacy' })
+  })
+
+  it('fails closed as soon as there is somewhere to misroute to: a second profile, or a live registry source', async () => {
+    gatewayMocks.activeConnectionId = null
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    await expect(dispatcher().request('session.resume', { session_id: 'stored-x' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+
+    gatewayMocks.activeConnectionId = 'local'
+    $profiles.set([{ name: 'default' }] as never)
+    await expect(dispatcher().request('session.resume', { session_id: 'stored-x' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+  })
+})
+
+describe('createSessionRpcDispatcher: exact owner rungs', () => {
+  it('routes by the connection-tagged row when the hint is gone (runtime id translated to the stored id)', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    const { ambientRequest, request } = dispatcher()
+
+    await expect(request('prompt.submit', { session_id: 'rt-omar', text: 'again' })).resolves.toEqual({ routed: true })
+
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledWith('local', 'omar', 'prompt.submit', {
+      session_id: 'rt-omar',
+      text: 'again'
+    })
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(probe.resolveSessionOwner).not.toHaveBeenCalled()
+  })
+
+  it('prefers the exact hint over an untagged row profile, and the probe result over nothing', async () => {
+    setSessions([makeSessionInfo({ id: 'stored-omar', profile: 'default' })])
+    setSessionOwnerHint('stored-omar', { connectionId: 'local', profile: 'omar' })
+
+    await expect(dispatcher().request('session.interrupt', { session_id: 'rt-omar' })).resolves.toEqual({
+      routed: true
+    })
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('local', 'omar', 'session.interrupt', {
+      session_id: 'rt-omar'
+    })
+
+    _resetSessionOwnerHintsForTests()
+    setSessions([])
+    probe.resolveSessionOwner.mockResolvedValue({ connectionId: 'homelab', profile: 'worker' })
+
+    await expect(dispatcher().request('session.activate', { session_id: 'stored-hidden' })).resolves.toEqual({
+      routed: true
+    })
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenLastCalledWith('homelab', 'worker', 'session.activate', {
+      session_id: 'stored-hidden'
+    })
+  })
+})

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -23,15 +23,20 @@
  *
  * Session-scoped RPCs route to the backend that OWNS the session — never to
  * whatever is "active" (active is presentation only). The owner ladder is
- * resolveSessionRpcOwner (tile route → exact unique owner hint → row profile),
- * then a cross-profile REST probe for a hidden/unlisted session. Only a
- * request with NO session at all falls to the ambient socket.
+ * resolveSessionRpcOwner (tile route → exact unique owner hint → the row's
+ * owner: exact when connection-tagged, else its profile), then a
+ * cross-profile REST probe for a hidden/unlisted session. A request with a
+ * session whose owner STILL cannot be named fails closed with an explicit
+ * SessionOwnerResolutionError rather than riding the ambient socket (the one
+ * exception: the legacy single-backend Desktop, where ambient IS the owner).
+ * Only a request with NO session at all falls to the ambient socket.
  */
 import type { MutableRefObject } from 'react'
 
-import { resolveSessionProfile } from '@/app/session/hooks/use-session-actions/utils'
+import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
 import { $sessions, getSessionOwnerHint, knownSessionOwner } from '@/store/session'
+import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 
@@ -78,15 +83,19 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     if (!owner && routingSessionId) {
       // Unknown owner for a REAL session: probe across profiles (REST, not the
       // gateway socket, so no recursion) rather than defaulting to active. A
-      // hit stamps ownership + caches a hint; a miss leaves owner undefined
-      // and the request falls to ambient, exactly as an unroutable session did
-      // before — but only after we tried, never as a silent active fallback.
-      const probed = await resolveSessionProfile(routingSessionId)
+      // hit stamps ownership on the row (exact when the row came back
+      // connection-tagged); a miss leaves owner undefined.
+      const probed = await resolveSessionOwner(routingSessionId)
 
       if (probed) {
         owner = probed
       }
     }
+
+    // A request that names a session but whose owner nobody can name must not
+    // ride the ambient socket: that turns missing metadata into a misleading
+    // backend "session not found" on a backend that never held the runtime.
+    assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
 
     return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
   }

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -1,0 +1,93 @@
+/**
+ * The window's ONE session-scoped RPC dispatcher, factored out of the contrib
+ * wiring controller so the exact production routing (not a re-implementation)
+ * can be driven by integration tests alongside the real session/prompt hooks.
+ *
+ * Route each RPC by the session IT targets, not by whatever tile is focused.
+ * `requestGateway` is one shared closure used for every session RPC in the
+ * window; keying the owner off $focusedStoredSessionId sent a NON-focused
+ * tile's RPC (any bot chat while another pane is active) to the focused tile's
+ * backend. That is the Bot Mode bug: a bot's prompt.submit carried its own
+ * session_id but ran on the default backend (served via ?profile= from the
+ * default's state.db), or 4001'd when the default backend didn't hold the
+ * runtime session.
+ *
+ * params.session_id is a RUNTIME id, while tiles and session rows key on the
+ * STORED id, so translate first (state cache, then a reverse scan of the
+ * stored->runtime map, then the persisted tile map — the same ladder
+ * use-session-tile-delegate uses, plus the tile rung that survives a reload
+ * when the state cache is cold). A miss on ALL rungs means the id is already a
+ * stored id (several RPCs pass stored ids directly), so use it as-is. Only an
+ * RPC with no session_id at all (ambient/config calls) keeps the focused-tile
+ * route.
+ *
+ * Session-scoped RPCs route to the backend that OWNS the session — never to
+ * whatever is "active" (active is presentation only). The owner ladder is
+ * resolveSessionRpcOwner (tile route → exact unique owner hint → row profile),
+ * then a cross-profile REST probe for a hidden/unlisted session. Only a
+ * request with NO session at all falls to the ambient socket.
+ */
+import type { MutableRefObject } from 'react'
+
+import { resolveSessionProfile } from '@/app/session/hooks/use-session-actions/utils'
+import type { ClientSessionState } from '@/app/types'
+import { $sessions, getSessionOwnerHint, knownSessionOwner } from '@/store/session'
+import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
+import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
+
+import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
+
+export type AmbientGatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+export interface SessionRpcDispatcherDeps {
+  ambientRequest: AmbientGatewayRequest
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
+  selectedStoredSessionIdRef: MutableRefObject<null | string>
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+}
+
+export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): AmbientGatewayRequest {
+  const { ambientRequest, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef } = deps
+
+  return async <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+    const paramSessionId = typeof params?.session_id === 'string' && params.session_id ? params.session_id : undefined
+
+    const routingSessionId = resolveRoutingSessionId({
+      focusedStoredSessionId: $focusedStoredSessionId.get(),
+      paramSessionId,
+      selectedStoredSessionId: selectedStoredSessionIdRef.current,
+      storedIdForRuntime: runtimeId =>
+        sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId ??
+        findStoredIdForRuntimeId(runtimeIdByStoredSessionIdRef.current, runtimeId) ??
+        storedSessionIdForRuntimeId(runtimeId) ??
+        undefined
+    })
+
+    let owner: SessionOwnerScope = resolveSessionRpcOwner({
+      routingSessionId,
+      sessionOwnerHint: storedSessionId => getSessionOwnerHint(storedSessionId),
+      sessionRowOwner: storedSessionId => knownSessionOwner($sessions.get(), storedSessionId),
+      tileOwnerRoute: sessionTileOwnerRoute
+    })
+
+    if (!owner && routingSessionId) {
+      // Unknown owner for a REAL session: probe across profiles (REST, not the
+      // gateway socket, so no recursion) rather than defaulting to active. A
+      // hit stamps ownership + caches a hint; a miss leaves owner undefined
+      // and the request falls to ambient, exactly as an unroutable session did
+      // before — but only after we tried, never as a silent active fallback.
+      const probed = await resolveSessionProfile(routingSessionId)
+
+      if (probed) {
+        owner = probed
+      }
+    }
+
+    return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+  }
+}

--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -118,6 +118,31 @@ describe('resolveSessionRpcOwner', () => {
     expect(owner).toEqual(omar)
   })
 
+  it('reconstructs the EXACT owner from a connection-tagged row when the hint is gone (evicted / relaunch)', () => {
+    // The bounded hint map is transient. A row tagged with its owning
+    // connection (optimistic create row, unified-list splice, or a tag
+    // mergeSessionPage carried across a refresh) names the same registry
+    // entry, so the second turn still dials the socket that holds the runtime.
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: 'stored-omar',
+        sessionOwnerHint: none,
+        sessionRowOwner: () => ({ connectionId: 'local', profile: 'omar' }),
+        tileOwnerRoute: none
+      })
+    ).toEqual({ connectionId: 'local', profile: 'omar' })
+
+    // The hint still outranks the row when both exist.
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: 'stored-omar',
+        sessionOwnerHint: () => omar,
+        sessionRowOwner: () => ({ connectionId: 'homelab', profile: 'omar' }),
+        tileOwnerRoute: none
+      })
+    ).toEqual(omar)
+  })
+
   it('falls back to the session row profile, then to undefined for the probe', () => {
     expect(
       resolveSessionRpcOwner({
@@ -133,6 +158,15 @@ describe('resolveSessionRpcOwner', () => {
         routingSessionId: 'stored-1',
         sessionOwnerHint: none,
         sessionRowOwner: () => '  ',
+        tileOwnerRoute: none
+      })
+    ).toBeUndefined()
+
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: 'stored-1',
+        sessionOwnerHint: none,
+        sessionRowOwner: () => null,
         tileOwnerRoute: none
       })
     ).toBeUndefined()

--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
+import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
 
 describe('findStoredIdForRuntimeId', () => {
   it('reverse-resolves a runtime id to its stored id', () => {
@@ -74,5 +74,67 @@ describe('resolveRoutingSessionId', () => {
         storedIdForRuntime: never
       })
     ).toBeNull()
+  })
+})
+
+describe('resolveSessionRpcOwner', () => {
+  const none = () => undefined
+  const omar = { connectionId: 'local', mode: 'local' as const, profile: 'omar' }
+  const homelab = { connectionId: 'homelab', mode: 'remote' as const, profile: 'worker', targetProfile: 'w' }
+
+  it('returns undefined for an RPC with no session (ambient chrome)', () => {
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: null,
+        sessionOwnerHint: none,
+        sessionRowOwner: none,
+        tileOwnerRoute: none
+      })
+    ).toBeUndefined()
+  })
+
+  it('prefers the persisted tile owner route over the hint and the row', () => {
+    const owner = resolveSessionRpcOwner({
+      routingSessionId: 'stored-bot',
+      sessionOwnerHint: () => omar,
+      sessionRowOwner: () => 'default',
+      tileOwnerRoute: () => homelab
+    })
+
+    expect(owner).toEqual(homelab)
+  })
+
+  it('prefers the exact unique owner hint over the session row profile', () => {
+    // The row is presentation state: an optimistic row minted while the
+    // ambient profile stayed `default` reads `default` even though the create
+    // ran on local::omar. The hint recorded at create time is exact.
+    const owner = resolveSessionRpcOwner({
+      routingSessionId: 'stored-omar',
+      sessionOwnerHint: id => (id === 'stored-omar' ? omar : undefined),
+      sessionRowOwner: () => 'default',
+      tileOwnerRoute: none
+    })
+
+    expect(owner).toEqual(omar)
+  })
+
+  it('falls back to the session row profile, then to undefined for the probe', () => {
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: 'stored-1',
+        sessionOwnerHint: none,
+        sessionRowOwner: () => 'coder',
+        tileOwnerRoute: none
+      })
+    ).toBe('coder')
+
+    expect(
+      resolveSessionRpcOwner({
+        routingSessionId: 'stored-1',
+        sessionOwnerHint: none,
+        sessionRowOwner: () => '  ',
+        tileOwnerRoute: none
+      })
+    ).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -48,3 +48,57 @@ export function resolveRoutingSessionId(args: {
 
   return focusedStoredSessionId ?? selectedStoredSessionId
 }
+
+/** The owner shapes the ladder below can return: an exact route (connection +
+ *  profile), a bare profile name, or undefined (unknown — probe, never
+ *  "active"). Structural twin of store/session-request-router's
+ *  SessionOwnerScope, kept local so this module stays import-free. */
+export interface SessionRpcOwnerRoute {
+  connectionId: string
+  mode?: 'local' | 'remote'
+  profile: string
+  targetProfile?: string
+}
+
+/**
+ * The SYNC owner a session-scoped RPC routes to, resolved in this order:
+ *
+ *   1. the persisted tile owner route (a bot chat / split tile records the
+ *      exact connectionId + profile it was opened with, survives relaunch);
+ *   2. the exact, UNIQUE session owner hint (recorded the moment a routed
+ *      session.create returns, or at plugin open time) — the only durable
+ *      exact owner a fresh main-pane chat or a hidden session has;
+ *   3. the session row's owner — an EXACT route when the row is
+ *      connection-tagged (optimistic row from a routed create, or the
+ *      unified list splice), else its bare profile (the cross-profile
+ *      aggregator tags rows, but a bare profile loses the connection and
+ *      can lag the create);
+ *   4. undefined → the caller runs the cross-profile probe.
+ *
+ * The hint outranks the row because the row is presentation state that can
+ * be stamped from the AMBIENT profile (an optimistic row minted while
+ * All-profiles / Bot routing left `default` active), and because it carries
+ * no connection: a fresh chat created on `local::omar` whose row read
+ * `default` ran its first turn on omar and then 4001'd "session not found"
+ * on the second, when the row's `default` owner won the route.
+ */
+export function resolveSessionRpcOwner(args: {
+  routingSessionId: null | string
+  tileOwnerRoute: (storedSessionId: string) => SessionRpcOwnerRoute | undefined
+  sessionOwnerHint: (storedSessionId: string) => SessionRpcOwnerRoute | undefined
+  sessionRowOwner: (storedSessionId: string) => null | SessionRpcOwnerRoute | string | undefined
+}): SessionRpcOwnerRoute | string | undefined {
+  const { routingSessionId, sessionOwnerHint, sessionRowOwner, tileOwnerRoute } = args
+
+  if (!routingSessionId) {
+    return undefined
+  }
+
+  const fromRow = sessionRowOwner(routingSessionId)
+
+  return (
+    tileOwnerRoute(routingSessionId) ??
+    sessionOwnerHint(routingSessionId) ??
+    (typeof fromRow === 'string' ? fromRow.trim() || undefined : (fromRow ?? undefined))
+  )
+}

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -5,6 +5,8 @@
  * React/Electron controller module.
  */
 
+import type { SessionOwnerRoute } from '@/store/session-request-router'
+
 /**
  * Resolve a runtime session id back to its stored id by reverse-scanning the
  * stored->runtime binding map — the same ladder use-session-tile-delegate's
@@ -51,14 +53,8 @@ export function resolveRoutingSessionId(args: {
 
 /** The owner shapes the ladder below can return: an exact route (connection +
  *  profile), a bare profile name, or undefined (unknown — probe, never
- *  "active"). Structural twin of store/session-request-router's
- *  SessionOwnerScope, kept local so this module stays import-free. */
-export interface SessionRpcOwnerRoute {
-  connectionId: string
-  mode?: 'local' | 'remote'
-  profile: string
-  targetProfile?: string
-}
+ *  "active"). The type-only import keeps this module runtime-import-free. */
+export type SessionRpcOwnerRoute = SessionOwnerRoute
 
 /**
  * The SYNC owner a session-scoped RPC routes to, resolved in this order:
@@ -66,21 +62,23 @@ export interface SessionRpcOwnerRoute {
  *   1. the persisted tile owner route (a bot chat / split tile records the
  *      exact connectionId + profile it was opened with, survives relaunch);
  *   2. the exact, UNIQUE session owner hint (recorded the moment a routed
- *      session.create returns, or at plugin open time) — the only durable
- *      exact owner a fresh main-pane chat or a hidden session has;
+ *      session.create returns, or at plugin open time; persisted, bounded);
  *   3. the session row's owner — an EXACT route when the row is
- *      connection-tagged (optimistic row from a routed create, or the
- *      unified list splice), else its bare profile (the cross-profile
- *      aggregator tags rows, but a bare profile loses the connection and
- *      can lag the create);
- *   4. undefined → the caller runs the cross-profile probe.
+ *      connection-tagged (optimistic row from a routed create, the unified
+ *      list splice, or a tag carried across a refresh), else its bare
+ *      profile (the cross-profile aggregator tags rows, but a bare profile
+ *      loses the connection and can lag the create);
+ *   4. undefined → the caller runs the cross-profile probe, and fails closed
+ *      if that misses too.
  *
  * The hint outranks the row because the row is presentation state that can
  * be stamped from the AMBIENT profile (an optimistic row minted while
  * All-profiles / Bot routing left `default` active), and because it carries
  * no connection: a fresh chat created on `local::omar` whose row read
  * `default` ran its first turn on omar and then 4001'd "session not found"
- * on the second, when the row's `default` owner won the route.
+ * on the second, when the row's `default` owner won the route. The
+ * connection-tagged row rung is what keeps two-turn continuity from resting
+ * on the transient hint alone (bounded, evictable, gone after a relaunch).
  */
 export function resolveSessionRpcOwner(args: {
   routingSessionId: null | string

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -14,7 +14,6 @@ import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEff
 import { useLocation, useNavigate } from 'react-router'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
-import { resolveSessionProfile } from '@/app/session/hooks/use-session-actions/utils'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { ConfirmHost } from '@/components/confirm-host'
@@ -72,16 +71,12 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  getSessionOwnerHint,
-  knownSessionOwner,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
 } from '@/store/session'
-import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
-import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -152,9 +147,9 @@ import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
+import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
-import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -298,93 +293,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   // When chrome stays on the launch backend (Bot Mode / all-profiles
   // navigation), session-owned RPCs still have to hit the session's backend.
-  //
-  // Route by the SESSION THIS RPC TARGETS first: a session-scoped RPC carries
-  // its target in params.session_id, and dispatching it by the WINDOW's
-  // focused tile instead sends a background bot's prompt.submit to whichever
-  // backend the focused pane happens to own — the bot then runs on the
-  // default backend (its store, its logs), or 4001s when default doesn't
-  // hold the session. params.session_id is a RUNTIME id while tile routes
-  // key on the STORED id, so translate via the tile map before resolving.
-  // Only when the RPC names no session (config reads, list refreshes, cron)
-  // does the focused-tile key apply — those are genuinely window-ambient.
-  //
-  // A bot chat is a persisted TILE that already records the EXACT owning route
-  // (connectionId + profile) it was opened with — the same authoritative owner
-  // Sessions mode reads off the session row. Prefer it. The canonical Bot Chat
-  // is hidden, so it never appears in $sessions and rememberedSessionProfile's
-  // row lookup misses and falls back to the ACTIVE profile — the Bot Mode
-  // "session not found" / hang. The tile route is per-session, survives
-  // relaunch, and needs no list membership, so it fixes an already-open chat
-  // too. Fall back to the list-derived profile only when no tile route exists.
-  // Session-scoped RPCs route to the backend that OWNS the session — its
-  // profile's own local gateway — never to whatever is "active" (active is
-  // presentation only). Resolve the owner from, in order: the tile's persisted
-  // route (bot chats carry an exact connectionId+profile), the exact UNIQUE
-  // session owner hint (stamped the moment a routed session.create returns,
-  // or at plugin open time), the session row's profile, then a cross-profile
-  // REST probe that stamps ownership for a hidden/unlisted session. The hint
-  // outranks the row: a row is presentation state that can be stamped from
-  // the AMBIENT profile and carries no connection, so a fresh chat created on
-  // local::omar while `default` stayed active ran turn one on omar and then
-  // 4001'd on turn two when the row's `default` won the route. Only a request
-  // with NO session at all (a fresh draft, global chrome) falls to the ambient
-  // socket. The probe result is cached as an owner hint so the next call is
-  // sync — see resolveSessionRpcOwner for the ladder.
-  const requestGateway = useCallback(
-    async <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
-      // Route each RPC by the session IT targets, not by whatever tile is
-      // focused. `requestGateway` is one shared closure used for every session
-      // RPC in the window; keying the owner off $focusedStoredSessionId sent a
-      // NON-focused tile's RPC (any bot chat while another pane is active) to
-      // the focused tile's backend. That is the Bot Mode bug: a bot's
-      // prompt.submit carried its own session_id but ran on the default backend
-      // (served via ?profile= from the default's state.db), or 4001'd when the
-      // default backend didn't hold the runtime session.
-      //
-      // params.session_id is a RUNTIME id, while tiles and session rows key on
-      // the STORED id, so translate first (state cache, then a reverse scan of
-      // the stored->runtime map, then the persisted tile map — the same ladder
-      // use-session-tile-delegate uses, plus the tile rung that survives a
-      // reload when the state cache is cold). A miss on ALL rungs means the id
-      // is already a stored id (several RPCs pass stored ids directly), so use
-      // it as-is. Only an RPC with no session_id at all (ambient/config calls)
-      // keeps the focused-tile route.
-      const paramSessionId = typeof params?.session_id === 'string' && params.session_id ? params.session_id : undefined
-
-      const routingSessionId = resolveRoutingSessionId({
-        focusedStoredSessionId: $focusedStoredSessionId.get(),
-        paramSessionId,
-        selectedStoredSessionId: selectedStoredSessionIdRef.current,
-        storedIdForRuntime: runtimeId =>
-          sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId ??
-          findStoredIdForRuntimeId(runtimeIdByStoredSessionIdRef.current, runtimeId) ??
-          storedSessionIdForRuntimeId(runtimeId) ??
-          undefined
-      })
-
-      let owner: SessionOwnerScope = resolveSessionRpcOwner({
-        routingSessionId,
-        sessionOwnerHint: storedSessionId => getSessionOwnerHint(storedSessionId),
-        sessionRowOwner: storedSessionId => knownSessionOwner($sessions.get(), storedSessionId),
-        tileOwnerRoute: sessionTileOwnerRoute
-      })
-
-      if (!owner && routingSessionId) {
-        // Unknown owner for a REAL session: probe across profiles (REST, not the
-        // gateway socket, so no recursion) rather than defaulting to active. A
-        // hit stamps ownership + caches a hint; a miss leaves owner undefined
-        // and the request falls to ambient, exactly as an unroutable session did
-        // before — but only after we tried, never as a silent active fallback.
-        const probed = await resolveSessionProfile(routingSessionId)
-
-        if (probed) {
-          owner = probed
-        }
-      }
-
-      return requestForSessionProfile<T>(owner, ambientRequestGateway, method, params ?? {}, timeoutMs, signal)
-    },
+  // The routing itself lives in createSessionRpcDispatcher (routed by the
+  // session the RPC targets, owner ladder in resolveSessionRpcOwner) so the
+  // exact production dispatcher is what the integration tests drive.
+  const requestGateway = useMemo(
+    () =>
+      createSessionRpcDispatcher({
+        ambientRequest: ambientRequestGateway,
+        runtimeIdByStoredSessionIdRef,
+        selectedStoredSessionIdRef,
+        sessionStateByRuntimeIdRef
+      }),
     [ambientRequestGateway, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef]
   )
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,6 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  getSessionOwnerHint,
   knownSessionOwner,
   sessionMatchesStoredId,
   sessionPinId,
@@ -153,7 +154,7 @@ import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
-import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
+import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -319,11 +320,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Session-scoped RPCs route to the backend that OWNS the session — its
   // profile's own local gateway — never to whatever is "active" (active is
   // presentation only). Resolve the owner from, in order: the tile's persisted
-  // route (bot chats carry an exact connectionId+profile), the known session
-  // owner (row or open-time hint), then a cross-profile REST probe that
-  // stamps ownership for a hidden/unlisted session. Only a request with NO
-  // session at all (a fresh draft, global chrome) falls to the ambient socket.
-  // The probe result is cached as an owner hint so the next call is sync.
+  // route (bot chats carry an exact connectionId+profile), the exact UNIQUE
+  // session owner hint (stamped the moment a routed session.create returns,
+  // or at plugin open time), the session row's profile, then a cross-profile
+  // REST probe that stamps ownership for a hidden/unlisted session. The hint
+  // outranks the row: a row is presentation state that can be stamped from
+  // the AMBIENT profile and carries no connection, so a fresh chat created on
+  // local::omar while `default` stayed active ran turn one on omar and then
+  // 4001'd on turn two when the row's `default` won the route. Only a request
+  // with NO session at all (a fresh draft, global chrome) falls to the ambient
+  // socket. The probe result is cached as an owner hint so the next call is
+  // sync — see resolveSessionRpcOwner for the ladder.
   const requestGateway = useCallback(
     async <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
       // Route each RPC by the session IT targets, not by whatever tile is
@@ -356,9 +363,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           undefined
       })
 
-      let owner: SessionOwnerScope =
-        (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        knownSessionOwner($sessions.get(), routingSessionId)
+      let owner: SessionOwnerScope = resolveSessionRpcOwner({
+        routingSessionId,
+        sessionOwnerHint: storedSessionId => getSessionOwnerHint(storedSessionId),
+        sessionRowOwner: storedSessionId => knownSessionOwner($sessions.get(), storedSessionId),
+        tileOwnerRoute: sessionTileOwnerRoute
+      })
 
       if (!owner && routingSessionId) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -674,6 +674,10 @@ export function useGatewayBoot({
     // (connectionId, profile) keep-set so two sources exposing the same
     // profile name (every source has a 'default') can't collide.
     configureGatewayRegistry({
+      // The primary socket has no secondary entry to carry registry identity.
+      // Electron's published active descriptor is authoritative after boot;
+      // a true legacy primary has no connectionId and remains unqualified.
+      activeConnectionId: () => $connection.get()?.connectionId ?? null,
       // Every dispose path in the registry (live-work pruner AND the
       // refcount-0 request leases) spares a socket a mounted tile, the
       // primary thread or a just-created session's owner hold is bound to

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -65,6 +65,7 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionOwnerHoldRevision,
   $sessionTiles,
   $workingSessionIds,
   foregroundSessionScopes,
@@ -854,6 +855,7 @@ export function useGatewayBoot({
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
     const offTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
     const offSelectedSession = $selectedStoredSessionId.subscribe(() => recomputeKeptGateways())
+    const offSessionOwnerHolds = $sessionOwnerHoldRevision.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
       const current = $connection.get()
@@ -1052,6 +1054,7 @@ export function useGatewayBoot({
       offActiveProfile()
       offTiles()
       offSelectedSession()
+      offSessionOwnerHolds()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)
       window.removeEventListener('focus', onFocus)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -54,8 +54,10 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $selectedStoredSessionId,
   $sessions,
   ensureDefaultWorkspaceCwd,
+  forgetSessionOwnerHintsForConnection,
   setConnection,
   setCurrentBranch,
   setCurrentCwd,
@@ -672,6 +674,11 @@ export function useGatewayBoot({
     // (connectionId, profile) keep-set so two sources exposing the same
     // profile name (every source has a 'default') can't collide.
     configureGatewayRegistry({
+      // Every dispose path in the registry (live-work pruner AND the
+      // refcount-0 request leases) spares a socket a mounted tile, the
+      // primary thread or a just-created session's owner hold is bound to
+      // (#93892).
+      foregroundScopes: foregroundSessionScopes,
       onActiveConnectionChanged: publish,
       // Keep $activeGatewayProfile in lockstep with the registry's OWN record
       // of which profile the active socket serves. The registry is the only
@@ -770,6 +777,13 @@ export function useGatewayBoot({
       }
 
       disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
+
+      if (payload.reason !== 'updated') {
+        // Nothing can dial the removed source again: drop the persisted exact
+        // owner hints naming it so its sessions are not pinned (fail-closed)
+        // to a route that no longer exists.
+        forgetSessionOwnerHintsForConnection(payload.connectionId)
+      }
     })
 
     const onOnline = () => void forceReconnectNow()
@@ -821,6 +835,11 @@ export function useGatewayBoot({
         keep.add(scope)
       }
 
+      // A just-created session's owner hold and every open pane's owner ride
+      // in through foregroundSessionScopes above; the registry ALSO reads that
+      // set itself (its `foregroundScopes` hook) so the refcount-0 lease
+      // releases agree with this pruner. This recompute only has to RUN when
+      // they change — see the tile / selected session / hold subscriptions.
       pruneSecondaryGateways(keep)
     }
 
@@ -830,6 +849,7 @@ export function useGatewayBoot({
     const offSessionTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
     const offTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
+    const offSelectedSession = $selectedStoredSessionId.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
       const current = $connection.get()
@@ -1027,6 +1047,7 @@ export function useGatewayBoot({
       offSessionTiles()
       offActiveProfile()
       offTiles()
+      offSelectedSession()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)
       window.removeEventListener('focus', onFocus)

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -26,7 +26,9 @@ import {
   $activeSessionId,
   $selectedStoredSessionId,
   $sessions,
+  _resetSessionOwnerHintsForTests,
   getSessionOwnerHint,
+  mergeSessionPage,
   sessionMatchesStoredId,
   setActiveSessionId,
   setAwaitingResponse,
@@ -35,6 +37,8 @@ import {
   setSelectedStoredSessionId,
   setSessions
 } from '@/store/session'
+import { foregroundSessionScopes } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../types'
 
@@ -64,7 +68,7 @@ import { useSessionStateCache } from './use-session-state-cache'
 // The explicit `local` source (This device) is different by design: a profile
 // pick made there takes the legacy profile-only door (ensureGatewayProfile,
 // so a per-profile remote override still resolves), and the draft's owner is
-// that v1 profile socket — the second case pins that the same one-socket
+// that v1 profile socket — the last case pins that the same one-socket
 // continuity holds there too.
 //
 // This suite drives the ACTUAL code path: the real registry store with mocked
@@ -344,6 +348,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     $newChatProfile.set(null)
     $newChatRoute.set(null)
     $newChatConnectionId.set(null)
+    _resetSessionOwnerHintsForTests({ storage: true })
   })
 
   afterEach(() => {
@@ -360,7 +365,10 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
-  it('session.create and both prompt.submit calls ride the SAME conn:homelab::omar socket', async () => {
+  /** Boot the exact field state: remote primary on `default`, `homelab` as
+   *  the active registry source, then selectProfile("omar") in the rail; mount
+   *  the window's real hook stack over the production dispatcher. */
+  async function bootProfileRailOmar() {
     // Primary / ambient source: a remote gateway on `default`.
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
@@ -396,8 +404,32 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     render(<Harness ambientRequest={ambientRequest as never} onReady={h => (handle = h)} />)
     await waitFor(() => expect(handle).not.toBeNull())
 
+    return { handle: handle!, omarSocket: omarSocket!, primary }
+  }
+
+  /** What the gateway's stream end does: the turn settles. */
+  async function settleTurn(handle: HarnessHandle) {
+    await act(async () => {
+      handle.updateSessionState(RUNTIME_ID, state => ({
+        ...state,
+        awaitingResponse: false,
+        busy: false,
+        streamId: null,
+        turnStartedAt: null
+      }))
+      handle.busyRef.current = false
+      setBusy(false)
+      setAwaitingResponse(false)
+    })
+  }
+
+  const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
+
+  it('session.create and both prompt.submit calls ride the SAME conn:homelab::omar socket', async () => {
+    const { handle, omarSocket, primary } = await bootProfileRailOmar()
+
     // Turn one: no session yet → createBackendSessionForSend → prompt.submit.
-    await expect(handle!.submitText('first prompt')).resolves.toBe(true)
+    await expect(handle.submitText('first prompt')).resolves.toBe(true)
     await waitFor(() => expect($activeSessionId.get()).toBe(RUNTIME_ID))
 
     // The stored↔runtime binding minted by the create must survive the first
@@ -405,35 +437,28 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     // (null) stored id, which the state cache read as a detach — after which
     // no session-scoped RPC could translate the runtime id back to the stored
     // id, so tile route / owner hint / row were all bypassed.
-    expect(handle!.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
+    expect(handle.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
 
-    // Answer one arrives: the turn settles (what the gateway's stream end does).
-    await act(async () => {
-      handle!.updateSessionState(RUNTIME_ID, state => ({
-        ...state,
-        awaitingResponse: false,
-        busy: false,
-        streamId: null,
-        turnStartedAt: null
-      }))
-      handle!.busyRef.current = false
-      setBusy(false)
-      setAwaitingResponse(false)
-    })
+    // From the moment the create returned, the owner socket is foreground-
+    // pinned (owner hold → selected-thread rung) so no prune / lease release
+    // can close it before the first prompt.submit lands.
+    expect(foregroundSessionScopes()).toContain(omarScope)
+
+    // Answer one arrives: the turn settles.
+    await settleTurn(handle)
 
     // Turn two on the now-existing session.
-    await expect(handle!.submitText('second prompt')).resolves.toBe(true)
-    expect(handle!.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
+    await expect(handle.submitText('second prompt')).resolves.toBe(true)
+    expect(handle.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
 
     // Every session-scoped RPC (create + both submits) hit ONE socket: the
     // registry entry conn:homelab::omar that minted the runtime.
-    const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
-    const omarCalls = calls(omarSocket!)
+    const omarCalls = calls(omarSocket)
 
     expect(omarCalls).toContain('session.create')
     expect(omarCalls.filter(method => method === 'prompt.submit')).toHaveLength(2)
     expect(
-      omarSocket!.request.mock.calls
+      omarSocket.request.mock.calls
         .filter(call => call[0] === 'prompt.submit')
         .map(call => [(call[1] as { session_id: string }).session_id, (call[1] as { text: string }).text])
     ).toEqual([
@@ -474,6 +499,66 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
       profile: 'omar'
     })
     expect($newChatConnectionId.get()).toBe(SOURCE_ID)
+  })
+
+  it('turn two still rides conn:homelab::omar after the transient hint is evicted AND a refresh returned the row untagged', async () => {
+    const { handle, omarSocket, primary } = await bootProfileRailOmar()
+
+    await expect(handle.submitText('first prompt')).resolves.toBe(true)
+    await waitFor(() => expect($activeSessionId.get()).toBe(RUNTIME_ID))
+    await settleTurn(handle)
+
+    // The two things that used to leave only a bare "omar" behind:
+    //  1. the bounded owner-hint map evicts (or the app relaunched);
+    //  2. the sidebar refresh comes back with the row untagged (the primary
+    //     aggregate serves a source's rows as plain profile rows whenever the
+    //     unified-list splice did not tag them).
+    _resetSessionOwnerHintsForTests()
+    expect(getSessionOwnerHint(STORED_ID)).toBeUndefined()
+
+    const untagged: SessionInfo = {
+      ...$sessions.get().find(session => sessionMatchesStoredId(session, STORED_ID))!,
+      profile: 'omar'
+    }
+
+    delete untagged.connection_id
+    setSessions(prev => mergeSessionPage(prev, [untagged], []))
+
+    // The row still names the exact owner: the refresh carried the tag.
+    expect($sessions.get().find(session => sessionMatchesStoredId(session, STORED_ID))).toMatchObject({
+      connection_id: SOURCE_ID,
+      profile: 'omar'
+    })
+
+    await expect(handle.submitText('second prompt')).resolves.toBe(true)
+    expect(handle.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
+
+    expect(
+      omarSocket.request.mock.calls
+        .filter(call => call[0] === 'prompt.submit')
+        .map(call => (call[1] as { session_id: string; text: string }).text)
+    ).toEqual(['first prompt', 'second prompt'])
+
+    // Nothing session-scoped reached the primary, a v1 "omar" socket, or any
+    // other socket; no REST probe, no session.close, no second create.
+    expect(calls(primary).filter(method => method === 'session.create' || method === 'prompt.submit')).toEqual([])
+    expect(sockets.some(socket => socket.connectUrl?.includes(`:${V1_PORT}`))).toBe(false)
+
+    for (const socket of sockets) {
+      if (socket !== omarSocket) {
+        expect(
+          socket.request.mock.calls.filter(call => sessionScoped(call[1]) || call[0] === 'session.create')
+        ).toEqual([])
+      }
+    }
+
+    expect(vi.mocked(getSession)).not.toHaveBeenCalled()
+
+    for (const socket of [primary, ...sockets]) {
+      expect(calls(socket).filter(method => method === 'session.close')).toEqual([])
+    }
+
+    expect(calls(omarSocket).filter(method => method === 'session.create')).toHaveLength(1)
   })
 
   it('a pick on the explicit `local` source is a legacy profile pick: create and both turns ride the ONE v1 omar socket', async () => {
@@ -540,8 +625,6 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
 
     // The legacy owner is the bare profile: no registry route, no hint — the
     // row's profile names the same v1 pool entry that minted the runtime.
-    const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
-
     expect(calls(v1Socket!).filter(method => method === 'session.create')).toHaveLength(1)
     expect(
       v1Socket!.request.mock.calls

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -1,0 +1,573 @@
+import { registryBackendScopeKey } from '@hermes/shared'
+import { useStore } from '@nanostores/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useMemo, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+import { createSessionRpcDispatcher } from '@/app/contrib/session-rpc-dispatcher'
+import { getSession } from '@/hermes'
+import {
+  activeGateway,
+  activeGatewayConnectionId,
+  activeGatewayProfileKey,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  setPrimaryGateway
+} from '@/store/gateway'
+import {
+  $activeGatewayProfile,
+  $newChatConnectionId,
+  $newChatProfile,
+  $newChatRoute,
+  ensureGatewayAgent,
+  selectProfile
+} from '@/store/profile'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  $sessions,
+  getSessionOwnerHint,
+  sessionMatchesStoredId,
+  setActiveSessionId,
+  setAwaitingResponse,
+  setBusy,
+  setMessages,
+  setSelectedStoredSessionId,
+  setSessions
+} from '@/store/session'
+
+import type { ClientSessionState } from '../../types'
+
+import { usePromptActions } from './use-prompt-actions'
+import { clearSingleFlightSessionResumeState } from './use-prompt-actions/single-flight-resume'
+import type { SubmitTextOptions } from './use-prompt-actions/utils'
+import { useSessionActions } from './use-session-actions'
+import { useSessionStateCache } from './use-session-state-cache'
+
+// ── The real profile-rail reproduction (#94071, Sessions mode) ───────────────
+//
+//   primary / ambient source  = a remote gateway on `default`
+//   active registry source    = `homelab` (a remote registry source)
+//   user action               = selectProfile("omar") in the profile rail
+//
+// selectProfile sets $newChatProfile = "omar" and deliberately CLEARS
+// $newChatRoute, so nothing explicit names the source. The draft's real owner
+// is the registry entry homelab::omar (scope `conn:homelab::omar`) — the
+// socket whose WebSocket mints the runtime. Before the fix the create rode
+// that socket ambiently, but the durable owner degraded to the bare string
+// "omar": the optimistic row was stamped from the ambient profile with no
+// connection, no owner hint was recorded, and every follow-up RPC dialed
+// requestGatewayForProfile("omar") — a DIFFERENT v1 socket/backend that never
+// held the runtime — and 4001'd "session not found" while the orphaned omar
+// runtime was left to be ws-orphan-reaped.
+//
+// The explicit `local` source (This device) is different by design: a profile
+// pick made there takes the legacy profile-only door (ensureGatewayProfile,
+// so a per-profile remote override still resolves), and the draft's owner is
+// that v1 profile socket — the second case pins that the same one-socket
+// continuity holds there too.
+//
+// This suite drives the ACTUAL code path: the real registry store with mocked
+// sockets, the real store/profile switch, the real useSessionStateCache /
+// useSessionActions / usePromptActions hooks, and the production session-RPC
+// dispatcher. It never supplies an owner by hand.
+
+const SOURCE_ID = 'homelab'
+const OMAR_PORT = 7171
+const SOURCE_DEFAULT_PORT = 7070
+const V1_PORT = 5151
+const RUNTIME_ID = 'rt-omar-fresh-1'
+const STORED_ID = 'stored-omar-fresh-1'
+
+type GatewayRequestMock = Mock<(method: string, params?: Record<string, unknown>) => Promise<unknown>>
+
+interface MockGateway {
+  connectUrl: null | string
+  connectionState: string
+  connect: Mock<(url: string) => Promise<void>>
+  close: Mock<() => void>
+  onEvent: Mock<() => () => void>
+  onState: Mock<() => () => void>
+  request: GatewayRequestMock
+}
+
+const sockets: MockGateway[] = []
+/** The port of the ONE socket allowed to mint (and then own) the runtime. */
+let ownerPort = OMAR_PORT
+/** The ids the owner socket mints — per case, so one case's owner records
+ *  (the hint map is module state) can never satisfy another's assertions. */
+let mintedRuntimeId = RUNTIME_ID
+let mintedStoredId = STORED_ID
+
+const sessionScoped = (params: unknown) =>
+  typeof (params as { session_id?: unknown } | undefined)?.session_id === 'string'
+
+/** The owner socket (the registry entry homelab::omar, or the v1 omar socket
+ *  for a legacy pick) answers; every other socket is a backend that never
+ *  held the runtime, exactly as in the field. */
+function answer(socket: MockGateway, method: string, params: Record<string, unknown>) {
+  const isOmar = socket.connectUrl?.includes(`:${ownerPort}`) ?? false
+
+  if (method === 'session.create') {
+    if (!isOmar) {
+      throw new Error(`session.create landed on the wrong socket: ${socket.connectUrl}`)
+    }
+
+    return { info: {}, session_id: mintedRuntimeId, stored_session_id: mintedStoredId }
+  }
+
+  if (sessionScoped(params) && !isOmar) {
+    throw new Error(`Session not found: ${String(params.session_id)} (socket ${socket.connectUrl}, ${method})`)
+  }
+
+  if (method === 'prompt.submit') {
+    return { ok: true }
+  }
+
+  if (method === 'session.resume' || method === 'session.activate') {
+    // The runtime is alive on this socket: a resume re-binds the SAME id.
+    return {
+      info: {},
+      message_count: 1,
+      messages: [],
+      resumed: mintedStoredId,
+      running: false,
+      session_id: mintedRuntimeId,
+      session_key: mintedStoredId
+    }
+  }
+
+  return {}
+}
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  HermesGateway: class {
+    connectUrl: null | string = null
+    connectionState = 'closed'
+    connect = vi.fn(async (url: string) => {
+      this.connectUrl = url
+      this.connectionState = 'open'
+    })
+    request = vi.fn(async (method: string, params: Record<string, unknown> = {}) => {
+      if (this.connectionState !== 'open') {
+        throw new Error('gateway is not connected')
+      }
+
+      return answer(this as unknown as MockGateway, method, params)
+    })
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+    })
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+
+    constructor() {
+      sockets.push(this as unknown as MockGateway)
+    }
+  },
+  getSession: vi.fn(async () => {
+    throw new Error('REST cross-profile probe must not be needed: the owner is known')
+  }),
+  setApiRequestConnection: vi.fn(),
+  setApiRequestProfile: vi.fn()
+}))
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    // v1 profile path (requestGatewayForProfile / ensureGatewayProfile): a
+    // per-profile local backend that is NOT the registry entry.
+    getConnection: vi.fn(async (profile: null | string) => {
+      const port = profile ? V1_PORT : 4242
+
+      return { port, profile, token: profile ? 'v1-token' : 'primary-token', wsUrl: `ws://127.0.0.1:${port}/ws` }
+    }),
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => {
+      const port =
+        connectionId === SOURCE_ID || connectionId === 'local'
+          ? profile === 'omar'
+            ? OMAR_PORT
+            : SOURCE_DEFAULT_PORT
+          : 9999
+
+      return { port, profile, token: `${connectionId}-${profile}-token`, wsUrl: `ws://127.0.0.1:${port}/ws` }
+    }),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+/** The remote primary. Session-scoped traffic here is the bug. */
+function makePrimary(): MockGateway {
+  const primary: MockGateway = {
+    connectUrl: 'ws://remote-primary:4242',
+    connectionState: 'open',
+    connect: vi.fn(),
+    close: vi.fn(),
+    onEvent: vi.fn(() => () => {}),
+    onState: vi.fn(() => () => {}),
+    request: vi.fn(async (method: string, params: Record<string, unknown> = {}) => answer(primary, method, params))
+  }
+
+  return primary
+}
+
+interface HarnessHandle {
+  busyRef: { current: boolean }
+  bindings: () => { runtimeForStored: null | string; storedForRuntime: null | string }
+  submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: null | string
+  ) => ClientSessionState
+}
+
+/** The window's real hook stack, wired the way contrib/wiring wires it. */
+function Harness({
+  ambientRequest,
+  onReady
+}: {
+  ambientRequest: MockGateway['request']
+  onReady: (h: HarnessHandle) => void
+}) {
+  const activeSessionId = useStore($activeSessionId)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const busyRef = useRef(false)
+  const creatingSessionRef = useRef(false)
+
+  const cache = useSessionStateCache({
+    activeSessionId,
+    busyRef,
+    selectedStoredSessionId,
+    setAwaitingResponse,
+    setBusy,
+    setMessages
+  })
+
+  const requestGateway = useMemo(
+    () =>
+      createSessionRpcDispatcher({
+        ambientRequest: ambientRequest as never,
+        runtimeIdByStoredSessionIdRef: cache.runtimeIdByStoredSessionIdRef,
+        selectedStoredSessionIdRef: cache.selectedStoredSessionIdRef,
+        sessionStateByRuntimeIdRef: cache.sessionStateByRuntimeIdRef
+      }),
+    [
+      ambientRequest,
+      cache.runtimeIdByStoredSessionIdRef,
+      cache.selectedStoredSessionIdRef,
+      cache.sessionStateByRuntimeIdRef
+    ]
+  )
+
+  const sessionActions = useSessionActions({
+    activeSessionId,
+    activeSessionIdRef: cache.activeSessionIdRef,
+    busyRef,
+    creatingSessionRef,
+    ensureSessionState: cache.ensureSessionState,
+    getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
+    navigate: vi.fn() as never,
+    requestGateway,
+    resetViewSync: cache.resetViewSync,
+    runtimeIdByStoredSessionIdRef: cache.runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef: cache.selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef: cache.sessionStateByRuntimeIdRef,
+    syncSessionStateToView: cache.syncSessionStateToView,
+    updateSessionState: cache.updateSessionState
+  })
+
+  const promptActions = usePromptActions({
+    activeSessionId,
+    activeSessionIdRef: cache.activeSessionIdRef,
+    branchCurrentSession: async () => true,
+    busyRef,
+    createBackendSessionForSend: sessionActions.createBackendSessionForSend,
+    getRoutedStoredSessionId: () => null,
+    getRuntimeIdForStoredSession: cache.getRuntimeIdForStoredSession,
+    getRouteToken: () => 'token',
+    handleSkinCommand: () => '',
+    openMemoryGraph: () => undefined,
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: sessionActions.resumeSession,
+    runtimeIdByStoredSessionIdRef: cache.runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionIdRef: cache.selectedStoredSessionIdRef,
+    startFreshSessionDraft: sessionActions.startFreshSessionDraft,
+    sttEnabled: false,
+    updateSessionState: cache.updateSessionState
+  })
+
+  const { submitText } = promptActions
+
+  useEffect(() => {
+    onReady({
+      busyRef,
+      bindings: () => ({
+        runtimeForStored: cache.runtimeIdByStoredSessionIdRef.current.get(mintedStoredId) ?? null,
+        storedForRuntime: cache.sessionStateByRuntimeIdRef.current.get(mintedRuntimeId)?.storedSessionId ?? null
+      }),
+      submitText: (...args) => act(async () => submitText(...args)) as Promise<boolean>,
+      updateSessionState: cache.updateSessionState as HarnessHandle['updateSessionState']
+    })
+  }, [
+    cache.runtimeIdByStoredSessionIdRef,
+    cache.sessionStateByRuntimeIdRef,
+    cache.updateSessionState,
+    onReady,
+    submitText
+  ])
+
+  return null
+}
+
+const omarScope = registryBackendScopeKey(SOURCE_ID, 'omar')
+
+describe('profile rail: a fresh Omar chat keeps its exact registry owner across turns (#94071)', () => {
+  beforeEach(() => {
+    sockets.length = 0
+    ownerPort = OMAR_PORT
+    mintedRuntimeId = RUNTIME_ID
+    mintedStoredId = STORED_ID
+    clearSingleFlightSessionResumeState()
+    configureGatewayRegistry({ onEvent: vi.fn() })
+    closeSecondaryGateways()
+    installDesktop()
+    setSessions([])
+    setMessages([])
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setBusy(false)
+    setAwaitingResponse(false)
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
+    $newChatConnectionId.set(null)
+  })
+
+  afterEach(() => {
+    cleanup()
+    closeSecondaryGateways()
+    setSessions([])
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
+    $newChatConnectionId.set(null)
+    $activeGatewayProfile.set('default')
+    vi.clearAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('session.create and both prompt.submit calls ride the SAME conn:homelab::omar socket', async () => {
+    // Primary / ambient source: a remote gateway on `default`.
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+
+    // Active registry source: `homelab` (a remote source), on its default
+    // profile — the state a connection-rail click leaves the window in.
+    await ensureGatewayAgent(SOURCE_ID, 'default')
+    expect(activeGatewayConnectionId()).toBe(SOURCE_ID)
+
+    // The profile rail: selectProfile("omar").
+    selectProfile('omar')
+    expect($newChatProfile.get()).toBe('omar')
+    expect($newChatRoute.get()).toBeNull()
+    await waitFor(() => expect(activeGatewayProfileKey()).toBe('omar'))
+    expect(activeGatewayConnectionId()).toBe(SOURCE_ID)
+
+    // The socket the registry dialed for homelab::omar (mocked HermesGateway
+    // instances register themselves on construction).
+    expect(sockets.length).toBeGreaterThan(0)
+    const omarSocket = sockets.find(socket => socket.connectUrl?.includes(`:${OMAR_PORT}`))
+    expect(
+      omarSocket,
+      `no socket dialed port ${OMAR_PORT}; dialed: ${sockets.map(s => s.connectUrl).join(', ')}`
+    ).toBeDefined()
+    expect(activeGateway()).toBe(omarSocket as never)
+
+    // Ambient dispatcher = whatever socket is active, as useGatewayRequest does.
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) =>
+      (activeGateway() as unknown as MockGateway).request(method, params)
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness ambientRequest={ambientRequest as never} onReady={h => (handle = h)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    // Turn one: no session yet → createBackendSessionForSend → prompt.submit.
+    await expect(handle!.submitText('first prompt')).resolves.toBe(true)
+    await waitFor(() => expect($activeSessionId.get()).toBe(RUNTIME_ID))
+
+    // The stored↔runtime binding minted by the create must survive the first
+    // turn: submit used to seed its optimistic bubble with the PRE-create
+    // (null) stored id, which the state cache read as a detach — after which
+    // no session-scoped RPC could translate the runtime id back to the stored
+    // id, so tile route / owner hint / row were all bypassed.
+    expect(handle!.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
+
+    // Answer one arrives: the turn settles (what the gateway's stream end does).
+    await act(async () => {
+      handle!.updateSessionState(RUNTIME_ID, state => ({
+        ...state,
+        awaitingResponse: false,
+        busy: false,
+        streamId: null,
+        turnStartedAt: null
+      }))
+      handle!.busyRef.current = false
+      setBusy(false)
+      setAwaitingResponse(false)
+    })
+
+    // Turn two on the now-existing session.
+    await expect(handle!.submitText('second prompt')).resolves.toBe(true)
+    expect(handle!.bindings()).toEqual({ runtimeForStored: RUNTIME_ID, storedForRuntime: STORED_ID })
+
+    // Every session-scoped RPC (create + both submits) hit ONE socket: the
+    // registry entry conn:homelab::omar that minted the runtime.
+    const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
+    const omarCalls = calls(omarSocket!)
+
+    expect(omarCalls).toContain('session.create')
+    expect(omarCalls.filter(method => method === 'prompt.submit')).toHaveLength(2)
+    expect(
+      omarSocket!.request.mock.calls
+        .filter(call => call[0] === 'prompt.submit')
+        .map(call => [(call[1] as { session_id: string }).session_id, (call[1] as { text: string }).text])
+    ).toEqual([
+      [RUNTIME_ID, 'first prompt'],
+      [RUNTIME_ID, 'second prompt']
+    ])
+    expect(activeGateway()).toBe(omarSocket as never)
+    expect(registryBackendScopeKey(activeGatewayConnectionId(), activeGatewayProfileKey())).toBe(omarScope)
+
+    // Nothing session-scoped reached the remote primary, the source's default
+    // socket, or a v1 requestGatewayForProfile("omar") socket.
+    expect(calls(primary).filter(method => method === 'session.create' || method === 'prompt.submit')).toEqual([])
+
+    for (const socket of sockets) {
+      if (socket !== omarSocket) {
+        expect(
+          socket.request.mock.calls.filter(call => sessionScoped(call[1]) || call[0] === 'session.create')
+        ).toEqual([])
+      }
+    }
+
+    expect(sockets.some(socket => socket.connectUrl?.includes(`:${V1_PORT}`))).toBe(false)
+
+    // No session-not-found: any misrouted RPC would have thrown out of
+    // submitText (asserted true above) — and no REST probe was needed.
+    expect(vi.mocked(getSession)).not.toHaveBeenCalled()
+
+    // No ws_orphan_reap precondition: the client never closed, re-created or
+    // abandoned the runtime it minted; the durable owner is the exact entry.
+    for (const socket of [primary, ...sockets]) {
+      expect(calls(socket).filter(method => method === 'session.close')).toEqual([])
+    }
+
+    expect(omarCalls.filter(method => method === 'session.create')).toHaveLength(1)
+    expect(getSessionOwnerHint(STORED_ID)).toEqual({ connectionId: SOURCE_ID, profile: 'omar' })
+    expect($sessions.get().find(session => sessionMatchesStoredId(session, STORED_ID))).toMatchObject({
+      connection_id: SOURCE_ID,
+      profile: 'omar'
+    })
+    expect($newChatConnectionId.get()).toBe(SOURCE_ID)
+  })
+
+  it('a pick on the explicit `local` source is a legacy profile pick: create and both turns ride the ONE v1 omar socket', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+
+    // Active registry source: `local` (This device), on its default profile.
+    await ensureGatewayAgent('local', 'default')
+    expect(activeGatewayConnectionId()).toBe('local')
+
+    // A profile pick on the explicit local source takes the profile-only door
+    // so a per-profile remote override resolves (the main process answers
+    // getConnection("omar")), never the registry entry local::omar. The draft's
+    // owner must be the socket that door opens: the v1 omar socket.
+    const LEGACY_RUNTIME_ID = 'rt-omar-legacy-1'
+    const LEGACY_STORED_ID = 'stored-omar-legacy-1'
+
+    ownerPort = V1_PORT
+    mintedRuntimeId = LEGACY_RUNTIME_ID
+    mintedStoredId = LEGACY_STORED_ID
+    selectProfile('omar')
+    expect($newChatProfile.get()).toBe('omar')
+    expect($newChatRoute.get()).toBeNull()
+    expect($newChatConnectionId.get()).toBeNull()
+    await waitFor(() => expect(activeGatewayProfileKey()).toBe('omar'))
+    expect(activeGatewayConnectionId()).toBeNull()
+
+    const desktop = window.hermesDesktop!
+
+    expect(desktop.getConnection).toHaveBeenCalledWith('omar')
+    expect(desktop.getConnectionFor).not.toHaveBeenCalledWith({ connectionId: 'local', profile: 'omar' })
+
+    const v1Socket = sockets.find(socket => socket.connectUrl?.includes(`:${V1_PORT}`))
+    expect(v1Socket, `no v1 socket dialed; dialed: ${sockets.map(s => s.connectUrl).join(', ')}`).toBeDefined()
+    expect(activeGateway()).toBe(v1Socket as never)
+    expect(sockets.some(socket => socket.connectUrl?.includes(`:${OMAR_PORT}`))).toBe(false)
+
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) =>
+      (activeGateway() as unknown as MockGateway).request(method, params)
+    )
+
+    let handle: HarnessHandle | null = null
+    render(<Harness ambientRequest={ambientRequest as never} onReady={h => (handle = h)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.submitText('first prompt')).resolves.toBe(true)
+    await waitFor(() => expect($activeSessionId.get()).toBe(LEGACY_RUNTIME_ID))
+    expect(handle!.bindings()).toEqual({ runtimeForStored: LEGACY_RUNTIME_ID, storedForRuntime: LEGACY_STORED_ID })
+
+    await act(async () => {
+      handle!.updateSessionState(LEGACY_RUNTIME_ID, state => ({
+        ...state,
+        awaitingResponse: false,
+        busy: false,
+        streamId: null,
+        turnStartedAt: null
+      }))
+      handle!.busyRef.current = false
+      setBusy(false)
+      setAwaitingResponse(false)
+    })
+
+    await expect(handle!.submitText('second prompt')).resolves.toBe(true)
+
+    // The legacy owner is the bare profile: no registry route, no hint — the
+    // row's profile names the same v1 pool entry that minted the runtime.
+    const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
+
+    expect(calls(v1Socket!).filter(method => method === 'session.create')).toHaveLength(1)
+    expect(
+      v1Socket!.request.mock.calls
+        .filter(call => call[0] === 'prompt.submit')
+        .map(call => (call[1] as { text: string }).text)
+    ).toEqual(['first prompt', 'second prompt'])
+    expect(calls(primary).filter(method => method === 'session.create' || method === 'prompt.submit')).toEqual([])
+
+    for (const socket of sockets) {
+      if (socket !== v1Socket) {
+        expect(
+          socket.request.mock.calls.filter(call => sessionScoped(call[1]) || call[0] === 'session.create')
+        ).toEqual([])
+      }
+    }
+
+    expect(sockets.some(socket => socket.connectUrl?.includes(`:${OMAR_PORT}`))).toBe(false)
+    expect(vi.mocked(getSession)).not.toHaveBeenCalled()
+
+    for (const socket of [primary, ...sockets]) {
+      expect(calls(socket).filter(method => method === 'session.close')).toEqual([])
+    }
+
+    expect(getSessionOwnerHint(LEGACY_STORED_ID)).toBeUndefined()
+    expect($sessions.get().find(session => sessionMatchesStoredId(session, LEGACY_STORED_ID))).toMatchObject({
+      profile: 'omar'
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -1,4 +1,4 @@
-import { registryBackendScopeKey } from '@hermes/shared'
+import { type GatewayEvent, registryBackendScopeKey } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useEffect, useMemo, useRef } from 'react'
@@ -20,6 +20,7 @@ import {
   $newChatProfile,
   $newChatRoute,
   ensureGatewayAgent,
+  newSessionInProfile,
   selectProfile
 } from '@/store/profile'
 import {
@@ -92,12 +93,16 @@ interface MockGateway {
   connectionState: string
   connect: Mock<(url: string) => Promise<void>>
   close: Mock<() => void>
-  onEvent: Mock<() => () => void>
-  onState: Mock<() => () => void>
+  eventListeners: Set<(event: GatewayEvent) => void>
+  onEvent: Mock<(listener: (event: GatewayEvent) => void) => () => void>
+  onState: Mock<(listener: (state: 'closed' | 'open') => void) => () => void>
   request: GatewayRequestMock
+  stateListeners: Set<(state: 'closed' | 'open') => void>
 }
 
 const sockets: MockGateway[] = []
+let runtimeOwner: MockGateway | null = null
+let registryOnEvent!: Mock<(event: GatewayEvent) => void>
 /** The port of the ONE socket allowed to mint (and then own) the runtime. */
 let ownerPort = OMAR_PORT
 /** The ids the owner socket mints — per case, so one case's owner records
@@ -108,9 +113,9 @@ let mintedStoredId = STORED_ID
 const sessionScoped = (params: unknown) =>
   typeof (params as { session_id?: unknown } | undefined)?.session_id === 'string'
 
-/** The owner socket (the registry entry homelab::omar, or the v1 omar socket
- *  for a legacy pick) answers; every other socket is a backend that never
- *  held the runtime, exactly as in the field. */
+/** The exact object that mints the runtime owns it. Endpoint equality is not
+ * ownership: a replacement WebSocket connected to the same URL has never held
+ * this in-memory runtime and must fail exactly like a different backend. */
 function answer(socket: MockGateway, method: string, params: Record<string, unknown>) {
   const isOmar = socket.connectUrl?.includes(`:${ownerPort}`) ?? false
 
@@ -119,11 +124,19 @@ function answer(socket: MockGateway, method: string, params: Record<string, unkn
       throw new Error(`session.create landed on the wrong socket: ${socket.connectUrl}`)
     }
 
+    if (runtimeOwner) {
+      throw new Error(`session.create attempted to replace runtime owner: ${socket.connectUrl}`)
+    }
+
+    runtimeOwner = socket
+
     return { info: {}, session_id: mintedRuntimeId, stored_session_id: mintedStoredId }
   }
 
-  if (sessionScoped(params) && !isOmar) {
-    throw new Error(`Session not found: ${String(params.session_id)} (socket ${socket.connectUrl}, ${method})`)
+  if (sessionScoped(params) && socket !== runtimeOwner) {
+    throw new Error(
+      `Session not found on concrete owner: ${String(params.session_id)} (socket ${socket.connectUrl}, ${method})`
+    )
   }
 
   if (method === 'prompt.submit') {
@@ -131,16 +144,7 @@ function answer(socket: MockGateway, method: string, params: Record<string, unkn
   }
 
   if (method === 'session.resume' || method === 'session.activate') {
-    // The runtime is alive on this socket: a resume re-binds the SAME id.
-    return {
-      info: {},
-      message_count: 1,
-      messages: [],
-      resumed: mintedStoredId,
-      running: false,
-      session_id: mintedRuntimeId,
-      session_key: mintedStoredId
-    }
+    throw new Error(`${method} is recovery, not uninterrupted continuity`)
   }
 
   return {}
@@ -151,6 +155,8 @@ vi.mock('@/hermes', async importOriginal => ({
   HermesGateway: class {
     connectUrl: null | string = null
     connectionState = 'closed'
+    eventListeners = new Set<(event: GatewayEvent) => void>()
+    stateListeners = new Set<(state: 'closed' | 'open') => void>()
     connect = vi.fn(async (url: string) => {
       this.connectUrl = url
       this.connectionState = 'open'
@@ -164,9 +170,27 @@ vi.mock('@/hermes', async importOriginal => ({
     })
     close = vi.fn(() => {
       this.connectionState = 'closed'
+      this.stateListeners.forEach(listener => listener('closed'))
+
+      if (runtimeOwner === (this as unknown as MockGateway)) {
+        this.eventListeners.forEach(listener =>
+          listener({
+            payload: { session_id: mintedRuntimeId, stored_session_id: mintedStoredId },
+            type: 'session.reclaimed'
+          } as GatewayEvent)
+        )
+      }
     })
-    onEvent = vi.fn(() => () => {})
-    onState = vi.fn(() => () => {})
+    onEvent = vi.fn((listener: (event: GatewayEvent) => void) => {
+      this.eventListeners.add(listener)
+
+      return () => this.eventListeners.delete(listener)
+    })
+    onState = vi.fn((listener: (state: 'closed' | 'open') => void) => {
+      this.stateListeners.add(listener)
+
+      return () => this.stateListeners.delete(listener)
+    })
 
     constructor() {
       sockets.push(this as unknown as MockGateway)
@@ -204,14 +228,27 @@ function installDesktop(): void {
 
 /** The remote primary. Session-scoped traffic here is the bug. */
 function makePrimary(): MockGateway {
+  const eventListeners = new Set<(event: GatewayEvent) => void>()
+  const stateListeners = new Set<(state: 'closed' | 'open') => void>()
+
   const primary: MockGateway = {
     connectUrl: 'ws://remote-primary:4242',
     connectionState: 'open',
     connect: vi.fn(),
     close: vi.fn(),
-    onEvent: vi.fn(() => () => {}),
-    onState: vi.fn(() => () => {}),
-    request: vi.fn(async (method: string, params: Record<string, unknown> = {}) => answer(primary, method, params))
+    eventListeners,
+    onEvent: vi.fn(listener => {
+      eventListeners.add(listener)
+
+      return () => eventListeners.delete(listener)
+    }),
+    onState: vi.fn(listener => {
+      stateListeners.add(listener)
+
+      return () => stateListeners.delete(listener)
+    }),
+    request: vi.fn(async (method: string, params: Record<string, unknown> = {}) => answer(primary, method, params)),
+    stateListeners
   }
 
   return primary
@@ -334,15 +371,17 @@ const omarScope = registryBackendScopeKey(SOURCE_ID, 'omar')
 describe('profile rail: a fresh Omar chat keeps its exact registry owner across turns (#94071)', () => {
   beforeEach(() => {
     sockets.length = 0
+    runtimeOwner = null
     ownerPort = OMAR_PORT
     mintedRuntimeId = RUNTIME_ID
     mintedStoredId = STORED_ID
     clearSingleFlightSessionResumeState()
     // Wired exactly as useGatewayBoot: the published active descriptor carries
     // a registry-backed primary's source identity across a renderer reload.
+    registryOnEvent = vi.fn()
     configureGatewayRegistry({
       activeConnectionId: () => $connection.get()?.connectionId ?? null,
-      onEvent: vi.fn()
+      onEvent: registryOnEvent
     })
     closeSecondaryGateways()
     installDesktop()
@@ -377,7 +416,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
   /** Boot the exact field state: remote primary on `default`, `homelab` as
    *  the active registry source, then selectProfile("omar") in the rail; mount
    *  the window's real hook stack over the production dispatcher. */
-  async function bootProfileRailOmar() {
+  async function bootProfileRailOmar(startDraft: 'newSessionInProfile' | 'selectProfile' = 'selectProfile') {
     // Primary / ambient source: a remote gateway on `default`.
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
@@ -387,8 +426,13 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     await ensureGatewayAgent(SOURCE_ID, 'default')
     expect(activeGatewayConnectionId()).toBe(SOURCE_ID)
 
-    // The profile rail: selectProfile("omar").
-    selectProfile('omar')
+    // Both profile-rail entry points must capture the same concrete source.
+    if (startDraft === 'newSessionInProfile') {
+      newSessionInProfile('omar')
+    } else {
+      selectProfile('omar')
+    }
+
     expect($newChatProfile.get()).toBe('omar')
     expect($newChatRoute.get()).toBeNull()
     await waitFor(() => expect(activeGatewayProfileKey()).toBe('omar'))
@@ -405,21 +449,25 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect(activeGateway()).toBe(omarSocket as never)
 
     // Ambient dispatcher = whatever socket is active, as useGatewayRequest does.
-    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) =>
-      (activeGateway() as unknown as MockGateway).request(method, params)
-    )
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create' || sessionScoped(params)) {
+        throw new Error(`session traffic must not use ambient dispatcher: ${method}`)
+      }
+
+      return (activeGateway() as unknown as MockGateway).request(method, params)
+    })
 
     let handle: HarnessHandle | null = null
     render(<Harness ambientRequest={ambientRequest as never} onReady={h => (handle = h)} />)
     await waitFor(() => expect(handle).not.toBeNull())
 
-    return { handle: handle!, omarSocket: omarSocket!, primary }
+    return { ambientRequest, handle: handle!, omarSocket: omarSocket!, primary }
   }
 
   /** What the gateway's stream end does: the turn settles. */
   async function settleTurn(handle: HarnessHandle) {
     await act(async () => {
-      handle.updateSessionState(RUNTIME_ID, state => ({
+      handle.updateSessionState(mintedRuntimeId, state => ({
         ...state,
         awaitingResponse: false,
         busy: false,
@@ -478,8 +526,31 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect($newChatConnectionId.get()).toBeNull()
   })
 
+  function expectUninterruptedOwner({
+    ambientRequest,
+    omarSocket,
+    primary
+  }: {
+    ambientRequest: GatewayRequestMock
+    omarSocket: MockGateway
+    primary: MockGateway
+  }) {
+    expect(runtimeOwner).toBe(omarSocket)
+    expect(ambientRequest.mock.calls.filter(call => call[0] === 'session.create' || sessionScoped(call[1]))).toEqual([])
+
+    for (const socket of [primary, ...sockets]) {
+      expect(socket.close).not.toHaveBeenCalled()
+      expect(socket.connectionState).toBe('open')
+      expect(
+        calls(socket).filter(method => ['session.activate', 'session.close', 'session.resume'].includes(method))
+      ).toEqual([])
+    }
+
+    expect(registryOnEvent.mock.calls.filter(([event]) => event.type === 'session.reclaimed')).toEqual([])
+  }
+
   it('session.create and both prompt.submit calls ride the SAME conn:homelab::omar socket', async () => {
-    const { handle, omarSocket, primary } = await bootProfileRailOmar()
+    const { ambientRequest, handle, omarSocket, primary } = await bootProfileRailOmar()
 
     // Turn one: no session yet → createBackendSessionForSend → prompt.submit.
     await expect(handle.submitText('first prompt')).resolves.toBe(true)
@@ -546,6 +617,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     }
 
     expect(omarCalls.filter(method => method === 'session.create')).toHaveLength(1)
+    expectUninterruptedOwner({ ambientRequest: ambientRequest as GatewayRequestMock, omarSocket, primary })
     expect(getSessionOwnerHint(STORED_ID)).toEqual({ connectionId: SOURCE_ID, profile: 'omar' })
     expect($sessions.get().find(session => sessionMatchesStoredId(session, STORED_ID))).toMatchObject({
       connection_id: SOURCE_ID,
@@ -555,7 +627,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
   })
 
   it('turn two still rides conn:homelab::omar after the transient hint is evicted AND a refresh returned the row untagged', async () => {
-    const { handle, omarSocket, primary } = await bootProfileRailOmar()
+    const { ambientRequest, handle, omarSocket, primary } = await bootProfileRailOmar('newSessionInProfile')
 
     await expect(handle.submitText('first prompt')).resolves.toBe(true)
     await waitFor(() => expect($activeSessionId.get()).toBe(RUNTIME_ID))
@@ -612,6 +684,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     }
 
     expect(calls(omarSocket).filter(method => method === 'session.create')).toHaveLength(1)
+    expectUninterruptedOwner({ ambientRequest: ambientRequest as GatewayRequestMock, omarSocket, primary })
   })
 
   it('a pick on the explicit `local` source is a legacy profile pick: create and both turns ride the ONE v1 omar socket', async () => {
@@ -649,6 +722,8 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect(activeGateway()).toBe(v1Socket as never)
     expect(sockets.some(socket => socket.connectUrl?.includes(`:${OMAR_PORT}`))).toBe(false)
 
+    // The legacy door's create legitimately rides the ambient dispatcher: the
+    // active socket IS the owner (no route, no registry entry to name).
     const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) =>
       (activeGateway() as unknown as MockGateway).request(method, params)
     )
@@ -661,23 +736,14 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     await waitFor(() => expect($activeSessionId.get()).toBe(LEGACY_RUNTIME_ID))
     expect(handle!.bindings()).toEqual({ runtimeForStored: LEGACY_RUNTIME_ID, storedForRuntime: LEGACY_STORED_ID })
 
-    await act(async () => {
-      handle!.updateSessionState(LEGACY_RUNTIME_ID, state => ({
-        ...state,
-        awaitingResponse: false,
-        busy: false,
-        streamId: null,
-        turnStartedAt: null
-      }))
-      handle!.busyRef.current = false
-      setBusy(false)
-      setAwaitingResponse(false)
-    })
+    await settleTurn(handle!)
 
     await expect(handle!.submitText('second prompt')).resolves.toBe(true)
 
     // The legacy owner is the bare profile: no registry route, no hint — the
-    // row's profile names the same v1 pool entry that minted the runtime.
+    // row's profile names the same v1 pool entry that minted the runtime, and
+    // that socket was never closed, resumed or replaced.
+    expect(runtimeOwner).toBe(v1Socket)
     expect(calls(v1Socket!).filter(method => method === 'session.create')).toHaveLength(1)
     expect(
       v1Socket!.request.mock.calls
@@ -698,9 +764,13 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect(vi.mocked(getSession)).not.toHaveBeenCalled()
 
     for (const socket of [primary, ...sockets]) {
-      expect(calls(socket).filter(method => method === 'session.close')).toEqual([])
+      expect(socket.close).not.toHaveBeenCalled()
+      expect(
+        calls(socket).filter(method => ['session.activate', 'session.close', 'session.resume'].includes(method))
+      ).toEqual([])
     }
 
+    expect(registryOnEvent.mock.calls.filter(([event]) => event.type === 'session.reclaimed')).toEqual([])
     expect(getSessionOwnerHint(LEGACY_STORED_ID)).toBeUndefined()
     expect($sessions.get().find(session => sessionMatchesStoredId(session, LEGACY_STORED_ID))).toMatchObject({
       profile: 'omar'

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/store/profile'
 import {
   $activeSessionId,
+  $connection,
   $selectedStoredSessionId,
   $sessions,
   _resetSessionOwnerHintsForTests,
@@ -33,6 +34,7 @@ import {
   setActiveSessionId,
   setAwaitingResponse,
   setBusy,
+  setConnection,
   setMessages,
   setSelectedStoredSessionId,
   setSessions
@@ -336,13 +338,19 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     mintedRuntimeId = RUNTIME_ID
     mintedStoredId = STORED_ID
     clearSingleFlightSessionResumeState()
-    configureGatewayRegistry({ onEvent: vi.fn() })
+    // Wired exactly as useGatewayBoot: the published active descriptor carries
+    // a registry-backed primary's source identity across a renderer reload.
+    configureGatewayRegistry({
+      activeConnectionId: () => $connection.get()?.connectionId ?? null,
+      onEvent: vi.fn()
+    })
     closeSecondaryGateways()
     installDesktop()
     setSessions([])
     setMessages([])
     setActiveSessionId(null)
     setSelectedStoredSessionId(null)
+    setConnection(null)
     setBusy(false)
     setAwaitingResponse(false)
     $newChatProfile.set(null)
@@ -357,6 +365,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     setSessions([])
     setActiveSessionId(null)
     setSelectedStoredSessionId(null)
+    setConnection(null)
     $newChatProfile.set(null)
     $newChatRoute.set(null)
     $newChatConnectionId.set(null)
@@ -424,6 +433,50 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
   }
 
   const calls = (socket: MockGateway) => socket.request.mock.calls.map(call => call[0] as string)
+
+  it('dials homelab::omar when boot published homelab on the active primary gateway', async () => {
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    expect(activeGateway()).toBe(primary as never)
+    // A true legacy primary has no published registry identity.
+    expect(activeGatewayConnectionId()).toBeNull()
+
+    // Cold boot publishes the resolved primary descriptor before profile-rail
+    // interaction. No registry secondary has been opened in this scenario.
+    setConnection({ connectionId: SOURCE_ID, mode: 'remote', profile: 'default' } as never)
+    expect(activeGatewayConnectionId()).toBe(SOURCE_ID)
+
+    selectProfile('omar')
+
+    const desktop = window.hermesDesktop!
+
+    await waitFor(() =>
+      expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: SOURCE_ID, profile: 'omar' })
+    )
+    expect(desktop.getConnection).not.toHaveBeenCalledWith('omar')
+    expect($newChatConnectionId.get()).toBe(SOURCE_ID)
+  })
+
+  it('keeps the legacy profile door when boot published `local` on the active primary gateway', async () => {
+    // The published identity survives the reload, but a pick on the explicit
+    // local source is still a legacy profile pick (per-profile remote
+    // overrides resolve through getConnection), so the draft's owner is the
+    // v1 profile socket, never the registry entry local::omar.
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    setConnection({ connectionId: 'local', mode: 'local', profile: 'default' } as never)
+    expect(activeGatewayConnectionId()).toBe('local')
+
+    selectProfile('omar')
+
+    const desktop = window.hermesDesktop!
+
+    await waitFor(() => expect(desktop.getConnection).toHaveBeenCalledWith('omar'))
+    expect(desktop.getConnectionFor).not.toHaveBeenCalledWith({ connectionId: 'local', profile: 'omar' })
+    expect($newChatConnectionId.get()).toBeNull()
+  })
 
   it('session.create and both prompt.submit calls ride the SAME conn:homelab::omar socket', async () => {
     const { handle, omarSocket, primary } = await bootProfileRailOmar()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -23,7 +23,13 @@ import { applyGoalStatusText } from '@/store/goals'
 import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { setPetScale } from '@/store/pet-gallery'
 import { $petGenInput, openPetGenerate } from '@/store/pet-generate'
-import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  captureNewChatSource,
+  ensureGatewayProfile,
+  normalizeProfileKey
+} from '@/store/profile'
 import {
   $connection,
   $sessions,
@@ -802,6 +808,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
             $newChatProfile.set(key)
             await ensureGatewayProfile(key)
+            // Capture the source the swap landed on (null on the v1 profile path)
+            // so the draft's owner matches the socket that will mint it.
+            captureNewChatSource()
             notify({ kind: 'success', message: copy.newChatsProfile(match.name) })
           } catch (err) {
             notifyError(err, copy.setProfileFailed)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -698,6 +698,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         startingStoredSessionId = selectedStoredSessionIdRef.current
         startingSelectedStoredSessionId = selectedStoredSessionIdRef.current
         startingRouteToken = getRouteToken()
+        // The target too: it was captured BEFORE the create (null for a fresh
+        // draft) and seedOptimistic hands it to updateSessionState as the
+        // stored id, which the state cache reads as a deliberate DETACH — so
+        // the freshly bound stored↔runtime mapping was severed the moment the
+        // chat existed. Every later session-scoped RPC then failed to
+        // translate the runtime id to the stored id, never saw the session's
+        // tile route / owner hint / row, probed REST by a runtime id, and fell
+        // to the ambient socket — the fresh-chat owner loss behind #94071.
+        targetStoredSessionId = selectedStoredSessionIdRef.current
 
         seedOptimistic(sessionId)
       }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -102,7 +102,8 @@ vi.mock('@/store/profile', async importOriginal => ({
 vi.mock('@/store/gateway', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   requestGatewayForAgent: vi.fn(),
-  requestGatewayForProfile: vi.fn()
+  requestGatewayForProfile: vi.fn(),
+  retainGatewayForAgent: vi.fn(async () => () => undefined)
 }))
 
 vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1,3 +1,4 @@
+import { registryBackendScopeKey } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
@@ -5,6 +6,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
+import { resolveSessionRpcOwner } from '@/app/contrib/wiring-routing'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
@@ -46,6 +48,9 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $turnStartedAt,
+  getSessionOwnerHint,
+  knownSessionOwner,
+  sessionMatchesStoredId,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -65,8 +70,8 @@ import {
   setSessions,
   setTurnStartedAt
 } from '@/store/session'
-import type { SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles } from '@/store/session-states'
+import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
+import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -3831,5 +3836,147 @@ describe('removeSession / archiveSession profile routing (#78836)', () => {
     expect(mockSetSessionArchived).not.toHaveBeenCalled()
     expect($messagingSessions.get().map(session => session.id)).toEqual(['tg-arch-unresolved'])
     expect($sessions.get()).toEqual([])
+  })
+})
+
+// A fresh chat created through $newChatRoute must keep the route as its EXACT
+// owner after session.create. The create RPC already rode
+// requestGatewayForAgent(capturedRoute); but the optimistic row was stamped
+// from $activeGatewayProfile (still `default` in All-profiles / Bot routing)
+// and no owner hint was recorded, so the first turn ran on omar while every
+// later session-scoped RPC resolved the row as `default` → "session not
+// found" on the default backend, and the orphaned omar runtime was eventually
+// ws-orphan-reaped.
+describe('routed fresh chat keeps its exact owner across turns', () => {
+  const route: SessionProfileRoute = { connectionId: 'local', mode: 'local', profile: 'omar' }
+  const STORED = 'stored-omar-fresh'
+
+  afterEach(() => {
+    cleanup()
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+    setSessions([])
+    setCurrentCwd('')
+    setNewChatWorkspaceTarget(undefined)
+    vi.restoreAllMocks()
+  })
+
+  // The SAME sync ladder contrib/wiring's requestGateway runs for every
+  // session-scoped RPC (prompt.submit, session.resume, attach, interrupt,
+  // redirect, recovery): tile route → exact unique hint → row owner.
+  const ownerFor = (storedSessionId: string) =>
+    resolveSessionRpcOwner({
+      routingSessionId: storedSessionId,
+      sessionOwnerHint: id => getSessionOwnerHint(id),
+      sessionRowOwner: (id: string) => knownSessionOwner($sessions.get(), id),
+      tileOwnerRoute: sessionTileOwnerRoute
+    })
+
+  async function createRoutedFreshChat() {
+    // Ambient dispatcher = the DEFAULT backend. It never heard of the session:
+    // any session-scoped RPC landing here is exactly the bug.
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (typeof params?.session_id === 'string') {
+        throw new Error(`Session not found: ${params.session_id} (ambient/default backend, ${method})`)
+      }
+
+      return {} as never
+    })
+
+    // The owning backend, local::omar. Anything else 4001s.
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (connectionId, profile, method) => {
+      if (connectionId === 'local' && profile === 'omar') {
+        if (method === 'session.create') {
+          return { session_id: RUNTIME_SESSION_ID, stored_session_id: STORED } as never
+        }
+
+        return { ok: true } as never
+      }
+
+      throw new Error(`Session not found (${connectionId}::${profile}, ${method})`)
+    })
+
+    // Ambient profile = default; the draft is routed at local::omar.
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set(route.profile)
+    $newChatRoute.set({ ...route })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    let runtimeId: null | string = null
+
+    await act(async () => {
+      runtimeId = await handle!.createBackendSessionForSend('hello omar')
+    })
+
+    expect(runtimeId).toBe(RUNTIME_SESSION_ID)
+
+    return { ambientRequest, runtimeId: runtimeId as unknown as string }
+  }
+
+  it('unit: an explicitly routed fresh create never resolves its follow-up owner to the ambient default', async () => {
+    await createRoutedFreshChat()
+
+    const followupOwner = ownerFor(STORED)
+    const foregroundScope = registryBackendScopeKey(route.connectionId, route.profile)
+
+    const followupOwnerKey =
+      followupOwner && typeof followupOwner === 'object'
+        ? `${followupOwner.connectionId}::${followupOwner.profile}`
+        : followupOwner
+
+    // The exact failing shape: the foreground socket is omar's, the follow-up
+    // routes to default.
+    expect({ followupOwner: followupOwnerKey, foregroundScope }).not.toEqual({
+      followupOwner: 'default',
+      foregroundScope: 'conn:local::omar'
+    })
+    expect({ followupOwner: followupOwnerKey, foregroundScope }).toEqual({
+      followupOwner: 'local::omar',
+      foregroundScope: 'conn:local::omar'
+    })
+
+    // Both owner records carry the route, and the ambient profile never moved.
+    expect(getSessionOwnerHint(STORED)).toEqual(route)
+    expect($sessions.get().find(session => sessionMatchesStoredId(session, STORED))).toMatchObject({
+      connection_id: 'local',
+      is_default_profile: false,
+      profile: 'omar'
+    })
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('integration: both turns hit local::omar with default ambient — no session-not-found, no orphaned runtime', async () => {
+    const { ambientRequest, runtimeId } = await createRoutedFreshChat()
+
+    const submitTurn = (text: string) =>
+      requestForSessionProfile(ownerFor(STORED), ambientRequest, 'prompt.submit', { session_id: runtimeId, text })
+
+    // First turn on omar.
+    await expect(submitTurn('first turn')).resolves.toEqual({ ok: true })
+
+    // Keep default as the ambient profile (All-profiles / Bot routing never
+    // moved it) and submit the second turn.
+    $activeGatewayProfile.set('default')
+    await expect(submitTurn('second turn')).resolves.toEqual({ ok: true })
+
+    const submits = vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'prompt.submit')
+
+    expect(submits.map(call => [call[0], call[1], (call[3] as { text: string }).text])).toEqual([
+      ['local', 'omar', 'first turn'],
+      ['local', 'omar', 'second turn']
+    ])
+    // No session-not-found: the default backend never saw a session-scoped RPC.
+    expect(ambientRequest).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+    expect(ambientRequest.mock.calls.filter(call => typeof call[1]?.session_id === 'string')).toEqual([])
+    // No ws_orphan_reap: the client never closed or abandoned the runtime it
+    // minted on omar — no session.close on any route, the binding stands.
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'session.close')).toEqual([])
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.close', expect.anything())
+    expect(getSessionOwnerHint(STORED)).toEqual(route)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -30,13 +30,13 @@ import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
   $newChatProfile,
-  $newChatRoute,
   $profiles,
   $showAllProfiles,
   type AgentProfileRoute,
   ensureGatewayAgent,
   ensureGatewayProfile,
-  normalizeProfileKey
+  normalizeProfileKey,
+  resolveNewChatOwnerRoute
 } from '@/store/profile'
 import {
   $projectScope,
@@ -218,7 +218,7 @@ function reconcileAuthoritativeMessages(
 // never the profile default (that lives in Settings → Model).
 async function desktopSessionCreateParams(
   cwd: string,
-  capturedRoute = $newChatRoute.get()
+  capturedRoute = resolveNewChatOwnerRoute()
 ): Promise<Record<string, unknown>> {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
@@ -474,7 +474,14 @@ export function useSessionActions({
               ? workspaceTarget.trim()
               : $currentCwd.get().trim() || resolveNewSessionCwd()
 
-        const capturedRoute = $newChatRoute.get()
+        // The EXACT owner for this create: an explicit agent route, else the
+        // (registry source, profile) pair the draft was made on. Read ONCE at
+        // the send linearization point and threaded through the create RPC,
+        // the owner hint, the optimistic row and the failure cleanup, so the
+        // profile-rail path (selectProfile clears $newChatRoute) can no longer
+        // reduce the owner to a bare profile name that later RPCs dial on a
+        // different socket than the one that minted the runtime.
+        const capturedRoute = resolveNewChatOwnerRoute()
         const params = await desktopSessionCreateParams(cwd, capturedRoute)
 
         const created = capturedRoute
@@ -637,7 +644,7 @@ export function useSessionActions({
         // `options?.cwd || resolve…` is wrong for Home: null is falsy and used
         // to fall through into the last project folder while main chat was
         // occupied (openTab path for "New session in Home").
-        const capturedRoute = options?.route === undefined ? $newChatRoute.get() : options.route
+        const capturedRoute = options?.route === undefined ? resolveNewChatOwnerRoute() : options.route
         const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
 
         const cwd =

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -79,6 +79,7 @@ import {
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
+  setSessionOwnerHint,
   setSessionStartedAt,
   setTurnStartedAt,
   setWorkspaceCwdOwner,
@@ -487,6 +488,19 @@ export function useSessionActions({
 
         const stored = created.stored_session_id ?? null
 
+        // Record the EXACT owner the moment a routed create returns a stored
+        // id — before the drift check, the optimistic row, navigation, or any
+        // session-scoped RPC can resolve this session's owner. The route is
+        // the only authority: in All-profiles / Bot routing the ambient
+        // $activeGatewayProfile stays on `default` while the session lives on
+        // `capturedRoute` (e.g. local::omar). Without this hint the optimistic
+        // row (stamped from ambient) was the only owner record, so the first
+        // turn ran on omar and every later session-scoped RPC resolved the row
+        // as `default` and 4001'd "session not found".
+        if (stored && capturedRoute) {
+          setSessionOwnerHint(stored, capturedRoute)
+        }
+
         // Only a genuine move to a DIFFERENT chat mid-create should orphan the
         // session we just minted. The active runtime ref is deliberately not a
         // prong: background gateway events retarget it while other sessions
@@ -505,7 +519,17 @@ export function useSessionActions({
 
         if (drift) {
           console.warn('[submit-drift-abort]', drift, { phase: 'mid-create' })
-          await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
+
+          // Close on the backend that minted the session: the ambient socket
+          // is a different machine/profile for a routed create and would
+          // 4001 while the orphan lives on (and later ws-orphan-reaps) there.
+          const closeCreated = capturedRoute
+            ? requestGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile, 'session.close', {
+                session_id: created.session_id
+              })
+            : requestGateway('session.close', { session_id: created.session_id })
+
+          await closeCreated.catch(() => undefined)
 
           return null
         }
@@ -521,7 +545,9 @@ export function useSessionActions({
           // reads meaningfully while the turn is in flight, instead of flashing
           // "Untitled session" until the turn persists and auto-title runs. The
           // server later returns its own preview/title and supersedes this.
-          upsertOptimisticSession(created, stored, null, preview?.trim() || null)
+          // The row carries the create route's exact owner (backend profile +
+          // connection), never the ambient profile — see upsertOptimisticSession.
+          upsertOptimisticSession(created, stored, null, preview?.trim() || null, null, undefined, capturedRoute)
           navigate(sessionRoute(stored), { replace: true })
           // Other windows (e.g. the main window when this is the pop-out) can't
           // see this session until they re-pull the shared list.
@@ -648,12 +674,18 @@ export function useSessionActions({
 
         createdThisRun.add(stored)
 
+        // Same ownership transition as createBackendSessionForSend: the route
+        // that minted the session is its exact owner from this moment on.
+        if (capturedRoute) {
+          setSessionOwnerHint(stored, capturedRoute)
+        }
+
         // Seed the per-runtime cache so the tile renders immediately without a
         // redundant resume. Only add the row to the SIDEBAR when `listed` — an
         // unlisted (draft) tab stays out of the session list until its first
         // turn persists and a refresh surfaces it.
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null)
+          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,7 +22,12 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
-import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
+import {
+  openGatewayForAgent,
+  openGatewayForProfile,
+  requestGatewayForAgent,
+  retainGatewayForAgent
+} from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -94,9 +99,11 @@ import {
   $sessionTiles,
   closeSessionTile,
   dropSessionState,
+  holdSessionOwnerUntilForeground,
   openSessionTile,
   patchSessionTile,
   publishSessionState,
+  releaseSessionOwnerHold,
   type SessionTileWorkspaceScope,
   type TileDock
 } from '@/store/session-states'
@@ -484,28 +491,49 @@ export function useSessionActions({
         const capturedRoute = resolveNewChatOwnerRoute()
         const params = await desktopSessionCreateParams(cwd, capturedRoute)
 
-        const created = capturedRoute
-          ? await requestGatewayForAgent<SessionCreateResponse>(
-              capturedRoute.connectionId,
-              capturedRoute.profile,
-              'session.create',
-              params
-            )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+        // Lease the owner socket for the whole create → owner-publication
+        // sequence (#93602 primitive). The per-request lease inside
+        // requestGatewayForAgent ends when session.create returns; the
+        // foreground hold below takes over from that point until the created
+        // chat is selected. Between the two, nothing may close the socket
+        // that just minted the runtime.
+        const releaseCreateLease = capturedRoute
+          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile)
+          : () => undefined
 
-        const stored = created.stored_session_id ?? null
+        let created: SessionCreateResponse
+        let stored: null | string
 
-        // Record the EXACT owner the moment a routed create returns a stored
-        // id — before the drift check, the optimistic row, navigation, or any
-        // session-scoped RPC can resolve this session's owner. The route is
-        // the only authority: in All-profiles / Bot routing the ambient
-        // $activeGatewayProfile stays on `default` while the session lives on
-        // `capturedRoute` (e.g. local::omar). Without this hint the optimistic
-        // row (stamped from ambient) was the only owner record, so the first
-        // turn ran on omar and every later session-scoped RPC resolved the row
-        // as `default` and 4001'd "session not found".
-        if (stored && capturedRoute) {
-          setSessionOwnerHint(stored, capturedRoute)
+        try {
+          created = capturedRoute
+            ? await requestGatewayForAgent<SessionCreateResponse>(
+                capturedRoute.connectionId,
+                capturedRoute.profile,
+                'session.create',
+                params
+              )
+            : await requestGateway<SessionCreateResponse>('session.create', params)
+
+          stored = created.stored_session_id ?? null
+
+          // Record the EXACT owner the moment a routed create returns a stored
+          // id — before the drift check, the optimistic row, navigation, or any
+          // session-scoped RPC can resolve this session's owner. The route is
+          // the only authority: in All-profiles / Bot routing the ambient
+          // $activeGatewayProfile stays on `default` while the session lives on
+          // `capturedRoute` (e.g. local::omar). Without this hint the optimistic
+          // row (stamped from ambient) was the only owner record, so the first
+          // turn ran on omar and every later session-scoped RPC resolved the row
+          // as `default` and 4001'd "session not found".
+          if (stored && capturedRoute) {
+            setSessionOwnerHint(stored, capturedRoute)
+            // Pin the owner socket until the foreground publication (route →
+            // $selectedStoredSessionId) covers it, so a prune or lease release
+            // in that gap cannot close the runtime before the first prompt.
+            holdSessionOwnerUntilForeground(stored, capturedRoute)
+          }
+        } finally {
+          releaseCreateLease()
         }
 
         // Only a genuine move to a DIFFERENT chat mid-create should orphan the
@@ -537,6 +565,10 @@ export function useSessionActions({
             : requestGateway('session.close', { session_id: created.session_id })
 
           await closeCreated.catch(() => undefined)
+
+          if (stored) {
+            releaseSessionOwnerHold(stored)
+          }
 
           return null
         }
@@ -655,16 +687,38 @@ export function useSessionActions({
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
 
-        const created = capturedRoute
-          ? await requestGatewayForAgent<SessionCreateResponse>(
-              capturedRoute.connectionId,
-              capturedRoute.profile,
-              'session.create',
-              params
-            )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+        // Same lease chain as createBackendSessionForSend: owner socket held
+        // across the create, then the foreground hold carries it until the
+        // tile is mounted ($sessionTiles names the owner from then on).
+        const releaseCreateLease = capturedRoute
+          ? await retainGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile)
+          : () => undefined
 
-        const stored = created.stored_session_id
+        let created: SessionCreateResponse
+        let stored: string | undefined
+
+        try {
+          created = capturedRoute
+            ? await requestGatewayForAgent<SessionCreateResponse>(
+                capturedRoute.connectionId,
+                capturedRoute.profile,
+                'session.create',
+                params
+              )
+            : await requestGateway<SessionCreateResponse>('session.create', params)
+
+          stored = created.stored_session_id
+
+          if (stored && capturedRoute) {
+            // Same ownership transition as createBackendSessionForSend: the
+            // route that minted the session is its exact owner from this
+            // moment on, and its socket stays pinned until the tile mounts.
+            setSessionOwnerHint(stored, capturedRoute)
+            holdSessionOwnerUntilForeground(stored, capturedRoute)
+          }
+        } finally {
+          releaseCreateLease()
+        }
 
         if (!stored) {
           const closeCreated = capturedRoute
@@ -680,12 +734,6 @@ export function useSessionActions({
         }
 
         createdThisRun.add(stored)
-
-        // Same ownership transition as createBackendSessionForSend: the route
-        // that minted the session is its exact owner from this moment on.
-        if (capturedRoute) {
-          setSessionOwnerHint(stored, capturedRoute)
-        }
 
         // Seed the per-runtime cache so the tile renders immediately without a
         // redundant resume. Only add the row to the SIDEBAR when `listed` — an

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1248,15 +1248,21 @@ export function upsertOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  ownerRoute?: SessionProfileRoute
+  owner?: null | SessionProfileRoute
 ) {
   const now = lastActive ?? Date.now() / 1000
-  // Stamp the profile/source the session was just created on so the scoped
-  // sidebar shows the new row immediately instead of filtering it out as
-  // "default" until the aggregator re-fetches. The active gateway is only a
-  // presentation detail: a concurrent source switch can move it before this
-  // optimistic row is inserted.
-  const profileKey = normalizeProfileKey(ownerRoute?.profile ?? $activeGatewayProfile.get())
+  // Stamp the profile the session was just created on so the scoped sidebar
+  // shows the new row immediately instead of filtering it out as "default"
+  // until the aggregator re-fetches. An explicitly routed create ($newChatRoute
+  // / a tile's route) names its EXACT owner: the backend profile that route
+  // serves, on that route's connection. The live gateway's profile is only the
+  // owner for an unrouted create — in All-profiles / Bot routing the ambient
+  // profile stays on `default` while the session lives on another backend (and
+  // a concurrent source switch can move the active gateway before this row is
+  // inserted), so a row stamped `default` then misroutes every session-scoped
+  // RPC that resolves its owner off the row ("session not found" on turn two).
+  const profileKey = normalizeProfileKey(owner ? owner.targetProfile || owner.profile : $activeGatewayProfile.get())
+  const connectionId = owner?.connectionId.trim() || ''
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
@@ -1279,11 +1285,11 @@ export function upsertOptimisticSession(
     started_at: now,
     title,
     tool_call_count: 0,
-    ...(ownerRoute?.connectionId.trim() ? { connection_id: ownerRoute.connectionId.trim() } : {})
+    ...(connectionId ? { connection_id: connectionId } : {})
   }
 
-  if (ownerRoute) {
-    setSessionOwnerHint(id, ownerRoute)
+  if (owner) {
+    setSessionOwnerHint(id, owner)
   }
 
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -37,6 +37,7 @@ import type { SessionProfileRoute } from '@/store/session-request-router'
 // Re-exported for the many session-actions/tile call sites that already import
 // it from here; the canonical definition lives in @/store/session.
 export { sessionMatchesStoredId }
+import { sessionOwnerRouteFromRow, type SessionOwnerScope } from '@/store/session-request-router'
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
 
@@ -1504,6 +1505,25 @@ export async function resolveSessionProfile(storedSessionId: null | string): Pro
   const profile = (await resolveStoredSession(storedSessionId))?.profile?.trim()
 
   return profile || undefined
+}
+
+/**
+ * The OWNER of a stored session through the same cache → active-backend →
+ * cross-profile ladder, preferring the EXACT route when the resolved row is
+ * connection-tagged (unified-list splice, optimistic create row, a carried
+ * tag) over its bare profile. Session-scoped RPC dispatch uses this as the
+ * async rung after the sync ladder (tile route → hint → row) misses, so a
+ * registry-owned session never degrades to a profile-only route that dials a
+ * different socket than the one holding its runtime.
+ */
+export async function resolveSessionOwner(storedSessionId: null | string): Promise<SessionOwnerScope> {
+  if (!storedSessionId) {
+    return undefined
+  }
+
+  const row = await resolveStoredSession(storedSessionId)
+
+  return sessionOwnerRouteFromRow(row) ?? (row?.profile?.trim() || undefined)
 }
 
 type SessionRuntimeStatePatch = Partial<

--- a/apps/desktop/src/store/connection-registry-state.ts
+++ b/apps/desktop/src/store/connection-registry-state.ts
@@ -7,5 +7,8 @@ import type { DesktopConnectionsRegistry } from '@/global'
 export const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
 
 export function hasRegistryTopology(): boolean {
-  return $connectionsRegistry.get() !== null
+  // The bridge exists before its asynchronous cache load. Treat that window
+  // (and a failed list IPC) as registry topology so owner routing fails closed;
+  // only an older Desktop without the registry capability is truly legacy.
+  return $connectionsRegistry.get() !== null || Boolean(window.hermesDesktop?.connections?.list)
 }

--- a/apps/desktop/src/store/connection-registry-state.ts
+++ b/apps/desktop/src/store/connection-registry-state.ts
@@ -1,0 +1,11 @@
+import { atom } from 'nanostores'
+
+import type { DesktopConnectionsRegistry } from '@/global'
+
+/** Null only for the legacy profile-only Desktop topology. Once Electron has
+ * published a registry, profile names are source-local and are not owners. */
+export const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
+
+export function hasRegistryTopology(): boolean {
+  return $connectionsRegistry.get() !== null
+}

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -70,6 +70,7 @@ vi.mock('@/store/profile', () => ({
   $activeGatewayProfile,
   $newChatProfile,
   $showAllProfiles,
+  captureNewChatSource: vi.fn(),
   ensureGatewayAgent,
   normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default',
   openGatewayAgent,

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -3,6 +3,7 @@ import { atom, computed } from 'nanostores'
 import type { DesktopConnectionsRegistry } from '@/global'
 import { persistStringRecord, storedStringRecord } from '@/lib/storage'
 import { isTimeoutError, withTimeout } from '@/lib/with-timeout'
+import { $connectionsRegistry } from '@/store/connection-registry-state'
 import {
   beginGatewaySwitch,
   endGatewaySwitch,
@@ -32,7 +33,7 @@ const SWITCH_DIAL_TIMEOUT_MS = 20_000
 const SWITCH_COMMIT_TIMEOUT_MS = 20_000
 const SWITCH_REMEMBER_TIMEOUT_MS = 5_000
 
-export const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
+export { $connectionsRegistry } from '@/store/connection-registry-state'
 
 // Use only the resolved descriptor identity Electron publishes. `primary`
 // means the registry default, not necessarily the source this window is using;

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -13,6 +13,7 @@ import {
   $activeGatewayProfile,
   $newChatProfile,
   $showAllProfiles,
+  captureNewChatSource,
   ensureGatewayAgent,
   normalizeProfileKey,
   openGatewayAgent,
@@ -245,6 +246,10 @@ export async function selectConnection(connectionId: string): Promise<void> {
   if (pendingTarget === null && currentConnectionId === connectionId && currentProfile === targetProfile) {
     $showAllProfiles.set(false)
     $newChatProfile.set(targetProfile)
+    // A connection switch is a new-chat intent on THAT source: keep the
+    // registry identity with the profile so the next create names local::x /
+    // <source>::x exactly, never a bare profile string.
+    captureNewChatSource()
     requestFreshSession()
     await rememberConnection(connectionId)
 
@@ -359,6 +364,7 @@ export async function selectConnection(connectionId: string): Promise<void> {
       }
 
       $newChatProfile.set(targetProfile)
+      captureNewChatSource()
       requestFreshSession()
       await refreshActiveProfile()
     }

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -64,6 +64,7 @@ const {
   openGatewayForProfile,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
+  retainGatewayForAgent,
   retireLocalProfileGateways,
   setPrimaryGateway
 } = await import('./gateway')
@@ -164,6 +165,44 @@ describe('disposeSecondariesForConnection', () => {
     // Old socket closed, fresh descriptor fetched (would carry the new URL).
     expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
     expect(getConnectionFor).toHaveBeenCalledTimes(2)
+  })
+
+  it('defers edit redials until request and foreground owners release the old sockets', async () => {
+    const foregroundScopes = new Set<string>()
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    configureGatewayRegistry({ foregroundScopes: () => foregroundScopes, onEvent: vi.fn() } as never)
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    await ensureGatewayForAgent('office', 'default')
+    const release = await retainGatewayForAgent('homelab', 'default')
+    await openGatewayForAgent('homelab', 'work')
+    foregroundScopes.add('conn:homelab::work')
+
+    const retainedSocket = gatewayMocks.instances[0]
+    const foregroundSocket = gatewayMocks.instances[2]
+
+    disposeSecondariesForConnection('homelab', { redial: true })
+
+    // An edit may need a new endpoint, but it cannot sever an in-flight turn
+    // or a mounted runtime's owner socket. No replacement is dialed yet.
+    expect(retainedSocket.close).not.toHaveBeenCalled()
+    expect(foregroundSocket.close).not.toHaveBeenCalled()
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(3)
+
+    release()
+    await vi.waitFor(() => expect(gatewayMocks.connect).toHaveBeenCalledTimes(4))
+    expect(retainedSocket.close).toHaveBeenCalledOnce()
+    expect(foregroundSocket.close).not.toHaveBeenCalled()
+
+    foregroundScopes.clear()
+    pruneSecondaryGateways(new Set(['conn:homelab::default']))
+    await vi.waitFor(() => expect(gatewayMocks.connect).toHaveBeenCalledTimes(5))
+    expect(foregroundSocket.close).toHaveBeenCalledOnce()
   })
 
   it('is a no-op for blank or unknown connection ids', async () => {

--- a/apps/desktop/src/store/gateway-foreground-retention.test.ts
+++ b/apps/desktop/src/store/gateway-foreground-retention.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// #93892 regression: the registry disposed the secondary socket an idle Bot
+// Chat tile was bound to — the live-work pruner for a pre-dialed (retained)
+// entry, and the refcount-0 request lease for one the tile's own resume
+// created. openGatewayForAgent marks the entry `retained`, but `retained` is
+// a one-way latch every hover pre-warm and profile switch also sets, so no
+// dispose path can honor it without leaking every socket ever warmed.
+// Instead the registry's `foregroundScopes` hook names the scopes FOREGROUND
+// surfaces are bound to (foregroundSessionScopes): a mounted tile pins its
+// owner socket for exactly as long as it is mounted, on every dispose path.
+
+const gatewayMocks = vi.hoisted(() => ({
+  closed: [] as string[]
+}))
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    wsUrl = ''
+    connect = async (wsUrl: string): Promise<void> => {
+      this.wsUrl = wsUrl
+      this.connectionState = 'open'
+    }
+    close = (): void => {
+      gatewayMocks.closed.push(this.wsUrl)
+      this.connectionState = 'closed'
+    }
+    request = async (): Promise<unknown> => ({})
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  openGatewayForAgent,
+  pruneSecondaryGateways,
+  requestGatewayForAgent,
+  setPrimaryGateway
+} = await import('./gateway')
+
+const { $sessionTiles, foregroundSessionScopes, liveSessionScopes } = await import('./session-states')
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async () => ({
+      authMode: 'token',
+      profile: 'default',
+      token: 't',
+      wsUrl: 'wss://local.invalid/api/ws?token=t'
+    })),
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      authMode: 'token',
+      connectionId,
+      profile,
+      token: 't',
+      wsUrl: `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    })),
+    getGatewayWsUrlFor: vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    ),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+// What use-gateway-boot's recomputeKeptGateways feeds the pruner for a
+// window with NO busy / needs-input work anywhere — the idle bot chat case.
+// Foreground pins are NOT in here: the registry reads them itself.
+const idleKeepSet = () => liveSessionScopes()
+
+const BOT_TILE = {
+  ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'bot' },
+  runtimeId: 'rt-bot',
+  storedSessionId: 'stored-bot'
+}
+
+beforeEach(() => {
+  installDesktop()
+  // Wired exactly as use-gateway-boot wires it.
+  configureGatewayRegistry({ foregroundScopes: foregroundSessionScopes, onEvent: vi.fn() })
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+  gatewayMocks.closed = []
+  $sessionTiles.set([])
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  $sessionTiles.set([])
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('foreground tile retention vs. the live-work pruner (#93892)', () => {
+  it('keeps an idle Bot Chat tile’s owner socket across prune recomputes', async () => {
+    // The BOTS workspace dials the bot's own backend without activating it
+    // (keepAllProfilesScope) and opens the canonical chat as a tile on that
+    // route. The global active profile stays primary/default.
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([BOT_TILE])
+
+    // Idle: no working / needs-input session anywhere. Before the fix this
+    // recompute closed the socket → backend reaped the runtime → reclaim →
+    // unbind → resume → … forever.
+    pruneSecondaryGateways(idleKeepSet())
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('keeps the socket while the tile is still resuming (no runtime bound yet)', async () => {
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([{ ...BOT_TILE, runtimeId: undefined }])
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('releases the socket once the tile is closed — the pin never latches', async () => {
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([BOT_TILE])
+    pruneSecondaryGateways(idleKeepSet())
+    expect(gatewayMocks.closed).toEqual([])
+
+    $sessionTiles.set([])
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('keeps the socket a tile’s OWN resume dialed (no pre-dial, refcount-0 lease path)', async () => {
+    // Relaunch with a persisted Bot Chat tab: nothing pre-dials the bot, so
+    // the tile's session.resume goes out through requestGatewayForAgent's
+    // per-request lease on a fresh, NON-retained entry. Before the fix the
+    // lease's `finally` disposed that socket the instant the resume returned
+    // — the runtime it had just minted was orphaned on the spot.
+    $sessionTiles.set([{ ...BOT_TILE, runtimeId: undefined }])
+
+    await requestGatewayForAgent('local', 'bot', 'session.resume', { session_id: 'stored-bot' })
+
+    expect(gatewayMocks.closed).toEqual([])
+
+    // …and the pruner agrees with the lease.
+    pruneSecondaryGateways(idleKeepSet())
+    expect(gatewayMocks.closed).toEqual([])
+
+    // Tile gone: the next lease release disposes as it always did.
+    $sessionTiles.set([])
+    await requestGatewayForAgent('local', 'bot', 'session.usage', { session_id: 'stored-bot' })
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('still prunes a merely pre-warmed (retained, no surface) socket — `retained` is not a pin', async () => {
+    // A roster hover warms the bot's socket through the same door and sets
+    // the same `retained` flag; with no tile bound to it, it is idle garbage.
+    await openGatewayForAgent('local', 'bot')
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('does not let a tile on one source pin another source’s same-named profile', async () => {
+    await openGatewayForAgent('homelab', 'bot')
+    $sessionTiles.set([BOT_TILE])
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://homelab.invalid/api/ws?profile=bot'])
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -24,6 +24,10 @@ const normKey = (profile: string | null | undefined): string => (profile ?? '').
 const isOpen = (gateway: HermesGateway | null): boolean => gateway?.connectionState === 'open'
 
 interface RegistryConfig {
+  /** Electron's published descriptor is authoritative for a primary gateway's
+   * registry identity. Kept as a getter so gateway.ts does not own or duplicate
+   * the connection store. */
+  activeConnectionId?: () => null | string
   onEvent: (event: GatewayEvent) => void
   onActiveConnectionInvalidated?: (fallbackProfile: string, activationEpoch: number) => void
   onActiveConnectionChanged?: (connection: HermesConnection) => void
@@ -304,15 +308,17 @@ export function activeGateway(): HermesGateway | null {
 
 /**
  * The registry connection serving the gateway the user is currently looking
- * at — null for the local/legacy primary path and for profile-keyed (local)
- * secondaries. Event consumers pair this with the event's own `connectionId`
- * tag so "from the active profile" really means "from the active SOURCE":
+ * at. A registry-backed primary takes its identity from the published primary
+ * connection, falling back to Electron's active descriptor until that is set;
+ * a true legacy primary (no resolved connectionId) and profile-keyed local
+ * secondaries remain null. Event consumers pair this with the event's own
+ * `connectionId` tag so "from the active profile" really means "from the active SOURCE":
  * two connected gateways can both expose a 'default' profile, and a bare
  * profile comparison attributed gateway B's 'default' activity to gateway A.
  */
 export function activeGatewayConnectionId(): null | string {
   if (g.activeKey === g.primaryProfile) {
-    return g.primaryConnectionId
+    return g.primaryConnectionId ?? (g.config?.activeConnectionId?.()?.trim() || null)
   }
 
   return g.secondaries.get(g.activeKey)?.connectionId ?? null

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -69,6 +69,8 @@ interface Secondary {
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
   reconnecting: boolean
+  /** A material connection edit is waiting for live owners to drain. */
+  pendingConnectionRedial: boolean
   /**
    * True when a foreground/prewarmed consumer owns this entry beyond one RPC.
    * Guards ONLY the dispose-at-refcount-0 paths (request/relay leases), never
@@ -611,6 +613,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     reconnectTimer: null,
     reconnectAttempt: 0,
     reconnecting: false,
+    pendingConnectionRedial: false,
     retained: false,
     relayRetainCount: 0,
     wantOpen: true,
@@ -840,6 +843,7 @@ export async function requestGatewayForAgent<T>(
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
     if (
+      !drainPendingConnectionRedial(entry) &&
       entry.activeRequests === 0 &&
       !entry.retained &&
       !relayRetained(entry) &&
@@ -888,6 +892,36 @@ function relayRetained(entry: Secondary): boolean {
 }
 
 /**
+ * Finish a material-edit redial once no request, relay, or foreground surface
+ * still owns the old socket. Removal deliberately bypasses this drain: a
+ * deleted source can never become valid again and must fail-stop immediately.
+ */
+function drainPendingConnectionRedial(entry: Secondary): boolean {
+  if (
+    entry.pendingConnectionRedial !== true ||
+    entry.activeRequests > 0 ||
+    relayRetained(entry) ||
+    foregroundPinned(entry) ||
+    g.secondaries.get(entry.scope) !== entry
+  ) {
+    return false
+  }
+
+  entry.pendingConnectionRedial = false
+  const wasActive = g.activeKey === entry.scope
+  disposeSecondary(entry)
+  g.secondaries.delete(entry.scope)
+
+  const reopen = wasActive
+    ? ensureGatewayForAgent(entry.connectionId, entry.profile)
+    : openGatewayForAgent(entry.connectionId, entry.profile)
+
+  void reopen.catch(() => undefined)
+
+  return true
+}
+
+/**
  * Pin the pooled socket for one relay route open across drain ticks. Returns
  * a once-only release. Local routes (null/empty or explicit `local` source)
  * are deliberately EXEMPT and get a no-op release: their Electron-spawned
@@ -926,6 +960,7 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
     entry.relayRetainCount = Math.max(0, (entry.relayRetainCount || 0) - 1)
 
     if (
+      !drainPendingConnectionRedial(entry) &&
       entry.relayRetainCount === 0 &&
       entry.activeRequests === 0 &&
       !entry.retained &&
@@ -991,6 +1026,10 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
 
     released = true
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
+
+    if (drainPendingConnectionRedial(entry)) {
+      return
+    }
 
     if (
       entry.activeRequests === 0 &&
@@ -1471,6 +1510,10 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
   const now = Date.now()
 
   for (const [key, entry] of [...g.secondaries]) {
+    if (drainPendingConnectionRedial(entry)) {
+      continue
+    }
+
     if (
       key === g.activeKey ||
       keep.has(key) ||
@@ -1604,12 +1647,13 @@ export function retireLocalProfileGateways(profile: string): void {
   }
 }
 
-// Registry lifecycle: a connection was removed or materially edited. Dispose
-// every secondary scoped to it (a removed remote/cloud source has no local
-// process to die, so without this its WebSocket stays open streaming ghost
-// events). With `redial` (the edit case) each disposed profile is re-dialed
-// through the normal open path so the fresh socket targets the NEW endpoint;
-// the active scope re-activates so the foreground keeps painting.
+// Registry lifecycle: a connection was removed or materially edited. Removal
+// disposes every scoped secondary immediately (a removed remote/cloud source
+// has no local process to die, so otherwise its WebSocket streams ghost
+// events). A material edit redials each profile through the normal open path so
+// fresh sockets target the NEW endpoint, but request/relay leases and mounted
+// foreground runtimes keep their old socket until they drain; the active scope
+// re-activates when its replacement is safe to publish.
 export function disposeSecondariesForConnection(connectionId: string, opts: { redial?: boolean } = {}): void {
   const id = String(connectionId || '').trim()
   let activeInvalidated = false
@@ -1625,6 +1669,12 @@ export function disposeSecondariesForConnection(connectionId: string, opts: { re
 
     const wasActive = key === g.activeKey
     activeInvalidated ||= wasActive
+
+    if (opts.redial && (entry.activeRequests > 0 || relayRetained(entry) || foregroundPinned(entry))) {
+      entry.pendingConnectionRedial = true
+
+      continue
+    }
 
     disposeSecondary(entry)
     g.secondaries.delete(key)

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -36,6 +36,19 @@ interface RegistryConfig {
    * (#89206: the stale-profile split-brain that stranded bot wake-ups).
    */
   onActiveRouteChanged?: (profile: string) => void
+  /**
+   * Scopes a FOREGROUND surface is bound to right now — every mounted
+   * session tile's owner and the primary thread's (foregroundSessionScopes in
+   * store/session-states; a config hook because that store imports this
+   * one). Consulted by EVERY dispose path — the live-work pruner and the
+   * dispose-at-refcount-0 request/relay leases alike (#93892): a tile's
+   * resume mints its runtime on its owner's socket, and any path that closes
+   * that socket makes the backend orphan-reap the runtime, whose
+   * `session.reclaimed` unbinds the tile and re-arms its resume — a spinner
+   * loop with no terminal state. Read at decision time, never cached: it
+   * follows the tile set, so closing the tile releases the socket.
+   */
+  foregroundScopes?: () => ReadonlySet<string>
 }
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
@@ -56,7 +69,16 @@ interface Secondary {
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
   reconnecting: boolean
-  /** True when a foreground/prewarmed consumer owns this entry beyond one RPC. */
+  /**
+   * True when a foreground/prewarmed consumer owns this entry beyond one RPC.
+   * Guards ONLY the dispose-at-refcount-0 paths (request/relay leases), never
+   * the live-work pruner: it is a one-way latch that every hover pre-warm and
+   * profile switch sets and nothing ever clears, so honoring it in
+   * pruneSecondaryGateways would pin every socket ever warmed. A foreground
+   * surface that must keep its owner socket (a mounted session tile, the
+   * primary thread) is represented in the pruner's keep-set instead — see
+   * foregroundSessionScopes in store/session-states (#93892).
+   */
   retained: boolean
   /**
    * Bot-relay retainers pinning this socket open across drain ticks (#93594).
@@ -695,7 +717,13 @@ async function gatewayForProfile(
       released = true
       entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-      if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+      if (
+        entry.activeRequests === 0 &&
+        !entry.retained &&
+        !relayRetained(entry) &&
+        !foregroundPinned(entry) &&
+        g.activeKey !== entry.scope
+      ) {
         disposeSecondary(entry)
 
         if (g.secondaries.get(entry.scope) === entry) {
@@ -811,7 +839,13 @@ export async function requestGatewayForAgent<T>(
   } finally {
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-    if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+    if (
+      entry.activeRequests === 0 &&
+      !entry.retained &&
+      !relayRetained(entry) &&
+      !foregroundPinned(entry) &&
+      g.activeKey !== entry.scope
+    ) {
       disposeSecondary(entry)
 
       if (g.secondaries.get(entry.scope) === entry) {
@@ -830,6 +864,22 @@ export async function requestGatewayForAgent<T>(
 // counted retention that keeps the pooled socket (and its existing
 // scheduleReconnect/backoff machinery) alive across ticks; stopBotRelay (and
 // plugin dispose) releases it, restoring the dispose-at-refcount-0 behavior.
+
+/**
+ * True when a foreground surface (mounted tile / primary thread) is bound to
+ * this entry's scope (#93892). Registry-scoped entries match on their
+ * composite key only; local/legacy entries also match on the bare profile —
+ * the same key language pruneSecondaryGateways' keep-set speaks.
+ */
+function foregroundPinned(entry: Secondary): boolean {
+  const scopes = g.config?.foregroundScopes?.()
+
+  if (!scopes) {
+    return false
+  }
+
+  return scopes.has(entry.scope) || (!entry.connectionId && scopes.has(entry.profile))
+}
 
 /** True when the bot relay currently pins this entry open. Number guard:
  *  dev-HMR entries predate the field. */
@@ -879,6 +929,7 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
       entry.relayRetainCount === 0 &&
       entry.activeRequests === 0 &&
       !entry.retained &&
+      !foregroundPinned(entry) &&
       g.activeKey !== entry.scope &&
       g.secondaries.get(entry.scope) === entry
     ) {
@@ -941,7 +992,13 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     released = true
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-    if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+    if (
+      entry.activeRequests === 0 &&
+      !entry.retained &&
+      !relayRetained(entry) &&
+      !foregroundPinned(entry) &&
+      g.activeKey !== entry.scope
+    ) {
       disposeSecondary(entry)
 
       if (g.secondaries.get(entry.scope) === entry) {
@@ -1400,6 +1457,16 @@ function restoreActiveToPrimaryIfEvicted(): void {
 // source exposes a 'default' profile, so matching a non-local entry on the
 // bare profile name kept gateway B's 'default' socket alive off gateway A's
 // 'default' activity (and vice versa) — cross-connection attribution.
+//
+// Live work is not the only thing worth a socket: an idle tile still holds a
+// resumed runtime on its owner's socket, and closing that socket makes the
+// backend detach and orphan-reap the runtime, whose `session.reclaimed`
+// unbinds the tile and re-resumes it on a fresh socket that the next
+// recompute closes again — a spinner loop with no terminal state (#93892).
+// Foreground-bound scopes come from the registry's `foregroundScopes` hook
+// (foregroundPinned), not from `keep`, so every dispose path sees the same
+// pin. `entry.retained` is deliberately NOT consulted here (see the field's
+// doc).
 export function pruneSecondaryGateways(keep: Set<string>): void {
   const now = Date.now()
 
@@ -1412,6 +1479,9 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       // its whole active lifetime; the live-work pruner must not undo that
       // pin between drain ticks or the socket churn returns.
       relayRetained(entry) ||
+      // A mounted tile / the primary thread is bound to a runtime on this
+      // socket (#93892) — pinned for as long as that surface is mounted.
+      foregroundPinned(entry) ||
       // Mid-dial activation target: the profile being switched TO is not yet
       // active and has no live work, so without this lease any recompute
       // during its cold spawn disposed the entry and the click died silently

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -162,6 +162,61 @@ describe('ensureGatewayAgent shares the gatewaySwitch mutex with profile switche
     expect($connection.get()?.profile).toBe('research')
   })
 
+  it('serializes every profile waiter after three overlapping activations wake together', async () => {
+    const firstGate = deferred()
+    const secondGate = deferred()
+    const thirdGate = deferred()
+    const order: string[] = []
+
+    ensureGatewayForProfile.mockImplementation(async (profile: string) => {
+      order.push(`start:${profile}`)
+
+      if (profile === 'worker') {
+        await firstGate.promise
+      } else if (profile === 'research') {
+        await secondGate.promise
+      } else if (profile === 'writer') {
+        await thirdGate.promise
+      }
+
+      order.push(`finish:${profile}`)
+    })
+    getConnection.mockImplementation(async profile => localConn({ profile: profile || 'default' }))
+
+    const first = ensureGatewayProfile('worker')
+    await Promise.resolve()
+    const second = ensureGatewayProfile('research')
+    const third = ensureGatewayProfile('writer')
+    await Promise.resolve()
+
+    expect(order).toEqual(['start:worker'])
+
+    firstGate.resolve()
+    await first
+    await vi.waitFor(() => expect(order).toContain('start:research'))
+
+    // The third activation was requested last, but it must not enter while the
+    // second waiter owns the switch mutex after both woke behind `worker`.
+    expect(order).not.toContain('start:writer')
+
+    secondGate.resolve()
+    await second
+    await vi.waitFor(() => expect(order).toContain('start:writer'))
+    thirdGate.resolve()
+    await third
+
+    expect(order).toEqual([
+      'start:worker',
+      'finish:worker',
+      'start:research',
+      'finish:research',
+      'start:writer',
+      'finish:writer'
+    ])
+    expect($activeGatewayProfile.get()).toBe('writer')
+    expect($connection.get()?.profile).toBe('writer')
+  })
+
   it('serializes a profile switch behind an in-flight agent activation', async () => {
     const agentGate = deferred()
     const order: string[] = []

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -261,6 +261,74 @@ export interface AgentProfileRoute {
 // change before the first Send; the draft's owner must not change with it.
 export const $newChatRoute = atom<AgentProfileRoute | null>(null)
 
+// The registry source captured TOGETHER with a $newChatProfile intent
+// (selectProfile / newSessionInProfile / a connection switch / `/profile`).
+// A profile is not a machine-global name: "omar" picked while the remote
+// registry source `homelab` is active means homelab::omar — the exact registry
+// entry whose WebSocket will mint the runtime. Without this the profile-rail
+// path (which deliberately clears $newChatRoute) reduced the owner to the bare
+// string "omar", and every follow-up RPC dialed requestGatewayForProfile
+// ("omar") — a DIFFERENT socket than the one that created the session —
+// and 4001'd "session not found" (#94071). null = the intent dials the legacy
+// profile-only path (a v1 primary with no registry identity, or a profile
+// pick on the explicit `local` source — see profilePickConnectionId).
+export const $newChatConnectionId = atom<null | string>(null)
+
+/** Capture the registry source a new-chat profile intent lands on — by
+ *  default the active one; callers that dial a different door (a profile
+ *  pick, see profilePickConnectionId) pass the source that door uses. */
+export function captureNewChatSource(connectionId: null | string = activeGatewayConnectionId()): void {
+  $newChatConnectionId.set(connectionId)
+}
+
+/**
+ * The registry source a PROFILE PICK dials, mirroring activateOnCurrentSource:
+ * a live remote registry source keeps its connection id, while the primary and
+ * the explicit `local` source take the legacy profile-only path (null) so the
+ * main process can resolve a per-profile remote override before falling back
+ * to a local backend. The draft's owner must name the socket that activation
+ * dials — capturing `local` for a pick would mint the session on the registry
+ * entry local::x while the window shows the override's socket.
+ */
+function profilePickConnectionId(): null | string {
+  const connectionId = activeGatewayConnectionId()
+
+  return connectionId && connectionId !== LOCAL_CONNECTION_ID ? connectionId : null
+}
+
+/**
+ * The EXACT owner route the next new chat is created on, or null for the
+ * legacy ambient path. An explicit agent route ($newChatRoute) wins; else,
+ * whenever a registry source is live, the (connection, profile) pair is
+ * derived from the source captured with the profile intent — falling back to
+ * the source a profile pick would dial (an uncaptured intent), or to the
+ * active source when there is no profile intent at all — so session.create,
+ * the owner hint, the optimistic row and every later session-scoped RPC name
+ * the same registry entry. A legacy profile-only activation yields null.
+ */
+export function resolveNewChatOwnerRoute(): AgentProfileRoute | null {
+  const explicit = $newChatRoute.get()
+
+  if (explicit) {
+    return explicit
+  }
+
+  const intentProfile = $newChatProfile.get()
+
+  const connectionId = (
+    (intentProfile ? ($newChatConnectionId.get() ?? profilePickConnectionId()) : activeGatewayConnectionId()) ?? ''
+  ).trim()
+
+  if (!connectionId) {
+    return null
+  }
+
+  return {
+    connectionId,
+    profile: normalizeProfileKey(intentProfile || $activeGatewayProfile.get())
+  }
+}
+
 // Bumped whenever the open session should be dropped for a fresh new-session
 // draft: a profile switch/create (below), or deleting the project that owns the
 // currently-open session (store/projects). The chat controller subscribes and
@@ -681,6 +749,11 @@ export function selectProfile(name: string): void {
   $showAllProfiles.set(false)
   $newChatProfile.set(target)
   $newChatRoute.set(null)
+  // Clearing the agent route must NOT discard the registry identity: the pick
+  // is made on the source the user is looking at (activateOnCurrentSource
+  // dials exactly that pair), so the draft's exact owner is that pair — or the
+  // legacy profile-only path when that is the door the pick takes.
+  captureNewChatSource(profilePickConnectionId())
 
   if (switching) {
     requestFreshSession()
@@ -723,11 +796,9 @@ export function selectProfile(name: string): void {
 // the main process can resolve a per-profile remote override before falling
 // back to a local backend.
 function activateOnCurrentSource(target: string): Promise<void> {
-  const connectionId = activeGatewayConnectionId()
+  const connectionId = profilePickConnectionId()
 
-  return connectionId && connectionId !== LOCAL_CONNECTION_ID
-    ? ensureGatewayAgent(connectionId, target)
-    : ensureGatewayProfile(target)
+  return connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target)
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
@@ -740,6 +811,7 @@ export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
   $newChatRoute.set(null)
+  captureNewChatSource(profilePickConnectionId())
   requestFreshSession()
   // #81094: surface the failed dial instead of failing silently.
   void activateOnCurrentSource(target).catch((error: unknown) => {
@@ -766,6 +838,7 @@ export function newSessionInAgent(route: AgentProfileRoute): void {
 
   $newChatProfile.set(captured.profile)
   $newChatRoute.set(captured)
+  $newChatConnectionId.set(captured.connectionId)
   requestFreshSession()
   // #81094: surface the failed dial instead of failing silently.
   void ensureGatewayAgent(captured.connectionId, captured.profile).catch((error: unknown) => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -26,6 +26,7 @@ import {
 import { notifyError } from '@/store/notifications'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { setConnection } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -250,12 +251,9 @@ export const $activeGatewayProfile = atom<string>('default')
 // Profile for the NEXT new chat (chosen via the new-chat picker). null = primary
 // / default, so single-profile users are unaffected.
 export const $newChatProfile = atom<string | null>(null)
-export interface AgentProfileRoute {
-  connectionId: string
-  mode?: 'local' | 'remote'
-  profile: string
-  targetProfile?: string
-}
+/** The draft's exact owner — the same shape every session-scoped surface
+ *  routes by (store/session-request-router SessionOwnerRoute). */
+export type AgentProfileRoute = SessionOwnerRoute
 
 // A draft remembers the source it was created for. The active gateway may
 // change before the first Send; the draft's owner must not change with it.

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -470,14 +470,16 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     return
   }
 
-  // Serialize concurrent activations so two rapid session switches don't race
-  // the active pointer.
-  if (gatewaySwitch) {
+  // Serialize concurrent activations so rapid session switches cannot race the
+  // active pointer. Re-acquire after every wake: multiple waiters can observe
+  // the same settled switch, and the first one starts the next switch before
+  // the others resume.
+  while (gatewaySwitch) {
     await gatewaySwitch.catch(() => undefined)
+  }
 
-    if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
-      return
-    }
+  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+    return
   }
 
   $gatewaySwapTarget.set(target)

--- a/apps/desktop/src/store/session-owner-resolution.test.ts
+++ b/apps/desktop/src/store/session-owner-resolution.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { $connectionsRegistry } from './connections'
+import { $profiles } from './profile'
+import {
+  ambientGatewayOwnsEverySession,
+  assertSessionOwnerResolved,
+  sessionOwnerIsKnown
+} from './session-owner-resolution'
+
+const registry = (...ids: string[]) =>
+  ({
+    connections: ids.map(id => ({ id })),
+    lastUsed: ids[0] ?? null,
+    launchMode: 'primary',
+    primary: ids[0] ?? null
+  }) as never
+
+beforeEach(() => {
+  $connectionsRegistry.set(null)
+  $profiles.set([])
+})
+
+describe('session owner topology', () => {
+  it('fails closed on an unknown owner in registry topology while preserving legacy profile routes', () => {
+    // A connection registry means the ambient gateway is never provably the
+    // sole backend, even with one profile listed: an unknown owner fails
+    // closed. A bare profile still names a backend — the legacy profile door
+    // (a pick on the primary / explicit `local` source) mints sessions owned
+    // by that profile's pool socket in every topology.
+    $connectionsRegistry.set(registry('local'))
+    $profiles.set([{ name: 'default' }] as never)
+
+    expect(sessionOwnerIsKnown('default')).toBe(true)
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() =>
+      assertSessionOwnerResolved('default', { method: 'session.resume', sessionId: 'registry-profile' })
+    ).not.toThrow()
+    expect(() => assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'unknown-owner' })).toThrow(
+      /could not be resolved/i
+    )
+
+    $connectionsRegistry.set(registry('local', 'homelab'))
+    expect(sessionOwnerIsKnown(null)).toBe(false)
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() => assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'unknown-owner' })).toThrow(
+      /could not be resolved/i
+    )
+
+    $connectionsRegistry.set(null)
+    expect(sessionOwnerIsKnown('default')).toBe(true)
+    expect(ambientGatewayOwnsEverySession()).toBe(true)
+    expect(() =>
+      assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'legacy-single-profile' })
+    ).not.toThrow()
+
+    $profiles.set([{ name: 'default' }, { name: 'loki' }] as never)
+    expect(sessionOwnerIsKnown('loki')).toBe(true)
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() =>
+      assertSessionOwnerResolved('loki', { method: 'session.resume', sessionId: 'legacy-profile-owner' })
+    ).not.toThrow()
+  })
+})

--- a/apps/desktop/src/store/session-owner-resolution.test.ts
+++ b/apps/desktop/src/store/session-owner-resolution.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connectionsRegistry } from './connections'
 import { $profiles } from './profile'
@@ -21,7 +21,28 @@ beforeEach(() => {
   $profiles.set([])
 })
 
+afterEach(() => {
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
 describe('session owner topology', () => {
+  it('fails closed while the modern registry bridge is present but its async cache is not loaded', () => {
+    ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = {
+      connections: { list: vi.fn(async () => Promise.reject(new Error('ipc unavailable'))) }
+    }
+    $connectionsRegistry.set(null)
+    $profiles.set([{ name: 'default' }] as never)
+
+    expect(sessionOwnerIsKnown('default')).toBe(true)
+    expect(ambientGatewayOwnsEverySession()).toBe(false)
+    expect(() =>
+      assertSessionOwnerResolved('default', { method: 'session.resume', sessionId: 'registry-loading' })
+    ).not.toThrow()
+    expect(() => assertSessionOwnerResolved(null, { method: 'session.resume', sessionId: 'registry-loading' })).toThrow(
+      /could not be resolved/i
+    )
+  })
+
   it('fails closed on an unknown owner in registry topology while preserving legacy profile routes', () => {
     // A connection registry means the ambient gateway is never provably the
     // sole backend, even with one profile listed: an unknown owner fails

--- a/apps/desktop/src/store/session-owner-resolution.ts
+++ b/apps/desktop/src/store/session-owner-resolution.ts
@@ -13,12 +13,12 @@
  * session is left untouched for the next correctly-routed attempt.
  *
  * The ONE case where the ambient gateway is not a fallback but the owner by
- * construction: no registry source is live (legacy v1 primary) AND at most
+ * construction: no registry topology exists (legacy v1 primary) AND at most
  * one profile exists — a single backend serves every session, so there is
  * nothing to misroute to. Older single-profile backends omit `profile` on
  * their rows entirely; those users keep working unchanged.
  */
-import { activeGatewayConnectionId } from './gateway'
+import { hasRegistryTopology } from './connection-registry-state'
 import { $profiles } from './profile'
 import { isSessionOwnerRoute, type SessionOwnerScope } from './session-request-router'
 
@@ -44,13 +44,19 @@ export function isSessionOwnerResolutionError(error: unknown): error is SessionO
 }
 
 /** True when the ambient gateway is provably the only backend any session
- *  can live on (legacy single-backend Desktop): no registry source is active
- *  and there is at most one profile. Everything else has somewhere to misroute. */
+ *  can live on (legacy single-backend Desktop): Electron has published no
+ *  connection registry and there is at most one profile. The active route is
+ *  presentation state; a null active connection does not prove sole topology. */
 export function ambientGatewayOwnsEverySession(): boolean {
-  return activeGatewayConnectionId() === null && $profiles.get().length <= 1
+  return !hasRegistryTopology() && $profiles.get().length <= 1
 }
 
-/** True when `owner` names a backend (an exact route or a profile). */
+/** True when `owner` names a backend: an exact connection route, or a bare
+ *  profile. A bare profile stays an owner in registry topology too — a profile
+ *  pick on the primary or the explicit `local` source takes the legacy
+ *  profile-only door (store/profile activateOnCurrentSource, so a per-profile
+ *  remote override resolves), and a session minted there is owned by that
+ *  profile's pool socket, which requestForSessionProfile dials by name. */
 export function sessionOwnerIsKnown(owner: SessionOwnerScope): boolean {
   if (isSessionOwnerRoute(owner)) {
     return Boolean(owner.connectionId.trim())

--- a/apps/desktop/src/store/session-owner-resolution.ts
+++ b/apps/desktop/src/store/session-owner-resolution.ts
@@ -1,0 +1,76 @@
+/**
+ * Fail-closed owner resolution for session-scoped RPCs.
+ *
+ * A request that carries a `session_id` only means anything on the backend
+ * that OWNS that session. When every rung of the owner ladder (tile route →
+ * exact owner hint → connection-tagged / profiled row → cross-profile REST
+ * probe) misses, the request must NOT quietly ride the ambient presentation
+ * gateway: "active" is presentation state with no routing authority, and an
+ * ambient fallback turns missing ownership metadata into a misleading backend
+ * "session not found" (or, worse, an answer from a backend that merely happens
+ * to know a same-named session). Surface an explicit owner-resolution error
+ * instead — the caller's error UX shows it, and the runtime that minted the
+ * session is left untouched for the next correctly-routed attempt.
+ *
+ * The ONE case where the ambient gateway is not a fallback but the owner by
+ * construction: no registry source is live (legacy v1 primary) AND at most
+ * one profile exists — a single backend serves every session, so there is
+ * nothing to misroute to. Older single-profile backends omit `profile` on
+ * their rows entirely; those users keep working unchanged.
+ */
+import { activeGatewayConnectionId } from './gateway'
+import { $profiles } from './profile'
+import { isSessionOwnerRoute, type SessionOwnerScope } from './session-request-router'
+
+export class SessionOwnerResolutionError extends Error {
+  constructor(
+    readonly sessionId: string,
+    readonly method: string
+  ) {
+    super(
+      `Session owner could not be resolved for "${sessionId}" (${method}): ` +
+        'no owner route, hint, connection-tagged row or profile probe named the backend that holds this session, ' +
+        'and routing it to the active gateway would be a guess.'
+    )
+    this.name = 'SessionOwnerResolutionError'
+  }
+}
+
+export function isSessionOwnerResolutionError(error: unknown): error is SessionOwnerResolutionError {
+  return (
+    error instanceof SessionOwnerResolutionError ||
+    (error as { name?: unknown })?.name === 'SessionOwnerResolutionError'
+  )
+}
+
+/** True when the ambient gateway is provably the only backend any session
+ *  can live on (legacy single-backend Desktop): no registry source is active
+ *  and there is at most one profile. Everything else has somewhere to misroute. */
+export function ambientGatewayOwnsEverySession(): boolean {
+  return activeGatewayConnectionId() === null && $profiles.get().length <= 1
+}
+
+/** True when `owner` names a backend (an exact route or a profile). */
+export function sessionOwnerIsKnown(owner: SessionOwnerScope): boolean {
+  if (isSessionOwnerRoute(owner)) {
+    return Boolean(owner.connectionId.trim())
+  }
+
+  return owner != null && Boolean(String(owner).trim())
+}
+
+/**
+ * Gate before a session-scoped RPC falls to the ambient dispatcher. Throws
+ * SessionOwnerResolutionError when the session's owner is unknown and the
+ * ambient gateway is not the sole backend; otherwise returns normally.
+ */
+export function assertSessionOwnerResolved(
+  owner: SessionOwnerScope,
+  context: { method: string; sessionId: null | string | undefined }
+): void {
+  if (!context.sessionId || sessionOwnerIsKnown(owner) || ambientGatewayOwnsEverySession()) {
+    return
+  }
+
+  throw new SessionOwnerResolutionError(context.sessionId, context.method)
+}

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -78,6 +78,7 @@ const {
 } = await import('./gateway')
 
 const { requestForSessionProfile, sessionRpcNeedsProfileRoute } = await import('./session-request-router')
+const { $connectionsRegistry } = await import('./connection-registry-state')
 
 function installDesktop(): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -103,6 +104,7 @@ function makePrimary() {
 beforeEach(() => {
   secondaryGateways.length = 0
   promptAckStatus = null
+  $connectionsRegistry.set(null)
   configureGatewayRegistry({ onEvent: vi.fn() })
   closeSecondaryGateways()
 })
@@ -177,6 +179,26 @@ describe('sessionRpcNeedsProfileRoute', () => {
 })
 
 describe('requestForSessionProfile', () => {
+  it('keeps routing a bare profile owner through its legacy profile pool when a connection registry exists', async () => {
+    // A profile pick on the primary or the explicit `local` source takes the
+    // legacy profile-only door (store/profile activateOnCurrentSource), so a
+    // session minted there is owned by that profile's pool socket in every
+    // topology — a registry does not turn the bare profile into a guess.
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop()
+    $connectionsRegistry.set({ connections: [{ id: 'local' }] } as never)
+    const ambient = vi.fn(async () => ({ ambient: true }))
+
+    await expect(
+      requestForSessionProfile('loki', ambient as never, 'session.resume', { session_id: 'stored-a' })
+    ).resolves.toEqual({ method: 'session.resume', params: { session_id: 'stored-a' } })
+    expect(window.hermesDesktop!.getConnection).toHaveBeenCalledWith('loki')
+    expect(secondaryGateways).toHaveLength(1)
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
   it('keeps concurrent same-name requests pinned while foreground activation changes', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -131,6 +131,8 @@ async function withRoutedTurnLease<T>(
  *
  * A KNOWN owner (route or profile name) always needs its own socket: the
  * session belongs to that profile regardless of what the window is showing.
+ * A bare profile names the legacy profile door's pool socket in every
+ * topology (a pick on the primary / explicit `local` source dials it).
  * There is deliberately NO comparison against the active profile — "active" is
  * presentation state, never a routing authority. Only a null/empty owner (a
  * fresh draft with no session, or global chrome) routes ambient.

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -1,13 +1,47 @@
 import { requestGatewayForAgent, requestGatewayForProfile, retainGatewayForSessionTurn } from '@/store/gateway'
 
-export interface SessionProfileRoute {
+/**
+ * The ONE authoritative exact owner of a session: the registry connection whose
+ * socket minted (or resumed) the runtime, plus the Desktop profile that selects
+ * that route. `targetProfile` is the backend profile the route serves when it
+ * differs from the Desktop-side name (remote overrides); `mode` is informative.
+ *
+ * Captured ONCE at the new-chat intent / send linearization point
+ * (store/profile resolveNewChatOwnerRoute) and carried through session.create,
+ * the owner hint, the optimistic row, the runtime binding, the foreground hold
+ * and every later session-scoped RPC. Never re-derived from ambient state after
+ * an asynchronous activation: connection/profile EQUALITY is not enough — the
+ * runtime lives on one concrete WebSocket, and only this route names the
+ * registry entry that holds it.
+ */
+export interface SessionOwnerRoute {
   connectionId: string
   mode?: 'local' | 'remote'
   profile: string
   targetProfile?: string
 }
 
-export type SessionOwnerScope = undefined | null | string | SessionProfileRoute
+/** @deprecated Alias kept for existing imports; new code names SessionOwnerRoute. */
+export type SessionProfileRoute = SessionOwnerRoute
+
+export type SessionOwnerScope = undefined | null | string | SessionOwnerRoute
+
+/** Exact owner reconstructed from a CONNECTION-TAGGED session row (the
+ *  Electron unified-list splice tags foreign registry rows; an optimistic row
+ *  carries the create route's connection; mergeSessionPage carries the tag
+ *  across refreshes). A row without a connection tag yields undefined — a bare
+ *  profile is not an exact owner. */
+export function sessionOwnerRouteFromRow(
+  row: { connection_id?: null | string; profile?: null | string } | null | undefined
+): SessionOwnerRoute | undefined {
+  const connectionId = String(row?.connection_id ?? '').trim()
+
+  if (!connectionId) {
+    return undefined
+  }
+
+  return { connectionId, profile: String(row?.profile ?? '').trim() || 'default' }
+}
 
 // ── Session-scoped RPC routing (the #89206 class) ───────────────────────────
 // A session-scoped RPC (session.resume / session.activate / session.usage /
@@ -29,8 +63,10 @@ export type SessionOwnerScope = undefined | null | string | SessionProfileRoute
 
 const normKey = (profile: null | string | undefined): string => (profile ?? '').trim() || 'default'
 
-const isRoute = (owner: SessionOwnerScope): owner is SessionProfileRoute =>
+export const isSessionOwnerRoute = (owner: SessionOwnerScope): owner is SessionOwnerRoute =>
   Boolean(owner && typeof owner === 'object' && 'connectionId' in owner)
+
+const isRoute = isSessionOwnerRoute
 
 function routeParams(route: SessionProfileRoute, params: Record<string, unknown>): Record<string, unknown> {
   if (!route.targetProfile || !Object.prototype.hasOwnProperty.call(params, 'profile')) {

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $selectedStoredSessionId,
+  _resetSessionOwnerHintsForTests,
+  setActiveSessionId,
+  setSessionOwnerHint
+} from '@/store/session'
+
+import {
+  $sessionTiles,
+  _resetSessionOwnerHoldsForTests,
+  foregroundSessionScopes,
+  holdSessionOwnerUntilForeground,
+  recordSessionEventScope,
+  releaseSessionOwnerHold
+} from './session-states'
+
+// A routed session.create returns a stored id on the owner's socket, but the
+// surface that will pin that socket (the selected primary thread, or a tile)
+// is published later and asynchronously. The hold names the owner in
+// foregroundSessionScopes — the gateway keep-set — from the moment the create
+// returns until the foreground publication takes over, the caller releases
+// it, or a bounded TTL expires. Nothing latches.
+
+afterEach(() => {
+  $sessionTiles.set([])
+  setActiveSessionId(null)
+  $selectedStoredSessionId.set(null)
+  _resetSessionOwnerHoldsForTests()
+  _resetSessionOwnerHintsForTests({ storage: true })
+  vi.useRealTimers()
+})
+
+describe('foregroundSessionScopes: owner hold across the create → foreground gap', () => {
+  const omar = { connectionId: 'local', mode: 'local' as const, profile: 'omar' }
+
+  it('names the owner from the moment a routed create returns, before anything is selected or tiled', () => {
+    holdSessionOwnerUntilForeground('stored-fresh', omar)
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
+  })
+
+  it('retires once the foreground publication covers it (selected primary thread / mounted tile)', () => {
+    holdSessionOwnerUntilForeground('stored-fresh', omar)
+    setSessionOwnerHint('stored-fresh', omar)
+
+    // Selected, but the runtime's event scope is not known yet: the hold is
+    // still the only thing naming the owner socket, so it stays.
+    $selectedStoredSessionId.set('stored-fresh')
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
+
+    // The first event from the owner socket records the runtime's scope; the
+    // selected-thread rung now covers it and the hold retires for good.
+    recordSessionEventScope({ connectionId: 'local', profile: 'omar', session_id: 'rt-fresh' })
+    setActiveSessionId('rt-fresh')
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
+    setActiveSessionId(null)
+    $selectedStoredSessionId.set(null)
+    _resetSessionOwnerHintsForTests()
+    expect(foregroundSessionScopes()).toEqual(new Set())
+
+    holdSessionOwnerUntilForeground('stored-tile', { connectionId: 'homelab', profile: 'bot' })
+    $sessionTiles.set([{ ownerRoute: { connectionId: 'homelab', profile: 'bot' }, storedSessionId: 'stored-tile' }])
+    // Covered by the tile's own route rung now; the hold retired.
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:homelab::bot']))
+    $sessionTiles.set([])
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('is released explicitly by the caller (failed create / drift close) and expires on its own', () => {
+    vi.useFakeTimers()
+
+    const release = holdSessionOwnerUntilForeground('stored-a', omar)
+    holdSessionOwnerUntilForeground('stored-b', { connectionId: 'homelab', profile: 'worker' })
+
+    release()
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:homelab::worker']))
+
+    releaseSessionOwnerHold('stored-b')
+    expect(foregroundSessionScopes()).toEqual(new Set())
+
+    holdSessionOwnerUntilForeground('stored-c', omar)
+    vi.advanceTimersByTime(60_000 + 1)
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('ignores blank ids, null owners and profile-only owners map to the legacy pool key', () => {
+    holdSessionOwnerUntilForeground('  ', omar)
+    holdSessionOwnerUntilForeground('stored-null', null)
+    holdSessionOwnerUntilForeground('stored-legacy', 'research')
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['research']))
+  })
+})

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/store/session'
 
 import {
+  $sessionOwnerHoldRevision,
   $sessionTiles,
   _resetSessionOwnerHoldsForTests,
   foregroundSessionScopes,
@@ -83,6 +84,25 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     holdSessionOwnerUntilForeground('stored-c', omar)
     vi.advanceTimersByTime(60_000 + 1)
     expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('publishes hold release and TTL expiry so pending gateway redials can drain without unrelated UI state', () => {
+    vi.useFakeTimers()
+    const revisions: number[] = []
+    const off = $sessionOwnerHoldRevision.subscribe(value => revisions.push(value))
+
+    const release = holdSessionOwnerUntilForeground('stored-release', omar)
+    const afterHold = revisions.at(-1)!
+    release()
+    expect(revisions.at(-1)).toBeGreaterThan(afterHold)
+
+    holdSessionOwnerUntilForeground('stored-expiry', omar)
+    const beforeExpiry = revisions.at(-1)!
+    vi.advanceTimersByTime(60_000 + 1)
+    expect(revisions.at(-1)).toBeGreaterThan(beforeExpiry)
+    expect(foregroundSessionScopes()).toEqual(new Set())
+
+    off()
   })
 
   it('ignores blank ids, null owners and profile-only owners map to the legacy pool key', () => {

--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -1,6 +1,18 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $sessionTiles, storedSessionIdForRuntimeId } from '@/store/session-states'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $profiles } from '@/store/profile'
+import { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } from '@/store/session'
+import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
+import {
+  $sessionTiles,
+  clearAllSessionStates,
+  knownOwnerForSession,
+  publishSessionState,
+  requestForOwnedSession,
+  storedSessionIdForRuntimeId
+} from '@/store/session-states'
+import { makeSessionInfo } from '@/test/session-info'
 
 // #92687-adjacent Bot Mode misroute: a session RPC (prompt.submit et al.)
 // carries its target as a RUNTIME id, while tile owner routes key on the
@@ -47,6 +59,20 @@ describe('storedSessionIdForRuntimeId', () => {
     expect(storedSessionIdForRuntimeId('undefined')).toBeNull()
   })
 
+  it('maps a MAIN-PANE runtime id through the per-runtime state mirror (no tile involved)', () => {
+    // approval.respond from a native notification, a queued send: the caller
+    // holds the runtime id of the primary thread, which no tile knows. The
+    // state mirror carries the stored id the wiring cache bound.
+    publishSessionState('rt-main', createClientSessionState('stored-main'))
+
+    expect(storedSessionIdForRuntimeId('rt-main')).toBe('stored-main')
+    // A detached runtime (null stored id) is still unknown.
+    publishSessionState('rt-detached', createClientSessionState(null))
+    expect(storedSessionIdForRuntimeId('rt-detached')).toBeNull()
+
+    clearAllSessionStates()
+  })
+
   it('prefers the stored-id identity when one tile is stored-matched and another is runtime-matched', () => {
     // Pathological but possible after a stale rebind: some other tile's dead
     // runtimeId equals a live tile's storedSessionId. The stored-id claim is
@@ -57,5 +83,47 @@ describe('storedSessionIdForRuntimeId', () => {
     ])
 
     expect(storedSessionIdForRuntimeId('collision')).toBe('collision')
+  })
+})
+
+describe('knownOwnerForSession / requestForOwnedSession', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+    clearAllSessionStates()
+    setSessions([])
+    $profiles.set([])
+    _resetSessionOwnerHintsForTests({ storage: true })
+  })
+
+  it('resolves a main-pane runtime id to its EXACT owner via the mirror + the hint, then the tagged row', () => {
+    publishSessionState('rt-main', createClientSessionState('stored-main'))
+    setSessionOwnerHint('stored-main', { connectionId: 'local', profile: 'omar' })
+
+    expect(knownOwnerForSession('rt-main')).toEqual({ connectionId: 'local', profile: 'omar' })
+
+    _resetSessionOwnerHintsForTests()
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-main', profile: 'omar' })])
+    expect(knownOwnerForSession('rt-main')).toEqual({ connectionId: 'local', profile: 'omar' })
+
+    setSessions([makeSessionInfo({ id: 'stored-main', profile: 'coder' })])
+    expect(knownOwnerForSession('rt-main')).toBe('coder')
+  })
+
+  it('fails closed with an explicit owner-resolution error instead of the ambient socket', async () => {
+    // Somewhere to misroute to: two profiles exist.
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    const ambient = vi.fn(async () => ({ ok: true }))
+
+    await expect(
+      requestForOwnedSession('rt-orphan', ambient as never, 'approval.respond', { session_id: 'rt-orphan' })
+    ).rejects.toSatisfy(isSessionOwnerResolutionError)
+    expect(ambient).not.toHaveBeenCalled()
+
+    // Legacy single backend: the ambient gateway IS the owner.
+    $profiles.set([{ name: 'default' }] as never)
+    await expect(
+      requestForOwnedSession('rt-orphan', ambient as never, 'approval.respond', { session_id: 'rt-orphan' })
+    ).resolves.toEqual({ ok: true })
+    expect(ambient).toHaveBeenCalledWith('approval.respond', { session_id: 'rt-orphan' })
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -53,7 +53,8 @@ import {
   setBusy,
   setSessions
 } from './session'
-import { requestForSessionProfile, type SessionOwnerScope, type SessionProfileRoute } from './session-request-router'
+import { assertSessionOwnerResolved } from './session-owner-resolution'
+import { requestForSessionProfile, type SessionOwnerRoute, type SessionOwnerScope } from './session-request-router'
 import { ackStoredSessionId, markSessionUnreadFinished } from './session-unread'
 import { isBrowserWindow, isSecondaryWindow } from './windows'
 
@@ -102,6 +103,43 @@ export function liveSessionScopes(): Set<string> {
   return scopes
 }
 
+// ── Owner hold across the create → foreground gap ───────────────────────────
+// A routed session.create returns a stored id on the owner's socket, but the
+// surface that will PIN that socket (the selected primary thread, or a tile)
+// is published later and asynchronously: navigate → route effect →
+// $selectedStoredSessionId, or openSessionTile → $sessionTiles. In that gap
+// the entry has no active request, is not yet foreground-bound and, if the
+// user switched source meanwhile, is not the active key either — so the
+// live-work pruner or a refcount-0 lease release could close the socket that
+// holds the just-minted runtime before the first prompt.submit. The hold
+// names the owner in foregroundSessionScopes from the moment the create
+// returns until the foreground publication takes over (the stored id becomes
+// selected or tiled), the caller releases it (failed create / drift close),
+// or a bounded TTL expires — nothing latches.
+const SESSION_OWNER_HOLD_TTL_MS = 60_000
+const sessionOwnerHolds = new Map<string, { owner: SessionOwnerScope; until: number }>()
+
+export function holdSessionOwnerUntilForeground(storedSessionId: string, owner: SessionOwnerScope): () => void {
+  const id = storedSessionId.trim()
+
+  if (!id || !owner) {
+    return () => undefined
+  }
+
+  sessionOwnerHolds.set(id, { owner, until: Date.now() + SESSION_OWNER_HOLD_TTL_MS })
+
+  return () => releaseSessionOwnerHold(id)
+}
+
+export function releaseSessionOwnerHold(storedSessionId: string): void {
+  sessionOwnerHolds.delete(storedSessionId.trim())
+}
+
+/** @internal Tests. */
+export function _resetSessionOwnerHoldsForTests(): void {
+  sessionOwnerHolds.clear()
+}
+
 /**
  * Registry scopes owned by an open foreground surface, when known.
  *
@@ -111,6 +149,11 @@ export function liveSessionScopes(): Set<string> {
  * the same ownership contract: a non-focused idle tile is still user-visible
  * state and must not be evicted just because another pane has focus. Prefer the
  * live event scope, with the tile's persisted route as the pre-bind fallback.
+ *
+ * A just-created session's owner is named by its create → foreground hold
+ * (holdSessionOwnerUntilForeground) until the selected/tiled publication or
+ * a bounded TTL retires it, so nothing can close the socket that minted the
+ * runtime before the first prompt lands.
  */
 export function foregroundSessionScopes(): Set<string> {
   const scopes = new Set<string>()
@@ -123,7 +166,7 @@ export function foregroundSessionScopes(): Set<string> {
     }
   }
 
-  const addRouteScope = (route: SessionProfileRoute | undefined) => {
+  const addRouteScope = (route: SessionOwnerRoute | undefined) => {
     const connectionId = route?.connectionId?.trim()
     const profile = route?.profile?.trim()
 
@@ -137,6 +180,28 @@ export function foregroundSessionScopes(): Set<string> {
   for (const tile of $sessionTiles.get()) {
     addRuntimeScope(tile.runtimeId)
     addRouteScope(tile.ownerRoute)
+  }
+
+  // Create → foreground holds. A hold whose scope the rungs above already
+  // name (the runtime's event scope once selected, a mounted tile's route) is
+  // covered and retires; an expired one retires too.
+  const now = Date.now()
+
+  for (const [storedSessionId, hold] of [...sessionOwnerHolds]) {
+    const scope =
+      typeof hold.owner === 'string'
+        ? normalizeProfileKey(hold.owner)
+        : hold.owner?.connectionId?.trim()
+          ? registryBackendScopeKey(hold.owner.connectionId.trim(), normalizeProfileKey(hold.owner.profile))
+          : null
+
+    if (!scope || hold.until <= now || scopes.has(scope)) {
+      sessionOwnerHolds.delete(storedSessionId)
+
+      continue
+    }
+
+    scopes.add(scope)
   }
 
   return scopes
@@ -609,13 +674,13 @@ export interface SessionTile {
   /** Exact opaque owner key for Bot Mode tabs. */
   workspaceOwnerKey?: string
   /** Credential-free exact route used to resume this tab after relaunch. */
-  ownerRoute?: SessionProfileRoute
+  ownerRoute?: SessionOwnerRoute
   /** Stable title for hidden relationship chats absent from the Sessions list. */
   workspaceTabTitle?: string
 }
 
 export interface SessionTileWorkspaceScope {
-  ownerRoute?: SessionProfileRoute
+  ownerRoute?: SessionOwnerRoute
   workspaceMode: WorkspaceMode
   workspaceOwnerKey?: string
   workspaceTabTitle?: string
@@ -803,7 +868,7 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
   saveTiles($sessionTiles.get().map(t => (t.storedSessionId === storedSessionId ? { ...t, ...patch } : t)))
 }
 
-export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRoute | undefined {
+export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRoute | undefined {
   return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
 }
 
@@ -846,11 +911,12 @@ export function openTileGatewayScopes(): Set<string> {
  * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
  * Tile route first (exact connectionId+profile, survives relaunch), then the
  * exact unique owner hint (stamped when a routed create returns / at open
- * time), then the known session owner (a connection-tagged row's exact route,
- * else its profile / the hint). The hint outranks the row for the same reason
- * as contrib/wiring's ladder: a row can be stamped from the ambient profile
- * and carries no connection. Returns undefined when no owner is known — the
- * caller falls back to ambient, never to "active".
+ * time; persisted), then the session row's owner (an exact route when the row
+ * is connection-tagged, else its bare profile, else the hint's profile). The
+ * hint outranks the row for the same reason as contrib/wiring's ladder: a
+ * row can be stamped from the ambient profile and carries no connection.
+ * Returns undefined when no owner is known — the caller fails closed
+ * (assertSessionOwnerResolved), never falls to "active".
  */
 export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
   if (!sessionId) {
@@ -889,10 +955,12 @@ export function isSessionRemote(sessionId: null | string | undefined): boolean {
 
 /**
  * Dispatch a session-scoped RPC through the OWNER of `sessionId` (tile route →
- * known profile), falling back to the ambient dispatcher only when no owner is
- * known. This is the client half of #91684: approval.respond (and siblings)
- * sent on the ambient socket land on whatever backend is active, which for a
- * cross-profile session is a backend that never held the approval.
+ * hint → connection-tagged row / known profile). This is the client half of
+ * #91684: approval.respond (and siblings) sent on the ambient socket land on
+ * whatever backend is active, which for a cross-profile session is a backend
+ * that never held the approval. An UNKNOWN owner fails closed with an
+ * explicit SessionOwnerResolutionError unless the ambient gateway is provably
+ * the only backend (legacy single-profile, no registry source).
  */
 export function requestForOwnedSession<T>(
   sessionId: null | string | undefined,
@@ -907,7 +975,15 @@ export function requestForOwnedSession<T>(
   timeoutMs?: number,
   signal?: AbortSignal
 ): Promise<T> {
-  return requestForSessionProfile<T>(knownOwnerForSession(sessionId), ambientRequest, method, params, timeoutMs, signal)
+  const owner = knownOwnerForSession(sessionId)
+
+  try {
+    assertSessionOwnerResolved(owner, { method, sessionId })
+  } catch (error) {
+    return Promise.reject(error)
+  }
+
+  return requestForSessionProfile<T>(owner, ambientRequest, method, params, timeoutMs, signal)
 }
 
 /** Resolve a session id THAT MAY BE A RUNTIME ID to the stored id its tile
@@ -935,7 +1011,14 @@ export function storedSessionIdForRuntimeId(sessionId: string): null | string {
     }
   }
 
-  return null
+  // The per-runtime state mirror carries the stored id the wiring cache bound
+  // (ensureSessionState / a resume). This is how a MAIN-PANE runtime id — an
+  // approval.respond from a native notification, a queued send — finds its
+  // durable identity, and through it the exact owner (hint / tagged row).
+  // Without this rung such ids fell straight to the ambient socket.
+  const mirrored = $sessionStates.get()[sessionId]?.storedSessionId?.trim()
+
+  return mirrored || null
 }
 
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -117,7 +117,34 @@ export function liveSessionScopes(): Set<string> {
 // selected or tiled), the caller releases it (failed create / drift close),
 // or a bounded TTL expires — nothing latches.
 const SESSION_OWNER_HOLD_TTL_MS = 60_000
-const sessionOwnerHolds = new Map<string, { owner: SessionOwnerScope; until: number }>()
+
+const sessionOwnerHolds = new Map<
+  string,
+  { owner: SessionOwnerScope; timer: ReturnType<typeof setTimeout>; until: number }
+>()
+
+export const $sessionOwnerHoldRevision = atom(0)
+
+function bumpSessionOwnerHoldRevision(): void {
+  $sessionOwnerHoldRevision.set($sessionOwnerHoldRevision.get() + 1)
+}
+
+function forgetSessionOwnerHold(storedSessionId: string, publish: boolean): boolean {
+  const hold = sessionOwnerHolds.get(storedSessionId)
+
+  if (!hold) {
+    return false
+  }
+
+  clearTimeout(hold.timer)
+  sessionOwnerHolds.delete(storedSessionId)
+
+  if (publish) {
+    bumpSessionOwnerHoldRevision()
+  }
+
+  return true
+}
 
 export function holdSessionOwnerUntilForeground(storedSessionId: string, owner: SessionOwnerScope): () => void {
   const id = storedSessionId.trim()
@@ -126,18 +153,33 @@ export function holdSessionOwnerUntilForeground(storedSessionId: string, owner: 
     return () => undefined
   }
 
-  sessionOwnerHolds.set(id, { owner, until: Date.now() + SESSION_OWNER_HOLD_TTL_MS })
+  forgetSessionOwnerHold(id, false)
+  const until = Date.now() + SESSION_OWNER_HOLD_TTL_MS
+  const timer = setTimeout(() => releaseSessionOwnerHold(id), SESSION_OWNER_HOLD_TTL_MS)
+
+  sessionOwnerHolds.set(id, { owner, timer, until })
+  bumpSessionOwnerHoldRevision()
 
   return () => releaseSessionOwnerHold(id)
 }
 
 export function releaseSessionOwnerHold(storedSessionId: string): void {
-  sessionOwnerHolds.delete(storedSessionId.trim())
+  forgetSessionOwnerHold(storedSessionId.trim(), true)
 }
 
 /** @internal Tests. */
 export function _resetSessionOwnerHoldsForTests(): void {
+  const hadHolds = sessionOwnerHolds.size > 0
+
+  for (const hold of sessionOwnerHolds.values()) {
+    clearTimeout(hold.timer)
+  }
+
   sessionOwnerHolds.clear()
+
+  if (hadHolds) {
+    bumpSessionOwnerHoldRevision()
+  }
 }
 
 /**
@@ -196,7 +238,9 @@ export function foregroundSessionScopes(): Set<string> {
           : null
 
     if (!scope || hold.until <= now || scopes.has(scope)) {
-      sessionOwnerHolds.delete(storedSessionId)
+      // This recompute was already triggered by the covering publication (or
+      // is itself observing expiry), so avoid recursively publishing.
+      forgetSessionOwnerHold(storedSessionId, false)
 
       continue
     }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -43,6 +43,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
+  getSessionOwnerHint,
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
@@ -844,8 +845,12 @@ export function openTileGatewayScopes(): Set<string> {
 /**
  * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
  * Tile route first (exact connectionId+profile, survives relaunch), then the
- * known session owner (row or open-time hint). Returns undefined when no
- * owner is known — the caller falls back to ambient, never to "active".
+ * exact unique owner hint (stamped when a routed create returns / at open
+ * time), then the known session owner (a connection-tagged row's exact route,
+ * else its profile / the hint). The hint outranks the row for the same reason
+ * as contrib/wiring's ladder: a row can be stamped from the ambient profile
+ * and carries no connection. Returns undefined when no owner is known — the
+ * caller falls back to ambient, never to "active".
  */
 export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
   if (!sessionId) {
@@ -854,7 +859,11 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner($sessions.get(), storedSessionId)
+  return (
+    sessionTileOwnerRoute(storedSessionId) ??
+    getSessionOwnerHint(storedSessionId) ??
+    knownSessionOwner($sessions.get(), storedSessionId)
+  )
 }
 
 /**

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -26,13 +26,16 @@ import {
   $sessions,
   $unreadFinishedSessionIds,
   _resetLegacyDiscardForTests,
+  _resetSessionOwnerHintsForTests,
   applyConfiguredDefaultProjectDir,
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
+  forgetSessionOwnerHintsForConnection,
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  hydrateSessionOwnerHints,
   knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
@@ -61,6 +64,10 @@ import {
 const session = (over: Partial<SessionInfo>): SessionInfo => makeSessionInfo({ id: 'live', ...over })
 
 describe('session owner hints', () => {
+  afterEach(() => {
+    _resetSessionOwnerHintsForTests({ storage: true })
+  })
+
   it('preserves the registry owner recorded on a discovered session row', () => {
     expect(
       knownSessionOwner(
@@ -108,6 +115,93 @@ describe('session owner hints', () => {
     const scope = { connectionId: 'bounded-source', profile: 'worker' }
     expect(getSessionOwnerHint('bounded-0', scope)).toBeUndefined()
     expect(getSessionOwnerHint('bounded-256', scope)).toMatchObject({ connectionId: 'bounded-source' })
+  })
+
+  it('survives a relaunch: hints are persisted and rehydrated in LRU order', () => {
+    const omar = { connectionId: 'local', mode: 'local' as const, profile: 'omar' }
+    const remote = { connectionId: 'homelab', mode: 'remote' as const, profile: 'worker', targetProfile: 'w' }
+
+    setSessionOwnerHint('stored-omar', omar)
+    setSessionOwnerHint('stored-remote', remote)
+
+    // "Relaunch": the in-memory map is gone, storage is not.
+    _resetSessionOwnerHintsForTests()
+    expect(getSessionOwnerHint('stored-omar')).toBeUndefined()
+
+    hydrateSessionOwnerHints()
+
+    expect(getSessionOwnerHint('stored-omar')).toEqual(omar)
+    expect(getSessionOwnerHint('stored-remote')).toEqual(remote)
+
+    // LRU order survives: the oldest persisted entry is the first evicted.
+    for (let index = 0; index < 255; index += 1) {
+      setSessionOwnerHint(`filler-${index}`, { connectionId: 'filler', profile: 'p' })
+    }
+
+    expect(getSessionOwnerHint('stored-omar')).toBeUndefined()
+    expect(getSessionOwnerHint('stored-remote')).toEqual(remote)
+  })
+
+  it('ignores malformed persisted entries and never throws on hydrate', () => {
+    window.localStorage.setItem(
+      'hermes.desktop.sessionOwnerHints.v1',
+      JSON.stringify([
+        'junk',
+        ['no-route', null],
+        ['bad-shape', { connectionId: 7, profile: 'x' }],
+        ['good', { connectionId: 'local', profile: 'omar', mode: 'sideways' }]
+      ])
+    )
+
+    _resetSessionOwnerHintsForTests()
+    expect(() => hydrateSessionOwnerHints()).not.toThrow()
+    expect(getSessionOwnerHint('good')).toEqual({ connectionId: 'local', profile: 'omar' })
+    expect(getSessionOwnerHint('no-route')).toBeUndefined()
+    expect(getSessionOwnerHint('bad-shape')).toBeUndefined()
+  })
+
+  it('forgets every hint naming a removed connection, in memory and on disk', () => {
+    setSessionOwnerHint('stored-a', { connectionId: 'gone', profile: 'omar' })
+    setSessionOwnerHint('stored-b', { connectionId: 'gone', profile: 'default' })
+    setSessionOwnerHint('stored-c', { connectionId: 'local', profile: 'omar' })
+
+    forgetSessionOwnerHintsForConnection('gone')
+
+    expect(getSessionOwnerHint('stored-a')).toBeUndefined()
+    expect(getSessionOwnerHint('stored-b')).toBeUndefined()
+    expect(getSessionOwnerHint('stored-c')).toEqual({ connectionId: 'local', profile: 'omar' })
+
+    _resetSessionOwnerHintsForTests()
+    hydrateSessionOwnerHints()
+    expect(getSessionOwnerHint('stored-a')).toBeUndefined()
+    expect(getSessionOwnerHint('stored-c')).toEqual({ connectionId: 'local', profile: 'omar' })
+  })
+})
+
+describe('knownSessionOwner', () => {
+  afterEach(() => {
+    _resetSessionOwnerHintsForTests({ storage: true })
+  })
+
+  it('returns the EXACT route for a connection-tagged row, the bare profile otherwise', () => {
+    const rows = [
+      session({ connection_id: 'local', id: 'tagged', profile: 'omar' }),
+      session({ id: 'untagged', profile: 'coder' }),
+      session({ connection_id: '  ', id: 'blank-tag', profile: 'coder' })
+    ]
+
+    expect(knownSessionOwner(rows, 'tagged')).toEqual({ connectionId: 'local', profile: 'omar' })
+    expect(knownSessionOwner(rows, 'untagged')).toBe('coder')
+    expect(knownSessionOwner(rows, 'blank-tag')).toBe('coder')
+    expect(knownSessionOwner(rows, null)).toBeUndefined()
+  })
+
+  it('falls through to the EXACT hint route for an unlisted session', () => {
+    const route = { connectionId: 'homelab', profile: 'worker', targetProfile: 'w' }
+
+    setSessionOwnerHint('hidden', route)
+
+    expect(knownSessionOwner([], 'hidden')).toEqual(route)
   })
 })
 
@@ -201,6 +295,39 @@ describe('shouldMigrateComposerScope', () => {
 })
 
 describe('mergeSessionPage', () => {
+  it('carries the owning connection onto a row that comes back untagged (local registry source)', () => {
+    // A `local` registry source's rows are served by the primary aggregate as
+    // plain local rows: the unified-list splice tags only non-local sources.
+    // The refresh must not strip the exact owner the routed create stamped.
+    const previous = [session({ connection_id: 'local', id: 'omar-1', last_active: 5, profile: 'omar' })]
+    const incoming = [session({ id: 'omar-1', last_active: 5, profile: 'omar' })]
+
+    expect(mergeSessionPage(previous, incoming, [])[0]).toMatchObject({ connection_id: 'local', profile: 'omar' })
+  })
+
+  it('drops the carried tag when the refreshed row names a different profile, and never overrides an incoming tag', () => {
+    const previous = [
+      session({ connection_id: 'local', id: 'moved', profile: 'omar' }),
+      session({ connection_id: 'local', id: 'foreign', profile: 'omar' })
+    ]
+
+    const incoming = [
+      session({ id: 'moved', profile: 'default' }),
+      session({ connection_id: 'homelab', id: 'foreign', profile: 'omar' })
+    ]
+
+    const merged = mergeSessionPage(previous, incoming, [])
+    expect(merged.find(s => s.id === 'moved')?.connection_id).toBeUndefined()
+    expect(merged.find(s => s.id === 'foreign')?.connection_id).toBe('homelab')
+  })
+
+  it('keeps reference identity when the carried tag is already present', () => {
+    const previous = [session({ connection_id: 'local', id: 'same', last_active: 1, profile: 'omar' })]
+    const incoming = [session({ connection_id: 'local', id: 'same', last_active: 1, profile: 'omar' })]
+
+    expect(mergeSessionPage(previous, incoming, [])[0]).toBe(incoming[0])
+  })
+
   it('returns the server page untouched when there is nothing to keep', () => {
     const previous = [session({ id: 'a' }), session({ id: 'b' })]
     const incoming = [session({ id: 'a' })]

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -6,11 +6,11 @@ import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { activeConnectionScopeSuffix, rescopeConnectionScopedStores } from '@/lib/connection-scoped'
-import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
+import { persistBoolean, persistString, readJson, storedBoolean, storedString, writeJson } from '@/lib/storage'
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
-import type { SessionProfileRoute } from './session-request-router'
+import type { SessionOwnerRoute, SessionOwnerScope } from './session-request-router'
 import { clearUnreadOnOpen } from './session-unread-remote'
 
 type Updater<T> = T | ((current: T) => T)
@@ -132,16 +132,18 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
 }
 
 /**
- * The complete known owner of a session, including its registry connection
- * when the row or an open-time hint carries one. Session-scoped RPC callers
- * must use this instead of `knownSessionProfile`: two sources can expose the
- * same profile name, so returning only that name silently collapses the route
- * back to the local/profile-only path.
+ * The complete known owner of a session: the EXACT route when the row is
+ * connection-tagged (an optimistic row from a routed create, a foreign
+ * registry row from the unified-list splice, or a tag mergeSessionPage carried
+ * across a refresh), else the open-time / create-time owner hint when it
+ * agrees with the row, else the bare profile. Session-scoped RPC callers must
+ * use this instead of `knownSessionProfile`: two sources can expose the same
+ * profile name, so returning only that name silently collapses the route back
+ * to the local/profile-only path. The exact rungs are what let a session's
+ * owner be reconstructed after the bounded hint map has evicted it or the app
+ * relaunched.
  */
-export function knownSessionOwner(
-  sessions: readonly SessionInfo[],
-  sessionId: null | string
-): SessionProfileRoute | string | undefined {
+export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: null | string): SessionOwnerScope {
   if (!sessionId) {
     return undefined
   }
@@ -457,6 +459,24 @@ export function resolveComposerSessionKey(
  *  either its live `id` or its `_lineage_root_id`. Optimistic deletes/archives
  *  drop the row from `previous` (and unpin it), so a removed session can't be
  *  resurrected here. */
+const profileKeyOf = (profile: null | string | undefined): string => (profile ?? '').trim() || 'default'
+
+function carriedConnectionId(prev: SessionInfo | undefined, incoming: SessionInfo): string | undefined {
+  if (incoming.connection_id?.trim()) {
+    return incoming.connection_id
+  }
+
+  const carried = prev?.connection_id?.trim()
+
+  if (!carried) {
+    return undefined
+  }
+
+  return !incoming.profile?.trim() || profileKeyOf(incoming.profile) === profileKeyOf(prev?.profile)
+    ? carried
+    : undefined
+}
+
 export function mergeSessionPage(
   previous: SessionInfo[],
   incoming: SessionInfo[],
@@ -480,8 +500,19 @@ export function mergeSessionPage(
     // (last_active = MAX(messages.timestamp)). Keep the fresher of the two.
     const last_active = Math.max(prev?.last_active ?? 0, session.last_active ?? 0)
     const title = session.title?.trim() ? session.title : prev?.title?.trim() ? prev.title : session.title
+    // Carry the owning connection onto a row that arrives untagged. The
+    // primary aggregate serves a `local` registry source's rows as plain
+    // local rows (the unified-list splice tags only NON-local sources), so
+    // the first refresh after a routed create used to replace the optimistic
+    // row's exact owner (connection_id + profile) with a bare profile — after
+    // which only the transient owner hint knew which socket held the runtime.
+    // A refresh is new information layered over what we know, not a clobber;
+    // the tag is kept only while the row still names the same profile.
+    const connection_id = carriedConnectionId(prev, session)
 
-    return last_active === session.last_active && title === session.title ? session : { ...session, last_active, title }
+    return last_active === session.last_active && title === session.title && connection_id === session.connection_id
+      ? session
+      : { ...session, last_active, title, ...(connection_id ? { connection_id } : {}) }
   })
 
   if (keep.size === 0) {
@@ -657,31 +688,53 @@ export const $awaitingResponse = atom(false)
 // Null whenever the active route has a healthy (or in-flight) resume.
 export const $resumeFailedSessionId = atom<string | null>(null)
 export interface SessionResumeRequest {
-  ownerRoute?: SessionProfileRoute
+  ownerRoute?: SessionOwnerRoute
   sequence: number
   sessionId: string
 }
 let sessionResumeRequestSequence = 0
 export const $sessionResumeRequest = atom<SessionResumeRequest | null>(null)
+// ── Exact session owner hints ───────────────────────────────────────────────
+// The (connectionId, profile[, targetProfile, mode]) route a session was
+// created / resumed / opened on, keyed by stored id. Bounded LRU and
+// PERSISTED (best-effort, same origin storage as the tiles): the runtime a
+// routed create minted lives on one concrete socket, and after the sidebar
+// refresh replaced the optimistic row, or after a relaunch, this record is
+// how the exact owner is reconstructed for that session's next RPC instead of
+// degrading to a bare profile name that dials a different socket. Connection
+// ids are stable registry identities (`local`, registry uuids), so a hint
+// stays valid across restarts; forgetSessionOwnerHintsForConnection drops
+// them when a connection is removed from the registry.
 const SESSION_OWNER_HINT_LIMIT = 256
-const sessionOwnerHints = new Map<string, { id: string; route: SessionProfileRoute }>()
+const SESSION_OWNER_HINTS_KEY = 'hermes.desktop.sessionOwnerHints.v1'
+const sessionOwnerHints = new Map<string, { id: string; route: SessionOwnerRoute }>()
 
-function sessionOwnerHintKey(sessionId: string, route: Pick<SessionProfileRoute, 'connectionId' | 'profile'>): string {
+function sessionOwnerHintKey(sessionId: string, route: Pick<SessionOwnerRoute, 'connectionId' | 'profile'>): string {
   return JSON.stringify([route.connectionId.trim(), route.profile.trim() || 'default', sessionId])
 }
 
-export function setSessionOwnerHint(sessionId: string, route: SessionProfileRoute): void {
-  const id = sessionId.trim()
-
-  const normalized = {
+function normalizeOwnerRoute(route: SessionOwnerRoute): SessionOwnerRoute {
+  return {
     ...route,
     connectionId: route.connectionId.trim(),
     profile: route.profile.trim() || 'default',
     ...(route.targetProfile ? { targetProfile: route.targetProfile.trim() || 'default' } : {})
   }
+}
+
+function persistSessionOwnerHints(): void {
+  writeJson(
+    SESSION_OWNER_HINTS_KEY,
+    sessionOwnerHints.size === 0 ? null : [...sessionOwnerHints.values()].map(entry => [entry.id, entry.route])
+  )
+}
+
+function rememberSessionOwnerHint(sessionId: string, route: SessionOwnerRoute): boolean {
+  const id = sessionId.trim()
+  const normalized = normalizeOwnerRoute(route)
 
   if (!id || !normalized.connectionId) {
-    return
+    return false
   }
 
   const key = sessionOwnerHintKey(id, normalized)
@@ -697,9 +750,89 @@ export function setSessionOwnerHint(sessionId: string, route: SessionProfileRout
 
     sessionOwnerHints.delete(oldest)
   }
+
+  return true
 }
 
-export function getSessionOwnerHints(sessionId: string): SessionProfileRoute[] {
+/** Load persisted hints (oldest first, so LRU order survives). Malformed or
+ *  foreign-shaped entries are skipped; nothing here can throw. */
+export function hydrateSessionOwnerHints(): void {
+  const raw = readJson<unknown>(SESSION_OWNER_HINTS_KEY)
+
+  if (!Array.isArray(raw)) {
+    return
+  }
+
+  for (const entry of raw) {
+    if (!Array.isArray(entry) || entry.length !== 2) {
+      continue
+    }
+
+    const [id, route] = entry as [unknown, unknown]
+
+    if (
+      typeof id !== 'string' ||
+      !route ||
+      typeof route !== 'object' ||
+      typeof (route as SessionOwnerRoute).connectionId !== 'string' ||
+      typeof (route as SessionOwnerRoute).profile !== 'string'
+    ) {
+      continue
+    }
+
+    const candidate = route as SessionOwnerRoute
+
+    rememberSessionOwnerHint(id, {
+      connectionId: candidate.connectionId,
+      profile: candidate.profile,
+      ...(typeof candidate.targetProfile === 'string' ? { targetProfile: candidate.targetProfile } : {}),
+      ...(candidate.mode === 'local' || candidate.mode === 'remote' ? { mode: candidate.mode } : {})
+    })
+  }
+}
+
+hydrateSessionOwnerHints()
+
+export function setSessionOwnerHint(sessionId: string, route: SessionOwnerRoute): void {
+  if (rememberSessionOwnerHint(sessionId, route)) {
+    persistSessionOwnerHints()
+  }
+}
+
+/** Drop every hint naming `connectionId` — the registry no longer has it, so
+ *  nothing can dial that route again (fail-closed would otherwise pin those
+ *  sessions to a dead source forever). */
+export function forgetSessionOwnerHintsForConnection(connectionId: string): void {
+  const id = connectionId.trim()
+
+  if (!id) {
+    return
+  }
+
+  let changed = false
+
+  for (const [key, entry] of [...sessionOwnerHints]) {
+    if (entry.route.connectionId === id) {
+      sessionOwnerHints.delete(key)
+      changed = true
+    }
+  }
+
+  if (changed) {
+    persistSessionOwnerHints()
+  }
+}
+
+/** @internal Tests: forget every in-memory hint (storage untouched unless asked). */
+export function _resetSessionOwnerHintsForTests({ storage = false }: { storage?: boolean } = {}): void {
+  sessionOwnerHints.clear()
+
+  if (storage) {
+    writeJson(SESSION_OWNER_HINTS_KEY, null)
+  }
+}
+
+export function getSessionOwnerHints(sessionId: string): SessionOwnerRoute[] {
   const id = sessionId.trim()
 
   return [...sessionOwnerHints.values()].filter(entry => entry.id === id).map(entry => ({ ...entry.route }))
@@ -707,8 +840,8 @@ export function getSessionOwnerHints(sessionId: string): SessionProfileRoute[] {
 
 export function getSessionOwnerHint(
   sessionId: string,
-  scope?: Pick<SessionProfileRoute, 'connectionId' | 'profile'>
-): SessionProfileRoute | undefined {
+  scope?: Pick<SessionOwnerRoute, 'connectionId' | 'profile'>
+): SessionOwnerRoute | undefined {
   const id = sessionId.trim()
 
   if (scope) {
@@ -896,7 +1029,7 @@ export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($message
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 
-export const requestSessionResume = (sessionId: string, ownerRoute?: SessionProfileRoute) => {
+export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwnerRoute) => {
   const id = sessionId.trim()
 
   if (!id) {

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -15,6 +15,23 @@ vi.mock('@/lib/storage', () => ({
       storage.set(key, value)
     }
   },
+  // store/session persists its exact owner hints through the JSON helpers.
+  readJson: (key: string) => {
+    const value = storage.get(key)
+
+    try {
+      return value === undefined ? null : JSON.parse(value)
+    } catch {
+      return null
+    }
+  },
+  writeJson: (key: string, value: unknown) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, JSON.stringify(value))
+    }
+  },
   storedBoolean: (key: string, fallback: boolean) => {
     const value = storage.get(key)
 

--- a/contributors/emails/claw.8op8q@8alias.com
+++ b/contributors/emails/claw.8op8q@8alias.com
@@ -1,0 +1,1 @@
+Zeus-Deus


### PR DESCRIPTION
## What does this PR do?

Focused follow-up for **core Desktop profile-rail session-owner continuity**. Standalone on `main` since 2026-08-26 (rebased after #95080, #95082 and #95087 landed): #94145's commits are now in `main`, and nothing from #94147 or #94178 is included here.

`selectProfile(name)` / `newSessionInProfile(name)` keep only `$newChatProfile` and clear `$newChatRoute`. The send path captures the (registry source, profile) pair as the draft's exact owner at the send linearization point. Three gaps still let a session created on the composite gateway `conn:local::omar` degrade to the bare string `"omar"` — and `requestGatewayForProfile("omar")` is a **different WebSocket** than the one that minted the runtime, so the next session-scoped RPC 4001'd "session not found" while the runtime was ws-orphan-reaped. Connection/profile *equality* is not enough; the runtime must stay on the concrete gateway object that created or resumed it.

### 1. One authoritative owner, reconstructible without the transient hint

- **`SessionOwnerRoute`** (`store/session-request-router`) is the one canonical shape `{ connectionId, profile, targetProfile?, mode? }`; `AgentProfileRoute` / `SessionProfileRoute` / `SessionRpcOwnerRoute` are aliases. It is captured once (`resolveNewChatOwnerRoute`: explicit `$newChatRoute` → selected `$newChatProfile` + active source → bare profile only for legacy/profile-only routes) and carried through `session.create`, the create→runtime binding, `setSessionOwnerHint`, the optimistic row's `profile` **and** `connection_id`, the failed-create `session.close`, and every later RPC via `requestGatewayForAgent(connectionId, profile, …)`.
- **Ownership persistence.** The exact owner used to live only in the bounded in-memory hint map. The primary aggregate serves a `local` registry source's rows **without** `connection_id` (Electron's unified-list splice tags non-local sources only — `pooledRegistrySessionSources` skips `kind === 'local'`), and `mergeSessionPage` replaced the optimistic row with that untagged row on the first sidebar refresh. After a hint eviction or a relaunch nothing exact was left. Now:
  - every owner ladder gains the **connection-tagged row rung** (`knownSessionOwner` / `sessionOwnerRouteFromRow`): the session-RPC dispatcher, `knownOwnerForSession`, the tile delegate, `foregroundSessionScopes`, and the async probe (`resolveSessionOwner`) all yield the exact route when the row carries its connection;
  - `mergeSessionPage` **carries `connection_id`** onto a row that comes back untagged for the same profile (merge, don't clobber);
  - owner hints are **persisted** (bounded LRU, `hermes.desktop.sessionOwnerHints.v1`) and rehydrated in LRU order; a removed registry connection drops its hints (`use-gateway-boot` `onChanged`) so fail-closed can't pin sessions to a dead source.

### 2. Fail closed

A request carrying `session_id` whose owner no rung could name silently fell to the ambient presentation gateway, turning missing metadata into a misleading backend "session not found". `createSessionRpcDispatcher` and `requestForOwnedSession` now reject with an explicit **`SessionOwnerResolutionError`** (`store/session-owner-resolution`). The one case where ambient *is* the owner by construction stays ambient: no registry source live **and** at most one profile (legacy single-backend Desktop; older backends omit `profile` on rows). Main-pane runtime ids (native-notification `approval.respond`, queued sends) now translate to their stored id through the per-runtime state mirror (`storedSessionIdForRuntimeId`), so they resolve an owner instead of tripping the gate.

### 3. Lifecycle: leased/pinned from `session.create` to foreground retention

Between `session.create` returning and the foreground publication (`$selectedStoredSessionId` via navigate → route effect, or `$sessionTiles`), the owner entry had no active request and was not yet foreground-pinned: a prune recompute or a refcount-0 lease release could close the socket holding the just-minted runtime before the first `prompt.submit`. Both create paths now hold `retainGatewayForAgent` across the create RPC and hand off to **`holdSessionOwnerUntilForeground`** (`session-states`), which names the owner in `foregroundSessionScopes` — every registry dispose path honors it through the `foregroundScopes` registry hook carried in this PR — until the session becomes selected/tiled, the caller releases it (failed create, mid-create drift close), or a 60 s TTL expires. Nothing latches.

## Related Issue

Follow-up to #94071 (profile-rail half); builds on #95080 (which landed #94145), #95082 and #95087 in `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `store/session-request-router.ts` — `SessionOwnerRoute`, `sessionOwnerRouteFromRow`, `isSessionOwnerRoute`
- `store/session-owner-resolution.ts` (new) — `SessionOwnerResolutionError`, `ambientGatewayOwnsEverySession`, `assertSessionOwnerResolved`
- `store/session.ts` — persisted/bounded owner hints (`hydrateSessionOwnerHints`, `forgetSessionOwnerHintsForConnection`), `knownSessionOwner`, `mergeSessionPage` carries `connection_id`
- `store/session-states.ts` — `holdSessionOwnerUntilForeground` / `releaseSessionOwnerHold` folded into `foregroundSessionScopes`; row rung in `knownOwnerForSession`; state-mirror rung in `storedSessionIdForRuntimeId`; fail-closed `requestForOwnedSession`
- `app/contrib/session-rpc-dispatcher.ts`, `wiring-routing.ts` — row-owner rung + fail-closed gate
- `app/session/hooks/use-session-actions/index.ts` — both create paths: lease across create → owner hint → foreground hold; release on drift close
- `app/session/hooks/use-session-actions/utils.ts` — `resolveSessionOwner`
- `app/contrib/hooks/use-session-tile-delegate.ts` — same ladder for tile RPCs
- `app/gateway/hooks/use-gateway-boot.ts` — forget hints on connection removal
- `store/profile.ts` — `AgentProfileRoute = SessionOwnerRoute`
- Tests: `profile-rail-fresh-chat-owner.test.tsx` (hint evicted **and** untagged refresh → turn two still on `conn:local::omar`; owner pinned from create), `session-rpc-dispatcher.test.ts` (new), `session.test.ts`, `session-states-foreground-scopes.test.ts`, `session-states-runtime-map.test.ts`, `wiring-routing.test.ts`, `updates.test.ts` (storage mock gains the JSON helpers)

## How to Test

1. Two registry sources (primary = a remote gateway on `default`; active source = **This device**). In the profile rail pick `omar`, send two prompts. Before: turn two → "session not found". After: both `prompt.submit` calls ride the same `conn:local::omar` socket; the sidebar row keeps `connection_id: local` across refreshes; relaunch and continue the chat — it resumes on the same registry entry.
2. Remove the owning connection from Settings → its sessions' persisted hints are dropped; a session whose owner cannot be resolved reports `SessionOwnerResolutionError` instead of a bogus "session not found".
3. `cd apps/desktop && npx vitest run --project ui` → 600 files / 5807 tests pass; `npm run typecheck` (renderer + electron + e2e) clean; `eslint --max-warnings 0` clean on every touched file (repo-wide warning count unchanged at 122 vs. base); `prettier --check` clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — deliberately opened as its own PR rather than expanding #94145/#94147/#94178
- [x] My PR contains **only** changes related to this fix/feature (the three stacked PRs are the base)
- [x] I've run the desktop test suite (`vitest --project ui`) and all tests pass — Python `pytest` is unaffected (renderer only)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Omarchy/Arch), Node 26

### Documentation & Housekeeping

- [x] Documentation — N/A (renderer-internal; contracts documented inline)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (follows the "one resolver owns each policy / fail closed on authoritative writes" ladder rules in `apps/desktop/AGENTS.md`)
- [x] Cross-platform impact — N/A (renderer store logic, no platform code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Final packaged verification

After the original PR review, seven focused follow-up commits closed the remaining owner-topology, profile-activation, reload-identity, lifecycle-drain, regression-coverage, and React 19 thread-list snapshot gaps.

The final Linux package was built from runtime commit `b862aa06a` with a clean source stamp (the current head adds only the required contributor-attribution mapping) and exercised through the real Desktop profile rail:

1. Select `omar` on **This device**.
2. Create a fresh conversation.
3. Submit a first prompt and wait for its response.
4. Submit a second prompt in the same conversation.

CDP WebSocket tracing confirmed that `session.create` and both `prompt.submit` calls used the same concrete WebSocket and runtime session. The socket remained open through turn two. Omar's profile database gained exactly one session and four ordered messages (`user -> assistant -> user -> assistant`); the default profile database gained none. No `session not found`, ambient/default prompt RPC, disconnect, reclaim, or `ws_orphan_reap` occurred.

Additional packaged debugging also found an independent React 19 crash in the installed `@assistant-ui/core` thread-list snapshot path. The included compatibility fix mirrors current upstream memoization semantics and has focused stability/invalidation coverage.

Final verification:

- Desktop UI: **602 files / 5,818 tests passed**
- Electron/platform: **121 files / 1,735 tests passed**
- Plugins: **571 tests passed**
- Renderer, Electron, and E2E TypeScript checks passed
- ESLint and `git diff --check` passed
- Two independent focused audits: **approved, no concrete blockers**
- Packaged two-turn Omar profile-rail acceptance: **passed**

## Rebase note (2026-08-26)

Rebuilt as a linear, standalone branch on current `main` (10 commits, 32 files, all under `apps/desktop/src` plus one contributor-email mapping). Dropped from the old stacked branch: the #94145 commits (now in `main`), the old copies of #94147/#94178, the merge commits, and the thread-list snapshot commit that is its own PR (#94969). Where `main` moved under the branch, two rules were adapted rather than dropped:

- A profile pick while **This device** is the source still goes through `main`'s legacy per-profile socket path (7d6bf56c7b), so the exact-registry-owner guarantee here applies to remote registry sources; `local` picks keep one consistent socket via that path (covered by a dedicated test).
- A session that only knows its profile name is still routed to that profile's socket (as `main` does) instead of being refused; the fail-closed guard now applies when no owner at all is known in a registry topology.

Validation at head (rebased onto `main` @ `1a19c52dd2`; one line in `activeGatewayConnectionId()` merged with #95365's `primaryConnectionId` so `main`'s published id wins and the descriptor getter only covers the reload window): `tsc --noEmit` clean, eslint `--max-warnings 0` + prettier clean on all changed files, full `vitest run --project ui` 608 files / 5944 tests passing, and a clean `git merge-tree` against `main`.