### PR TITLE
fix(agent): enforce positional tool-result pairing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3826,89 +3826,6 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             elif isinstance(tc, dict):
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
-    # --- Enforce positional tool_call <-> tool-result pairing ---
-    # Strict OpenAI-compatible providers require every assistant tool_calls
-    # message to be immediately followed by a contiguous run of tool results
-    # covering every declared call. A global id-presence check is insufficient:
-    # compaction or replay can repeat a call id whose only result is historical,
-    # so that old result masks a positionally unanswered replay (#94704).
-    #
-    # Walk one assistant/result transaction at a time. Match through the shared
-    # variant helpers so ``id``, ``call_id``, ``response_item_id`` and composite
-    # bridge spellings remain equivalent (#55626, #63000, #93251).
-    paired: List[Dict[str, Any]] = []
-    removed_positional_orphans = 0
-    added_positional_stubs = 0
-    index = 0
-    while index < len(messages):
-        msg = messages[index]
-        if msg.get("role") != "assistant":
-            if msg.get("role") == "tool" and tool_result_id_variants(
-                msg.get("tool_call_id")
-            ):
-                removed_positional_orphans += 1
-            else:
-                paired.append(msg)
-            index += 1
-            continue
-
-        paired.append(msg)
-        calls = [
-            (tc, tool_call_id_variants(tc))
-            for tc in msg.get("tool_calls") or []
-        ]
-        matched_calls: set[int] = set()
-        cursor = index + 1
-        while cursor < len(messages) and messages[cursor].get("role") == "tool":
-            result = messages[cursor]
-            result_variants = tool_result_id_variants(result.get("tool_call_id"))
-            if not result_variants:
-                # Preserve legacy/provider-specific tool rows with no usable id;
-                # the existing sanitizer deliberately treated these as opaque.
-                paired.append(result)
-            else:
-                candidates = [
-                    call_index
-                    for call_index, (_, call_variants) in enumerate(calls)
-                    if call_index not in matched_calls
-                    and call_variants
-                    and call_variants & result_variants
-                ]
-                if candidates:
-                    matched_calls.add(candidates[0])
-                    paired.append(result)
-                else:
-                    removed_positional_orphans += 1
-            cursor += 1
-
-        for call_index, (tc, variants) in enumerate(calls):
-            if call_index in matched_calls or not variants:
-                continue
-            cid = coalesce_tool_call_id(tc) or sorted(variants)[0]
-            paired.append({
-                "role": "tool",
-                "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                "content": "[Result unavailable — see context summary above]",
-                "tool_call_id": cid,
-            })
-            added_positional_stubs += 1
-
-        index = cursor
-
-    if removed_positional_orphans or added_positional_stubs:
-        messages = paired
-    if removed_positional_orphans:
-        _ra().logger.debug(
-            "Pre-call sanitizer: removed %d positionally orphaned tool result(s)",
-            removed_positional_orphans,
-        )
-    if added_positional_stubs:
-        _ra().logger.debug(
-            "Pre-call sanitizer: added %d stub result(s) for positionally "
-            "unanswered tool call(s)",
-            added_positional_stubs,
-        )
-
     # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a
     # payload where the same tool_call_id appears more than once with HTTP 400
     # "Duplicate value for 'tool_call_id'" (#58327). Duplicates can arise from
@@ -3966,6 +3883,12 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 msg = {**msg, "tool_calls": kept_tcs}
             elif len(kept_tcs) != len(msg.get("tool_calls") or []):
                 msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+                if not _msg_has_payload(msg):
+                    # Dedup runs after the early empty-message healer. If it
+                    # removes the only payload from a replayed assistant turn,
+                    # do not create a new empty non-final message that strict
+                    # providers reject.
+                    continue
             deduped.append(msg)
         elif role == "tool":
             result_variants = tool_result_id_variants(msg.get("tool_call_id"))
