### PR TITLE
fix: port local Hermes compatibility safeguards

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -62,8 +62,10 @@ class GatewayLifecycleBlocked(ValueError):
 # is anchored on a concrete command identifier so a match can only fire on
 # actual shell-command-shaped strings, not on prose.
 _KILL_AT_COMMAND_POSITION = (
-    r"(?:\A|[;&|(){}\n])[ \t]*(?:sudo[ \t]+(?:-\S+[ \t]+)*)?p?kill\b"
+    r"(?:\A|[;&|(){}\n])[ \t]*(?:sudo[ \t]+(?:-\S+[ \t]+)*)?"
+    r"(?:[^\s;&|(){}]*/)?p?kill\b"
 )
+_GATEWAY_KILL_TARGET_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 
 
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
@@ -157,12 +159,24 @@ def _resolve_gateway_main_pid():
 
 def kill_targets_gateway_main_pid(text: str) -> bool:
     """Fail-open numeric-PID companion to the command-shaped text guard."""
-    if not text or not _KILL_COMMAND_RE.search(text):
+    if not text:
+        return False
+    kill_segments = list(_iter_kill_command_segments(text))
+    raw_kill_match = _KILL_COMMAND_RE.search(text)
+    if not kill_segments and not raw_kill_match:
         return False
     pid = _resolve_gateway_main_pid()
     if not pid:
         return False
-    return re.search(r"(?<![0-9])" + str(pid) + r"(?![0-9])", text) is not None
+    pid_re = re.compile(r"(?<![0-9])" + str(pid) + r"(?![0-9])")
+    if kill_segments:
+        return any(
+            pid_re.search(" ".join(segment[index:]))
+            for segment, index in kill_segments
+        )
+    # If shlex cannot recover a malformed command, preserve the bounded raw
+    # fallback instead of letting a syntax error disable the guard entirely.
+    return raw_kill_match is not None and pid_re.search(text) is not None
 
 
 # A backslash immediately followed by a newline is a POSIX shell line
@@ -335,6 +349,8 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     # from execute_code, where commas and brackets — not spaces — separate
     # the argv words the OS will actually see.
     for segment in _iter_command_segments(normalized):
+        if _segment_kill_targets_gateway(segment):
+            return True
         joined = " ".join(segment)
         if joined and _GATEWAY_LIFECYCLE_PATTERN.search(joined):
             return True
@@ -645,6 +661,43 @@ def _peel_transparent_prefixes(segment: list[str], index: int) -> int:
             if index < len(segment) and not segment[index].startswith("-"):
                 index += 1
     return index
+
+
+def _kill_executable_index(segment: list[str]) -> Optional[int]:
+    """Return the executable index when a segment runs ``kill``/``pkill``.
+
+    Absolute paths and transparent wrapper chains are normalized through the
+    same helpers used by the referenced-script walker. This keeps
+    ``/bin/kill``, ``command kill`` and ``env /usr/bin/pkill`` equivalent to
+    their bare executable forms without matching the word ``kill`` in data.
+    """
+    index = _command_token_index(segment)
+    if index is None:
+        return None
+    index = _peel_transparent_prefixes(segment, index)
+    if index >= len(segment):
+        return None
+    if _executable_name(segment[index]).lower() not in {"kill", "pkill"}:
+        return None
+    return index
+
+
+def _iter_kill_command_segments(text: str) -> Iterator[tuple[list[str], int]]:
+    """Yield tokenized command segments whose effective executable is kill."""
+    normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
+    for segment in _iter_command_segments(normalized):
+        index = _kill_executable_index(segment)
+        if index is not None:
+            yield segment, index
+
+
+def _segment_kill_targets_gateway(segment: list[str]) -> bool:
+    """Return True when one executable kill segment names the gateway."""
+    index = _kill_executable_index(segment)
+    return index is not None and any(
+        _GATEWAY_KILL_TARGET_RE.search(token)
+        for token in segment[index + 1 :]
+    )
 
 
 def _command_token_index(segment: list[str]) -> Optional[int]:

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -44,7 +44,10 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import stat
+import subprocess
+import time
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
@@ -58,6 +61,11 @@ class GatewayLifecycleBlocked(ValueError):
 # Shell-level command shapes that target the gateway lifecycle. Each branch
 # is anchored on a concrete command identifier so a match can only fire on
 # actual shell-command-shaped strings, not on prose.
+_KILL_AT_COMMAND_POSITION = (
+    r"(?:\A|[;&|(){}\n])[ \t]*(?:sudo[ \t]+(?:-\S+[ \t]+)*)?p?kill\b"
+)
+
+
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
     # Branch A: destructive `hermes gateway` operations.
@@ -71,7 +79,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # matching via the `/hermes` tail, while every real command position
     # (start of text, whitespace, `;`/`&`/`|`, `$(`, backtick, even a
     # U+FFFD from binary-content decoding) still matches.
-    r"(?:(?<![/\w.\-])hermes\s+gateway\s+(?:restart|stop|uninstall)\b)"
+    r"(?:(?<![/\w.\-])hermes[ \t]+(?:(?!gateway\b)\S+[ \t]+)*gateway[ \t]+(?:restart|stop|install|uninstall)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -93,14 +101,68 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # "force=True cannot help here" — let them through (#80260).
     r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch C: systemctl ops on a hermes-gateway unit.
-    r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
+    r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start|enable|disable)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
     # Leading \b ensures we match "pkill" or "kill" as whole words, not as
     # suffixes of other words (e.g. "skill" -> "kill").
-    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    rf"|(?:{_KILL_AT_COMMAND_POSITION}[^\n]*\bhermes[.\-]?gateway)"
+    rf"|(?:\bhermes[.\-]?gateway\b[^\n]*{_KILL_AT_COMMAND_POSITION})"
 )
+
+_KILL_COMMAND_RE = re.compile(_KILL_AT_COMMAND_POSITION, re.IGNORECASE)
+_MAIN_PID_TTL_SECONDS = 5.0
+_main_pid_cache = (0.0, None)
+
+
+def _resolve_gateway_main_pid():
+    """Return the supervised gateway MainPID, or ``None`` on any failure."""
+    global _main_pid_cache
+    now = time.monotonic()
+    stamp, cached = _main_pid_cache
+    if cached is not None and (now - stamp) < _MAIN_PID_TTL_SECONDS:
+        return cached
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return None
+    try:
+        from hermes_cli.gateway import get_service_name
+
+        service = get_service_name()
+    except Exception:
+        service = "hermes-gateway"
+    for scope in (["--user"], []):
+        try:
+            result = subprocess.run(
+                [
+                    systemctl,
+                    *scope,
+                    "show",
+                    service,
+                    "--property=MainPID",
+                    "--value",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except Exception:
+            continue
+        value = (result.stdout or "").strip()
+        if value.isdigit() and int(value) > 0:
+            _main_pid_cache = (now, int(value))
+            return int(value)
+    return None
+
+
+def kill_targets_gateway_main_pid(text: str) -> bool:
+    """Fail-open numeric-PID companion to the command-shaped text guard."""
+    if not text or not _KILL_COMMAND_RE.search(text):
+        return False
+    pid = _resolve_gateway_main_pid()
+    if not pid:
+        return False
+    return re.search(r"(?<![0-9])" + str(pid) + r"(?![0-9])", text) is not None
 
 
 # A backslash immediately followed by a newline is a POSIX shell line

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6928,7 +6928,9 @@ class BasePlatformAdapter(ABC):
                 )
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
-            if callable(_post_cb):
+            if callable(_post_cb) and (
+                not delivery_attempted or delivery_succeeded
+            ):
                 try:
                     _post_result = _post_cb()
                     if inspect.isawaitable(_post_result):
@@ -6938,6 +6940,11 @@ class BasePlatformAdapter(ABC):
                         )
                 except (asyncio.TimeoutError, Exception):
                     pass
+            elif callable(_post_cb):
+                logger.debug(
+                    "[%s] Skipping post-delivery callback because final delivery failed",
+                    self.name,
+                )
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5449,8 +5449,17 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
-        _want_stream_deltas = _streaming_enabled
         _want_interim_messages = ctx.interim_assistant_messages_enabled
+        # A Telegram turn that exposes interim commentary uses one temporary
+        # live-status bubble, then the normal delivery path sends the completed
+        # answer and removes the status. Plain Telegram streaming keeps the
+        # upstream delta/finalize contract when no status bubble is requested.
+        _telegram_status_mode = bool(
+            ctx.source.platform == Platform.TELEGRAM and _want_interim_messages
+        )
+        _want_stream_deltas = (
+            _streaming_enabled and not _telegram_status_mode
+        )
         _want_interim_consumer = _want_interim_messages
         if _want_stream_deltas or _want_interim_consumer:
             try:
