### PR TITLE
fix(computer_use): normalize Windows HiDPI DPI scaling for coordinate clicks (#94538)

### DIFF
--- a/tests/tools/test_computer_use_cua_dpi_normalization.py
+++ b/tests/tools/test_computer_use_cua_dpi_normalization.py
@@ -1,0 +1,233 @@
+"""Regression tests for Windows HiDPI coordinate normalization (#94538).
+
+cua-driver's Windows backend captures screenshots in physical pixels while
+its input dispatch (SendInput) operates in logical units, so on a scaled
+display (e.g. 150%) a click at screenshot coordinate ``[x, y]`` lands at
+``[x * scale, y * scale]`` and misses the intended element. The Hermes
+wrapper must divide coordinate inputs by the display scale factor
+(DPI / 96) before dispatching them to the driver.
+
+These tests pin that contract without needing a live cua-driver binary:
+the DPI probe is patched and the MCP args the backend would send are
+asserted directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+
+class _FakeSession:
+    """Minimal stand-in for ``_CuaDriverSession`` recording tool-call args."""
+
+    def __init__(
+        self,
+        out: Optional[Dict[str, Any]] = None,
+        *,
+        scroll_coords: bool = True,
+    ) -> None:
+        self.out = out or {
+            "isError": False,
+            "data": {},
+            "structuredContent": {"effect": "confirmed"},
+        }
+        self.scroll_coords = scroll_coords
+        self.calls = []  # type: list[tuple[str, Dict[str, Any]]]
+
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
+        self.calls.append((name, dict(args)))
+        return self.out
+
+    def supports_capability(self, capability: str, tool: Optional[str] = None) -> bool:
+        return self.scroll_coords and capability == "input.scroll.coordinates"
+
+    def supports_input_property(self, tool: str, prop: str) -> bool:
+        return False
+
+    def _has_tool(self, name: str) -> bool:
+        return True
+
+
+def _make_backend(session: _FakeSession):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend.__new__(CuaDriverBackend)
+    backend._session = session
+    backend._session_id = "hermes-session"
+    backend._snapshot_tokens = {}
+    backend._active_pid = 4242
+    backend._active_window_id = 77
+    return backend
+
+
+def _last_call(session: _FakeSession):
+    assert session.calls, "expected a cua-driver tool call"
+    return session.calls[-1]
+
+
+@pytest.fixture(autouse=True)
+def _sanitize_env(monkeypatch):
+    """The kill switch is env/config driven; keep each test opt-in clean."""
+    monkeypatch.delenv("HERMES_CUA_NO_DPI_NORMALIZATION", raising=False)
+    yield
+
+
+def _patch_scale(monkeypatch, scale):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend, "_win32_dpi_scale", lambda pid: scale)
+    return cua_backend
+
+
+def test_click_coordinates_are_divided_by_scale_on_windows_hidpi(monkeypatch):
+    """150% DPI: screenshot-space [300, 450] must dispatch as [200, 300]."""
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    result = backend.click(x=300, y=450)
+
+    assert result.ok
+    _, args = _last_call(session)
+    assert args["x"] == 200
+    assert args["y"] == 300
+
+
+def test_double_click_coordinates_are_normalized(monkeypatch):
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=300, y=450, click_count=2)
+
+    name, args = _last_call(session)
+    assert name == "double_click"
+    assert args["x"] == 200
+    assert args["y"] == 300
+
+
+def test_drag_coordinates_are_normalized(monkeypatch):
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.drag(from_xy=(300, 450), to_xy=(600, 900))
+
+    _, args = _last_call(session)
+    assert (args["from_x"], args["from_y"]) == (200, 300)
+    assert (args["to_x"], args["to_y"]) == (400, 600)
+
+
+def test_scroll_coordinates_are_normalized(monkeypatch):
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession(scroll_coords=True)
+    backend = _make_backend(session)
+
+    backend.scroll(direction="down", amount=3, x=300, y=450)
+
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (200, 300)
+
+
+def test_normalization_rounds_to_nearest_integer(monkeypatch):
+    """445 / 1.5 = 296.67 → 297, matching the issue's 285/1.5-style math."""
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=445, y=285)
+
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (297, 190)
+
+
+def test_coordinates_unchanged_when_scale_is_unavailable(monkeypatch):
+    """A driver/host that cannot report DPI must behave exactly as before."""
+    _patch_scale(monkeypatch, None)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=300, y=450)
+    backend.drag(from_xy=(300, 450), to_xy=(600, 900))
+    backend.scroll(direction="down", amount=3, x=300, y=450)
+
+    _, click_args = session.calls[0]
+    assert (click_args["x"], click_args["y"]) == (300, 450)
+    _, drag_args = session.calls[1]
+    assert (drag_args["from_x"], drag_args["from_y"]) == (300, 450)
+    assert (drag_args["to_x"], drag_args["to_y"]) == (600, 900)
+    _, scroll_args = session.calls[2]
+    assert (scroll_args["x"], scroll_args["y"]) == (300, 450)
+
+
+def test_coordinates_unchanged_at_100_percent_scale(monkeypatch):
+    _patch_scale(monkeypatch, 1.0)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=300, y=450)
+
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (300, 450)
+
+
+def test_env_kill_switch_disables_normalization(monkeypatch):
+    _patch_scale(monkeypatch, 1.5)
+    monkeypatch.setenv("HERMES_CUA_NO_DPI_NORMALIZATION", "1")
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=300, y=450)
+
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (300, 450)
+
+
+def test_config_kill_switch_disables_normalization(monkeypatch):
+    from tools.computer_use import cua_backend
+
+    _patch_scale(monkeypatch, 1.5)
+    monkeypatch.setattr(
+        cua_backend, "_computer_use_cfg", lambda: {"dpi_normalization": False}
+    )
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(x=300, y=450)
+
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (300, 450)
+
+
+def test_element_index_clicks_are_not_scaled(monkeypatch):
+    """Element clicks resolve server-side in the driver's own space."""
+    _patch_scale(monkeypatch, 1.5)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.click(element=3)
+
+    _, args = _last_call(session)
+    assert args["element_index"] == 3
+    assert "x" not in args and "y" not in args
+
+
+def test_win32_dpi_scale_returns_none_off_windows(monkeypatch):
+    """The raw probe must be a no-op on non-Windows hosts."""
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend.sys, "platform", "linux")
+    assert cua_backend._win32_dpi_scale(4242) is None
+
+
+def test_normalize_coordinate_helper(monkeypatch):
+    from tools.computer_use.cua_backend import _normalize_coordinate
+
+    assert _normalize_coordinate(300, 1.5) == 200
+    assert _normalize_coordinate(445, 1.5) == 297
+    assert _normalize_coordinate(230, 1.25) == 184
+    assert _normalize_coordinate(0, 2.0) == 0
+    assert _normalize_coordinate(300, 1.0) == 300
+    assert _normalize_coordinate(300, None) == 300

