### PR TITLE
feat(cron): add per-job post_script hook run after the run is recorded

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1933,6 +1933,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    post_script: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1990,6 +1991,13 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        post_script: Optional path to a script run AFTER the run has been
+                recorded, on both the success and the failure path (same
+                resolution/containment rules as ``script``). It receives
+                ``HERMES_JOB_ID`` and ``HERMES_RUN_ID`` in its environment,
+                so a job can declare its outcome to an external tracker,
+                release a claim, or kick a downstream pipeline. Best-effort:
+                a failing post_script is logged, never fails the run.
         reasoning_effort: Optional per-job reasoning effort pin. One of the
                 canonical Hermes levels (none|minimal|low|medium|high|xhigh|
                 max|ultra, case-insensitive). When set, it wins over BOTH the
@@ -2037,6 +2045,8 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    normalized_post_script = str(post_script).strip() if isinstance(post_script, str) else None
+    normalized_post_script = normalized_post_script or None
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -2111,6 +2121,9 @@ def create_job(
         "base_url": normalized_base_url,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
+        # Optional hook run after the run is recorded, on both the success
+        # and the failure path — lets a job declare its outcome downstream.
+        "post_script": normalized_post_script,
         "monitor_script": normalized_monitor_script,
         "monitor_url": normalized_monitor_url,
         # Hash-suppression state for monitor jobs: {"last_output_hash": ...,
@@ -2247,13 +2260,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
 
-            # Normalize monitor fields the same way create_job does (empty
-            # string clears the field).
-            for _mon_field in ("monitor_script", "monitor_url"):
-                if _mon_field in updates:
-                    _mv = updates[_mon_field]
-                    _mv = str(_mv).strip() if isinstance(_mv, str) else None
-                    updates[_mon_field] = _mv or None
+            # Normalize the optional path/URL fields the same way create_job
+            # does (empty string clears the field).
+            for _opt_field in ("monitor_script", "monitor_url", "post_script"):
+                if _opt_field in updates:
+                    _ov = updates[_opt_field]
+                    _ov = str(_ov).strip() if isinstance(_ov, str) else None
+                    updates[_opt_field] = _ov or None
 
             # Validate/normalize the per-job reasoning effort pin the same
             # way create_job does: canonical grammar only, empty string (or

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4182,6 +4182,134 @@ def _run_job_script_with_claim_heartbeat(
         heartbeat_thread.join(timeout=1.0)
 
 
+_POST_SCRIPT_TIMEOUT_SECONDS = 60
+
+
+def _run_post_script(job: dict, execution_id: str) -> None:
+    """Best-effort post-run hook for a cron job.
+
+    Some jobs need a deterministic step after the agent has finished and the
+    run has been recorded — declaring an outcome to an external tracker,
+    releasing a claim, kicking a downstream pipeline. ``post_script`` on the
+    job names a script that is executed after ``finish_execution`` on both
+    the success and the failure path, with ``HERMES_JOB_ID`` and
+    ``HERMES_RUN_ID`` in its environment. It is skipped on the fenced paths
+    (fire-claim ownership lost, gateway-shutdown interrupt) where the run's
+    outcome belongs to a replacement worker. A monitor job's suppressed
+    no-change tick DOES fire it: that tick is a recorded, successful run.
+
+    Containment and interpreter rules match ``_run_job_script``: the script
+    must live inside HERMES_HOME/scripts/ (path traversal, absolute-path
+    injection and symlink escape are all rejected), ``.sh``/``.bash`` run
+    under bash, anything else under the current Python interpreter, and the
+    environment goes through ``build_subprocess_env`` so Hermes-managed
+    secrets are not inherited (SECURITY.md §2.3).
+
+    Failures are logged but never fail the cron run itself — by the time
+    this hook runs, the run's status has already been recorded.
+    """
+    post_script = job.get("post_script")
+    if not post_script:
+        return
+
+    job_id = job.get("id")
+    scripts_dir = _get_hermes_home() / "scripts"
+    scripts_dir_resolved = scripts_dir.resolve()
+
+    # Same ingestion contract as _run_job_script: reject NUL bytes and
+    # unexpandable paths eagerly instead of crashing the scheduler.
+    if "\x00" in str(post_script):
+        logger.warning(
+            "Job '%s': post_script path contains a NUL byte: %r",
+            job_id, post_script,
+        )
+        return
+    try:
+        raw = Path(str(post_script)).expanduser()
+    except (ValueError, RuntimeError, OSError):
+        logger.warning(
+            "Job '%s': post_script is not a valid filesystem path: %r",
+            job_id, post_script,
+        )
+        return
+    if raw.is_absolute():
+        path = raw.resolve()
+    else:
+        path = (scripts_dir / raw).resolve()
+
+    try:
+        path.relative_to(scripts_dir_resolved)
+    except ValueError:
+        logger.warning(
+            "Job '%s': post_script resolves outside the scripts directory "
+            "(%s): %r",
+            job_id, scripts_dir_resolved, post_script,
+        )
+        return
+
+    if not path.is_file():
+        logger.warning("Job '%s': post_script not found: %s", job_id, path)
+        return
+
+    suffix = path.suffix.lower()
+    if suffix in {".sh", ".bash"}:
+        _bash = shutil.which("bash") or (
+            "/bin/bash" if os.path.isfile("/bin/bash") else None
+        )
+        if _bash is None:
+            logger.warning(
+                "Job '%s': cannot run post_script %r: bash not found on PATH",
+                job_id, path.name,
+            )
+            return
+        argv = [_bash, str(path)]
+        env_overlay: dict[str, str] = {}
+    else:
+        python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
+        if env_overlay:
+            argv = _windows_cron_bootstrap_argv(python_exe, env_overlay, str(path))
+        else:
+            argv = [python_exe, str(path)]
+
+    try:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env()
+    except Exception:
+        env = os.environ.copy()
+    env.update(env_overlay)
+    env["HERMES_JOB_ID"] = str(job_id or "")
+    env["HERMES_RUN_ID"] = str(execution_id or "")
+
+    popen_kwargs: dict[str, Any] = {}
+    if sys.platform == "win32":
+        popen_kwargs = {"creationflags": windows_hide_flags()}
+
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_POST_SCRIPT_TIMEOUT_SECONDS,
+            cwd=str(path.parent),
+            env=env,
+            **popen_kwargs,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "Job '%s': post_script failed (rc=%s): %s",
+                job_id,
+                result.returncode,
+                (result.stderr or "").strip()[:500],
+            )
+        else:
+            logger.info("Job '%s': post_script completed", job_id)
+    except Exception as e:
+        logger.warning("Job '%s': post_script raised: %s", job_id, e)
+
+
 def _parse_wake_gate(script_output: str) -> bool:
     """Parse the last non-empty stdout line of a cron job's pre-check script
     as a wake gate.
@@ -7100,6 +7228,7 @@ def _run_one_job_body(
             error=error,
             delivery_outcome=delivery_outcome,
         )
+        _run_post_script(job, execution_id)
         return True
 
     except BaseException as e:  # noqa: BLE001 — deliberate: see below
@@ -7185,7 +7314,12 @@ def _run_one_job_body(
                 job["id"], record_err,
             )
         if not isinstance(e, Exception):
+            # Cancellation / KeyboardInterrupt / SystemExit: the gateway is
+            # tearing down. The hook's subprocess would hold shutdown for up
+            # to _POST_SCRIPT_TIMEOUT_SECONDS, and this run's outcome is not
+            # final anyway — skip it and let the exception propagate.
             raise
+        _run_post_script(job, execution_id)
         return False
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -409,6 +409,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        post_script=getattr(args, "post_script", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
     )
@@ -427,6 +428,8 @@ def cron_create(args):
         print(f"  Monitor: {job_data['monitor_script']} (agent runs only on output change)")
     if job_data.get("monitor_url"):
         print(f"  Monitor: {job_data['monitor_url']} (agent runs only on output change)")
+    if job_data.get("post_script"):
+        print(f"  Post-run hook: {job_data['post_script']}")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("continuity"):
@@ -484,6 +487,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        post_script=getattr(args, "post_script", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
     )

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -84,6 +84,18 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--post-script",
+        dest="post_script",
+        help=(
+            "Path to a script under ~/.hermes/scripts/ run AFTER the run is "
+            "recorded, on both success and failure. Receives HERMES_JOB_ID "
+            "and HERMES_RUN_ID in its environment — use it to declare the "
+            "run's outcome to an external tracker, release a claim, or kick "
+            "a downstream pipeline. Its stdout is not delivered, and a "
+            "failure is logged without failing the run."
+        ),
+    )
+    cron_create.add_argument(
         "--monitor-url",
         dest="monitor_url",
         help=(
@@ -226,6 +238,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="monitor_url",
         help=(
             "Set/replace the monitor source URL. Pass empty string to clear."
+        ),
+    )
+    cron_edit.add_argument(
+        "--post-script",
+        dest="post_script",
+        help=(
+            "Set/replace the post-run hook script (see `hermes cron create "
+            "--post-script`). Pass empty string to clear."
         ),
     )
     cron_edit.add_argument(

--- a/tests/cron/test_post_script.py
+++ b/tests/cron/test_post_script.py
@@ -1,0 +1,436 @@
+"""Coverage for the per-job ``post_script`` hook.
+
+``post_script`` runs after the run has been recorded (``finish_execution``),
+on both the success and the failure path, so a job can declare its outcome
+to an external tracker. It shares ``_run_job_script``'s containment rules:
+the script must live inside HERMES_HOME/scripts/, and its environment goes
+through ``build_subprocess_env``.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def scripts_dir(tmp_path, monkeypatch):
+    """Point HERMES_HOME at tmp_path and return its scripts/ directory."""
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    d = tmp_path / "scripts"
+    d.mkdir()
+    return d
+
+
+def _write_marker_script(scripts_dir: Path, name: str = "post.py") -> Path:
+    """A post_script that records the env Hermes handed it."""
+    marker = scripts_dir.parent / "marker.txt"
+    script = scripts_dir / name
+    script.write_text(
+        "import os\n"
+        f"open({str(marker)!r}, 'w').write(\n"
+        "    os.environ.get('HERMES_JOB_ID', '') + '|'\n"
+        "    + os.environ.get('HERMES_RUN_ID', '')\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    return marker
+
+
+class TestExecution:
+    def test_runs_with_job_and_run_id_in_env(self, scripts_dir):
+        import cron.scheduler as scheduler
+
+        marker = _write_marker_script(scripts_dir)
+        scheduler._run_post_script(
+            {"id": "job-42", "post_script": "post.py"}, "exec-7"
+        )
+        assert marker.read_text() == "job-42|exec-7"
+
+    def test_absolute_path_inside_scripts_dir_allowed(self, scripts_dir):
+        import cron.scheduler as scheduler
+
+        marker = _write_marker_script(scripts_dir)
+        scheduler._run_post_script(
+            {"id": "job-42", "post_script": str(scripts_dir / "post.py")},
+            "exec-7",
+        )
+        assert marker.read_text() == "job-42|exec-7"
+
+    @pytest.mark.skipif(
+        not Path("/bin/bash").is_file(), reason="bash not available"
+    )
+    def test_bash_script_runs_under_bash(self, scripts_dir):
+        import cron.scheduler as scheduler
+
+        marker = scripts_dir.parent / "marker.txt"
+        script = scripts_dir / "post.sh"
+        script.write_text(
+            f'printf "%s|%s" "$HERMES_JOB_ID" "$HERMES_RUN_ID" > {str(marker)!r}\n',
+            encoding="utf-8",
+        )
+        scheduler._run_post_script(
+            {"id": "job-42", "post_script": "post.sh"}, "exec-7"
+        )
+        assert marker.read_text() == "job-42|exec-7"
+
+    def test_no_post_script_is_a_noop(self, scripts_dir):
+        import cron.scheduler as scheduler
+
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script({"id": "job-42"}, "exec-7")
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": ""}, "exec-7"
+            )
+        mock_run.assert_not_called()
+
+
+class TestNeverRaises:
+    """The run is already recorded by the time this hook fires — a broken
+    post_script must never propagate out of it."""
+
+    def test_missing_script_logged_not_raised(self, scripts_dir, caplog):
+        import cron.scheduler as scheduler
+
+        scheduler._run_post_script(
+            {"id": "job-42", "post_script": "nope.py"}, "exec-7"
+        )
+        assert "not found" in caplog.text
+
+    def test_nonzero_exit_logged_not_raised(self, scripts_dir, caplog):
+        import cron.scheduler as scheduler
+
+        (scripts_dir / "post.py").write_text(
+            "import sys; sys.stderr.write('boom'); sys.exit(3)\n",
+            encoding="utf-8",
+        )
+        scheduler._run_post_script(
+            {"id": "job-42", "post_script": "post.py"}, "exec-7"
+        )
+        assert "rc=3" in caplog.text
+
+    def test_subprocess_failure_logged_not_raised(self, scripts_dir, caplog):
+        import cron.scheduler as scheduler
+
+        (scripts_dir / "post.py").write_text("pass\n", encoding="utf-8")
+        with patch(
+            "subprocess.run", side_effect=OSError("no exec for you")
+        ):
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "post.py"}, "exec-7"
+            )
+        assert "no exec for you" in caplog.text
+
+
+class TestContainment:
+    """Same guarantees as _run_job_script: nothing outside scripts/ runs."""
+
+    def test_traversal_blocked(self, scripts_dir, tmp_path, caplog):
+        import cron.scheduler as scheduler
+
+        outside = tmp_path / "outside.py"
+        outside.write_text("open('/tmp/should-not-exist-hermes','w')\n", encoding="utf-8")
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "../outside.py"}, "exec-7"
+            )
+        mock_run.assert_not_called()
+        assert "outside the scripts directory" in caplog.text
+
+    def test_absolute_path_outside_blocked(self, scripts_dir, tmp_path, caplog):
+        import cron.scheduler as scheduler
+
+        outside = tmp_path / "outside.py"
+        outside.write_text("pass\n", encoding="utf-8")
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": str(outside)}, "exec-7"
+            )
+        mock_run.assert_not_called()
+        assert "outside the scripts directory" in caplog.text
+
+    @pytest.mark.skipif(
+        not hasattr(Path, "symlink_to"), reason="symlinks unsupported"
+    )
+    def test_symlink_escape_blocked(self, scripts_dir, tmp_path, caplog):
+        import cron.scheduler as scheduler
+
+        outside = tmp_path / "outside.py"
+        outside.write_text("pass\n", encoding="utf-8")
+        link = scripts_dir / "link.py"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not permitted")
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "link.py"}, "exec-7"
+            )
+        mock_run.assert_not_called()
+        assert "outside the scripts directory" in caplog.text
+
+    def test_nul_byte_rejected(self, scripts_dir, caplog):
+        import cron.scheduler as scheduler
+
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "post\x00.py"}, "exec-7"
+            )
+        mock_run.assert_not_called()
+        assert "NUL byte" in caplog.text
+
+    def test_directory_is_not_runnable(self, scripts_dir, caplog):
+        import cron.scheduler as scheduler
+
+        (scripts_dir / "adir.py").mkdir()
+        with patch("subprocess.run") as mock_run:
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "adir.py"}, "exec-7"
+            )
+        mock_run.assert_not_called()
+        assert "not found" in caplog.text
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME so jobs/scripts don't leak between tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+class TestJobPlumbing:
+    def test_create_job_stores_post_script(self, hermes_env):
+        from cron.jobs import create_job, get_job
+
+        (hermes_env / "scripts" / "post.sh").write_text("echo hi\n", encoding="utf-8")
+        job = create_job(
+            prompt="do the thing",
+            schedule="every 5m",
+            post_script="post.sh",
+            deliver="local",
+        )
+        assert get_job(job["id"])["post_script"] == "post.sh"
+
+    def test_create_job_without_post_script_stores_none(self, hermes_env):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="p", schedule="every 5m", deliver="local")
+        assert get_job(job["id"])["post_script"] is None
+
+    def test_update_job_sets_and_clears_post_script(self, hermes_env):
+        from cron.jobs import create_job, get_job, update_job
+
+        (hermes_env / "scripts" / "post.sh").write_text("echo hi\n", encoding="utf-8")
+        job = create_job(prompt="p", schedule="every 5m", deliver="local")
+
+        update_job(job["id"], {"post_script": "  post.sh  "})
+        assert get_job(job["id"])["post_script"] == "post.sh"
+
+        # Empty string clears, same contract as the monitor fields.
+        update_job(job["id"], {"post_script": ""})
+        assert get_job(job["id"])["post_script"] is None
+
+
+class TestToolBoundaryValidation:
+    """The tool boundary is stricter than the scheduler: absolute paths and
+    ~ expansion are rejected outright so prompt injection cannot name one."""
+
+    def test_absolute_path_rejected(self, hermes_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path("/etc/evil.sh") is not None
+
+    def test_traversal_rejected(self, hermes_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path("../../evil.sh") is not None
+
+    def test_plain_relative_name_accepted(self, hermes_env):
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path("post.sh") is None
+
+
+class TestCallSites:
+    """run_one_job must fire the hook on both terminal paths — and only
+    those. A run whose outcome belongs to another worker (fire-claim taken
+    over, gateway shutdown) must not run it.
+
+    ``run_job`` returns ``(success, output, final_response, error)``; the
+    jobs here carry no ``fire_claim`` so the owner-fencing branches stay
+    inert and the genuine terminal path is what gets exercised.
+    """
+
+    def _job(self):
+        return {
+            "id": "job-ps",
+            "name": "post script",
+            "prompt": "p",
+            "post_script": "post.py",
+        }
+
+    def _patches(self, run_side_effect):
+        return (
+            patch("cron.scheduler.claim_dispatch", return_value=True),
+            patch("agent.secret_scope.set_secret_scope", return_value=None),
+            patch("agent.secret_scope.build_profile_secret_scope", return_value=None),
+            patch("agent.secret_scope.reset_secret_scope"),
+            patch("cron.scheduler.run_job", side_effect=run_side_effect),
+            patch("cron.scheduler._deliver_result", return_value=None),
+        )
+
+    def test_success_path_runs_hook(self):
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(
+            lambda *a, **kw: (True, "out", "final answer", None)
+        )
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark, \
+             patch("cron.scheduler.finish_execution") as mock_finish, \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            assert sched.run_one_job(self._job()) is True
+
+        # Guard against a harness that silently lands on a fenced path:
+        # this must be the real success terminal write.
+        assert mock_mark.call_args.args[:3] == ("job-ps", True, None)
+        assert mock_finish.call_args.kwargs["success"] is True
+        mock_hook.assert_called_once()
+        assert mock_hook.call_args.args[0]["id"] == "job-ps"
+
+    def test_agent_failure_path_runs_hook(self):
+        """A failed run is still a recorded run — the hook fires, which is
+        precisely when an external tracker most needs to hear about it."""
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(
+            lambda *a, **kw: (False, "out", "", "model exploded")
+        )
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark, \
+             patch("cron.scheduler.finish_execution") as mock_finish, \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            sched.run_one_job(self._job())
+
+        assert mock_mark.call_args.args[1] is False
+        assert mock_finish.call_args.kwargs["success"] is False
+        mock_hook.assert_called_once()
+
+    def test_monitor_suppressed_tick_runs_hook(self):
+        """A monitor job's no-change tick suppresses the AGENT and skips
+        delivery, but the tick itself is a recorded, successful run — so the
+        hook fires."""
+        import cron.scheduler as sched
+
+        from cron.scheduler import SILENT_MARKER
+
+        p1, p2, p3, p4, p5, p6 = self._patches(
+            lambda *a, **kw: (True, "# no_change", SILENT_MARKER, None)
+        )
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True), \
+             patch("cron.scheduler.finish_execution") as mock_finish, \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            sched.run_one_job(self._job())
+
+        assert mock_finish.call_args.kwargs["success"] is True
+        mock_hook.assert_called_once()
+
+    def test_exception_path_runs_hook(self):
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(RuntimeError("boom"))
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True) as mock_mark, \
+             patch("cron.scheduler.finish_execution") as mock_finish, \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            assert sched.run_one_job(self._job()) is False
+
+        assert mock_mark.call_args.args[:3] == ("job-ps", False, "boom")
+        assert mock_finish.call_args.kwargs["success"] is False
+        mock_hook.assert_called_once()
+
+    def test_gateway_shutdown_skips_hook(self):
+        """A CancelledError means the gateway is tearing down: the hook's
+        subprocess would hold shutdown open for its whole timeout, and this
+        run's outcome is not final anyway."""
+        import asyncio
+
+        import cron.scheduler as sched
+
+        p1, p2, p3, p4, p5, p6 = self._patches(asyncio.CancelledError())
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.mark_job_run", return_value=True), \
+             patch("cron.scheduler.finish_execution"), \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            with pytest.raises(asyncio.CancelledError):
+                sched.run_one_job(self._job())
+
+        mock_hook.assert_not_called()
+
+    def test_fire_claim_taken_over_skips_hook(self):
+        """Owner fencing: when this worker's fire claim is taken over while
+        the run is in flight, the outcome belongs to the replacement worker
+        — the stale worker must not fire the hook."""
+        import cron.scheduler as sched
+
+        job = dict(self._job(), fire_claim={"by": "owner-ps"})
+        # True for the pre-execution ownership check, False afterwards: the
+        # claim is taken over while run_job is in flight.
+        beats = iter([True])
+
+        def _heartbeat(*a, **kw):
+            return next(beats, False)
+
+        p1, p2, p3, p4, p5, p6 = self._patches(
+            lambda *a, **kw: (True, "out", "final answer", None)
+        )
+        with p1, p2, p3, p4, p5, p6, \
+             patch("cron.scheduler.heartbeat_fire_claim", side_effect=_heartbeat), \
+             patch("cron.scheduler.mark_job_run", return_value=True), \
+             patch("cron.scheduler.finish_execution") as mock_finish, \
+             patch("cron.scheduler._run_post_script") as mock_hook:
+            sched.run_one_job(job)
+
+        assert mock_finish.called
+        assert mock_finish.call_args.kwargs["success"] is False
+        mock_hook.assert_not_called()
+
+
+class TestEnvironmentHygiene:
+    def test_env_goes_through_build_subprocess_env(self, scripts_dir):
+        """Provider credentials must not leak into the hook (SECURITY.md
+        §2.3) — the env is built by build_subprocess_env, not inherited."""
+        import cron.scheduler as scheduler
+
+        (scripts_dir / "post.py").write_text("pass\n", encoding="utf-8")
+        with (
+            patch(
+                "tools.environments.local.build_subprocess_env",
+                return_value={"SAFE": "1"},
+            ) as mock_env,
+            patch("subprocess.run") as mock_run,
+        ):
+            scheduler._run_post_script(
+                {"id": "job-42", "post_script": "post.py"}, "exec-7"
+            )
+        mock_env.assert_called_once()
+        passed = mock_run.call_args.kwargs["env"]
+        assert passed["SAFE"] == "1"
+        assert passed["HERMES_JOB_ID"] == "job-42"
+        assert passed["HERMES_RUN_ID"] == "exec-7"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -693,6 +693,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("reasoning_effort"):
         result["reasoning_effort"] = job["reasoning_effort"]
