### PR TITLE
fix(gateway): suppress session lease-wait lifecycle status when interim assistant messages are muted

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -351,6 +351,23 @@ _COMPRESSION_PROGRESS_STATUS_RE = re.compile(
 )
 
 
+# #94658 session turn-lease contention lifecycle statuses, emitted by
+# run_agent._emit_status during cross-process turn-lease wait / reclaim
+# (run_agent.py ~line 8646 / 8735). These are interim assistant chatter and
+# must be muted when a platform turns interim assistant messages off —
+# but ONLY these, so durable must-see lifecycle statuses (fallback-switch
+# notices, terminal provider-failure notices) keep flowing regardless. The
+# three literal strings are escaped verbatim; the ``(<N>s)`` seconds counter
+# is matched numerically so it stays robust to the elapsed time.
+_SESSION_TURN_LEASE_LIFECYCLE_RE = re.compile(
+    r"⏳\s+Another\s+Hermes\s+process\s+is\s+using\s+this\s+session"
+    r"|⏳\s+Still\s+waiting\s+for\s+the\s+other\s+Hermes\s+process\s+on\s+this\s+"
+    r"session\s+\(\d+s\)"
+    r"|Session\s+is\s+free;\s+loading\s+the\s+latest\s+transcript",
+    re.IGNORECASE,
+)
+
+
 def _gateway_compression_progress_notices_enabled() -> bool:
     """True when the user opted into routine compression progress notices.
 
@@ -841,7 +858,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(platform: Any, event_type: str, message: str, interim_enabled: bool = True) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
     Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
@@ -852,6 +869,17 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return None
     if _gateway_surface_passes_raw_text(platform):
         return text
+
+    if event_type == "lifecycle" and not interim_enabled and _SESSION_TURN_LEASE_LIFECYCLE_RE.search(text):
+        # #94658: session turn-lease contention statuses ("⏳ Another Hermes
+        # process is using this session...", "⏳ Still waiting ... (Ns)...",
+        # "Session is free; loading the latest transcript...") are interim
+        # assistant chatter. When the platform mutes interim assistant
+        # messages (interim_assistant_messages: off), suppress them here —
+        # but ONLY these lease strings, so durable lifecycle statuses
+        # (fallback-switch notices, terminal provider-failure notices) keep
+        # reaching the gateway regardless of the interim mute.
+        return None
 
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
@@ -5315,6 +5343,7 @@ class TurnRunner:
             ctx.source.platform,
             event_type,
             message,
+            interim_enabled=ctx.interim_assistant_messages_enabled,
         )
         if prepared_message is None:
             logger.debug(

--- a/tests/gateway/test_lifecycle_interim_mute.py
+++ b/tests/gateway/test_lifecycle_interim_mute.py
@@ -1,0 +1,86 @@
+"""Lifecycle lease-wait statuses must honour the interim-assistant-messages mute.
+
+#94658: session turn-lease contention statuses ("⏳ Another Hermes process is
+using this session...", "⏳ Still waiting ... (Ns)...", "Session is free;
+loading the latest transcript...") are emitted by run_agent as ``lifecycle``
+status callbacks. When a platform mutes interim assistant messages
+(interim_assistant_messages: off), those transient statuses must be
+suppressed by _prepare_gateway_status_message rather than pushed to chat.
+"""
+
+import pytest
+
+from agent.conversation_compression import COMPACTION_DONE_STATUS
+from gateway.config import Platform
+from gateway.run import _prepare_gateway_status_message
+
+# Exact lifecycle strings emitted by run_agent._emit_status during turn-lease
+# contention / reclaim (run_agent.py ~line 8646 / 8735).
+LEASE_WAIT_FIRST = (
+    "⏳ Another Hermes process is using this session; "
+    "waiting for it to finish before starting your turn..."
+)
+LEASE_WAIT_STILL = (
+    "⏳ Still waiting for the other Hermes process on this session (5s)..."
+)
+SESSION_FREE = "Session is free; loading the latest transcript..."
+
+LIFECYCLE_MESSAGES = [LEASE_WAIT_FIRST, LEASE_WAIT_STILL, SESSION_FREE]
+
+
+@pytest.mark.parametrize("message", LIFECYCLE_MESSAGES)
+@pytest.mark.parametrize("platform", [Platform.TELEGRAM, Platform.SLACK])
+def test_lifecycle_lease_statuses_suppressed_when_interim_muted(platform, message):
+    """interim_enabled=False must swallow the lifecycle lease-wait chatter."""
+    assert (
+        _prepare_gateway_status_message(platform, "lifecycle", message, interim_enabled=False)
+        is None
+    )
+
+
+@pytest.mark.parametrize("message", LIFECYCLE_MESSAGES)
+def test_lifecycle_lease_statuses_flow_when_interim_enabled(message):
+    """interim_enabled=True (the default) keeps lifecycle messages flowing."""
+    assert (
+        _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message)
+        == message
+    )
+
+
+def test_lifecycle_gate_is_scoped_to_lifecycle_only():
+    """A NON-lifecycle event_type must not be suppressed by the interim flag."""
+    platform = Platform.TELEGRAM
+    # A warn event that otherwise passes the filter must keep passing even
+    # with interim assistant messages muted.
+    warn = "⚠️ Tool execution failed; retrying with a different approach."
+    assert _prepare_gateway_status_message(platform, "warn", warn, interim_enabled=False) == warn
+    # Compacted event likewise.
+    assert (
+        _prepare_gateway_status_message(platform, "compacted", COMPACTION_DONE_STATUS, interim_enabled=False)
+        == COMPACTION_DONE_STATUS
+    )
+
+
+# Durable must-see lifecycle statuses that reach the gateway today and MUST
+# keep flowing even when interim assistant messages are muted. These are
+# emitted as ``lifecycle`` callbacks but are NOT lease-contention chatter:
+# a blanket event_type=="lifecycle" gate would silently drop them — a
+# regression this suite pins against.
+DURABLE_LIFECYCLE_MESSAGES = [
+    # Fallback-switch notice (run_agent._emit_pending_fallback_notice, ~line 1211).
+    "↻ Switched to fallback: gpt-4o (openai)",
+    # Terminal provider-failure notice, buffered via _buffer_status and
+    # replayed via _emit_status on terminal flush.
+    "❌ Connection to provider failed after 3 attempts. The provider may be "
+    "experiencing issues — try again in a moment.",
+]
+
+
+@pytest.mark.parametrize("message", DURABLE_LIFECYCLE_MESSAGES)
+@pytest.mark.parametrize("platform", [Platform.TELEGRAM, Platform.SLACK])
+def test_durable_lifecycle_statuses_flow_when_interim_muted(platform, message):
+    """interim_enabled=False must NOT swallow durable lifecycle messages."""
+    assert (
+        _prepare_gateway_status_message(platform, "lifecycle", message, interim_enabled=False)
+        == message
+    )


### PR DESCRIPTION
## Summary

Fixes #94658

Session turn-lease contention produces transient "lifecycle" status callbacks ("⏳ Another Hermes process is using this session…", "⏳ Still waiting for the other Hermes process on this session (Ns)…", "Session is free; loading the latest transcript…"). These were delivered to gateway chat platforms even when the user had muted interim assistant messages via `display.platforms.<platform>.interim_assistant_messages: off`, because the gateway status filter never checked that resolved setting.

## Changes

- `gateway/run.py`: added a module-level matcher `_SESSION_TURN_LEASE_LIFECYCLE_RE` matching the three lease-contention strings, and threaded the already-resolved per-platform `interim_assistant_messages` flag (`ctx.interim_assistant_messages_enabled`) into `_prepare_gateway_status_message()`. When interim assistant messages are muted for a platform, the three lease-contention lifecycle statuses are suppressed.
- The gate is scoped to ONLY those three lease strings — durable lifecycle signals (fallback-switch notices, terminal provider-failure notices) still flow regardless of the interim mute.
- New regression test `tests/gateway/test_lifecycle_interim_mute.py`.

## Tests

- `tests/gateway/test_lifecycle_interim_mute.py` — 14 passed.
- Adjacent: `tests/gateway/test_telegram_noise_filter.py`, `tests/gateway/test_compression_progress_notices.py`, `tests/run_agent/test_cross_process_turn_lease.py` — 183 passed.
- Revert-proof: with the source gate removed the lease-suppression tests fail (11 failed); with a blanket all-lifecycle gate the durable-passthrough tests fail (4 failed) — the suite pins both the bug and the over-suppression boundary.

Closes #94658