--- a/tests/tools/test_computer_use_cua_dpi_normalization.py
+++ b/tests/tools/test_computer_use_cua_dpi_normalization.py
@@ -9,11 +9,18 @@ wrapper must divide coordinate inputs by the display scale factor
 
 These tests pin that contract without needing a live cua-driver binary:
 the DPI probe is patched and the MCP args the backend would send are
-asserted directly.
+asserted directly. The Win32 ctypes probe chain (EnumWindows →
+GetDpiForWindow → GetDpiForSystem) is exercised with a fake ``ctypes``
+module, and the #94666 review findings (per-capture re-probe, retry of
+failed probes, kill-switch truthiness, scroll passthrough, concurrency)
+are covered in dedicated cases below.
 """
 
 from __future__ import annotations
 
+import sys
+import threading
+import types
 from typing import Any, Dict, Optional
 
 import pytest
@@ -50,6 +57,24 @@ class _FakeSession:
         return True
 
 
+class _ProbeSpy:
+    """Stand-in for ``_win32_dpi_probe`` recording pids and replaying results.
+
+    Each element is either ``None`` (probe failure) or an ``(hwnd, scale)``
+    tuple, consumed in order — a failed probe is never retained.
+    """
+
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []  # type: list[Optional[int]]
+
+    def __call__(self, pid):
+        self.calls.append(pid)
+        if not self.results:
+            return None
+        return self.results.pop(0)
+
+
 def _make_backend(session: _FakeSession):
     from tools.computer_use.cua_backend import CuaDriverBackend
 
@@ -59,6 +84,8 @@ def _make_backend(session: _FakeSession):
     backend._snapshot_tokens = {}
     backend._active_pid = 4242
     backend._active_window_id = 77
+    backend._capture_dpi_scale = None
+    backend._dpi_scale_lock = threading.Lock()
     return backend
 
 
@@ -77,8 +104,11 @@ def _sanitize_env(monkeypatch):
 def _patch_scale(monkeypatch, scale):
     from tools.computer_use import cua_backend
 
-    monkeypatch.setattr(cua_backend, "_win32_dpi_scale", lambda pid: scale)
+    monkeypatch.setattr(cua_backend, "_win32_dpi_probe", lambda pid: (None, scale))
     return cua_backend
+
+
+# ── Coordinate normalization ──────────────────────────────────────────
 
 
 def test_click_coordinates_are_divided_by_scale_on_windows_hidpi(monkeypatch):
@@ -173,6 +203,20 @@ def test_coordinates_unchanged_at_100_percent_scale(monkeypatch):
     assert (args["x"], args["y"]) == (300, 450)
 
 
+def test_scroll_coordinates_pass_through_untruncated_at_identity_scale(monkeypatch):
+    """#94666 review: at scale 1.0/None scroll coordinates must pass through
+    untouched — no int truncation (299.7 stays 299.7, not 299)."""
+    _patch_scale(monkeypatch, None)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend.scroll(direction="down", amount=3, x=299.7, y=3.4)
+
+    _, args = _last_call(session)
+    assert args["x"] == 299.7 and isinstance(args["x"], float)
+    assert args["y"] == 3.4 and isinstance(args["y"], float)
+
+
 def test_env_kill_switch_disables_normalization(monkeypatch):
     _patch_scale(monkeypatch, 1.5)
     monkeypatch.setenv("HERMES_CUA_NO_DPI_NORMALIZATION", "1")
@@ -201,6 +245,33 @@ def test_config_kill_switch_disables_normalization(monkeypatch):
     assert (args["x"], args["y"]) == (300, 450)
 
 
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "TRUE", "Yes", "anything", "2"])
+def test_env_kill_switch_accepts_any_nonempty_truthy_value(monkeypatch, raw):
+    """#94666 review: the docs say 'any truthy value'; the code must accept
+    arbitrary non-empty spellings, not just the 4-value whitelist."""
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+    monkeypatch.setenv("HERMES_CUA_NO_DPI_NORMALIZATION", raw)
+    assert cua_backend._cua_dpi_normalization_disabled() is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off", "   "])
+def test_env_kill_switch_ignores_falsy_values(monkeypatch, raw):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+    monkeypatch.setenv("HERMES_CUA_NO_DPI_NORMALIZATION", raw)
+    assert cua_backend._cua_dpi_normalization_disabled() is False
+
+
+def test_env_kill_switch_unset_keeps_normalization_enabled(monkeypatch):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend, "_computer_use_cfg", lambda: {})
+    assert cua_backend._cua_dpi_normalization_disabled() is False
+
+
 def test_element_index_clicks_are_not_scaled(monkeypatch):
     """Element clicks resolve server-side in the driver's own space."""
     _patch_scale(monkeypatch, 1.5)
@@ -214,12 +285,332 @@ def test_element_index_clicks_are_not_scaled(monkeypatch):
     assert "x" not in args and "y" not in args
 
 
