### PR TITLE
fix(desktop): always offer project creation; disable project delete in all-profiles view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1752,6 +1752,22 @@ export function ChatSidebar({
                       </div>
                     ) : (
                       <>
+                        {!showAllProfiles && !agentsGrouped ? (
+                          <Tip label={s.projects.newButton}>
+                            <Button
+                              aria-label={s.projects.newButton}
+                              className={HEADER_ACTION_BTN}
+                              onClick={event => {
+                                event.stopPropagation()
+                                openProjectCreate()
+                              }}
+                              size="icon-xs"
+                              variant="ghost"
+                            >
+                              <Codicon name="add" size="0.75rem" />
+                            </Button>
+                          </Tip>
+                        ) : null}
                         {!showAllProfiles ? (
                           <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
                             <Button

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -4,7 +4,10 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 
-afterEach(cleanup)
+afterEach(() => {
+  showAllProfilesMock.value = false
+  cleanup()
+})
 
 // Steerable stand-in for the nanostores atom so individual tests can toggle
 // the unified "All profiles" sidebar view.
@@ -153,5 +156,18 @@ describe('ProjectMenu', () => {
     // Per-profile RPCs cannot be scoped with no active profile, so the
     // destructive action must be disabled instead of failing silently.
     expect(deleteItem.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('does not open Delete confirmation when activated with Enter in all-profiles view', async () => {
+    showAllProfilesMock.value = true
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    const trigger = screen.getByRole('button', { name: 'Actions' })
+    openTriggerMenu(trigger)
+
+    const deleteItem = await screen.findByRole('menuitem', { name: 'Delete…' })
+    fireEvent.keyDown(deleteItem, { key: 'Enter' })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -6,6 +6,21 @@ import type { SidebarProjectTree } from './workspace-groups'
 
 afterEach(cleanup)
 
+// Steerable stand-in for the nanostores atom so individual tests can toggle
+// the unified "All profiles" sidebar view.
+const { showAllProfilesMock } = vi.hoisted(() => ({
+  showAllProfilesMock: {
+    value: false,
+    get: () => showAllProfilesMock.value,
+    listen: () => () => {},
+    subscribe: () => () => {},
+  } as { value: boolean; get: () => boolean; listen: () => () => void; subscribe: () => () => void }
+}))
+
+vi.mock('@/store/profile', () => ({
+  $showAllProfiles: showAllProfilesMock
+}))
+
 // jsdom doesn't implement ResizeObserver; Radix's PopoverContent/Arrow use it
 // (via @radix-ui/react-use-size) to measure the arrow once the popover is
 // actually mounted. The kebab-only test above never opens a Popover, so it
@@ -115,4 +130,28 @@ describe('ProjectMenu', () => {
     // chain rather than getting silently dropped on an intermediate wrapper.
     expect(await screen.findByRole('button', { name: 'No color' })).toBeTruthy()
   }, 15000)
+
+  it('keeps Delete enabled for explicit projects outside the all-profiles view', async () => {
+    showAllProfilesMock.value = false
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    const trigger = screen.getByRole('button', { name: 'Actions' })
+    openTriggerMenu(trigger)
+
+    const deleteItem = await screen.findByRole('menuitem', { name: 'Delete…' })
+    expect(deleteItem.getAttribute('aria-disabled')).not.toBe('true')
+  })
+
+  it('disables Delete for explicit projects while viewing all profiles', async () => {
+    showAllProfilesMock.value = true
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    const trigger = screen.getByRole('button', { name: 'Actions' })
+    openTriggerMenu(trigger)
+
+    const deleteItem = await screen.findByRole('menuitem', { name: 'Delete…' })
+    // Per-profile RPCs cannot be scoped with no active profile, so the
+    // destructive action must be disabled instead of failing silently.
+    expect(deleteItem.getAttribute('aria-disabled')).toBe('true')
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -22,6 +22,7 @@ import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { $panesFlipped, dismissAutoProject } from '@/store/layout'
+import { $showAllProfiles } from '@/store/profile'
 import {
   copyPath,
   deleteProject,
@@ -56,6 +57,12 @@ function useProjectActions({
   const p = t.sidebar.projects
   const target = { id: project.id, name: project.label }
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  // Project RPCs are per-profile: the unified "All profiles" sidebar view has
+  // no active profile to send, so deleteProject would fail and roll back
+  // silently. Disable the destructive action there instead of letting a
+  // confirmed delete appear to do nothing (projectParams throws
+  // "Projects are unavailable while viewing all profiles").
+  const showAllProfiles = useStore($showAllProfiles)
 
   const removeAuto = () => {
     dismissAutoProject(project.id)
@@ -118,6 +125,9 @@ function useProjectActions({
         icon: 'trash',
         key: 'delete',
         label: `${p.menuDelete}…`,
+        // No active profile in the all-profiles view: the delete RPC cannot be
+        // scoped, so keep the destructive path from silently no-op'ing.
+        disabled: showAllProfiles,
         onSelect: () => setConfirmDeleteOpen(true),
         variant: 'destructive'
       }


### PR DESCRIPTION
Fixes #94738

## Problem

Two user-visible gaps in the projects sidebar, reported as "delete does nothing" and "no way to create a project":

1. **Delete can fail silently.** `projectParams()` in `store/projects.ts` throws whenever `$profileScope === ALL_PROFILES` ("Projects are unavailable while viewing all profiles"). `deleteProject()` removes the project optimistically, `persistOrRollback` restores it and re-throws — a confirmed delete looks like a no-op. Verified against the live backend that `projects.delete` itself works; the failure is purely the renderer scoping guard.
2. **Create is unreachable in the flat sessions view.** The section-header `+` in `app/chat/sidebar/index.tsx` only calls `openProjectCreate()` while `agentsGrouped`; otherwise the same button starts a session (`onNewSessionInWorkspace`). The shipped-but-invisible "New project" dialog (#54317) stays hidden for every user in the flat/ungrouped view.

## Fix

- `app/chat/sidebar/index.tsx`: render an additional `+` ("New project", `openProjectCreate()`) in the section header whenever `!showAllProfiles && !agentsGrouped` — exactly the mode in which the existing `+` is a new-session button, so no duplicate affordance in grouped mode. Reuses the existing `s.projects.newButton` i18n key (`New project`, already localized in all six locales).
- `app/chat/sidebar/projects/project-menu.tsx`: disable the destructive **Delete…** item for explicit projects while `$showAllProfiles` is active (project RPCs are per-profile and cannot be scoped with no active profile), instead of a confirmed delete that silently rolls back. Auto-project "Remove from sidebar" is unaffected (local dismissal).

## Testing

- `project-menu.test.tsx`: two new cases — Delete stays enabled outside the all-profiles view, and is `aria-disabled` while viewing all profiles (steerable `$showAllProfiles` mock).
- `npx vitest run src/app/chat/sidebar/projects/` → 5 files, **81 passed**.
- `npx tsc -p tsconfig.json --noEmit` → clean.

## Notes

- No behavior change for grouped mode (`agentsGrouped`): the original `+` already opened the create dialog there; the new button only covers the flat view.
- The all-profiles view already hides the create `+` (project RPCs are unavailable there); the disabled Delete is the consistent counterpart.

## AI assistance disclosure

Investigation (live WebSocket RPC repro against the local gateway, code audit) and the fix/test draft were done with the help of an autonomous coding agent. All commands shown were actually run.