### PR TITLE
fix(codex): coalesce pending Responses calls by call_id

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1292,9 +1292,25 @@ def _consume_codex_event_stream(
                 # The .done event's own output_index wins when present, with
                 # the announced index as its fallback.
                 done_id = str(_item_field(done_item, "id", ""))
+                done_call_id = str(_item_field(done_item, "call_id", "") or "")
+                pending_aliases = []
+                if done_call_id:
+                    pending_aliases = [
+                        (pending_id, pending)
+                        for pending_id, pending in pending_function_calls.items()
+                        if str(_item_field(pending.get("item"), "call_id", "") or "")
+                        == done_call_id
+                    ]
                 announced_sequence, announced_index = announced_output_order.get(
                     done_id, (None, None)
                 )
+                if announced_sequence is None and pending_aliases:
+                    _, announced_alias = min(
+                        pending_aliases,
+                        key=lambda alias: alias[1]["sequence"],
+                    )
+                    announced_sequence = announced_alias["sequence"]
+                    announced_index = announced_alias["output_index"]
                 done_index = _event_field(event, "output_index", None)
                 if done_index is None:
                     done_index = announced_index
@@ -1304,8 +1320,12 @@ def _consume_codex_event_stream(
                 collected_output_indexes.append(done_index)
                 collected_output_sequences.append(announced_sequence)
                 # Confirmed by the authoritative per-item done event; remove
-                # from pending so it is not settled twice.
+                # from pending so it is not settled twice. GitHub Responses
+                # may use a different item id on the .done event, so also
+                # coalesce aliases by the provider's authoritative call_id.
                 pending_function_calls.pop(done_id, None)
+                for pending_id, _pending in pending_aliases:
+                    pending_function_calls.pop(pending_id, None)
                 done_phase = _item_field(done_item, "phase", None)
                 done_phase = done_phase.strip().lower() if isinstance(done_phase, str) else None
                 if done_phase == "commentary" and on_commentary_message is not None:
@@ -1379,15 +1399,12 @@ def _consume_codex_event_stream(
     else:
         output = []
 
-    # Settle function calls that were announced via output_item.added and
-    # streamed argument deltas but never confirmed by output_item.done: some
-    # OpenAI-compatible backends omit per-item done events on a successful
-    # completion (anomalyco/opencode#37159).  Done items stay authoritative;
-    # this only fills the gap so the call executes instead of vanishing.
-    if pending_function_calls and saw_response_completed:
-        # Assemble settled calls and .done items in output_index order instead
-        # of appending at the tail: a pending call that streamed before a later
-        # .done item must keep its position, or dependent side effects invert.
+    # Preserve announced order for confirmed items and settle function calls
+    # that never received output_item.done. Some compatible backends omit done
+    # events entirely; others confirm calls under aliased ids or in a different
+    # order. Done items stay authoritative, but all items retain their original
+    # output_index/sequence so dependent side effects cannot invert.
+    if saw_response_completed and (collected_output_items or pending_function_calls):
         indexed = [
             (index, sequence, position, item)
             for position, (index, sequence, item) in enumerate(

--- a/tests/agent/test_codex_responses_settle_pending_tool_calls.py
+++ b/tests/agent/test_codex_responses_settle_pending_tool_calls.py
@@ -120,6 +120,94 @@ def test_control_stream_with_done_still_authoritative():
     assert final.status == "completed"
 
 
+def test_done_call_coalesces_pending_alias_with_same_call_id():
+    """GitHub Responses may use different item ids for added and done events."""
+    events = _stream_completed_without_done()
+    events.insert(
+        -1,
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1_done",
+                call_id="call_1",
+                name="get_weather",
+                arguments='{"city": "SF"}',
+            ),
+        ),
+    )
+    final = _consume_codex_event_stream(events, model="gpt-test")
+
+    calls = [
+        item
+        for item in final.output
+        if getattr(item, "type", "") == "function_call"
+    ]
+    assert len(calls) == 1
+    assert calls[0].id == "fc_1_done"
+    assert calls[0].arguments == '{"city": "SF"}'
+
+
+def test_done_aliases_preserve_announced_order_without_output_indexes():
+    """Aliased done ids must inherit the calls' announced sequence."""
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_a",
+                call_id="call_a",
+                name="tool_A",
+                arguments="",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_b",
+                call_id="call_b",
+                name="tool_B",
+                arguments="",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_b_done",
+                call_id="call_b",
+                name="tool_B",
+                arguments='{"step": 2}',
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_a_done",
+                call_id="call_a",
+                name="tool_A",
+                arguments='{"step": 1}',
+            ),
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(id="resp_1", status="completed", output=None),
+        ),
+    ]
+
+    final = _consume_codex_event_stream(events, model="gpt-test")
+    calls = [
+        item
+        for item in final.output
+        if getattr(item, "type", "") == "function_call"
+    ]
+
+    assert [call.id for call in calls] == ["fc_a_done", "fc_b_done"]
+
+
 def test_no_terminal_frame_does_not_settle_pending_function_call():
     """EOF/interruption before any terminal frame must NOT settle the pending
     call: unconfirmed stream state must not become executable authority.


### PR DESCRIPTION
## What does this PR do?

Prevents the Codex/OpenAI Responses SSE accumulator from settling one function call twice when `response.output_item.added` and `response.output_item.done` use different item IDs for the same `call_id`.

Pending calls are keyed by the item ID announced in `.added`. The existing `.done` handler removes only `done_item.id`, so a provider alias leaves the original pending entry behind. `response.completed` then settles that stale entry a second time. The fix keeps the item-ID fast path and also removes pending aliases matching the authoritative done item's `call_id`.

This preserves the intended fallback introduced by `720344cfb` for backends that genuinely omit `.done` while preventing duplicate settlement when `.done` is present under another item ID.

## Related Issue

Fixes #94707. Related identity-alias context: #93404, but this PR fixes an earlier and separate Responses accumulator path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Coalesce pending Responses function-call aliases by `call_id` when an authoritative `.done` item arrives.
- Add a deterministic regression test where added and done item IDs differ but `call_id` is stable.

## How to Test

1. `uv run pytest -q tests/agent/test_codex_responses_settle_pending_tool_calls.py`
2. `uv run pytest -q $(rg --files tests/agent | rg 'codex|responses')`
3. `uv run ruff check agent/codex_runtime.py tests/agent/test_codex_responses_settle_pending_tool_calls.py`
4. `git diff --check`

Results on `1bbb6e5bce56e721ab685af4cd87df21bbff4d35`:

- Focused tests: `9 passed`
- Codex/Responses-related tests: `287 passed`
- Ruff: passed
- Diff check: passed
- Full `tests/` collection is blocked here by missing optional `acp` and `aiohttp` dependencies (30 collection errors outside the touched paths).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs/issues; #93404 and #93769 affect downstream pairing/sanitization rather than this accumulator path
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` (blocked by the optional dependencies noted above)
- [x] I've added tests for my changes
- [x] I've tested on Linux with Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: provider-neutral Python logic and synthetic test
- [x] Tool descriptions/schemas: N/A