### PR TITLE
fix(tui): stop spurious 'Installing TUI dependencies…' on every launch with scoped installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2115,7 +2115,15 @@ def _tui_need_npm_install(root: Path) -> bool:
         return lock.stat().st_mtime > marker.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        # "dev"/"devOptional" are npm's recorded dependency-role annotations
+        # and legitimately differ between the canonical lock and the hidden
+        # lock after a scoped install actualizes the tree; they don't change
+        # what is on disk.
+        return {
+            k: v
+            for k, v in pkg.items()
+            if k not in _NPM_LOCK_RUNTIME_KEYS | {"dev", "devOptional"}
+        }
 
     for name, pkg in wanted.items():
         if not name:
@@ -2126,6 +2134,20 @@ def _tui_need_npm_install(root: Path) -> bool:
 
         if name not in installed:
             if pkg.get("optional") or pkg.get("peer"):
+                continue
+            # Scoped installs (e.g. `npm install --workspace ui-tui`) never
+            # materialize packages belonging to other workspaces — apps/,
+            # tests-js/, or root-hoisted deps of those workspaces — so they
+            # will always be missing from the hidden lockfile.  Only require
+            # TUI-workspace entries to be present; anything else being absent
+            # is expected and would otherwise trigger a spurious reinstall on
+            # every launch.  See #38772 / #42973 for related scoped-install
+            # fixes.
+            if not (
+                name.startswith(("ui-tui/", "packages/"))
+                or "/node_modules/ui-tui/" in f"/{name}"
+                or name.startswith("node_modules/@hermes/ink")
+            ):
                 continue
             return True
 


### PR DESCRIPTION
## Symptom

On installs where the TUI deps were provisioned via the scoped install path (`npm install --workspace ui-tui`), every `hermes --tui` launch printed **"Installing TUI dependencies…"** and re-ran npm — forever. The check never converged.

## Root cause

`_tui_need_npm_install()` compares the canonical root `package-lock.json` against npm's hidden `node_modules/.package-lock.json`. A scoped install deliberately materializes only the `ui-tui` workspace (see #38772 / #42973 for prior scoped-install fixes in this area) and skips Electron + node-pty. But the canonical lock declares the entire monorepo, so ~662 entries belonging to `apps/desktop`, `tests-js`, and the root-hoisted deps of those workspaces are *permanently* absent from the hidden lockfile. The function treated each absence as staleness → reinstall on every launch.

A second, smaller false positive: 15 packages differed only in npm's `dev`/`devOptional` dependency-role annotations between the two lockfiles — same class of non-material runtime annotation as the already-excluded `ideallyInert`/`peer`.

## Fix

Two changes inside `_tui_need_npm_install()`:

1. Only require entries under the TUI workspaces (`ui-tui/`, `packages/`, nested `node_modules/ui-tui/…`, `node_modules/@hermes/ink`) to be present in the hidden lock. Absence of other workspaces' packages is expected under a scoped install.
2. Add `dev`/`devOptional` to the excluded annotation set in `comparable()`.

## Verification

Against a real scoped-install tree (the reporter's machine):

- Before: `_tui_need_npm_install(Path('ui-tui'))` → `True`
- After: → `False`
- `_make_tui_argv(Path('ui-tui'), False)` resolves directly to `node --expose-gc ui-tui/dist/entry.js` with no npm step.

## Notes

- No behavior change for full-workspace installs: all TUI-relevant entries are still strictly checked (presence + content diff), so genuine staleness still triggers a reinstall/rebuild.
- The prebuilt-bundle early-out (nix/docker layouts, no lockfile) is untouched.