@@ -6458,7 +6467,16 @@ class TurnRunner:
                 _fr = result.get("final_response")
                 if isinstance(_fr, str) and _fr.strip() and _fr != "(empty)":
                     _final_for_stream = _fr
-            if _final_for_stream is not None:
+            _ephemeral_telegram_status = bool(
+                ctx.source.platform == Platform.TELEGRAM
+                and getattr(
+                    getattr(_stream_consumer, "cfg", None),
+                    "commentary_edit_in_place",
+                    False,
+                )
+                and not _want_stream_deltas
+            )
+            if _final_for_stream is not None and not _ephemeral_telegram_status:
                 # Duck-type safe: test doubles / older consumers may expose a
                 # zero-arg finish(). The payload is an optimization, not a
                 # requirement — fall back to the bare signal.
@@ -12270,8 +12288,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # before the owner was removed from it, must not silently
             # receive a full agent response on gateway restart just
             # because it has a resume-pending marker (issue #23778).
+            # Run the check inside the owning profile's runtime scope. Without
+            # it there is no secret scope installed here (this runs at startup,
+            # not inside a turn), so ``_auth_env`` -> ``get_secret`` raises
+            # ``UnscopedSecretError``, is swallowed, and silently falls back to
+            # the process-global ``os.environ`` - i.e. the DEFAULT profile's
+            # allowlist. A secondary-profile session then fails authorization
+            # against a list it was never meant to be on.
             try:
-                if not self._is_user_authorized(source):
+                try:
+                    _resume_home = self._resolve_profile_home_for_source(source)
+                except Exception:
+                    _resume_home = None
+                if _resume_home is not None:
+                    with _profile_runtime_scope(_resume_home):
+                        _resume_authorized = self._is_user_authorized(source)
+                else:
+                    _resume_authorized = self._is_user_authorized(source)
+                if not _resume_authorized:
                     logger.warning(
                         "Skipping auto-resume for %s: session owner is no "
                         "longer authorized under the current allowlist",
@@ -19030,7 +19064,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
-        _msg_start_time = time.time()
+        _msg_start_time_ms = time.time_ns() // 1_000_000
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
         _reply_id = getattr(event, "reply_to_message_id", None)
@@ -20474,7 +20508,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
-            _response_time = time.time() - _msg_start_time
+            _response_time = (
+                (time.time_ns() // 1_000_000) - _msg_start_time_ms
+            ) / 1000.0
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
             logger.info(
@@ -24644,6 +24680,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
 
+    def _resolve_session_cwd_for_source(self, source: SessionSource) -> str:
+        """Resolve a multiplex turn against its routed profile, never its owner."""
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return ""
+        try:
+            profile_home = Path(self._resolve_profile_home_for_source(source)).resolve()
+            with _profile_runtime_scope(profile_home):
+                from hermes_cli.config import load_config
+
+                profile_config = load_config()
+            terminal_config = profile_config.get("terminal") or {}
+            configured = str(terminal_config.get("cwd") or "").strip()
+            backend = str(terminal_config.get("backend") or "local").strip().lower()
+            if configured and configured not in CWD_PLACEHOLDERS:
+                if not _is_ssh_remote_tilde_cwd(backend, configured):
+                    configured = os.path.expanduser(configured)
+                if Path(configured).is_dir():
+                    return configured
+                logger.warning(
+                    "Profile-scoped terminal.cwd does not exist for %s: %s; "
+                    "falling back to profile home",
+                    getattr(source, "profile", "") or "default",
+                    configured,
+                )
+            return str(profile_home)
+        except Exception:
+            logger.warning(
+                "Could not resolve profile-scoped cwd for %s; suppressing "
+                "gateway-owner cwd",
+                getattr(source, "profile", "") or "default",
+                exc_info=True,
+            )
+            try:
+                return str(Path(self._resolve_profile_home_for_source(source)).resolve())
+            except Exception:
+                return ""
+
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.
 
@@ -24679,6 +24752,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=self._resolve_session_cwd_for_source(context.source),
             async_delivery=_async_delivery,
             cron_session="",
         )
@@ -27813,6 +27887,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             fresh_final_after_seconds=_fresh_final_secs,
             transport=scfg.transport or "edit",
             chat_type=getattr(source, "chat_type", "") or "",
+            commentary_edit_in_place=(source.platform == Platform.TELEGRAM),
         )
         return _consumer_cfg, _pause_typing_before_finalize
 
@@ -30060,6 +30135,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key or "?", _edit_err,
                         )
 
+        # The Telegram live-status bubble is temporary too. Add it to the same
+        # post-delivery cleanup list so ordering is guaranteed: send the final
+        # answer first, then call deleteMessage on the status id.
+        if (
+            source.platform == Platform.TELEGRAM
+            and _cleanup_progress
+            and _sc is not None
+            and getattr(getattr(_sc, "cfg", None), "commentary_edit_in_place", False)
+            and getattr(_sc, "message_id", None)
+        ):
+            _status_id = str(_sc.message_id)
+            if _status_id not in _cleanup_msg_ids:
+                _cleanup_msg_ids.append(_status_id)
+
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as
         # breadcrumbs for the user to see what work happened. Only fires on
@@ -30399,6 +30488,59 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     """
     from cron.scheduler_provider import InProcessCronScheduler
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
+
+
+def _run_profile_cron_provider(
+    profile_name: str,
+    profile_home: "Path",
+    provider,
+    stop_event,
+    *,
+    adapters=None,
+    loop=None,
+    can_dispatch=None,
+):
+    """Run a secondary profile's provider inside its isolated runtime/store."""
+    from cron.jobs import use_cron_store
+
+    with _profile_runtime_scope(Path(profile_home)):
+        with use_cron_store(profile_home):
+            logger.info(
+                "Starting isolated cron scheduler for multiplex profile %s",
+                profile_name,
+            )
+            kwargs = {"adapters": adapters, "loop": loop}
+            if can_dispatch is not None:
+                kwargs["can_dispatch"] = can_dispatch
+            provider.start(stop_event, **kwargs)
+
+
+def _start_secondary_profile_cron_schedulers(runner, stop_event, *, loop):
+    """Start one profile-scoped scheduler for each connected secondary profile."""
+    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    from hermes_cli.profiles import get_profile_dir
+
+    handles = []
+    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
+    for profile_name, adapters in sorted(profile_adapters.items()):
+        profile_home = Path(get_profile_dir(profile_name))
+        with _profile_runtime_scope(profile_home):
+            provider = resolve_cron_scheduler()
+        kwargs = {"adapters": adapters, "loop": loop}
+        if isinstance(provider, InProcessCronScheduler):
+            kwargs["can_dispatch"] = lambda: not (
+                runner._draining or runner._external_drain_active
+            )
+        thread = threading.Thread(
+            target=_run_profile_cron_provider,
+            args=(profile_name, profile_home, provider, stop_event),
+            kwargs=kwargs,
+            daemon=True,
+            name=f"cron-scheduler-{profile_name}",
+        )
+        thread.start()
+        handles.append((provider, thread))
+    return handles
 
 
 def _stop_cron_provider(provider) -> None:
@@ -31229,30 +31371,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
-    # Multiplex profiles: tell the built-in ticker which profile homes to
-    # tick so secondary-profile cron jobs actually fire (#69377).
-    # Without this, only the process-global HERMES_HOME (default profile)
-    # is iterated and every secondary profile's cron store is silently
-    # ignored — jobs show as "scheduled" with a valid next_run_at but
-    # never execute because no ticker owns that store.
-    if (
-        isinstance(cron_provider, InProcessCronScheduler)
-        and multiplex_cron
-    ):
-        try:
-            profile_homes = _multiplex_profile_homes(runner.config)
-            if profile_homes:
-                cron_start_kwargs["profile_homes"] = profile_homes
-                logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
-                    len(profile_homes),
-                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
-                )
-        except Exception as exc:
-            logger.warning(
-                "Could not resolve profile homes for multiplex cron: %s",
-                exc,
-            )
+    # Secondary stores need their own runtime, secret and adapter scope. The
+    # process-global provider therefore remains owner-profile-only.
 
     # External cron providers own their remote scheduling contract. Only the
     # in-process ticker polls local due jobs, so only it receives the local
@@ -31269,6 +31389,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-scheduler",
     )
     cron_thread.start()
+    secondary_cron_handles = (
+        _start_secondary_profile_cron_schedulers(
+            runner,
+            cron_stop,
+            loop=asyncio.get_running_loop(),
+        )
+        if multiplex_cron
+        else []
+    )
 
     # Preflight tell for the hosted fire path: an external cron provider
     # (Chronos) delivers scheduled fires over HTTP to THIS process's
@@ -31356,11 +31485,23 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # delivery finishes before we tear down.
     cron_stop.set()
     _stop_cron_provider(cron_provider)
