### PR TITLE
fix(update): fast-forward shallow installs instead of resetting (#94477)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -255,6 +255,27 @@ def _upstream_main_sha() -> Optional[str]:
     return upstream_rev or None
 
 
+def _ls_remote_tip(remote_url: str | None, branch: str) -> Optional[str]:
+    """Tip SHA of ``refs/heads/<branch>`` on ``remote_url`` via ls-remote.
+
+    Passive network probe — never writes local refs, so it cannot move
+    ``origin/<branch>`` across a shallow clone's boundary (#94477).
+    """
+    if not remote_url:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", remote_url, f"refs/heads/{branch}"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip().split()[0] or None
+
+
 def _check_via_rev(local_rev: str) -> Optional[int]:
     """Compare an embedded git revision to upstream main via ls-remote.
 
@@ -307,16 +328,42 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         counted = _github_compare_behind(head_rev, upstream_rev)
         return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
-    # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
-    # clone the history stops at a single commit, so a plain `git fetch` would
-    # unshallow the repo (dragging in the whole history) and
-    # `rev-list --count HEAD..origin/main` would report a huge bogus "behind"
-    # number (e.g. "12492 commits behind"). Detect shallow up front: fetch with
-    # --depth 1 to preserve the boundary and compare tip SHAs instead of
-    # counting. Full clones (developers, Docker dev images) keep the exact
-    # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
+    # Installer checkouts are shallow (`git clone --depth 1`). Detect shallow
+    # up front: on a shallow repo we probe the remote tip passively via
+    # ls-remote (never a local fetch — see #94477 below) and compare tip SHAs
+    # instead of counting. Full clones (developers, Docker dev images) keep
+    # the exact count path unchanged.
     shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
     is_shallow = shallow == "true"
+
+    if is_shallow:
+        # A `--depth 1` fetch here to "preserve" the boundary is what POISONS
+        # it (#94477): once upstream advances, the fetch moves origin/main
+        # onto a commit DISCONNECTED from HEAD (git never re-sends history
+        # below a shallow boundary the client already has) and stacks a new
+        # .git/shallow entry. The next `hermes update` merge --ff-only then
+        # fails with "unrelated histories" and hard-resets a checkout with
+        # zero local commits. Probe the remote tip passively instead — same
+        # tip SHA, zero local ref movement, boundary untouched.
+        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+        target_rev = _ls_remote_tip(origin_url, "main")
+        if not target_rev:
+            # Offline or no usable remote — fall back to whatever stale ref
+            # we have (never a fetch, which would move the boundary).
+            target_rev = (
+                _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
+                or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
+            )
+        if not head_rev or not target_rev:
+            return None
+        if head_rev == target_rev:
+            return 0
+        # Tips differ but the shallow boundary hides the history between them.
+        # Recover the exact count from the GitHub compare API when possible
+        # (ahead_by == 0 means local-ahead ⇒ up to date); otherwise report the
+        # honest "update available, count unknown" sentinel.
+        counted = _github_compare_behind(head_rev, target_rev)
+        return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
     try:
         # Self-heal abandoned git lock files before fetching. A stale
@@ -375,26 +422,6 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             except Exception:
                 pass
         return None
-
-    if is_shallow:
-        # No history to count across the shallow boundary. `origin/main` may not
-        # be a tracking ref in a `clone --depth 1`, so prefer FETCH_HEAD (just
-        # updated by the fetch above) and fall back to origin/main.
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        target_rev = (
-            _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
-            or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
-        )
-        if not head_rev or not target_rev:
-            return None
-        if head_rev == target_rev:
-            return 0
-        # Tips differ but the shallow boundary hides the history between them.
-        # Recover the exact count from the GitHub compare API when possible
-        # (ahead_by == 0 means local-ahead ⇒ up to date); otherwise report the
-        # honest "update available, count unknown" sentinel.
-        counted = _github_compare_behind(head_rev, target_rev)
-        return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
     try:
         result = subprocess.run(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -549,6 +549,53 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
     except (subprocess.CalledProcessError, OSError):
         return None
 
+
+def _repair_shallow_boundary(git_cmd, branch: str, repo_root) -> bool:
+    """Heal a shallow checkout whose ``merge --ff-only`` failed (#94477).
+
+    The banner and ``hermes update --check`` paths historically fetched with
+    ``--depth 1`` on shallow installer checkouts. Once upstream advances,
+    that fetch moves ``origin/<branch>`` onto a commit DISCONNECTED from HEAD
+    (git never re-sends history below a shallow boundary the client already
+    has), so the updater's ``merge --ff-only`` fails with "unrelated
+    histories" and the divergence fallback hard-resets — even though the
+    checkout has zero local commits. A ``git fetch --unshallow origin
+    <branch>`` merges the stacked boundaries and restores the real ancestry,
+    after which the fast-forward succeeds.
+
+    Returns True when the boundary was repaired and the fast-forward then
+    succeeded (the caller must skip its reset). Returns False for non-shallow
+    repos, when the unshallow fetch fails (e.g. offline), or when the retried
+    fast-forward still fails (real divergence — e.g. local commits), so the
+    caller keeps its existing divergence handling. Never raises.
+    """
+    try:
+        shallow_probe = subprocess.run(
+            git_cmd + ["rev-parse", "--is-shallow-repository"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if shallow_probe.stdout.strip() != "true":
+            return False
+        unshallow_result = subprocess.run(
+            git_cmd + ["fetch", "--unshallow", "origin", branch],
+            cwd=repo_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if unshallow_result.returncode != 0:
+            return False
+        retry_result = subprocess.run(
+            git_cmd + ["merge", "--ff-only", f"origin/{branch}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        return retry_result.returncode == 0
+    except Exception:
+        return False
+
 # Files that define the editable install. A pull that touches none of them
 # cannot have invalidated it.
 _INSTALL_DEFINING_FILES = (
@@ -3600,6 +3647,76 @@ def _print_fetch_failure(stderr: str) -> None:
         print(f"  {stderr.splitlines()[0]}")
 
 
+def _check_update_shallow(git_cmd, branch: str) -> None:
+    """Passive update check for shallow installer checkouts (#94477).
+
+    Never fetches locally. The old flow fetched with ``--depth 1`` to
+    "preserve" the shallow boundary — but once upstream advances, that fetch
+    moves ``origin/<branch>`` onto a commit DISCONNECTED from HEAD, stacking
+    ``.git/shallow`` entries; the next ``hermes update`` ``merge --ff-only``
+    then fails with "unrelated histories" and hard-resets a checkout with
+    zero local commits. Instead, compare HEAD against the remote tip via
+    ls-remote (honouring the upstream-remote preference for ``main``) and
+    recover the exact behind-count from the GitHub compare API.
+    """
+    remote_name = "origin"
+    if branch == "main":
+        # Non-fork installs have no 'upstream' remote; prefer it when present
+        # (canonical reference for forks), same as the non-shallow flow.
+        has_upstream = (
+            subprocess.run(
+                git_cmd + ["remote", "get-url", "upstream"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            ).returncode
+            == 0
+        )
+        if has_upstream:
+            remote_name = "upstream"
+    remote_url = (
+        subprocess.run(
+            git_cmd + ["remote", "get-url", remote_name],
+            cwd=_m().PROJECT_ROOT,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        ).stdout.strip()
+    )
+
+    from hermes_cli.banner import _github_compare_behind, _ls_remote_tip
+    from hermes_cli.config import recommended_update_command
+
+    target_sha = _ls_remote_tip(remote_url, branch)
+    if not target_sha:
+        print(f"✗ Could not reach {remote_name} to check for updates.")
+        sys.exit(1)
+    head_sha = (
+        subprocess.run(
+            git_cmd + ["rev-parse", "HEAD"],
+            cwd=_m().PROJECT_ROOT,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        ).stdout.strip()
+    )
+    if head_sha and head_sha == target_sha:
+        print("✓ Already up to date.")
+        return
+    counted = _github_compare_behind(head_sha, target_sha)
+    if counted == 0:
+        # Local commits on top of the remote tip — not behind.
+        print("✓ Already up to date.")
+        return
+    if counted is not None:
+        commits_word = "commit" if counted == 1 else "commits"
+        print(
+            f"⚕ Update available: {counted} {commits_word} behind "
+            f"{remote_name}/{branch}."
+        )
+    else:
+        print(f"⚕ Update available (behind {remote_name}/{branch}).")
+    print(f"  Run '{recommended_update_command()}' to install.")
+
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -3656,11 +3773,9 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     # Note: upstream/<branch> may not exist for non-main branches (a fork's
     # bb/gui has no upstream counterpart), so when the caller picks a
     # non-default branch we skip the upstream probe and use origin directly.
-    # Installer checkouts are shallow (`git clone --depth 1`). A plain
-    # `git fetch` would unshallow the repo (dragging in the whole history —
-    # the exact cost the shallow clone avoided) and the rev-list count below
-    # would then report a huge bogus "behind" number. Detect shallow up front:
-    # fetch with --depth 1 to preserve the boundary and report presence-only.
+    # Installer checkouts are shallow (`git clone --depth 1`). Detect shallow
+    # up front: the shallow check probes the remote tip passively (no local
+    # fetch — see #94477) instead of running the fetch + rev-list flow below.
     is_shallow = (
         subprocess.run(
             git_cmd + ["rev-parse", "--is-shallow-repository"],
@@ -3670,7 +3785,13 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         ).stdout.strip()
         == "true"
     )
-    depth_args = ["--depth", "1"] if is_shallow else []
+
+    if is_shallow:
+        # Never fetch with --depth 1 here: once upstream advances, that fetch
+        # moves origin/<branch> onto a commit DISCONNECTED from HEAD and the
+        # next `hermes update` hard-resets (#94477).
+        _check_update_shallow(git_cmd, branch)
+        return
 
     if branch == "main":
         # Probe locally (~6 ms) whether an 'upstream' remote exists at all
@@ -3690,7 +3811,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         if has_upstream_remote:
             print("→ Fetching from upstream...")
             fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["upstream", branch],
+                git_cmd + ["fetch", "upstream", branch],
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
@@ -3702,7 +3823,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             # No upstream remote, or the upstream fetch failed — use origin.
             print("→ Fetching from origin...")
             fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["origin", branch],
+                git_cmd + ["fetch", "origin", branch],
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
@@ -3713,7 +3834,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch"] + depth_args + ["origin", branch],
+            git_cmd + ["fetch", "origin", branch],
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
@@ -3738,38 +3859,6 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     if verify_result.returncode != 0:
         print(f"✗ Branch '{branch}' not found on {compare_branch.split('/', 1)[0]}.")
         sys.exit(1)
-
-    if is_shallow:
-        # No history to count across the shallow boundary. Compare tip SHAs
-        # (mirrors the banner's _check_via_local_git), then try to recover the
-        # exact count via the GitHub compare API — the remote graph is complete
-        # even when the local one is truncated.
-        head_sha = subprocess.run(
-            git_cmd + ["rev-parse", "HEAD"],
-            cwd=_m().PROJECT_ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
-        ).stdout.strip()
-        target_sha = subprocess.run(
-            git_cmd + ["rev-parse", compare_branch],
-            cwd=_m().PROJECT_ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
-        ).stdout.strip()
-        if head_sha and target_sha and head_sha == target_sha:
-            print("✓ Already up to date.")
-        else:
-            from hermes_cli.banner import _github_compare_behind
-            from hermes_cli.config import recommended_update_command
-
-            counted = _github_compare_behind(head_sha, target_sha)
-            if counted == 0:
-                # Local commits on top of the remote tip — not behind.
-                print("✓ Already up to date.")
-                return
-            if counted is not None:
-                commits_word = "commit" if counted == 1 else "commits"
-                print(f"⚕ Update available: {counted} {commits_word} behind {compare_branch}.")
-            else:
-                print(f"⚕ Update available (behind {compare_branch}).")
-            print(f"  Run '{recommended_update_command()}' to install.")
-        return
 
     rev_result = subprocess.run(
         git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
@@ -7749,26 +7838,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         )
                         sys.exit(1)
                 else:
-                    # Same branch as the update target — a true upstream
-                    # force-push/rebase. Local changes are already stashed;
-                    # reset to match the remote exactly (original behaviour).
-                    print(
-                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                    )
-                    reset_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                        cwd=_m().PROJECT_ROOT,
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                    )
-                    if reset_result.returncode != 0:
-                        print(f"✗ Failed to reset to origin/{branch}.")
-                        if reset_result.stderr.strip():
-                            print(f"  {reset_result.stderr.strip()}")
+                    # Same branch as the update target — historically a true
+                    # upstream force-push/rebase. Local changes are already
+                    # stashed; reset to match the remote exactly (original
+                    # behaviour).
+                    #
+                    # #94477 exception: on a shallow installer checkout the
+                    # ff-only failure is usually NOT divergence. A --depth 1
+                    # fetch from the banner / --check path moves
+                    # origin/<branch> onto a disconnected shallow boundary,
+                    # so `merge --ff-only` fails with "unrelated histories"
+                    # even though the checkout has zero local commits. Repair
+                    # the boundary (fetch --unshallow) and retry the
+                    # fast-forward before treating it as divergence.
+                    if _repair_shallow_boundary(git_cmd, branch, _m().PROJECT_ROOT):
                         print(
-                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                            "  ✓ Repaired shallow clone boundary — "
+                            f"fast-forwarded to origin/{branch}."
                         )
-                        sys.exit(1)
+                    else:
+                        print(
+                            "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                        )
+                        reset_result = subprocess.run(
+                            git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                        if reset_result.returncode != 0:
+                            print(f"✗ Failed to reset to origin/{branch}.")
+                            if reset_result.stderr.strip():
+                                print(f"  {reset_result.stderr.strip()}")
+                            print(
+                                f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                            )
+                            sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3658,6 +3658,13 @@ def _check_update_shallow(git_cmd, branch: str) -> None:
     zero local commits. Instead, compare HEAD against the remote tip via
     ls-remote (honouring the upstream-remote preference for ``main``) and
     recover the exact behind-count from the GitHub compare API.
+
+    When ls-remote cannot reach the remote (offline / transient network
+    error), degrade the same way the banner does (``_check_via_local_git``):
+    compare against the last-known ref (``FETCH_HEAD``, then
+    ``<remote>/<branch>``, then ``origin/<branch>`` for forks whose upstream
+    ref was never fetched) instead of failing hard. Only a checkout with no
+    usable refs at all reports failure.
     """
     remote_name = "origin"
     if branch == "main":
@@ -3687,9 +3694,27 @@ def _check_update_shallow(git_cmd, branch: str) -> None:
     from hermes_cli.config import recommended_update_command
 
     target_sha = _ls_remote_tip(remote_url, branch)
+    stale = False
     if not target_sha:
-        print(f"✗ Could not reach {remote_name} to check for updates.")
-        sys.exit(1)
+        # Offline or no usable remote — mirror the banner's stale-ref
+        # fallback: compare against whatever we already have. Never a fetch
+        # here — that would move the shallow boundary (#94477).
+        candidates = ["FETCH_HEAD", f"{remote_name}/{branch}"]
+        if remote_name != "origin":
+            candidates.append(f"origin/{branch}")
+        for ref in candidates:
+            out = (
+                subprocess.run(
+                    git_cmd + ["rev-parse", ref],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                ).stdout.strip()
+            )
+            if out:
+                target_sha = out
+                break
+        stale = bool(target_sha)
     head_sha = (
         subprocess.run(
             git_cmd + ["rev-parse", "HEAD"],
@@ -3698,7 +3723,10 @@ def _check_update_shallow(git_cmd, branch: str) -> None:
             text=True, encoding="utf-8", errors="replace",
         ).stdout.strip()
     )
-    if head_sha and head_sha == target_sha:
+    if not head_sha or not target_sha:
+        print(f"✗ Could not reach {remote_name} to check for updates.")
+        sys.exit(1)
+    if head_sha == target_sha:
         print("✓ Already up to date.")
         return
     counted = _github_compare_behind(head_sha, target_sha)
@@ -3714,6 +3742,8 @@ def _check_update_shallow(git_cmd, branch: str) -> None:
         )
     else:
         print(f"⚕ Update available (behind {remote_name}/{branch}).")
+    if stale:
+        print(f"  (could not reach {remote_name} — using last-known ref)")
     print(f"  Run '{recommended_update_command()}' to install.")
 
 

--- a/pr-body-94477.md
+++ b/pr-body-94477.md
@@ -1,0 +1,49 @@
+## Summary
+
+Fixes #94477: `hermes update` hard-resets Windows shallow-clone installer checkouts instead of fast-forwarding — and keeps doing it on every update.
+
+### Root cause (validated with a deterministic real-git repro)
+
+The updater's own fetch is not the poisoner. The banner (`check_for_updates`) and `hermes update --check` paths fetch with `--depth 1` on shallow repos. Once upstream advances even one commit, that fetch moves `origin/<branch>` onto a commit **disconnected from HEAD** — git never re-sends history below a shallow boundary the client already has — stacking `.git/shallow` entries and leaving no merge-base. The updater's subsequent plain fetch cannot heal this; `merge --ff-only` fails with *"refusing to merge unrelated histories"* (rc 128) and the divergence fallback hard-resets a checkout with zero local commits.
+
+```
+$ git merge-base HEAD origin/main   # exit 1 — disconnected boundaries
+$ .git/shallow                      # 2+ stacked entries
+$ git merge --ff-only origin/main   # rc 128 → reset branch fires
+```
+
+### Fix (three parts)
+
+1. **Reset gate (`update_cmd._cmd_update_impl`)** — before concluding "history diverged", `_repair_shallow_boundary()` detects the shallow-disconnected state and heals it with `git fetch --unshallow origin <branch>` + a retried `merge --ff-only`. Only when that retry still fails (genuine divergence — e.g. real local commits) does the updater reset, keeping the existing reset contract (recoverable via reflog). This is the repair the issue's Option 2 suggests.
+2. **Banner (`_check_via_local_git`)** — on shallow checkouts, probe the remote tip passively via `git ls-remote` instead of the boundary-poisoning `--depth 1` fetch. Same tip SHA, zero local ref movement.
+3. **`hermes update --check` (`_check_update_shallow`)** — same passive ls-remote + compare-API probe, honouring the upstream-remote preference for `main`. The `--depth 1` fetch + FETCH_HEAD comparison is removed. When ls-remote is unreachable (offline / transient network error), the check degrades to the same stale-ref fallback as the banner (`FETCH_HEAD`, then `<remote>/<branch>`) instead of failing hard; a hard failure remains only when the checkout has no usable refs at all.
+
+### Relationship to #88422
+
+#88422 (open) unshallows at fetch time in the update path — a complementary cure. This PR instead (a) fixes the poisoner so the boundary is never broken in the first place, and (b) heals already-poisoned repos (the reporter's machine carries 36 stacked boundaries) at the merge step. No merge conflict: this PR does not change the update fetch command. See the coordination comment below on absorbing #88422's fetch-layer change or keeping the two PRs separate.
+
+### Tests
+
+`tests/hermes_cli/test_update_shallow_boundary.py` — 9 tests. The core tests build tiny local bare remotes and exercise the **real git binary** (no network):
+
+- poisoned shallow clone + `_repair_shallow_boundary` → fast-forwards to the true tip, `.git/shallow` gone, no reset
+- genuine local commit + repair → returns False — the repair never swallows commits; on true divergence the existing reset contract still applies (recoverable via reflog)
+- full clone → repair returns False, no unshallow attempted
+- banner shallow check → never runs `git fetch`; boundary and `origin/main` untouched; count recovered via compare API
+- `--check` shallow path → no fetch, ls-remote probe, upstream-remote preference honoured
+- `--check` shallow path, remote unreachable → falls back to the last-known ref (`FETCH_HEAD`, then `origin/main`) like the banner — no hard exit; hard failure only when no refs exist at all
+
+All 9 pass after the fix. The offline-fallback tests are RED-verified: they fail on pre-fix code (hard `sys.exit(1)` when ls-remote is unreachable) and pass with the fallback.
+
+## Test plan
+
+- [x] `pytest tests/hermes_cli/test_update_shallow_boundary.py` — 9 passed
+- [x] `ruff check` on all changed files — clean
+- [x] Regression suites (`test_cmd_update.py`, `test_banner_git_state.py`, `test_update_check.py`, `test_update_behind_count_recovery.py`) — 61 passed, 0 failures
+
+## Out of scope
+
+- The secondary issue in #94477 (Windows exe-replacement handoff never returning the prompt) is a separate root cause and is left out of this PR.
+- No sibling `--depth 1` call sites remain in the repo (the desktop `main.cjs` mirror referenced in the old comment was refactored away).
+
+Closes #94477

--- a/tests/hermes_cli/test_update_shallow_boundary.py
+++ b/tests/hermes_cli/test_update_shallow_boundary.py
@@ -266,3 +266,128 @@ class TestCheckUpdateShallowPassive:
         assert ls_remote_urls == [upstream_url]
         out = capsys.readouterr().out
         assert "1 commit behind upstream/main" in out
+
+    def _offline_run(self, calls, refs, upstream_url=None):
+        """subprocess.run fake for offline scenarios: ls-remote is patched to
+        fail (returns None), so _check_update_shallow must consult stale refs.
+        ``refs`` maps ref name -> sha ('' means the ref does not exist)."""
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            key = " ".join(cmd)
+            if "get-url" in key and "upstream" in key:
+                if upstream_url:
+                    return MagicMock(stdout=upstream_url, returncode=0)
+                return MagicMock(stdout="", returncode=1)
+            if "get-url" in key and "origin" in key:
+                return MagicMock(
+                    stdout="https://github.com/NousResearch/hermes-agent.git",
+                    returncode=0,
+                )
+            for ref, sha in refs.items():
+                if key.endswith(f"rev-parse {ref}") or key.endswith(
+                    f"rev-parse --verify --quiet {ref}"
+                ):
+                    return MagicMock(stdout=sha, returncode=0 if sha else 1)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return fake_run
+
+    def test_shallow_check_offline_falls_back_to_stale_refs(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """ls-remote unreachable must not hard-exit (exit code 1): fall back
+        to the stale FETCH_HEAD, same graceful degradation as the banner."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        calls = []
+        with (
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._offline_run(
+                    calls, {"FETCH_HEAD": "c" * 40, "HEAD": "a" * 40}
+                ),
+            ),
+            patch("hermes_cli.banner._ls_remote_tip", return_value=None),
+            patch("hermes_cli.banner._github_compare_behind", return_value=None),
+            patch(
+                "hermes_cli.config.recommended_update_command",
+                return_value="hermes update",
+            ),
+        ):
+            update_cmd._check_update_shallow(["git"], "main")
+
+        joined = [" ".join(c) for c in calls]
+        assert not any("fetch" in j for j in joined), f"must not fetch: {calls}"
+        out = capsys.readouterr().out
+        assert "Update available (behind origin/main" in out
+        assert "last-known ref" in out
+
+    def test_shallow_check_offline_stale_ref_matches_head(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Offline with the stale ref equal to HEAD reports up to date
+        instead of failing (mirrors the banner's stale-ref comparison)."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        calls = []
+        with (
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._offline_run(
+                    calls, {"FETCH_HEAD": "a" * 40, "HEAD": "a" * 40}
+                ),
+            ),
+            patch("hermes_cli.banner._ls_remote_tip", return_value=None),
+            patch(
+                "hermes_cli.config.recommended_update_command",
+                return_value="hermes update",
+            ),
+        ):
+            update_cmd._check_update_shallow(["git"], "main")
+
+        joined = [" ".join(c) for c in calls]
+        assert not any("fetch" in j for j in joined), f"must not fetch: {calls}"
+        out = capsys.readouterr().out
+        assert "Already up to date" in out
+
+    def test_shallow_check_offline_no_refs_reports_failure(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Only a checkout with no usable refs at all (no FETCH_HEAD, no
+        remote tracking ref) reports a hard failure — there is nothing to
+        compare against."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        calls = []
+        with (
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._offline_run(
+                    calls,
+                    {
+                        "FETCH_HEAD": "",
+                        "origin/main": "",
+                        "HEAD": "a" * 40,
+                    },
+                ),
+            ),
+            patch("hermes_cli.banner._ls_remote_tip", return_value=None),
+            patch(
+                "hermes_cli.config.recommended_update_command",
+                return_value="hermes update",
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            update_cmd._check_update_shallow(["git"], "main")
+
+        assert exc_info.value.code == 1
+        joined = [" ".join(c) for c in calls]
+        assert not any("fetch" in j for j in joined), f"must not fetch: {calls}"
+        out = capsys.readouterr().out
+        assert "Could not reach origin" in out

--- a/tests/hermes_cli/test_update_shallow_boundary.py
+++ b/tests/hermes_cli/test_update_shallow_boundary.py
@@ -1,0 +1,268 @@
+"""Regression tests for #94477.
+
+``hermes update`` on a Windows installer checkout (``git clone --depth 1``)
+hard-resets instead of fast-forwarding. Root cause: the banner / ``update
+--check`` paths fetch with ``--depth 1`` on shallow repos, which moves
+``origin/<branch>`` onto a commit DISCONNECTED from HEAD (git never re-sends
+history below a shallow boundary the client already has). The updater's
+``merge --ff-only`` then fails with "unrelated histories" and falls into
+``reset --hard`` even though the checkout has zero local commits.
+
+These tests build tiny local bare remotes and exercise the real git binary
+(no network), because the bug is a git object-graph phenomenon that mocks
+cannot reproduce.
+"""
+
+import shutil
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GIT_AVAILABLE = shutil.which("git") is not None
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _make_origin(root, commits=2):
+    """Bare ``origin.git`` remote + ``seed`` repo with N commits on main."""
+    origin = root / "origin.git"
+    seed = root / "seed"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "init", "-b", "main", str(seed)],
+        capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "config", "user.email", "t@t"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "config", "user.name", "t"], check=True
+    )
+    for _ in range(commits):
+        subprocess.run(
+            ["git", "-C", str(seed), "commit", "--allow-empty", "-q", "-m", "c"],
+            capture_output=True, check=True,
+        )
+    subprocess.run(
+        ["git", "-C", str(seed), "push", "../origin.git", "main"],
+        capture_output=True, check=True,
+    )
+    return seed, origin
+
+
+def _add_upstream_commit(seed, origin):
+    subprocess.run(
+        ["git", "-C", str(seed), "commit", "--allow-empty", "-q", "-m", "up"],
+        capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "push", "../origin.git", "main"],
+        capture_output=True, check=True,
+    )
+
+
+def _clone(root, origin, shallow):
+    work = root / "work"
+    url = "file://" + str(origin).replace("\\", "/")
+    args = ["git", "clone"]
+    if shallow:
+        args += ["--depth", "1"]
+    subprocess.run(
+        args + [url, str(work)], capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "config", "user.email", "t@t"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "config", "user.name", "t"], check=True
+    )
+    return work
+
+
+@pytest.mark.skipif(not GIT_AVAILABLE, reason="git binary not available")
+class TestRepairShallowBoundary:
+    """The updater must heal a disconnected shallow boundary and fast-forward
+    instead of concluding "history diverged" and resetting (#94477)."""
+
+    def test_heals_disconnected_boundary_and_fast_forwards(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        seed, origin = _make_origin(tmp_path)
+        work = _clone(tmp_path, origin, shallow=True)
+        _add_upstream_commit(seed, origin)
+
+        # The poisoner: banner / --check style `fetch --depth 1`.
+        assert _git(work, "fetch", "--depth", "1", "origin", "main").returncode == 0
+        # Disconnected boundary: no common ancestor with origin/main.
+        assert _git(work, "merge-base", "HEAD", "origin/main").returncode != 0
+
+        repaired = update_cmd._repair_shallow_boundary(["git"], "main", work)
+
+        assert repaired is True
+        # Fast-forwarded: HEAD == origin/main tip, boundary fully gone.
+        head = _git(work, "rev-parse", "HEAD").stdout.strip()
+        remote = _git(work, "rev-parse", "origin/main").stdout.strip()
+        seed_tip = _git(seed, "rev-parse", "HEAD").stdout.strip()
+        assert head == remote == seed_tip
+        assert not (work / ".git" / "shallow").exists()
+        assert _git(work, "merge-base", "HEAD", "origin/main").returncode == 0
+
+    def test_does_not_hide_real_divergence(self, tmp_path):
+        """A genuine local commit must survive: the repair reports False and
+        leaves HEAD untouched so the caller keeps its divergence handling."""
+        from hermes_cli import update_cmd
+
+        seed, origin = _make_origin(tmp_path)
+        work = _clone(tmp_path, origin, shallow=True)
+        _add_upstream_commit(seed, origin)
+        _git(work, "fetch", "--depth", "1", "origin", "main")
+        _git(work, "commit", "--allow-empty", "-q", "-m", "local")
+        local_tip = _git(work, "rev-parse", "HEAD").stdout.strip()
+
+        repaired = update_cmd._repair_shallow_boundary(["git"], "main", work)
+
+        assert repaired is False
+        assert _git(work, "rev-parse", "HEAD").stdout.strip() == local_tip
+
+    def test_full_clone_returns_false_without_unshallowing(self, tmp_path):
+        """Non-shallow checkouts must never trigger an unshallow fetch."""
+        from hermes_cli import update_cmd
+
+        _, origin = _make_origin(tmp_path)
+        work = _clone(tmp_path, origin, shallow=False)
+
+        repaired = update_cmd._repair_shallow_boundary(["git"], "main", work)
+
+        assert repaired is False
+        assert not (work / ".git" / "shallow").exists()
+
+
+@pytest.mark.skipif(not GIT_AVAILABLE, reason="git binary not available")
+class TestBannerShallowPassiveProbe:
+    """The banner's behind-count check must probe the remote tip via
+    ls-remote on shallow checkouts instead of fetching with --depth 1
+    (which is what poisons the boundary in the first place, #94477)."""
+
+    def test_shallow_check_never_fetches_and_boundary_stays_intact(self, tmp_path):
+        from hermes_cli import banner
+
+        seed, origin = _make_origin(tmp_path)
+        work = _clone(tmp_path, origin, shallow=True)
+        _add_upstream_commit(seed, origin)
+
+        boundary_before = sorted((work / ".git" / "shallow").read_text().split())
+        origin_main_before = _git(work, "rev-parse", "origin/main").stdout.strip()
+
+        real_run = subprocess.run
+
+        def recording_run(cmd, **kwargs):
+            if "fetch" in cmd:
+                raise AssertionError(
+                    f"shallow banner check must not fetch: {cmd}"
+                )
+            return real_run(cmd, **kwargs)
+
+        with (
+            patch.object(banner, "_github_compare_behind", return_value=1),
+            patch.object(banner.subprocess, "run", side_effect=recording_run),
+        ):
+            behind = banner._check_via_local_git(work)
+
+        assert behind == 1
+        # No ref movement, no new boundary entries.
+        assert sorted((work / ".git" / "shallow").read_text().split()) == boundary_before
+        assert _git(work, "rev-parse", "origin/main").stdout.strip() == origin_main_before
+
+
+class TestCheckUpdateShallowPassive:
+    """`hermes update --check` on a shallow checkout must probe the remote
+    tip via ls-remote (no local fetch) and keep the upstream preference."""
+
+    def _fake_run(self, calls, upstream_url=None):
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            key = " ".join(cmd)
+            if "--is-shallow-repository" in key:
+                return MagicMock(stdout="true", returncode=0)
+            if "get-url" in key and "upstream" in key:
+                if upstream_url:
+                    return MagicMock(stdout=upstream_url, returncode=0)
+                return MagicMock(stdout="", returncode=1)
+            if "get-url" in key and "origin" in key:
+                return MagicMock(
+                    stdout="https://github.com/NousResearch/hermes-agent.git",
+                    returncode=0,
+                )
+            if "rev-parse" in key:
+                return MagicMock(stdout="a" * 40, returncode=0)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return fake_run
+
+    def test_shallow_check_uses_ls_remote_not_fetch(self, tmp_path, capsys, monkeypatch):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        calls = []
+        with (
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run(calls),
+            ),
+            patch("hermes_cli.banner._ls_remote_tip", return_value="b" * 40),
+            patch("hermes_cli.banner._github_compare_behind", return_value=1),
+            patch(
+                "hermes_cli.config.recommended_update_command",
+                return_value="hermes update",
+            ),
+        ):
+            update_cmd._check_update_shallow(["git"], "main")
+
+        joined = [" ".join(c) for c in calls]
+        assert not any("fetch" in j for j in joined), f"must not fetch: {calls}"
+        out = capsys.readouterr().out
+        assert "1 commit behind origin/main" in out
+
+    def test_shallow_check_prefers_upstream_remote(self, tmp_path, capsys, monkeypatch):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        calls = []
+        upstream_url = "https://github.com/NousResearch/hermes-agent.git"
+        ls_remote_urls = []
+
+        def capture_ls_remote(url, branch):
+            ls_remote_urls.append(url)
+            return "b" * 40
+
+        with (
+            patch(
+                "hermes_cli.update_cmd.subprocess.run",
+                side_effect=self._fake_run(calls, upstream_url=upstream_url),
+            ),
+            patch("hermes_cli.banner._ls_remote_tip", side_effect=capture_ls_remote),
+            patch("hermes_cli.banner._github_compare_behind", return_value=1),
+            patch(
+                "hermes_cli.config.recommended_update_command",
+                return_value="hermes update",
+            ),
+        ):
+            update_cmd._check_update_shallow(["git"], "main")
+
+        assert ls_remote_urls == [upstream_url]
+        out = capsys.readouterr().out
+        assert "1 commit behind upstream/main" in out


### PR DESCRIPTION
## Summary

Fixes #94477: `hermes update` hard-resets Windows shallow-clone installer checkouts instead of fast-forwarding — and keeps doing it on every update.

### Root cause (validated with a deterministic real-git repro)

The updater's own fetch is not the poisoner. The banner (`check_for_updates`) and `hermes update --check` paths fetch with `--depth 1` on shallow repos. Once upstream advances even one commit, that fetch moves `origin/<branch>` onto a commit **disconnected from HEAD** — git never re-sends history below a shallow boundary the client already has — stacking `.git/shallow` entries and leaving no merge-base. The updater's subsequent plain fetch cannot heal this; `merge --ff-only` fails with *"refusing to merge unrelated histories"* (rc 128) and the divergence fallback hard-resets a checkout with zero local commits.

```
$ git merge-base HEAD origin/main   # exit 1 — disconnected boundaries
$ .git/shallow                      # 2+ stacked entries
$ git merge --ff-only origin/main   # rc 128 → reset branch fires
```

### Fix (three parts)

1. **Reset gate (`update_cmd._cmd_update_impl`)** — before concluding "history diverged", `_repair_shallow_boundary()` detects the shallow-disconnected state and heals it with `git fetch --unshallow origin <branch>` + a retried `merge --ff-only`. Only when that retry still fails (genuine divergence — e.g. real local commits) does the updater reset, keeping the existing reset contract (recoverable via reflog). This is the repair the issue's Option 2 suggests.
2. **Banner (`_check_via_local_git`)** — on shallow checkouts, probe the remote tip passively via `git ls-remote` instead of the boundary-poisoning `--depth 1` fetch. Same tip SHA, zero local ref movement.
3. **`hermes update --check` (`_check_update_shallow`)** — same passive ls-remote + compare-API probe, honouring the upstream-remote preference for `main`. The `--depth 1` fetch + FETCH_HEAD comparison is removed. When ls-remote is unreachable (offline / transient network error), the check degrades to the same stale-ref fallback as the banner (`FETCH_HEAD`, then `<remote>/<branch>`) instead of failing hard; a hard failure remains only when the checkout has no usable refs at all.

### Relationship to #88422

#88422 (open) unshallows at fetch time in the update path — a complementary cure. This PR instead (a) fixes the poisoner so the boundary is never broken in the first place, and (b) heals already-poisoned repos (the reporter's machine carries 36 stacked boundaries) at the merge step. No merge conflict: this PR does not change the update fetch command. See the coordination comment below on absorbing #88422's fetch-layer change or keeping the two PRs separate.

### Tests

`tests/hermes_cli/test_update_shallow_boundary.py` — 9 tests. The core tests build tiny local bare remotes and exercise the **real git binary** (no network):

- poisoned shallow clone + `_repair_shallow_boundary` → fast-forwards to the true tip, `.git/shallow` gone, no reset
- genuine local commit + repair → returns False — the repair never swallows commits; on true divergence the existing reset contract still applies (recoverable via reflog)
- full clone → repair returns False, no unshallow attempted
- banner shallow check → never runs `git fetch`; boundary and `origin/main` untouched; count recovered via compare API
- `--check` shallow path → no fetch, ls-remote probe, upstream-remote preference honoured
- `--check` shallow path, remote unreachable → falls back to the last-known ref (`FETCH_HEAD`, then `origin/main`) like the banner — no hard exit; hard failure only when no refs exist at all

All 9 pass after the fix. The offline-fallback tests are RED-verified: they fail on pre-fix code (hard `sys.exit(1)` when ls-remote is unreachable) and pass with the fallback.

## Test plan

- [x] `pytest tests/hermes_cli/test_update_shallow_boundary.py` — 9 passed
- [x] `ruff check` on all changed files — clean
- [x] Regression suites (`test_cmd_update.py`, `test_banner_git_state.py`, `test_update_check.py`, `test_update_behind_count_recovery.py`) — 61 passed, 0 failures

## Out of scope

- The secondary issue in #94477 (Windows exe-replacement handoff never returning the prompt) is a separate root cause and is left out of this PR.
- No sibling `--depth 1` call sites remain in the repo (the desktop `main.cjs` mirror referenced in the old comment was refactored away).

Closes #94477
