### PR TITLE
fix(gateway): bound ffmpeg conversions in async message pipelines

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -94,6 +94,9 @@ DEFAULT_API_VERSION = "v20.0"
 DEFAULT_WEBHOOK_HOST = None
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
+# ffmpeg voice-note conversion ceiling: malformed/truncated media can make
+# ffmpeg hang forever, wedging the adapter's send path (input is external).
+_FFMPEG_OPUS_TIMEOUT_S = 120.0
 GRAPH_API_BASE = "https://graph.facebook.com"
 WEBHOOK_MAX_BODY_BYTES = 3 * 1024 * 1024
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -1284,7 +1287,22 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await proc.communicate()
+            # ffmpeg hangs indefinitely on malformed/truncated media. This
+            # input comes from external senders, so the conversion must be
+            # bounded or the adapter's send path wedges forever.
+            try:
+                _, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=_FFMPEG_OPUS_TIMEOUT_S
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                logger.error(
+                    "[whatsapp_cloud] ffmpeg opus conversion timed out "
+                    "after %ss: %s",
+                    _FFMPEG_OPUS_TIMEOUT_S,
+                    mp3_path,
+                )
+                return None
             if proc.returncode != 0 or not Path(out_path).exists():
                 logger.error(
                     "[whatsapp_cloud] ffmpeg opus conversion failed "

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -39,6 +39,10 @@ from tools.transcription_tools import transcribe_audio
 
 logger = logging.getLogger(__name__)
 
+# ffmpeg audio-extraction ceiling: malformed/truncated recordings can make
+# ffmpeg hang forever; the pipeline must retry, not wedge.
+_FFMPEG_EXTRACT_TIMEOUT_S = 180.0
+
 TERMINAL_PIPELINE_STATES = {"completed", "failed", "retry_scheduled"}
 ACTIVE_PIPELINE_STATES = {
     "received",
@@ -517,7 +521,18 @@ class TeamsMeetingPipeline:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        _stdout, stderr = await proc.communicate()
+        # ffmpeg hangs indefinitely on malformed/truncated recordings; bound
+        # the extraction so the pipeline retries instead of wedging.
+        try:
+            _stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=_FFMPEG_EXTRACT_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise TeamsPipelineRetryableError(
+                f"ffmpeg audio extraction timed out after "
+                f"{_FFMPEG_EXTRACT_TIMEOUT_S:.0f}s: {recording_path.name}"
+            )
         if proc.returncode != 0:
             detail = stderr.decode("utf-8", errors="replace").strip()
             raise TeamsPipelineRetryableError(f"ffmpeg audio extraction failed: {detail}")


### PR DESCRIPTION
## Problem

Two async pipelines ran ffmpeg with an **unbounded** `await proc.communicate()` on externally-supplied media:

- `WhatsApp Cloud` `_convert_to_opus()`: voice-note MP3 → opus. Input arrives from **any WhatsApp sender**; ffmpeg hangs indefinitely on malformed/truncated containers (well-documented with crafted files).
- `teams_pipeline` `_prepare_audio_path()`: meeting-recording → WAV extraction before STT.

One crafted voice note or broken recording wedged the calling path **forever**: the WhatsApp adapter's send flow blocked on the voice-bubble conversion, and the Teams pipeline job sat in-flight with no timeout, no kill, no retry.

## Fix

Both conversions now run under `asyncio.wait_for` (120s for ≤16MB voice notes, 180s for meeting recordings), **kill the orphaned ffmpeg process** on timeout, and degrade to the existing fallbacks:

- WhatsApp: log + `return None` → caller sends the original MP3 as an audio attachment (documented fallback)
- Teams: raise `TeamsPipelineRetryableError` → existing retry machinery

## Verification

`tests/gateway/test_whatsapp_cloud.py`: 43/43 pass; both modules syntax-checked.