### PR TITLE
fix(gateway): keep voice_only replies as voice after catch-up turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7248,6 +7248,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
+        # Sessions whose latest inbound user turn was voice. Catch-up /
+        # resume-pending synthetics are TEXT events; this stamp lets
+        # voice_only still reply in voice after a lease wait (#94660).
+        self._pending_voice_reply_sessions: set[str] = set()
         # Recent voice transcripts per (guild,user) for duplicate suppression.
         # Protects against the same utterance being emitted twice by the voice
         # capture / STT pipeline, which otherwise produces a second delayed reply.
@@ -12314,6 +12318,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source=source,
                 internal=True,
             )
+            self._restore_voice_type_on_catchup(entry.session_key, event)
             task = asyncio.create_task(
                 self._run_startup_resume_event(adapter, event, entry.session_key)
             )
@@ -16990,6 +16995,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        self._remember_voice_inbound(_quick_key, event)
+        self._restore_voice_type_on_catchup(_quick_key, event)
         allow_gateway_control = event.allow_gateway_control
         _up_state = self._peek_session_state(_quick_key)
         if (
@@ -21011,6 +21018,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ):
                 await self._send_voice_reply(event, response)
 
+            if (
+                session_key
+                and agent_result
+                and not agent_result.get("interrupted")
+                and not agent_result.get("failed")
+            ):
+                self._clear_pending_voice_reply(session_key)
+
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
             # sends raw text chunks that include MEDIA: tags — the normal
@@ -22265,6 +22280,123 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.handle_message(event)
 
+    # --------------------------------------------------------------------------------------
+    # Voice-Input Provenance Across Catch-Up / Resume Turns
+    # --------------------------------------------------------------------------------------
+
+    _PENDING_VOICE_REPLY_META = "last_inbound_message_type"
+
+    def _is_catchup_system_note(self, event: MessageEvent) -> bool:
+        """True when this event's text is a gateway catch-up / resume wrapper."""
+        text = (getattr(event, "text", None) or "").lstrip()
+        return text.startswith("[System note:")
+
+    def _is_voice_catchup_event(self, event: MessageEvent) -> bool:
+        """Synthetic turns that stand in for a queued voice inbound.
+
+        Empty internal resume-pending events and system-note catch-up wraps
+        are the replacement path. Other internals (heartbeat, plugin inject,
+        loop ticks) must stay TEXT so they do not inherit a stale voice stamp.
+        """
+        if self._is_catchup_system_note(event):
+            return True
+        text = (getattr(event, "text", None) or "").strip()
+        return bool(getattr(event, "internal", False) and not text)
+
+    def _clear_pending_voice_reply(self, session_key: Optional[str]) -> None:
+        if not session_key:
+            return
+        pending = getattr(self, "_pending_voice_reply_sessions", None)
+        if isinstance(pending, set):
+            pending.discard(session_key)
+        try:
+            store = getattr(self, "session_store", None)
+            if store is not None:
+                store.set_session_metadata(
+                    session_key, self._PENDING_VOICE_REPLY_META, None
+                )
+        except Exception:
+            logger.debug(
+                "Failed to clear pending voice-reply stamp for %s",
+                session_key,
+                exc_info=True,
+            )
+
+    def _session_has_pending_voice_reply(self, session_key: Optional[str]) -> bool:
+        if not session_key:
+            return False
+        pending = getattr(self, "_pending_voice_reply_sessions", None)
+        if isinstance(pending, set) and session_key in pending:
+            return True
+        try:
+            store = getattr(self, "session_store", None)
+            if store is None:
+                return False
+            return store.get_session_metadata(
+                session_key, self._PENDING_VOICE_REPLY_META
+            ) == "voice"
+        except Exception:
+            return False
+
+    def _remember_voice_inbound(self, session_key: Optional[str], event: MessageEvent) -> None:
+        """Stamp or clear voice-input provenance for this routing key.
+
+        Real user TEXT clears the stamp so a later text turn is not treated as
+        voice. Internal / catch-up synthetics leave the stamp in place so a
+        queued voice turn can still answer in voice after a lease wait.
+        """
+        if not session_key:
+            return
+        if getattr(event, "message_type", None) == MessageType.VOICE:
+            pending = getattr(self, "_pending_voice_reply_sessions", None)
+            if not isinstance(pending, set):
+                self._pending_voice_reply_sessions = set()
+                pending = self._pending_voice_reply_sessions
+            pending.add(session_key)
+            try:
+                store = getattr(self, "session_store", None)
+                if store is not None:
+                    store.set_session_metadata(
+                        session_key, self._PENDING_VOICE_REPLY_META, "voice"
+                    )
+            except Exception:
+                logger.debug(
+                    "Failed to persist pending voice-reply stamp for %s",
+                    session_key,
+                    exc_info=True,
+                )
+            return
+        if getattr(event, "internal", False) or self._is_voice_catchup_event(event):
+            return
+        self._clear_pending_voice_reply(session_key)
+
+    def _restore_voice_type_on_catchup(
+        self, session_key: Optional[str], event: MessageEvent
+    ) -> None:
+        """Re-attach VOICE to synthetic catch-up/resume events.
+
+        Those events are constructed as TEXT (empty resume, history catch-up)
+        even when the triggering inbound was voice. Adapter auto-TTS and
+        voice_only routing both read ``event.message_type``.
+        """
+        if getattr(event, "message_type", None) == MessageType.VOICE:
+            return
+        if not self._session_has_pending_voice_reply(session_key):
+            return
+        if self._is_voice_catchup_event(event):
+            event.message_type = MessageType.VOICE
+
+    def _event_is_voice_input(self, event: MessageEvent) -> bool:
+        if getattr(event, "message_type", None) == MessageType.VOICE:
+            return True
+        if not self._is_voice_catchup_event(event):
+            return False
+        try:
+            session_key = self._session_key_for_source(event.source)
+        except Exception:
+            return False
+        return self._session_has_pending_voice_reply(session_key)
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -22289,7 +22421,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         chat_id = event.source.chat_id
         voice_key = self._voice_key(event.source.platform, chat_id)
         voice_mode = self._voice_mode.get(voice_key)
