### PR TITLE
fix(gateway): suppress lease-contention lifecycle statuses when interim assistant messages muted (#94658)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -816,7 +816,13 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(
+    platform: Any,
+    event_type: str,
+    message: str,
+    *,
+    interim_assistant_messages_enabled: bool | None = None,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
     Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
@@ -827,7 +833,20 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return None
     if _gateway_surface_passes_raw_text(platform):
         return text
-
+    # Lease-contention lifecycle statuses ("Another Hermes process is using
+    # this session", "Still waiting …", "Session is free …") are in-between
+    # chatter — suppress them when the user muted interim assistant messages
+    # for this platform (display.platforms.*.interim_assistant_messages:
+    # false), the same gate that disables the streaming delta consumer.
+    # Routine compression progress is exempt: it has its own opt-in gate
+    # (compression.progress_notices) and must keep flowing when that gate is
+    # open, regardless of interim mode.
+    if (
+        interim_assistant_messages_enabled is False
+        and event_type == "lifecycle"
+        and not _COMPRESSION_PROGRESS_STATUS_RE.search(text)
+    ):
+        return None
     text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
@@ -5043,6 +5062,9 @@ class TurnRunner:
             ctx.source.platform,
             event_type,
             message,
+            interim_assistant_messages_enabled=getattr(
+                ctx, "interim_assistant_messages_enabled", None
+            ),
         )
         if prepared_message is None:
             logger.debug(

--- a/tests/gateway/test_lease_wait_lifecycle_interim_mute.py
+++ b/tests/gateway/test_lease_wait_lifecycle_interim_mute.py
@@ -1,0 +1,101 @@
+"""Lease-contention lifecycle statuses respect interim_assistant_messages mute.
+
+#94658: "Another Hermes process is using this session", "Still waiting …"
+and "Session is free …" are emitted via ``_emit_status`` →
+``status_callback("lifecycle", …)`` unconditionally. On chat gateways they
+bypassed ``display.platforms.*.interim_assistant_messages: false`` because
+``_prepare_gateway_status_message`` had no interim-setting gate. Routine
+compression progress keeps its own opt-in gate (``compression.progress_notices``)
+and must NOT be suppressed by the interim mute.
+"""
+
+import pytest
+
+from agent.conversation_compression import ROUTINE_COMPRESSION_STATUS_SAMPLES
+from gateway.run import _prepare_gateway_status_message
+
+# Exact lease-wait strings from run_agent.py acquire_session_turn_lease flow
+# (plus the post-acquire "Session is free" status).
+LEASE_WAIT_LIFECYCLE = [
+    (
+        "⏳ Another Hermes process is using this session; "
+        "waiting for it to finish before starting your turn..."
+    ),
+    "⏳ Still waiting for the other Hermes process on this session (42s)...",
+    "🎭 Session is free; loading the latest transcript...",
+]
+
+CHAT_PLATFORMS = ["telegram", "discord", "slack", "whatsapp"]
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize("message", LEASE_WAIT_LIFECYCLE, ids=lambda m: m[:28])
+def test_lease_wait_suppressed_when_interim_muted(platform, message):
+    """interim_assistant_messages: false silences lease-contention chatter."""
+    assert (
+        _prepare_gateway_status_message(
+            platform,
+            "lifecycle",
+            message,
+            interim_assistant_messages_enabled=False,
+        )
+        is None
+    ), f"lease-wait lifecycle must be suppressed for {platform}"
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize("message", LEASE_WAIT_LIFECYCLE, ids=lambda m: m[:28])
+def test_lease_wait_delivered_when_interim_enabled(platform, message):
+    """interim_assistant_messages: true (default) keeps the status visible."""
+    assert (
+        _prepare_gateway_status_message(
+            platform,
+            "lifecycle",
+            message,
+            interim_assistant_messages_enabled=True,
+        )
+        == message
+    )
+    # Default (None) keeps legacy behavior byte-identical.
+    assert (
+        _prepare_gateway_status_message(platform, "lifecycle", message)
+        == message
+    )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_compression_progress_not_suppressed_by_interim_mute(monkeypatch, platform):
+    """Routine compression progress keeps its own opt-in gate (#52995)."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"compression": {"progress_notices": True}},
+    )
+    for message in ROUTINE_COMPRESSION_STATUS_SAMPLES:
+        # When progress_notices is open, interim mute must not swallow it.
+        assert (
+            _prepare_gateway_status_message(
+                platform,
+                "lifecycle",
+                message,
+                interim_assistant_messages_enabled=False,
+            )
+            == message
+        ), f"compression progress must survive interim mute on {platform}"
+
+
+@pytest.mark.parametrize("message", LEASE_WAIT_LIFECYCLE, ids=lambda m: m[:28])
+def test_lease_wait_raw_surfaces_unaffected(message):
+    """Programmatic surfaces keep raw text regardless of the interim mute."""
+    for platform in ("local", "api_server", "webhook"):
+        assert (
+            _prepare_gateway_status_message(
+                platform,
+                "lifecycle",
+                message,
+                interim_assistant_messages_enabled=False,
+            )
+            == message
+        )


### PR DESCRIPTION
## Summary

When two Hermes processes contend for the same session's turn lease (e.g. the desktop app and a WhatsApp gateway on the same conversation), the gateway emits lease-contention lifecycle statuses — "⏳ Another Hermes process is using this session…", "⏳ Still waiting for the other Hermes process…", "🎭 Session is free…" — as separate chat messages. These bypassed `display.platforms.*.interim_assistant_messages: false`, so users who muted interim chatter still received them.

## Root Cause

`AIAgent._emit_status()` (run_agent.py) unconditionally calls `status_callback("lifecycle", message)` — no display-config check at the source. The gateway consumer `TurnRunner._status_callback_sync` routes every status event through `_prepare_gateway_status_message()`, whose filters only cover compression/aux retry noise (`_TELEGRAM_NOISY_STATUS_RE`, gated by `compression.progress_notices`) and provider-error text. The `interim_assistant_messages`/`tool_progress` display settings are consumed by entirely separate paths (the streaming delta consumer and `tool.started`/`tool.completed` events) and were never wired into the lifecycle status rail.

## Change

`gateway/run.py`:

- `_prepare_gateway_status_message()` gains an optional `interim_assistant_messages_enabled` keyword argument. When `False` and `event_type == "lifecycle"`, lease-contention lifecycle messages are suppressed (return `None`).
- Routine compression progress is exempt: `_COMPRESSION_PROGRESS_STATUS_RE` keeps its own opt-in gate (`compression.progress_notices`) and still flows when that gate is open, regardless of the interim mute — matching the existing silent-by-default contract pinned by `test_compression_progress_notices.py`.
- `TurnRunner._status_callback_sync` threads `ctx.interim_assistant_messages_enabled` (already computed in `_run_agent_inner` from `display.platforms.*.interim_assistant_messages`) into the filter.

Existing callers without the new keyword are unaffected (default `None` keeps legacy behavior byte-identical).

## Verification

- New `tests/gateway/test_lease_wait_lifecycle_interim_mute.py` (31 cases): the three exact lease-wait strings from the `acquire_session_turn_lease` flow are suppressed on chat platforms (telegram/discord/slack/whatsapp) when interim is muted, delivered when enabled or unset (legacy default), raw surfaces (local/api_server/webhook) stay raw, and routine compression samples survive the interim mute when `progress_notices` is open.
- `pytest tests/gateway/test_lease_wait_lifecycle_interim_mute.py tests/gateway/test_compression_progress_notices.py tests/gateway/test_telegram_noise_filter.py` → 202 passed.

## Closes

Closes #94658
