### PR TITLE
fix(tools): stop treating a post-registration reconnect drop as an initial-connect failure

### DIFF
--- a/tests/tools/test_mcp_parked_self_probe.py
+++ b/tests/tools/test_mcp_parked_self_probe.py
@@ -88,6 +88,7 @@ def test_parked_server_self_probes_and_revives(monkeypatch, tmp_path):
                     # First connect succeeds (sets _ready), then dies.
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                     raise RuntimeError("backend outage begins")
                 if not state["backend_up"]:

--- a/tests/tools/test_mcp_reconnect_log_hygiene.py
+++ b/tests/tools/test_mcp_reconnect_log_hygiene.py
@@ -68,6 +68,7 @@ def test_retry_attempts_log_debug_transitions_warn(monkeypatch, tmp_path, caplog
                 if state["transport_calls"] == 1:
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                 raise ConnectionError("backend down")
 

--- a/tests/tools/test_mcp_reconnect_retry_reset.py
+++ b/tests/tools/test_mcp_reconnect_retry_reset.py
@@ -62,6 +62,7 @@ def test_reconnect_counter_resets_after_successful_session(monkeypatch, tmp_path
                     # First connect: succeed (sets _ready), then fail.
                     self.session = object()
                     self._ready.set()
+                    self._ever_connected = True
                     self.session = None
                     raise RuntimeError("blip 1")
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1421,6 +1421,73 @@ class TestReconnection:
 
         asyncio.run(_test())
 
+    def test_reconnect_failures_after_initial_success_use_reconnect_budget(self):
+        """A server that already registered tools must not be re-classified
+        as "never connected" just because a later reconnect attempt fails
+        while ``_ready`` is momentarily clear (#94654).
+
+        ``_MAX_INITIAL_CONNECT_RETRIES`` is 3 and ``_MAX_RECONNECT_RETRIES``
+        is 5. Four consecutive post-success reconnect failures exceed the
+        (buggy) initial-connect ladder but not the reconnect budget, so this
+        distinguishes the two code paths.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        run_count = 0
+        target_server = None
+
+        async def patched_run_stdio(self_srv, config):
+            nonlocal run_count, target_server
+            run_count += 1
+            if target_server is not self_srv:
+                return None
+            if run_count == 1:
+                # Initial connection succeeds and registers tools. Setting
+                # ``_ever_connected`` mirrors what the real ``_run_stdio``
+                # does right after a successful ``_discover_tools()`` call;
+                # guarded because the pre-fix class has no such slot.
+                self_srv.session = MagicMock()
+                self_srv._tools = []
+                self_srv._ready.set()
+                try:
+                    self_srv._ever_connected = True
+                except AttributeError:
+                    pass
+                return "reconnect"
+            if run_count <= 5:
+                # Four consecutive failures on later reconnect attempts --
+                # a flapping transport, not a server that never connected.
+                raise ConnectionError("reconnect attempt failed")
+            self_srv._shutdown_event.set()
+            await self_srv._shutdown_event.wait()
+
+        async def patched_wait_parked(self_srv, timeout=None):
+            # If the code under test parks early, unblock immediately
+            # instead of waiting out the real park interval.
+            self_srv._shutdown_event.set()
+            return "shutdown"
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch.object(
+                     MCPServerTask, "_wait_for_reconnect_or_shutdown",
+                     patched_wait_parked,
+                 ), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({"command": "test"})
+
+            assert server._was_parked is False, (
+                "server parked after only 4 reconnect failures following a "
+                "successful initial connection -- it was misclassified as "
+                "never having connected and re-entered the initial-connect "
+                "ladder instead of the (larger) reconnect budget"
+            )
+
+        asyncio.run(_test())
 
     def test_preflight_probe_runs_on_initial_http_connect(self):
         """The content-type preflight probe fires on the first HTTP connect."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1444,15 +1444,11 @@ class TestReconnection:
             if run_count == 1:
                 # Initial connection succeeds and registers tools. Setting
                 # ``_ever_connected`` mirrors what the real ``_run_stdio``
-                # does right after a successful ``_discover_tools()`` call;
-                # guarded because the pre-fix class has no such slot.
+                # does right after a successful ``_discover_tools()`` call.
                 self_srv.session = MagicMock()
                 self_srv._tools = []
                 self_srv._ready.set()
-                try:
-                    self_srv._ever_connected = True
-                except AttributeError:
-                    pass
+                self_srv._ever_connected = True
                 return "reconnect"
             if run_count <= 5:
                 # Four consecutive failures on later reconnect attempts --

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2396,6 +2396,7 @@ class MCPServerTask:
         "_reconnect_retries", "_session_proven", "_was_parked",
         "_inflight_tasks", "_reconnecting", "_suspect_reason",
         "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
+        "_ever_connected",
     )
 
     def __init__(self, name: str):
@@ -2426,6 +2427,12 @@ class MCPServerTask:
         # keeps getting charged and still reaches the park instead of
         # hot-cycling respawns forever.
         self._session_proven: bool = False
+        # Set once tools have ever been registered and never cleared again,
+        # unlike ``_ready`` (which is cleared on every reconnect cycle). Used
+        # to tell a genuine first-connection failure from a later reconnect
+        # failure that merely happens to occur while ``_ready`` is
+        # momentarily clear — see the ``initial_retries`` ladder in run().
+        self._ever_connected: bool = False
         # True while parked (reconnect budget exhausted) or after a park,
         # until the session proves healthy again — used to log the
         # parked→revived transition exactly once.
@@ -3335,6 +3342,7 @@ class MCPServerTask:
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
+                    self._ever_connected = True
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
@@ -3706,6 +3714,7 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
+                        self._ever_connected = True
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -3771,6 +3780,7 @@ class MCPServerTask:
                             self.session = session
                             await self._discover_tools()
                             self._ready.set()
+                            self._ever_connected = True
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
                             # isn't gated on a stale failure count (#16788).
@@ -3818,6 +3828,7 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
+                        self._ever_connected = True
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
                         # gated on a stale consecutive-failure count (#16788).
@@ -4116,9 +4127,14 @@ class MCPServerTask:
 
                 # If this is the first connection attempt, retry with backoff
                 # before giving up. A transient DNS/network blip at startup
-                # should not permanently kill the server.
+                # should not permanently kill the server. Gated on
+                # ``_ever_connected`` rather than ``_ready`` — ``_ready`` is
+                # cleared on every reconnect cycle (see below), so a server
+                # that already registered tools once and then dropped would
+                # otherwise be misclassified as never having connected and
+                # re-enter this initial-connect ladder (#94654).
                 # (Ported from Kilo Code's MCP resilience fix.)
-                if not self._ready.is_set():
+                if not self._ever_connected:
                     if failure_class == "permanent":
                         # Deterministic failure (bad command, non-MCP URL,
                         # 401/403): every retry hits the same wall. Park

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4133,6 +4133,7 @@ class MCPServerTask:
                 # that already registered tools once and then dropped would
                 # otherwise be misclassified as never having connected and
                 # re-enter this initial-connect ladder (#94654).
+                # ``_ever_connected`` itself is set once and never cleared.
                 # (Ported from Kilo Code's MCP resilience fix.)
                 if not self._ever_connected:
                     if failure_class == "permanent":


### PR DESCRIPTION
## What does this PR do?

Fixes a long-lived-gateway MCP bug where a server that already registered
its tools successfully gets reclassified as having "failed initial
connection" and parked forever, even though it connected fine.

`MCPServerTask.run()` distinguishes a genuine first-connection failure
from a later reconnect failure using `self._ready.is_set()`. But
`_ready` is **cleared on every reconnect cycle** (`run()` clears it right
before looping back into `_run_stdio`/`_run_http`), not just before the
very first connect. So the sequence is:

1. First connect succeeds: tools register, `_ready.set()`.
2. Something (keepalive failure, transport TaskGroup drop, auth refresh,
   etc.) asks for a reconnect. `run()` clears `_ready` and re-enters the
   transport.
3. If *that* reconnect attempt fails, `run()` sees `_ready.is_set() ==
   False` and — incorrectly — treats it as if the server had *never*
   connected, entering the 3-attempt `initial_retries` ladder
   (`_MAX_INITIAL_CONNECT_RETRIES = 3`) instead of the 5-attempt
   `_reconnect_retries` budget (`_MAX_RECONNECT_RETRIES = 5`) meant for a
   server that has already proven it can connect.
4. After only 3-4 such failures, it logs `failed initial connection
   after 3 attempts, parking...` and deregisters the tools — exactly the
   symptom in #94654, reproduced there with a stdio Todoist MCP server
   that registered 51 tools and was parked ~8 seconds later.

## Fix

Add a sticky `_ever_connected` flag (`tools/mcp_tool.py`) that is set
once, right alongside `_ready.set()`, immediately after a successful
`_discover_tools()` call in each of the four connect-success sites
(stdio, SSE, new Streamable HTTP, legacy Streamable HTTP) — and never
cleared again. The initial-vs-reconnect branch in `run()` now checks
`self._ever_connected` instead of `self._ready.is_set()`, so a server
that has proven it can connect always uses the (larger, more forgiving)
reconnect budget for subsequent drops, regardless of how `_ready`
happens to be toggling.

## Related Issue

Fixes #94654

## How to Test

Added `TestReconnection::test_reconnect_failures_after_initial_success_use_reconnect_budget`
in `tests/tools/test_mcp_tool.py`. It drives `MCPServerTask.run()` with a
patched `_run_stdio` that succeeds once (setting `_ready` and
`_ever_connected`, mirroring the real success path) and then fails 4
times in a row with a transient `ConnectionError`, and asserts the
server is not parked.

- Confirmed the test **fails without the fix** (reverting only
  `tools/mcp_tool.py`, keeping the new test):

  ```
  FAILED tests/tools/test_mcp_tool.py::TestReconnection::test_reconnect_failures_after_initial_success_use_reconnect_budget
  AssertionError: server parked after only 4 reconnect failures following a successful initial connection ...
  Captured log call:
  WARNING tools.mcp_tool:mcp_tool.py:4177 MCP server 'test_srv' failed initial connection after 3 attempts, parking until a reconnect is requested (state: connecting → parked): ConnectionError: reconnect attempt failed
  ```

  That's the exact log line from the issue report.

- With the fix applied, the full suite passes:

  ```
  $ python -m pytest tests/tools/test_mcp_tool.py -q
  98 passed, 2 warnings in 3.65s

  $ python -m pytest tests/tools/test_mcp_tool_session_expired.py \
      tests/tools/test_mcp_tool_issue_948.py \
      tests/tools/test_mcp_tool_401_handling.py \
      tests/tools/test_setup_mcp_tool.py \
      tests/tools/test_refresh_agent_mcp_tools.py \
      tests/hermes_cli/test_mcp_tools_config.py -q
  40 passed, 2 warnings in 6.72s
  ```

  (The two `_watch_stdio_children` RuntimeWarnings are pre-existing and
  unrelated to this change — present on both runs.)

- `ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py` — all
  checks passed.

## What platforms you tested on

Linux (test suite only — no real MCP server was spun up; this is a pure
unit-level fix to the reconnect classification logic).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (targeted: the mcp-related test files above) and all tests pass
- [x] I've added a test for this change
- [x] I've tested on my platform: Linux (unit tests)
- [ ] Updated docs / config example / CONTRIBUTING / AGENTS.md — N/A, no user-facing behavior or config surface changed
- [x] Cross-platform impact considered — the change is pure Python state-tracking logic, no OS-specific behavior touched

## AI assistance disclosure

This fix was authored with AI assistance (Claude Code), including
locating the root cause in `tools/mcp_tool.py`, writing the fix and the
regression test, and running the verification above.
