### PR TITLE
fix(secrets): hydrate profile secret scope when source snapshot is empty

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -299,6 +299,16 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
     try:
         from hermes_cli.env_loader import get_secret_source_values
         external_secrets = get_secret_source_values(home)
+        if not external_secrets:
+            # The process-global snapshot can be empty when this module's
+            # env_loader import ran apply_all() during an earlier (pre-dotenv)
+            # import order and the fetch only OVERRODE pre-existing env vars
+            # (provenance tracks only newly applied names, so the snapshot
+            # stays empty). Resolve this home's sources directly so the scope
+            # still carries vault secrets (#16958-regression: cron zai jobs
+            # failed with "No usable credentials found for provider 'zai'").
+            from hermes_cli.env_loader import hydrate_profile_secret_sources
+            external_secrets = hydrate_profile_secret_sources(home)
     except Exception:
         external_secrets = {}
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -246,10 +246,43 @@ class TestEnvFileParsing:
         monkeypatch.setitem(
             env_loader._SECRET_SOURCE_VALUES_BY_HOME,
             str(other.resolve()),
-            {"XIAOMI_API_KEY": "sk-other-profile"},
+            {"XIAOMI_API_KEY": "«redacted:sk-…»"},
         )
 
         assert ss.build_profile_secret_scope(profile) == {}
+
+    def test_build_profile_secret_scope_hydrates_when_snapshot_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: a pre-dotenv env_loader import (cron-before-gateway
+        import order, commit 0583692c2d) can leave the process-global source
+        snapshot EMPTY — the startup apply_all only OVERRODE pre-existing env
+        values and provenance tracks only newly-applied names. In that case
+        build_profile_secret_scope() must still resolve the home's external
+        sources directly so scoped credential reads (cron zai jobs) do not
+        fail with "No usable credentials found for provider 'zai'".
+        """
+        (tmp_path / ".env").write_text("ZAI_REGION=us\n")
+        from hermes_cli import env_loader
+
+        # Snapshot is empty for this home — the failing state.
+        home_key = str(tmp_path.resolve())
+        monkeypatch.setitem(env_loader._SECRET_SOURCE_VALUES_BY_HOME, home_key, {})
+
+        # Fake the direct hydration path with a vault secret.
+        def fake_hydrate(hermes_home):
+            from pathlib import Path
+
+            if str(Path(hermes_home).resolve()) == home_key:
+                return {"GLM_API_KEY": "«redacted:sk-…»"}
+            return {}
+
+        monkeypatch.setattr(
+            env_loader, "hydrate_profile_secret_sources", fake_hydrate
+        )
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+        assert scope == {"ZAI_REGION": "us", "GLM_API_KEY": "«redacted:sk-…»"}
 
 
 class TestApiServerListenerGlobals:


### PR DESCRIPTION
## Summary

Cron LLM jobs (zai provider) fail with `No usable credentials found for provider 'zai'` after a gateway restart when the import order puts `cron.scheduler` before the gateway's dotenv load.

## Root cause

Import-order regression from `0583692c2d` ("fix(secrets): scope BWS-injected provider keys"):

1. `gateway/run.py` imports `cron.scheduler._resolve_home_env_var` at module scope (line 1660) **above** its `load_hermes_dotenv()` at line 1708.
2. `agent/secret_scope.py:283` does a module-local `from hermes_cli.env_loader import get_secret_source_values`. When `cron.scheduler` (or anything importing it) loads *before* the gateway dotenv load, importing `env_loader` runs its import-time `apply_all()` on the Hermes home.
3. In that early `apply_all`, the 1Password source **overrides** pre-existing env vars (`override_existing: true`), but `report.provenance` records only *newly-applied* names — so `_apply_external_secret_sources` marks the home as applied with `applied_any = False` and `_SECRET_SOURCE_VALUES_BY_HOME` stays **empty**.
4. Each cron job's `build_profile_secret_scope(_get_hermes_home())` then reads the empty snapshot → scope has only `.env` keys → `resolve_runtime_provider` fails for every zai-provider LLM job.

## Fix

When `get_secret_source_values(home)` returns empty, fall back to `hydrate_profile_secret_sources(home)` — the existing, fail-open direct-resolution path (same one `gateway/run.py`'s `_profile_runtime_scope` uses for multiplexed profiles) that resolves this home's configured sources into a private mapping without mutating `os.environ`.

## Reproduction

```python
import os, sys
sys.path.insert(0, '.')
os.environ['HERMES_HOME'] = '/home/hermes/.hermes'
os.environ.pop('GLM_API_KEY', None)
# Failing order: import cron.scheduler BEFORE the module that calls load_hermes_dotenv
from cron.scheduler import _resolve_home_env_var  # noqa
from agent.secret_scope import build_profile_secret_scope
scope = build_profile_secret_scope('/home/hermes/.hermes')
assert 'GLM_API_KEY' in scope  # FAILS before fix, passes after
```

## Tests

- New regression test `test_build_profile_secret_scope_hydrates_when_snapshot_empty` (fails pre-fix, passes post-fix).
- `tests/agent/test_secret_scope.py`, `tests/test_env_loader_op_bootstrap.py`, `tests/agent/test_credential_pool.py`: 85 passed.

## Notes

- No behavior change when the snapshot is non-empty (fast path unchanged).
- The `except Exception` guard means a hydration failure degrades exactly as before (empty external secrets) — fail-open preserved.