### PR TITLE
fix(compression): stream Ollama Cloud auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9080,6 +9080,9 @@ def _provider_requires_stream(provider: str, base_url: Optional[str]) -> bool:
     # Tencent Copilot — "Non-stream chat request is currently not supported"
     if base_url_host_matches(_url, "copilot.tencent.com"):
         return True
+    # Ollama Cloud — non-streaming requests to reasoning models time out
+    if provider == "ollama-cloud" or base_url_host_matches(_url, "ollama.com"):
+        return True
     try:
         from hermes_cli.config import load_config
         aux_cfg = (load_config() or {}).get("auxiliary", {})

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -271,6 +271,11 @@ class TestProviderRequiresStream:
         assert _provider_requires_stream(
             "auto", "https://not-ollama.example.com/v1"
         ) is False
+        # Provider-name branch is intentionally URL-agnostic: the label alone
+        # forces the streamed path even for custom/self-hosted base URLs.
+        assert _provider_requires_stream(
+            "ollama-cloud", "https://my-server.local:11434/v1"
+        ) is True
 
 
 

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -255,6 +255,23 @@ class TestProviderRequiresStream:
                 "custom", "https://other.example.com/v1"
             ) is False
 
+    def test_ollama_cloud_always_requires_stream(self):
+        # Ollama Cloud reasoning models leave non-streaming requests waiting
+        # until timeout or return an empty payload — force the streamed
+        # auxiliary path regardless of provider label (auto/ollama-cloud).
+        assert _provider_requires_stream(
+            "ollama-cloud", "https://ollama.com/v1"
+        ) is True
+        assert _provider_requires_stream(
+            "auto", "https://ollama.com/v1"
+        ) is True
+        assert _provider_requires_stream(
+            "auto", "https://ollama.com/api/chat"
+        ) is True
+        assert _provider_requires_stream(
+            "auto", "https://not-ollama.example.com/v1"
+        ) is False
+
 
 
 class TestForceStream:


### PR DESCRIPTION
## What does this PR do?

Ollama Cloud users can enable plugin-owned structured auxiliary tasks such as LCM assertion extraction without every call timing out or returning an empty payload. The auxiliary transport now preserves the streamed request shape already used by successful main-chat and compression calls, then aggregates the chunks back into the complete response expected by plugin callers.

### Symptom

With `ollama-cloud` as the main provider, structured assertion extraction repeatedly times out, falls back, or returns no payload, while ordinary compression succeeds against the same endpoint.

### Root Cause

**Trigger:** `agent/auxiliary_client.py` / `_provider_requires_stream()` when a plugin calls `complete_structured(..., task="assertion_extraction")` without a compression progress hook.

**Causal chain:**
1. The plugin facade routes the registered auxiliary task through `call_llm()`.
2. Unlike the main chat and progress-hooked compression paths, the structured plugin request used non-streaming chat completions because Ollama Cloud was not classified as requiring the streamed auxiliary path.
3. Ollama Cloud reasoning models can leave that non-streaming request waiting until timeout or return an empty structured payload, so no assertions are persisted.

### Fix

Classify `ollama-cloud` routes and `ollama.com` endpoints as stream-required auxiliary transports. This applies even while the provider label is still `auto`, and reuses the existing bounded stream aggregation and fallback behavior.

Related issue: #94669

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## How to Test

```bash
pytest tests/agent/test_aux_progress_streaming.py -q -v
```

Result: 17 passed.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] My PR contains only changes related to this fix
- [x] I have added tests for my changes
- [x] All tests pass
- [x] I have tested on my platform: Linux
