### PR TITLE
fix(a2a): wait for final reply after early success

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -1262,8 +1262,8 @@ class A2AAdapter(BasePlatformAdapter):
             self._resolve_task(task_id, protocol.STATE_FAILED, "[agent processing failed]")
         elif outcome == ProcessingOutcome.CANCELLED:
             self._resolve_task(task_id, protocol.STATE_CANCELED, "")
-        else:
-            self._resolve_task(task_id, protocol.STATE_COMPLETED, "")
+        # SUCCESS may occur before the final notify-marked reply. Keep the
+        # task pending; send() completes it once that reply is available.
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         return None

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -688,6 +688,20 @@ class TestReplyCapture:
         finally:
             adapter._pop_pending("task-ok")
 
+    def test_success_before_final_reply_keeps_task_pending(self):
+        """Async gateways may report success before emitting the final reply."""
+        from gateway.platforms.base import ProcessingOutcome
+
+        adapter = _bare_adapter()
+        fut = adapter._add_pending("task-early-success", "ctx-early-success")
+        event = SimpleNamespace(message_id="task-early-success")
+
+        try:
+            asyncio.run(adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS))
+            assert fut.done() is False
+        finally:
+            adapter._pop_pending("task-early-success")
+
 
 # --------------------------------------------------------------------------
 # Adapter RPC handlers (driven directly, no HTTP)


### PR DESCRIPTION
## Summary
- keep pending A2A tasks open when gateway success precedes the final notify-marked reply
- preserve immediate failure and cancellation handling
- add regression coverage for early success before the final reply

## Validation
- pytest -q tests/plugins/test_a2a_plugin.py — 107 passed, 10 deselected
- reproduced Max → Shu → Jair response recovery in the deployed runtime