### PR TITLE
feat(kanban): open worker chats from the task drawer

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -31,6 +31,17 @@ def kanban_stop_nudge_enabled() -> bool:
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
+
+    from agent.delegation_context import (
+        is_delegated_child_process_context,
+        is_dispatcher_owned_worker_context,
+    )
+
+    if (
+        is_delegated_child_process_context()
+        or not is_dispatcher_owned_worker_context()
+    ):
+        return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
     return bool(task)
 

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3922,7 +3922,7 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
-      workerSession && t.status === "running" ? h("div", {
+      workerSession ? h("div", {
         className: "flex items-center gap-2 mb-3",
       },
         h(Button, {

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3874,6 +3874,14 @@
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
     const childResults = props.data.child_results || [];
+    const workerSession = props.data.worker_session || null;
+
+    function openWorkerSession() {
+      if (!workerSession || !workerSession.session_id) return;
+      const params = new URLSearchParams({ resume: workerSession.session_id });
+      if (workerSession.profile) params.set("profile", workerSession.profile);
+      window.open(`/chat?${params.toString()}`, "_blank", "noopener,noreferrer");
+    }
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
@@ -3914,6 +3922,16 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
+      workerSession && t.status === "running" ? h("div", {
+        className: "flex items-center gap-2 mb-3",
+      },
+        h(Button, {
+          size: "sm",
+          variant: "outline",
+          onClick: openWorkerSession,
+          title: tx(i18n, "openWorkChatTitle", "Open this worker session in a new tab"),
+        }, tx(i18n, "openWorkChat", "Open work chat")),
+      ) : null,
       h(StatusActions, {
         task: t,
         onPatch: props.onPatch,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -247,9 +247,6 @@ def _worker_session_dict(
     dispatcher prompt. Fail closed: a missing profile/store/session simply
     hides the UI affordance instead of breaking the task drawer.
     """
-    if task.status != "running":
-        return None
-
     latest_run = runs[-1] if runs else None
     profile = (latest_run.profile if latest_run else None) or task.assignee
     if not profile:
@@ -261,9 +258,15 @@ def _worker_session_dict(
         if isinstance(session_id, str) and session_id.strip():
             return {
                 "session_id": session_id.strip(),
-                "profile": profile,
+                "profile": run.profile or profile,
                 "active": run.ended_at is None,
             }
+
+    # Running workers may not have stamped their session id into run metadata
+    # yet, so resolve the live session from the assignee's store. Completed
+    # runs must use their durable metadata and never guess from an old session.
+    if task.status != "running":
+        return None
 
     try:
         from hermes_cli.profiles import resolve_profile_env

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -235,6 +235,77 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
     }
 
 
+def _worker_session_dict(
+    task: kanban_db.Task,
+    runs: list[kanban_db.Run],
+) -> Optional[dict[str, Any]]:
+    """Resolve the live chat session for one running kanban worker.
+
+    Completed workers stamp ``worker_session_id`` into run metadata. While a
+    worker is still running that handoff may not exist yet, so fall back to the
+    assignee profile's session store and locate the kanban session by its exact
+    dispatcher prompt. Fail closed: a missing profile/store/session simply
+    hides the UI affordance instead of breaking the task drawer.
+    """
+    if task.status != "running":
+        return None
+
+    latest_run = runs[-1] if runs else None
+    profile = (latest_run.profile if latest_run else None) or task.assignee
+    if not profile:
+        return None
+
+    for run in reversed(runs):
+        metadata = run.metadata if isinstance(run.metadata, dict) else {}
+        session_id = metadata.get("worker_session_id")
+        if isinstance(session_id, str) and session_id.strip():
+            return {
+                "session_id": session_id.strip(),
+                "profile": profile,
+                "active": run.ended_at is None,
+            }
+
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+
+        state_db = Path(resolve_profile_env(profile)) / "state.db"
+        if not state_db.is_file():
+            return None
+        session_conn = sqlite3.connect(
+            f"file:{state_db.resolve().as_posix()}?mode=ro",
+            uri=True,
+            timeout=1.0,
+        )
+        session_conn.row_factory = sqlite3.Row
+        try:
+            row = session_conn.execute(
+                """
+                SELECT s.id, s.ended_at
+                FROM sessions AS s
+                JOIN messages AS m ON m.session_id = s.id
+                WHERE s.source = 'kanban'
+                  AND m.role = 'user'
+                  AND m.content = ?
+                ORDER BY (s.ended_at IS NULL) DESC, s.last_activity_at DESC
+                LIMIT 1
+                """,
+                (f"work kanban task {task.id}",),
+            ).fetchone()
+        finally:
+            session_conn.close()
+    except Exception as exc:
+        log.debug("could not resolve worker session for %s: %s", task.id, exc)
+        return None
+
+    if row is None:
+        return None
+    return {
+        "session_id": row["id"],
+        "profile": profile,
+        "active": row["ended_at"] is None,
+    }
+
+
 # Hallucination-warning event kinds — see complete_task() in kanban_db.py.
 # completion_blocked_hallucination: kernel rejected created_cards with
 #   phantom ids; task stays in prior state.
@@ -571,6 +642,12 @@ def get_task(
         if diag_list:
             task_d["diagnostics"] = diag_list
             task_d["warnings"] = _warnings_summary_from_diagnostics(diag_list)
+        runs = kanban_db.list_runs(
+            conn,
+            task_id,
+            state_type=run_state_type,
+            state_name=run_state_name,
+        )
         return {
             "task": task_d,
             "comments": [_comment_dict(c) for c in kanban_db.list_comments(conn, task_id)],
@@ -578,15 +655,8 @@ def get_task(
             "attachments": [_attachment_dict(a) for a in kanban_db.list_attachments(conn, task_id)],
             "links": links,
             "child_results": child_results,
-            "runs": [
-                _run_dict(r)
-                for r in kanban_db.list_runs(
-                    conn,
-                    task_id,
-                    state_type=run_state_type,
-                    state_name=run_state_name,
-                )
-            ],
+            "runs": [_run_dict(r) for r in runs],
+            "worker_session": _worker_session_dict(task, runs),
         }
     finally:
         conn.close()

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -29,6 +29,16 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
+def test_delegated_child_does_not_receive_parent_worker_stop_nudge(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_parent")
+
+    from agent.delegation_context import delegated_child_context
+
+    with delegated_child_context("child-session"):
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
 def test_nudge_when_no_terminal_tool(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
     messages = [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from hermes_state import SessionDB
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +191,17 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
 
 
+def test_running_task_drawer_opens_profile_scoped_worker_chat():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text(encoding="utf-8")
+
+    assert 'tx(i18n, "openWorkChat", "Open work chat")' in js
+    assert 'const workerSession = props.data.worker_session || null;' in js
+    assert 'params.set("profile", workerSession.profile);' in js
+    assert 'window.open(`/chat?${params.toString()}`, "_blank", "noopener,noreferrer");' in js
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------
@@ -218,6 +230,43 @@ def test_task_detail_includes_links_and_events(client):
 
     # Events exist from creation.
     assert len(data["events"]) >= 1
+
+
+def test_running_task_detail_resolves_live_worker_session(client, kanban_home):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "active worker", "assignee": "coder"},
+    ).json()["task"]
+
+    with kb.connect() as conn:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running' WHERE id = ?",
+                (task["id"],),
+            )
+
+    profile_home = kanban_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    session = SessionDB(db_path=profile_home / "state.db")
+    try:
+        session.create_session(session_id="worker-session", source="kanban")
+        session.append_message(
+            session_id="worker-session",
+            role="user",
+            content=f"work kanban task {task['id']}",
+        )
+    finally:
+        session.close()
+
+    response = client.get(f"/api/plugins/kanban/tasks/{task['id']}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["worker_session"] == {
+        "session_id": "worker-session",
+        "profile": "coder",
+        "active": True,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -200,6 +200,7 @@ def test_running_task_drawer_opens_profile_scoped_worker_chat():
     assert 'const workerSession = props.data.worker_session || null;' in js
     assert 'params.set("profile", workerSession.profile);' in js
     assert 'window.open(`/chat?${params.toString()}`, "_blank", "noopener,noreferrer");' in js
+    assert 'workerSession && t.status === "running"' not in js
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +267,37 @@ def test_running_task_detail_resolves_live_worker_session(client, kanban_home):
         "session_id": "worker-session",
         "profile": "coder",
         "active": True,
+    }
+
+
+def test_completed_task_detail_keeps_durable_worker_session(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "completed worker", "assignee": "coder"},
+    ).json()["task"]
+
+    with kb.connect() as conn:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task["id"],))
+        claimed = kb.claim_task(conn, task["id"], claimer="test-worker")
+        assert claimed is not None
+        run = kb.latest_run(conn, task["id"])
+        assert run is not None
+        assert kb.complete_task(
+            conn,
+            task["id"],
+            summary="done",
+            metadata={"worker_session_id": "completed-worker-session"},
+            expected_run_id=run.id,
+        )
+
+    response = client.get(f"/api/plugins/kanban/tasks/{task['id']}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["worker_session"] == {
+        "session_id": "completed-worker-session",
+        "profile": "coder",
+        "active": False,
     }
 
 

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -28,6 +28,41 @@ describe('toTranscriptMessages', () => {
     expect(toTranscriptMessages(rows)[1]?.tools?.[0]).toContain('Search Files')
   })
 
+  it('keeps tool-only worker progress visible before the next prompt', () => {
+    const rows = [
+      { role: 'user', text: 'work kanban task t_example' },
+      { role: 'assistant', text: '' },
+      { role: 'tool', context: 'tests', name: 'terminal', text: 'passed' },
+      { role: 'assistant', text: '' },
+      { role: 'tool', context: 'HANDOVER.md', name: 'patch', text: 'updated' },
+      { role: 'user', text: 'final review' }
+    ]
+
+    const result = toTranscriptMessages(rows)
+
+    expect(result.map(msg => [msg.kind, msg.role, msg.text])).toEqual([
+      [undefined, 'user', 'work kanban task t_example'],
+      ['trail', 'assistant', ''],
+      [undefined, 'user', 'final review']
+    ])
+    expect(result[1]?.tools).toHaveLength(2)
+    expect(result[1]?.tools?.[0]).toContain('Terminal')
+    expect(result[1]?.tools?.[1]).toContain('Patch')
+  })
+
+  it('keeps trailing tool-only worker progress visible while the task is running', () => {
+    const rows = [
+      { role: 'user', text: 'work kanban task t_example' },
+      { role: 'tool', context: 'npm test', name: 'terminal', text: 'passed' },
+      { role: 'assistant', text: '' }
+    ]
+
+    const result = toTranscriptMessages(rows)
+
+    expect(result.at(-1)).toMatchObject({ kind: 'trail', role: 'assistant', text: '' })
+    expect(result.at(-1)?.tools?.[0]).toContain('Terminal')
+  })
+
   it('skips hidden display_kind rows entirely', () => {
     const rows = [
       { role: 'user', text: 'visible prompt' },

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -23,6 +23,11 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
 
   const out: Msg[] = []
   let pending: string[] = []
+  const flushPendingTools = () => {
+    if (!pending.length) return
+    out.push({ kind: 'trail', role: 'assistant', text: '', tools: pending })
+    pending = []
+  }
 
   for (const row of rows) {
     if (!row || typeof row !== 'object') {
@@ -51,22 +56,22 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
     }
 
     if (display_kind === 'model_switch') {
+      flushPendingTools()
       out.push({ kind: 'event', role: 'system', text: 'model changed' })
-      pending = []
 
       continue
     }
 
     if (display_kind === 'auto_continue') {
+      flushPendingTools()
       out.push({ kind: 'event', role: 'system', text: 'resumed interrupted turn' })
-      pending = []
 
       continue
     }
 
     if (display_kind === 'personality_switch') {
+      flushPendingTools()
       out.push({ kind: 'event', role: 'system', text: 'personality changed' })
-      pending = []
 
       continue
     }
@@ -80,8 +85,8 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
           ? 'background agent work finished'
           : `${count} background agent${count === 1 ? '' : 's'} finished`
 
+      flushPendingTools()
       out.push({ kind: 'event', role: 'system', text: label })
-      pending = []
 
       continue
     }
@@ -90,11 +95,12 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
       out.push({ role, text, ...(createdAt !== undefined && { createdAt }), ...(pending.length && { tools: pending }) })
       pending = []
     } else if (role === 'user' || role === 'system') {
+      flushPendingTools()
       out.push({ role, text, ...(createdAt !== undefined && { createdAt }) })
-      pending = []
     }
   }
 
+  flushPendingTools()
   return out
 }
 


### PR DESCRIPTION
## Summary

- expose the profile-scoped worker session in Kanban task details and add an Open work chat action for running and completed work
- preserve tool-only progress when rendering worker transcripts so an active chat does not appear blank
- prevent delegated child agents from inheriting the parent Kanban stop nudge

## Validation

- `45 passed` — focused Kanban dashboard and stop-guard tests
- `18 passed` — focused TUI transcript tests
- TUI TypeScript typecheck
- Ruff on all changed Python and test files
- `git diff --check`