### PR TITLE
fix(cli): TUI no longer reinstalls deps on every launch with scoped installs and npm>=10 lockfiles (salvage #67011, #52245, #84640)

### DIFF
--- a/contributors/emails/qazasdsdqaza@users.noreply.github.com
+++ b/contributors/emails/qazasdsdqaza@users.noreply.github.com
@@ -1,0 +1,1 @@
+qazasdsdqaza

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1990,7 +1990,24 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset(
+    {
+        "ideallyInert",
+        "peer",
+        # npm writes these boolean annotation fields non-deterministically
+        # between the declarative package-lock.json and the hidden actualized
+        # .package-lock.json.  The intersection comparison (see
+        # _tui_need_npm_install) already handles the "field present in root
+        # but absent in hidden" case for structured fields like version,
+        # dependencies, license, etc.  These boolean flags need explicit
+        # exclusion because when present in *both* lockfiles they may still
+        # differ (e.g. dev: true → stripped in hidden).
+        "dev",
+        "extraneous",
+        "hasInstallScript",
+        "optional",
+    }
+)
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing
@@ -2000,6 +2017,13 @@ on dev-dependencies that are *also* declared as peers — the canonical
 it.  Neither key represents a real skew between what was declared and what was
 installed, so we exclude them from the comparison in :func:`_tui_need_npm_install`
 to avoid false-positive reinstalls on every launch.
+
+``dev``, ``optional``, ``extraneous``, and ``hasInstallScript`` are boolean
+annotations that npm populates differently in the hidden lock (e.g. ``dev: true``
+from the root lock may be absent or ``false`` in the hidden actualized tree).
+They never indicate a changed dependency — the authoritative check is the
+``resolved``/``integrity`` pair, which the intersection comparison always
+catches.
 """
 
 
@@ -2181,8 +2205,13 @@ def _tui_need_npm_install(root: Path) -> bool:
     For each entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
-      - present but with differing fields (excluding npm-written runtime
-        annotations like ``ideallyInert``) → reinstall
+      - present in both → compare only the **intersection** of fields (after
+        stripping ``_NPM_LOCK_RUNTIME_KEYS``).  npm's hidden lock
+        intentionally omits many metadata fields (version, license, engines,
+        dependencies, funding, etc.) — those one-side-only fields are normal
+        npm artefacts, not real skew.  A real version/dependency change will
+        change ``resolved``/``integrity``, which are present in both locks
+        and will be caught by the intersection comparison.
 
     Extra entries that exist only in the hidden lock are ignored — stale
     transitives left over from a removed dependency don't break runtime and
@@ -2247,10 +2276,21 @@ def _tui_need_npm_install(root: Path) -> bool:
                 continue
             return True
 
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(
-            installed[name]
-        ):
-            return True
+        if isinstance(installed[name], dict):
+            w = comparable(pkg)
+            i = comparable(installed[name])
+            # Only compare keys present in *both* lockfiles.  npm's hidden
+            # .package-lock.json intentionally omits many metadata fields
+            # (version, dependencies, license, engines, dev, optional, etc.)
+            # that the root lock records.  Missing-on-one-side is a normal
+            # npm artefact, not a real skew.  The authoritative fields
+            # "resolved" and "integrity" are always present for installed
+            # packages, so a real version/dependency change will still
+            # be caught through them.
+            common = set(w) & set(i)
+            for k in common:
+                if w[k] != i[k]:
+                    return True
 
     return False
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2056,18 +2056,24 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
-def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
-    """Package-map keys reachable from workspace ``start`` via npm resolution.
+def _npm_lock_workspace_closure(packages: dict, starts) -> Optional[set]:
+    """Package-map keys reachable from the selected workspaces via npm resolution.
 
-    Returns ``None`` when ``start`` is absent from *packages* so callers fall
-    back to the full-lockfile comparison.
+    *starts* is the set of workspace keys the launch install explicitly scopes
+    to (a single str is accepted for convenience).  ``devDependencies`` are
+    followed for **each** of those workspaces, since ``npm install`` installs
+    the dev toolchain for every workspace it selects.  Returns ``None`` when
+    none of *starts* are present in *packages* so callers fall back to the
+    full-lockfile comparison.
 
     The launch install is scoped with ``npm install --workspace ui-tui`` (see
     ``_make_tui_argv``), so only the ui-tui workspace's dependency closure is
-    written to the hidden ``.package-lock.json``.  The shared root
-    ``package-lock.json`` additionally lists every *other* workspace's deps
-    (``apps/desktop``, ``web``, …); comparing the two in full reports those
-    unrelated packages as "missing" and reinstalls on every launch (#66978).
+    written to the hidden ``.package-lock.json``.  On Termux it additionally
+    selects ui-tui's child ``packages/*`` workspaces, so their devDependencies
+    join the closure too.  The shared root ``package-lock.json`` additionally
+    lists every *other* workspace's deps (``apps/desktop``, ``web``, …);
+    comparing the two in full reports those unrelated packages as "missing" and
+    reinstalls on every launch (#66978).
 
     Keys follow npm's v3 ``packages`` map (``""`` root, ``ui-tui`` /
     ``apps/desktop`` workspace members, ``node_modules/<name>`` hoisted deps,
@@ -2076,7 +2082,9 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
     workspace symlinks (``link: true``) are followed to their real entry so a
     linked workspace's own deps join the closure.
     """
-    if start not in packages:
+    start_set = {starts} if isinstance(starts, str) else {s for s in starts if s}
+    present = [s for s in start_set if s in packages]
+    if not present:
         return None
 
     def resolve(from_key: str, dep: str) -> Optional[str]:
@@ -2091,7 +2099,7 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
             base = base.rsplit("/", 1)[0] if "/" in base else ""
 
     seen: set = set()
-    stack = [start]
+    stack = list(present)
     while stack:
         key = stack.pop()
         if key in seen:
@@ -2105,10 +2113,10 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
         resolved = entry.get("resolved")
         if entry.get("link") and isinstance(resolved, str) and resolved in packages:
             stack.append(resolved)
-        # devDependencies are installed for the workspace being scoped (ui-tui's
-        # build toolchain), but not for transitive deps.
+        # devDependencies are installed for each explicitly-selected workspace
+        # (its build toolchain), but not for transitive deps.
         fields = ["dependencies", "optionalDependencies", "peerDependencies"]
-        if key == start:
+        if key in start_set:
             fields.append("devDependencies")
         for field in fields:
             deps = entry.get(field)
@@ -2119,6 +2127,35 @@ def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
                 if target is not None:
                     stack.append(target)
     return seen
+
+
+def _tui_selected_workspace_keys(tui_dir: Path, ws_root: Path) -> set:
+    """Lock-map keys for the workspaces the launch install scopes to.
+
+    Mirrors ``_make_tui_argv``: always the ui-tui workspace, plus its child
+    ``packages/*`` workspaces on Termux (where ``include_child_workspaces=True``
+    in ``_termux_workspace_install_context``).  ``npm install`` installs the
+    devDependencies of every workspace it selects, so the freshness closure must
+    treat each as a dev-included root — otherwise a devDependency unique to a
+    selected child is dropped from the closure and a genuine missing package
+    slips past the check.  Returns an empty set when ui-tui can't be located
+    under *ws_root*, so the caller falls back to the full comparison.
+    """
+    try:
+        primary = tui_dir.relative_to(ws_root).as_posix()
+    except ValueError:
+        return set()
+    keys = {primary}
+    if _is_termux_startup_environment():
+        packages_dir = tui_dir / "packages"
+        if packages_dir.is_dir():
+            for child in sorted(packages_dir.iterdir()):
+                if child.is_dir() and (child / "package.json").is_file():
+                    try:
+                        keys.add(child.relative_to(ws_root).as_posix())
+                    except ValueError:
+                        continue
+    return keys
 
 
 def _tui_need_npm_install(root: Path) -> bool:
@@ -2183,19 +2220,17 @@ def _tui_need_npm_install(root: Path) -> bool:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
     # In a shared workspace checkout the launch install is scoped to the ui-tui
-    # workspace, so only its dependency closure lands in the hidden lock.  Limit
-    # the comparison to that closure so unrelated workspace deps (apps/desktop,
+    # workspace (plus its child packages/* workspaces on Termux), so only that
+    # dependency closure lands in the hidden lock.  Limit the comparison to the
+    # same selected-workspace closure so unrelated workspace deps (apps/desktop,
     # web, …) don't force a reinstall every launch (#66978).  Standalone /
     # own-lockfile layouts (ws_root == root) do a full install, so keep the full
     # comparison; a missing/unlocatable workspace falls back to it too.
     closure: Optional[set] = None
     if ws_root != root:
-        try:
-            workspace_key = root.relative_to(ws_root).as_posix()
-        except ValueError:
-            workspace_key = ""
-        if workspace_key:
-            closure = _npm_lock_workspace_closure(wanted, workspace_key)
+        selected = _tui_selected_workspace_keys(root, ws_root)
+        if selected:
+            closure = _npm_lock_workspace_closure(wanted, selected)
 
     for name, pkg in wanted.items():
         if not name:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2056,6 +2056,71 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _npm_lock_workspace_closure(packages: dict, start: str) -> Optional[set]:
+    """Package-map keys reachable from workspace ``start`` via npm resolution.
+
+    Returns ``None`` when ``start`` is absent from *packages* so callers fall
+    back to the full-lockfile comparison.
+
+    The launch install is scoped with ``npm install --workspace ui-tui`` (see
+    ``_make_tui_argv``), so only the ui-tui workspace's dependency closure is
+    written to the hidden ``.package-lock.json``.  The shared root
+    ``package-lock.json`` additionally lists every *other* workspace's deps
+    (``apps/desktop``, ``web``, …); comparing the two in full reports those
+    unrelated packages as "missing" and reinstalls on every launch (#66978).
+
+    Keys follow npm's v3 ``packages`` map (``""`` root, ``ui-tui`` /
+    ``apps/desktop`` workspace members, ``node_modules/<name>`` hoisted deps,
+    ``<dir>/node_modules/<name>`` nested deps).  Dependency names resolve to a
+    key by walking up ``node_modules`` ancestors, mirroring node resolution, and
+    workspace symlinks (``link: true``) are followed to their real entry so a
+    linked workspace's own deps join the closure.
+    """
+    if start not in packages:
+        return None
+
+    def resolve(from_key: str, dep: str) -> Optional[str]:
+        base = from_key
+        while True:
+            prefix = f"{base}/" if base else ""
+            candidate = f"{prefix}node_modules/{dep}"
+            if candidate in packages:
+                return candidate
+            if not base:
+                return None
+            base = base.rsplit("/", 1)[0] if "/" in base else ""
+
+    seen: set = set()
+    stack = [start]
+    while stack:
+        key = stack.pop()
+        if key in seen:
+            continue
+        seen.add(key)
+        entry = packages.get(key)
+        if not isinstance(entry, dict):
+            continue
+        # Workspace symlink (e.g. node_modules/@hermes/ink → ui-tui/packages/…):
+        # follow to the real package entry so its dependencies join the closure.
+        resolved = entry.get("resolved")
+        if entry.get("link") and isinstance(resolved, str) and resolved in packages:
+            stack.append(resolved)
+        # devDependencies are installed for the workspace being scoped (ui-tui's
+        # build toolchain), but not for transitive deps.
+        fields = ["dependencies", "optionalDependencies", "peerDependencies"]
+        if key == start:
+            fields.append("devDependencies")
+        for field in fields:
+            deps = entry.get(field)
+            if not isinstance(deps, dict):
+                continue
+            for dep in deps:
+                target = resolve(key, dep)
+                if target is not None:
+                    stack.append(target)
+    return seen
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -2117,8 +2182,26 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
+    # In a shared workspace checkout the launch install is scoped to the ui-tui
+    # workspace, so only its dependency closure lands in the hidden lock.  Limit
+    # the comparison to that closure so unrelated workspace deps (apps/desktop,
+    # web, …) don't force a reinstall every launch (#66978).  Standalone /
+    # own-lockfile layouts (ws_root == root) do a full install, so keep the full
+    # comparison; a missing/unlocatable workspace falls back to it too.
+    closure: Optional[set] = None
+    if ws_root != root:
+        try:
+            workspace_key = root.relative_to(ws_root).as_posix()
+        except ValueError:
+            workspace_key = ""
+        if workspace_key:
+            closure = _npm_lock_workspace_closure(wanted, workspace_key)
+
     for name, pkg in wanted.items():
         if not name:
+            continue
+
+        if closure is not None and name not in closure:
             continue
 
         if not isinstance(pkg, dict):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2246,19 +2246,28 @@ def _tui_need_npm_install(root: Path) -> bool:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return lock.stat().st_mtime > marker.stat().st_mtime
 
-    def comparable(pkg: dict) -> dict:
-        # npm >= 10/11 writes a reduced hidden lockfile that omits declarative
-        # fields (`version`, `dependencies`, `dev`, `engines`, `bin`, ...) or
-        # stores them as null.  Comparing every key field-by-field then flags
-        # nearly every installed package as "changed".  Compare only the keys
-        # both sides actually record with a non-null value (`resolved`,
-        # `integrity`, ...): a genuinely stale install (root lockfile bumped
-        # while node_modules is behind) still differs on those keys, while the
-        # reduced-lockfile field omissions no longer false-positive.
+    def entries_differ(pkg: dict, installed_pkg: dict) -> bool:
+        # Only compare keys present in *both* lockfiles with non-null values.
+        # npm's hidden .package-lock.json intentionally omits many metadata
+        # fields the root lock records (version, dependencies, license,
+        # engines, bin, ...), and npm >= 10/11 writes a further *reduced*
+        # hidden lockfile that stores some of them as null.  Missing- or
+        # null-on-one-side is a normal npm artefact, not a real skew.  The
+        # authoritative fields "resolved" and "integrity" are present in both
+        # locks for installed packages, so a genuinely stale install (root
+        # lockfile bumped while node_modules is behind) still differs on them.
         a = {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
-        b = {k: v for k, v in installed_pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
-        common = a.keys() & b.keys()
-        return {k: a[k] for k in common if a[k] is not None and b[k] is not None}
+        b = {
+            k: v
+            for k, v in installed_pkg.items()
+            if k not in _NPM_LOCK_RUNTIME_KEYS
+        }
+        for k in a.keys() & b.keys():
+            if a[k] is None or b[k] is None:
+                continue
+            if a[k] != b[k]:
+                return True
+        return False
 
     # In a shared workspace checkout the launch install is scoped to the ui-tui
     # workspace (plus its child packages/* workspaces on Termux), so only that
@@ -2295,21 +2304,10 @@ def _tui_need_npm_install(root: Path) -> bool:
                 continue
             return True
 
-        if isinstance(installed[name], dict):
-            w = comparable(pkg)
-            i = comparable(installed[name])
-            # Only compare keys present in *both* lockfiles.  npm's hidden
-            # .package-lock.json intentionally omits many metadata fields
-            # (version, dependencies, license, engines, dev, optional, etc.)
-            # that the root lock records.  Missing-on-one-side is a normal
-            # npm artefact, not a real skew.  The authoritative fields
-            # "resolved" and "integrity" are always present for installed
-            # packages, so a real version/dependency change will still
-            # be caught through them.
-            common = set(w) & set(i)
-            for k in common:
-                if w[k] != i[k]:
-                    return True
+        if isinstance(installed[name], dict) and entries_differ(
+            pkg, installed[name]
+        ):
+            return True
 
     return False
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2019,8 +2019,9 @@ installed, so we exclude them from the comparison in :func:`_tui_need_npm_instal
 to avoid false-positive reinstalls on every launch.
 
 ``dev``, ``optional``, ``extraneous``, and ``hasInstallScript`` are boolean
-annotations that npm populates differently in the hidden lock (e.g. ``dev: true``
-from the root lock may be absent or ``false`` in the hidden actualized tree).
+annotations that npm populates differently in the hidden lock (npm >= 10/11
+writes ``extraneous`` into the hidden lock only, and ``dev: true`` from the
+root lock may be absent or ``false`` in the hidden actualized tree).
 They never indicate a changed dependency — the authoritative check is the
 ``resolved``/``integrity`` pair, which the intersection comparison always
 catches.
@@ -2246,7 +2247,18 @@ def _tui_need_npm_install(root: Path) -> bool:
         return lock.stat().st_mtime > marker.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        # npm >= 10/11 writes a reduced hidden lockfile that omits declarative
+        # fields (`version`, `dependencies`, `dev`, `engines`, `bin`, ...) or
+        # stores them as null.  Comparing every key field-by-field then flags
+        # nearly every installed package as "changed".  Compare only the keys
+        # both sides actually record with a non-null value (`resolved`,
+        # `integrity`, ...): a genuinely stale install (root lockfile bumped
+        # while node_modules is behind) still differs on those keys, while the
+        # reduced-lockfile field omissions no longer false-positive.
+        a = {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        b = {k: v for k, v in installed_pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+        common = a.keys() & b.keys()
+        return {k: a[k] for k in common if a[k] is not None and b[k] is not None}
 
     # In a shared workspace checkout the launch install is scoped to the ui-tui
     # workspace (plus its child packages/* workspaces on Termux), so only that
@@ -2272,7 +2284,14 @@ def _tui_need_npm_install(root: Path) -> bool:
             continue
 
         if name not in installed:
-            if pkg.get("optional") or pkg.get("peer"):
+            # Workspace link entries (`"link": true`, paths outside
+            # node_modules/ like `apps/desktop`, `node_modules/web`) are never
+            # materialized by a partial `npm install --workspace ui-tui` —
+            # they're deliberately skipped (see #38772) and would otherwise
+            # force a reinstall on every launch.
+            if pkg.get("optional") or pkg.get("peer") or pkg.get("link"):
+                continue
+            if not name.startswith("node_modules/"):
                 continue
             return True
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -224,6 +224,62 @@ def test_workspace_closure_returns_none_when_start_absent(main_mod) -> None:
     assert main_mod._npm_lock_workspace_closure({"node_modules/foo": {}}, "ui-tui") is None
 
 
+def test_workspace_closure_includes_dev_deps_of_selected_child_workspace(main_mod) -> None:
+    """On Termux the install also scopes to ui-tui's child packages/* workspaces,
+    so each selected child's devDependencies join the closure — a dev dep unique
+    to a child is NOT dropped (regression for the child-scope false-negative)."""
+    packages = {
+        "ui-tui": {"dependencies": {"@hermes/ink": "*"}},
+        "node_modules/@hermes/ink": {
+            "link": True,
+            "resolved": "ui-tui/packages/hermes-ink",
+        },
+        "ui-tui/packages/hermes-ink": {"devDependencies": {"child-dev-only": "1"}},
+        "node_modules/child-dev-only": {},
+    }
+    # Only ui-tui selected (desktop): the child's dev dep is not installed.
+    desktop = main_mod._npm_lock_workspace_closure(packages, {"ui-tui"})
+    assert "node_modules/child-dev-only" not in desktop
+    # ui-tui + child selected (Termux): the child's dev dep is in the closure.
+    termux = main_mod._npm_lock_workspace_closure(
+        packages, {"ui-tui", "ui-tui/packages/hermes-ink"}
+    )
+    assert "node_modules/child-dev-only" in termux
+
+
+def test_termux_install_catches_missing_child_workspace_dev_dep(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """On Termux the launch install selects ui-tui/packages/* too, installing
+    each child's devDependencies.  A child dev dep missing from the hidden lock
+    must trigger a reinstall — off Termux (child not selected) it must not."""
+    ws_lock = (
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"devDependencies":{"child-dev-only":"1.0.0"}},'
+        '"node_modules/child-dev-only":{"version":"1.0.0"}'
+        "}}"
+    )
+    hidden_lock = (
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"devDependencies":{"child-dev-only":"1.0.0"}}'
+        "}}"
+    )
+    tui_dir = _write_ws(tmp_path, ws_lock, hidden_lock)
+    child = tui_dir / "packages" / "hermes-ink"
+    child.mkdir(parents=True, exist_ok=True)
+    (child / "package.json").write_text('{"name":"@hermes/ink"}')
+
+    monkeypatch.setattr(main_mod, "_is_termux_startup_environment", lambda: False)
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+    monkeypatch.setattr(main_mod, "_is_termux_startup_environment", lambda: True)
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_no_install_prebuilt_bundle_mode(tmp_path: Path, main_mod) -> None:
     """dist/entry.js present and no package-lock.json → prebuilt bundle, skip npm install."""
     _touch_tui_entry(tmp_path)

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,5 +1,6 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
+import json
 import os
 import types
 from pathlib import Path
@@ -563,6 +564,135 @@ def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
     # hidden lockfile to compare against, and ink is missing → True.
     # But the key invariant is: ws_root for the need-check == ws_root
     # for the install cwd — both use _workspace_root(sub).
+
+
+def test_need_npm_install_false_with_reduced_npm11_hidden_lockfile(
+    tmp_path: Path, main_mod
+) -> None:
+    """npm >= 10/11 writes a reduced hidden `.package-lock.json` that omits
+    declarative fields (version/dependencies/dev) and adds `extraneous`,
+    and it never materializes workspace `"link": true` entries. A fresh
+    install therefore used to look perpetually stale and re-ran `npm install`
+    on every TUI launch (#84617). After the fix it must be stable."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "version": "5.0.0",
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                        "dependencies": {"yocto": "^1.0.0"},
+                    },
+                    "apps/desktop": {"link": True, "resolved": "apps/desktop"},
+                }
+            }
+        )
+    )
+    # Hidden lockfile as npm 11 writes it: reduced, plus extraneous.
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                        "extraneous": True,
+                    },
+                    "apps/desktop": {"link": True, "resolved": "apps/desktop"},
+                }
+            }
+        )
+    )
+
+    # Must be False: real skew keys (resolved/integrity) match, declarative
+    # omissions and extraneous are ignored, and the workspace link is skipped.
+    assert main_mod._tui_need_npm_install(ws) is False
+
+
+def test_need_npm_install_true_when_resolved_drifts(tmp_path: Path, main_mod) -> None:
+    """A genuinely stale install (lockfile bumped the resolved URL/integrity
+    while node_modules is behind) must still be detected — the reduced-lockfile
+    fix must not paper over real skew (#84617)."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "version": "5.0.0",
+                        "resolved": "https://reg/ink-NEW.tgz",
+                        "integrity": "sha512-bbbb",
+                    },
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink-OLD.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                }
+            }
+        )
+    )
+
+    # resolved/integrity differ on both sides → must reinstall.
+    assert main_mod._tui_need_npm_install(ws) is True
+
+
+def test_need_npm_install_true_when_regular_pkg_missing(tmp_path: Path, main_mod) -> None:
+    """A real non-link node_modules/ package missing from the install must
+    still trigger a reinstall — only workspace links and optional/peer skips
+    are exempt (#84617)."""
+    ws = tmp_path / "ui-tui"
+    ws.mkdir()
+    (ws / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                    "node_modules/missing-pkg": {
+                        "resolved": "https://reg/missing.tgz",
+                        "integrity": "sha512-cccc",
+                    },
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/ink": {
+                        "resolved": "https://reg/ink.tgz",
+                        "integrity": "sha512-aaaa",
+                    },
+                }
+            }
+        )
+    )
+
+    assert main_mod._tui_need_npm_install(ws) is True
 
 
 def test_no_stray_lockfiles_in_workspace_subdirs(main_mod) -> None:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -57,6 +57,415 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
     runnable bundled TUI on disk. The bundled shortcut must succeed without
     ever touching the (missing) ui-tui workspace or git.
     """
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"node_modules/foo":{"version":"1.0.0","dev":true,"peer":true,"resolved":"https://x/foo.tgz"}'
+        '}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"node_modules/foo":{"version":"1.0.0","dev":true,"resolved":"https://x/foo.tgz"}'
+        '}}'
+    )
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_install_when_version_differs_even_with_peer_drop(tmp_path: Path, main_mod) -> None:
+    """The peer-drop tolerance must not mask a real version skew."""
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"2.0.0","dev":true,"peer":true}}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0","dev":true}}}'
+    )
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_no_install_when_lock_older_than_marker(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "node_modules" / ".package-lock.json").write_text("{}")
+    os.utime(tmp_path / "package-lock.json", (100, 100))
+    os.utime(tmp_path / "node_modules" / ".package-lock.json", (200, 200))
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_need_install_when_marker_missing(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text("{}")
+    assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_no_install_without_lockfile_when_ink_present(tmp_path: Path, main_mod) -> None:
+    _touch_ink(tmp_path)
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+# ── workspace-scoped comparison (#66978) ────────────────────────────
+#
+# In a shared workspace checkout the launch install is scoped to the ui-tui
+# workspace, so only its dependency closure lands in the hidden lock while the
+# root lock lists every other workspace's deps too. The comparison must ignore
+# those unrelated packages instead of reinstalling on every launch.
+
+
+def _write_ws(root: Path, ws_lock: str, hidden_lock: str) -> Path:
+    """Lay out a workspace root + ui-tui member and return the ui-tui dir.
+
+    ``@hermes/ink`` and the marker live at the workspace root (hoisted);
+    ``ui-tui/`` has no lockfile of its own so ``_workspace_root`` treats the
+    parent as the workspace root and the launch scopes to ``--workspace ui-tui``.
+    """
+    (root / "package-lock.json").write_text(ws_lock)
+    _touch_ink(root)
+    (root / "node_modules" / ".package-lock.json").write_text(hidden_lock)
+    tui_dir = root / "ui-tui"
+    tui_dir.mkdir(parents=True, exist_ok=True)
+    # package.json (and no own lockfile) is what makes _workspace_root treat the
+    # parent as the workspace root and the launch scope to --workspace ui-tui.
+    (tui_dir / "package.json").write_text('{"name":"hermes-tui"}')
+    return tui_dir
+
+
+def test_no_install_when_only_other_workspace_deps_missing(tmp_path: Path, main_mod) -> None:
+    """Deps that belong to apps/desktop / web (never installed by the ui-tui
+    scoped install) must not trigger a reinstall on every launch (#66978)."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"},'
+        '"apps/desktop":{"dependencies":{"desktop-only":"1.0.0"}},'
+        '"node_modules/desktop-only":{"version":"1.0.0"},'
+        '"apps/desktop/node_modules/nested":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_need_install_when_ui_tui_dep_missing_in_workspace_layout(tmp_path: Path, main_mod) -> None:
+    """A genuinely missing ui-tui dependency is still caught after scoping."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0","bar":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"},'
+        '"node_modules/bar":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"1.0.0","bar":"1.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_need_install_when_linked_workspace_dep_missing(tmp_path: Path, main_mod) -> None:
+    """The closure follows workspace symlinks (@hermes/ink → ui-tui/packages/…)
+    so a linked workspace's own missing dep triggers a reinstall."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"dependencies":{"inkdep":"1.0.0"}},'
+        '"node_modules/inkdep":{"version":"1.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"@hermes/ink":"*"}},'
+        '"node_modules/@hermes/ink":{"link":true,"resolved":"ui-tui/packages/hermes-ink"},'
+        '"ui-tui/packages/hermes-ink":{"dependencies":{"inkdep":"1.0.0"}}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_need_install_when_closure_package_version_drifts(tmp_path: Path, main_mod) -> None:
+    """Version drift on an in-closure package still forces a reinstall."""
+    tui_dir = _write_ws(
+        tmp_path,
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"2.0.0"}},'
+        '"node_modules/foo":{"version":"2.0.0"}'
+        "}}",
+        '{"packages":{'
+        '"ui-tui":{"dependencies":{"foo":"2.0.0"}},'
+        '"node_modules/foo":{"version":"1.0.0"}'
+        "}}",
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_workspace_closure_includes_dev_deps_of_scoped_workspace(main_mod) -> None:
+    """ui-tui's devDependencies (esbuild/typescript build toolchain) are part of
+    the closure; a transitive package's devDependencies are not."""
+    packages = {
+        "ui-tui": {
+            "dependencies": {"foo": "1"},
+            "devDependencies": {"esbuild": "1"},
+        },
+        "node_modules/foo": {"devDependencies": {"foo-dev-only": "1"}},
+        "node_modules/esbuild": {},
+        "node_modules/foo-dev-only": {},
+    }
+    closure = main_mod._npm_lock_workspace_closure(packages, "ui-tui")
+    assert "node_modules/esbuild" in closure
+    assert "node_modules/foo-dev-only" not in closure
+
+
+def test_workspace_closure_returns_none_when_start_absent(main_mod) -> None:
+    """Missing workspace key → None so the caller falls back to full compare."""
+    assert main_mod._npm_lock_workspace_closure({"node_modules/foo": {}}, "ui-tui") is None
+
+
+def test_no_install_prebuilt_bundle_mode(tmp_path: Path, main_mod) -> None:
+    """dist/entry.js present and no package-lock.json → prebuilt bundle, skip npm install."""
+    _touch_tui_entry(tmp_path)
+    assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_need_rebuild_when_tui_bundle_missing(tmp_path: Path, main_mod) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "entry.tsx").write_text("console.log('src')")
+
+    assert main_mod._tui_need_rebuild(tmp_path) is True
+
+
+def test_no_rebuild_when_tui_bundle_newer_than_inputs(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "entry.tsx").write_text("console.log('src')")
+    os.utime(src / "entry.tsx", (100, 100))
+    os.utime(tmp_path / "dist" / "entry.js", (200, 200))
+
+    assert main_mod._tui_need_rebuild(tmp_path) is False
+
+
+def test_rebuild_when_tui_source_newer_than_bundle(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "entry.tsx").write_text("console.log('src')")
+    os.utime(tmp_path / "dist" / "entry.js", (100, 100))
+    os.utime(src / "entry.tsx", (200, 200))
+
+    assert main_mod._tui_need_rebuild(tmp_path) is True
+
+
+def test_make_tui_argv_skips_build_only_on_termux_when_fresh(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh Termux TUI launch must not rebuild")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_skips_install_on_termux_when_bundle_fresh(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh Termux TUI launch must not run npm")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_scopes_npm_install_on_termux_workspace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    ink_dir = tui_dir / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    (ink_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.setenv("TERMUX_VERSION", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:7] == [
+        "/bin/npm",
+        "install",
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "ui-tui/packages/hermes-ink",
+        "--include-workspace-root=false",
+    ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+    _assert_utf8_replace_capture(calls[0][1])
+    _assert_utf8_replace_capture(calls[1][1])
+
+
+def test_make_tui_argv_keeps_desktop_workspace_install_behaviour(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert calls[0][0][0] == [
+        "/bin/npm",
+        "install",
+        "--workspace",
+        "ui-tui",
+        "--include=dev",
+        "--silent",
+        "--no-fund",
+        "--no-audit",
+        "--progress=false",
+    ]
+    assert calls[0][1]["cwd"] == str(tmp_path)
+    _assert_utf8_replace_capture(calls[0][1])
+    _assert_utf8_replace_capture(calls[1][1])
+
+
+def test_make_tui_argv_npm_install_forces_include_dev(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """The TUI-launch npm install must force --include=dev: ui-tui's build
+    toolchain (esbuild, typescript) lives in devDependencies, and an inherited
+    NODE_ENV=production (container shells; a parent TUI sets it on its own
+    subprocess env) or an npm `omit=dev` config would silently skip them,
+    breaking the TUI build with `tsc`/`esbuild: command not found."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("NODE_ENV", "production")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:2] == ["/bin/npm", "install"]
+    assert "--include=dev" in install_cmd
+
+
+def test_make_tui_argv_keeps_desktop_always_build_behaviour(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert calls
+    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    _assert_utf8_replace_capture(calls[0][1])
+
+
+def test_make_tui_argv_decodes_dev_prebuild_with_utf8_replace(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    ink_dir = tmp_path / "packages" / "hermes-ink"
+    ink_dir.mkdir(parents=True)
+    tsx = tmp_path / "node_modules" / ".bin" / "tsx"
+    tsx.parent.mkdir(parents=True)
+    tsx.write_text("")
+
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=True)
+
+    assert argv == [str(tsx), "src/entry.tsx"]
+    assert cwd == tmp_path
+    assert calls[0][0][0] == ["/bin/npm", "run", "build"]
+    assert calls[0][1]["cwd"] == str(ink_dir)
+    _assert_utf8_replace_capture(calls[0][1])
+
+
+def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Missing ui-tui + no git checkout → clean error, never touches node/npm."""
     monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
     monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
 


### PR DESCRIPTION
## Summary

`hermes --tui` no longer re-runs "Installing TUI dependencies…" on every launch when the TUI deps were provisioned via a scoped install (`npm install --workspace ui-tui`) or with npm >= 10's reduced hidden lockfile. Consolidated salvage of PRs #67011, #52245, and #84640 — the same launch loop was reported and fixed independently eight times.

Root cause: `_tui_need_npm_install()` compared the canonical root `package-lock.json` (declares every workspace: `apps/desktop`, `web`, `tests-js`, …) against npm's hidden `node_modules/.package-lock.json` (contains only what a scoped install materialized). ~999 other-workspace entries were permanently "missing" and annotation fields (`dev`, `extraneous`, …) permanently differed, so the check never converged and npm ran on every launch.

## Changes

- `hermes_cli/main.py`:
  - `_npm_lock_workspace_closure()` / `_tui_selected_workspace_keys()` (salvaged from #67011 by @PRATHAMESH75): the freshness check now walks the real dependency closure of the workspaces the launch install actually selects (ui-tui, plus its `packages/*` children on Termux), mirroring node resolution incl. nested `node_modules` walk-up and `link: true` workspace symlinks. Entries outside that closure are expected to be absent under a scoped install and no longer trigger a reinstall. Standalone/own-lockfile layouts keep the full comparison.
  - Field comparison (salvaged from #52245 by @qazasdsdqaza + #84640 by @andyst-dev): entries present in both locks are compared only on the intersection of non-null fields, killing the annotation-drift class (`dev`, `devOptional`, `extraneous`, `deprecated`, `hasInstallScript`, npm >= 10/11 reduced hidden lockfiles) in one rule instead of per-field whack-a-mole. Genuine staleness is still caught via `resolved`/`integrity`, which both locks always record. Workspace `link: true` entries and non-`node_modules/` paths never materialized by a partial install are skipped.
- `tests/hermes_cli/test_tui_npm_install.py`: contributor tests from both salvaged branches (30 tests, incl. the npm 11 reduced-lockfile fixture and workspace-closure cases).

## Validation

Live repro against a **real** scoped-install tree (copied workspace manifests + `npm install --workspace ui-tui` with npm 10.9.8):

| | origin/main | this branch |
|---|---|---|
| `_tui_need_npm_install(ui-tui)` on fresh scoped install | `True` (999 false-missing entries) | `False` |
| `_make_tui_argv()` launch path | npm install every launch | resolves to `node --expose-gc dist/entry.js`, 0 npm runs (stable across repeated launches) |
| Tampered `integrity` of an in-closure dep | — | `True` (genuine staleness still fires) |
| New in-closure dep added to root lock, absent on disk | — | `True` |
| Full-workspace install (live repo checkout) | `False` | `False` (unchanged) |

`tests/hermes_cli/test_tui_npm_install.py`: 30 passed. Sibling TUI launch suites (bundled/heap/resume/backcompat): 12 passed. ruff clean.

**Live repro:** bug fired on origin/main against the real scoped tree (`need: True`, 999 missing); fixed at head on the same tree (`need: False`, launch runs zero npm commands; adversarial staleness still detected).

Credits: @PRATHAMESH75 (#67011, closure walk — earliest complete closure fix lineage starts at #54291 by @vanhoof), @qazasdsdqaza (#52245, earliest intersection-comparison fix), @andyst-dev (#84640, npm >= 10 reduced-lockfile + link handling), @ayushdecoded (#94682, scoped-install diagnosis incl. `devOptional`). Closes #94682. Supersedes #54291, #54814, #76232, #80214, #52245, #67011, #84640.

## Infographic

![TUI launch check fixed — 1-bit Mac infographic](https://v3b.fal.media/files/b/0aa7c064/t9P8T0rLeaOYXD86-QZXE_RwLfKRFw.png)
