### PR TITLE
feat(whatsapp): add send_or_update_status for in-place progress edits

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -486,6 +486,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # send_or_update_status() bookkeeping: {(chat_id, status_key) -> bridge message_id}.
+        # Mirrors Telegram's adapter (#30045): tracks status bubbles owned by
+        # this adapter so subsequent calls with the same key edit the same
+        # message instead of appending new ones.
+        self._status_message_ids: Dict[tuple, str] = {}
 
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
@@ -991,6 +996,43 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
+
+    async def send_or_update_status(
+        self,
+        chat_id: str,
+        status_key: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a status message, or edit the previous one with the same key.
+
+        Mirrors the Telegram adapter's method of the same name (#30045):
+        progress/status callbacks used to append a fresh bubble on every
+        call. The first call for a (chat_id, status_key) pair sends fresh
+        and remembers the message id; subsequent calls edit that same
+        message in place. If the edit fails (message deleted, bridge error,
+        etc.) the cached id is dropped and this falls back to a fresh send.
+
+        Unlike Telegram's ``edit_message``, WhatsApp's does not accept
+        ``metadata`` and always returns the same message_id it was given on
+        success (confirmed by reading the bridge's ``/edit`` handler — an
+        edit targets the existing message key rather than creating a new
+        one), so there is no id to refresh from the edit result the way
+        Telegram's version does.
+        """
+        key = (str(chat_id), str(status_key))
+        cached_id = self._status_message_ids.get(key)
+        if cached_id is not None:
+            result = await self.edit_message(chat_id, cached_id, content)
+            if result.success:
+                return result
+            # Edit failed — clear the cached id and fall through to a fresh send.
+            self._status_message_ids.pop(key, None)
+        result = await self.send(chat_id, content, metadata=metadata)
+        if result.success and result.message_id:
+            self._status_message_ids[key] = str(result.message_id)
+        return result
 
     async def edit_message(
         self,

--- a/tests/gateway/test_whatsapp_status_update.py
+++ b/tests/gateway/test_whatsapp_status_update.py
@@ -1,0 +1,95 @@
+"""Tests for WhatsAppAdapter.send_or_update_status (issue #30045).
+
+Mirrors tests/gateway/test_telegram_status_update.py's structure. The
+status-update path must:
+  1. Send a fresh message on the first call for a (chat_id, status_key) pair.
+  2. Edit that same message on subsequent calls with the same key.
+  3. Fall back to sending fresh when the cached message edit fails.
+  4. Keep distinct keys independent (no cross-talk).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+@pytest.fixture
+def adapter():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    a = WhatsAppAdapter(PlatformConfig(enabled=True))
+    # Patch send / edit_message so tests can drive them directly, same as
+    # the Telegram fixture — no bridge process involved.
+    a.send = AsyncMock()
+    a.edit_message = AsyncMock()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_first_call_sends_and_caches_message_id(adapter):
+    """First call for a (chat, key) pair must send and remember the id."""
+    adapter.send.return_value = SendResult(success=True, message_id="wamid.100")
+
+    result = await adapter.send_or_update_status("chat-1", "lifecycle", "starting")
+
+    assert result.success is True
+    assert result.message_id == "wamid.100"
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "wamid.100"
+
+
+@pytest.mark.asyncio
+async def test_second_call_edits_same_message(adapter):
+    """Second call with the same key must edit, not send fresh."""
+    adapter.send.return_value = SendResult(success=True, message_id="wamid.100")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="wamid.100")
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "starting")
+    result = await adapter.send_or_update_status("chat-1", "lifecycle", "in progress")
+
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once_with("chat-1", "wamid.100", "in progress")
+    assert result.success is True
+    assert result.message_id == "wamid.100"
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_falls_back_to_fresh_send(adapter):
+    """If the cached message's edit fails, drop the cache and send fresh."""
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="wamid.100"),
+        SendResult(success=True, message_id="wamid.200"),
+    ]
+    adapter.edit_message.return_value = SendResult(success=False, error="message not found")
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "starting")
+    result = await adapter.send_or_update_status("chat-1", "lifecycle", "in progress")
+
+    assert adapter.send.await_count == 2
+    adapter.edit_message.assert_awaited_once_with("chat-1", "wamid.100", "in progress")
+    assert result.success is True
+    assert result.message_id == "wamid.200"
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "wamid.200"
+
+
+@pytest.mark.asyncio
+async def test_distinct_status_keys_do_not_collide(adapter):
+    """A different status_key gets its own message; the original isn't touched."""
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id="wamid.100"),
+        SendResult(success=True, message_id="wamid.200"),
+    ]
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "ctx pressure")
+    await adapter.send_or_update_status("chat-1", "model-switch", "switched to opus")
+
+    assert adapter.send.await_count == 2
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "wamid.100"
+    assert adapter._status_message_ids[("chat-1", "model-switch")] == "wamid.200"


### PR DESCRIPTION
## Summary
- WhatsApp status/progress messages (context-pressure warnings, compression-in-progress notices, etc.) each posted as a fresh message instead of editing a running status bubble in place, unlike Telegram and Slack.
- Adds `WhatsAppAdapter.send_or_update_status()`, mirroring the Telegram adapter's method of the same name (#30045) exactly: the first call for a `(chat_id, status_key)` pair sends fresh and remembers the message id; subsequent calls edit that message in place; a failed edit drops the cached id and falls back to a fresh send.
- The underlying edit primitive was already live in production for streaming-reply edits (`WhatsAppAdapter.edit_message()`, the bridge's `/edit` route) — this only adds the missing status-bubble wrapper, no bridge changes needed.
- Simpler than Telegram's version: WhatsApp's `edit_message` doesn't accept `metadata` and always returns the same `message_id` it was given (confirmed by reading the bridge's `/edit` handler), so there's no id to refresh after a successful edit.
- `gateway/run.py`'s status callback already dispatches via `getattr(adapter, "send_or_update_status", None)` — no dispatch changes needed, WhatsApp is picked up automatically now that the method exists.

## Test plan
- [x] New unit tests (`tests/gateway/test_whatsapp_status_update.py`): first-call-sends, second-call-edits, edit-failure-falls-back-to-fresh-send, distinct-keys-do-not-collide — all passing
- [x] Existing WhatsApp test suite (formatting, group gating) — 29 passed, no regressions
- [x] Dogfooded on a live install (gateway restarted, healthy)