-        is_voice_input = (event.message_type == MessageType.VOICE)
+        is_voice_input = self._event_is_voice_input(event)
 
         adapter = self.adapters.get(event.source.platform)
         adapter_auto_tts = False
@@ -29815,6 +29947,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
+                    if next_message_type is None and self._session_has_pending_voice_reply(
+                        next_session_key
+                    ):
+                        next_message_type = MessageType.VOICE
 
                 # Clear the completed streaming marker from the prior logical
                 # turn so the recursive turn's streaming TTS is not suppressed
@@ -29857,6 +29993,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # recursive call runs under so the snapshot matches exactly
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
+
+                if next_message_type is None and self._session_has_pending_voice_reply(
+                    next_session_key
+                ):
+                    next_message_type = MessageType.VOICE
 
                 followup_result = await self._run_agent(
                     message=next_message,

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -93,11 +93,70 @@ class TestAutoVoiceReplyFormat:
         voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
         assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
+    def test_voice_only_catchup_text_keeps_voice_reply_after_lease(self):
+        """Catch-up TEXT after a voice inbound must still answer in voice (#94660).
+
+        Lease contention replaces the original VOICE MessageEvent with a
+        synthetic catch-up/resume turn. voice_only must not treat that as
+        text-in → text-out.
+        """
+        runner = _make_runner()
+        chat_id = "15551234567"
+        runner._voice_mode[f"whatsapp:{chat_id}"] = "voice_only"
+        adapter = _make_adapter(Platform.WHATSAPP)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.WHATSAPP] = adapter
+
+        voice = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.VOICE)
+        session_key = runner._session_key_for_source(voice.source)
+        runner._remember_voice_inbound(session_key, voice)
+
+        catchup = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.TEXT)
+        catchup.text = (
+            "[System note: A new message has arrived. The conversation "
+            "history contains pending tool outputs from an interrupted turn. "
+            "IGNORE those pending results. Address the user's NEW message "
+            "below FIRST. Do NOT re-execute old tool calls from the history.]\n\n"
+            "transcribed voice: hello"
+        )
+        catchup.internal = True
+        runner._restore_voice_type_on_catchup(session_key, catchup)
+
+        assert catchup.message_type == MessageType.VOICE
+        assert runner._should_send_voice_reply(catchup, "hello", [], already_sent=True) is True
+
+        later_text = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.TEXT)
+        later_text.text = "actually typed this"
+        runner._remember_voice_inbound(session_key, later_text)
+        assert runner._should_send_voice_reply(later_text, "hello", []) is False
+
+    def test_resume_pending_synthetic_inherits_voice_stamp(self):
+        runner = _make_runner()
+        chat_id = "15551234567"
+        voice = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.VOICE)
+        session_key = runner._session_key_for_source(voice.source)
+        runner._remember_voice_inbound(session_key, voice)
+
+        resume = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.TEXT)
+        resume.text = ""
+        resume.internal = True
+        runner._restore_voice_type_on_catchup(session_key, resume)
+        assert resume.message_type == MessageType.VOICE
+
+        heartbeat = _make_event(Platform.WHATSAPP, chat_id=chat_id, message_type=MessageType.TEXT)
+        heartbeat.text = "heartbeat tick"
+        heartbeat.internal = True
+        runner._restore_voice_type_on_catchup(session_key, heartbeat)
+        assert heartbeat.message_type == MessageType.TEXT
+        assert runner._should_send_voice_reply(heartbeat, "hello", []) is False
+
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):
         runner = GatewayRunner.__new__(GatewayRunner)
         runner._voice_mode = {}
