### PR TITLE
fix(desktop): probe a cached pooled remote backend before dispatching to it

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -275,6 +275,7 @@ import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySet
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
+  ensureHealthyPooledRemoteBackendForDispatch,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -1314,6 +1315,7 @@ let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
+const registryDispatchRevalidation = new RemoteRevalidationCoordinator()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -10246,8 +10248,37 @@ async function ensureRegistryBackend(connectionId, profile) {
 
   if (existing) {
     existing.lastActiveAt = Date.now()
+    const connectionPromise = existing.connectionPromise
 
-    return existing.connectionPromise
+    // A remote process can die while its local SSH forward stays LISTENing.
+    // Validate the exact cached descriptor at dispatch time; background
+    // revalidation is renderer-driven and may never run while the Bots pane is
+    // closed. Concurrent clicks share one retire/reconnect sequence.
+    return registryDispatchRevalidation.run(connectionPromise, () =>
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise,
+        currentConnectionPromise: () => backendPool.get(key)?.connectionPromise || null,
+        probe: (connection, requestPath, options) => fetchJsonForBackend(connection, requestPath, options),
+        reconnect: () => ensureRegistryBackend(id, profile),
+        retire: async (error: any) => {
+          // A late failure from an old descriptor must never tear down a newer
+          // entry that another caller has already installed.
+          if (backendPool.get(key) !== existing) {
+            return
+          }
+
+          rememberLog(
+            `Pooled remote backend "${key}" failed its dispatch probe (${error?.message || error}); reconnecting on demand.`
+          )
+          await stopPoolBackend(key)
+
+          if (source.kind === 'ssh') {
+            await sshBootstrapCoordinator.cancelAndWait(key)
+            await teardownSshConnection(key)
+          }
+        }
+      })
+    )
   }
 
   evictLruPoolBackends(POOL_MAX_BACKENDS - 1)

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  ensureHealthyPooledRemoteBackendForDispatch,
+  POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS,
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
@@ -254,6 +256,47 @@ describe('revalidateRemoteConnection', () => {
 
     await expect(revalidateRemoteConnection(rejected.options)).resolves.toEqual({ ok: true, rebuilt: false })
     expect(rejected.probe).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
+  it('retires a dead cached descriptor and gives dispatch the replacement', async () => {
+    const stale = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const replacement = { baseUrl: 'http://127.0.0.1:53968', mode: 'remote' }
+    const stalePromise = Promise.resolve(stale)
+    let currentPromise: Promise<typeof stale> | null = stalePromise
+
+    const retire = vi.fn(async () => {
+      currentPromise = null
+    })
+
+    const reconnect = vi.fn(async () => {
+      currentPromise = Promise.resolve(replacement)
+
+      return replacement
+    })
+
+    const probe = vi.fn(async connection => {
+      if (connection === stale) {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:49525')
+      }
+    })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: stalePromise,
+        currentConnectionPromise: () => currentPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(replacement)
+
+    expect(probe).toHaveBeenCalledWith(stale, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(retire).toHaveBeenCalledOnce()
+    expect(reconnect).toHaveBeenCalledOnce()
   })
 })
 

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,4 +1,9 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
+// Dispatch is synchronous user intent: a cached descriptor must prove its
+// forwarded endpoint is alive before it can be returned. Keep this probe much
+// shorter than the background liveness budget so a dead tunnel reconnects
+// promptly instead of making the click feel hung.
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).
@@ -61,6 +66,60 @@ export class RemoteRevalidationCoordinator {
 
     return pending
   }