+# ── #94666 review: cache invalidation / retry semantics ────────────────
+
+
+def test_recapture_reprobes_and_never_reuses_stale_scale(monkeypatch):
+    """#94666 review ①: the scale must match the capture. A re-capture, or a
+    window moved to another monitor (same pid, different DPI), rebinds a
+    fresh factor — the previous capture's scale is never reused."""
+    from tools.computer_use import cua_backend
+
+    spy = _ProbeSpy([(None, 1.25), (None, 1.5)])
+    monkeypatch.setattr(cua_backend, "_win32_dpi_probe", spy)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend._dpi_bind_for_capture()  # first capture: monitor A at 125%
+    backend.click(x=400, y=500)
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (320, 400)
+
+    backend._dpi_bind_for_capture()  # re-capture: window now on monitor B at 150%
+    backend.click(x=300, y=450)
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (200, 300)
+    assert spy.calls == [4242, 4242]  # exactly one probe per capture
+
+
+def test_failed_probe_is_retried_not_cached(monkeypatch):
+    """#94666 review ②: a failed probe must not be pinned forever — the next
+    action or capture probes again."""
+    from tools.computer_use import cua_backend
+
+    spy = _ProbeSpy([None, None, (None, 1.5)])
+    monkeypatch.setattr(cua_backend, "_win32_dpi_probe", spy)
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend._dpi_bind_for_capture()  # capture: probe fails
+    backend.click(x=300, y=450)      # click re-probes, still fails → passthrough
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (300, 450)
+
+    backend._dpi_bind_for_capture()  # next capture: probe succeeds now
+    backend.click(x=300, y=450)
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (200, 300)
+    assert spy.calls == [4242, 4242, 4242]
+
+
+def test_focus_app_retarget_invalidates_capture_bound_scale(monkeypatch):
+    """A target change outside capture() must not reuse the old capture's
+    scale — the next coordinate action probes the new window."""
+    from tools.computer_use import cua_backend
+
+    spy = _ProbeSpy([(None, 1.25), (None, 2.0)])
+    monkeypatch.setattr(cua_backend, "_win32_dpi_probe", spy)
+    monkeypatch.setattr(
+        cua_backend.CuaDriverBackend,
+        "_load_windows",
+        lambda self: [{"pid": 999, "window_id": 88, "app_name": "Other"}],
+    )
+    monkeypatch.setattr(
+        cua_backend.CuaDriverBackend,
+        "_match_windows_for_app",
+        lambda self, windows, app: [{"pid": 999, "window_id": 88, "app_name": "Other"}],
+    )
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    backend._dpi_bind_for_capture()  # capture binds 1.25 for pid 4242
+    backend.click(x=400, y=500)
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (320, 400)
+
+    result = backend.focus_app("Other")
+    assert result.ok
+    assert backend._active_pid == 999
+
+    backend.click(x=400, y=500)  # new target: re-probe, never reuse 1.25
+    _, args = _last_call(session)
+    assert (args["x"], args["y"]) == (200, 250)
+    assert spy.calls == [4242, 999]
+
+
+def test_concurrent_coordinate_actions_are_safe(monkeypatch):
+    """#94666 review (concurrency): parallel click/scroll threads must not
+    race on the DPI scale binding (the old lock-free per-pid dict could
+    raise RuntimeError 'dictionary changed size during iteration'). With
+    the lock + scalar binding, exactly one probe runs and every dispatched
+    coordinate is consistent."""
+    from tools.computer_use import cua_backend
+
+    probe_calls = []
+    probe_lock = threading.Lock()
+
+    def fake_probe(pid):
+        with probe_lock:
+            probe_calls.append(pid)
+        return (None, 1.5)
+
+    monkeypatch.setattr(cua_backend, "_win32_dpi_probe", fake_probe)
+    session = _FakeSession()
+    backend = _make_backend(session)
+    errors = []
+
+    def worker():
+        try:
+            for _ in range(20):
+                backend.click(x=300, y=450)
+                backend.scroll(direction="down", amount=3, x=300, y=450)
+        except Exception as exc:  # pragma: no cover - failure signal
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert len(session.calls) == 8 * 20 * 2
+    assert len(probe_calls) == 1  # bound once; every later call reads the binding
+    for name, args in session.calls:
+        assert (args["x"], args["y"]) == (200, 300)
+
+
+# ── Win32 ctypes probe chain (fake ctypes module) ──────────────────────
+
+
+class _FakeDWORD:
+    def __init__(self, value: int = 0) -> None:
+        self.value = value
+
+
+class _FakeWintypes:
+    BOOL = bool
+    HWND = int
+    LPARAM = int
+    DWORD = _FakeDWORD
+
+
+class _FakeUser32:
+    """Records calls and drives the EnumWindows/DPI chain deterministically."""
+
+    def __init__(
+        self,
+        windows,
+        *,
+        dpi_window=None,
+        dpi_system: int = 0,
+        raise_window_dpi: bool = False,
+    ) -> None:
+        self.windows = list(windows)
+        self.by_hwnd = {w["hwnd"]: w for w in self.windows}
+        self.dpi_window = dict(dpi_window or {})
+        self.dpi_system = dpi_system
+        self.raise_window_dpi = raise_window_dpi
+        self.enumerated = []  # hwnds visited by the EnumWindows callback
+        self.dpi_window_calls = []
+        self.dpi_system_calls = 0
+
+    def IsWindowVisible(self, hwnd):
+        return bool(self.by_hwnd[hwnd]["visible"])
+
+    def GetWindowThreadProcessId(self, hwnd, proc_id_ref):
+        proc_id_ref.value = self.by_hwnd[hwnd]["pid"]
+        return 1
+
+    def EnumWindows(self, callback, lparam):
+        for window in self.windows:
+            self.enumerated.append(window["hwnd"])
+            if not callback(window["hwnd"], 0):
+                break
+        return True
+
+    def GetDpiForWindow(self, hwnd):
+        self.dpi_window_calls.append(hwnd)
+        if self.raise_window_dpi:
+            raise OSError("GetDpiForWindow unavailable")
+        return self.dpi_window.get(hwnd, 0)
+
+    def GetDpiForSystem(self):
+        self.dpi_system_calls += 1
+        return self.dpi_system
+
+
+class _FakeCtypes:
+    """Minimal ctypes surface the probe uses: WINFUNCTYPE, byref, windll."""
+
+    def __init__(self, user32: _FakeUser32) -> None:
+        self.wintypes = _FakeWintypes
+        self.windll = types.SimpleNamespace(user32=user32)
+
+    def WINFUNCTYPE(self, *restype):
+        return lambda fn: fn  # keep the callback alive, pass it through
+
+    def byref(self, obj):
+        return obj
+
+
+def _install_fake_ctypes(monkeypatch, user32):
+    """Swap the real ctypes for a fake and pretend we're on win32."""
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "ctypes", _FakeCtypes(user32))
+    return user32
+
+
+def test_win32_hwnd_for_pid_stops_at_first_visible_match(monkeypatch):
+    user32 = _FakeUser32(
+        [
+            {"hwnd": 11, "pid": 999, "visible": False},
+            {"hwnd": 22, "pid": 4242, "visible": True},
+            {"hwnd": 33, "pid": 4242, "visible": True},
+        ]
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_hwnd_for_pid(user32, 4242) == 22
+    assert user32.enumerated == [11, 22]  # enumeration stops at the match
+
+
+def test_win32_hwnd_for_pid_returns_none_without_visible_match(monkeypatch):
+    user32 = _FakeUser32(
+        [
+            {"hwnd": 11, "pid": 999, "visible": False},
+            {"hwnd": 22, "pid": 555, "visible": True},
+        ]
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_hwnd_for_pid(user32, 4242) is None
+    assert user32.enumerated == [11, 22]
+
+
+def test_win32_dpi_probe_prefers_get_dpi_for_window(monkeypatch):
+    user32 = _FakeUser32(
+        [{"hwnd": 22, "pid": 4242, "visible": True}],
+        dpi_window={22: 144},
+        dpi_system=96,
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) == (22, 1.5)
+    assert user32.dpi_window_calls == [22]
+    assert user32.dpi_system_calls == 0  # per-window DPI wins
+
+
+def test_win32_dpi_probe_falls_back_to_system_dpi_when_window_dpi_zero(monkeypatch):
+    user32 = _FakeUser32(
+        [{"hwnd": 22, "pid": 4242, "visible": True}],
+        dpi_window={22: 0},
+        dpi_system=120,
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) == (22, 1.25)
+    assert user32.dpi_window_calls == [22]
+    assert user32.dpi_system_calls == 1
+
+
+def test_win32_dpi_probe_falls_back_when_window_probe_raises(monkeypatch):
+    user32 = _FakeUser32(
+        [{"hwnd": 22, "pid": 4242, "visible": True}],
+        dpi_system=96,
+        raise_window_dpi=True,
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) == (22, 1.0)
+    assert user32.dpi_system_calls == 1
+
+
+def test_win32_dpi_probe_uses_system_dpi_only_when_no_window(monkeypatch):
+    user32 = _FakeUser32([{"hwnd": 22, "pid": 999, "visible": True}], dpi_system=168)
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) == (None, 1.75)
+    assert user32.dpi_window_calls == []
+    assert user32.dpi_system_calls == 1
+
+
+def test_win32_dpi_probe_returns_none_when_dpi_missing(monkeypatch):
+    user32 = _FakeUser32([], dpi_system=0)
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) is None
+
+
+def test_win32_dpi_probe_rejects_implausible_dpi(monkeypatch):
+    user32 = _FakeUser32([], dpi_system=9600)  # 100x scale — probe garbage
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_probe(4242) is None
+
+
+def test_win32_dpi_scale_wraps_probe(monkeypatch):
+    user32 = _FakeUser32(
+        [{"hwnd": 22, "pid": 4242, "visible": True}],
+        dpi_window={22: 144},
+        dpi_system=96,
+    )
+    _install_fake_ctypes(monkeypatch, user32)
+    from tools.computer_use import cua_backend
+
+    assert cua_backend._win32_dpi_scale(4242) == 1.5
+
+
+# ── Pure helpers ───────────────────────────────────────────────────────
+
+
 def test_win32_dpi_scale_returns_none_off_windows(monkeypatch):
     """The raw probe must be a no-op on non-Windows hosts."""
     from tools.computer_use import cua_backend
 
     monkeypatch.setattr(cua_backend.sys, "platform", "linux")
     assert cua_backend._win32_dpi_scale(4242) is None
