### PR TITLE
feat(tools): allow per-tool spillover budgets

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -709,6 +709,11 @@ DEFAULT_CONFIG = {
         "max_bytes": 50_000,
         "max_lines": 2000,
         "max_line_length": 2000,
+        # Spillovers preserve the full result on disk and put only a preview
+        # in model context. MCP tools use the tighter prefix-wide threshold;
+        # exact tool names can be lowered independently for chatty providers.
+        "mcp_result_size_chars": 50_000,
+        "tool_overrides": {},
     },
 
     # Tool loop guardrails nudge models when they repeat failed or

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -218,6 +218,52 @@ class TestMcpPrefixThreshold:
         # Generic tools are untouched by the MCP knob.
         assert cfg.default_result_size == DEFAULT_RESULT_SIZE_CHARS
 
+
+class TestConfiguredToolOverrides:
+    """Operators can spill a chatty named tool before the generic 100K cap."""
+
+    def test_named_override_is_loaded_from_config(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    web_search: 20000\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(None)
+
+        assert cfg.resolve_threshold("web_search") == 20_000
+        assert cfg.resolve_threshold("terminal") == DEFAULT_RESULT_SIZE_CHARS
+
+    def test_invalid_named_overrides_are_ignored(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    zero: 0\n"
+            "    negative: -1\n"
+            "    boolean: true\n"
+            "    text: nope\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(None)
+
+        assert cfg.tool_overrides == {}
+
+    def test_named_override_cannot_exceed_scaled_model_budget(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    web_search: 90000\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(65_536)
+
+        assert cfg.resolve_threshold("web_search") == cfg.default_result_size
+
     def test_config_override_survives_window_scaling(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
             "tool_budget:\n  mcp_result_size_chars: 30000\n"

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -210,7 +210,7 @@ class TestMcpPrefixThreshold:
 
     def test_config_override_via_hermes_home(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n  mcp_result_size_chars: 30000\n"
+            "tool_output:\n  mcp_result_size_chars: 30000\n"
         )
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(None)
@@ -224,7 +224,7 @@ class TestConfiguredToolOverrides:
 
     def test_named_override_is_loaded_from_config(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    web_search: 20000\n"
         )
@@ -237,7 +237,7 @@ class TestConfiguredToolOverrides:
 
     def test_invalid_named_overrides_are_ignored(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    zero: 0\n"
             "    negative: -1\n"
@@ -254,7 +254,7 @@ class TestConfiguredToolOverrides:
         self, tmp_path, monkeypatch
     ):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    web_search: 90000\n"
         )
@@ -266,14 +266,14 @@ class TestConfiguredToolOverrides:
 
     def test_config_override_survives_window_scaling(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n  mcp_result_size_chars: 30000\n"
+            "tool_output:\n  mcp_result_size_chars: 30000\n"
         )
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(200_000)
         assert cfg.mcp_result_size == 30_000
 
     def test_malformed_config_falls_back_to_default(self, tmp_path, monkeypatch):
-        (tmp_path / "config.yaml").write_text("tool_budget: not-a-mapping\n")
+        (tmp_path / "config.yaml").write_text("tool_output: not-a-mapping\n")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(None)
         assert cfg.resolve_threshold("mcp_x_y") == 50_000

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -27,7 +27,7 @@ DEFAULT_PREVIEW_SIZE_CHARS: int = 1_500
 # harnesses cap harder (OpenCode 50KB, pi 50KB, Claude Code 30K chars,
 # Codex ~10K tokens); 50K chars keeps parity with the strictest general-
 # purpose caps while spillover (unlike truncation) preserves the full
-# payload on disk. Overridable via ``tool_budget.mcp_result_size_chars``
+# payload on disk. Overridable via ``tool_output.mcp_result_size_chars``
 # in config.yaml.
 DEFAULT_MCP_RESULT_SIZE_CHARS: int = 50_000
 
@@ -36,35 +36,43 @@ DEFAULT_MCP_RESULT_SIZE_CHARS: int = 50_000
 MCP_TOOL_PREFIX: str = "mcp_"
 
 
-def _configured_mcp_result_size() -> int:
-    """Read ``tool_budget.mcp_result_size_chars`` from the active config.
+def _configured_budget_block() -> dict:
+    """Return the spillover config, preferring the recognized ``tool_output`` key.
 
-    Goes through :func:`hermes_cli.config.load_config_readonly` (the
-    sanctioned read path — raw config.yaml parsing outside owner modules
-    is guarded by tests/hermes_cli/test_config_read_guard.py). Fully
-    guarded: any error, missing key, or non-positive value returns the
-    built-in default. The ``tool_budget:`` block name is shared with the
-    wider configurable-caps proposal (#80508) so the two can merge
-    without a key rename.
+    ``tool_budget`` was the short-lived original spelling. Keep it as a
+    read-only compatibility fallback so existing installations do not silently
+    lose their MCP threshold after upgrading.
     """
     try:
         from hermes_cli.config import load_config_readonly
 
         data = load_config_readonly()
-        block = data.get("tool_budget") if isinstance(data, dict) else None
-        if isinstance(block, dict):
-            raw = block.get("mcp_result_size_chars")
-            if raw is not None:
-                value = int(raw)
-                if value > 0:
-                    return value
+        if not isinstance(data, dict):
+            return {}
+        primary = data.get("tool_output")
+        if isinstance(primary, dict):
+            return primary
+        legacy = data.get("tool_budget")
+        return legacy if isinstance(legacy, dict) else {}
+    except Exception:
+        return {}
+
+
+def _configured_mcp_result_size() -> int:
+    """Read ``tool_output.mcp_result_size_chars`` from active config."""
+    try:
+        raw = _configured_budget_block().get("mcp_result_size_chars")
+        if raw is not None and not isinstance(raw, bool):
+            value = int(raw)
+            if value > 0:
+                return value
     except Exception:
         pass
     return DEFAULT_MCP_RESULT_SIZE_CHARS
 
 
 def _configured_tool_overrides() -> Dict[str, int]:
-    """Read positive per-tool spill thresholds from ``tool_budget``.
+    """Read positive per-tool spill thresholds from ``tool_output``.
 
     Tool handlers and providers do not always keep their documented result
     shape bounded. A named override lets an operator spill a known-chatty tool
@@ -72,11 +80,7 @@ def _configured_tool_overrides() -> Dict[str, int]:
     model's context window. Invalid entries are ignored fail-closed.
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        data = load_config_readonly()
-        block = data.get("tool_budget") if isinstance(data, dict) else None
-        raw = block.get("tool_overrides") if isinstance(block, dict) else None
+        raw = _configured_budget_block().get("tool_overrides")
         if not isinstance(raw, dict):
             return {}
         overrides: Dict[str, int] = {}

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -63,6 +63,39 @@ def _configured_mcp_result_size() -> int:
     return DEFAULT_MCP_RESULT_SIZE_CHARS
 
 
+def _configured_tool_overrides() -> Dict[str, int]:
+    """Read positive per-tool spill thresholds from ``tool_budget``.
+
+    Tool handlers and providers do not always keep their documented result
+    shape bounded. A named override lets an operator spill a known-chatty tool
+    before the generic 100K threshold without shrinking every tool or the
+    model's context window. Invalid entries are ignored fail-closed.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        data = load_config_readonly()
+        block = data.get("tool_budget") if isinstance(data, dict) else None
+        raw = block.get("tool_overrides") if isinstance(block, dict) else None
+        if not isinstance(raw, dict):
+            return {}
+        overrides: Dict[str, int] = {}
+        for name, threshold in raw.items():
+            if not isinstance(name, str) or not name.strip():
+                continue
+            if isinstance(threshold, bool):
+                continue
+            try:
+                value = int(threshold)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                overrides[name.strip()] = value
+        return overrides
+    except Exception:
+        return {}
+
+
 @dataclass(frozen=True)
 class BudgetConfig:
     """Immutable budget constants for the 3-layer tool result persistence system.
@@ -151,11 +184,18 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
     always survives.
     """
     mcp_result_size = _configured_mcp_result_size()
+    tool_overrides = _configured_tool_overrides()
 
     if not context_length or context_length <= 0:
-        if mcp_result_size == DEFAULT_MCP_RESULT_SIZE_CHARS:
+        if (
+            mcp_result_size == DEFAULT_MCP_RESULT_SIZE_CHARS
+            and not tool_overrides
+        ):
             return DEFAULT_BUDGET
-        return BudgetConfig(mcp_result_size=mcp_result_size)
+        return BudgetConfig(
+            mcp_result_size=mcp_result_size,
+            tool_overrides=tool_overrides,
+        )
 
     window_chars = context_length * _CHARS_PER_TOKEN
     per_result = int(window_chars * _PER_RESULT_WINDOW_FRACTION)
@@ -171,4 +211,8 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
         turn_budget=per_turn,
         preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
         mcp_result_size=mcp_result_size,
+        tool_overrides={
+            name: min(threshold, per_result)
+            for name, threshold in tool_overrides.items()
+        },
     )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -750,6 +750,16 @@ tool_output:
 
 Separately from truncation, oversized tool *results* are spilled to disk rather than cut: the full output is saved under `$HERMES_HOME/cache/spillover/` and the in-context content is replaced by a preview plus the saved file's path (readable with `read_file` using `offset`/`limit`, or processable with `execute_code`). The generic per-result spillover threshold is 100,000 chars, scaled down automatically for small-context models.
 
+The generic per-result threshold can be lowered for a known-chatty tool without shrinking every tool or the model context window:
+
+```yaml
+tool_budget:
+  tool_overrides:
+    web_search: 20000       # spill this named tool above 20K chars
+```
+
+Overrides must be positive integers, are keyed by the exact tool name, and are capped by the active model's context-scaled generic threshold. `read_file` remains pinned to unlimited inline output so a spill can always be paged back without creating a spill/read loop.
+
 MCP tool results (tools named `mcp_*`) spill at a tighter **50,000-char** default: MCP servers routinely return large un-paginated payloads (tool-discovery catalogs, batched executions) that would otherwise sit under the generic threshold and bloat context on every subsequent turn. Nothing is lost — the full result is preserved on disk. Override the threshold via:
 
 ```yaml

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -753,7 +753,7 @@ Separately from truncation, oversized tool *results* are spilled to disk rather 
 The generic per-result threshold can be lowered for a known-chatty tool without shrinking every tool or the model context window:
 
 ```yaml
-tool_budget:
+tool_output:
   tool_overrides:
     web_search: 20000       # spill this named tool above 20K chars
 ```
@@ -763,7 +763,7 @@ Overrides must be positive integers, are keyed by the exact tool name, and are c
 MCP tool results (tools named `mcp_*`) spill at a tighter **50,000-char** default: MCP servers routinely return large un-paginated payloads (tool-discovery catalogs, batched executions) that would otherwise sit under the generic threshold and bloat context on every subsequent turn. Nothing is lost — the full result is preserved on disk. Override the threshold via:
 
 ```yaml
-tool_budget:
+tool_output:
   mcp_result_size_chars: 50000   # per-result spillover threshold for mcp_* tools
 ```
 


### PR DESCRIPTION
## Summary
- add config-driven per-tool spillover thresholds under `tool_output.tool_overrides`
- preserve full oversized results on disk while keeping only a preview in model context
- make the existing MCP spillover threshold a recognized `tool_output` setting, with read compatibility for the short-lived `tool_budget` spelling
- cap named overrides to the active model's context-scaled generic budget

## Motivation
A provider can return a result far larger than its documented metadata shape. In production, one `web_search` response returned 57,501 bytes despite `limit: 3`, consuming almost an entire downstream evidence budget. The existing generic spill threshold is 100K, so operators could not contain one known-chatty tool without shrinking the model context or patching core.

## Verification
- RED observed: named `web_search: 20000` config still resolved to 100000
- 87 targeted tests pass across budget resolution, spillover storage, config coercion, and validation
- exact 57,501-character repro spills to a 1,992-character in-context preview and preserves the full file under `cache/spillover`