+}
+
+interface EnsureHealthyPooledRemoteBackendForDispatchOptions<
+  TConnection extends RemoteConnectionDescriptor
+> {
+  connectionPromise: Promise<TConnection>
+  currentConnectionPromise: () => null | Promise<TConnection>
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
+  reconnect: () => Promise<TConnection>
+  retire: (error: unknown) => Promise<void> | void
+}
+
+/**
+ * Gate dispatch through a cheap health probe of the exact cached descriptor.
+ *
+ * A failed descriptor is retired before reconnecting, while identity checks
+ * prevent a late probe from tearing down a replacement installed by another
+ * caller. The caller should single-flight this function per cached promise so
+ * concurrent dispatches share one retire/reconnect sequence.
+ */
+export async function ensureHealthyPooledRemoteBackendForDispatch<
+  TConnection extends RemoteConnectionDescriptor
+>({
+  connectionPromise,
+  currentConnectionPromise,
+  probe,
+  reconnect,
+  retire
+}: EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection>): Promise<TConnection> {
+  let connection: TConnection
+
+  try {
+    connection = await connectionPromise
+
+    if (currentConnectionPromise() !== connectionPromise) {
+      return reconnect()
+    }
+
+    await probe(connection, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+  } catch (error) {
+    if (currentConnectionPromise() === connectionPromise) {
+      await retire(error)
+    }
+
+    return reconnect()
+  }
+
+  if (currentConnectionPromise() !== connectionPromise) {
+    return reconnect()
+  }
+
+  return connection
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Desktop keeps pooled remote backends (Bot Mode / group chat on another machine) cached in `backendPool` together with their SSH forward. When the *remote* Desktop relaunches, its backend process dies but the local forward keeps LISTENing, so `ensureRegistryBackend()` hands every dispatch the dead descriptor. Every turn to that machine fails until the local app is restarted.

The background sweep does not catch this. `revalidatePooledRemoteBackends()` only runs from the renderer's reconnect IPC, which never fires while the primary connection is healthy — the usual state when the *other* machine is the one that restarted.

This PR validates the exact cached descriptor at dispatch time:

- `ensureRegistryBackend()` probes the cached descriptor's `/api/status` with a short budget (`POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2.5 s`) before returning it.
- On failure it retires the pool entry, cancels any SSH bootstrap, tears down the forward, and reconnects on demand.
- Concurrent dispatches share one retire/reconnect sequence via a `RemoteRevalidationCoordinator` keyed on the cached promise.
- Identity checks (`currentConnectionPromise() === connectionPromise`, `backendPool.get(key) === existing`) stop a late failure from an old descriptor tearing down a replacement another caller already installed.

The probe helper lives in `remote-liveness.ts` with the callbacks injected so it can be unit-tested; `main.ts` has no test harness.

Complements #94416 (#94381): that PR widens the *background* sweep's failure window so a dead pooled backend is eventually dropped between sweeps. This PR covers the dispatch path the sweep never reaches while the primary is healthy. Both are needed.

## Related Issue

Related to #94381 (dead pooled remote descriptors served until restart) and the self-heal lineage in #82679. No existing issue covers the relaunch-of-the-remote-machine case specifically.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/remote-liveness.ts` — `POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS`, `ensureHealthyPooledRemoteBackendForDispatch()`
- `apps/desktop/electron/main.ts` — `ensureRegistryBackend()` gates the cached descriptor through the probe; `registryDispatchRevalidation` coordinator
- `apps/desktop/electron/remote-liveness.test.ts` — regression test: dead cached descriptor is retired and dispatch receives the replacement

## How to Test

1. Two machines, Desktop on both, machine B registered on machine A as an SSH connection. Create a group chat on A that includes a bot on B; send a message — B replies.
2. Quit and relaunch Desktop on B. Send another message from A.
3. Before this PR: the turn to B fails forever (`ECONNRESET` / no reply) until A is restarted. After: A's log shows `failed its dispatch probe (...); reconnecting on demand`, the forward is rebuilt, and B replies.
4. `cd apps/desktop && npx vitest run electron/remote-liveness.test.ts`

Verified on macOS 26 (MacBook + Mac mini over SSH): after relaunching the mini, the next group-chat turn from the MacBook reached the mini's backend and its reply was written to the mini's `state.db` in 8 s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `scripts/run_tests.sh` on macOS: 36,405 passed, 134 failed, all in Python files this PR does not touch (this PR changes no Python). The failures are local-environment: `security.allow_lazy_installs=false` in my config, optional extras not installed (`fal_client`, `hindsight_client_api`), `AF_UNIX path too long` on macOS temp paths.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, two-machine Desktop setup

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
