### PR TITLE
fix(agent): resolve OpenRouter @preset aliases to real context length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover — runtime import is lazy (see below)
 
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, base_url_hostname
 
-from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_constants import OPENROUTER_MODELS_URL, OPENROUTER_PRESETS_URL
 from agent.message_metadata import PERSISTENCE_ONLY_MESSAGE_FIELDS
 
 logger = logging.getLogger(__name__)
@@ -2914,6 +2914,139 @@ def _resolve_nous_context_length(
     return None, ""
 
 
+# --------------------------------------------------------------------------------------
+# OpenRouter @preset/ Alias Resolution
+# --------------------------------------------------------------------------------------
+
+_OPENROUTER_PRESET_MARKER = "@preset/"
+_OPENROUTER_PRESET_CACHE_TTL = 300.0
+# slug -> (resolved_model, monotonic_ts)
+_openrouter_preset_model_cache: Dict[str, tuple[str, float]] = {}
+
+
+def _parse_openrouter_preset_ref(model: str) -> tuple[Optional[str], Optional[str]]:
+    """Parse an OpenRouter preset reference.
+
+    ``@preset/hermes-primary`` → ``("hermes-primary", None)``
+    ``deepseek/deepseek-v4-pro@preset/hermes-primary`` →
+        ``("hermes-primary", "deepseek/deepseek-v4-pro")``
+    Ordinary model ids → ``(None, None)``.
+    """
+    raw = str(model or "").strip()
+    marker = _OPENROUTER_PRESET_MARKER
+    if marker not in raw:
+        return None, None
+    if raw.startswith(marker):
+        slug = raw[len(marker):].strip()
+        return (slug or None), None
+    base, _, rest = raw.partition(marker)
+    slug = rest.strip()
+    explicit = base.strip()
+    return (slug or None), (explicit or None)
+
+
+def _extract_openrouter_preset_designated_model(payload: Any) -> str:
+    """Pull the designated version's concrete model from a presets API payload."""
+    if not isinstance(payload, dict):
+        return ""
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        return ""
+    dv = data.get("designated_version")
+    cfg: Any = {}
+    if isinstance(dv, dict):
+        cfg = dv.get("config") or {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    if not cfg:
+        maybe = data.get("config")
+        if isinstance(maybe, dict):
+            cfg = maybe
+
+    def _usable(value: Any) -> str:
+        if not isinstance(value, str):
+            return ""
+        text = value.strip()
+        if not text or _OPENROUTER_PRESET_MARKER in text:
+            return ""
+        return text
+
+    found = _usable(cfg.get("model"))
+    if found:
+        return found
+    models = cfg.get("models")
+    if isinstance(models, list):
+        for item in models:
+            found = _usable(item)
+            if found:
+                return found
+    return ""
+
+
+def _fetch_openrouter_preset_payload(slug: str, api_key: str) -> Optional[dict]:
+    """GET ``/api/v1/presets/{slug}`` (auth required). Returns JSON or None."""
+    if not slug or not api_key:
+        return None
+    try:
+        _ensure_requests()
+        response = requests.get(
+            f"{OPENROUTER_PRESETS_URL}/{slug}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=(5, 10),
+            verify=_resolve_requests_verify(),
+        )
+        if response.status_code != 200:
+            logger.debug(
+                "OpenRouter preset %r lookup returned HTTP %s",
+                slug, response.status_code,
+            )
+            return None
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        logger.debug("OpenRouter preset %r lookup failed", slug, exc_info=True)
+        return None
+
+
+def _resolve_openrouter_preset_model(model: str, api_key: str = "") -> str:
+    """Resolve ``@preset/<slug>`` to the designated version's concrete model id.
+
+    Combined refs (``model@preset/slug``) use the explicit base model and
+    skip the network. Bare aliases hit the OpenRouter presets API. Failures
+    return ``""`` so the caller can fall through to the 256K default.
+    """
+    slug, explicit = _parse_openrouter_preset_ref(model)
+    if not slug:
+        return ""
+    if explicit:
+        return explicit
+    cached = _openrouter_preset_model_cache.get(slug)
+    if cached and (time.monotonic() - cached[1]) < _OPENROUTER_PRESET_CACHE_TTL:
+        return cached[0]
+    key = (api_key or os.getenv("OPENROUTER_API_KEY") or "").strip()
+    if not key:
+        return ""
+    payload = _fetch_openrouter_preset_payload(slug, key)
+    if not payload:
+        return ""
+    resolved = _extract_openrouter_preset_designated_model(payload)
+    if resolved:
+        _openrouter_preset_model_cache[slug] = (resolved, time.monotonic())
+    return resolved
+
+
+def _looks_like_openrouter_preset_context(
+    model: str, provider: str, base_url: str,
+) -> bool:
+    if _OPENROUTER_PRESET_MARKER not in str(model or ""):
+        return False
+    prov = (provider or "").strip().lower()
+    if prov in ("", "openrouter"):
+        return True
+    host = base_url_hostname(base_url) if base_url else ""
+    return bool(host and "openrouter.ai" in host)
+
+
 def get_model_context_length(
     model: str,
     base_url: str = "",
@@ -2926,7 +3059,9 @@ def get_model_context_length(
 
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
+    0a. MoA preset name → aggregator model (provider==moa)
     0b. model_overrides config (per-provider+model context_window override)
+    0b-or. OpenRouter ``@preset/`` alias → designated version's concrete model
     0c. Endpoint-scoped metadata for models validated on one multiplexed endpoint
     1. Persistent cache (previously discovered via probing).  Nous URLs,
        LM Studio, and Codex OAuth bypass the cache here so their provider
@@ -3003,6 +3138,22 @@ def get_model_context_length(
                 return mo_ctx
         except Exception:
             pass  # fall through to other resolution paths
+
+    # 0b-or. OpenRouter @preset/ aliases are not catalog slugs. The same
+    # failure mode as MoA step 0a: matching falls through to 256K. After
+    # honoring model_overrides on the alias itself (the documented
+    # workaround), resolve slug → designated_version.config.model via the
+    # presets API and continue the normal chain on that concrete id.
+    if _looks_like_openrouter_preset_context(model, provider, base_url):
+        resolved = _resolve_openrouter_preset_model(model, api_key=api_key)
+        if resolved and resolved != model:
+            return get_model_context_length(
+                resolved,
+                base_url=base_url or "https://openrouter.ai/api/v1",
+                api_key=api_key,
+                provider=provider or "openrouter",
+                custom_providers=custom_providers,
+            )
 
     # 0c. custom_providers per-model override — check before any probe.
     # This closes the gap where /model switch and display paths used to fall

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1607,6 +1607,7 @@ FINISH_REASON_LENGTH = "length"
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
+OPENROUTER_PRESETS_URL = f"{OPENROUTER_BASE_URL}/presets"
 
 AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1849,3 +1849,162 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+class TestOpenRouterPresetContextLength:
+    """@preset/ aliases must resolve to the designated model's window, not 256K."""
+
+    def setup_method(self):
+        from agent import model_metadata as mm
+        mm._openrouter_preset_model_cache.clear()
+
+    def test_parse_bare_and_combined_refs(self):
+        from agent.model_metadata import _parse_openrouter_preset_ref
+        assert _parse_openrouter_preset_ref("@preset/hermes-primary") == (
+            "hermes-primary", None,
+        )
+        assert _parse_openrouter_preset_ref(
+            "deepseek/deepseek-v4-pro@preset/hermes-primary"
+        ) == ("hermes-primary", "deepseek/deepseek-v4-pro")
+        assert _parse_openrouter_preset_ref("deepseek/deepseek-v4-pro") == (None, None)
+
+    def test_extract_designated_model_and_models_list(self):
+        from agent.model_metadata import _extract_openrouter_preset_designated_model
+        payload = {
+            "data": {
+                "slug": "hermes-primary",
+                "designated_version": {
+                    "config": {"model": "deepseek/deepseek-v4-pro"},
+                },
+            }
+        }
+        assert _extract_openrouter_preset_designated_model(payload) == (
+            "deepseek/deepseek-v4-pro"
+        )
+        listed = {
+            "designated_version": {
+                "config": {"models": ["openai/gpt-oss-120b", "openai/gpt-5.4"]},
+            }
+        }
+        assert _extract_openrouter_preset_designated_model(listed) == (
+            "openai/gpt-oss-120b"
+        )
+        nested_alias = {
+            "designated_version": {"config": {"model": "@preset/other"}},
+        }
+        assert _extract_openrouter_preset_designated_model(nested_alias) == ""
+
+    def test_bare_preset_resolves_to_designated_context(self):
+        with patch(
+            "agent.model_metadata._resolve_openrouter_preset_model",
+            return_value="deepseek/deepseek-v4-pro",
+        ):
+            preset_ctx = get_model_context_length(
+                "@preset/hermes-primary",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+        concrete_ctx = get_model_context_length(
+            "deepseek/deepseek-v4-pro",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+        )
+        assert preset_ctx == concrete_ctx
+        assert preset_ctx != DEFAULT_FALLBACK_CONTEXT
+        assert preset_ctx >= 1_000_000
+
+    def test_small_context_designated_model_does_not_overreport(self):
+        with patch(
+            "agent.model_metadata._resolve_openrouter_preset_model",
+            return_value="openai/gpt-oss-120b",
+        ):
+            preset_ctx = get_model_context_length(
+                "@preset/hermes-hindsight",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+        concrete_ctx = get_model_context_length(
+            "openai/gpt-oss-120b",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+        )
+        assert preset_ctx == concrete_ctx
+        assert preset_ctx == 131_072
+
+    def test_combined_ref_skips_preset_fetch(self):
+        fetch = MagicMock()
+        with patch(
+            "agent.model_metadata._fetch_openrouter_preset_payload",
+            fetch,
+        ):
+            combined = get_model_context_length(
+                "openai/gpt-oss-120b@preset/hermes-hindsight",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+        fetch.assert_not_called()
+        assert combined == get_model_context_length(
+            "openai/gpt-oss-120b",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+        )
+
+    def test_unknown_preset_falls_back_to_256k(self):
+        with patch(
+            "agent.model_metadata._resolve_openrouter_preset_model",
+            return_value="",
+        ):
+            ctx = get_model_context_length(
+                "@preset/does-not-exist-xyz",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+        assert ctx == DEFAULT_FALLBACK_CONTEXT
+
+    def test_model_overrides_on_alias_still_win(self):
+        with patch(
+            "agent.models_dev._override_context_window",
+            return_value=1_048_576,
+        ), patch(
+            "agent.model_metadata._resolve_openrouter_preset_model",
+        ) as resolve:
+            ctx = get_model_context_length(
+                "@preset/hermes-primary",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+        resolve.assert_not_called()
+        assert ctx == 1_048_576
+
+    def test_presets_api_payload_is_used(self):
+        payload = {
+            "data": {
+                "slug": "hermes-primary",
+                "designated_version": {
+                    "config": {"model": "deepseek/deepseek-v4-pro"},
+                },
+            }
+        }
+        with patch(
+            "agent.model_metadata._fetch_openrouter_preset_payload",
+            return_value=payload,
+        ) as fetch:
+            ctx = get_model_context_length(
+                "@preset/hermes-primary",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="sk-or-test",
+                provider="openrouter",
+            )
+            ctx_again = get_model_context_length(
+                "@preset/hermes-primary",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="sk-or-test",
+                provider="openrouter",
+            )
+        fetch.assert_called_once()
+        assert ctx == ctx_again
+        assert ctx == get_model_context_length(
+            "deepseek/deepseek-v4-pro",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+        )


### PR DESCRIPTION
## What does this PR do?

OpenRouter `@preset/<slug>` aliases are not catalog model ids. `get_model_context_length` could not match them, so every preset-backed route fell through to `DEFAULT_FALLBACK_CONTEXT` (256,000 tokens). Compression then used the wrong window: large models (e.g. a preset whose designated version is `deepseek/deepseek-v4-pro`, 1,048,576) compressed far too early, and smaller models (e.g. `openai/gpt-oss-120b`, 131,072) were over-reported.

This adds a resolution step after explicit `model_overrides` (so the existing per-alias workaround still wins): parse `@preset/` and `model@preset/slug` refs, GET `/api/v1/presets/{slug}` for the designated version's concrete model, then continue the normal context-length chain on that id. Combined refs use the explicit base model and skip the network.

## Related Issue

Fixes #94696

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: step 0b-or — resolve OpenRouter `@preset/` aliases via the presets API (or the combined-ref base model), then recurse into the existing resolver.
- `hermes_constants.py`: add `OPENROUTER_PRESETS_URL`.
- `tests/agent/test_model_metadata.py`: `TestOpenRouterPresetContextLength` — parse/extract helpers, large-window and small-window designated models, combined-ref skip-fetch, unknown-preset 256K fallback, `model_overrides` still wins, presets-API payload + cache.

## How to Test

1. On current `main`, call `get_model_context_length("@preset/<your-slug>", base_url="https://openrouter.ai/api/v1", provider="openrouter", api_key=OPENROUTER_API_KEY)` and confirm it returns 256000 with the fallback warning.
2. Apply this branch and repeat for a real account preset. The returned length should match `get_model_context_length` on the preset's designated model (e.g. 1048576 for `deepseek/deepseek-v4-pro`).
3. Run `pytest tests/agent/test_model_metadata.py::TestOpenRouterPresetContextLength -q` — 8 tests in that class (plus the existing MoA aggregator case if desired).
4. Confirm a `model_overrides.openrouter.'@preset/<slug>'.context_window` entry still overrides without a presets API call.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
WARNING:agent.model_metadata:Could not determine context length for model '@preset/hermes-primary'
(base_url=https://openrouter.ai/api/v1) — falling back to 256,000 tokens.

# after fix, live presets GET + resolver
get_model_context_length('@preset/<slug>') -> 1048576
get_model_context_length('deepseek/deepseek-v4-pro') -> 1048576
```