+        runner._pending_voice_reply_sessions = set()
         runner.adapters = {}
+        runner.session_store = None
     return runner
 
 


### PR DESCRIPTION
## What does this PR do?

With WhatsApp `voice_only` (voice-in → voice-out, text-in → text-out), a voice message that lands while another Hermes process holds the shared session lease can be answered as **text**. The original `MessageEvent` is `VOICE` and transcribes correctly, but the turn that actually runs after the lease is a synthetic catch-up or resume-pending event constructed as `TEXT`. Adapter auto-TTS and `_should_send_voice_reply()` both key off `event.message_type`, so they apply the text-in → text-out rule.

This stamps voice inbound on the session, re-attaches `MessageType.VOICE` onto empty resume-pending events and `[System note:` catch-up wraps, and still treats a later real typed message as text.

## Related Issue

Fixes #94660

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: remember voice inbound per session; restore `VOICE` on catch-up/resume synthetics; `_should_send_voice_reply()` uses `_event_is_voice_input()`; clear the stamp after a completed non-failed turn or a real typed inbound
- `tests/gateway/test_auto_voice_reply_format.py`: WhatsApp `voice_only` catch-up keeps a voice reply; resume-pending empty internal inherits `VOICE`; heartbeat internals stay text

## How to Test

1. Set a WhatsApp (or any messaging) chat to `/voice voice_only`.
2. Start a long-running turn on the same shared session from another Hermes surface so the session lease is held.
3. Send a voice message to that chat while the other turn is still running. Wait for the lease to release.
4. Confirm the reply is a voice bubble, not a text message claiming the user sent text.
5. Send a typed text follow-up in the same chat and confirm the reply stays text.
6. `scripts/run_tests.sh tests/gateway/test_auto_voice_reply_format.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/gateway/test_auto_voice_reply_format.py
=== Summary: 1 files, 8 tests passed, 0 failed ===
```
