### PR TITLE
fix(gateway): repair computer_use screenshot paths before send_message/yb_send_dm media extraction

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3457,6 +3457,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                messages=messages,
             )
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2525,6 +2525,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            messages=messages,
                         )
 
                 (
@@ -2607,6 +2608,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            messages=messages,
                         )
 
                 (

--- a/model_tools.py
+++ b/model_tools.py
@@ -1189,6 +1189,14 @@ def _emit_post_tool_call_hook(
         logger.debug("post_tool_call hook error: %s", _hook_err)
 
 
+# Tools that can forward an already-emitted computer_use screenshot path
+# mid-turn (via a MEDIA: tag in a message/text argument) and therefore need
+# `messages` to run gateway/media_repair.py's model-mangled-path repair
+# before their own media extraction runs — see tools/send_message_tool.py
+# and tools/yuanbao_tools.py::_handle_yb_send_dm.
+_MEDIA_REPAIR_ELIGIBLE_TOOL_NAMES = frozenset({"send_message", "yb_send_dm"})
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -1205,6 +1213,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    messages: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1226,6 +1235,12 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        messages: Current conversation messages, forwarded only to tools in
+                       ``_MEDIA_REPAIR_ELIGIBLE_TOOL_NAMES`` so they can
+                       recover a model-mangled computer_use screenshot path
+                       before extracting media. ``None`` for callers that
+                       don't have a live conversation (CLI one-shot send,
+                       MCP server) — those tools just skip the repair.
 
     Returns:
         Function result as a JSON string.
@@ -1500,6 +1515,21 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                    )
+            elif function_name in _MEDIA_REPAIR_ELIGIBLE_TOOL_NAMES:
+                # These tools can forward an already-emitted computer_use
+                # screenshot mid-turn (a MEDIA: tag in their message/text
+                # argument). They need conversation `messages` to run the
+                # same model-mangled-path repair the turn-completion delivery
+                # surfaces apply (gateway/media_repair.py) before the model's
+                # path gets validated and possibly dropped.
+                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    return registry.dispatch(
+                        function_name, next_args,
+                        task_id=task_id,
+                        session_id=session_id,
+                        user_task=user_task,
+                        messages=messages,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2112,6 +2112,7 @@ class TestConcurrentToolExecution:
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
                 tool_request_middleware_trace=[],
+                messages=None,
             )
             assert result == "result"
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -356,6 +356,66 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_forwarded_computer_use_screenshot_path_is_repaired_before_extraction(self):
+        # A model that just ran computer_use and forwards the screenshot via
+        # send_message (instead of putting MEDIA: in its own final response)
+        # can mangle the absolute path the same way it can in a final turn
+        # response. The turn-completion delivery surfaces already repair
+        # this (gateway/run.py, cron/scheduler.py); send_message must too,
+        # using the `messages` conversation history passed through
+        # model_tools.handle_function_call for tools in
+        # _MEDIA_REPAIR_ELIGIBLE_TOOL_NAMES.
+        from gateway.platforms.base import BasePlatformAdapter
+
+        config, telegram_cfg = _make_config()
+        basename_hex = "a" * 32
+        canonical_path = (
+            f"C:\\Users\\Alice\\AppData\\Local\\Hermes\\cache\\computer_use_{basename_hex}.png"
+        )
+        mangled_path = (
+            f"/Users/Alice/AppData/Local/Hermes/cache/computer_use_{basename_hex}.png"
+        )
+        conversation_messages = [
+            {"role": "user", "content": "take a screenshot and DM it to alice"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "computer_use",
+                "content": (
+                    "Screenshot captured. "
+                    f"(shareable screenshot saved to {canonical_path})"
+                ),
+            },
+        ]
+
+        real_extract_media = BasePlatformAdapter.extract_media
+        captured: dict = {}
+
+        def _spy_extract_media(content):
+            captured["content"] = content
+            return real_extract_media(content)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True), \
+             patch.object(BasePlatformAdapter, "extract_media", staticmethod(_spy_extract_media)):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": f"Here you go\nMEDIA:{mangled_path}",
+                    },
+                    messages=conversation_messages,
+                )
+            )
+
+        assert result["success"] is True
+        assert canonical_path in captured["content"]
+        assert mangled_path not in captured["content"]
+
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
         leaked = "very-secret-query-token-123456"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -258,7 +258,7 @@ def send_message_tool(args, **kw):
     if action == "unreact":
         return _handle_react(args, remove=True)
 
-    return _handle_send(args)
+    return _handle_send(args, messages=kw.get("messages"))
 
 
 def _handle_list():
@@ -360,7 +360,7 @@ def _handle_react(args, remove=False):
     return json.dumps({"success": bool(result)})
 
 
-def _handle_send(args):
+def _handle_send(args, messages=None):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
@@ -434,6 +434,15 @@ def _handle_send(args):
     # instead of send_photo so the original bytes survive (e.g. info-graph
     # JPGs where Telegram's sendPhoto recompresses to 1280px).
     force_document_attachments = "[[as_document]]" in message
+
+    if messages:
+        # A model that just ran computer_use and now forwards that
+        # screenshot via send_message can mangle the absolute path the same
+        # way it can in a final turn response — recover it before media
+        # extraction/validation, mirroring the repair every other delivery
+        # surface (gateway/run.py, cron/scheduler.py) already applies.
+        from gateway.media_repair import repair_explicit_computer_use_media_paths
+        message = repair_explicit_computer_use_media_paths(message, messages)
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)

