### PR TITLE
fix(desktop): decide image/file byte-upload by the session's own connection, not ambient

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,8 +22,8 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
-import { $sessionStates, patchSessionTile, sessionTileDelegate } from '@/store/session-states'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
+import { $sessionStates, isSessionRemote, patchSessionTile, sessionTileDelegate } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
@@ -178,7 +178,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
     ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
-      const remote = $connection.get()?.mode === 'remote'
+      const remote = isSessionRemote(storedIdRef.current ?? sessionId)
       let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -27,7 +27,6 @@ import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import {
   $busy,
-  $connection,
   $currentCwd,
   $messages,
   $terminalBackend,
@@ -37,7 +36,7 @@ import {
   setMessages,
   setTurnStartedAt
 } from '@/store/session'
-import { $sessionStates } from '@/store/session-states'
+import { $sessionStates, isSessionRemote } from '@/store/session-states'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
@@ -340,8 +339,8 @@ export function usePromptActions({
       options: { updateComposerAttachments?: boolean } = {}
     ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
-      const remote = $connection.get()?.mode === 'remote'
       const storedSessionId = selectedStoredSessionIdRef.current
+      const remote = isSessionRemote(storedSessionId ?? sessionId)
       let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 
@@ -430,7 +429,7 @@ export function usePromptActions({
   // image.attach_bytes.
   const eagerlyUploadAttachment = useCallback(
     async (sessionId: string, attachment: ComposerAttachment) => {
-      const remote = $connection.get()?.mode === 'remote'
+      const remote = isSessionRemote(sessionId)
 
       setComposerAttachmentUploadState(attachment.id, 'uploading')
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -74,7 +74,8 @@ import { Loader2Icon } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import type { ComposerAttachment } from '@/store/composer'
 import { notifyError } from '@/store/notifications'
-import { $connection, $terminalBackend } from '@/store/session'
+import { $terminalBackend } from '@/store/session'
+import { isSessionRemote } from '@/store/session-states'
 import { notifyThreadEditClose } from '@/store/thread-scroll'
 
 interface UserEditComposerProps {
@@ -408,7 +409,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         return droppedFileInlineRefs(osDrops, cwd)
       }
 
-      const remote = $connection.get()?.mode === 'remote'
+      const remote = isSessionRemote(sessionId)
 
       const requestGateway = <T,>(method: string, params?: Record<string, unknown>) =>
         gateway.request<T>(method, params)

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -4,7 +4,7 @@ import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $selectedStoredSessionId, setSessions } from '@/store/session'
+import { $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
@@ -12,6 +12,7 @@ import {
   blankDraftTile,
   focusedSessionNeedsRoute,
   focusOpenSession,
+  isSessionRemote,
   knownOwnerForSession,
   markSelectionRestore,
   nextSessionTileForWorkspace,
@@ -625,5 +626,51 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
 
     expect(ambient).toHaveBeenCalledTimes(1)
     expect(ambient.mock.calls[0]).toEqual(['approval.respond', { choice: 'once', session_id: 'unknown-session' }])
+  })
+})
+
+describe('isSessionRemote (#94640)', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+  })
+  afterEach(() => {
+    $sessionTiles.set([])
+    setSessions([])
+    $connection.set(null)
+  })
+
+  it('falls back to the ambient connection when the session has no known owner route', () => {
+    $connection.set({ mode: 'remote' } as never)
+    expect(isSessionRemote('unknown-session')).toBe(true)
+
+    $connection.set({ mode: 'local' } as never)
+    expect(isSessionRemote('unknown-session')).toBe(false)
+  })
+
+  it("prefers the session's OWN owner route over an ambient connection of a different mode", () => {
+    // The window's active/ambient connection is local, but this session
+    // belongs to a registered secondary REMOTE connection (Bot Mode / the
+    // unified Sessions list). Composer image uploads must still upload
+    // bytes for it — reading ambient mode here shipped a client-local
+    // composer-images path to the remote backend (#94640).
+    $connection.set({ mode: 'local' } as never)
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'homelab', mode: 'remote', profile: 'default' },
+        runtimeId: 'rt-1',
+        storedSessionId: 'stored-1'
+      }
+    ])
+
+    expect(isSessionRemote('rt-1')).toBe(true)
+    expect(isSessionRemote('stored-1')).toBe(true)
+  })
+
+  it('falls back to ambient when the owner is a bare pool profile (no connectionId/mode)', () => {
+    $connection.set({ mode: 'remote' } as never)
+    setSessions([{ id: 'stored-2', profile: 'loki' } as never])
+
+    expect(isSessionRemote('stored-2')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -38,6 +38,7 @@ import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
   $activeSessionId,
+  $connection,
   $lastReadAtBySessionId,
   $selectedStoredSessionId,
   $sessions,
@@ -753,6 +754,27 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
   return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+}
+
+/**
+ * Whether the connection that OWNS `sessionId` is remote — never the ambient
+ * `$connection`. A session tied to a registered secondary connection (Bot
+ * Mode, the unified Sessions list) can differ from whichever connection the
+ * window currently shows; its RPCs already route to their own owner via
+ * `requestForSessionProfile`, but a caller that instead reads ambient mode to
+ * decide image.attach vs image.attach_bytes ships a client-local path to a
+ * remote backend that can't resolve it (#94640). A bare profile name (no
+ * connectionId) is a pool profile of the ambient connection, so ambient mode
+ * still applies there.
+ */
+export function isSessionRemote(sessionId: null | string | undefined): boolean {
+  const owner = knownOwnerForSession(sessionId)
+
+  if (owner && typeof owner === 'object' && owner.mode) {
+    return owner.mode === 'remote'
+  }
+
+  return $connection.get()?.mode === 'remote'
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Fixes the byte-vs-path decision for composer image/file attachments so it
follows the *session's own* connection instead of whatever connection the
window currently shows.

`uploadComposerAttachment()` (used for `image.attach` / `image.attach_bytes`
/ `file.attach`) decides whether to upload bytes with:

```ts
const remote = $connection.get()?.mode === 'remote'
```

`$connection` is the **ambient/active** connection — presentation state for
whatever the window happens to be showing. Since the multi-connection /
unified-Sessions-list work landed, a session can be owned by a *different*,
registered connection than the ambient one (Bot Mode, a secondary gateway
row). The gateway RPC itself already routes correctly to that owner via
`requestForSessionProfile` (see `session-request-router.ts` /
`session-states.ts`'s `knownOwnerForSession`), but the byte-vs-path decision
never consulted that same routing — so a window whose *ambient* connection
reads `local` while chatting in a session owned by a *registered remote*
connection calls `image.attach` with the client-local
`.../composer-images/composer_....png` path, which the remote backend can't
resolve: `media file not found: ...`.

## Related Issue

Fixes #94640

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-states.ts`: add `isSessionRemote(sessionId)`,
  which resolves the session's own owner route (tile route → known session
  profile) and reads its `mode` when known, falling back to the ambient
  `$connection` only when no owner route is known — mirroring the fallback
  rule `knownOwnerForSession`/`requestForSessionProfile` already use for RPC
  dispatch.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts`: use
  `isSessionRemote(...)` in `syncAttachmentsForSubmit` and
  `eagerlyUploadAttachment` instead of the ambient `$connection` read.
- `apps/desktop/src/app/chat/session-tile-actions.ts`: same, in the tile's
  `syncAttachmentsForSubmit`.
- `apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx`:
  same, in `uploadOsDropRefs` (message-edit OS-drop path).
- `apps/desktop/src/store/session-states.test.ts`: new `isSessionRemote`
  coverage (ambient fallback with no owner, owner-route override when ambient
  and owner disagree, bare pool-profile fallback).

## How to Test

1. Register two connections: a primary/ambient **local** connection and a
   secondary **remote** connection (e.g. via Bot Mode or the unified Sessions
   list), and open a chat that is owned by the remote one.
2. Paste/attach an image in that chat's composer and send.
3. Before this fix: the composer sends `image.attach` with the local
   `composer-images/...` path, and the remote backend's `vision_analyze`
   fails with `media file not found`.
4. After this fix: the composer sends `image.attach_bytes` with the file's
   base64 bytes, and the remote gateway writes the image into its own media
   directory.

### Test output

```
$ npx tsc -p . --noEmit
(no output — clean)

$ npx vitest run src/store/session-states.test.ts
 Test Files  1 passed (1)
      Tests  43 passed (43)

$ npx vitest run
 Test Files  717 passed | 1 skipped (718)
      Tests  7467 passed | 3 skipped (7470)
```

Confirmed the new test fails without the fix: reverted the four source files
to their pre-fix state (`git checkout HEAD~1 -- <files>` equivalent via
`git stash`) with the test file kept, and got:

```
FAIL  src/store/session-states.test.ts > isSessionRemote (#94640) > falls back to the ambient connection when the session has no known owner route
TypeError: isSessionRemote is not a function
```
(3 failures, matching the 3 new test cases) — then restored the fix and all
43 tests in that file passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — could not run the Electron app itself in this
      sandbox; verified via the unit test suite and `tsc --noEmit` only.

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architecture changed beyond the fix itself.

---

**AI-assistance disclosure:** this change (investigation, fix, and tests) was
produced by an AI coding agent (Claude/Anthropic) working autonomously from
the issue description, then verified against the repo's own typecheck and
test suite as shown above.
