### PR TITLE
feat(desktop): add hardened Windows system tray lifecycle

### DIFF
--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -2,7 +2,41 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { ensureMainWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow } from './main-window-lifecycle'
+
+test('reveals a tray-hidden primary window before focusing it', () => {
+  const calls: string[] = []
+
+  const hiddenWindow = {
+    focus: () => calls.push('focus'),
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => false,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show')
+  }
+
+  focusMainWindow(hiddenWindow)
+
+  assert.deepEqual(calls, ['show', 'focus'])
+})
+
+test('restores a minimized primary window before focusing it', () => {
+  const calls: string[] = []
+
+  const minimizedWindow = {
+    focus: () => calls.push('focus'),
+    isDestroyed: () => false,
+    isMinimized: () => true,
+    isVisible: () => true,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show')
+  }
+
+  focusMainWindow(minimizedWindow)
+
+  assert.deepEqual(calls, ['restore', 'focus'])
+})
 
 test('recreates a destroyed primary window without focusing it', () => {
   const destroyedWindow = {

--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -2,7 +2,30 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { ensureMainWindow, focusMainWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow, hideMainWindow } from './main-window-lifecycle'
+
+test('hides only a live visible primary window', () => {
+  const calls: string[] = []
+
+  const visibleWindow = {
+    hide: () => calls.push('hide'),
+    isDestroyed: () => false,
+    isVisible: () => true
+  }
+
+  assert.equal(hideMainWindow(visibleWindow), true)
+  assert.deepEqual(calls, ['hide'])
+
+  assert.equal(
+    hideMainWindow({
+      hide: () => assert.fail('an already hidden window must not be hidden again'),
+      isDestroyed: () => false,
+      isVisible: () => false
+    }),
+    false
+  )
+  assert.equal(hideMainWindow(null), false)
+})
 
 test('reveals a tray-hidden primary window before focusing it', () => {
   const calls: string[] = []

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -2,6 +2,30 @@ type MainWindowLike = {
   isDestroyed: () => boolean
 }
 
+type FocusableMainWindowLike = MainWindowLike & {
+  focus: () => unknown
+  isMinimized: () => boolean
+  isVisible: () => boolean
+  restore: () => unknown
+  show: () => unknown
+}
+
+export function focusMainWindow(window: FocusableMainWindowLike): void {
+  if (!window || window.isDestroyed()) {
+    return
+  }
+
+  if (window.isMinimized()) {
+    window.restore()
+  }
+
+  if (!window.isVisible()) {
+    window.show()
+  }
+
+  window.focus()
+}
+
 type EnsureMainWindowOptions<T extends MainWindowLike> = {
   isReady: boolean
   createWindow: () => unknown

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -10,6 +10,21 @@ type FocusableMainWindowLike = MainWindowLike & {
   show: () => unknown
 }
 
+type HideableMainWindowLike = MainWindowLike & {
+  hide: () => unknown
+  isVisible: () => boolean
+}
+
+export function hideMainWindow(window: HideableMainWindowLike | null | undefined): boolean {
+  if (!window || window.isDestroyed() || !window.isVisible()) {
+    return false
+  }
+
+  window.hide()
+
+  return true
+}
+
 export function focusMainWindow(window: FocusableMainWindowLike): void {
   if (!window || window.isDestroyed()) {
     return

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
@@ -212,7 +213,7 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
-import { ensureMainWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow as focusWindow } from './main-window-lifecycle'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
   oauthGuardMayHardFail,
@@ -374,6 +375,11 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
+import {
+  shouldCreateWindowsTray,
+  shouldHideMainWindowOnClose,
+  shouldStartMainWindowHidden
+} from './windows-tray-lifecycle'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -1311,6 +1317,8 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let windowsTray: Tray | null = null
+let isFinalQuitRequested = false
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -11262,22 +11270,6 @@ function wireWindowReveal(win, { show, onRevealed }: { show?: () => void; onReve
 // builder live in session-windows.ts so they stay unit-testable.
 const sessionWindows = createSessionWindowRegistry()
 
-function focusWindow(win) {
-  if (!win || win.isDestroyed()) {
-    return
-  }
-
-  if (win.isMinimized()) {
-    win.restore()
-  }
-
-  if (!win.isVisible()) {
-    win.show()
-  }
-
-  win.focus()
-}
-
 function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
@@ -12328,7 +12320,7 @@ function closeQuickEntryWindow() {
   quickEntryWindow = null
 }
 
-function createWindow() {
+function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
   mainWindow = new BrowserWindow({
@@ -12388,6 +12380,10 @@ function createWindow() {
   }
 
   const revealController = wireWindowReveal(createdMainWindow, {
+    // --hidden is a Windows cold-start affordance. Mark the window's reveal
+    // lifecycle complete without showing it so ready-to-show/fallback cannot
+    // unexpectedly surface a tray-started app.
+    show: startHidden ? () => {} : undefined,
     onRevealed: () => {
       // Persist geometry as soon as the window is visible so a crash before the
       // first clean resize/move/close still captures the restored bounds (#56726).
@@ -12436,6 +12432,12 @@ function createWindow() {
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    if (shouldHideMainWindowOnClose({ platform: process.platform, isQuitting: isFinalQuitRequested })) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   mainWindow.on('closed', () => {
@@ -12531,6 +12533,39 @@ function createWindow() {
     broadcastBootProgress()
     sendWindowStateChanged()
   })
+}
+
+function restoreMainWindow() {
+  ensureMainWindow(mainWindow, {
+    isReady: app.isReady(),
+    createWindow,
+    focusWindow
+  })
+}
+
+function createWindowsTray() {
+  if (!shouldCreateWindowsTray(process.platform) || windowsTray) {
+    return
+  }
+
+  const icon = getAppIconPath()
+
+  if (!icon) {
+    rememberLog('[tray] app icon not found; Windows tray unavailable')
+
+    return
+  }
+
+  windowsTray = new Tray(icon)
+  windowsTray.setToolTip('Hermes')
+  windowsTray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: 'Open Hermes', click: restoreMainWindow },
+      { type: 'separator' },
+      { label: 'Quit Hermes', click: () => app.quit() }
+    ])
+  )
+  windowsTray.on('double-click', restoreMainWindow)
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => {
@@ -15358,11 +15393,7 @@ function handleDeepLink(url) {
   }
 
   try {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
-
-    mainWindow.focus()
+    focusWindow(mainWindow)
     mainWindow.webContents.send('hermes:deep-link', payload)
     rememberLog(`[deeplink] delivered ${kind}/${name}`)
   } catch (err) {
@@ -15508,7 +15539,10 @@ app.whenReady().then(() => {
     screen.on('display-removed', reposition)
   }
 
-  createWindow()
+  createWindowsTray()
+  createWindow({
+    startHidden: shouldStartMainWindowHidden({ platform: process.platform, argv: process.argv })
+  })
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)
@@ -15604,6 +15638,10 @@ app.on('before-quit', event => {
     return
   }
 
+  // Main-window close events follow before-quit. Latch here so explicit quit,
+  // update/uninstall handoff, and confirmed active-work quit bypass close-to-tray.
+  isFinalQuitRequested = true
+
   if (!backendQuitTeardownDone) {
     event.preventDefault()
     void backendShutdown.run().finally(() => {
@@ -15685,6 +15723,11 @@ app.on('before-quit', event => {
   terminalIpc.disposeAllTerminalSessions()
 
   void backendShutdown.run()
+})
+
+app.on('will-quit', () => {
+  windowsTray?.destroy()
+  windowsTray = null
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -378,7 +378,8 @@ import { installWindowsSystemCaTrust } from './windows-system-ca'
 import {
   shouldCreateWindowsTray,
   shouldHideMainWindowOnClose,
-  shouldStartMainWindowHidden
+  shouldStartMainWindowHidden,
+  shouldTreatSessionEndAsFinalQuit
 } from './windows-tray-lifecycle'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
@@ -12426,6 +12427,15 @@ function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
   mainWindow.on('restore', () => sendWindowStateChanged())
   mainWindow.on('hide', () => sendWindowStateChanged())
   mainWindow.on('show', () => sendWindowStateChanged())
+
+  // Electron skips app.before-quit on Windows shutdown/restart/logout. Latch
+  // the native session-end request here so the following close event cannot be
+  // mistaken for a user clicking X and prevent the OS from ending the session.
+  if (shouldTreatSessionEndAsFinalQuit(process.platform)) {
+    mainWindow.on('query-session-end', () => {
+      isFinalQuitRequested = true
+    })
+  }
 
   // Reopen where the user left off. close is the backstop, flushed
   // synchronously before the window is gone.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -213,7 +213,7 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
-import { ensureMainWindow, focusMainWindow as focusWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow as focusWindow, hideMainWindow } from './main-window-lifecycle'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
   oauthGuardMayHardFail,
@@ -10688,6 +10688,7 @@ const backendShutdown = createBackendShutdownCoordinator(async () => {
 
 async function exitAfterBackendShutdown(code) {
   await backendShutdown.run()
+  disposeWindowsTray()
   app.exit(code)
 }
 
@@ -12441,7 +12442,7 @@ function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
       })
     ) {
       event.preventDefault()
-      mainWindow?.hide()
+      hideMainWindow(mainWindow)
     }
   })
 
@@ -12569,11 +12570,13 @@ function createWindowsTray(): boolean {
     tray.setToolTip('Hermes')
     tray.setContextMenu(
       Menu.buildFromTemplate([
-        { label: 'Open Hermes', click: restoreMainWindow },
+        { label: 'Show Hermes', click: restoreMainWindow },
+        { label: 'Hide Hermes', click: () => hideMainWindow(mainWindow) },
         { type: 'separator' },
         { label: 'Quit Hermes', click: () => app.quit() }
       ])
     )
+    tray.on('click', restoreMainWindow)
     tray.on('double-click', restoreMainWindow)
     windowsTray = tray
 
@@ -12584,6 +12587,11 @@ function createWindowsTray(): boolean {
 
     return false
   }
+}
+
+function disposeWindowsTray() {
+  windowsTray?.destroy()
+  windowsTray = null
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => {
@@ -15748,8 +15756,7 @@ app.on('before-quit', event => {
 })
 
 app.on('will-quit', () => {
-  windowsTray?.destroy()
-  windowsTray = null
+  disposeWindowsTray()
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12433,7 +12433,13 @@ function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
   mainWindow.on('close', event => {
-    if (shouldHideMainWindowOnClose({ platform: process.platform, isQuitting: isFinalQuitRequested })) {
+    if (
+      shouldHideMainWindowOnClose({
+        platform: process.platform,
+        isQuitting: isFinalQuitRequested,
+        trayAvailable: Boolean(windowsTray)
+      })
+    ) {
       event.preventDefault()
       mainWindow?.hide()
     }
@@ -12543,9 +12549,9 @@ function restoreMainWindow() {
   })
 }
 
-function createWindowsTray() {
+function createWindowsTray(): boolean {
   if (!shouldCreateWindowsTray(process.platform) || windowsTray) {
-    return
+    return Boolean(windowsTray)
   }
 
   const icon = getAppIconPath()
@@ -12553,19 +12559,31 @@ function createWindowsTray() {
   if (!icon) {
     rememberLog('[tray] app icon not found; Windows tray unavailable')
 
-    return
+    return false
   }
 
-  windowsTray = new Tray(icon)
-  windowsTray.setToolTip('Hermes')
-  windowsTray.setContextMenu(
-    Menu.buildFromTemplate([
-      { label: 'Open Hermes', click: restoreMainWindow },
-      { type: 'separator' },
-      { label: 'Quit Hermes', click: () => app.quit() }
-    ])
-  )
-  windowsTray.on('double-click', restoreMainWindow)
+  let tray: Tray | null = null
+
+  try {
+    tray = new Tray(icon)
+    tray.setToolTip('Hermes')
+    tray.setContextMenu(
+      Menu.buildFromTemplate([
+        { label: 'Open Hermes', click: restoreMainWindow },
+        { type: 'separator' },
+        { label: 'Quit Hermes', click: () => app.quit() }
+      ])
+    )
+    tray.on('double-click', restoreMainWindow)
+    windowsTray = tray
+
+    return true
+  } catch (error) {
+    tray?.destroy()
+    rememberLog(`[tray] Windows tray creation failed: ${error?.message || error}`)
+
+    return false
+  }
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => {
@@ -15539,9 +15557,13 @@ app.whenReady().then(() => {
     screen.on('display-removed', reposition)
   }
 
-  createWindowsTray()
+  const trayAvailable = createWindowsTray()
   createWindow({
-    startHidden: shouldStartMainWindowHidden({ platform: process.platform, argv: process.argv })
+    startHidden: shouldStartMainWindowHidden({
+      platform: process.platform,
+      argv: process.argv,
+      trayAvailable
+    })
   })
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.

--- a/apps/desktop/electron/windows-tray-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.test.ts
@@ -12,11 +12,19 @@ test('Windows close-to-tray lifecycle policy preserves explicit quit and non-Win
   assert.equal(shouldCreateWindowsTray('win32'), true)
   assert.equal(shouldCreateWindowsTray('darwin'), false)
 
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false }), true)
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true }), false)
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: true }), true)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: false }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true, trayAvailable: true }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false, trayAvailable: true }), false)
 
-  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'] }), true)
-  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'] }), false)
-  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'] }), false)
+  assert.equal(
+    shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'], trayAvailable: true }),
+    true
+  )
+  assert.equal(
+    shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'], trayAvailable: false }),
+    false
+  )
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'], trayAvailable: true }), false)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'], trayAvailable: true }), false)
 })

--- a/apps/desktop/electron/windows-tray-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  shouldCreateWindowsTray,
+  shouldHideMainWindowOnClose,
+  shouldStartMainWindowHidden
+} from './windows-tray-lifecycle'
+
+test('Windows close-to-tray lifecycle policy preserves explicit quit and non-Windows behavior', () => {
+  assert.equal(shouldCreateWindowsTray('win32'), true)
+  assert.equal(shouldCreateWindowsTray('darwin'), false)
+
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false }), true)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false }), false)
+
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'] }), true)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'] }), false)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'] }), false)
+})

