### PR TITLE
fix(gateway): quick-command output must survive non-UTF-8 bytes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17983,7 +17983,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 env=sanitized_env,
                             )
                             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-                            output = (stdout or stderr).decode().strip()
+                            output = (stdout or stderr).decode(errors="replace").strip()
                             # Redact any remaining sensitive patterns in output
                             if output:
                                 from agent.redact import redact_sensitive_text


### PR DESCRIPTION
## Problem

Gateway quick commands (`type: exec`) decoded subprocess output with **strict UTF-8**:

```python
output = (stdout or stderr).decode().strip()
```

On hosts whose console tools emit localized bytes (cp1252 on Western Windows, GBK, Shift-JIS — `dir` headers, system messages), the decode raised `UnicodeDecodeError`. The generic `except Exception` handler caught it, so no crash — but the user got **`Quick command error: 'utf-8' codec can't decode byte...`** instead of the command's actual output. The command ran; its result was discarded.

This is the same crash family as #89465 (terminal output decoding in the host codepage), but that PR touches only `tools/environments/{base,local}.py` — this gateway-side call site was missed.

## Fix

Decode with `errors="replace"`. The output is display-only and passes through `redact_sensitive_text` anyway: readable ASCII/UTF-8 content is preserved verbatim, non-decodable bytes become replacement characters instead of nuking the whole result.

## Verification

Single-site replacement; module parses clean. Behavior for valid UTF-8 output is byte-identical.