+    for profile_cron_provider, _profile_cron_thread in secondary_cron_handles:
+        _stop_cron_provider(profile_cron_provider)
     if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
         logger.warning(
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
             "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
         )
+    for _profile_cron_provider, profile_cron_thread in secondary_cron_handles:
+        if not await _await_thread_exit(
+            profile_cron_thread,
+            timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT,
+        ):
+            logger.warning(
+                "Profile cron ticker %s did not exit within %.0fs of shutdown.",
+                profile_cron_thread.name,
+                _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+            )
     await _await_thread_exit(
         housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -34,11 +34,28 @@ piecemeal, the footer is sent as a separate trailing message via
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+
+
+def _normalise_fields(value: Any) -> list[str] | None:
+    """Accept the documented YAML list plus config-CLI JSON-list strings."""
+    if isinstance(value, list) and value:
+        return [str(field) for field in value]
+    if isinstance(value, str) and value.strip():
+        text = value.strip()
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            parsed = None
+        if isinstance(parsed, list) and parsed:
+            return [str(field) for field in parsed]
+        return [text]
+    return None
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -80,8 +97,9 @@ def resolve_footer_config(
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
             resolved["enabled"] = bool(global_cfg.get("enabled"))
-        if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
-            resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        normalised = _normalise_fields(global_cfg.get("fields"))
+        if normalised:
+            resolved["fields"] = normalised
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -91,8 +109,9 @@ def resolve_footer_config(
             if isinstance(plat_footer, dict):
                 if "enabled" in plat_footer:
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
-                if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
-                    resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                normalised = _normalise_fields(plat_footer.get("fields"))
+                if normalised:
+                    resolved["fields"] = normalised
 
     return resolved
 
@@ -116,6 +135,7 @@ def format_runtime_footer(
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    duration_seconds: Optional[float] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -123,6 +143,9 @@ def format_runtime_footer(
     partially-populated footer is better than a line with ``?%`` or empty slots.
     """
     parts: list[str] = []
+    duration_value = (
+        duration_seconds if duration_seconds is not None else turn_seconds
+    )
     for field in fields:
         if field == "model":
             m = _model_short(model)
@@ -141,6 +164,9 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "duration":
+            if duration_value is not None and duration_value >= 0:
+                parts.append(f"⏱ Думал {duration_value:.1f} сек")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -157,6 +183,7 @@ def build_footer_line(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    duration_seconds: Optional[float] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -178,4 +205,5 @@ def build_footer_line(
         cwd=cwd,
         turn_seconds=turn_seconds,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        duration_seconds=duration_seconds,
     )

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -159,6 +159,9 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+    # Reuse one editable commentary bubble as live status. Callers may replace
+    # it with final text; Telegram keeps it temporary and sends final separately.
+    commentary_edit_in_place: bool = False
 
 
 class GatewayStreamConsumer:
@@ -1289,20 +1292,27 @@ class GatewayStreamConsumer:
                     return
 
                 if commentary_text is not None:
-                    # Stream-is-the-message adapters: commentary posts as its
-                    # own message (no notify → no seal-interception), and the
-                    # native stream continues cumulatively. Resetting here
-                    # would break the append-only invariant the connector's
-                    # delta computation depends on (whole-snapshot re-append).
-                    _stream_is_msg_c = self._stream_is_message()
-                    if _stream_is_msg_c and self._use_draft_streaming:
-                        await self._send_commentary(commentary_text)
+                    if self.cfg.commentary_edit_in_place:
+                        # Operational commentary is a live status, not durable
+                        # transcript content. Reuse the same message for every
+                        # status and, when deltas are enabled, the final answer.
+                        self._accumulated = ""
+                        await self._upsert_commentary(commentary_text)
                         self._last_edit_time = time.monotonic()
                     else:
-                        self._reset_segment_state()
-                        await self._send_commentary(commentary_text)
-                        self._last_edit_time = time.monotonic()
-                        self._reset_segment_state()
+                        # Stream-is-the-message adapters: commentary posts as
+                        # its own message while the native stream continues
+                        # cumulatively. Resetting would break its append-only
+                        # delta invariant.
+                        _stream_is_msg_c = self._stream_is_message()
+                        if _stream_is_msg_c and self._use_draft_streaming:
+                            await self._send_commentary(commentary_text)
+                            self._last_edit_time = time.monotonic()
+                        else:
+                            self._reset_segment_state()
+                            await self._send_commentary(commentary_text)
+                            self._last_edit_time = time.monotonic()
+                            self._reset_segment_state()
 
                 # Tool boundary: reset message state so the next text chunk
                 # creates a fresh message below any tool-progress messages.
@@ -2099,6 +2109,42 @@ class GatewayStreamConsumer:
             return result.success
         except Exception as e:
             logger.error("Commentary send error: %s", e)
+            return False
+
+    async def _upsert_commentary(self, text: str) -> bool:
+        """Create or edit the single live-status bubble in place."""
+        text = self._clean_for_display(text)
+        if not text.strip():
+            return False
+        try:
+            if self._message_id and self._message_id != "__no_edit__":
+                # Keep Telegram status edits inside its roughly one-edit/second
+                # envelope. The adapter also honours RetryAfter as a fallback.
+                min_interval = max(float(self.cfg.edit_interval or 0.0), 0.8)
+                elapsed = time.monotonic() - self._last_edit_time
+                if elapsed < min_interval:
+                    await asyncio.sleep(min_interval - elapsed)
+                result = await self._edit_message(
+                    message_id=self._message_id,
+                    content=text,
+                )
+            else:
+                result = await self.adapter.send(
+                    chat_id=self.chat_id,
+                    content=text,
+                    metadata=self._metadata_for_send(expect_edits=True),
+                )
+                if result.success and result.message_id:
+                    self._message_id = str(result.message_id)
+                    self._message_created_ts = time.monotonic()
+                    self._track_preview_ids_from_result(result)
+                    self._notify_new_message()
+            if result.success:
+                self._last_sent_text = text
+                self._delivered_commentary_texts.append(text)
+            return bool(result.success)
+        except Exception as e:
+            logger.error("Commentary upsert error: %s", e)
             return False
 
     def _should_send_fresh_final(self) -> bool:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -227,7 +227,6 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 # froze inbound on every platform (#91969).
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
 
-
 def _flood_cap_result(wait: float) -> "SendResult":
     """The shared fail-closed SendResult for an over-cap flood wait."""
     return SendResult(
@@ -319,6 +318,40 @@ def _probe_voice_duration_seconds(path: str) -> Optional[int]:
         pass
 
     return None
+
+
+def _coerce_dm_topics(raw: Any, adapter_name: str = "Telegram") -> List[Dict[str, Any]]:
+    """Normalize YAML or JSON-string DM topic configuration."""
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "[%s] extra.dm_topics is not valid JSON (%s); DM topics disabled.",
+                adapter_name,
+                exc,
+            )
+            return []
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        logger.warning(
+            "[%s] extra.dm_topics has unsupported type %s; DM topics disabled.",
+            adapter_name,
+            type(raw).__name__,
+        )
+        return []
+    entries = [entry for entry in raw if isinstance(entry, dict)]
+    dropped = len(raw) - len(entries)
+    if dropped:
+        logger.warning(
+            "[%s] extra.dm_topics ignored %d non-object entries.",
+            adapter_name,
+            dropped,
+        )
+    return entries
 
 
 def telegram_deps_present() -> bool:
@@ -809,12 +842,29 @@ class TelegramAdapter(BasePlatformAdapter):
         self._status_offline_text: str = str(
             self.config.extra.get("status_offline", "Offline")
         )
-        # DM Topics config from extra.dm_topics
-        self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # DM Topics config from extra.dm_topics. Coerced because config.yaml may
+        # deliver it as a JSON string rather than a YAML sequence.
+        self._dm_topics_config: List[Dict[str, Any]] = _coerce_dm_topics(
+            self.config.extra.get("dm_topics", []), self.name
+        )
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
         self._dm_topic_chat_ids: Set[str] = {
-            str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
+            str(e["chat_id"])
+            for e in self._dm_topics_config
+            if isinstance(e, dict) and "chat_id" in e
         }
+        # A configured-but-unreadable dm_topics used to fail silently: ``"chat_id"
+        # in e`` is a substring test on a str entry, so the set came out empty
+        # with no diagnostic at all. Say so instead of degrading quietly.
+        if self._dm_topics_config and not self._dm_topic_chat_ids:
+            logger.warning(
+                "[%s] dm_topics is configured (%d entr%s) but no chat_id could be "
+                "read from it - root-DM ignore and topic setup will be skipped. "
+                "Expected a list of {chat_id, topics} objects.",
+                self.name,
+                len(self._dm_topics_config),
+                "y" if len(self._dm_topics_config) == 1 else "ies",
+            )
         # Document size cap. Telegram's public Bot API caps getFile at 20MB; a
         # locally-hosted telegram-bot-api server (configured via extra.base_url)
         # raises that to 2GB, so the presence of base_url is the opt-in.
@@ -5220,7 +5270,9 @@ class TelegramAdapter(BasePlatformAdapter):
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if self._should_attempt_rich(
+                content, metadata=metadata
+            ):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -5237,21 +5289,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                 pass  # Typing failures are non-fatal
                     return rich_result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
-            chunks = self.truncate_message(
-                formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
-            )
-            if len(chunks) > 1:
-                # truncate_message appends a raw " (1/2)" suffix. Escape the
-                # MarkdownV2-special parentheses so Telegram doesn't reject the
-                # chunk and fall back to plain text.
-                chunks = [
-                    _separate_chunk_indicator_from_fence(
-                        re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
-                    )
-                    for chunk in chunks
-                ]
+            # Convert Markdown to safe Telegram HTML, then split only on block
+            # boundaries. Every chunk contains balanced code/pre tags.
+            chunks = self._html_chunks(content)
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
@@ -5319,22 +5359,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 msg = None
                 for _send_attempt in range(3):
                     try:
-                        # Try Markdown first, fall back to plain text if it fails
+                        # Try Telegram HTML first, fall back to plain text if it fails
                         try:
                             msg = await self._bot.send_message(
                                 chat_id=normalize_telegram_chat_id(chat_id),
                                 text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
+                                parse_mode=ParseMode.HTML,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
-                        except Exception as md_error:
-                            # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                                plain_chunk = _strip_mdv2(chunk)
+                        except Exception as html_error:
+                            # HTML parsing failed, try clean plain text.
+                            if "parse" in str(html_error).lower() or "entity" in str(html_error).lower():
+                                logger.warning("[%s] HTML parse failed, falling back to plain text: %s", self.name, html_error)
+                                plain_chunk = _html.unescape(re.sub(r"<[^>]+>", "", chunk))
                                 msg = await self._bot.send_message(
                                     chat_id=normalize_telegram_chat_id(chat_id),
                                     text=plain_chunk,
@@ -5657,26 +5697,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._last_overflow_preview[_preview_key] = content
                 return SendResult(success=True, message_id=message_id)
 
-            formatted = self.format_message(content)
+            formatted = self.format_message_html(content)
             try:
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=formatted,
-                    parse_mode=ParseMode.MARKDOWN_V2,
+                    parse_mode=ParseMode.HTML,
                 )
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
-                # Fallback: strip MarkdownV2 escapes and retry as clean plain text
+                # Fallback: strip HTML tags and retry as clean plain text.
                 safe_format_error = _redact_telegram_error_text(fmt_err)
                 logger.warning(
-                    "[%s] MarkdownV2 edit failed, falling back to plain text: %s",
+                    "[%s] HTML edit failed, falling back to plain text: %s",
                     self.name,
                     safe_format_error,
                 )
-                _plain = _strip_mdv2(content) if content else content
+                _plain = _html.unescape(re.sub(r"<[^>]+>", "", formatted)) if content else content
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
@@ -8394,6 +8434,200 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
 
+    def format_message_html(self, content: str) -> str:
+        """Convert agent Markdown to Telegram-safe HTML.
+
+        User text is escaped before supported markup is inserted. In ordinary
+        text only ``&``, ``<`` and ``>`` need escaping for Telegram HTML.
+        Code, preformatted blocks and link attributes are escaped separately.
+        """
+        if not content:
+            return content
+
+        placeholders: dict[str, str] = {}
+        counter = [0]
+        placeholder_prefix = "\x00HT"
+        while placeholder_prefix in content:
+            placeholder_prefix += "X"
+
+        def _ph(value: str) -> str:
+            key = f"{placeholder_prefix}{counter[0]}\x00"
+            counter[0] += 1
+            placeholders[key] = value
+            return key
+
+        text = _wrap_markdown_tables(content)
+
+        def _fenced(m):
+            lang = (m.group(1) or "").strip()
+            body = m.group(2)
+            escaped = _html.escape(body, quote=False)
+            if lang and re.fullmatch(r"[A-Za-z0-9_+.-]+", lang):
+                cls = _html.escape(f"language-{lang}", quote=True)
+                return _ph(f'<pre><code class="{cls}">{escaped}</code></pre>')
+            return _ph(f"<pre>{escaped}</pre>")
+
+        text = re.sub(
+            r"```([^\n`]*)\n([\s\S]*?)```",
+            _fenced,
+            text,
+        )
+        text = re.sub(
+            r"`([^`\n]+)`",
+            lambda m: _ph(f"<code>{_html.escape(m.group(1), quote=False)}</code>"),
+            text,
+        )
+
+        def _link(m):
+            label = _html.escape(m.group(1), quote=False)
+            href = _html.escape(m.group(2), quote=True)
+            return _ph(f'<a href="{href}">{label}</a>')
+
+        text = re.sub(
+            r"\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)",
+            _link,
+            text,
+        )
+
+        # Escape all remaining user/model text before adding Telegram HTML tags.
+        text = _html.escape(text, quote=False)
+        def _header(m):
+            inner = m.group(1).strip()
+            inner = re.sub(r"^\*\*(.*?)\*\*$", r"\1", inner)
+            return f"<b>{inner}</b>"
+
+        text = re.sub(
+            r"^#{1,6}\s+(.+)$",
+            _header,
+            text,
+            flags=re.MULTILINE,
+        )
+        text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+        text = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<i>\1</i>", text)
+        text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+        text = re.sub(r"\|\|(.+?)\|\|", r"<tg-spoiler>\1</tg-spoiler>", text)
+        text = re.sub(r"^&gt;\s?(.+)$", r"<blockquote>\1</blockquote>", text, flags=re.MULTILINE)
+        text = re.sub(r"^\s*[-*]\s+", "• ", text, flags=re.MULTILINE)
+
+        for key in reversed(list(placeholders.keys())):
+            text = text.replace(key, placeholders[key])
+        return text
+
+    def _html_chunks(self, content: str) -> list[str]:
+        """Format and split Markdown on block boundaries for Telegram HTML.
+
+        Fenced code blocks are atomic whenever they fit. Oversized code blocks
+        are split only at source line boundaries and each resulting chunk gets
+        its own complete ``pre/code`` wrapper, so HTML tags are never torn.
+        """
+        target = max(32, min(4000, int(self.MAX_MESSAGE_LENGTH) - 32))
+        lines = content.splitlines(keepends=True)
+        blocks: list[str] = []
+        buf: list[str] = []
+        in_fence = False
+
+        def flush() -> None:
+            if buf:
+                blocks.append("".join(buf))
+                buf.clear()
+
+        for line in lines:
+            if line.lstrip().startswith("```"):
+                if not in_fence:
+                    flush()
+                    in_fence = True
+                    buf.append(line)
+                else:
+                    buf.append(line)
+                    in_fence = False
+                    flush()
+                continue
+            if in_fence:
+                buf.append(line)
+            elif not line.strip():
+                flush()
+            else:
+                buf.append(line)
+        flush()
+
+        def split_large_plain(block: str) -> list[str]:
+            words = re.findall(r"\S+\s*", block)
+            parts: list[str] = []
+            current = ""
+
+            def split_overlong_token(token: str) -> list[str]:
+                token_parts: list[str] = []
+                token_current = ""
+                for char in token:
+                    candidate = token_current + char
+                    if (
+                        token_current
+                        and utf16_len(self.format_message_html(candidate)) > target
+                    ):
+                        token_parts.append(token_current)
+                        token_current = char
+                    else:
+                        token_current = candidate
+                if token_current:
+                    token_parts.append(token_current)
+                return token_parts
+
+            for word in words:
+                if utf16_len(self.format_message_html(word)) > target:
+                    if current:
+                        parts.append(current.rstrip())
+                        current = ""
+                    parts.extend(split_overlong_token(word))
+                    continue
+                candidate = current + word
+                if current and utf16_len(self.format_message_html(candidate)) > target:
+                    parts.append(current.rstrip())
+                    current = word
+                else:
+                    current = candidate
+            if current.strip():
+                parts.append(current.rstrip())
+            return parts or [block]
+
+        expanded: list[str] = []
+        for block in blocks or [content]:
+            if utf16_len(self.format_message_html(block)) <= target:
+                expanded.append(block)
+                continue
+            fence = re.fullmatch(r"```([^\n`]*)\n([\s\S]*?)```\s*", block)
+            if not fence:
+                expanded.extend(split_large_plain(block))
+                continue
+            lang, body = fence.group(1), fence.group(2)
+            current_lines: list[str] = []
+            for source_line in body.splitlines(keepends=True):
+                candidate_body = "".join(current_lines) + source_line
+                candidate = f"```{lang}\n{candidate_body}```"
+                if current_lines and utf16_len(self.format_message_html(candidate)) > target:
+                    expanded.append(f"```{lang}\n{''.join(current_lines)}```")
+                    current_lines = [source_line]
+                else:
+                    current_lines.append(source_line)
+            if current_lines:
+                expanded.append(f"```{lang}\n{''.join(current_lines)}```")
+
+        raw_chunks: list[str] = []
+        current = ""
+        for block in expanded:
+            candidate = block if not current else f"{current}\n\n{block}"
+            if current and utf16_len(self.format_message_html(candidate)) > target:
+                raw_chunks.append(current)
+                current = block
+            else:
+                current = candidate
+        if current:
+            raw_chunks.append(current)
+
+        chunks = [self.format_message_html(chunk) for chunk in raw_chunks]
+        if len(chunks) > 1:
+            chunks = [f"{chunk}\n\n({i}/{len(chunks)})" for i, chunk in enumerate(chunks, 1)]
+        return chunks
+
     def format_message(self, content: str) -> str:
         """
         Convert standard markdown to Telegram MarkdownV2 format.
@@ -10319,11 +10553,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._dm_topic_chat_ids = set()
                 return
 
-            # Update in-memory config and cache any new thread_ids
+            # Update in-memory config and cache any new thread_ids. Coerce here
+            # too: a config reload re-reads the same JSON-string shape.
+            dm_topics = _coerce_dm_topics(dm_topics, self.name)
             self._dm_topics_config = dm_topics
             # Rebuild the chat_id set for O(1) root-DM ignore lookup
             self._dm_topic_chat_ids = {
-                str(chat_entry["chat_id"]) for chat_entry in dm_topics if "chat_id" in chat_entry
+                str(chat_entry["chat_id"])
+                for chat_entry in dm_topics
+                if isinstance(chat_entry, dict) and "chat_id" in chat_entry
             }
             for chat_entry in dm_topics:
                 cid = chat_entry.get("chat_id")

--- a/tests/cron/test_lifecycle_guard_contexts.py
+++ b/tests/cron/test_lifecycle_guard_contexts.py
@@ -1,0 +1,127 @@
+"""Gateway lifecycle guard: command shapes and execution context (2026-07-28).
+
+Scope reminder, mirrored from ``cron/lifecycle_guard.py``: this guard is an
+accident-and-carelessness barrier, NOT a security boundary. Every profile's
+agent runs as the same UNIX user and can reach the same APIs from Python. These
+tests lock in the two bypasses seen in production and the fail-open contract of
+the PID check.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cron import lifecycle_guard as lg
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+BLOCKED = [
+    # canonical shape
+    "hermes gateway restart",
+    "hermes gateway stop",
+    # bypass #1, seen 2026-07-27 22:19:48 and 2026-07-28 00:33:16: global flags
+    # between the binary and the subcommand
+    "hermes --profile default gateway restart",
+    "hermes -p altex gateway stop",
+    "hermes --profile altex gateway restart && echo done",
+    # incident 2026-07-27 started here: a second poller on the same bot token
+    "hermes --profile altex gateway install",
+    "hermes gateway uninstall",
+    # systemd shapes
+    "systemctl --user restart hermes-gateway.service",
+    "systemctl --user stop hermes-gateway",
+    # registering a unit directly is the same vector as `gateway install`
+    "systemctl --user enable hermes-gateway-altex.service",
+    "systemctl --user disable hermes-gateway",
+    (
+        "systemd-run --user --unit=hermes-gateway-restart-once --on-active=2s "
+        "--collect /usr/bin/systemctl --user restart hermes-gateway.service"
+    ),
+    # bypass #2, seen 2026-07-28 01:25:45: kill AFTER the gateway identifier
+    'pid=$(systemctl --user show hermes-gateway.service -p MainPID --value); kill -USR1 "$pid"',
+    # and the historical order, which the old pattern already caught
+    "pkill -f hermes-gateway",
+    "kill -9 $(pgrep -f hermes-gateway)",
+    # newline separator, not just ';'
+    'pid=$(systemctl --user show hermes-gateway.service -p MainPID --value)\nkill -TERM "$pid"',
+]
+
+ALLOWED = [
+    # read-only inspection must stay usable
+    "hermes gateway status",
+    "hermes --profile altex gateway status",
+    "systemctl --user show hermes-gateway.service -p MainPID --value",
+    "systemctl --user is-active hermes-gateway.service",
+    # read-only verb that merely contains "enable" as a substring
+    "systemctl --user is-enabled hermes-gateway.service",
+    "systemctl --user list-unit-files | grep hermes-gateway",
+    "journalctl --user -u hermes-gateway.service -n 50 --no-pager",
+    # the word "kill" as an argument, not a command — this is why the kill
+    # branch is anchored to a command position
+    "journalctl --user -u hermes-gateway.service | grep -i kill",
+    "grep -rn kill /home/hermesagent/.hermes/hermes-agent/gateway/run.py",
+    # start is deliberately not a lifecycle verb here
+    "hermes gateway start",
+    # the update conveyor: its own systemctl calls live inside the script, not
+    # in the command text the agent submits
+    "hermes-safe-update",
+    "/home/hermesagent/.local/bin/hermes-safe-update --check-only",
+    # unrelated subcommands and prose
+    "hermes --profile altex sessions list",
+    "echo 'we should restart the gateway tomorrow'",
+    "hermes cron list",
+]
+
+
+@pytest.mark.parametrize("command", BLOCKED)
+def test_lifecycle_shapes_are_blocked(command):
+    assert lg.contains_gateway_lifecycle_command(command) is True
+
+
+@pytest.mark.parametrize("command", ALLOWED)
+def test_benign_shapes_are_allowed(command):
+    assert lg.contains_gateway_lifecycle_command(command) is False
+
+
+def test_kill_by_pid_is_blocked_when_pid_resolves(monkeypatch):
+    monkeypatch.setattr(lg, "_resolve_gateway_main_pid", lambda: 133375)
+    assert lg.kill_targets_gateway_main_pid("kill -USR1 133375") is True
+    assert lg.kill_targets_gateway_main_pid("kill -TERM 133375") is True
+
+
+def test_kill_by_pid_fails_open_when_pid_unknown(monkeypatch):
+    """Unresolvable PID must ALLOW: losing a legitimate kill is worse."""
+    monkeypatch.setattr(lg, "_resolve_gateway_main_pid", lambda: None)
+    assert lg.kill_targets_gateway_main_pid("kill -USR1 133375") is False
+
+
+def test_kill_by_pid_does_not_overmatch(monkeypatch):
+    monkeypatch.setattr(lg, "_resolve_gateway_main_pid", lambda: 133375)
+    # substring of a longer number must not count
+    assert lg.kill_targets_gateway_main_pid("kill -9 1333750") is False
+    # no kill at a command position -> no PID lookup, no block
+    assert lg.kill_targets_gateway_main_pid("echo 133375") is False
+    assert lg.kill_targets_gateway_main_pid("grep 133375 /tmp/pids") is False
+
+
+def test_pid_lookup_is_skipped_without_a_kill(monkeypatch):
+    """The subprocess lookup must not run for ordinary commands."""
+
+    def _boom():
+        raise AssertionError("PID resolution ran for a command without kill")
+
+    monkeypatch.setattr(lg, "_resolve_gateway_main_pid", _boom)
+    assert lg.kill_targets_gateway_main_pid("ls -la /tmp") is False
+
+
+def test_terminal_guard_is_no_longer_env_gated():
+    """Regression lock: the guard must not depend on _HERMES_GATEWAY.
+
+    That marker is set only by gateway/run.py, so gating on it left serve,
+    cli and standalone cron uncovered.
+    """
+    src = (REPO / "tools/terminal_tool.py").read_text(encoding="utf-8")
+    assert 'os.environ.get("_HERMES_GATEWAY") == "1"' not in src
+    assert "contains_gateway_lifecycle_command(command)" in src
+    assert "kill_targets_gateway_main_pid(command)" in src

--- a/tests/cron/test_lifecycle_guard_contexts.py
+++ b/tests/cron/test_lifecycle_guard_contexts.py
@@ -42,6 +42,9 @@ BLOCKED = [
     'pid=$(systemctl --user show hermes-gateway.service -p MainPID --value); kill -USR1 "$pid"',
     # and the historical order, which the old pattern already caught
     "pkill -f hermes-gateway",
+    "/usr/bin/pkill -f hermes-gateway",
+    "command /usr/bin/pkill -f hermes-gateway",
+    "env -i PATH=/usr/bin /usr/bin/pkill -f hermes-gateway",
     "kill -9 $(pgrep -f hermes-gateway)",
     # newline separator, not just ';'
     'pid=$(systemctl --user show hermes-gateway.service -p MainPID --value)\nkill -TERM "$pid"',
@@ -84,10 +87,19 @@ def test_benign_shapes_are_allowed(command):
     assert lg.contains_gateway_lifecycle_command(command) is False
 
 
-def test_kill_by_pid_is_blocked_when_pid_resolves(monkeypatch):
+@pytest.mark.parametrize(
+    "command",
+    [
+        "kill -USR1 133375",
+        "/bin/kill -TERM 133375",
+        "command /bin/kill -TERM 133375",
+        "env -i PATH=/usr/bin /usr/bin/kill -TERM 133375",
+        "sudo /bin/kill -TERM 133375",
+    ],
+)
+def test_kill_by_pid_is_blocked_when_pid_resolves(monkeypatch, command):
     monkeypatch.setattr(lg, "_resolve_gateway_main_pid", lambda: 133375)
-    assert lg.kill_targets_gateway_main_pid("kill -USR1 133375") is True
-    assert lg.kill_targets_gateway_main_pid("kill -TERM 133375") is True
+    assert lg.kill_targets_gateway_main_pid(command) is True
 
 
 def test_kill_by_pid_fails_open_when_pid_unknown(monkeypatch):
@@ -103,6 +115,9 @@ def test_kill_by_pid_does_not_overmatch(monkeypatch):
     # no kill at a command position -> no PID lookup, no block
     assert lg.kill_targets_gateway_main_pid("echo 133375") is False
     assert lg.kill_targets_gateway_main_pid("grep 133375 /tmp/pids") is False
+    assert lg.kill_targets_gateway_main_pid("echo /bin/kill -TERM 133375") is False
+    # A different command mentioning the PID must not be attributed to kill.
+    assert lg.kill_targets_gateway_main_pid("kill -TERM 99; echo 133375") is False
 
 
 def test_pid_lookup_is_skipped_without_a_kill(monkeypatch):

--- a/tests/gateway/test_multiplex_profile_cron.py
+++ b/tests/gateway/test_multiplex_profile_cron.py
@@ -1,0 +1,107 @@
+"""Regression tests for multiplex gateway profile-local cron scheduling.
+
+A default-profile multiplex gateway owns the live adapters for secondary
+profiles.  It must tick each secondary profile's isolated cron store under that
+profile's runtime scope; starting only the default ticker leaves those jobs
+permanently scheduled but never executed.
+"""
+
+from pathlib import Path
+import threading
+
+
+def test_profile_cron_provider_runs_in_isolated_profile_scope(tmp_path):
+    from gateway.run import _run_profile_cron_provider
+    from hermes_constants import (
+        get_hermes_home,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from cron.jobs import get_cron_output_dir
+    from agent.secret_scope import get_secret
+
+    root = tmp_path / "root"
+    profile = root / "profiles" / "polymarket"
+    profile.mkdir(parents=True)
+    (profile / ".env").write_text("PROFILE_CRON_SENTINEL=polymarket-only\n")
+    adapters = {"telegram": object()}
+    seen = {}
+
+    class FakeProvider:
+        def start(self, stop_event, **kwargs):
+            seen["home"] = get_hermes_home().resolve()
+            seen["output"] = get_cron_output_dir().resolve()
+            seen["secret"] = get_secret("PROFILE_CRON_SENTINEL")
+            seen["adapters"] = kwargs["adapters"]
+            seen["can_dispatch"] = kwargs["can_dispatch"]()
+
+    root_token = set_hermes_home_override(str(root))
+    try:
+        _run_profile_cron_provider(
+            "polymarket",
+            profile,
+            FakeProvider(),
+            threading.Event(),
+            adapters=adapters,
+            loop=object(),
+            can_dispatch=lambda: True,
+        )
+        assert seen == {
+            "home": profile.resolve(),
+            "output": (profile / "cron" / "output").resolve(),
+            "secret": "polymarket-only",
+            "adapters": adapters,
+            "can_dispatch": True,
+        }
+        assert get_hermes_home().resolve() == root.resolve()
+        assert get_secret("PROFILE_CRON_SENTINEL") is None
+    finally:
+        reset_hermes_home_override(root_token)
+
+
+def test_secondary_profile_cron_threads_use_profile_adapters(tmp_path, monkeypatch):
+    from gateway import run
+
+    profile = tmp_path / "profiles" / "polymarket"
+    profile.mkdir(parents=True)
+    profile_adapters = {"telegram": object()}
+    default_adapters = {"telegram": object()}
+    starts = []
+
+    class FakeProvider:
+        def start(self, *args, **kwargs):
+            raise AssertionError("thread target must not execute in construction test")
+
+    class FakeThread:
+        def __init__(self, *, target, args, kwargs, daemon, name):
+            starts.append({
+                "target": target,
+                "args": args,
+                "kwargs": kwargs,
+                "daemon": daemon,
+                "name": name,
+            })
+        def start(self):
+            starts[-1]["started"] = True
+
+    class Runner:
+        adapters = default_adapters
+        _profile_adapters = {"polymarket": profile_adapters}
+        _draining = False
+        _external_drain_active = False
+
+    monkeypatch.setattr(run.threading, "Thread", FakeThread)
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda name: profile)
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: FakeProvider())
+
+    handles = run._start_secondary_profile_cron_schedulers(
+        Runner(), threading.Event(), loop=object()
+    )
+
+    assert len(handles) == 1
+    assert starts[0]["started"] is True
+    assert starts[0]["name"] == "cron-scheduler-polymarket"
+    assert starts[0]["args"][0] == "polymarket"
+    assert starts[0]["args"][1] == profile
+    assert starts[0]["kwargs"]["adapters"] is profile_adapters
+    assert starts[0]["kwargs"]["adapters"] is not default_adapters

--- a/tests/gateway/test_multiplex_profile_cwd_isolation.py
+++ b/tests/gateway/test_multiplex_profile_cwd_isolation.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from agent.prompt_builder import build_context_files_prompt
+from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+def _runner(profile_home: Path) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+    return runner
+
+
+def _context(profile: str = "polymarket"):
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="chat",
+        chat_type=None,
+        chat_name="",
+        thread_id=None,
+        user_id="user",
+        user_id_alt=None,
+        user_name="",
+        scope_id=None,
+        message_id="message",
+        profile=profile,
+    )
+    return SimpleNamespace(source=source, session_key="agent:polymarket:telegram:chat")
+
+
+def test_multiplex_turn_uses_routed_profile_cwd_and_project_rules(tmp_path, monkeypatch):
+    foreign = tmp_path / "general"
+    foreign.mkdir()
+    (foreign / "AGENTS.md").write_text("FOREIGN_GENERAL_CONTEXT", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(foreign))
+
+    project = tmp_path / "polimarket"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / ".hermes.md").write_text("POLYMARKET_PROJECT_CONTEXT", encoding="utf-8")
+
+    profile_home = tmp_path / "profiles" / "polymarket"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local", "cwd": str(project)}}),
+        encoding="utf-8",
+    )
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_context_cwd() == project
+        assert resolve_agent_cwd() == project
+        prompt = build_context_files_prompt(cwd=str(resolve_context_cwd()), skip_soul=True)
+        assert "POLYMARKET_PROJECT_CONTEXT" in prompt
+        assert "FOREIGN_GENERAL_CONTEXT" not in prompt
+    finally:
+        runner._clear_session_env(tokens)
+
+
+def test_multiplex_missing_profile_cwd_never_falls_back_to_gateway_owner(tmp_path, monkeypatch):
+    foreign = tmp_path / "general"
+    foreign.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(foreign))
+
+    profile_home = tmp_path / "profiles" / "polymarket"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text("terminal: {}\n", encoding="utf-8")
+
+    runner = _runner(profile_home)
+    tokens = runner._set_session_env(_context())
+    try:
+        assert resolve_agent_cwd() == profile_home
+        assert resolve_context_cwd() == profile_home
+        assert resolve_agent_cwd() != foreign
+    finally:
+        runner._clear_session_env(tokens)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1183,6 +1183,34 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
 
 
+@pytest.mark.asyncio
+async def test_telegram_streaming_keeps_status_separate_from_final(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-telegram-status-separate-final",
+        config_data={
+            "display": {"interim_assistant_messages": True},
+            "streaming": {
+                "enabled": True,
+                "edit_interval": 0.01,
+                "buffer_threshold": 1,
+            },
+        },
+        platform=Platform.TELEGRAM,
+    )
+
+    # The temporary status was created and updated, but the completed answer
+    # remains for the gateway's normal final-delivery path. This is what makes
+    # cleanup_progress safe: deleting the status cannot delete the answer.
+    assert result.get("already_sent") is not True
+    assert [call["content"] for call in adapter.sent] == [
+        "I'll inspect the repo first."
+    ]
+    assert all(edit["content"] != "done" for edit in adapter.edits)
+
+
 class TransformedStreamAgent:
     """Streams a response, then signals the gateway that a plugin hook
     (``transform_llm_output``) modified the final text after streaming

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -74,9 +74,43 @@ def test_format_footer_skips_missing_context_length():
     assert "/tmp/wd" in out
 
 
+def test_format_footer_duration_uses_russian_timer_line():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("duration",),
+        duration_seconds=54.04,
+    )
+    assert out == "⏱ Думал 54.0 сек"
+
+
+def test_format_footer_duration_reuses_turn_measurement():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        fields=("duration",),
+        turn_seconds=54.04,
+    )
+    assert out == "⏱ Думал 54.0 сек"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
+
+
+def test_resolve_fields_accepts_config_cli_json_string():
+    user = {
+        "display": {
+            "runtime_footer": {"enabled": True, "fields": '["duration"]'}
+        }
+    }
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["fields"] == ["duration"]
 
 
 def test_resolve_platform_override_wins():

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -831,6 +831,44 @@ class TestInterimCommentaryMessages:
         assert sent_texts == ["I'll inspect the repository first.", "Done."]
         assert consumer.final_response_sent is True
 
+    @pytest.mark.asyncio
+    async def test_commentary_edit_in_place_reuses_status_for_final(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="status_1")
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="status_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(
+                edit_interval=0.01,
+                buffer_threshold=5,
+                commentary_edit_in_place=True,
+            ),
+        )
+
+        consumer.on_commentary("🔎 Проверяю…")
+        consumer.on_commentary("🧩 Собираю ответ…")
+        consumer.on_delta("Готово.")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.call_count == 1
+        assert adapter.send.call_args.kwargs["content"] == "🔎 Проверяю…"
+        edited_texts = [
+            call.kwargs["content"]
+            for call in adapter.edit_message.call_args_list
+        ]
+        assert "🧩 Собираю ответ…" in edited_texts
+        assert edited_texts[-1] == "Готово."
+        assert consumer.final_response_sent is True
+
 
 class TestCancelledConsumerSetsFlags:
     """Cancellation must set final_response_sent when already_sent is True.
@@ -1487,4 +1525,3 @@ class TestFlushPendingSync:
 
         consumer.finish()
         await task
-

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import utf16_len
+from telegram.constants import ParseMode
 
 
 # ---------------------------------------------------------------------------
@@ -439,7 +441,7 @@ class TestFormatMessageTables:
 
 
 @pytest.mark.asyncio
-async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
+async def test_send_uses_html_chunk_indicators(adapter):
     adapter.MAX_MESSAGE_LENGTH = 80
     adapter._bot = MagicMock()
 
@@ -458,8 +460,66 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
 
     assert result.success is True
     assert len(sent_texts) > 1
-    assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[0])
-    assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[-1])
+    assert re.search(r"\([0-9]+/[0-9]+\)$", sent_texts[0])
+    assert adapter._bot.send_message.await_args_list[0].kwargs["parse_mode"] == ParseMode.HTML
+    assert re.search(r"\([0-9]+/[0-9]+\)$", sent_texts[-1])
+
+
+@pytest.mark.asyncio
+async def test_html_special_characters_and_code_deliver_without_fallback(adapter):
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=77))
+    content = "Спецсимволы: . ! - ( ) # + = | { } &\n\n`x < 3 && y > 1`"
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    assert adapter._bot.send_message.await_count == 1
+    call = adapter._bot.send_message.await_args.kwargs
+    assert call["parse_mode"] == ParseMode.HTML
+    assert "&amp;" in call["text"]
+    assert "<code>x &lt; 3 &amp;&amp; y &gt; 1</code>" in call["text"]
+
+
+@pytest.mark.asyncio
+async def test_html_long_answer_splits_on_blocks_with_balanced_pre_tags(adapter):
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[SimpleNamespace(message_id=i) for i in range(1, 10)]
+    )
+    paragraph = "Длинный блок текста. " * 120
+    content = f"{paragraph}\n\n```python\nprint('код')\n```\n\n{paragraph}"
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    calls = adapter._bot.send_message.await_args_list
+    assert len(calls) >= 2
+    for call in calls:
+        text = call.kwargs["text"]
+        assert utf16_len(text) <= adapter.MAX_MESSAGE_LENGTH
+        assert text.count("<pre") == text.count("</pre>")
+        assert text.count("<code") == text.count("</code>")
+        assert call.kwargs["parse_mode"] == ParseMode.HTML
+
+
+@pytest.mark.asyncio
+async def test_html_long_unbroken_token_stays_within_limit(adapter):
+    adapter.MAX_MESSAGE_LENGTH = 80
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=lambda **kwargs: SimpleNamespace(
+            message_id=adapter._bot.send_message.await_count
+        )
+    )
+
+    result = await adapter.send("123", "x" * 500)
+
+    assert result.success is True
+    assert adapter._bot.send_message.await_count > 1
+    for call in adapter._bot.send_message.await_args_list:
+        assert utf16_len(call.kwargs["text"]) <= adapter.MAX_MESSAGE_LENGTH
+        assert call.kwargs["parse_mode"] == ParseMode.HTML
 
 
 # =========================================================================
@@ -468,6 +528,29 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
 
 
 class TestEditMessageStreamingSafety:
+
+    @pytest.mark.asyncio
+    async def test_final_edit_uses_html_with_plain_fallback(self):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=[Exception("can't parse entities"), None]
+        )
+
+        result = await adapter.edit_message(
+            "123", "456", "final **bold**", finalize=True
+        )
+
+        assert result.success is True
+        first_call = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        second_call = adapter._bot.edit_message_text.await_args_list[1].kwargs
+        assert first_call["text"] == "final <b>bold</b>"
+        assert first_call["parse_mode"] == ParseMode.HTML
+        assert second_call == {
+            "chat_id": 123,
+            "message_id": 456,
+            "text": "final bold",
+        }
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -58,7 +58,7 @@ class TestSendWithReplyToMode:
         adapter = adapter_factory(reply_to_mode="off")
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
-        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2", "chunk3"]
+        adapter._html_chunks = lambda content: ["chunk1", "chunk2", "chunk3"]
 
         await adapter.send("12345", "test content", reply_to="999")
 
@@ -70,7 +70,7 @@ class TestSendWithReplyToMode:
         adapter = adapter_factory(reply_to_mode="first")
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
-        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2", "chunk3"]
+        adapter._html_chunks = lambda content: ["chunk1", "chunk2", "chunk3"]
 
         await adapter.send("12345", "test content", reply_to="999")
 
@@ -200,7 +200,7 @@ class TestDMTopicFallbackReplyToMode:
         adapter = adapter_factory(reply_to_mode="off")
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
-        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1"]
+        adapter._html_chunks = lambda content: ["chunk1"]
 
         await adapter.send("12345", "test content", metadata=self.DM_TOPIC_METADATA)
 
@@ -296,7 +296,7 @@ class TestDMTopicSyntheticSendRouting:
         adapter = adapter_factory()
         adapter._bot = MagicMock()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
-        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1"]
+        adapter._html_chunks = lambda content: ["chunk1"]
         metadata = {
             "thread_id": "42",
             "telegram_dm_topic_reply_fallback": True,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -20988,3 +20988,12 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_project_tree_excludes_internal_worker_sources():
+    assert set(server._PROJECT_TREE_EXCLUDED_SOURCES) == {
+        "cron",
+        "kanban",
+        "tool",
+        "subagent",
+    }

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,88 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_real_sdk_annotations_read_only_hint_survives_2x_rename(self):
+        pytest.importorskip("mcp.types")
+        from mcp.types import ToolAnnotations
+
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(readOnlyHint=True))
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(readOnlyHint=False))
+        ) is False
+
+    def test_real_sdk_tool_read_only_hint_captured_at_registration(self):
+        pytest.importorskip("mcp.types")
+        from mcp.types import Tool, ToolAnnotations
+        from tools.registry import ToolRegistry
+
+        server = mcp_tool.MCPServerTask("srv-sdk")
+        server.session = MagicMock()
+        server._tools = [
+            Tool(
+                name="list_repos",
+                description="",
+                inputSchema={"type": "object"},
+                annotations=ToolAnnotations(readOnlyHint=True),
+            ),
+            Tool(
+                name="delete_repo",
+                description="",
+                inputSchema={"type": "object"},
+                annotations=ToolAnnotations(readOnlyHint=False),
+            ),
+        ]
+        config = {
+            "trust": "untrusted",
+            "tools": {"resources": False, "prompts": False},
+        }
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool._track_mcp_tool_server"):
+            mcp_tool._register_server_tools("srv-sdk", server, config)
+
+        hints = mcp_tool._tool_read_only_hints["srv-sdk"]
+        assert hints.get("list_repos") is True
+        assert hints.get("delete_repo") is False
+
+    def test_real_sdk_tool_input_schema_survives_2x_rename_in_cache_write_through(self):
+        pytest.importorskip("mcp.types")
+        from mcp.types import Tool
+        from tools.registry import ToolRegistry
+
+        real_schema = {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+        server = mcp_tool.MCPServerTask("srv-schema")
+        server.session = MagicMock()
+        server._tools = [
+            Tool(
+                name="read_file",
+                description="Read a file",
+                inputSchema=real_schema,
+            )
+        ]
+        config = {
+            "trust": "full",
+            "tools": {"resources": False, "prompts": False},
+        }
+        captured = {}
+
+        def _capture_write(_name, _fingerprint, **kwargs):
+            captured["tools"] = kwargs["tools"]
+
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool._track_mcp_tool_server"), \
+             patch(
+                 "tools.mcp_schema_cache.write_cache_entry",
+                 side_effect=_capture_write,
+             ):
+            mcp_tool._register_server_tools("srv-schema", server, config)
+
+        entry = next(
+            item for item in captured["tools"] if item["name"] == "read_file"
+        )
+        assert entry["inputSchema"] == real_schema

--- a/tests/tools/test_terminal_gateway_lifecycle_guard.py
+++ b/tests/tools/test_terminal_gateway_lifecycle_guard.py
@@ -1,0 +1,59 @@
+"""Terminal wiring for the all-turn shared-gateway lifecycle guard."""
+
+import json
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from cron import lifecycle_guard
+from tools import terminal_tool
+
+
+def test_force_cannot_bypass_absolute_gateway_pid_kill(monkeypatch):
+    monkeypatch.setattr(
+        lifecycle_guard,
+        "_resolve_gateway_main_pid",
+        lambda: 133375,
+    )
+    mock_env = MagicMock()
+    mock_env.cwd = "/tmp"
+    mock_env.execute.return_value = {"output": "unexpected", "returncode": 0}
+    config = {
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("tools.terminal_tool._get_env_config", return_value=config)
+        )
+        stack.enter_context(patch("tools.terminal_tool._start_cleanup_thread"))
+        stack.enter_context(
+            patch("tools.terminal_tool._active_environments", {"default": mock_env})
+        )
+        stack.enter_context(
+            patch("tools.terminal_tool._last_activity", {"default": 0})
+        )
+        stack.enter_context(patch("tools.terminal_tool._session_cwd", {}))
+        stack.enter_context(
+            patch(
+                "tools.terminal_tool._check_all_guards",
+                return_value={"approved": True},
+            )
+        )
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="/bin/kill -TERM 133375",
+                force=True,
+            )
+        )
+
+    assert result["status"] == "error"
+    assert "shared Hermes gateway" in result["error"]
+    mock_env.execute.assert_not_called()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4602,7 +4602,7 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if isinstance(annotations, dict):
         hint = annotations.get("readOnlyHint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = mcp_field(annotations, "read_only_hint", "readOnlyHint")
     return hint is True
 
 
@@ -7329,7 +7329,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             for mcp_tool in server._tools:
                 if not _should_register(mcp_tool.name):
                     continue
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
                 tools_payload.append({
                     "name": mcp_tool.name,
                     "description": mcp_tool.description or "",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2921,6 +2921,35 @@ def terminal_tool(
         # owned, no supervisor) now also PASSES this guard: intentional and
         # harmless, since without a supervisor there is no KeepAlive to turn a
         # self-restart into a respawn loop.
+        # Every agent turn shares the same service boundary, including CLI,
+        # serve/Desktop and standalone cron contexts. Block direct lifecycle
+        # commands and numeric signals before the narrower supervised-gateway
+        # referenced-script scan below.
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command,
+            kill_targets_gateway_main_pid,
+        )
+
+        if contains_gateway_lifecycle_command(command) or kill_targets_gateway_main_pid(command):
+            logger.warning(
+                "Blocked gateway-lifecycle command from an agent turn: %s",
+                _safe_command_preview(command),
+            )
+            return json.dumps(
+                {
+                    "output": "",
+                    "exit_code": 1,
+                    "error": (
+                        "Blocked: an agent turn may not restart, stop, install, "
+                        "uninstall, enable, disable, or signal the shared Hermes "
+                        "gateway. Ask the owner to perform the lifecycle action "
+                        "from a shell outside Hermes."
+                    ),
+                    "status": "error",
+                },
+                ensure_ascii=False,
+            )
+
         from tools.process_registry import _is_supervised_gateway_process
 
         if _is_supervised_gateway_process():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13794,11 +13794,11 @@ def _discover_repos_payload(
     return out
 
 
-# Sources excluded from the project tree: cron runs, and kanban dispatcher
-# workers, are not user conversations. Subagent/compression children are
-# already dropped by list_sessions_rich(include_children=False); cron has its
-# own section, and kanban runs are read on the board.
-_PROJECT_TREE_EXCLUDED_SOURCES = ["cron", "kanban"]
+# Sources excluded from the project tree are internal worker rows, not user
+# conversations. Child rows are normally dropped by include_children=False,
+# but delegated workers can persist as top-level legacy ``tool`` or
+# ``subagent`` rows. Cron has its own section and kanban runs live on the board.
+_PROJECT_TREE_EXCLUDED_SOURCES = ["cron", "kanban", "tool", "subagent"]
 
 
 def _project_tree_row(r: dict) -> dict:


### PR DESCRIPTION
## What changed and why

This PR publishes one exact, independently validated compatibility bundle used to close several Hermes gateway/runtime gaps without changing a deployed installation:

- harden the gateway lifecycle guard against executable-path, wrapper, separator, and force-mode kill-command bypasses
- isolate multiplexed profile authentication, working directory, cron state, and progress-topic behavior
- support MCP 2.x snake-case SDK attributes for read-only annotations and input schemas while retaining wire-format compatibility
- improve Telegram status/final delivery, cleanup, formatting, reply routing, and streaming safety
- keep internal rows out of the TUI presentation layer and preserve runtime-footer behavior

## Exact candidate binding

- candidate base: `41447a6d7063b2772b0c2f26a5b22d9bd444fb43`
- approved HEAD: `d8f2322febee03c1f4209a15eab27a6ed91b6ad3`
- tree: `50dcfb45ba0818d52e2936d399d202e1874b0718`
- parent: `16451fbf719c97acb87b5b2a57e47da52d2825c5`
- changed files: 20

## How to test

Validation completed on Linux:

- gateway/cron broad matrix: **7,232 passed, 11 skipped**
- Telegram/streaming post-fix matrix: **217 passed**
- gateway Unix-socket matrix with short basetemp: **18 passed**
- tools/MCP/terminal/TUI broad matrix: **9,008 passed, 84 skipped**
- Unix-socket path rerun with short basetemp: **60 passed, 2 OS-skipped**
- MCP trust-gating suite: **14 passed**
- primary MCP tool suite: **97 passed**
- TUI server suite: **611 passed**
- final lifecycle guard and terminal gateway suite: **44 passed**
- approval suite: **108 passed**
- targeted real-SDK MCP checks: **2 passed**
- Ruff, Python byte-compilation, conflict-marker scan, secret-assignment scan, and `git diff --check`: passed
- exact-diff Codex Security review: full coverage, **0 reportable findings**

The initial Unix-socket failures were path-length artifacts from the temporary test root, not product failures. Both affected sets passed when rerun with a short basetemp. There are no unresolved local test failures.

Additional independent validation on macOS arm64 passed 301 selected tests across 12 affected test files, including lifecycle guard, MCP trust, approvals, multiplex profile cron/CWD, Telegram, stream consumer, runtime footer, progress topics, and the changed TUI case. Ruff, Python byte-compilation, and `git diff --check` also passed on the exact HEAD. Windows was not manually exercised.

## Related upstream work

A post-publication duplicate check found related focused work in #88372, #78289, #84584, #89177, #91394, #93491, and #94379. This PR does not claim to supersede those reviews; it preserves the exact integrated compatibility bundle and its cross-component validation for maintainer assessment.

## Safety and lifecycle state

- **APPROVED:** publication of this exact HEAD as one feature branch and one PR
- **IMPLEMENTED:** exact candidate above
- **PUBLISHED:** feature branch and this PR, both bound to the exact HEAD
- **MERGED:** no
- **DEPLOYED:** no
- **EFFECTIVE:** no

The production checkout remains byte-for-byte and path-for-path unchanged at its verified baseline; its service remains active. This PR changes no profile, gateway configuration, credentials, authorization state, or trading state.

Trading authority remains false. Arbitron, exchange, credential, execution, risk, and funds-movement scope is none. Merge and runtime activation require separate gated decisions.