--- a/apps/desktop/electron/windows-tray-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.test.ts
@@ -5,12 +5,15 @@ import { test } from 'vitest'
 import {
   shouldCreateWindowsTray,
   shouldHideMainWindowOnClose,
-  shouldStartMainWindowHidden
+  shouldStartMainWindowHidden,
+  shouldTreatSessionEndAsFinalQuit
 } from './windows-tray-lifecycle'
 
 test('Windows close-to-tray lifecycle policy preserves explicit quit and non-Windows behavior', () => {
   assert.equal(shouldCreateWindowsTray('win32'), true)
   assert.equal(shouldCreateWindowsTray('darwin'), false)
+  assert.equal(shouldTreatSessionEndAsFinalQuit('win32'), true)
+  assert.equal(shouldTreatSessionEndAsFinalQuit('darwin'), false)
 
   assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: true }), true)
   assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: false }), false)

--- a/apps/desktop/electron/windows-tray-lifecycle.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.ts
@@ -6,20 +6,24 @@ export function shouldCreateWindowsTray(platform: Platform): boolean {
 
 export function shouldHideMainWindowOnClose({
   platform,
-  isQuitting
+  isQuitting,
+  trayAvailable
 }: {
   platform: Platform
   isQuitting: boolean
+  trayAvailable: boolean
 }): boolean {
-  return platform === 'win32' && !isQuitting
+  return platform === 'win32' && trayAvailable && !isQuitting
 }
 
 export function shouldStartMainWindowHidden({
   platform,
-  argv
+  argv,
+  trayAvailable
 }: {
   platform: Platform
   argv: readonly string[]
+  trayAvailable: boolean
 }): boolean {
-  return platform === 'win32' && argv.includes('--hidden')
+  return platform === 'win32' && trayAvailable && argv.includes('--hidden')
 }

--- a/apps/desktop/electron/windows-tray-lifecycle.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.ts
@@ -1,0 +1,25 @@
+type Platform = NodeJS.Platform
+
+export function shouldCreateWindowsTray(platform: Platform): boolean {
+  return platform === 'win32'
+}
+
+export function shouldHideMainWindowOnClose({
+  platform,
+  isQuitting
+}: {
+  platform: Platform
+  isQuitting: boolean
+}): boolean {
+  return platform === 'win32' && !isQuitting
+}
+
+export function shouldStartMainWindowHidden({
+  platform,
+  argv
+}: {
+  platform: Platform
+  argv: readonly string[]
+}): boolean {
+  return platform === 'win32' && argv.includes('--hidden')
+}

--- a/apps/desktop/electron/windows-tray-lifecycle.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.ts
@@ -4,6 +4,11 @@ export function shouldCreateWindowsTray(platform: Platform): boolean {
   return platform === 'win32'
 }
 
+/** Windows does not emit app.before-quit for OS shutdown, restart, or logout. */
+export function shouldTreatSessionEndAsFinalQuit(platform: Platform): boolean {
+  return platform === 'win32'
+}
+
 export function shouldHideMainWindowOnClose({
   platform,
   isQuitting,


### PR DESCRIPTION
## What does this PR do?

Adds native Windows system-tray behavior to Hermes Desktop.

- Clicking the main window's **X** hides Hermes to the tray instead of terminating it.
- The tray menu provides **Show Hermes**, **Hide Hermes**, and **Quit Hermes**.
- Clicking or double-clicking the tray icon restores the existing main window.
- `Hermes.exe --hidden` starts without showing the main window.

The behavior is Windows-only. Other platforms keep their existing window lifecycle.

## Related Issue

Fixes #38007

Related: #67064

## Type of Change

- [x] ✨ New feature
- [x] ✅ Tests

## Changes Made

- Added Windows tray lifecycle policy helpers and tests.
- Added reusable primary-window show/hide helpers.
- Kept real quit paths separate from close-to-tray, including active-work confirmation, updater/uninstall handoff, backend shutdown, fatal relaunch, and Windows session end.
- Falls back to normal close behavior if the tray icon cannot be created.
- Cleans up the tray on both normal quit and direct `app.exit()` paths.
- Added no dependencies, config keys, or model tools.

This branch updates the implementation from #75393 to current `main`; the original commit authorship is preserved.

## How to Test

```bash
cd apps/desktop
npx vitest run --project electron electron/main-window-lifecycle.test.ts electron/windows-tray-lifecycle.test.ts electron/quit-guard.test.ts electron/update-gate.test.ts electron/updater-process.test.ts
npm run typecheck
npm run build
```

Manual Windows verification:

1. Start Hermes normally and click **X**. The window should disappear while the process remains alive.
2. Click the tray icon or launch Hermes again. The same main window should return.
3. Use **Hide Hermes** and **Quit Hermes** from the tray menu.
4. Start `Hermes.exe --hidden`. No main window should appear; launching Hermes again should restore it.

## Verification

- 50 focused lifecycle/update tests passed.
- ESLint passed for all changed files.
- Renderer, Electron, and E2E TypeScript checks passed.
- Production build passed.
- Native Windows package test confirmed close-to-tray, same-process restore, and hidden startup.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit messages.
- [x] Existing issue and PR search completed.
- [x] Only five Electron files changed.
- [x] Tests added.
- [x] Tested on native Windows 10.
- [x] Cross-platform impact considered; non-Windows behavior is unchanged.
- [x] Documentation/config/tool updates are not required for this change.
