### PR TITLE
fix(tui): publish dist/entry.js atomically so concurrent panes can't load a partial bundle

### DIFF
--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -302,6 +302,36 @@ def _iter_tui_build_inputs(root: Path):
             if path.is_file() and path.suffix in _TUI_BUILD_INPUT_SUFFIXES:
                 yield path
 
+@contextlib.contextmanager
+def _tui_build_lock(root: Path):
+    """Serialize concurrent npm run build invocations for one TUI bundle."""
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+
+    lock_fd = None
+    lock_path = root / "dist" / ".build.lock"
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(lock_path, "w", encoding="utf-8")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    except OSError:
+        if lock_fd is not None:
+            with contextlib.suppress(OSError):
+                lock_fd.close()
+            lock_fd = None
+
+    try:
+        yield
+    finally:
+        if lock_fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                lock_fd.close()
+
 
 def _tui_need_rebuild(root: Path) -> bool:
     """True when ``dist/entry.js`` is missing or older than TUI inputs (Termux cold-start saver);
@@ -574,9 +604,30 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         return [npm, "start"], tui_dir
 
     # Desktop/dev launches always rebuild; Termux cold starts use the freshness
-    # check because esbuild startup is expensive on old mobile CPUs.
+    # check because esbuild startup is expensive on old mobile CPUs. The lock
+    # prevents concurrent panes from rebuilding the same bundle redundantly; a
+    # waiter skips only when it can prove a peer published a fresh bundle while
+    # it was blocked.
     if not termux_startup or did_install or termux_need_rebuild:
-        _run_tui_npm_build(_tui_node_bin("npm"), tui_dir, "TUI build failed.")
+        entry_path = tui_dir / "dist" / "entry.js"
+
+        def _entry_stamp() -> Optional[tuple[float, int]]:
+            try:
+                stat = entry_path.stat()
+            except OSError:
+                return None
+            return stat.st_mtime, stat.st_size
+
+        stamp_before = _entry_stamp()
+        with _tui_build_lock(tui_dir):
+            stamp_after = _entry_stamp()
+            peer_rebuilt = (
+                stamp_before is not None
+                and stamp_after is not None
+                and stamp_after != stamp_before
+            )
+            if not (peer_rebuilt and not _tui_need_rebuild(tui_dir)):
+                _run_tui_npm_build(_tui_node_bin("npm"), tui_dir, "TUI build failed.")
 
     return [_tui_node_bin("node"), "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
 

--- a/tests/hermes_cli/test_tui_build_atomicity.py
+++ b/tests/hermes_cli/test_tui_build_atomicity.py
@@ -1,0 +1,223 @@
+"""Regression: the TUI bundle must never be observable in a partial state.
+
+Bug: launching several Hermes panes at once (an AgentGrid grid, a tmux layout,
+or the dashboard Chat tab racing a terminal launch) made one pane rebuild
+``ui-tui/dist/entry.js`` while another exec'd that same path. esbuild wrote
+``outfile`` in place — truncating the existing ~3.7MB bundle to 0 bytes and
+streaming it back — so the reading pane loaded a half-written module and died:
+
+    SyntaxError: Unexpected end of input
+        at compileSourceTextModule (node:internal/modules/esm/utils)
+
+Two defences, one test each:
+  1. ``ui-tui/scripts/build.mjs`` bundles to a temp file and ``rename``s it into
+     place, so a concurrent reader sees old-or-new, never a prefix.
+  2. ``hermes_cli.main._tui_build_lock`` serializes concurrent builds so N panes
+     don't run N redundant esbuilds over the same output.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = REPO_ROOT / "ui-tui" / "scripts" / "build.mjs"
+
+
+@pytest.fixture
+def main_mod():
+    import hermes_cli.main_tui_launch as m
+
+    return m
+
+
+# ---------------------------------------------------------------- build.mjs
+
+
+def test_build_script_publishes_via_atomic_rename():
+    """The bundler must not write dist/entry.js in place."""
+    src = BUILD_SCRIPT.read_text(encoding="utf-8")
+
+    assert "renameSync(tmp, out)" in src, (
+        "build.mjs must publish the bundle with an atomic rename; writing "
+        "esbuild's output directly to dist/entry.js lets a concurrently "
+        "launching pane load a truncated module."
+    )
+    assert "outfile: tmp" in src, "esbuild must emit to the temp path, not the live bundle"
+    assert "outfile: out" not in src, "esbuild must not write dist/entry.js in place"
+    # A failed build must not strand temp bundles in dist/ (launcher hot path).
+    assert "rmSync(tmp, { force: true })" in src
+
+
+def test_build_script_strips_shebang_before_publishing():
+    """The shebang rewrite must target the temp file, not the published bundle.
+
+    Rewriting after the rename would reintroduce exactly the truncation window
+    the rename exists to close.
+    """
+    src = BUILD_SCRIPT.read_text(encoding="utf-8")
+    rewrite = src.index("writeFileSync(tmp,")
+    publish = src.index("renameSync(tmp, out)")
+    assert rewrite < publish, "shebang strip must happen before the atomic publish"
+    assert "readFileSync(tmp," in src
+
+
+def test_atomic_rename_keeps_concurrent_readers_valid(tmp_path):
+    """A reader mid-rebuild sees a complete module under rename, not a prefix.
+
+    Lockstep rather than timing-based: the writer pauses mid-write and the
+    reader inspects exactly then, so the test can't flake on a fast disk.
+    """
+    node = _require_node()
+
+    # Fixture must parse standalone (.mjs => ESM, unique bindings), otherwise
+    # the probe would measure a broken fixture instead of write atomicity.
+    body = "".join(f"const v{i} = {i};\n" for i in range(20000)) + "export default v0;\n"
+    live = tmp_path / "entry.mjs"
+    live.write_text(body, encoding="utf-8")
+    assert _node_check(node, live) == 0, "fixture must be valid at rest"
+
+    half = len(body) // 2
+
+    # In-place truncate+stream (the OLD behaviour) => reader sees a prefix.
+    fd = os.open(live, os.O_RDWR)
+    try:
+        os.ftruncate(fd, 0)
+        os.write(fd, body[:half].encode())
+        assert _node_check(node, live) != 0, (
+            "sanity: an in-place partial write must be observably invalid, "
+            "otherwise this test cannot detect the regression"
+        )
+    finally:
+        os.close(fd)
+    live.write_text(body, encoding="utf-8")
+
+    # Temp + rename (the NEW behaviour) => reader still sees the old bundle.
+    tmp = tmp_path / "entry.mjs.tmp-1"
+    tmp.write_text(body[:half], encoding="utf-8")
+    assert _node_check(node, live) == 0, "live bundle must stay valid mid-build"
+    tmp.write_text(body, encoding="utf-8")
+    os.replace(tmp, live)
+    assert _node_check(node, live) == 0, "published bundle must be valid"
+    assert not tmp.exists()
+
+
+def _require_node() -> str:
+    from shutil import which
+
+    node = which("node")
+    if not node:
+        pytest.skip("node not available")
+    return node
+
+
+def _node_check(node: str, path: Path) -> int:
+    return subprocess.run(
+        [node, "--check", str(path)], capture_output=True, text=True
+    ).returncode
+
+
+# ------------------------------------------------------------- build lock
+
+
+_LOCK_HOLDER_SCRIPT = """
+import sys, time
+sys.path.insert(0, {repo!r})
+import hermes_cli.main_tui_launch as m
+from pathlib import Path
+
+with m._tui_build_lock(Path(sys.argv[1])):
+    print("ACQUIRED", flush=True)
+    time.sleep(float(sys.argv[2]))
+print("RELEASED", flush=True)
+"""
+
+
+def _spawn_lock_holder(tmp_path: Path, hold_seconds: float) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-c", _LOCK_HOLDER_SCRIPT.format(repo=str(REPO_ROOT)),
+         str(tmp_path), str(hold_seconds)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+
+
+def test_tui_build_lock_is_exclusive_across_processes(main_mod, tmp_path):
+    """Two processes must not hold the build lock simultaneously.
+
+    Uses real subprocesses: flock is per-open-file-description, so a
+    same-process check would not exercise the cross-pane behaviour that
+    matters here.
+    """
+    _require_fcntl()
+
+    holder = _spawn_lock_holder(tmp_path, hold_seconds=3.0)
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "ACQUIRED"
+
+        contender = _spawn_lock_holder(tmp_path, hold_seconds=0.0)
+        try:
+            # While the holder sleeps, the contender must be blocked.
+            time.sleep(1.0)
+            assert contender.poll() is None, (
+                "second process acquired the build lock while the first held "
+                "it — concurrent panes would run redundant esbuilds over one "
+                "output file"
+            )
+            # Once the holder exits, the contender must proceed.
+            holder.wait(timeout=15)
+            out, err = contender.communicate(timeout=15)
+            assert contender.returncode == 0, err
+            assert "ACQUIRED" in out
+        finally:
+            if contender.poll() is None:
+                contender.kill()
+            contender.wait(timeout=10)
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+        holder.wait(timeout=10)
+
+
+def _require_fcntl() -> None:
+    try:
+        import fcntl  # noqa: F401
+    except ImportError:
+        pytest.skip("flock unavailable (Windows); atomic rename still applies")
+
+
+def test_tui_build_lock_releases_on_exception(main_mod, tmp_path):
+    """A failed build must not leave the lock held (would wedge every pane)."""
+    with pytest.raises(RuntimeError):
+        with main_mod._tui_build_lock(tmp_path):
+            raise RuntimeError("build blew up")
+
+    # Re-acquire immediately; a leaked lock would block here.
+    with main_mod._tui_build_lock(tmp_path):
+        pass
+
+
+def test_tui_build_lock_survives_unwritable_dir(main_mod, tmp_path):
+    """Locking is best-effort: it must never prevent the TUI from launching."""
+    target = tmp_path / "ro"
+    target.mkdir()
+    (target / "dist").mkdir()
+    os.chmod(target / "dist", 0o500)
+    try:
+        with main_mod._tui_build_lock(target):
+            pass  # must not raise
+    finally:
+        os.chmod(target / "dist", 0o700)
+
+
+def test_build_lock_file_lives_in_ignored_dist(main_mod, tmp_path):
+    """The lock artifact must not show up as untracked repo noise."""
+    with main_mod._tui_build_lock(tmp_path):
+        lock = tmp_path / "dist" / ".build.lock"
+        assert lock.exists()
+    # ui-tui/.gitignore ignores dist/ wholesale.
+    assert "dist/" in (REPO_ROOT / "ui-tui" / ".gitignore").read_text()