--- a/tools/yuanbao_tools.py
+++ b/tools/yuanbao_tools.py
@@ -468,6 +468,15 @@ async def _handle_yb_send_dm(args, **kw):
     # Extract MEDIA:<path> tags embedded in the message text (LLM often puts
     # file paths there instead of using the media_files parameter).
     message = args.get("message", "")
+    conversation_messages = kw.get("messages")
+    if conversation_messages:
+        # A model that just ran computer_use and now forwards that
+        # screenshot via yb_send_dm can mangle the absolute path the same
+        # way it can in a final turn response — recover it before media
+        # extraction/validation, mirroring the repair every other delivery
+        # surface (gateway/run.py, cron/scheduler.py) already applies.
+        from gateway.media_repair import repair_explicit_computer_use_media_paths
+        message = repair_explicit_computer_use_media_paths(message, conversation_messages)
     from gateway.platforms.base import BasePlatformAdapter
     embedded_media, message = BasePlatformAdapter.extract_media(message)
     if embedded_media:


### PR DESCRIPTION
## What does this PR do?

`gateway/media_repair.py::repair_explicit_computer_use_media_paths()` recovers a model-mangled `computer_use` screenshot path (e.g. a Windows path rewritten into a POSIX-looking one) before `extract_media`/delivery-path validation runs. It's already wired into every turn-completion delivery surface:

- `gateway/run.py`'s main turn completion path
- `gateway/run.py`'s background task delivery path
- `cron/scheduler.py`'s job delivery path

It was **not** wired into the two tool-invoked, mid-turn delivery paths: `send_message` (`tools/send_message_tool.py`) and the Yuanbao `yb_send_dm` tool (`tools/yuanbao_tools.py`). A model that runs `computer_use`, then forwards that screenshot mid-turn via one of these tools (rather than putting `MEDIA:` in its own final response — a documented use of `send_message` for cross-channel forwarding) hits the same silent-drop failure the other three surfaces were fixed for: the mangled path doesn't exist on disk, delivery-path validation rejects it, and the attachment is dropped with no signal to the model.

### Why this needed touching the tool dispatcher

Unlike the turn-completion surfaces (which already have the full `messages` list in scope via the completed turn's `result` dict), `send_message`/`yb_send_dm` execute *mid-turn* through the generic tool registry (`model_tools.handle_function_call` → `tools/registry.py::dispatch`), which never threaded conversation `messages` down to individual tool handlers.

- `model_tools.handle_function_call` gains an optional `messages` parameter (default `None`, so every other caller — `tools/code_execution_tool.py`, the MCP server, CLI one-shot send — is unaffected).
- A new `_MEDIA_REPAIR_ELIGIBLE_TOOL_NAMES = frozenset({"send_message", "yb_send_dm"})` allowlist scopes `messages` forwarding to just these two tools, so no other tool handler's call signature changes.
- The three call sites that already have `messages` in scope (`agent/agent_runtime_helpers.py::invoke_tool`, `agent/tool_executor.py`'s two inline dispatch paths) now forward it through.
- `send_message_tool._handle_send` and `yuanbao_tools._handle_yb_send_dm` run `repair_explicit_computer_use_media_paths(message, messages)` before `extract_media`, mirroring the existing turn-completion surfaces exactly. When `messages` isn't available (CLI, MCP), the repair is skipped — same as before this change.

### Regression test

Added `test_forwarded_computer_use_screenshot_path_is_repaired_before_extraction`, which builds a `messages` history containing a `computer_use` tool result with a canonical Windows-style capture path, then calls `send_message_tool(..., messages=...)` with a message containing the same screenshot referenced by a POSIX-mangled path. Asserts `extract_media` receives the repaired canonical path, not the mangled one.

Confirmed via mutation testing: with only the test added and the fix reverted, the test fails (`assert canonical_path in captured["content"]` — the mangled path survives, and the real `extract_media`/`filter_media_delivery_paths` chain logs "Skipping unsafe MEDIA directive path" for it). With the fix restored, it passes.

### Related PR

#34178 also touches `tools/send_message_tool.py::_handle_send` around the same `extract_media`/`filter_media_delivery_paths` call, but for a different concern (surfacing a warning when the allowlist drops media *after* extraction, for any reason) — not a duplicate, just textually adjacent. My change inserts a repair step *before* `extract_media` runs; that PR changes the line *after* it. No semantic overlap, but whichever lands second may need a small rebase.

## Test plan

- [x] New regression test added and mutation-verified (fails without the fix, passes with it)
- [x] `tests/tools/test_send_message_tool.py` — 50 passed
- [x] `tests/test_yuanbao_integration.py`, `tests/test_yuanbao_pipeline.py`, `tests/gateway/platforms/test_yuanbao_recall_db_only.py`, `tests/gateway/test_yuanbao_media_ssrf.py` — 89 passed
- [x] `tests/test_model_tools.py`, `tests/test_model_tools_async_bridge.py`, `tests/agent/test_tool_executor_checkpoint_paths.py`, `tests/run_agent/test_tool_executor_contextvar_propagation.py` — 40 passed
- [x] `tests/gateway/test_media_extraction.py`, `tests/gateway/test_platform_base.py` — 107 passed, 1 skipped (pre-existing)
- [x] Broad tool-dispatch regression sweep (`tests/run_agent/*`, `tests/agent/test_memory_provider.py`, `tests/tools/test_interrupt.py`) — 436 passed, 1 skipped; one pre-existing exact-kwargs assertion (`test_invoke_tool_dispatches_to_handle_function_call`) updated for the new `messages=None` default