### PR TITLE
feat(cli): show FAST badge in classic status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6302,6 +6302,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "active_background_tasks": 0,
             "active_background_processes": 0,
             "active_background_subagents": 0,
+            # Session-scoped /fast state. ``self.service_tier`` is the
+            # canonical toggle and remains available while /fast rebuilds the
+            # agent, so the badge updates immediately instead of disappearing
+            # during that transition.
+            "fast_mode": getattr(self, "service_tier", None) == "priority",
             "battery_label": "",
             "battery_category": "dim",
             # Focus view badge (/focus). Persistent indicator so the reduced
@@ -7030,11 +7035,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_prefix = f"{battery_label} │ " if battery_label else ""
             focus_label = snapshot.get("focus_label") or ""
             session_title = snapshot.get("session_title") or ""
+            fast_label = "⚡ FAST" if snapshot.get("fast_mode") else ""
 
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
             if width < 52:
-                text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{battery_prefix}⚕ {snapshot['model_short']}"
+                if fast_label:
+                    text += f" · {fast_label}"
+                text += f" · {duration_label}"
                 if goal_segment:
                     text += f" · {goal_segment}"
                 if focus_label:
@@ -7043,7 +7052,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     text += " · ⚠ YOLO"
                 return self._right_align_status_title(text, session_title, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot['model_short']}"]
+                if fast_label:
+                    parts.append(fast_label)
+                parts.append(percent_label)
                 if battery_label:
                     parts.insert(0, battery_label)
                 compressions = snapshot.get("compressions", 0)
@@ -7075,7 +7087,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {snapshot['model_short']}"]
+            if fast_label:
+                parts.append(fast_label)
+            parts.extend([context_label, percent_label])
             if battery_label:
                 parts.insert(0, battery_label)
             if compressions:
@@ -7124,14 +7139,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             battery_style = self._battery_status_style(snapshot.get("battery_category", "dim"))
             focus_label = snapshot.get("focus_label") or ""
             session_title = snapshot.get("session_title") or ""
+            fast_label = "⚡ FAST" if snapshot.get("fast_mode") else ""
 
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                if fast_label:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-strong", fast_label))
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                ]
+                ])
                 if goal_segment:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-strong", goal_segment))
@@ -7153,9 +7174,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    if fast_label:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-strong", fast_label))
+                    frags.extend([
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -7198,13 +7224,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    if fast_label:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-strong", fast_label))
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -120,6 +120,30 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_fast_mode_badge_is_shown_in_plain_status_bar_at_every_width(self):
+        cli_obj = _make_cli("gpt-5.4")
+        cli_obj.service_tier = "priority"
+
+        for width in (40, 60, 120):
+            text = cli_obj._build_status_bar_text(width=width)
+            assert "⚡ FAST" in text, f"missing fast badge at width={width}: {text!r}"
+
+        cli_obj.service_tier = None
+        assert "FAST" not in cli_obj._build_status_bar_text(width=120)
+
+    def test_fast_mode_badge_is_shown_in_styled_status_bar_at_every_width(self):
+        cli_obj = _make_cli("gpt-5.4")
+        cli_obj.service_tier = "priority"
+        cli_obj._status_bar_visible = True
+
+        for width in (40, 60, 120):
+            mock_app = MagicMock()
+            mock_app.output.get_size.return_value = MagicMock(columns=width)
+            with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+                fragments = cli_obj._get_status_bar_fragments()
+            text = "".join(value for _, value in fragments)
+            assert "⚡ FAST" in text, f"missing fast badge at width={width}: {text!r}"
+
 
     def test_input_height_counts_prompt_only_on_first_wrapped_row(self):
         # Regression for prompt_toolkit classic CLI resize glitches: the prompt

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -135,13 +135,14 @@ A persistent status bar sits above the input area, updating in real time:
 | Token count | Context tokens used / max context window |
 | Context bar | Visual fill indicator with color-coded thresholds |
 | Cost | Estimated session cost (or `n/a` for unknown/zero-priced models) |
+| ⚡ FAST | **Fast mode indicator** — shown whenever the current CLI session uses `/fast fast` (OpenAI Priority Processing or Anthropic Fast Mode). Disappears immediately after `/fast normal`. |
 | 🗜️ N | **Context compression count** — how many times the running session has been auto-compressed. Appears once the first compression fires. |
 | ▶ N | **Active background tasks** — how many `/background` prompts are still running in the current session. Appears whenever at least one task is in flight. |
 | Duration | Elapsed session time |
 | Session title | Once the session has a title, it appears as a gold badge pinned to the far-right edge. Long titles truncate before displacing the essential model and context fields. |
 | ⚠ YOLO | **YOLO mode warning** — shown whenever `HERMES_YOLO_MODE` is on (either `hermes --yolo` at launch or `/yolo` toggled mid-session). Mirrors the banner-line warning so you can't forget you're in auto-approve mode. |
 
-The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 52–75, minimal (model + duration, plus the YOLO badge when active) below 52.
+The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 52–75, minimal (model + duration, plus active FAST and YOLO badges) below 52.
 
 **Context color coding:**
 


### PR DESCRIPTION
## Summary

- Show `⚡ FAST` in the classic CLI status bar whenever the current session is in fast/priority mode
- Derive the badge from session-scoped `HermesCLI.service_tier == "priority"` so `/fast` updates immediately, including while the agent is rebuilt
- Keep both renderers in sync: plain `_build_status_bar_text()` and styled `_get_status_bar_fragments()`

## Motivation

`/fast` already toggles OpenAI Priority Processing, Anthropic Fast Mode, and Grok 4.6 priority. The TUI/desktop payload already exposes `fast`, but the classic CLI chrome does not. YOLO and focus already have persistent badges; fast mode should too.

Related but not a duplicate of #9847: that PR also adds reasoning effort and uses a compact `⚡` next to the model name. This change is only the FAST badge, uses the explicit `⚡ FAST` label, and places it in all three width tiers.

## Changes

- Add `fast_mode` to `_get_status_bar_snapshot()` from `self.service_tier`, not from config or `agent.service_tier`
- Insert `⚡ FAST` immediately after the model name in minimal, compact, and wide layouts
- Document the badge in `website/docs/user-guide/cli.md`
- Cover both renderers at 40, 60, and 120 columns; assert the badge disappears when `service_tier` is `None`

## Test Plan

- [x] `uv run --with pytest==9.1.1 python -m pytest tests/cli/test_cli_status_bar.py tests/cli/test_cli_status_command.py tests/cli/test_cli_background_status_indicator.py tests/cli/test_cli_status_bar_goal.py -q -o 'addopts='` — 46 passed
- [x] Sabotage: new tests fail on stock `cli.py`, then pass after the patch
- [x] `ruff check` and `py_compile` on the touched Python files
- [x] Live render through the installed interpreter:

```
40: ⚕ grok-4.6 · ⚡ FAST · 0s
60: ⚕ grok-4.6 · ⚡ FAST · -- · 0s
120: ⚕ grok-4.6 │ ⚡ FAST │ ctx -- │ -- │ 0s │ ⏲ 0s
normal: ⚕ grok-4.6 │ ctx -- │ -- │ 0s │ ⏲ 0s
```

## Notes for Reviewers

- `/fast` clears `self.agent` on purpose. Reading `agent.service_tier` would drop the badge during that rebuild.
- The badge is placed after the model name so lower-priority counters are trimmed first on a narrow terminal.
- An already-running CLI process must be restarted to load the change.