### PR TITLE
fix(tools): enforce browser.backend=off at browser_exec invocation time

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -1120,6 +1120,34 @@ def test_browser_exec_fails_closed_when_backend_off(monkeypatch):
     assert "browser.backend is off" in out
 
 
+def test_browser_exec_kill_switch_precedes_url_blocklist(monkeypatch):
+    """When the backend is off and the code also carries a blocked URL, the
+    backend-off refusal wins: the kill switch runs first, and the reply must
+    not leak that the URL blocklist would also have fired (#94702 review)."""
+    monkeypatch.setattr(
+        bu_cli, "get_browser_backend", lambda: bu_cli.BACKEND_DISABLED
+    )
+
+    def must_not_run():
+        raise AssertionError(
+            "disabled browser_exec still tried to resolve the CLI"
+        )
+
+    monkeypatch.setattr(bu_cli, "_find_cli", must_not_run)
+
+    def blocklist_must_not_run(code):
+        raise AssertionError(
+            "URL blocklist was consulted while the kill switch had already refused"
+        )
+
+    monkeypatch.setattr(bu_cli, "_blocked_url_in_code", blocklist_must_not_run)
+
+    out = bu_cli.browser_exec('new_tab("https://definitely-blocked.example")')
+
+    assert isinstance(out, str)
+    assert "browser.backend is off" in out
+
+
 def test_browser_exec_still_runs_when_backend_enabled(monkeypatch):
     """The kill switch must not fire for an enabled backend: resolve the
     CLI path normally (the exec itself is stubbed at the subprocess seam)."""

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -1092,3 +1092,53 @@ class TestDefaultDowngradeNotice:
         )
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: None)
         assert bu_cli.default_downgrade_notice() is None
+
+
+def test_browser_exec_fails_closed_when_backend_off(monkeypatch):
+    """#94702: browser.backend=off is an invocation-time kill switch.
+
+    A conversation's tool schema is intentionally stable, so browser_exec can
+    stay advertised after the operator disables the backend. The handler must
+    refuse before any CLI lookup or subprocess launch — mirroring the issue's
+    deterministic repro (a disabled backend with a _find_cli that must never
+    run).
+    """
+    monkeypatch.setattr(
+        bu_cli, "get_browser_backend", lambda: bu_cli.BACKEND_DISABLED
+    )
+
+    def must_not_run():
+        raise AssertionError(
+            "disabled browser_exec still tried to resolve the CLI"
+        )
+
+    monkeypatch.setattr(bu_cli, "_find_cli", must_not_run)
+
+    out = bu_cli.browser_exec("print(page_info())")
+
+    assert isinstance(out, str)
+    assert "browser.backend is off" in out
+
+
+def test_browser_exec_still_runs_when_backend_enabled(monkeypatch):
+    """The kill switch must not fire for an enabled backend: resolve the
+    CLI path normally (the exec itself is stubbed at the subprocess seam)."""
+    import subprocess
+
+    monkeypatch.setattr(bu_cli, "get_browser_backend", lambda: "browser-use")
+    monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["browser-use"])
+
+    ran = {}
+
+    def fake_run(cmd, **kwargs):
+        ran["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout='{"ok": true}', stderr=""
+        )
+
+    monkeypatch.setattr(bu_cli.subprocess, "run", fake_run)
+
+    out = bu_cli.browser_exec("print(page_info())")
+
+    assert ran["cmd"] == ["browser-use"]
+    assert "ok" in out

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -611,6 +611,18 @@ def browser_exec(
     if not code or not code.strip():
         return tool_error("No code provided. Pass Python that uses the pre-imported helpers, e.g. new_tab(\"https://example.com\") then print(page_info()).")
 
+    # ``browser.backend=off`` is an invocation-time kill switch, not just a
+    # schema-time filter. A conversation's tool schema is intentionally
+    # stable (prompt caching), so browser_exec can stay advertised after the
+    # operator disables the backend — the handler must fail closed before
+    # any CLI lookup or subprocess launch (#94702).
+    if get_browser_backend() == BACKEND_DISABLED:
+        return tool_error(
+            "browser_exec is disabled: browser.backend is off. Re-enable a "
+            "backend (e.g. `hermes config set browser.backend browser-use`) "
+            "to use browser automation."
+        )
+
     blocked = _blocked_url_in_code(code)
     if blocked:
         return tool_error(blocked)


### PR DESCRIPTION
## What does this PR do?

`browser.backend=off` is advertised as an explicit kill switch, but `browser_exec`'s handler never re-checked it: the tool's `check_fn` (`is_browser_use_cli_mode`) only gates **schema-time** advertisement, and a conversation's tool definitions are intentionally stable for prompt caching. A conversation opened while Browser Use was active kept `browser_exec` in its cached schema, and invoking it after `hermes config set browser.backend off` still resolved and launched the Browser Use CLI — in the reported Windows incident it opened a `chrome://inspect` URL and triggered the OS "get an app to open this link" chooser (#94702).

The fix enforces the kill switch at **invocation time**: the top of `browser_exec()` now returns an actionable tool error when `get_browser_backend()` reports `BACKEND_DISABLED`, before any CLI lookup, backend resolution, or subprocess launch. The cached tool schema stays intact — no prompt-cache invalidation is needed for the operator to disable the backend.

## Related Issue

Fixes #94702

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_use_cli.py` — `browser_exec()` fails closed with an actionable error ("browser_exec is disabled: browser.backend is off. Re-enable a backend ...") when the live backend is `off`.
- `tests/tools/test_browser_use_cli.py` — two regressions: a disabled backend with a `_find_cli` that must never run returns the tool error (mirroring the issue's deterministic repro); an enabled backend still resolves and runs the CLI normally (the kill switch must not over-fire), with the exec stubbed at the subprocess seam.

## How to Test

1. `pytest tests/tools/test_browser_use_cli.py -q` — should pass (97 passed).
2. Observed result: with this PR's source reverted (plain main), the fail-closed test fails — `browser_exec` reaches `_find_cli()` even with the backend off (the issue's `AssertionError: disabled browser_exec still tried to resolve the CLI`); with the change it returns the disabled tool error before any lookup.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Deterministic repro from the issue (against plain main, before this fix):

```python
bu.get_browser_backend = lambda: bu.BACKEND_DISABLED
bu._find_cli = must_not_run            # raises if reached
bu.browser_exec("print(page_info())")
# AssertionError: disabled browser_exec still tried to resolve the CLI
```

After this fix the same call returns the tool error without touching `_find_cli`.