@@ -3998,6 +3921,114 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
+        )
+
+    # --- Enforce positional tool_call <-> tool-result pairing ---
+    # Run this AFTER duplicate-call cleanup so a synthetic stub cannot make an
+    # outstanding duplicate look like a completed round. Strict providers
+    # require every assistant tool_calls message to be immediately followed by
+    # a contiguous run of tool results covering every declared call. A global
+    # id-presence check is insufficient: compaction/replay can repeat a call id
+    # whose only result is historical, masking a positionally unanswered replay
+    # (#94704; salvaged from #84481).
+    paired: List[Dict[str, Any]] = []
+    removed_positional_orphans = 0
+    added_positional_stubs = 0
+    index = 0
+    while index < len(messages):
+        msg = messages[index]
+        if msg.get("role") != "assistant":
+            if msg.get("role") == "tool" and tool_result_id_variants(
+                msg.get("tool_call_id")
+            ):
+                removed_positional_orphans += 1
+            else:
+                paired.append(msg)
+            index += 1
+            continue
+
+        # Canonicalise the whole assistant/tool segment up to the next user or
+        # system boundary. Compaction/replay can interleave declarations and
+        # results (A1, result(A1), A2, result(A1), result(A2)); a one-message
+        # lookahead loses real output in that shape. Assign each result to the
+        # nearest preceding assistant with an unmatched alias-equivalent call,
+        # then emit every assistant followed by its own contiguous result run.
+        batches: List[Dict[str, Any]] = []
+        cursor = index
+        while cursor < len(messages) and messages[cursor].get("role") in {
+            "assistant", "tool",
+        }:
+            current = messages[cursor]
+            if current.get("role") == "assistant":
+                batches.append({
+                    "message": current,
+                    "calls": [
+                        (tc, tool_call_id_variants(tc))
+                        for tc in current.get("tool_calls") or []
+                    ],
+                    "matched": set(),
+                    "results": [],
+                })
+                cursor += 1
+                continue
+
+            result_variants = tool_result_id_variants(current.get("tool_call_id"))
+            if not result_variants:
+                # Preserve legacy/provider-specific tool rows with no usable id;
+                # the pre-existing sanitizer deliberately treated these as opaque.
+                batches[-1]["results"].append(current)
+                cursor += 1
+                continue
+
+            owner = None
+            owner_call_index = None
+            for batch in reversed(batches):
+                for call_index, (_, call_variants) in enumerate(batch["calls"]):
+                    if (
+                        call_index not in batch["matched"]
+                        and call_variants
+                        and call_variants & result_variants
+                    ):
+                        owner = batch
+                        owner_call_index = call_index
+                        break
+                if owner is not None:
+                    break
+            if owner is None:
+                removed_positional_orphans += 1
+            else:
+                owner["matched"].add(owner_call_index)
+                owner["results"].append(current)
+            cursor += 1
+
+        for batch in batches:
+            paired.append(batch["message"])
+            paired.extend(batch["results"])
+            for call_index, (tc, variants) in enumerate(batch["calls"]):
+                if call_index in batch["matched"] or not variants:
+                    continue
+                cid = coalesce_tool_call_id(tc) or sorted(variants)[0]
+                paired.append({
+                    "role": "tool",
+                    "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                    "content": "[Result unavailable — see context summary above]",
+                    "tool_call_id": cid,
+                })
+                added_positional_stubs += 1
+
+        index = cursor
+
+    messages = paired
+    if removed_positional_orphans:
+        _ra().logger.debug(
+            "Pre-call sanitizer: removed %d positionally orphaned tool result(s)",
+            removed_positional_orphans,
+        )
+    if added_positional_stubs:
+        _ra().logger.debug(
+            "Pre-call sanitizer: added %d stub result(s) for positionally "
+            "unanswered tool call(s)",
+            added_positional_stubs,
         )
     return messages
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3826,83 +3826,87 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             elif isinstance(tc, dict):
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
-    assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
-    surviving_call_ids: set[str] = set()
-    for msg in messages:
+    # --- Enforce positional tool_call <-> tool-result pairing ---
+    # Strict OpenAI-compatible providers require every assistant tool_calls
+    # message to be immediately followed by a contiguous run of tool results
+    # covering every declared call. A global id-presence check is insufficient:
+    # compaction or replay can repeat a call id whose only result is historical,
+    # so that old result masks a positionally unanswered replay (#94704).
+    #
+    # Walk one assistant/result transaction at a time. Match through the shared
+    # variant helpers so ``id``, ``call_id``, ``response_item_id`` and composite
+    # bridge spellings remain equivalent (#55626, #63000, #93251).
+    paired: List[Dict[str, Any]] = []
+    removed_positional_orphans = 0
+    added_positional_stubs = 0
+    index = 0
+    while index < len(messages):
+        msg = messages[index]
         if msg.get("role") != "assistant":