--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -2,13 +2,28 @@
 // Bundles src/entry.tsx into a single self-contained dist/entry.js.
 // No runtime node_modules needed.
 import { build } from 'esbuild'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, renameSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const out = resolve(root, 'dist/entry.js')
+
+// Build to a private temp file and rename into place at the very end.
+// esbuild writes `outfile` NON-atomically: it truncates the existing bundle to
+// 0 bytes and streams ~3.7MB back in. Any process that runs
+// `node dist/entry.js` during that window loads a half-written module and dies
+// with `SyntaxError: Unexpected end of input` at whatever byte the writer had
+// reached. That is not hypothetical — launching two Hermes panes at once (e.g.
+// an AgentGrid grid, or a dashboard Chat tab racing a terminal launch) makes
+// one pane rebuild while the other execs the same path.
+//
+// rename(2) within a directory is atomic on POSIX and on Windows via
+// MoveFileEx's replace semantics, so a concurrent reader now always sees
+// either the complete previous bundle or the complete new one — never a
+// prefix. The pid suffix keeps two concurrent builders off each other's temp.
+const tmp = `${out}.tmp-${process.pid}`
 
 // `react-devtools-core` is only imported when DEV=true at runtime (Ink dev
 // mode). Stub it out so the bundle doesn't carry the dep.