+    if job.get("post_script"):
+        result["post_script"] = job["post_script"]
     if job.get("monitor_script"):
         result["monitor_script"] = job["monitor_script"]
     if job.get("monitor_url"):
@@ -1281,6 +1283,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    post_script: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1325,6 +1328,12 @@ def cronjob(
                 monitor_error = _validate_cron_script_path(monitor_script)
                 if monitor_error:
                     return tool_error(monitor_error, success=False)
+
+            # Same containment rules for the post-run hook.
+            if post_script:
+                post_error = _validate_cron_script_path(post_script)
+                if post_error:
+                    return tool_error(post_error, success=False)
 
             # Reject a model-supplied base_url that would route a named
             # provider's stored credential to an attacker endpoint (F8).
@@ -1387,6 +1396,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    post_script=_normalize_optional_job_value(post_script),
                     # reasoning_effort reaches here from the CLI
                     # (hermes cron create --reasoning-effort) ONLY — it is
                     # deliberately absent from CRONJOB_SCHEMA and the model
@@ -1637,6 +1647,15 @@ def cronjob(
                 updates["monitor_url"] = (
                     _normalize_optional_job_value(monitor_url) if monitor_url else None
                 )
+            if post_script is not None:
+                # Pass empty string to clear an existing post_script
+                if post_script:
+                    post_error = _validate_cron_script_path(post_script)
+                    if post_error:
+                        return tool_error(post_error, success=False)
+                updates["post_script"] = (
+                    _normalize_optional_job_value(post_script) if post_script else None
+                )
             if monitor_script is not None or monitor_url is not None:
                 eff_mon_script = (
                     updates["monitor_script"] if "monitor_script" in updates else job.get("monitor_script")
@@ -1794,6 +1813,10 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "type": "string",
                 "description": "Optional http(s) URL used as the monitor source instead of a script — fetched with a bounded GET (30s timeout, 256KB cap) each tick. Same hash-suppression semantics as monitor_script. Mutually exclusive with monitor_script. On update, pass empty string to clear."
             },
+            "post_script": {
+                "type": "string",
+                "description": f"Optional hook script run AFTER the run has been recorded, on both the success and the failure path (same rules as `script`: relative to {display_hermes_home()}/scripts/, .sh/.bash via bash, else Python). It receives HERMES_JOB_ID and HERMES_RUN_ID in its environment — use it to declare the run's outcome to an external tracker, release a claim, or kick a downstream pipeline. Best-effort: a failing post_script is logged, never fails the run, and its stdout is NOT delivered. On update, pass empty string to clear."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -1911,6 +1934,7 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        post_script=args.get("post_script"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),


### PR DESCRIPTION
## What does this PR do?

Adds an optional per-job `post_script` hook: a script that runs **after** a cron run has been recorded, on both the success and the failure path, with `HERMES_JOB_ID` and `HERMES_RUN_ID` in its environment.

Cron jobs today can run a script *before* the agent (`script` for context injection, `monitor_script` for change-suppression), but there is no hook *after* a run reaches a terminal state. That leaves a gap for any job whose completion means something outside Hermes: declaring the run's outcome to an external tracker, releasing a claim/lease the job took, or kicking a downstream pipeline. Today the only way is to ask the agent to do it in-prompt — which is non-deterministic, costs tokens, and silently does nothing when the run *fails*, which is exactly when the outcome most needs recording.

`post_script` is deliberately narrow: its stdout is **not** delivered (it is a hook, not a second payload), and a failure is logged and swallowed — by the time it fires, the run's status is already recorded, so nothing it does can change the run's outcome.

I've been running this on my own install to close the loop on jobs that hand work to an external state machine.

**Where it fires** — after `finish_execution()` on the two terminal paths in `run_one_job()`, and deliberately *not* on the paths where this run's outcome is not final and belongs to someone else:

| Path | Hook runs? |
|---|---|
| Normal completion (success or agent failure) | ✅ |
| `Exception` escaping the run body | ✅ |
| Monitor job's suppressed no-change tick | ✅ (the tick is a recorded, successful run) |
| Fire-claim ownership lost / taken over | ❌ (a replacement worker owns this run) |
| Gateway-shutdown interrupt | ❌ |
| `CancelledError` / `KeyboardInterrupt` / `SystemExit` | ❌ (would hold shutdown open for the hook's timeout) |

## Related Issue

No existing issue — searched open and closed PRs/issues for "post_script", "cron hook after job": no duplicate.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cron/scheduler.py` — `_run_post_script()` plus the two call sites in `run_one_job()`. Containment and interpreter selection are the same rules as `_run_job_script()`: the script must resolve inside `HERMES_HOME/scripts/` (path traversal, absolute-path injection and symlink escape rejected), NUL bytes and unexpandable paths rejected eagerly, `.sh`/`.bash` run under bash and everything else under `sys.executable` (including the Windows uv-venv bootstrap), env built by `build_subprocess_env()` so Hermes-managed credentials are not inherited (SECURITY.md §2.3), 60s timeout.
- `cron/jobs.py` — `post_script` param on `create_job()`, stored on the record, and normalized on update (empty string clears, same contract as the monitor fields).
- `tools/cronjob_tools.py` — `post_script` on create and update, validated through the existing `_validate_cron_script_path()` boundary (stricter than the scheduler: absolute paths and `~` are rejected outright so prompt injection cannot name one), plus the schema entry and job summary.
- `hermes_cli/subcommands/cron.py`, `hermes_cli/cron.py` — `--post-script` on `hermes cron create` and `hermes cron edit`.
- `tests/cron/test_post_script.py` — new, 25 cases.

## How to Test

```bash
cat > ~/.hermes/scripts/declare.py <<'PY'
import os
print(f"job={os.environ['HERMES_JOB_ID']} run={os.environ['HERMES_RUN_ID']}")
PY

hermes cron create "every 5m" "do the thing" --post-script declare.py
# →   Post-run hook: declare.py

hermes cron run <job-id>            # hook fires after the run is recorded
hermes cron edit <job-id> --post-script ""     # clears it
hermes cron edit <job-id> --post-script /etc/passwd
# → Failed to update job: Script path must be relative to ~/.hermes/scripts/…
```

Automated: `pytest tests/cron/ -q` → 971 passed, 1 skipped (946 pre-existing + 25 new).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/cron/ tests/tools/ -q`: `tests/cron/` is fully green (971 passed, 1 skipped). `tests/tools/` reports 64 failures — I verified these are **pre-existing on `main`**, not introduced here: running the same suite on a clean `origin/main` worktree yields a byte-identical failure set (64 failed / 7512 passed on both). None of them touch cron: they sit in video generation, Daytona sandboxes, approval modes, browser, STT and image generation, and look like missing-credential / external-service cases in my environment.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (kernel 7.1), Python 3.11

Test coverage (`tests/cron/test_post_script.py`, 25 cases):
- **Execution** — env carries `HERMES_JOB_ID`/`HERMES_RUN_ID`; relative and absolute-inside-scripts-dir paths; `.sh` runs under bash; no-op when unset or empty.
- **Never raises** — missing script, non-zero exit, and a `subprocess.run` failure are each logged, never propagated.
- **Containment** — `../` traversal, absolute path outside, symlink escape, NUL byte, and a directory named like a script are all refused *without* reaching `subprocess.run`.
- **Call sites** — success, agent-failure, monitor-suppressed-tick and `Exception` paths each fire the hook; `CancelledError` (gateway shutdown) and a fire claim taken over mid-run do not. These assert on the terminal `mark_job_run`/`finish_execution` call as well as on the hook, so a harness that silently lands on a fenced path can't make them pass vacuously.
- **Env hygiene** — the env is built by `build_subprocess_env()`, not inherited from the scheduler process.
- **Plumbing** — `create_job` stores it (and `None` when unset), `update_job` sets/strips/clears it, and the tool boundary rejects absolute and traversal paths.

### Documentation & Housekeeping

- [x] Documentation updated — docstrings on `_run_post_script()` and `create_job()`, `--post-script` CLI help, and the `cronjob` tool schema description
- [x] `cli-config.yaml.example` — N/A (per-job field, not a config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — considered: interpreter selection reuses `_windows_cron_python_invocation()` / `_windows_cron_bootstrap_argv()` and `windows_hide_flags()`; the bash branch degrades to a clear logged error when bash is absent; the bash and symlink tests skip where unsupported. Tested on Linux.
- [x] Tool descriptions/schemas updated — `post_script` added to `CRONJOB_SCHEMA` and the job summary