+            if msg.get("role") == "tool" and tool_result_id_variants(
+                msg.get("tool_call_id")
+            ):
+                removed_positional_orphans += 1
+            else:
+                paired.append(msg)
+            index += 1
             continue
-        for tc in msg.get("tool_calls") or []:
-            # A tool_call may carry SEVERAL equivalent id spellings (``id``
-            # fc_..., ``call_id`` call_..., ``response_item_id``, or a
-            # composite ``call|item`` bridge id). ``_get_tool_call_id_static``
-            # returns only the preferred one, but a tool result keyed on any
-            # OTHER spelling would then look orphaned and get dropped +
-            # replaced with a bogus "[Result unavailable]" stub — silently
-            # eating a perfectly valid tool result (#55626, #63000). Register
-            # EVERY variant so a result matching any of them survives.
-            variants = tool_call_id_variants(tc)
-            if variants:
-                assistant_call_variants.append((tc, variants))
-                surviving_call_ids.update(variants)
 
-    result_entries = [
-        (msg, tool_result_id_variants(msg.get("tool_call_id")))
-        for msg in messages
-        if msg.get("role") == "tool"
-    ]
-
-    # 1. Drop tool results whose complete alias set matches no assistant call.
-    orphaned_result_objects = {
-        id(msg)
-        for msg, variants in result_entries
-        if variants and not (variants & surviving_call_ids)
-    }
-    if orphaned_result_objects:
-        messages = [m for m in messages if id(m) not in orphaned_result_objects]
-        result_entries = [
-            (msg, variants)
-            for msg, variants in result_entries
-            if id(msg) not in orphaned_result_objects
+        paired.append(msg)
+        calls = [
+            (tc, tool_call_id_variants(tc))
+            for tc in msg.get("tool_calls") or []
         ]
-        _ra().logger.debug(
-            "Pre-call sanitizer: removed %d orphaned tool result(s)",
-            len(orphaned_result_objects),
-        )
+        matched_calls: set[int] = set()
+        cursor = index + 1
+        while cursor < len(messages) and messages[cursor].get("role") == "tool":
+            result = messages[cursor]
+            result_variants = tool_result_id_variants(result.get("tool_call_id"))
+            if not result_variants:
+                # Preserve legacy/provider-specific tool rows with no usable id;
+                # the existing sanitizer deliberately treated these as opaque.
+                paired.append(result)
+            else:
+                candidates = [
+                    call_index
+                    for call_index, (_, call_variants) in enumerate(calls)
+                    if call_index not in matched_calls
+                    and call_variants
+                    and call_variants & result_variants
+                ]
+                if candidates:
+                    matched_calls.add(candidates[0])
+                    paired.append(result)
+                else:
+                    removed_positional_orphans += 1
+            cursor += 1
 
-    # 2. Inject one stub per assistant call with no result on ANY alias.
-    surviving_result_variants = [
-        variants for _, variants in result_entries if variants
-    ]
-    missing_tool_calls = [
-        tc
-        for tc, variants in assistant_call_variants
-        if not any(variants & result_variants for result_variants in surviving_result_variants)
-    ]
-    if missing_tool_calls:
-        missing_tool_call_objects = {id(tc) for tc in missing_tool_calls}
-        patched: List[Dict[str, Any]] = []
-        for msg in messages:
-            patched.append(msg)
-            if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls") or []:
-                    if id(tc) not in missing_tool_call_objects:
-                        continue
-                    cid = coalesce_tool_call_id(tc)
-                    if not cid:
-                        variants = tool_call_id_variants(tc)
-                        cid = sorted(variants)[0] if variants else ""
-                    if not cid:
-                        continue
-                    patched.append({
-                        "role": "tool",
-                        "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                        "content": "[Result unavailable — see context summary above]",
-                        "tool_call_id": cid,
-                    })
-        messages = patched
+        for call_index, (tc, variants) in enumerate(calls):
+            if call_index in matched_calls or not variants:
+                continue
+            cid = coalesce_tool_call_id(tc) or sorted(variants)[0]
+            paired.append({
+                "role": "tool",
+                "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                "content": "[Result unavailable — see context summary above]",
+                "tool_call_id": cid,
+            })
+            added_positional_stubs += 1
+
+        index = cursor
+
+    if removed_positional_orphans or added_positional_stubs:
+        messages = paired
+    if removed_positional_orphans:
         _ra().logger.debug(
-            "Pre-call sanitizer: added %d stub tool result(s)",
-            len(missing_tool_calls),
+            "Pre-call sanitizer: removed %d positionally orphaned tool result(s)",
+            removed_positional_orphans,
+        )
+    if added_positional_stubs:
+        _ra().logger.debug(
+            "Pre-call sanitizer: added %d stub result(s) for positionally "
+            "unanswered tool call(s)",
+            added_positional_stubs,
         )
 
     # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a

--- a/contributors/emails/shauneccles@gmail.com
+++ b/contributors/emails/shauneccles@gmail.com
@@ -1,0 +1,2 @@
+shauneccles
+# PR #94731 first contribution

--- a/contributors/emails/tiberiud99@gmail.com
+++ b/contributors/emails/tiberiud99@gmail.com
@@ -1,0 +1,2 @@
+TiberiuD
+# PR #94731 salvage of #84481

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -616,6 +616,33 @@ def test_sanitize_drops_result_with_no_preceding_call():
     assert [m for m in out if m.get("role") == "tool"] == []
 
 
+def test_sanitize_preserves_leading_tool_row_with_no_usable_id():
+    """A leading ``role=tool`` row with no usable id is preserved opaquely.
+
+    The positional pairing pass is only entered from an assistant message, so a
+    leading id-less tool row is handled by the outer loop's non-assistant branch
+    and never reaches the ``batches[-1]`` append — it must not raise IndexError
+    and must survive verbatim. Regression guard against the false-positive
+    crash concern raised on PR #94731.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "tool", "tool_call_id": "", "content": "legacy no-id row"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # The id-less legacy row survives opaquely (not treated as an orphan).
+    assert any(
+        m.get("role") == "tool" and m.get("content") == "legacy no-id row"
+        for m in out
+    )
+
+
 def test_sanitize_drops_empty_tool_calls_array():
     """sanitize_api_messages strips ``tool_calls: []`` from assistant messages.
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -763,6 +763,65 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
     assert assistant2["content"] == "retrying"
 
 
+def test_full_pipeline_closes_replayed_call_with_only_historical_result():
+    """A historical result must not satisfy a replayed call positionally.
+
+    Production session ``20260825_173121_8c9021`` contained this shape after
+    compaction: a completed call/result pair remained earlier in history, then
+    the same call id was replayed beside a fresh call whose result was the only
+    one immediately following. DeepSeek rejects the replayed call because its
+    old result is not in the contiguous tool-result run after the declaration.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    def call(call_id: str, content: str = "") -> dict:
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [{
+                "id": call_id,
+                "call_id": call_id,
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }],
+        }
+
+    messages = [
+        {"role": "user", "content": "first task"},
+        call("call_old"),
+        {"role": "tool", "tool_call_id": "call_old", "content": "old result"},
+        {"role": "user", "content": "new task"},
+        call("call_old"),  # replayed by compaction; only historical result exists
+        call("call_new", content="continuing"),
+        {"role": "tool", "tool_call_id": "call_new", "content": "new result"},
+    ]
+
+    agent = _bare_agent()
+    AIAgent._repair_message_sequence(agent, messages)
+    out = sanitize_api_messages(messages)
+
+    for index, message in enumerate(out):
+        calls = message.get("tool_calls") or []
+        if message.get("role") != "assistant" or not calls:
+            continue
+        declared = {
+            tc.get("call_id") or tc.get("id")
+            for tc in calls
+            if tc.get("call_id") or tc.get("id")
+        }
+        answered = set()
+        cursor = index + 1
+        while cursor < len(out) and out[cursor].get("role") == "tool":
+            tool_call_id = out[cursor].get("tool_call_id")
+            if tool_call_id:
+                answered.add(tool_call_id)
+            cursor += 1
+        assert declared <= answered, (
+            f"assistant at index {index} has positionally unanswered calls: "
+            f"{sorted(declared - answered)}"
+        )
+
+
 def test_repair_drops_duplicate_tool_result_keyed_on_sibling_id():
     """A duplicate result must be dropped even when it uses the OTHER id variant.
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -761,6 +761,169 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
     assert "tool_calls" not in assistant2
     # Content should be preserved
     assert assistant2["content"] == "retrying"
+    assert [m["content"] for m in out if m.get("role") == "tool"] == ["result 1"]
+    assert [m["role"] for m in out] == ["user", "assistant", "tool", "assistant"]
+
+
+def test_sanitize_preserves_real_result_across_mid_run_splitter():
+    """A call-free assistant inside a parallel result run must not lose output."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "run both"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "one", "arguments": "{}"}},
+            {"id": "c2", "type": "function",
+             "function": {"name": "two", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "REAL r1"},
+        {"role": "assistant", "content": "interim commentary"},
+        {"role": "tool", "tool_call_id": "c2", "content": "REAL r2"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert [m["role"] for m in out] == [
+        "user", "assistant", "tool", "tool", "assistant",
+    ]
+    assert [m["content"] for m in out if m.get("role") == "tool"] == [
+        "REAL r1", "REAL r2",
+    ]
+
+
+def test_sanitize_preserves_codex_carrier_while_repairing_result_run():
+    """Codex replay metadata survives when moved behind its owning tool run."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    carrier = {
+        "role": "assistant",
+        "content": "",
+        "finish_reason": "incomplete",
+        "codex_reasoning_items": [{"type": "reasoning", "id": "rs_1"}],
+    }
+    messages = [
+        {"role": "user", "content": "run both"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "one", "arguments": "{}"}},
+            {"id": "c2", "type": "function",
+             "function": {"name": "two", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "REAL r1"},
+        carrier,
+        {"role": "tool", "tool_call_id": "c2", "content": "REAL r2"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert [m["role"] for m in out] == [
+        "user", "assistant", "tool", "tool", "assistant",
+    ]
+    assert out[-1] is carrier
+    assert out[-1]["codex_reasoning_items"] == [
+        {"type": "reasoning", "id": "rs_1"},
+    ]
+    assert [m["content"] for m in out if m.get("role") == "tool"] == [
+        "REAL r1", "REAL r2",
+    ]
+
+
+def test_sanitize_assigns_partial_dedup_results_to_owning_round():
+    """A later partial replay must not split an earlier call from its result."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    def tc(call_id: str) -> dict:
+        return {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": call_id, "arguments": "{}"},
+        }
+
+    messages = [
+        {"role": "user", "content": "run"},
+        {"role": "assistant", "content": "", "tool_calls": [tc("c1"), tc("c2")]},
+        {"role": "tool", "tool_call_id": "c1", "content": "REAL r1"},
+        {"role": "assistant", "content": "next", "tool_calls": [tc("c2"), tc("c3")]},
+        {"role": "tool", "tool_call_id": "c2", "content": "REAL r2"},
+        {"role": "tool", "tool_call_id": "c3", "content": "REAL r3"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert [m["role"] for m in out] == [
+        "user", "assistant", "tool", "tool", "assistant", "tool",
+    ]
+    assert [m["content"] for m in out if m.get("role") == "tool"] == [
+        "REAL r1", "REAL r2", "REAL r3",
+    ]
+    assert [tc["id"] for tc in out[4]["tool_calls"]] == ["c3"]
+
+
+def test_sanitize_dedup_drops_newly_empty_duplicate_assistant():
+    """Dedup must not create an empty non-final assistant turn.
+
+    The empty-message healer runs before duplicate-call cleanup. If dedup strips
+    the only tool call from an otherwise-empty replay, the newly-empty turn must
+    be removed rather than sent between a completed stubbed call and a user
+    message — strict providers reject that shape.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "step 1"},
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "call_A",
+            "type": "function",
+            "function": {"name": "foo", "arguments": "{}"},
+        }]},
+        {"role": "assistant", "content": "", "tool_calls": [{
+            "id": "call_A",
+            "type": "function",
+            "function": {"name": "foo", "arguments": "{}"},
+        }]},
+        {"role": "user", "content": "continue"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert not any(
+        msg.get("role") == "assistant"
+        and not msg.get("content")
+        and not msg.get("tool_calls")
+        for msg in out
+    )
+
+
+def test_sanitize_dedup_runs_before_positional_stub_injection():
+    """A stub must not re-arm a duplicate call id before dedup runs."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    tool_call = {
+        "id": "call_A",
+        "type": "function",
+        "function": {"name": "foo", "arguments": "{}"},
+    }
+    messages = [
+        {"role": "user", "content": "step 1"},
+        {"role": "assistant", "content": "running", "tool_calls": [tool_call]},
+        {"role": "assistant", "content": "retrying", "tool_calls": [dict(tool_call)]},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    calls = [
+        tc["id"]
+        for msg in out
+        for tc in msg.get("tool_calls") or []
+    ]
+    results = [
+        msg["tool_call_id"]
+        for msg in out
+        if msg.get("role") == "tool"
+    ]
+    assert calls == ["call_A"]
+    assert results == ["call_A"]
 
 
 def test_full_pipeline_closes_replayed_call_with_only_historical_result():
@@ -773,6 +936,10 @@ def test_full_pipeline_closes_replayed_call_with_only_historical_result():
     old result is not in the contiguous tool-result run after the declaration.
     """
     from agent.agent_runtime_helpers import sanitize_api_messages
+    from agent.message_sanitization import (
+        tool_call_id_variants,
+        tool_result_id_variants,
+    )
 
     def call(call_id: str, content: str = "") -> dict:
         return {
@@ -800,26 +967,33 @@ def test_full_pipeline_closes_replayed_call_with_only_historical_result():
     AIAgent._repair_message_sequence(agent, messages)
     out = sanitize_api_messages(messages)
 
+    assert [message["role"] for message in out] == [
+        "user", "assistant", "tool", "user", "assistant", "tool", "tool",
+    ]
+    assert [
+        message["content"] for message in out if message.get("role") == "tool"
+    ] == [
+        "old result",
+        "new result",
+        "[Result unavailable — see context summary above]",
+    ]
+
     for index, message in enumerate(out):
         calls = message.get("tool_calls") or []
         if message.get("role") != "assistant" or not calls:
             continue
-        declared = {
-            tc.get("call_id") or tc.get("id")
-            for tc in calls
-            if tc.get("call_id") or tc.get("id")
-        }
-        answered = set()
+        declared_groups = [tool_call_id_variants(tc) for tc in calls]
+        answered_groups = []
         cursor = index + 1
         while cursor < len(out) and out[cursor].get("role") == "tool":
-            tool_call_id = out[cursor].get("tool_call_id")
-            if tool_call_id:
-                answered.add(tool_call_id)
+            answered_groups.append(
+                tool_result_id_variants(out[cursor].get("tool_call_id"))
+            )
             cursor += 1
-        assert declared <= answered, (
-            f"assistant at index {index} has positionally unanswered calls: "
-            f"{sorted(declared - answered)}"
-        )
+        assert all(
+            any(declared & answered for answered in answered_groups)
+            for declared in declared_groups
+        ), f"assistant at index {index} has a positionally unanswered call"
 
 
 def test_repair_drops_duplicate_tool_result_keyed_on_sibling_id():


### PR DESCRIPTION
## Summary

Strict OpenAI-compatible providers require each assistant `tool_calls` message to be immediately followed by a contiguous run of `tool` results covering every declared call. Hermes' final sanitizer instead accepted a matching result anywhere in history, so a historical result could mask a replayed call with no immediate result and let an invalid payload reach DeepSeek.

This PR salvages the final pre-send sanitizer layer from #84481. Tiberiu Danciu's authored commit is preserved, with its message corrected to describe the code carried here. The implementation is then adapted to current `main`, where shared variant-aware ID handling landed after #84481 was opened. The original PR's durable-history repair pass and six tests are not carried over; this PR fixes the final per-call safety boundary independently.

- run duplicate/outstanding-call cleanup before positional enforcement, so stubs cannot re-arm duplicate IDs
- remove positionally orphaned tool results at the final pre-provider boundary
- canonicalise each assistant/tool segment so every real result is assigned to the nearest preceding declaration that owns it
- preserve call-free and Codex replay carriers while moving them behind the completed tool run
- add deterministic unavailable-result stubs for calls not answered anywhere in their segment
- preserve valid parallel batches, repeated-ID rounds, and `id` / `call_id` / `response_item_id` / composite aliases
- drop replay turns made entirely payload-empty by duplicate cleanup

Closes #94704. Supersedes the conflicted #84481 while retaining its sanitizer implementation and original authorship.

## Reproduction

The bug reproduces deterministically on current `main`; no provider call or observability backend is required.

**RED — test-only commit (`88cf30938`)**

```text
assistant at index 4 has positionally unanswered calls: ['call_old']
```

The persisted production transcript contained 378 messages and three positional violations. Replaying it through the real `repair_message_sequence -> sanitize_api_messages` pipeline produced one invalid wire batch on `main`; this branch produces zero.

## How to test

Run on WSL2/Linux with Python 3.11:

```bash
uv run pytest tests/run_agent/test_message_sequence_repair.py -q
uv run pytest tests/run_agent/ -q
uv run ruff check agent/agent_runtime_helpers.py \
  tests/run_agent/test_message_sequence_repair.py
```

Results on this branch:

- focused sequence suite: 41 passed
- `tests/run_agent/`: 1,857 passed, 4 skipped, 2 deselected
- `tests/agent/` canonical isolated runner: 428/429 files clean; three failures in `test_model_metadata_local_ctx.py` reproduce identically on untouched `origin/main`
- production transcript replay: 3 stored violations -> 0 wire violations

`ruff format --check` is not clean on these files on `origin/main`; formatting them would create a large drive-by diff, so this PR does not reformat them.

## Scope and compatibility

This fixes the final pre-send invariant regardless of whether replayed IDs came from compaction, rehydration, retry, or another history-repair path. Production rows demonstrate replay across compacted and active generations, but the PR does not claim one exclusive producer.

Hermes deliberately permits a provider to reuse a tool-call ID after the prior round is completed (#70724). This PR retains that outstanding-call policy rather than treating IDs as globally unique; each reused declaration must still have its own immediate result run.

The triage duplicate note on #94704 predates this salvage. If this PR is accepted, #84481 can be closed as superseded.