### PR TITLE
fix(fallback): apply host_mandated_api_mode when re-determining fallback api_mode

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2635,7 +2635,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
 
         if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
-            if fb_provider == "openai-codex":
+            from hermes_cli.providers import host_mandated_api_mode
+
+            _fb_mandated = host_mandated_api_mode(fb_base_url)
+            if _fb_mandated:
+                # Hosts that only speak one wire protocol (Kimi /coding →
+                # anthropic_messages, official OpenAI → codex_responses,
+                # Bedrock → bedrock_converse…) must be mapped here the same
+                # way agent init does, or a kimi-coding fallback entry 404s
+                # on every call (POST /coding/chat/completions) while the
+                # same provider works as a primary. (Fix 2026-08-15, carried.)
+                fb_api_mode = _fb_mandated
+            elif fb_provider == "openai-codex":
                 fb_api_mode = "codex_responses"
             elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
                 # Portal is dual-wire: anthropic/* must land on /v1/messages.

--- a/tests/run_agent/test_fallback_api_mode_preservation.py
+++ b/tests/run_agent/test_fallback_api_mode_preservation.py
@@ -160,6 +160,59 @@ class TestOriginalUrlDetection:
         assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
 
 
+class TestHostMandatedRedetection:
+    def test_kimi_coding_provider_lands_on_anthropic_messages(self):
+        """A kimi-coding fallback entry resolves api.kimi.com/coding from
+        provider config, not the entry, so the pre-resolve hint check never
+        sees it. The /coding endpoint only speaks Anthropic Messages
+        (POST /coding/chat/completions returns HTTP 404), so post-resolve
+        re-detection must consult host_mandated_api_mode the same way agent
+        init does."""
+        fbs = [{"provider": "kimi-coding", "model": "kimi-k2.6", "api_key": "k"}]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.kimi.com/coding", "kimi-k2.6")
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_kimi_coding_base_url_entry_detected(self):
+        """Same endpoint spelled directly on the fallback entry."""
+        fbs = [{
+            "provider": "custom",
+            "model": "kimi-k2.6",
+            "base_url": "https://api.kimi.com/coding",
+            "api_key": "k",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.kimi.com/coding", "kimi-k2.6")
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_explicit_api_mode_still_wins_over_host_mandate(self):
+        """The fallback path keeps the existing contract: an explicit
+        fb.api_mode is never clobbered, host mandate included."""
+        fbs = [{
+            "provider": "custom",
+            "model": "kimi-k2.6",
+            "base_url": "https://api.kimi.com/coding",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.kimi.com/coding", "kimi-k2.6")
+        assert agent.api_mode == "chat_completions"
+
+    def test_plain_kimi_chat_host_not_mandated(self):
+        """api.kimi.com WITHOUT /coding is an ordinary OpenAI-compatible
+        surface — no mandate, stays chat_completions."""
+        fbs = [{
+            "provider": "custom",
+            "model": "kimi-k2.6",
+            "base_url": "https://api.kimi.com/v1",
+            "api_key": "k",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.kimi.com/v1", "kimi-k2.6")
+        assert agent.api_mode == "chat_completions"
+
+
 class TestPlainFallbackUnchanged:
     def test_plain_openrouter_fallback_stays_chat_completions(self):
         fbs = [{


### PR DESCRIPTION
## What does this PR do?

A `kimi-coding` entry in `fallback_providers` 404s on **every** call, while the exact same provider/model works fine as a primary.

`api.kimi.com/coding` only speaks the Anthropic Messages wire. The primary path knows this — `host_mandated_api_mode()` in `hermes_cli/providers.py` maps the host, and `agent/agent_init.py` consults it. The fallback activation path in `try_activate_fallback()` does not: it re-derives `fb_api_mode` from a hand-rolled chain (`openai-codex` → `nous` → `/anthropic` suffix → Azure → direct-OpenAI → Bedrock) that has no entry for Kimi, so the entry lands on the `chat_completions` default and every fallback call becomes `POST /coding/chat/completions` → **HTTP 404 `resource_not_found_error`**.

Observed on my own install as 8/8 failed retries on each failover (2026-08-13 05:07, 2026-08-15 01:17): the primary rate-limits, the fallback activates, and every subsequent request 404s until the primary recovers — so the fallback silently provides no coverage at all.

The fix consults `host_mandated_api_mode(fb_base_url)` first when re-determining the mode, exactly like agent init does. That is the function whose docstring already declares these mappings *mandatory* ("a session carrying a stale api_mode … must be overridden to the host's required mode"), so this makes the fallback path honour a contract that already exists rather than adding a second Kimi special-case.

Because the mandate lookup is shared rather than Kimi-specific, the same bug is fixed for every other mandated host reachable as a named-provider fallback: `api.meta.ai` and the official OpenAI host family (→ `codex_responses`), and `bedrock-runtime.*.amazonaws.com` (→ `bedrock_converse`, previously only caught by a narrower inline check).

## Related Issue

No existing issue — found and reproduced locally. Searched open and closed PRs/issues for "kimi fallback", "fallback api_mode", `host_mandated_api_mode`: no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — in the post-resolve `fb_api_mode` re-determination, consult `host_mandated_api_mode(fb_base_url)` before the existing provider/URL chain. Guarded by the pre-existing `not fb_api_mode_explicit` condition, so an explicitly configured `api_mode` still always wins.
- `tests/run_agent/test_fallback_api_mode_preservation.py` — new `TestHostMandatedRedetection` covering the fix and its boundaries.

## How to Test

1. Configure a Kimi Code fallback:
   ```yaml
   fallback_providers:
     - provider: kimi-coding
       model: kimi-k2.6
   ```
2. Force a failover (rate-limit or kill the primary). **Before:** every fallback call is `POST https://api.kimi.com/coding/chat/completions` → 404 `resource_not_found_error`, retried to exhaustion. **After:** calls go out on `/v1/messages` and succeed.
3. `pytest tests/run_agent/test_fallback_api_mode_preservation.py -q` → 12 passed (8 pre-existing + 4 new). The new `test_kimi_coding_provider_lands_on_anthropic_messages` fails on `main` and passes with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites (`tests/run_agent/`, `tests/agent/`) and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (kernel 7.1), Python 3.11

New test cases:
- `test_kimi_coding_provider_lands_on_anthropic_messages` — the reported bug: provider resolves the URL from config, so the pre-resolve hint check never sees it.
- `test_kimi_coding_base_url_entry_detected` — same endpoint spelled directly on the entry.
- `test_explicit_api_mode_still_wins_over_host_mandate` — the existing contract is preserved: an explicit `api_mode: chat_completions` is never clobbered, host mandate included.
- `test_plain_kimi_chat_host_not_mandated` — `api.kimi.com` *without* `/coding` is an ordinary OpenAI-compatible surface and stays on `chat_completions` (guards against over-broad host matching).

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface change; the code comment carries the rationale)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure URL-mapping logic, no platform-specific paths)
- [x] Tool descriptions/schemas — N/A