+    assert cua_backend._win32_dpi_probe(4242) is None
 
 
 def test_normalize_coordinate_helper(monkeypatch):
@@ -229,5 +620,11 @@ def test_normalize_coordinate_helper(monkeypatch):
     assert _normalize_coordinate(445, 1.5) == 297
     assert _normalize_coordinate(230, 1.25) == 184
     assert _normalize_coordinate(0, 2.0) == 0
+    # Identity scale passes values through untouched — no int truncation.
     assert _normalize_coordinate(300, 1.0) == 300
     assert _normalize_coordinate(300, None) == 300
+    assert _normalize_coordinate(299.7, 1.0) == 299.7
+    assert _normalize_coordinate(299.7, None) == 299.7
+    assert _normalize_coordinate(None, 1.0) is None
+    assert _normalize_coordinate(None, None) is None
+    assert _normalize_coordinate(None, 1.5) is None

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -261,6 +261,129 @@ def _cua_no_overlay() -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Windows HiDPI coordinate normalization (#94538)
+# ---------------------------------------------------------------------------
+#
+# cua-driver's Windows backend captures screenshots in physical pixels while
+# its input dispatch (SendInput) operates in logical units. On a scaled
+# display (e.g. 150%) a click at screenshot coordinate [x, y] therefore lands
+# at [x * scale, y * scale] — the input pipeline multiplies by the DPI scale
+# — and misses the intended element. The wrapper divides coordinate inputs
+# by the display scale factor (DPI / 96) before dispatching, mirroring what
+# Anthropic's reference computer-use implementation does with its
+# display_width_px / screen_width normalization.
+
+_CUA_NO_DPI_NORMALIZATION_ENV = "HERMES_CUA_NO_DPI_NORMALIZATION"
+
+# Sanity bounds for a plausible Windows display scale (25% .. 800%). Values
+# outside this range are probe garbage, not a real DPI setting; treating
+# them as scale would send clicks to nonsense coordinates.
+_MIN_WINDOWS_SCALE = 0.25
+_MAX_WINDOWS_SCALE = 8.0
+
+
+def _cua_dpi_normalization_disabled() -> bool:
+    """True when coordinate DPI normalization is explicitly turned off.
+
+    Normalization is automatic on Windows scaled displays. This is the
+    escape hatch for hosts/drivers that already normalize server-side:
+    ``HERMES_CUA_NO_DPI_NORMALIZATION`` (any truthy value) or
+    ``computer_use.dpi_normalization: false`` in config.
+    """
+    raw = os.environ.get(_CUA_NO_DPI_NORMALIZATION_ENV, "").strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    return _computer_use_cfg().get("dpi_normalization") is False
+
+
+def _normalize_coordinate(value: Any, scale: Any) -> int:
+    """Map a screenshot-space coordinate into the driver's input space.
+
+    Identity when ``scale`` is 1.0 or unavailable; otherwise divides by the
+    display scale and rounds to the nearest integer (SendInput coordinates
+    are integral).
+    """
+    try:
+        if not isinstance(scale, (int, float)) or scale == 1.0:
+            return int(value)
+        return int(round(float(value) / float(scale)))
+    except (TypeError, ValueError):
+        return int(value)
+
+
+def _win32_hwnd_for_pid(user32: Any, pid: int) -> Optional[int]:
+    """Best-effort HWND of the first visible top-level window of ``pid``."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+        found = []
+
+        def _enum_cb(hwnd, _lparam):
+            try:
+                if not user32.IsWindowVisible(hwnd):
+                    return True
+                proc_id = wintypes.DWORD()
+                user32.GetWindowThreadProcessId(hwnd, ctypes.byref(proc_id))
+                if proc_id.value == pid:
+                    found.append(hwnd)
+                    return False  # found — stop enumeration
+            except Exception:
+                return False
+            return True
+
+        user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
+        return int(found[0]) if found else None
+    except Exception:
+        return None
+
+
+def _win32_dpi_scale(pid: Optional[int]) -> Optional[float]:
+    """Display scale factor (DPI / 96) for a Windows target process, or None.
+
+    Prefers ``GetDpiForWindow`` for a visible top-level window of ``pid``
+    (per-monitor DPI); falls back to ``GetDpiForSystem``. Returns None when
+    the platform is not Windows or no DPI could be read, which callers
+    treat as "no normalization". See #94538.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        user32 = ctypes.windll.user32
+        hwnd = None
+        if pid:
+            hwnd = _win32_hwnd_for_pid(user32, int(pid))
+        dpi = 0
+        if hwnd:
+            try:
+                dpi = int(user32.GetDpiForWindow(hwnd))
+            except Exception:
+                dpi = 0
+        if dpi <= 0:
+            try:
+                dpi = int(user32.GetDpiForSystem())
+            except Exception:
+                dpi = 0
+        if dpi <= 0:
+            return None
+        scale = dpi / 96.0
+        if not (_MIN_WINDOWS_SCALE <= scale <= _MAX_WINDOWS_SCALE):
+            logger.warning(
+                "computer_use: implausible Windows DPI %s ignored for "
+                "coordinate normalization",
+                dpi,
+            )
+            return None
+        return scale
+    except Exception as exc:
+        logger.debug("computer_use: Windows DPI probe failed: %s", exc)
+        return None
+
+
 def _cua_telemetry_disabled() -> bool:
     """True when Hermes should disable cua-driver telemetry for this user.
 
@@ -2625,6 +2748,11 @@ class CuaDriverBackend(ComputerUseBackend):
         # element. Cleared whenever a fresh capture overwrites the
         # snapshot context.
         self._snapshot_tokens: Dict[int, str] = {}
+        # Windows HiDPI (#94538): cached DPI scale per active target pid.
+        # None means "probe failed / not applicable" and disables
+        # normalization; populated lazily so __new__-constructed test
+        # backends behave identically.
+        self._dpi_scale_cache: Dict[Optional[int], Optional[float]] = {}
         # Per-instance public cua-driver session label. The MCP transport owns
         # the private lifecycle and releases it when the connection closes.
         # start_session/end_session attach this stable label to cursor,
@@ -2779,6 +2907,7 @@ class CuaDriverBackend(ComputerUseBackend):
         self._last_app = None
         self._last_target = None
         self._snapshot_tokens = {}
+        self._dpi_scale_cache = {}
 
     def _failed_capture(self, mode: str, message: str = "") -> CaptureResult:
         """Return an empty capture after disarming any prior target context."""
@@ -3476,6 +3605,35 @@ class CuaDriverBackend(ComputerUseBackend):
             }
         return result
 
+    def _coordinate_scale(self) -> float:
+        """Scale factor to divide coordinate inputs by before dispatch.
+
+        Windows HiDPI (#94538): cua-driver captures screenshots in physical
+        pixels while its input dispatch operates in logical units, so raw
+        screenshot coordinates drift by the DPI scale. Dividing by the
+        display scale maps the screenshot space onto the driver's native
+        input space. Returns 1.0 (a no-op identical to pre-fix behavior)
+        when normalization is disabled, the host is not Windows, or the
+        DPI probe fails.
+        """
+        if _cua_dpi_normalization_disabled():
+            return 1.0
+        pid = self._active_pid
+        cache = getattr(self, "_dpi_scale_cache", None)
+        if cache is None:
+            cache = {}
+            self._dpi_scale_cache = cache
+        if pid in cache:
+            return cache[pid] or 1.0
+        try:
+            scale = _win32_dpi_scale(pid)
+        except Exception:
+            scale = None
+        if not isinstance(scale, (int, float)) or scale <= 0:
+            scale = None
+        cache[pid] = scale
+        return scale or 1.0
+
     def click(
         self,
         *,
@@ -3518,6 +3676,16 @@ class CuaDriverBackend(ComputerUseBackend):
             if self._active_window_id is None:
                 return ActionResult(ok=False, action=tool,
                                     message="No active window_id for coordinate click.")
+            scale = self._coordinate_scale()
+            if scale != 1.0:
+                norm_x = _normalize_coordinate(x, scale)
+                norm_y = _normalize_coordinate(y, scale)
+                logger.debug(
+                    "computer_use: click coordinates normalized for Windows "
+                    "DPI (scale=%.3f): (%s, %s) -> (%s, %s)",
+                    scale, x, y, norm_x, norm_y,
+                )
+                x, y = norm_x, norm_y
             args["x"] = x
             args["y"] = y
             args["window_id"] = self._active_window_id
@@ -3557,8 +3725,15 @@ class CuaDriverBackend(ComputerUseBackend):
             if self._active_window_id is None:
                 return ActionResult(ok=False, action="drag",
                                     message="No active window_id for coordinate drag.")
-            args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
-            args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
+            scale = self._coordinate_scale()
+            args["from_x"], args["from_y"] = (
+                _normalize_coordinate(from_xy[0], scale),
+                _normalize_coordinate(from_xy[1], scale),
+            )
+            args["to_x"], args["to_y"] = (
+                _normalize_coordinate(to_xy[0], scale),
+                _normalize_coordinate(to_xy[1], scale),
+            )
             args["window_id"] = self._active_window_id
         else:
             return ActionResult(ok=False, action="drag",
@@ -3602,8 +3777,9 @@ class CuaDriverBackend(ComputerUseBackend):
             if self._session.supports_capability(
                 "input.scroll.coordinates", tool="scroll"
             ):
-                args["x"] = x
-                args["y"] = y
+                scale = self._coordinate_scale()
+                args["x"] = _normalize_coordinate(x, scale)
+                args["y"] = _normalize_coordinate(y, scale)
             args["window_id"] = self._active_window_id
         return self._run_input_action("scroll", args, delivery_mode, bring_to_front)
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -273,6 +273,13 @@ def _cua_no_overlay() -> bool:
 # by the display scale factor (DPI / 96) before dispatching, mirroring what
 # Anthropic's reference computer-use implementation does with its
 # display_width_px / screen_width normalization.
+#
+# Rounding: SendInput coordinates are integral, so normalized values round
+# to the nearest integer. The rounding error is bounded to < 0.5 logical
+# px (sub-pixel at any display scale) and cannot drift a click off its
+# target element. At identity scale (1.0 / probe unavailable) values pass
+# through untouched — no int truncation, matching pre-fix behavior exactly
+# (#94666 review).
 
 _CUA_NO_DPI_NORMALIZATION_ENV = "HERMES_CUA_NO_DPI_NORMALIZATION"
 
@@ -288,28 +295,33 @@ def _cua_dpi_normalization_disabled() -> bool:
 
     Normalization is automatic on Windows scaled displays. This is the
     escape hatch for hosts/drivers that already normalize server-side:
-    ``HERMES_CUA_NO_DPI_NORMALIZATION`` (any truthy value) or
-    ``computer_use.dpi_normalization: false`` in config.
+    ``HERMES_CUA_NO_DPI_NORMALIZATION`` (any non-empty truthy value —
+    the conventional false spellings ``0``/``false``/``no``/``off`` are
+    ignored) or ``computer_use.dpi_normalization: false`` in config.
     """
     raw = os.environ.get(_CUA_NO_DPI_NORMALIZATION_ENV, "").strip().lower()
-    if raw in {"1", "true", "yes", "on"}:
+    if raw and raw not in {"0", "false", "no", "off"}:
         return True
     return _computer_use_cfg().get("dpi_normalization") is False
 
 
-def _normalize_coordinate(value: Any, scale: Any) -> int:
+def _normalize_coordinate(value: Any, scale: Any) -> Any:
     """Map a screenshot-space coordinate into the driver's input space.
 
-    Identity when ``scale`` is 1.0 or unavailable; otherwise divides by the
-    display scale and rounds to the nearest integer (SendInput coordinates
-    are integral).
+    Identity when ``scale`` is 1.0 or unavailable — the original value
+    (including ``None`` and non-integral floats) is returned untouched, so
+    scroll coordinates pass through without int truncation exactly as they
+    did before normalization. Otherwise divides by the display scale and
+    rounds to the nearest integer (SendInput coordinates are integral).
     """
+    if value is None:
+        return None
     try:
         if not isinstance(scale, (int, float)) or scale == 1.0:
-            return int(value)
+            return value
         return int(round(float(value) / float(scale)))
     except (TypeError, ValueError):
-        return int(value)
+        return value
 
 
 def _win32_hwnd_for_pid(user32: Any, pid: int) -> Optional[int]:
@@ -340,13 +352,15 @@ def _win32_hwnd_for_pid(user32: Any, pid: int) -> Optional[int]:
         return None
 
 
-def _win32_dpi_scale(pid: Optional[int]) -> Optional[float]:
-    """Display scale factor (DPI / 96) for a Windows target process, or None.
+def _win32_dpi_probe(pid: Optional[int]) -> Optional[Tuple[Optional[int], float]]:
+    """``(hwnd, display scale)`` for a Windows target process, or None.
 
     Prefers ``GetDpiForWindow`` for a visible top-level window of ``pid``
-    (per-monitor DPI); falls back to ``GetDpiForSystem``. Returns None when
-    the platform is not Windows or no DPI could be read, which callers
-    treat as "no normalization". See #94538.
+    (per-monitor DPI, resolved via ``EnumWindows`` /
+    ``GetWindowThreadProcessId``); falls back to ``GetDpiForSystem``.
+    Returns None when the platform is not Windows or no DPI could be read,
+    which callers treat as "no normalization". ``hwnd`` is None when the
+    system-DPI fallback was used. See #94538.
     """
     if sys.platform != "win32":
         return None
@@ -378,10 +392,20 @@ def _win32_dpi_scale(pid: Optional[int]) -> Optional[float]:
                 dpi,
             )
             return None
-        return scale
+        return (int(hwnd) if hwnd else None, scale)
     except Exception as exc:
         logger.debug("computer_use: Windows DPI probe failed: %s", exc)
         return None
+
+
+def _win32_dpi_scale(pid: Optional[int]) -> Optional[float]:
+    """Display scale factor (DPI / 96) for a Windows target process, or None.
+
+    Thin wrapper around :func:`_win32_dpi_probe` exposing the scale only;
+    see that function for the per-window-first probe and fallback contract.
+    """
+    probe = _win32_dpi_probe(pid)
+    return probe[1] if probe else None
 
 
 def _cua_telemetry_disabled() -> bool:
@@ -2748,11 +2772,16 @@ class CuaDriverBackend(ComputerUseBackend):
         # element. Cleared whenever a fresh capture overwrites the
         # snapshot context.
         self._snapshot_tokens: Dict[int, str] = {}
-        # Windows HiDPI (#94538): cached DPI scale per active target pid.
-        # None means "probe failed / not applicable" and disables
-        # normalization; populated lazily so __new__-constructed test
-        # backends behave identically.
-        self._dpi_scale_cache: Dict[Optional[int], Optional[float]] = {}
+        # Windows HiDPI (#94538): display scale bound to the current
+        # capture snapshot. Re-probed on every successful capture (a
+        # re-capture or a window moved to another monitor can never reuse a
+        # stale scale) and never set from a failed probe, so failures are
+        # retried on the next action instead of being pinned. None means
+        # "no capture yet / probe failed / not applicable". Guarded by
+        # ``_dpi_scale_lock``: capture and concurrent click/drag/scroll
+        # threads can race on the binding (#94666 review).
+        self._capture_dpi_scale: Optional[float] = None
+        self._dpi_scale_lock = threading.Lock()
         # Per-instance public cua-driver session label. The MCP transport owns
         # the private lifecycle and releases it when the connection closes.
         # start_session/end_session attach this stable label to cursor,
@@ -2907,7 +2936,7 @@ class CuaDriverBackend(ComputerUseBackend):
         self._last_app = None
         self._last_target = None
         self._snapshot_tokens = {}
-        self._dpi_scale_cache = {}
+        self._capture_dpi_scale = None
 
     def _failed_capture(self, mode: str, message: str = "") -> CaptureResult:
         """Return an empty capture after disarming any prior target context."""
@@ -3500,6 +3529,14 @@ class CuaDriverBackend(ComputerUseBackend):
             except Exception:
                 png_bytes_len = len(png_b64) * 3 // 4
 
+        # Windows HiDPI (#94538): bind the display scale to this fresh
+        # capture. Every successful capture re-probes, so the scale always
+        # matches the screenshot the model will reason over — a re-capture
+        # or a window moved between monitors can never reuse a stale
+        # factor, and a failed probe (nothing bound) is retried on the
+        # next action.
+        self._dpi_bind_for_capture()
+
         return CaptureResult(
             mode=mode,
             width=width,
@@ -3615,24 +3652,65 @@ class CuaDriverBackend(ComputerUseBackend):
         input space. Returns 1.0 (a no-op identical to pre-fix behavior)
         when normalization is disabled, the host is not Windows, or the
         DPI probe fails.
+
+        The scale is bound per capture (see :meth:`_dpi_bind_for_capture`)
+        so it always matches the screenshot the model reasoned over. When
+        no capture has bound one yet (e.g. a ``focus_app``-only target), a
+        lazy probe binds it for the active target; a *failed* probe is
+        never retained, so the next action retries instead of pinning "no
+        normalization".
         """
         if _cua_dpi_normalization_disabled():
             return 1.0
-        pid = self._active_pid
-        cache = getattr(self, "_dpi_scale_cache", None)
-        if cache is None:
-            cache = {}
-            self._dpi_scale_cache = cache
-        if pid in cache:
-            return cache[pid] or 1.0
-        try:
-            scale = _win32_dpi_scale(pid)
-        except Exception:
-            scale = None
-        if not isinstance(scale, (int, float)) or scale <= 0:
-            scale = None
-        cache[pid] = scale
-        return scale or 1.0
+        bound = getattr(self, "_capture_dpi_scale", None)
+        if isinstance(bound, (int, float)) and bound > 0:
+            return bound
+        lock = getattr(self, "_dpi_scale_lock", None)
+        if lock is None:  # __new__-constructed backends (tests) get a lock lazily
+            lock = threading.Lock()
+            self._dpi_scale_lock = lock
+        with lock:
+            bound = getattr(self, "_capture_dpi_scale", None)
+            if isinstance(bound, (int, float)) and bound > 0:
+                return bound
+            try:
+                probe = _win32_dpi_probe(self._active_pid)
+            except Exception:
+                probe = None
+            scale = probe[1] if probe else None
+            if not isinstance(scale, (int, float)) or scale <= 0:
+                return 1.0
+            self._capture_dpi_scale = scale
+            return scale
+
+    def _dpi_bind_for_capture(self) -> None:
+        """Bind the display scale to the just-completed capture (#94538).
+
+        Re-probed on *every* successful capture: the scale must match the
+        screenshot the model will reason over, so a re-capture or a window
+        moved between monitors with different DPI (same pid) always gets a
+        fresh factor — a stale scale can never be reused. A failed probe
+        binds nothing (``_capture_dpi_scale`` stays None), so the next
+        coordinate action or capture probes again. The probe-and-bind runs
+        under ``_dpi_scale_lock`` so a capture racing concurrent
+        click/drag/scroll threads is safe (#94666 review).
+        """
+        if _cua_dpi_normalization_disabled():
+            self._capture_dpi_scale = None
+            return
+        lock = getattr(self, "_dpi_scale_lock", None)
+        if lock is None:  # __new__-constructed backends (tests) get a lock lazily
+            lock = threading.Lock()
+            self._dpi_scale_lock = lock
+        with lock:
+            try:
+                probe = _win32_dpi_probe(self._active_pid)
+            except Exception:
+                probe = None
+            scale = probe[1] if probe else None
+            self._capture_dpi_scale = (
+                scale if isinstance(scale, (int, float)) and scale > 0 else None
+            )
 
     def click(
         self,
@@ -3726,13 +3804,17 @@ class CuaDriverBackend(ComputerUseBackend):
                 return ActionResult(ok=False, action="drag",
                                     message="No active window_id for coordinate drag.")
             scale = self._coordinate_scale()
+            # int() preserves the pre-normalization contract for drag
+            # coordinates (they were always truncated before dispatch);
+            # at a non-identity scale _normalize_coordinate already
+            # returns an int, making this a no-op.
             args["from_x"], args["from_y"] = (
-                _normalize_coordinate(from_xy[0], scale),
-                _normalize_coordinate(from_xy[1], scale),
+                int(_normalize_coordinate(from_xy[0], scale)),
+                int(_normalize_coordinate(from_xy[1], scale)),
             )
             args["to_x"], args["to_y"] = (
-                _normalize_coordinate(to_xy[0], scale),
-                _normalize_coordinate(to_xy[1], scale),
+                int(_normalize_coordinate(to_xy[0], scale)),
+                int(_normalize_coordinate(to_xy[1], scale)),
             )
             args["window_id"] = self._active_window_id
         else:
@@ -3905,6 +3987,10 @@ class CuaDriverBackend(ComputerUseBackend):
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
             self._snapshot_tokens = {}
+            # Target changed without a fresh capture: drop the capture-bound
+            # DPI scale (#94538) so the next coordinate action probes the
+            # new window instead of reusing the previous capture's scale.
+            self._capture_dpi_scale = None
             self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
             self._last_target = {
                 "pid": self._active_pid,


### PR DESCRIPTION
## Summary

Fixes #94538 — `cua-driver`'s Windows backend captures screenshots in **physical pixels**, but its input dispatch (`SendInput`) operates in **logical units**. On a scaled display (e.g. 150%), a `computer_use(action="click", coordinate=[x, y])` derived from a `mode="vision"` capture was dispatched at `[x * scale, y * scale]` and missed the target (the issue's repro: a click at screenshot `[230, 285]` landed at physical `[285 * 1.5 = 427]`).

The Hermes `cua_backend` wrapper now divides coordinate inputs by the target window's DPI scale factor (`DPI / 96`) before forwarding them to cua-driver, so screenshot-space coordinates land exactly on the visual element.

## Changes

`tools/computer_use/cua_backend.py`:

- **New `_win32_dpi_scale(pid)` probe** — prefers `GetDpiForWindow` for a visible top-level window of the active target pid (per-monitor DPI, resolved via `EnumWindows`/`GetWindowThreadProcessId`), falling back to `GetDpiForSystem`. Fully guarded: returns `None` on non-Windows hosts, when the API is missing (pre-Win10 1607), or when the result is implausible (clamped to 0.25–8.0). A failed probe is a silent no-op.
- **`CuaDriverBackend._coordinate_scale()` / `_dpi_bind_for_capture()`** — the display scale is **bound to each capture snapshot**: every successful capture re-probes and rebinds, so a re-capture or a window moved between monitors (same pid, different DPI) can never reuse a stale scale. A *failed* probe is never retained — the next action or capture retries instead of pinning "no normalization". The binding is guarded by a `threading.Lock` so concurrent capture/click/drag/scroll threads are safe. Returns `1.0` when normalization is disabled, the host isn't Windows, or the probe fails.
- **Normalization applied to coordinate input paths**: `click`/`double_click` (`x`/`y`), `drag` (`from_xy`/`to_xy`), and `scroll` (`x`/`y` when the driver advertises coordinate scrolling). Coordinates are divided by the scale and rounded (`int(round(v / scale))`); a debug log records the transform. Element-index clicks are untouched (the driver resolves those server-side in its own coordinate space).
- **Escape hatch** — `HERMES_CUA_NO_DPI_NORMALIZATION` (any non-empty truthy value; the conventional false spellings `0`/`false`/`no`/`off` are ignored) or `computer_use.dpi_normalization: false` in config restores the pre-fix passthrough for drivers that normalize server-side. At identity scale (1.0 / probe unavailable) coordinates pass through **untouched** — scroll floats are not int-truncated; drag keeps its pre-fix `int()` truncation.

Behavior is identical to pre-fix everywhere except Windows hosts with a non-100% display scale, where coordinate inputs are now mapped correctly.

## Review follow-ups (#94666)

Adversarial review findings addressed:

1. **Per-pid scale cache was invalidatable** (same pid across monitors / re-capture could reuse a stale scale) → replaced with a **per-capture binding** (`_dpi_bind_for_capture`, called on every successful capture). The scale always matches the screenshot the model reasoned over; `focus_app` retargets invalidate the binding. (Reviewer option: re-probe each capture.)
2. **Probe failure `None` was permanently cached** → failures are never retained; every subsequent coordinate action or capture probes again.
3. **Win32 ctypes probe path had zero automated tests** → new tests drive `EnumWindows` → `GetDpiForWindow` → `GetDpiForSystem` (per-window DPI win, zero-window fallback, raise-fallback, no-window system-only path, missing/implausible DPI rejection) through a fake `ctypes` module injected into `sys.modules`.
4. **Kill-switch whitelist (4 values) contradicted the documented "any truthy value"** → now any non-empty truthy env value disables normalization (`0`/`false`/`no`/`off`/blank ignored); docs and code agree.
5. **Concurrency (Enough1122)** — the old lock-free per-pid dict could raise `RuntimeError: dictionary changed size during iteration` under concurrent click+scroll. The scalar per-capture binding is guarded by `threading.Lock` (double-checked), and a new 8-thread click+scroll stress test asserts a single probe and consistent dispatch.
6. **1px rounding documented** — normalization rounds to the nearest integer; error is bounded to < 0.5 logical px (sub-pixel), noted in the module comment.

## Tests

New `tests/tools/test_computer_use_cua_dpi_normalization.py` (**40 tests**, red before the fix → green after):

- click / double_click / drag / scroll coordinates divided by 1.5 (150% DPI)
- rounding to nearest integer (`445 / 1.5 → 297`)
- no-op when scale is unavailable, `1.0`, or normalization disabled via env/config kill switch
- element-index clicks are never scaled
- per-capture re-probe (no stale scale across re-captures / monitor moves), probe-failure retry, focus_app retarget invalidation
- kill-switch truthiness parametrized (accepts any non-empty truthy; ignores `0`/`false`/`no`/`off`)
- scroll coordinate passthrough without int truncation at identity scale
- 8-thread concurrent click/scroll stress test (one probe, consistent coordinates, no races)
- fake-`ctypes` Win32 probe chain: EnumWindows stop-at-first-visible-match, GetDpiForWindow → GetDpiForSystem fallback, raise-fallback, system-only path, missing/implausible DPI → `None`
- `_win32_dpi_scale`/`_win32_dpi_probe` return `None` on non-Windows; `_normalize_coordinate` identity/None/float passthrough

`pytest tests/tools/test_computer_use*.py tests/computer_use/` → **384 passed**, 6 skipped, **4 failed** — the same 4 pre-existing failures as before this change (native-Windows WSL path-separator tests + 2 session-reconnect/capture tests; confirmed byte-identical on the previous head).

Validated the real Win32 probe path on a Windows 11 host: `GetDpiForWindow` returns 144 (150%) for a scaled window while `GetDpiForSystem` returns 96 (100%), confirming the per-window-first probe design.

Closes #94538
