### PR TITLE
feat(sessions): date-range filters for \sessions list\ (--after/--before)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13561,6 +13561,18 @@ def main():
         help="Only sessions in one workspace: a git repo root or project dir "
         "(matched by path substring or basename).",
     )
+    sessions_list.add_argument(
+        "--after",
+        metavar="TIME",
+        help="Only sessions started at/after TIME — inclusive lower bound "
+        "(duration ago like '5h', or ISO timestamp like '2026-08-01').",
+    )
+    sessions_list.add_argument(
+        "--before",
+        metavar="TIME",
+        help="Only sessions started before TIME — exclusive upper bound "
+        "(duration ago like '5h', or ISO timestamp).",
+    )
 
     def _add_session_filter_args(p, default_older_help):
         p.add_argument(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -328,9 +328,39 @@ def cmd_sessions(args, sessions_parser=None):
 
     if action == "list":
         from hermes_state import workspace_key as _ws_key
+        from hermes_cli.session_filters import parse_point_in_time
+
+        # Explicit start-time window (#91900): --after inclusive, --before
+        # exclusive — same vocabulary and parsing as archive/prune/export.
+        started_after = None
+        started_before = None
+        _after_raw = getattr(args, "after", None)
+        _before_raw = getattr(args, "before", None)
+        try:
+            if _after_raw:
+                started_after = parse_point_in_time(_after_raw, "--after")
+            if _before_raw:
+                started_before = parse_point_in_time(_before_raw, "--before")
+        except ValueError as e:
+            print(f"Error: {e}")
+            return
+        if (
+            started_after is not None
+            and started_before is not None
+            and started_after >= started_before
+        ):
+            print(
+                f"Error: --after ({_after_raw}) is not earlier than "
+                f"--before ({_before_raw})."
+            )
+            return
 
         sessions = db.list_sessions_rich(
-            source=args.source, exclude_sources=_exclude, limit=args.limit
+            source=args.source,
+            exclude_sources=_exclude,
+            limit=args.limit,
+            started_after=started_after,
+            started_before=started_before,
         )
 
         # Workspace filter: match a session by its workspace key (git repo

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9833,6 +9833,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         offset: int = 0,
         include_children: bool = False,
         min_message_count: int = 0,
+        started_after: float = None,
+        started_before: float = None,
         project_compression_tips: bool = True,
         order_by_last_active: bool = False,
         include_archived: bool = False,
@@ -9941,6 +9943,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
+        # Explicit start-time window (#91900): --after is the inclusive lower
+        # bound, --before the exclusive upper bound — matching the archive /
+        # prune / export vocabulary.
+        if started_after is not None:
+            where_clauses.append("s.started_at >= ?")
+            params.append(started_after)
+        if started_before is not None:
+            where_clauses.append("s.started_at < ?")
+            params.append(started_before)
         if archived_only:
             where_clauses.append("s.archived = 1")
         elif not include_archived:

--- a/tests/hermes_cli/test_sessions_list_date_filters.py
+++ b/tests/hermes_cli/test_sessions_list_date_filters.py
@@ -1,0 +1,147 @@
+"""``hermes sessions list --after/--before`` date-window filters (#91900).
+
+Non-mutating metadata listing bounded by session START time: ``--after``
+is the inclusive lower bound, ``--before`` the exclusive upper bound —
+the same vocabulary and parsing the archive/prune/export commands
+already use (``session_filters.parse_point_in_time``).
+
+Drives a real SessionDB against a temp HERMES_HOME; the CLI handler is
+exercised through its public entry with an argparse-style namespace.
+"""
+
+import types
+
+import pytest
+
+from hermes_cli.session_filters import parse_point_in_time
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = SessionDB(db_path=tmp_path / "state.db")
+    return database
+
+
+def _add_session(database, sid, started_at):
+    database.create_session(sid, source="cli")
+    # Backdate started_at (same sanctioned pattern as test_hermes_state).
+    database._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?", (started_at, sid)
+    )
+    database._conn.commit()
+
+
+def test_list_sessions_rich_started_window_bounds(db):
+    base = 1_700_000_000.0
+    _add_session(db, "old", base - 100)
+    _add_session(db, "in1", base)
+    _add_session(db, "in2", base + 50)
+    _add_session(db, "new", base + 10_000)
+
+    rows = db.list_sessions_rich(
+        limit=50, started_after=base, started_before=base + 10_000
+    )
+    ids = {r["id"] for r in rows}
+    # --after inclusive, --before exclusive.
+    assert ids == {"in1", "in2"}
+
+
+def test_list_sessions_rich_open_ended_bounds(db):
+    base = 1_700_000_000.0
+    _add_session(db, "old", base - 100)
+    _add_session(db, "new", base + 5)
+
+    only_after = {
+        r["id"] for r in db.list_sessions_rich(limit=50, started_after=base)
+    }
+    assert only_after == {"new"}
+
+    only_before = {
+        r["id"] for r in db.list_sessions_rich(limit=50, started_before=base)
+    }
+    assert only_before == {"old"}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CLI handler wiring
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _run_list(db, monkeypatch, capsys, **extra):
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    ns = types.SimpleNamespace(
+        sessions_action="list",
+        source=None,
+        limit=20,
+        workspace=None,
+        after=None,
+        before=None,
+        **extra,
+    )
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda *a, **k: db, raising=False
+    )
+    # cmd_sessions opens its own SessionDB via get_hermes_home; the env var
+    # fixture above already redirects it.
+    import hermes_state as hs
+
+    monkeypatch.setattr(hs.SessionDB, "__init__", lambda self, *a, **k: None) if False else None
+    rc = cmd_sessions(ns)
+    out = capsys.readouterr().out
+    return rc, out
+
+
+def test_cli_list_filters_by_date_window(db, tmp_path, monkeypatch, capsys):
+    from datetime import datetime, timezone as dt_timezone
+
+    aug5 = datetime(2026, 8, 5, 12, 0, tzinfo=dt_timezone.utc).timestamp()
+    _add_session(db, "aug1", aug5)
+    _add_session(db, "aug20", aug5 + 15 * 86400)
+
+    ns = types.SimpleNamespace(
+        sessions_action="list",
+        source=None,
+        limit=20,
+        workspace=None,
+        after="2026-08-01",
+        before="2026-08-10",
+    )
+    # cmd_sessions imports SessionDB inside the function; patch the
+    # module-level symbol it resolves at call time.
+    import hermes_state as hs
+
+    monkeypatch.setattr(hs, "SessionDB", lambda *a, **k: db)
+
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    cmd_sessions(ns)
+    out = capsys.readouterr().out
+    assert "aug1" in out
+    assert "aug20" not in out, "--before must be exclusive"
+
+
+def test_cli_list_rejects_inverted_window(db, tmp_path, monkeypatch, capsys):
+    import hermes_state as hs
+
+    monkeypatch.setattr(hs, "SessionDB", lambda *a, **k: db)
+    ns = types.SimpleNamespace(
+        sessions_action="list",
+        source=None,
+        limit=20,
+        workspace=None,
+        after="2026-08-08",
+        before="2026-08-01",
+    )
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    cmd_sessions(ns)
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "not earlier than" in out
+
+
+def test_parse_point_in_time_rejects_garbage():
+    with pytest.raises(ValueError):
+        parse_point_in_time("not-a-date", "--after")