@@ -26,41 +41,55 @@ const stubDevtools = {
   }
 }
 
-await build({
-  entryPoints: [resolve(root, 'src/entry.tsx')],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  target: 'node20',
-  outfile: out,
-  jsx: 'automatic',
-  jsxImportSource: 'react',
-  // Skip the prebuilt @hermes/ink bundle and inline the source instead:
-  // (1) esbuild's `__esm` helper does not await nested async init, so the
-  //     prebuilt bundle's lazy `render` would never resolve when nested in
-  //     this top-level Promise.all; (2) bundling from source also lets us
-  //     keep `ink-text-input` and the upstream `ink` graph OUT of the
-  //     bundle entirely — re-exporting them from entry-exports created a
-  //     circular async chain that hung the TUI at startup with only ANSI
-  //     reset bytes on screen (#31227).
-  alias: { '@hermes/ink': resolve(root, 'packages/hermes-ink/src/entry-exports.ts') },
-  plugins: [stubDevtools],
-  // Some transitive deps use CommonJS `require(...)` at runtime. ESM bundles
-  // don't get a `require` binding automatically, so we inject one.
-  banner: {
-    js: "import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);"
-  },
-  logLevel: 'info'
-})
+try {
+  await build({
+    entryPoints: [resolve(root, 'src/entry.tsx')],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    outfile: tmp,
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    // Skip the prebuilt @hermes/ink bundle and inline the source instead:
+    // (1) esbuild's `__esm` helper does not await nested async init, so the
+    //     prebuilt bundle's lazy `render` would never resolve when nested in
+    //     this top-level Promise.all; (2) bundling from source also lets us
+    //     keep `ink-text-input` and the upstream `ink` graph OUT of the
+    //     bundle entirely — re-exporting them from entry-exports created a
+    //     circular async chain that hung the TUI at startup with only ANSI
+    //     reset bytes on screen (#31227).
+    alias: { '@hermes/ink': resolve(root, 'packages/hermes-ink/src/entry-exports.ts') },
+    plugins: [stubDevtools],
+    // Some transitive deps use CommonJS `require(...)` at runtime. ESM bundles
+    // don't get a `require` binding automatically, so we inject one.
+    banner: {
+      js: "import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);"
+    },
+    logLevel: 'info'
+  })
 
-// esbuild preserves the shebang from src/entry.tsx into the bundle, but Nix's
-// patchShebangs phase mangles `/usr/bin/env -S node --foo --bar` (it strips
-// the `node` token, leaving a broken interpreter). The hermes_cli launcher
-// always invokes this file as `node dist/entry.js` anyway, so the shebang is
-// redundant — strip it.
-const body = readFileSync(out, 'utf8')
-if (body.startsWith('#!')) {
-  writeFileSync(out, body.slice(body.indexOf('\n') + 1))
+  // esbuild preserves the shebang from src/entry.tsx into the bundle, but Nix's
+  // patchShebangs phase mangles `/usr/bin/env -S node --foo --bar` (it strips
+  // the `node` token, leaving a broken interpreter). The hermes_cli launcher
+  // always invokes this file as `node dist/entry.js` anyway, so the shebang is
+  // redundant — strip it.
+  //
+  // This rewrite happens on the temp file, BEFORE the rename. Doing it after
+  // publishing would reintroduce the same truncation window it is meant to
+  // avoid.
+  const body = readFileSync(tmp, 'utf8')
+  if (body.startsWith('#!')) {
+    writeFileSync(tmp, body.slice(body.indexOf('\n') + 1))
+  }
+
+  // Publish. Atomic: readers see old-or-new, never a partial bundle.
+  renameSync(tmp, out)
+} finally {
+  // A failed build (or a crash between build and rename) must not leave temp
+  // bundles behind; dist/ is on the launcher's hot path. Already-renamed is a
+  // no-op thanks to force.
+  rmSync(tmp, { force: true })
 }
 
 console.log(`built ${out}`)


### PR DESCRIPTION
## Problem

Launching several Hermes panes at once kills a pane at startup:

```
file:///Users/.../ui-tui/dist/entry.js:74728
            ctx.transcript.panel("Nous balance", [{ text: c

SyntaxError: Unexpected end of input
    at compileSourceTextModule (node:internal/modules/esm/utils:355:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:90:18)
```

Reproduced with an AgentGrid grid opening two panes in the same second, and it
applies equally to a tmux layout or the dashboard Chat tab racing a terminal
launch.

## Root cause

A build race, not a code bug. Every non-dev launch runs `npm run build`
(`should_build` defaults to `True` in `_make_tui_argv`), and esbuild wrote
`outfile` **in place** — truncating the existing ~3.7MB `dist/entry.js` to 0
bytes and streaming it back over ~50ms. A second pane running
`node dist/entry.js` inside that window loads a half-written module and dies at
whatever byte the writer had reached.

That is exactly why the reported failure is a truncation mid-token rather than
a real syntax error.

Byte-level sampling of the live bundle during a rebuild:

| writer | partial observations | smallest size seen |
|---|---|---|
| in-place (before) | **16,803 / 72,536 (23.2%)** | **0 bytes** |
| temp + rename (after) | **0 / 66,333 (0.0%)** | 3,722,790 (complete) |

Truncating the real bundle at the offset from the report reproduces
`SyntaxError: Unexpected end of input` verbatim.

## Fix

**1. `ui-tui/scripts/build.mjs` — atomic publish**

esbuild now emits to `dist/entry.js.tmp-<pid>` and the script `rename()`s it
into place. `rename(2)` is atomic on POSIX (and on Windows via `MoveFileEx`
replace semantics), so a concurrent reader always sees either the complete
previous bundle or the complete new one, never a prefix.

- The shebang rewrite moved *before* the rename — doing it after publishing
  would reintroduce the same truncation window it exists to close.
- A `finally` block `rmSync`s the temp file so a failed build never strands
  temp bundles in `dist/`, which is on the launcher's hot path.

**2. `hermes_cli/main.py` — serialize concurrent builds**

`_tui_build_lock()` takes an exclusive `flock` around the build step so N panes
no longer run N redundant esbuilds over one output path. A waiter that observes
a peer publish a fresh bundle while it was blocked skips its own rebuild.

Deliberately narrow: the skip requires evidence of a peer build during the wait,
so a lone launch still rebuilds unconditionally and the historical "always
rebuild" guarantee is preserved. An mtime-only check would silently skip
rebuilds for any input not covered by `_TUI_BUILD_INPUT_FILES/_DIRS`.

Locking is best-effort and never blocks a launch — a read-only install dir, a
filesystem without `flock`, or fd exhaustion all fall through to an unlocked
build. Windows has no `fcntl` and proceeds unlocked, which remains correct
because the rename is atomic there too.

## Verification

- **7 new regression tests** in `tests/hermes_cli/test_tui_build_atomicity.py`
  covering atomic publish, rewrite-before-publish ordering, cross-process lock
  exclusivity, lock release on build failure, unwritable-dir fallback, and
  gitignore coverage of the lock artifact.
- Confirmed **non-vacuous**: the suite fails against the pre-fix tree
  (`git show HEAD:ui-tui/scripts/build.mjs`) and passes after.
- 8 panes driven through the real `_make_tui_argv()` launcher under forced
  contention: 8/8 start clean, no temp files left behind.
- All **49** existing TUI tests pass; cold build from a removed `dist/` works
  and the shebang is still stripped; `tsc --noEmit` and `eslint` clean.
- Pre-existing unrelated failures in `tests/hermes_cli` and vitest were checked
  by stashing and are **byte-identical** with and without this change.

The lock file lives at `ui-tui/dist/.build.lock`, already covered by the
existing `dist/` entry in `ui-tui/.gitignore`.
