### PR TITLE
fix(compression): make Ollama Cloud assertion extraction complete

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9077,6 +9077,13 @@ def _provider_requires_stream(provider: str, base_url: Optional[str]) -> bool:
     _url = str(base_url or "").lower()
     if not _url:
         return False
+    # Ollama Cloud reasoning models can leave non-streaming requests waiting
+    # until the client timeout (or return an empty structured payload), while
+    # the same request succeeds through the streamed main/compression path.
+    # Match the endpoint as well as the route label so an auto-routed client
+    # keeps the wire contract after provider resolution.
+    if provider == "ollama-cloud" or base_url_host_matches(_url, "ollama.com"):
+        return True
     # Tencent Copilot — "Non-stream chat request is currently not supported"
     if base_url_host_matches(_url, "copilot.tencent.com"):
         return True

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -236,6 +236,16 @@ class TestFenceProgress:
 
 class TestProviderRequiresStream:
 
+    def test_ollama_cloud_is_streamed_without_a_progress_hook(self):
+        assert _provider_requires_stream(
+            "ollama-cloud", "https://ollama.com/v1"
+        ) is True
+        # Auto-routed clients must retain the endpoint contract even when the
+        # provider label has not yet been narrowed to ollama-cloud.
+        assert _provider_requires_stream(
+            "auto", "https://ollama.com/v1"
+        ) is True
+
     def test_normal_endpoints_are_not(self):
         assert _provider_requires_stream(
             "openrouter", "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## What does this PR do?

Ollama Cloud users can enable plugin-owned structured auxiliary tasks such as LCM assertion extraction without every call timing out or returning an empty payload. The auxiliary transport now preserves the streamed request shape already used by successful main-chat and compression calls, then aggregates the chunks back into the complete response expected by plugin callers.

### Symptom

With `ollama-cloud` as the main provider, structured assertion extraction repeatedly times out, falls back, or returns no payload, while ordinary compression succeeds against the same endpoint.

### Impact

LCM source rows are marked as processed with zero assertions, so assertion-backed query and evidence features receive no data while each compression pass also pays retry and fallback latency.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py` / `_provider_requires_stream()` when a plugin calls `complete_structured(..., task="assertion_extraction")` without a compression progress hook.

**Causal chain:**
1. The plugin facade routes the registered auxiliary task through `call_llm()`.
2. Unlike the main chat and progress-hooked compression paths, the structured plugin request used non-streaming chat completions because Ollama Cloud was not classified as requiring the streamed auxiliary path.
3. Ollama Cloud reasoning models can leave that non-streaming request waiting until timeout or return an empty structured payload, so no assertions are persisted.

**Why it is wrong:** Hermes already has a provider-aware stream-and-aggregate seam for endpoints whose auxiliary requests need streaming, but the Ollama Cloud route did not opt into it.

**Working sibling / contrast:** Main chat streams natively, and ordinary compression installs an auxiliary progress hook that also upgrades its request to streaming. Both therefore avoid the failing request shape.

**Ruled out:** The separately reported bare `/v1` context attachment is not an LLM request from the Desktop renderer. Desktop turns pasted URLs into `@url:` references, and the shared context-reference expander fetches the exact referenced URL. An Ollama API root URL therefore returns its own `path "/v1" not found` body as attached URL content; rewriting that user reference to `/chat/completions` would be incorrect.

### Fix

Classify `ollama-cloud` routes and `ollama.com` endpoints as stream-required auxiliary transports. This applies even while the provider label is still `auto`, and reuses the existing bounded stream aggregation and fallback behavior.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py` - route Ollama Cloud auxiliary completions through stream aggregation.
- `tests/agent/test_aux_progress_streaming.py` - cover explicit and auto-routed Ollama Cloud endpoint classification.

## How to Test

1. Run the auxiliary stream regression suite.
2. Run the plugin LLM structured-routing suites.
3. In an Ollama Cloud environment with LCM assertion extraction enabled, trigger pre-compaction extraction and verify assertions are persisted without non-streaming timeouts.

```bash
scripts/run_tests.sh tests/agent/test_aux_progress_streaming.py -q
scripts/run_tests.sh tests/agent/test_plugin_llm.py tests/agent/test_plugin_llm_task_routing.py -q
scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q
scripts/run_tests.sh tests/agent/test_plugin_context_references.py -q
```

Local result: 270 tests passed. The new route assertion was verified red before the implementation and green afterward.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the behavior is internal transport routing
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the change is provider/URL routing with no OS-specific behavior
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed

## Screenshots / Logs

The focused regression test failed before the implementation because `_provider_requires_stream("ollama-cloud", "https://ollama.com/v1")` returned `False`; it passes after the change.
