### PR TITLE
fix(mcp): un-invert stdio children liveness check — stop unconditional stdio fast-fail (Closes #94637)

### DIFF
--- a/tests/tools/test_mcp_stdio_liveness.py
+++ b/tests/tools/test_mcp_stdio_liveness.py
@@ -1,0 +1,84 @@
+"""Regression tests for ``MCPServerTask._stdio_children_dead`` (#94637).
+
+Commit ``786f37071`` inverted the liveness check: the function returned
+``True`` ("every stdio child has exited") the moment it found a single
+LIVE pid, so the #81995 pre-call fast-fail raised
+``TimeoutError: MCP stdio subprocess for '<server>' has exited`` for every
+stdio ``tools/call`` even while the subprocess was demonstrably healthy.
+These tests pin the corrected polarity and the documented best-effort
+contract ("returns False — unknown, don't fail fast — otherwise").
+"""
+
+import builtins
+import os
+import subprocess
+import sys
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _task_with_pids(pids):
+    task = MCPServerTask("liveness-test")
+    task._stdio_child_pids = set(pids)
+    return task
+
+
+class TestStdioChildrenDead:
+    def test_live_child_is_not_dead(self):
+        # The pytest process itself is a live tracked pid: must report
+        # "not all dead" (pre-fix code returned True → instant fast-fail).
+        task = _task_with_pids([os.getpid()])
+        assert task._stdio_children_dead() is False
+
+    def test_spawned_live_child_is_not_dead(self):
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"])
+        try:
+            task = _task_with_pids([proc.pid])
+            assert task._stdio_children_dead() is False
+        finally:
+            proc.kill()
+            proc.wait()
+
+    def test_all_dead_reports_dead(self, monkeypatch):
+        import psutil
+
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: False)
+        task = _task_with_pids([1, 2, 3])
+        assert task._stdio_children_dead() is True
+
+    def test_mixed_alive_and_dead_is_not_all_dead(self, monkeypatch):
+        import psutil
+
+        def fake_exists(pid):
+            return pid != 424242
+
+        monkeypatch.setattr(psutil, "pid_exists", fake_exists)
+        # All tracked pids dead → True.
+        assert _task_with_pids([424242])._stdio_children_dead() is True
+        # At least one alive → False (pre-fix returned True on the live pid).
+        task = _task_with_pids([424242, os.getpid()])
+        assert task._stdio_children_dead() is False
+
+    def test_no_pids_is_unknown_not_dead(self):
+        assert _task_with_pids([])._stdio_children_dead() is False
+
+    def test_http_server_never_dead(self):
+        task = MCPServerTask("http-test")
+        task._config = {"url": "http://127.0.0.1:9"}
+        task._stdio_child_pids = {os.getpid()}
+        assert task._stdio_children_dead() is False
+
+    def test_psutil_missing_is_unknown_not_dead(self, monkeypatch):
+        # The pre-fix code ran a bare `import psutil` inside the loop: with
+        # psutil unavailable it raised ImportError instead of honoring the
+        # "unknown → don't fail fast" contract.
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "psutil":
+                raise ImportError("psutil unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        task = _task_with_pids([os.getpid()])
+        assert task._stdio_children_dead() is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2987,16 +2987,20 @@ class MCPServerTask:
         pids = getattr(self, "_stdio_child_pids", None)
         if not pids or self._is_http():
             return False
-        for pid in pids:
-            # windows-footgun: ok — psutil.pid_exists handles Windows; the
-            # os.kill probe below only runs when psutil is unavailable.
+        try:
             import psutil
-
-            if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+        except ImportError:
+            return False  # unknown → don't fail fast
+        for pid in pids:
+            # pid_exists handles Windows (no signal-permission noise, unlike
+            # the os.kill probe it replaced); any probe error means unknown.
+            try:
+                alive = psutil.pid_exists(pid)
+            except Exception:
+                return False  # unknown → don't fail fast
+            if alive:
+                return False  # at least one child alive → not all dead
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
Closes #94637

## Problem

Every `tools/call` against a stdio MCP server fails instantly (< 30 ms) with:

```
TimeoutError: MCP stdio subprocess for '<server>' has exited; failing the call fast instead of waiting 300s
```

while the server subprocess is demonstrably alive (`hermes mcp test <server>` passes, tools are registered). HTTP servers are unaffected because they never reach the check.

## Root cause

`786f37071` rewrote `MCPServerTask._stdio_children_dead()` and inverted the boolean polarity: the loop returned `True` ("all children dead") on the **first live** pid, with the intended `return False` dead-coded directly beneath it. The #81995 pre-call fast-fail gate reports that verdict verbatim, so every call fast-fails unconditionally whenever `_stdio_child_pids` is non-empty (e.g. spawn paths that capture child PIDs).

The same commit also violated the function's documented best-effort contract ("returns False — unknown, don't fail fast — otherwise") with a bare `import psutil` inside the loop: if psutil is unavailable the function raises `ImportError` instead of returning `False`.

## Fix

Un-invert the liveness verdict, restore the best-effort contract, and delete the unreachable line:

```python
try:
    import psutil
except ImportError:
    return False  # unknown → don't fail fast
for pid in pids:
    try:
        alive = psutil.pid_exists(pid)
    except Exception:
        return False  # unknown → don't fail fast
    if alive:
        return False  # at least one child alive → not all dead
return True  # every tracked child has exited
```

Sibling-site sweep: `_stdio_children_dead` is the only aggregate-liveness check; the other `pid_exists` call sites (browser daemon, process registry, async delegation) are single-pid liveness probes with unrelated semantics. The `os.kill` fallback flagged in #94335 no longer exists — `786f37071` replaced it entirely rather than inverting it.

## Tests

`tests/tools/test_mcp_stdio_liveness.py` (new) — 7 cases pinning the contract:
- live pid (own process) → not dead
- live spawned subprocess → not dead
- all tracked pids dead → dead
- mixed alive + dead → not dead
- no pids → unknown, not dead
- http transport → never dead
- psutil unavailable → unknown, not dead (ImportError guard)

Proven RED→GREEN: 4 of the 7 fail on pre-fix code and pass with the fix; a sabotage run (fix reverted to the `786f37071` behavior) reproduces exactly those 4 failures.

## Verification

- `pytest tests/tools/test_mcp_stdio_liveness.py -q` → **7 passed**
- `pytest tests/tools/test_mcp_*.py -q` → **583 passed, 5 skipped, 2 failed** — both failures are pre-existing at pristine HEAD on this Windows host (a POSIX-only 0o600 chmod assertion and a `ProgramFiles` env-var case), unrelated to this diff
- `ruff check` clean on both changed files; changed lines are `ruff format` clean (the file has pre-existing format drift elsewhere at HEAD, left untouched)

## Note on overlap

Open PR #94339 un-inverts the same return value. This PR additionally restores the best-effort contract for the missing-psutil and probe-error cases (the "additional issues" called out in #94637's body) and ships the regression suite; either PR resolves the failure.
