### PR TITLE
fix(desktop): key synced group-chat members by install_id, not device-local connection ids

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13143,7 +13143,7 @@ async function probeSshProfileInventory(connection) {
       SSH_INVENTORY_RETRY_MS
     )
   ) {
-    return
+    return connectionInstallIds.get(connection.id)?.id
   }
 
   sshInventoryAttemptedAt.set(connection.id, Date.now())
@@ -13158,7 +13158,7 @@ async function probeSshProfileInventory(connection) {
   })
 
   if (!sshConfig) {
-    return
+    return connectionInstallIds.get(connection.id)?.id
   }
 
   const ssh = createSshProbeConnection(
@@ -13169,9 +13169,14 @@ async function probeSshProfileInventory(connection) {
   try {
     await ssh.open()
     const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
+    const installId = await remoteLifecycle.probeRemoteHermesInstallId(ssh)
 
     if (profiles.length > 0) {
       sshRosterCache.set(connection.id, profiles)
+    }
+
+    if (installId) {
+      rememberConnectionInstallId(connection.id, { install_id: installId })
     }
   } catch (error: any) {
     sshRememberLog(`[ssh] profile inventory failed for ${connection.id}: ${error?.message || error}`)
@@ -13182,6 +13187,8 @@ async function probeSshProfileInventory(connection) {
       void 0
     }
   }
+
+  return connectionInstallIds.get(connection.id)?.id
 }
 
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
@@ -13220,8 +13227,8 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
         // respawn Spark/Mini every Bot Mode poll (~5s), then the mux died
         // (ECONNRESET / liveness probe drop).
         if (connection.kind === 'ssh') {
-          await probeSshProfileInventory(connection)
-          raw = { connection, profiles: null, error: 'connect-on-demand' }
+          const installId = await probeSshProfileInventory(connection)
+          raw = { connection, profiles: null, error: 'connect-on-demand', ...(installId ? { installId } : {}) }
         } else {
           // Same connect-on-demand courtesy for the forced-local path: when
           // the primary route is remote, enumerating "This device" would

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { exec as execCallback, spawn } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -22,6 +22,7 @@ import {
   openForward,
   ownershipDirectory,
   pidIsOurDashboard,
+  probeRemoteHermesInstallId,
   probeRemotePlatform,
   PROTOCOL_VERSION,
   readLockfile,
@@ -98,6 +99,31 @@ test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawn
     ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
     false
   )
+})
+
+test('probeRemoteHermesInstallId reads the stable identity without spawning a dashboard', async () => {
+  const ssh = fakeSsh([
+    [/HERMES_HOME/, '/Users/test/.hermes\n'],
+    [/install_id/, '0123456789abcdef0123456789abcdef\n']
+  ])
+
+  assert.equal(await probeRemoteHermesInstallId(ssh), '0123456789abcdef0123456789abcdef')
+  assert.ok(ssh.calls.some(call => call.includes('install_id')))
+  assert.ok(ssh.calls.every(call => !call.includes('serve') && !call.includes('dashboard')))
+})
+
+test('SSH roster wiring carries the probed install id into the public source row', async () => {
+  const main = await readFile(new URL('./main.ts', import.meta.url), 'utf8')
+  const start = main.indexOf('async function probeSshProfileInventory')
+  const end = main.indexOf("ipcMain.handle('hermes:agents:roster'", start)
+  const roster = main.slice(start, end)
+
+  assert.notEqual(start, -1)
+  assert.notEqual(end, -1)
+  assert.match(roster, /probeRemoteHermesInstallId\(ssh\)/)
+  assert.match(roster, /rememberConnectionInstallId\(connection\.id, \{ install_id: installId \}\)/)
+  assert.match(roster, /raw = \{ connection, profiles: null, error: 'connect-on-demand', \.\.\.\(installId \? \{ installId \} : \{\}\) \}/)
+  assert.match(main, /sources: enumerations\.map\(\(\{ connection, error, installId, profiles \}\)/)
 })
 
 test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -278,6 +278,25 @@ async function listRemoteHermesProfiles(ssh) {
   return parseRemoteProfileListing(listing)
 }
 
+async function probeRemoteHermesInstallId(ssh) {
+  const home = assertSafeRemoteHome(await probeRemoteHermesHome(ssh))
+  const file = expandRemotePath(`${home}/install_id`)
+  let output = ''
+
+  try {
+    output = await ssh.exec(`if [ -f ${file} ]; then IFS= read -r value < ${file}; printf '%s\\n' "$value"; fi`)
+  } catch (cause) {
+    const error: any = new Error('Could not read the remote Hermes install id.')
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+
+  const value = String(output || '').trim().split('\n').pop() || ''
+
+  return /^[A-Za-z0-9._:-]{8,160}$/.test(value) ? value : ''
+}
+
 function assertSafeRemoteHome(home) {
   const value = String(home || '').trim()
 
@@ -973,6 +992,7 @@ export {
   pidIsOurDashboard,
   probeHermesVersion,
   probeRemoteHermesHome,
+  probeRemoteHermesInstallId,
   probeRemotePlatform,
   PROTOCOL_VERSION,
   readLockfile,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -554,6 +554,7 @@ const groupChatSyncInFlightConnections = new Set()
 const groupChatSyncRetryTimers = new Map()
 const groupChatSyncRetryCounts = new Map()
 let groupChatSyncDisposed = false
+let groupChatSyncSourceFingerprint = ''
 
 /** Conservative byte count for the gateway's ensure_ascii JSON encoding.
  *  Python also inserts separator spaces, so reserve one extra byte per JS
@@ -621,6 +622,160 @@ function normalizeGroupChatSyncSnapshot(snapshot) {
   return { version: 3, updatedAt: Number(snapshot.updatedAt || 0), rooms, deleted }
 }
 
+function groupChatSyncSource(connectionId, installId = '', sources = $lastSources.get()) {
+  const stableId = String(installId || '').trim()
+  const localId = String(connectionId || '').trim()
+  const rows = Array.isArray(sources) ? sources : []
+
+  if (stableId) {
+    const byInstall = rows.find(source => String(source?.installId || '').trim() === stableId)
+
+    return byInstall || null
+  }
+
+  return rows.find(source => String(source?.connectionId || '').trim() === localId) || null
+}
+
+function groupChatMemberForSync(member) {
+  const source = groupChatSyncSource(member?.connectionId, member?.sourceInstallId)
+  const sourceInstallId = String(member?.sourceInstallId || source?.installId || '').trim()
+
+  if (sourceInstallId) {
+    // Device-local connection ids/labels (especially `local` / `This device`)
+    // must never enter the shared projection: another Desktop would interpret
+    // them as its own machine and two writers would flap the room forever.
+    return {
+      name: String(member?.name || '').slice(0, 128),
+      sourceInstallId: sourceInstallId.slice(0, 160),
+      sourceScoped: true
+    }
+  }
+
+  return {
+    name: String(member?.name || '').slice(0, 128),
+    ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
+    ...(member?.connectionId ? { connectionId: String(member.connectionId).slice(0, 128) } : {}),
+    ...(member?.connectionKind ? { connectionKind: String(member.connectionKind).slice(0, 64) } : {}),
+    ...(member?.connectionLabel ? { connectionLabel: String(member.connectionLabel).slice(0, 128) } : {}),
+    ...(member?.sourceScoped ? { sourceScoped: true } : {})
+  }
+}
+
+/** Translate a synced machine identity back into this Desktop's connection
+ * registry. Connection ids such as `local` are device-relative; install_id is
+ * the stable backend identity shared by both computers. */
+function rebindSyncedGroupMember(member) {
+  const source = groupChatSyncSource(member?.connectionId, member?.sourceInstallId)
+
+  if (!source) {
+    return { ...member, remoteSource: true }
+  }
+
+  const connectionId = String(source.connectionId || member?.connectionId || '')
+  const name = String(member?.name || '')
+  const roster = (Array.isArray($lastRoster.get()) ? $lastRoster.get() : []).find(row =>
+    String(row?.connectionId || '') === connectionId &&
+    String(row?.name || row?.profile || '') === name
+  )
+
+  return {
+    ...member,
+    connectionId,
+    connectionKind: source.kind || member?.connectionKind,
+    connectionLabel: source.label || member?.connectionLabel,
+    ...(source.installId ? { sourceInstallId: String(source.installId) } : {}),
+    ...(roster?.handle ? { handle: String(roster.handle) } : {}),
+    sourceScoped: true,
+    remoteSource: source.kind !== 'local'
+  }
+}
+
+function rebindKnownGroupChatMembers(all = $groupChats.get()) {
+  let changed = false
+  const rooms = {}
+
+  for (const [name, room] of Object.entries(all || {})) {
+    let roomChanged = false
+    const members = (Array.isArray(room?.members) ? room.members : []).map(member => {
+      if (!member?.sourceInstallId) {
+        return member
+      }
+
+      const rebound = rebindSyncedGroupMember(member)
+      const differs =
+        rebound.connectionId !== member.connectionId ||
+        rebound.connectionKind !== member.connectionKind ||
+        rebound.connectionLabel !== member.connectionLabel ||
+        rebound.handle !== member.handle ||
+        rebound.remoteSource !== member.remoteSource
+
+      if (differs) {
+        changed = true
+        roomChanged = true
+      }
+
+      return rebound
+    })
+
+    rooms[name] = roomChanged ? { ...room, members } : room
+  }
+
+  return { rooms, changed }
+}
+
+/** Upgrade one locally-authored legacy room only when every member's old
+ * connection id resolves on this Desktop. That is true on the room's origin
+ * machine and false on a synced peer where `local` / custom ids mean something
+ * else. The origin can then publish one higher-revision canonical membership. */
+function canonicalizeResolvableGroupChatMembers(all = $groupChats.get()) {
+  const rooms = { ...(all || {}) }
+  const changedRooms = []
+
+  for (const [name, room] of Object.entries(rooms)) {
+    const members = Array.isArray(room?.members) ? room.members : []
+
+    if (!members.length || !members.some(member => !member?.sourceInstallId)) {
+      continue
+    }
+
+    const sources = members.map(member =>
+      groupChatSyncSource(member?.connectionId, member?.sourceInstallId)
+    )
+
+    if (sources.some(source => !source?.installId)) {
+      continue
+    }
+
+    const canonicalMembers = new Map()
+    members.forEach((member, index) => {
+      const canonical = rebindSyncedGroupMember({ ...member, sourceInstallId: String(sources[index].installId) })
+      canonicalMembers.set(groupChatSyncMemberKey(canonical), canonical)
+    })
+
+    rooms[name] = {
+      ...room,
+      members: [...canonicalMembers.values()]
+    }
+    changedRooms.push(name)
+  }
+
+  return { rooms, changedRooms }
+}
+
+/** Reconcile both halves of stable group membership in one pass. Source
+ * inventory and persisted/shared rooms hydrate independently at startup, so
+ * either one may arrive first. */
+function reconcileKnownGroupChatMembers(all = $groupChats.get()) {
+  const rebound = rebindKnownGroupChatMembers(all)
+  const canonicalized = canonicalizeResolvableGroupChatMembers(rebound.rooms)
+
+  return {
+    rooms: canonicalized.changedRooms.length ? canonicalized.rooms : rebound.rooms,
+    changed: rebound.changed || canonicalized.changedRooms.length > 0,
+    changedRooms: canonicalized.changedRooms
+  }
+}
+
 /** Compact, display-oriented copy of Desktop's room log for gateway clients.
  *  The live orchestration state stays in plugin storage; this bounded mirror
  *  rides the default profile's ui_meta so mobile can show the same messages.
@@ -660,19 +815,17 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       at: Number(entry?.at || 0),
       ...(entry?.thread ? { thread: String(entry.thread).slice(0, 128) } : {})
     }))
+    const projectedMembers = new Map()
+    for (const member of (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS)) {
+      const projected = groupChatMemberForSync(member)
+      projectedMembers.set(groupChatSyncMemberKey(projected), projected)
+    }
     const compact = {
       name: String(name).slice(0, 64),
       ...(typeof room?.roomId === 'string' && room.roomId ? { roomId: String(room.roomId).slice(0, 128) } : {}),
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
-      members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
-        name: String(member?.name || '').slice(0, 128),
-        ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
-        ...(member?.connectionId ? { connectionId: String(member.connectionId).slice(0, 128) } : {}),
-        ...(member?.connectionKind ? { connectionKind: String(member.connectionKind).slice(0, 64) } : {}),
-        ...(member?.connectionLabel ? { connectionLabel: String(member.connectionLabel).slice(0, 128) } : {}),
-        ...(member?.sourceScoped ? { sourceScoped: true } : {})
-      })),
+      members: [...projectedMembers.values()],
       ...(typeof room?.image === 'string' && room.image.length <= GROUP_CHAT_SYNC_IMAGE_CHARS
         ? { image: room.image }
         : {})
@@ -716,6 +869,12 @@ function groupChatSyncEntryKey(entry) {
 }
 
 function groupChatSyncMemberKey(member) {
+  const sourceInstallId = String(member?.sourceInstallId || '').trim()
+
+  if (sourceInstallId) {
+    return JSON.stringify(['install', sourceInstallId, String(member?.name || '')])
+  }
+
   return JSON.stringify([
     String(member?.source || ''),
     String(member?.connectionId || ''),
@@ -959,7 +1118,8 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
         members.clear()
       }
       for (const member of Array.isArray(projected.members) ? projected.members : []) {
-        members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+        const rebound = rebindSyncedGroupMember(member)
+        members.set(groupChatSyncMemberKey(rebound), rebound)
       }
     }
 
@@ -6272,16 +6432,25 @@ function groupLastActivity(room) {
 /** Seat a group's member roster: local bots whose meta names the group, plus
  *  the room record's stored descriptors (remote members can't ride bot-meta).
  *  Prefers the LIVE roster row for a stored descriptor when present. */
+function groupChatMemberIdentityKey(bot) {
+  const source = groupChatSyncSource(bot?.connectionId, bot?.sourceInstallId)
+  const sourceInstallId = String(bot?.sourceInstallId || source?.installId || '').trim()
+
+  return sourceInstallId
+    ? `install:${sourceInstallId}::${bot?.name || 'default'}`
+    : botRosterKey(bot)
+}
+
 function groupChatMemberBots(group, roster, metaByName) {
   const local = (roster || []).filter(
     bot => botGroups(botRosterMeta(bot, metaByName)).includes(group)
   )
   const stored = ($groupChats.get()[group] || {}).members || []
-  const seated = new Set(local.map(botRosterKey))
+  const seated = new Set(local.map(groupChatMemberIdentityKey))
   const remote = []
 
   for (const descriptor of stored) {
-    const key = botRosterKey(descriptor)
+    const key = groupChatMemberIdentityKey(descriptor)
 
     if (seated.has(key)) {
       continue
@@ -6291,7 +6460,7 @@ function groupChatMemberBots(group, roster, metaByName) {
     // A selected-but-offline ghost intentionally carries only enough identity
     // to paint the roster. Never let it replace the room's durable descriptor,
     // which owns the full handle/title used by mentions and remote sync.
-    remote.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || descriptor)
+    remote.push((roster || []).find(bot => !bot?.ghost && groupChatMemberIdentityKey(bot) === key) || descriptor)
   }
 
   return [...local, ...remote]
@@ -6307,6 +6476,8 @@ function durableGroupChatMembers(bots) {
     // route — the same degraded shape the hydrate annotate produces. The
     // strict throw here would lose the entire room update over one row.
     const route = resolveBotConnectionRoute(bot).route
+    const source = groupChatSyncSource(bot?.connectionId, bot?.sourceInstallId)
+    const sourceInstallId = String(bot?.sourceInstallId || source?.installId || '').trim()
     // Keep the friendly identity on the stored descriptor: after a
     // connection switch the live roster row may be gone, and renamed-tag
     // mentions must still resolve against the persisted member.
@@ -6320,6 +6491,7 @@ function durableGroupChatMembers(bots) {
       connectionId: bot.connectionId,
       connectionKind: bot.connectionKind,
       connectionLabel: bot.connectionLabel,
+      ...(sourceInstallId ? { sourceInstallId } : {}),
       ...(route ? { route, targetProfile: route.targetProfile } : {}),
       // A swept/annotated member keeps its degraded mark across the rebuild —
       // otherwise the next room send would silently un-mark an orphaned row.
@@ -14239,6 +14411,28 @@ function BotsPane() {
     $lastRoster.set(roster.filter(row => !row?.ghost))
     if (Array.isArray(data?.sources)) {
       $lastSources.set(data.sources)
+      const reconciled = reconcileKnownGroupChatMembers()
+
+      if (reconciled.changed) {
+        $groupChats.set(reconciled.rooms)
+        void persistGroupChatRooms(reconciled.rooms)
+      }
+
+      // install_id is the first machine-stable identity available after a
+      // cold roster load. Publish once when that inventory changes so legacy
+      // room members gain stable ids; payload equality makes later polls free.
+      const sourceFingerprint = data.sources
+        .map(source => `${String(source?.connectionId || '')}:${String(source?.installId || '')}`)
+        .sort()
+        .join('|')
+
+      if (sourceFingerprint && sourceFingerprint !== groupChatSyncSourceFingerprint) {
+        groupChatSyncSourceFingerprint = sourceFingerprint
+        scheduleGroupChatServerSync(
+          reconciled.changed ? reconciled.rooms : $groupChats.get(),
+          { changedRooms: reconciled.changedRooms }
+        )
+      }
     }
     mergeServerMeta(activeSourceRoster, data?.fetchedAt || 0)
     pullServerAvatars(activeSourceRoster)
@@ -15009,7 +15203,15 @@ export default {
           // must hydrate the gateway projection instead of merely avoiding an
           // empty overwrite and then rendering an empty conversation.
           await pullGroupChatServerState().catch(() => false)
-          scheduleGroupChatServerSync($groupChats.get())
+          const reconciled = reconcileKnownGroupChatMembers()
+
+          if (reconciled.changed) {
+            $groupChats.set(reconciled.rooms)
+            await persistGroupChatRooms(reconciled.rooms)
+          }
+          scheduleGroupChatServerSync(reconciled.changed ? reconciled.rooms : $groupChats.get(), {
+            changedRooms: reconciled.changedRooms
+          })
         })
         .catch(() => undefined)
     } catch {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -204,7 +204,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, rebindKnownGroupChatMembers, canonicalizeResolvableGroupChatMembers, reconcileKnownGroupChatMembers, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, $lastSources, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -631,6 +631,202 @@ test('group gateway mirror is size bounded and favors recent messages', () => {
   assert.ok(snapshot.rooms['name:Large'].log.length <= 16)
   assert.match(snapshot.rooms['name:Large'].log.at(-1).text, /^99:/)
   assert.ok(snapshot.rooms['name:Large'].log.at(-1).text.length <= 1200)
+})
+
+test('group gateway mirror gives members stable machine identities', () => {
+  const gc = load(() => '(pass)')
+  gc.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'macbook-install' },
+    { connectionId: 'mac-mini', kind: 'ssh', label: 'Mac Mini', installId: 'mini-install' }
+  ])
+
+  const snapshot = gc.groupChatSyncSnapshot({
+    Shared: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [
+        { name: 'default', connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', sourceScoped: true },
+        { name: 'default', connectionId: 'mac-mini', connectionKind: 'ssh', connectionLabel: 'Mac Mini', sourceScoped: true }
+      ]
+    }
+  })
+
+  assert.equal(
+    JSON.stringify(snapshot.rooms['name:Shared'].members.map(member => member.sourceInstallId)),
+    JSON.stringify(['macbook-install', 'mini-install'])
+  )
+  assert.ok(snapshot.rooms['name:Shared'].members.every(member => !('connectionId' in member)))
+})
+
+test('synced group members rebind to this Desktop connection ids', () => {
+  const gc = load(() => '(pass)')
+  gc.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'mini-install' },
+    { connectionId: 'macbook', kind: 'ssh', label: 'MacBook', installId: 'macbook-install' }
+  ])
+  gc.$lastRoster.set([
+    { name: 'default', connectionId: 'local', handle: 'default-this-device' },
+    { name: 'default', connectionId: 'macbook', handle: 'default-macbook' }
+  ])
+
+  const merged = gc.mergeRemoteGroupChatSnapshotIntoRooms({
+    version: 3,
+    rooms: {
+      'name:Shared': {
+        name: 'Shared',
+        revision: 2,
+        log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+        members: [
+          {
+            name: 'default',
+            connectionId: 'local',
+            connectionKind: 'local',
+            connectionLabel: 'This device',
+            sourceInstallId: 'macbook-install',
+            sourceScoped: true
+          },
+          {
+            name: 'default',
+            connectionId: 'mac-mini',
+            connectionKind: 'ssh',
+            connectionLabel: 'Mac Mini',
+            sourceInstallId: 'mini-install',
+            sourceScoped: true
+          }
+        ]
+      }
+    }
+  }, {})
+
+  assert.equal(
+    JSON.stringify(merged.Shared.members.map(member => ({
+      connectionId: member.connectionId,
+      connectionLabel: member.connectionLabel,
+      handle: member.handle,
+      remoteSource: member.remoteSource
+    }))),
+    JSON.stringify([
+      { connectionId: 'macbook', connectionLabel: 'MacBook', handle: 'default-macbook', remoteSource: true },
+      { connectionId: 'local', connectionLabel: 'This device', handle: 'default-this-device', remoteSource: false }
+    ])
+  )
+})
+
+test('synced group members rebind after the source inventory arrives late', () => {
+  const gc = load(() => '(pass)')
+  const imported = gc.mergeRemoteGroupChatSnapshotIntoRooms({
+    version: 3,
+    rooms: {
+      'name:Shared': {
+        name: 'Shared',
+        revision: 1,
+        log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+        members: [{ name: 'default', sourceInstallId: 'macbook-install', sourceScoped: true }]
+      }
+    }
+  }, {})
+
+  assert.equal(imported.Shared.members[0].connectionId, undefined)
+  assert.equal(imported.Shared.members[0].remoteSource, true)
+
+  gc.$lastSources.set([
+    { connectionId: 'macbook', kind: 'ssh', label: 'MacBook', installId: 'macbook-install' }
+  ])
+  gc.$lastRoster.set([
+    { name: 'default', connectionId: 'macbook', handle: 'default-macbook' }
+  ])
+  const rebound = gc.rebindKnownGroupChatMembers(imported)
+
+  assert.equal(rebound.changed, true)
+  assert.equal(rebound.rooms.Shared.members[0].connectionId, 'macbook')
+  assert.equal(rebound.rooms.Shared.members[0].handle, 'default-macbook')
+})
+
+test('legacy room membership canonicalizes only on the origin connection registry', () => {
+  const origin = load(() => '(pass)')
+  origin.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'macbook-install' },
+    { connectionId: 'mac-mini', kind: 'ssh', label: 'Mac Mini', installId: 'mini-install' }
+  ])
+  const rooms = {
+    Shared: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [
+        { name: 'default', connectionId: 'local', sourceScoped: true },
+        { name: 'default', connectionId: 'mac-mini', sourceScoped: true }
+      ]
+    }
+  }
+  const canonical = origin.canonicalizeResolvableGroupChatMembers(rooms)
+
+  assert.equal(JSON.stringify(canonical.changedRooms), JSON.stringify(['Shared']))
+  assert.equal(
+    JSON.stringify(canonical.rooms.Shared.members.map(member => member.sourceInstallId)),
+    JSON.stringify(['macbook-install', 'mini-install'])
+  )
+
+  const peer = load(() => '(pass)')
+  peer.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'mini-install' },
+    { connectionId: 'macbook', kind: 'ssh', label: 'MacBook', installId: 'macbook-install' }
+  ])
+  const untouched = peer.canonicalizeResolvableGroupChatMembers(rooms)
+
+  assert.equal(untouched.changedRooms.length, 0)
+  assert.equal(untouched.rooms.Shared, rooms.Shared)
+})
+
+test('canonical membership collapses legacy and stable copies of the same machines', () => {
+  const gc = load(() => '(pass)')
+  gc.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'macbook-install' },
+    { connectionId: 'mac-mini', kind: 'ssh', label: 'Mac Mini', installId: 'mini-install' }
+  ])
+  const rooms = {
+    Shared: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [
+        { name: 'default', connectionId: 'local' },
+        { name: 'default', connectionId: 'mac-mini' },
+        { name: 'default', sourceInstallId: 'mini-install' }
+      ]
+    }
+  }
+  const canonical = gc.canonicalizeResolvableGroupChatMembers(rooms)
+  const snapshot = gc.groupChatSyncSnapshot(canonical.rooms)
+
+  assert.equal(canonical.rooms.Shared.members.length, 2)
+  assert.equal(snapshot.rooms['name:Shared'].members.length, 2)
+  assert.equal(
+    JSON.stringify(snapshot.rooms['name:Shared'].members.map(member => member.sourceInstallId).sort()),
+    JSON.stringify(['macbook-install', 'mini-install'])
+  )
+})
+
+test('late room hydration replaces legacy aliases with one stable member per machine', () => {
+  const gc = load(() => '(pass)')
+
+  // The roster can finish before storage/server room hydration on a cold boot.
+  gc.$lastSources.set([
+    { connectionId: 'local', kind: 'local', label: 'This device', installId: 'macbook-install' },
+    { connectionId: 'mac-mini', kind: 'ssh', label: 'Mac Mini', installId: 'mini-install' }
+  ])
+  const reconciled = gc.reconcileKnownGroupChatMembers({
+    Shared: {
+      log: [{ id: 'm1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      members: [
+        { name: 'default', connectionId: 'local' },
+        { name: 'default', connectionId: 'mac-mini' },
+        { name: 'default', sourceInstallId: 'mini-install', sourceScoped: true }
+      ]
+    }
+  })
+
+  assert.equal(reconciled.changed, true)
+  assert.equal(reconciled.rooms.Shared.members.length, 2)
+  assert.equal(
+    JSON.stringify(reconciled.rooms.Shared.members.map(member => member.sourceInstallId).sort()),
+    JSON.stringify(['macbook-install', 'mini-install'])
+  )
 })
 
 test('group gateway mirror preserves threads and budgets escaped Unicode', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -30,7 +30,7 @@ function load() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, knownGroups, stripPreviewMarkdown, $groupChats };\n'
+      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, knownGroups, stripPreviewMarkdown, $groupChats, $lastSources };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   return context.__groups
@@ -151,6 +151,32 @@ test('groupChatMemberBots: stored descriptors beat presentation-only ghosts', ()
   assert.equal(members.length, 1)
   assert.equal(members[0], stored)
   assert.equal(members[0].handle, 'spark-work')
+})
+
+test('groupChatMemberBots: stable install identity dedupes device-relative connection ids', () => {
+  const { groupChatMemberBots, $groupChats, $lastSources } = load()
+  const local = { name: 'default', connectionId: 'local' }
+  const macbook = { name: 'default', connectionId: 'macbook' }
+  $lastSources.set([
+    { connectionId: 'local', kind: 'local', installId: 'mini-install' },
+    { connectionId: 'macbook', kind: 'ssh', installId: 'macbook-install' }
+  ])
+  $groupChats.set({
+    Research: {
+      log: [],
+      members: [
+        { name: 'default', connectionId: 'local', sourceInstallId: 'macbook-install' },
+        { name: 'default', connectionId: 'mac-mini', sourceInstallId: 'mini-install' }
+      ]
+    }
+  })
+
+  const members = groupChatMemberBots('Research', [local, macbook], {
+    'macbook::default': { group: 'Research' }
+  })
+
+  assert.equal(members.length, 2)
+  assert.equal(JSON.stringify(members.map(member => member.connectionId).sort()), JSON.stringify(['local', 'macbook']))
 })
 
 test('durableGroupChatMembers: retains active and remote source identities', () => {


### PR DESCRIPTION
## What does this PR do?

Group-chat rooms are mirrored between Desktops through the gateway, but each member is stored with the `connectionId` of the Desktop that wrote it — `local`, or whatever the user named their SSH connection. Those ids are device-relative. When the other machine hydrates the room, `local` now points at *itself* and the SSH id resolves to nothing, so the room seats the wrong backends and the two Desktops keep rewriting each other's membership.

Fix: carry the backend's stable `install_id` on each synced member — the same identity #88828 / #88922 already use to collapse roster rows — and rebind to local connection ids on hydration.

- SSH inventory reads the remote `install_id` next to the profile list and publishes it on the source row (`probeRemoteHermesInstallId` in `remote-lifecycle.ts`; `probeSshProfileInventory` / `enumerateRegistryAgentSources` in `main.ts`).
- The shared projection emits `{ name, sourceInstallId }` for members whose machine identity is known. Device-local ids and labels never enter the mirror.
- On hydration, `rebindSyncedGroupMember()` maps a member back to this Desktop's connection registry by `install_id`.
- Legacy rooms (members without `sourceInstallId`) are canonicalized once, only on the machine where every old connection id still resolves, so the origin publishes one higher-revision membership and peers converge on it instead of flapping.
- Seat/dedupe (`groupChatMemberBots`, `durableGroupChatMembers`) keys on the install identity, so a machine reachable under two connection ids appears once.

Sources and persisted rooms hydrate independently at startup, so reconciliation runs when either arrives (`reconcileKnownGroupChatMembers`) and publishes when the source fingerprint changes.

## Related Issue

No open issue covers cross-machine room membership. The mirror itself came from #89796 / #89800 (server-side room sync); this fixes what it carries. Builds on the identity work merged in #88828 and #88922.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/remote-lifecycle.ts` — `probeRemoteHermesInstallId()`
- `apps/desktop/electron/main.ts` — SSH inventory returns the probed install id; source row carries `installId`
- `apps/desktop/src/plugins/hermes-bots/plugin.js` — install_id-keyed projection, rebind, canonicalization, seat/dedupe
- `apps/desktop/electron/remote-lifecycle.test.ts`, `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`, `tests/roster-groups.test.mjs` — tests for projection, rebind (early and late source arrival), legacy canonicalization, dedupe

## How to Test

1. Two machines, Desktop on both, each registered on the other over SSH. On machine A create a group chat with A's bot and B's bot.
2. Open the same room on B. Before: B's copy seats `local` as its own bot and cannot resolve A's SSH id — turns route to the wrong backend or nowhere, and each side keeps rewriting the room. After: both sides show the same two machines and turns reach the right backend from either side.
3. Restart either Desktop; membership stays stable.
4. `cd apps/desktop && node --test src/plugins/hermes-bots/tests/*.test.mjs && npx vitest run electron/remote-lifecycle.test.ts`

Verified on macOS 26 (MacBook + Mac mini over SSH) with both directions of a shared room after restarts on each side.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `scripts/run_tests.sh` on macOS: 36,405 passed, 134 failed, all in Python files this PR does not touch (this PR changes no Python). The failures are local-environment: `security.allow_lazy_installs=false` in my config, optional extras not installed (`fal_client`, `hindsight_client_api`), `AF_UNIX path too long` on macOS temp paths.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, two-machine Desktop setup

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