### PR DESCRIPTION
## What does this PR do?

Adds non-mutating date-range filters to `hermes sessions list`, exactly as specified in the issue:

```bash
hermes sessions list --after "2026-08-01" --before "2026-08-08"
```

- `--after` = **inclusive** lower bound on session start time; `--before` = **exclusive** upper bound;
- accepts the same formats the sibling commands already use (durations like `5h`, ISO dates/datetimes) via the shared `session_filters.parse_point_in_time`;
- composes with `--source`, `--workspace`, and `--limit`; behavior with neither flag is byte-identical to today;
- inverted windows (`--after` not earlier than `--before`) are rejected with a clear error instead of silently returning nothing.

The window is enforced at SQL level: `SessionDB.list_sessions_rich()` gains optional `started_after` / `started_before` parameters. Because the pinned-conversation back-fill reuses the same WHERE clause, pinned sessions obey the window exactly like the page — a date-filtered listing can't resurrect out-of-window rows through the pin path.

This closes the gap where archive/prune/export spoke the explicit-bound vocabulary but the only read-only browsing surface did not.

## Related Issue

Fixes #91900

## Type of Change

- [x] ✨ New feature (non-breaking, adds CLI filtering capability)
- [x] 🧪 Tests

## Changes Made

- `hermes_state.py` — `list_sessions_rich(..., started_after=None, started_before=None)`: optional SQL bounds on `s.started_at` (`>=` / `<`), inserted before the WHERE snapshot so the pinned back-fill inherits them.
- `hermes_cli/main.py` — `sessions list` gains `--after TIME` / `--before TIME` arguments documenting inclusivity/exclusivity and accepted formats.
- `hermes_cli/sessions_cmd.py` — the `list` branch parses both flags through `session_filters.parse_point_in_time`, validates ordering, and passes the resolved epochs into the DB call.
- `tests/hermes_cli/test_sessions_list_date_filters.py` — 5 tests against a real SessionDB in a temp HERMES_HOME:
  - closed window returns only in-range ids (inclusive start / exclusive end);
  - open-ended windows (`--after` only, `--before` only);
  - CLI end-to-end: seeded Aug-5 session listed, Aug-20 excluded under an Aug-1…Aug-10 window;
  - inverted window rejected with "not earlier than" error;
  - garbage timestamps raise the shared parse error.

## How to Test

1. `uv run python -m pytest tests/hermes_cli/test_sessions_list_date_filters.py -q` → 5 passed.
2. State-layer neighbors: `uv run python -m pytest tests/test_hermes_state.py -q` → 243 passed, 2 skipped.
3. `ruff check hermes_state.py hermes_cli/sessions_cmd.py hermes_cli/main.py tests/hermes_cli/test_sessions_list_date_filters.py` → clean.
4. Manual: seed a couple of sessions across days, then `hermes sessions list --after 2026-08-01 --before 2026-08-08` lists only the in-window ones.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Flag help text documents formats and bound semantics
- [x] cli-config.yaml.example N/A · CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A
