### PR TITLE
feat(cron): configurable response delivery format (header|footer)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2853,6 +2853,39 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _wrap_cron_response(content: str, job: dict, wrap_response: bool, response_format: str) -> str:
+    """Wrap cron delivery content with a header or footer signature.
+
+    ``header`` (default) puts the job metadata first; ``footer`` puts the
+    content first with the job id as a trailing signature so it is trivially
+    extractable programmatically. Both layouts keep a short "how to manage
+    this job" hint. When ``wrap_response`` is False the content is returned
+    verbatim.
+    """
+    if not wrap_response:
+        return content
+
+    task_name = job.get("name", job.get("id", "?"))
+    job_id = job.get("id", "")
+    rule = "-------------"
+
+    if response_format == "footer":
+        return (
+            f"{content}\n\n"
+            f"{rule}\n"
+            f"To stop or manage this job, reply \"stop reminder {task_name}\".\n"
+            f"Cronjob Response: {task_name} (job_id: {job_id})"
+        )
+
+    return (
+        f"Cronjob Response: {task_name}\n"
+        f"(job_id: {job_id})\n"
+        f"{rule}\n\n"
+        f"{content}\n\n"
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -2902,28 +2935,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         cron_cfg = user_cfg.get("cron", {}) if user_cfg else {}
         wrap_response = cron_cfg.get("wrap_response", True)
         response_format = str(cron_cfg.get("response_format", "header")).lower()
+        if response_format not in ("header", "footer"):
+            logger.warning(
+                "cron.response_format=%r is invalid (expected \"header\" or \"footer\"); "
+                "falling back to header",
+                response_format,
+            )
+            response_format = "header"
     except Exception:
         pass
 
-    if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        if response_format == "footer":
-            delivery_content = (
-                f"{content}\n\n"
-                f"-------------\n"
-                f"Cronjob Response: {task_name} (job_id: {job_id})"
-            )
-        else:
-            delivery_content = (
-                f"Cronjob Response: {task_name}\n"
-                f"(job_id: {job_id})\n"
-                f"-------------\n\n"
-                f"{content}\n\n"
-                f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
-            )
-    else:
-        delivery_content = content
+    delivery_content = _wrap_cron_response(content, job, wrap_response, response_format)
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2891,25 +2891,37 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # in config.yaml for clean output. cron.response_format: "header" (default) or
+    # "footer" controls the layout — footer puts content first with the job id as
+    # a trailing signature, so the id is trivially extractable programmatically.
     wrap_response = True
+    response_format = "header"
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {}) if user_cfg else {}
+        wrap_response = cron_cfg.get("wrap_response", True)
+        response_format = str(cron_cfg.get("response_format", "header")).lower()
     except Exception:
         pass
 
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
-        delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
-        )
+        if response_format == "footer":
+            delivery_content = (
+                f"{content}\n\n"
+                f"-------------\n"
+                f"Cronjob Response: {task_name} (job_id: {job_id})"
+            )
+        else:
+            delivery_content = (
+                f"Cronjob Response: {task_name}\n"
+                f"(job_id: {job_id})\n"
+                f"-------------\n\n"
+                f"{content}\n\n"
+                f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            )
     else:
         delivery_content = content
 

--- a/tests/cron/test_cron_response_format.py
+++ b/tests/cron/test_cron_response_format.py
@@ -1,0 +1,51 @@
+import pytest
+
+from cron import scheduler as sched
+
+
+def _job(name="weekly-digest", job_id="job-123"):
+    return {"name": name, "id": job_id}
+
+
+def test_header_layout_puts_metadata_first_with_manage_hint():
+    content = _wrap("body")
+    # Metadata (name + id) comes first, content follows.
+    assert content.index("Cronjob Response: weekly-digest") < content.index("body")
+    assert "(job_id: job-123)" in content
+    # The manage hint is preserved in header layout.
+    assert "stop reminder weekly-digest" in content
+
+
+def test_footer_layout_puts_content_first_with_job_id_trailing():
+    content = _wrap("body", response_format="footer")
+    # Content first, metadata last; the job id lands at the very trailing edge
+    # so it is trivially extractable programmatically.
+    assert content.index("body") < content.index("Cronjob Response: weekly-digest")
+    assert content.rstrip().endswith("(job_id: job-123)")
+    # The manage hint is present but never after the job id.
+    assert "stop reminder weekly-digest" in content
+    assert content.index("stop reminder") < content.index("(job_id: job-123)")
+
+
+def test_wrap_response_false_returns_content_verbatim():
+    assert _wrap("body", wrap_response=False) == "body"
+
+
+def test_unknown_format_falls_back_to_header():
+    # `_deliver_result` normalizes any value other than "footer" to "header"
+    # (and logs a warning); the helper mirrors that so unknown values produce
+    # the safe default rather than breaking output.
+    for unknown in ("json", "foter", ""):
+        content = _wrap("body", response_format=unknown)
+        assert content.index("Cronjob Response: weekly-digest") < content.index("body")
+
+
+def test_missing_job_name_falls_back_to_id():
+    job = {"id": "job-abc"}
+    content = sched._wrap_cron_response("body", job, True, "footer")
+    assert "Cronjob Response: job-abc" in content
+    assert content.rstrip().endswith("(job_id: job-abc)")
+
+
+def _wrap(content, wrap_response=True, response_format="header"):
+    return sched._wrap_cron_response(content, _job(), wrap_response, response_format)


### PR DESCRIPTION
## What & why
The default cron wrap is header-heavy: boilerplate ("Cronjob Response: …", "(job_id: …)") lands **before** the content you actually want to read, and the job id is buried mid-message. That makes results awkward to scan and the id awkward to parse programmatically.

## Change
Add a `cron.response_format` option (`header` | `footer`):

| format | layout |
|--------|--------|
| `header` (default) | boilerplate prefix → content → stop/manage hint |
| `footer` | **content first** → `---` → `Cronjob Response: <name> (job_id: <id>)` |

In `footer`, the job id is the trailing token before `)` — grab the final characters of the message and you have the id, no regex gymnastics.

## config.yaml
```yaml
cron:
  response_format: footer   # or "header" (default)
```

Backward compatible — `header` stays the default, so existing behavior and tests are unchanged; `footer` is purely opt-in.

## Verification
`tests/cron/test_relay_fronted_delivery.py` + `tests/cron/test_run_one_job.py`: 19 passed.