### PR TITLE
fix(memory): key OpenViking user-space cache on the resolving client's own snapshot

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -3166,16 +3166,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         snapshot = self._conn_snapshot
         if snapshot is not None:
             endpoint, api_key, account, user, agent = snapshot
-            return _VikingClient(
+            client = _VikingClient(
                 endpoint, api_key, account=account, user=user, agent=agent,
             )
-        return _VikingClient(
-            self._endpoint,
-            self._api_key,
-            account=self._account,
-            user=self._user,
-            agent=self._agent,
-        )
+        else:
+            client = _VikingClient(
+                self._endpoint,
+                self._api_key,
+                account=self._account,
+                user=self._user,
+                agent=self._agent,
+            )
+        # Stamp the client with the snapshot it was actually built from, so
+        # _user_space() can key/publish its identity cache against the
+        # connection this specific client speaks for — not whatever
+        # self._conn_snapshot happens to be when the resolution runs. Callers
+        # like on_memory_write() build a client on one thread and resolve/use
+        # it later on a background thread; a reload in between must not let
+        # this stale client's resolved identity get cached under the new
+        # connection's key (see _user_space()).
+        client._conn_snapshot = snapshot
+        return client
 
     @staticmethod
     def _text_part(content: str) -> Dict[str, str]:
@@ -3919,7 +3930,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # snapshot, so object-identity keying would miss the cache on every
         # write. The snapshot tuple is published atomically under
         # _client_refresh_lock and changes on every config reload.
-        snapshot = getattr(self, "_conn_snapshot", None)
+        #
+        # When an explicit client was passed in, use THAT client's own
+        # frozen snapshot (stamped by _new_client()) rather than the live
+        # self._conn_snapshot. Background writers (on_memory_write,
+        # sync_turn) build a client on one thread and resolve/use it later;
+        # if a reload swaps self._conn_snapshot in between, reading the live
+        # value here would resolve the old client's identity but publish it
+        # under the NEW connection's cache key, poisoning every subsequent
+        # lookup for the new connection with the old one's user.
+        if client is not None and hasattr(client, "_conn_snapshot"):
+            snapshot = client._conn_snapshot
+        else:
+            snapshot = getattr(self, "_conn_snapshot", None)
         cached = getattr(self, "_user_space_cache", None)
         if active is not None and cached is not None and cached[0] == snapshot:
             return cached[1]
@@ -3928,7 +3951,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
             resolved = _resolve_user_space(active, timeout=timeout)
             if resolved:
                 # Only publish when the snapshot hasn't changed under us.
-                current_snapshot = getattr(self, "_conn_snapshot", None)
+                # (An explicit client's stamped snapshot is immutable once
+                # set, so this recheck only matters for the self._client path.)
+                if client is not None and hasattr(client, "_conn_snapshot"):
+                    current_snapshot = client._conn_snapshot
+                else:
+                    current_snapshot = getattr(self, "_conn_snapshot", None)
                 if snapshot is not None and snapshot is current_snapshot:
                     self._user_space_cache = (snapshot, resolved)
                 return resolved

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1367,6 +1367,53 @@ def test_memory_write_uses_one_connection_for_identity_uri_and_post(monkeypatch)
     assert provider._memory_write_threads == set()
 
 
+def test_user_space_cache_not_poisoned_by_stale_client_across_reload():
+    """A client frozen via _new_client() before a reload must have its
+    resolved identity cached under ITS OWN snapshot, not whatever
+    self._conn_snapshot has moved on to by the time resolution runs.
+
+    Background writers (on_memory_write, sync_turn) capture a client early
+    and resolve/use it later, possibly after a profile reload has already
+    swapped the live connection. If the old client's resolved identity gets
+    published under the new connection's cache key, every subsequent lookup
+    for the new connection returns the old connection's user.
+    """
+    provider = OpenVikingMemoryProvider()
+
+    class StubClient:
+        def __init__(self, user):
+            self._user = user
+
+        def get(self, path, **kwargs):
+            assert path == "/api/v1/system/status"
+            return {"status": "ok", "result": {"user": self._user}}
+
+    def make_frozen_client(user):
+        # Mirrors _new_client(): stamp the client with whatever
+        # self._conn_snapshot is at the moment it's built.
+        client = StubClient(user)
+        client._conn_snapshot = provider._conn_snapshot
+        return client
+
+    # Connection A is live; a background writer freezes a client from it.
+    provider._conn_snapshot = ("http://a", "", "acct", "alice", "agent")
+    frozen_alice_client = make_frozen_client("alice")
+
+    # A reload swaps the live connection to B before the writer's deferred
+    # identity resolution runs.
+    provider._conn_snapshot = ("http://b", "", "acct", "bob", "agent")
+
+    # The writer resolves identity using its now-stale, frozen client.
+    resolved = provider._user_space(frozen_alice_client)
+    assert resolved == "alice"
+
+    # The live connection (B) must resolve and cache its OWN identity, not
+    # reuse the frozen client's "alice" from the write that just happened.
+    provider._client = make_frozen_client("bob")
+    resolved_live = provider._user_space()
+    assert resolved_live == "bob"
+
+
 def _make_prefetch_provider() -> OpenVikingMemoryProvider:
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()


### PR DESCRIPTION
## What does this PR do?

`OpenVikingMemoryProvider._user_space()` caches the server-resolved current-user identity, keyed on `self._conn_snapshot` — the *live* connection identity — regardless of which client object is actually being resolved.

Background writers (`on_memory_write`, `sync_turn`) call `self._new_client()` on one thread to freeze a client from the connection that's live *at that moment*, then resolve/use that client later (after real network I/O, on a background thread). If a config reload (profile switch, credential rotation) swaps `self._conn_snapshot` to a different connection while that write is in flight, `_user_space()` still reads the *live* `self._conn_snapshot` when it publishes the cache entry — so the **old** client's resolved identity gets cached under the **new** connection's key. Every subsequent identity lookup for the new connection then returns the previous connection's user until the next reload or process restart — a cross-connection memory-identity mixup.

### Fix

- `_new_client()` now stamps the client it builds with the exact snapshot it was built from (`client._conn_snapshot`).
- `_user_space()` uses that stamped snapshot — not the live `self._conn_snapshot` — to key and publish the cache entry when an explicit `client` argument is passed. The `self._client` / `client=None` path (unaffected by this race) is unchanged.

### Regression test

Added `test_user_space_cache_not_poisoned_by_stale_client_across_reload`, which freezes a client under connection A, swaps the live connection to B, resolves identity through the frozen A-client, then asserts a fresh resolution against the live B-connection returns B's own identity rather than the cached A identity.

Confirmed via mutation testing: with only the test added and the fix reverted, the new test fails with `AssertionError: assert 'alice' == 'bob'`, reproducing the cache-poisoning cross-user leak. With the fix restored, it passes.

## Test plan

- [x] New regression test added and mutation-verified (fails without the fix, passes with it)
- [x] `tests/plugins/memory/test_openviking_provider.py` — 63 passed
- [x] `tests/openviking_plugin/test_openviking.py` — 59 passed (combined with checkpoint-contract suite)
- [x] `tests/plugins/memory/test_openviking_endpoint_always_blocked.py`, `tests/plugins/memory/test_openviking_shutdown.py` — 11 passed