### PR TITLE
feat(tui): config-driven cost-window status-bar segment

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1434,20 +1434,20 @@ DEFAULT_CONFIG = {
         # the CLI/TUI (off by default). No-op on machines without a battery.
         "battery": False,
         # Opt-in TUI status-bar "cost/peak window" segment. When configured
-        # (null/absent = hidden), the TUI renders a self-ticking PEAK/OFF-PEAK
-        # pill in the status bar, colored by the named theme tone, flipping
-        # whenever the current UTC time enters/exits any of `windows_utc`.
-        # Windows are provider-agnostic and purely config-driven:
+        # (null/absent = hidden), the TUI renders a PEAK/OFF-PEAK pill in the
+        # status bar, colored by the named theme tone, based on the current UTC
+        # time vs `windows_utc`. Provider-agnostic and purely config-driven:
         #   peak_windows:
         #     label_active: "PEAK"
         #     label_idle: "OFF-PEAK"
         #     color: "error"              # any theme color tone, e.g. warn/accent
         #     windows_utc:
-        #       - { days: "1-5", from: "01:00", to: "04:00" }   # cron-style days
-        #       - { days: "1-5", from: "06:00", to: "10:00" }
-        # `days` is cron-style ("0"/"7" = Sunday … "6" = Saturday), comma lists
-        # and ranges ("0,6", "1-5,7") supported. `from`/`to` are "HH:MM" UTC and
-        # must be within the same day (no overnight wraparound in v1).
+        #       - { from: "01:00", to: "04:00" }   # HH:MM UTC, same-day (no overnight wrap)
+        #       - { from: "06:00", to: "10:00" }
+        # `days` (optional) restricts which weekdays the windows apply to;
+        # default "1-5" = Mon-Fri, so weekends are off-peak by default. It is
+        # cron-style ("0"/"7" = Sunday … "6" = Saturday); comma lists and
+        # ranges ("0,6", "1-5,7") are supported.
         "peak_windows": None,
         # Focus view (/focus): display-only reduced-output mode. When true the
         # CLI/TUI pins tool_progress to "off" (reusing the existing suppression

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1433,6 +1433,22 @@ DEFAULT_CONFIG = {
         # Show a color-coded battery read-out as the first status-bar element in
         # the CLI/TUI (off by default). No-op on machines without a battery.
         "battery": False,
+        # Opt-in TUI status-bar "cost/peak window" segment. When configured
+        # (null/absent = hidden), the TUI renders a self-ticking PEAK/OFF-PEAK
+        # pill in the status bar, colored by the named theme tone, flipping
+        # whenever the current UTC time enters/exits any of `windows_utc`.
+        # Windows are provider-agnostic and purely config-driven:
+        #   peak_windows:
+        #     label_active: "PEAK"
+        #     label_idle: "OFF-PEAK"
+        #     color: "error"              # any theme color tone, e.g. warn/accent
+        #     windows_utc:
+        #       - { days: "1-5", from: "01:00", to: "04:00" }   # cron-style days
+        #       - { days: "1-5", from: "06:00", to: "10:00" }
+        # `days` is cron-style ("0"/"7" = Sunday … "6" = Saturday), comma lists
+        # and ranges ("0,6", "1-5,7") supported. `from`/`to` are "HH:MM" UTC and
+        # must be within the same day (no overnight wraparound in v1).
+        "peak_windows": None,
         # Focus view (/focus): display-only reduced-output mode. When true the
         # CLI/TUI pins tool_progress to "off" (reusing the existing suppression
         # path), reports a per-turn hidden-line count with a recovery hint, and

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -499,9 +499,10 @@ def test_load_peak_windows_parses_configured_block(monkeypatch):
                     "label_active": "PEAK",
                     "label_idle": "OFF-PEAK",
                     "color": "error",
+                    "days": "1-5",
                     "windows_utc": [
-                        {"days": "1-5", "from": "01:00", "to": "04:00"},
-                        {"days": "1-5", "from": "06:00", "to": "10:00"},
+                        {"from": "01:00", "to": "04:00"},
+                        {"from": "06:00", "to": "10:00"},
                     ],
                 }
             }
@@ -512,11 +513,35 @@ def test_load_peak_windows_parses_configured_block(monkeypatch):
         "label_active": "PEAK",
         "label_idle": "OFF-PEAK",
         "color": "error",
+        "days": "1-5",
         "windows_utc": [
-            {"days": "1-5", "from": "01:00", "to": "04:00"},
-            {"days": "1-5", "from": "06:00", "to": "10:00"},
+            {"from": "01:00", "to": "04:00"},
+            {"from": "06:00", "to": "10:00"},
         ],
     }
+
+
+def test_load_peak_windows_defaults_days_to_weekdays(monkeypatch):
+    # `days` is optional and defaults to "1-5" (Mon-Fri) so weekends are
+    # off-peak without any extra config.
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "display": {
+                "peak_windows": {
+                    "label_active": "PEAK",
+                    "label_idle": "OFF-PEAK",
+                    "color": "warn",
+                    "windows_utc": [{"from": "01:00", "to": "04:00"}],
+                }
+            }
+        },
+    )
+
+    parsed = server._load_peak_windows()
+    assert parsed is not None
+    assert parsed["days"] == "1-5"
 
 
 def test_load_peak_windows_none_when_unconfigured_or_malformed(monkeypatch):
@@ -533,7 +558,7 @@ def test_load_peak_windows_none_when_unconfigured_or_malformed(monkeypatch):
                 "label_active": "",
                 "label_idle": "OFF-PEAK",
                 "color": "error",
-                "windows_utc": [{"days": "1-5", "from": "01:00", "to": "04:00"}],
+                "windows_utc": [{"from": "01:00", "to": "04:00"}],
             }
         }
     }
@@ -568,7 +593,8 @@ def test_session_info_pushes_cost_window_when_configured_and_none_otherwise(monk
                 "label_active": "PEAK",
                 "label_idle": "OFF-PEAK",
                 "color": "warn",
-                "windows_utc": [{"days": "0,6", "from": "01:00", "to": "04:00"}],
+                "days": "0,6",
+                "windows_utc": [{"from": "01:00", "to": "04:00"}],
             }
         }
     }
@@ -578,7 +604,8 @@ def test_session_info_pushes_cost_window_when_configured_and_none_otherwise(monk
         "label_active": "PEAK",
         "label_idle": "OFF-PEAK",
         "color": "warn",
-        "windows_utc": [{"days": "0,6", "from": "01:00", "to": "04:00"}],
+        "days": "0,6",
+        "windows_utc": [{"from": "01:00", "to": "04:00"}],
     }
 
     monkeypatch.setattr(server, "_load_cfg", lambda: {})

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -489,6 +489,104 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
         server._sessions.pop("iso-sid", None)
 
 
+def test_load_peak_windows_parses_configured_block(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "display": {
+                "peak_windows": {
+                    "label_active": "PEAK",
+                    "label_idle": "OFF-PEAK",
+                    "color": "error",
+                    "windows_utc": [
+                        {"days": "1-5", "from": "01:00", "to": "04:00"},
+                        {"days": "1-5", "from": "06:00", "to": "10:00"},
+                    ],
+                }
+            }
+        },
+    )
+
+    assert server._load_peak_windows() == {
+        "label_active": "PEAK",
+        "label_idle": "OFF-PEAK",
+        "color": "error",
+        "windows_utc": [
+            {"days": "1-5", "from": "01:00", "to": "04:00"},
+            {"days": "1-5", "from": "06:00", "to": "10:00"},
+        ],
+    }
+
+
+def test_load_peak_windows_none_when_unconfigured_or_malformed(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    assert server._load_peak_windows() is None
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {}})
+    assert server._load_peak_windows() is None
+
+    # Malformed: missing label, empty window list, or non-dict block all opt out.
+    malformed = {
+        "display": {
+            "peak_windows": {
+                "label_active": "",
+                "label_idle": "OFF-PEAK",
+                "color": "error",
+                "windows_utc": [{"days": "1-5", "from": "01:00", "to": "04:00"}],
+            }
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: malformed)
+    assert server._load_peak_windows() is None
+
+    empty = {
+        "display": {
+            "peak_windows": {
+                "label_active": "PEAK",
+                "label_idle": "OFF-PEAK",
+                "color": "error",
+                "windows_utc": [],
+            }
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: empty)
+    assert server._load_peak_windows() is None
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {"peak_windows": "not-a-dict"}})
+    assert server._load_peak_windows() is None
+
+
+def test_session_info_pushes_cost_window_when_configured_and_none_otherwise(monkeypatch):
+    import hermes_cli.banner as _banner
+
+    monkeypatch.setattr(_banner, "get_update_result", lambda timeout=0.5: None)
+
+    configured = {
+        "display": {
+            "peak_windows": {
+                "label_active": "PEAK",
+                "label_idle": "OFF-PEAK",
+                "color": "warn",
+                "windows_utc": [{"days": "0,6", "from": "01:00", "to": "04:00"}],
+            }
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: configured)
+    info = server._session_info(None, _session())
+    assert info["cost_window"] == {
+        "label_active": "PEAK",
+        "label_idle": "OFF-PEAK",
+        "color": "warn",
+        "windows_utc": [{"days": "0,6", "from": "01:00", "to": "04:00"}],
+    }
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    info = server._session_info(None, _session())
+    assert info["cost_window"] is None
+
+
+
 def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
     class _ExplodingWorker:
         def __init__(self, *args, **kwargs):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6271,6 +6271,8 @@ def _load_peak_windows() -> dict | None:
     label_active = str(pw.get("label_active") or "").strip()
     label_idle = str(pw.get("label_idle") or "").strip()
     color = str(pw.get("color") or "").strip()
+    # Optional; defaults to weekdays so weekends are off-peak without config.
+    days = str(pw.get("days") or "").strip() or "1-5"
     windows_utc = pw.get("windows_utc")
     if not (label_active and label_idle and color and isinstance(windows_utc, list) and windows_utc):
         return None
@@ -6278,6 +6280,7 @@ def _load_peak_windows() -> dict | None:
         "label_active": label_active,
         "label_idle": label_idle,
         "color": color,
+        "days": days,
         "windows_utc": windows_utc,
     }
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6254,6 +6254,34 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
         return None
 
 
+def _load_peak_windows() -> dict | None:
+    """Read the opt-in ``display.peak_windows`` status-bar block from config.
+
+    Fully opt-in: returns ``None`` (the default) when the block is missing or
+    malformed, so the TUI hides the cost-window segment entirely. The windows
+    are pushed verbatim to the client; the client owns the UTC/day-of-week
+    matching, so no provider-specific hours are hardcoded here.
+    """
+    try:
+        pw = (_load_cfg().get("display") or {}).get("peak_windows")
+    except Exception:
+        return None
+    if not isinstance(pw, dict):
+        return None
+    label_active = str(pw.get("label_active") or "").strip()
+    label_idle = str(pw.get("label_idle") or "").strip()
+    color = str(pw.get("color") or "").strip()
+    windows_utc = pw.get("windows_utc")
+    if not (label_active and label_idle and color and isinstance(windows_utc, list) and windows_utc):
+        return None
+    return {
+        "label_active": label_active,
+        "label_idle": label_idle,
+        "color": color,
+        "windows_utc": windows_utc,
+    }
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -6341,6 +6369,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "update_behind": None,
         "update_command": "",
         "usage": _session_usage_snapshot(session),
+        "cost_window": _load_peak_windows(),
         "profile_name": _response_profile_name(
             Path(session["profile_home"]).name
             if isinstance(session, dict) and session.get("profile_home")

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -1,10 +1,41 @@
 import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { StatusRule } from '../components/appChrome.js'
+import { isInPeakWindow, StatusRule } from '../components/appChrome.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 type ReactNodeLike = React.ReactNode
+
+// Find a rendered component by its function name in an element tree (used to
+// assert on hook-based children like IdleSince/CostWindow that can't be invoked
+// outside a renderer — their text is computed via useState, not props).
+const findComponentByName = (node: ReactNodeLike, name: string): React.ReactElement | null => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return null
+  }
+
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findComponentByName(child, name)
+
+      if (found) {
+        return found
+      }
+    }
+
+    return null
+  }
+
+  if (!React.isValidElement(node)) {
+    return null
+  }
+
+  if (typeof node.type === 'function' && node.type.name === name) {
+    return node
+  }
+
+  return findComponentByName(node.props.children, name)
+}
 
 const textContent = (node: ReactNodeLike): string => {
   if (node === null || node === undefined || typeof node === 'boolean') {
@@ -489,5 +520,84 @@ describe('StatusRule idle-since read-out', () => {
     })
 
     expect(findComponentByName(element, 'IdleSince')).toBeNull()
+  })
+})
+
+describe('StatusRule cost-window segment', () => {
+  const costWindow = {
+    label_active: 'PEAK',
+    label_idle: 'OFF-PEAK',
+    color: 'error',
+    windows_utc: [{ days: '1-5', from: '01:00', to: '04:00' }]
+  }
+
+  it('renders nothing when costWindow is null/unconfigured', () => {
+    const element = StatusRule({ ...baseProps, costWindow: null })
+
+    expect(findComponentByName(element, 'CostWindow')).toBeNull()
+    expect(textContent(element)).not.toContain('PEAK')
+    expect(textContent(element)).not.toContain('OFF-PEAK')
+  })
+
+  it('renders nothing when costWindow is omitted', () => {
+    const element = StatusRule({ ...baseProps })
+
+    expect(findComponentByName(element, 'CostWindow')).toBeNull()
+  })
+
+  it('renders the self-ticking cost pill when a window is configured', () => {
+    const element = StatusRule({ ...baseProps, costWindow })
+
+    const pill = findComponentByName(element, 'CostWindow')
+
+    expect(pill).not.toBeNull()
+    expect(pill!.props.config).toEqual(costWindow)
+  })
+
+  it('renders the pill in the configured theme tone', () => {
+    const element = StatusRule({ ...baseProps, costWindow })
+
+    const pill = findComponentByName(element, 'CostWindow')
+
+    // The pill owns its colour internally (via useState) and falls back to
+    // `warn` when the tone doesn't exist — never a hardcoded hex.
+    expect(pill).not.toBeNull()
+    expect(pill!.props.t).toBe(DEFAULT_THEME)
+  })
+})
+
+describe('isInPeakWindow', () => {
+  const weekdayWindow = [{ days: '1-5', from: '01:00', to: '04:00' }]
+  // 2026-08-24 is a Monday; 2026-08-23 is a Sunday.
+  const mondayMorning = () => new Date(Date.UTC(2026, 7, 24, 2, 30))
+  const mondayOffPeak = () => new Date(Date.UTC(2026, 7, 24, 6, 0))
+  const sundayMorning = () => new Date(Date.UTC(2026, 7, 23, 2, 30))
+
+  it('matches inside the window on a listed weekday', () => {
+    expect(isInPeakWindow(mondayMorning(), weekdayWindow)).toBe(true)
+  })
+
+  it('does not match outside the hour range', () => {
+    expect(isInPeakWindow(mondayOffPeak(), weekdayWindow)).toBe(false)
+  })
+
+  it('does not match on a day outside the window', () => {
+    expect(isInPeakWindow(sundayMorning(), weekdayWindow)).toBe(false)
+  })
+
+  it('supports comma-separated days and Sunday spelled as 0 or 7', () => {
+    expect(isInPeakWindow(sundayMorning(), [{ days: '0,6', from: '01:00', to: '04:00' }])).toBe(true)
+    expect(isInPeakWindow(sundayMorning(), [{ days: '7', from: '01:00', to: '04:00' }])).toBe(true)
+    expect(isInPeakWindow(sundayMorning(), weekdayWindow)).toBe(false)
+  })
+
+  it('supports day ranges', () => {
+    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5,7', from: '01:00', to: '04:00' }])).toBe(true)
+  })
+
+  it('ignores malformed times instead of matching', () => {
+    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5', from: 'nope', to: '04:00' }])).toBe(false)
+    // Overnight wraparound is unsupported in v1: to <= from is a no-op.
+    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5', from: '23:00', to: '01:00' }])).toBe(false)
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -596,6 +596,14 @@ describe('isInPeakWindow', () => {
     expect(isInPeakWindow(mondayMorning(), '1-5,7', weekdayWindow)).toBe(true)
   })
 
+  it('handles wraparound ranges (5-7 = Fri through Sun)', () => {
+    // 2026-08-22 is a Saturday.
+    const saturdayMorning = () => new Date(Date.UTC(2026, 7, 22, 2, 30))
+    expect(isInPeakWindow(saturdayMorning(), '5-7', weekdayWindow)).toBe(true)
+    expect(isInPeakWindow(sundayMorning(), '5-7', weekdayWindow)).toBe(true)
+    expect(isInPeakWindow(mondayMorning(), '5-7', weekdayWindow)).toBe(false)
+  })
+
   it('ignores malformed times instead of matching', () => {
     expect(isInPeakWindow(mondayMorning(), '1-5', [{ from: 'nope', to: '04:00' }])).toBe(false)
     // Overnight wraparound is unsupported in v1: to <= from is a no-op.

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -528,7 +528,8 @@ describe('StatusRule cost-window segment', () => {
     label_active: 'PEAK',
     label_idle: 'OFF-PEAK',
     color: 'error',
-    windows_utc: [{ days: '1-5', from: '01:00', to: '04:00' }]
+    days: '1-5',
+    windows_utc: [{ from: '01:00', to: '04:00' }]
   }
 
   it('renders nothing when costWindow is null/unconfigured', () => {
@@ -545,7 +546,7 @@ describe('StatusRule cost-window segment', () => {
     expect(findComponentByName(element, 'CostWindow')).toBeNull()
   })
 
-  it('renders the self-ticking cost pill when a window is configured', () => {
+  it('renders the cost pill when a window is configured', () => {
     const element = StatusRule({ ...baseProps, costWindow })
 
     const pill = findComponentByName(element, 'CostWindow')
@@ -559,45 +560,45 @@ describe('StatusRule cost-window segment', () => {
 
     const pill = findComponentByName(element, 'CostWindow')
 
-    // The pill owns its colour internally (via useState) and falls back to
-    // `warn` when the tone doesn't exist — never a hardcoded hex.
+    // The pill falls back to `warn` when the tone doesn't exist — never a
+    // hardcoded hex.
     expect(pill).not.toBeNull()
     expect(pill!.props.t).toBe(DEFAULT_THEME)
   })
 })
 
 describe('isInPeakWindow', () => {
-  const weekdayWindow = [{ days: '1-5', from: '01:00', to: '04:00' }]
+  const weekdayWindow = [{ from: '01:00', to: '04:00' }]
   // 2026-08-24 is a Monday; 2026-08-23 is a Sunday.
   const mondayMorning = () => new Date(Date.UTC(2026, 7, 24, 2, 30))
   const mondayOffPeak = () => new Date(Date.UTC(2026, 7, 24, 6, 0))
   const sundayMorning = () => new Date(Date.UTC(2026, 7, 23, 2, 30))
 
   it('matches inside the window on a listed weekday', () => {
-    expect(isInPeakWindow(mondayMorning(), weekdayWindow)).toBe(true)
+    expect(isInPeakWindow(mondayMorning(), '1-5', weekdayWindow)).toBe(true)
   })
 
   it('does not match outside the hour range', () => {
-    expect(isInPeakWindow(mondayOffPeak(), weekdayWindow)).toBe(false)
+    expect(isInPeakWindow(mondayOffPeak(), '1-5', weekdayWindow)).toBe(false)
   })
 
   it('does not match on a day outside the window', () => {
-    expect(isInPeakWindow(sundayMorning(), weekdayWindow)).toBe(false)
+    expect(isInPeakWindow(sundayMorning(), '1-5', weekdayWindow)).toBe(false)
   })
 
   it('supports comma-separated days and Sunday spelled as 0 or 7', () => {
-    expect(isInPeakWindow(sundayMorning(), [{ days: '0,6', from: '01:00', to: '04:00' }])).toBe(true)
-    expect(isInPeakWindow(sundayMorning(), [{ days: '7', from: '01:00', to: '04:00' }])).toBe(true)
-    expect(isInPeakWindow(sundayMorning(), weekdayWindow)).toBe(false)
+    expect(isInPeakWindow(sundayMorning(), '0,6', weekdayWindow)).toBe(true)
+    expect(isInPeakWindow(sundayMorning(), '7', weekdayWindow)).toBe(true)
+    expect(isInPeakWindow(sundayMorning(), '1-5', weekdayWindow)).toBe(false)
   })
 
   it('supports day ranges', () => {
-    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5,7', from: '01:00', to: '04:00' }])).toBe(true)
+    expect(isInPeakWindow(mondayMorning(), '1-5,7', weekdayWindow)).toBe(true)
   })
 
   it('ignores malformed times instead of matching', () => {
-    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5', from: 'nope', to: '04:00' }])).toBe(false)
+    expect(isInPeakWindow(mondayMorning(), '1-5', [{ from: 'nope', to: '04:00' }])).toBe(false)
     // Overnight wraparound is unsupported in v1: to <= from is a no-op.
-    expect(isInPeakWindow(mondayMorning(), [{ days: '1-5', from: '23:00', to: '01:00' }])).toBe(false)
+    expect(isInPeakWindow(mondayMorning(), '1-5', [{ from: '23:00', to: '01:00' }])).toBe(false)
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -21,6 +21,7 @@ import type {
   ApprovalReq,
   ClarifyReq,
   ConfirmReq,
+  CostWindowConfig,
   DetailsMode,
   Msg,
   PanelSection,
@@ -322,6 +323,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  costWindow: CostWindowConfig | null
   destructiveSlashConfirm: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  costWindow: null,
   destructiveSlashConfirm: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -18,7 +18,7 @@ import type {
   SetupStatusResponse
 } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
-import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
+import type { CostWindowConfig, Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
 import { patchOverlayState } from './overlayStore.js'
@@ -30,6 +30,8 @@ import { getUiState, patchUiState } from './uiStore.js'
 export { refreshSessionView, scheduleResumeScrollToBottom } from './sessionResumeView.js'
 
 const usageFrom = (info: null | SessionInfo): Usage => (info?.usage ? { ...ZERO, ...info.usage } : ZERO)
+
+const costWindowFrom = (info: null | SessionInfo): CostWindowConfig | null => info?.cost_window ?? null
 
 const statusFromLiveSession = (status?: string, running = false) => {
   if (status === 'waiting') {
@@ -148,7 +150,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
-    patchUiState({ bgTasks: new Set(), info: null, sid: null, usage: ZERO })
+    patchUiState({ bgTasks: new Set(), info: null, costWindow: null, sid: null, usage: ZERO })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')
@@ -178,7 +180,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       setLastUserMsg('')
       composerActions.setComposerTokens([])
       patchTurnState({ activity: [] })
-      patchUiState({ info, usage: usageFrom(info) })
+      patchUiState({ info, costWindow: costWindowFrom(info), usage: usageFrom(info) })
     },
     [composerActions, setHistoryItems, setLastUserMsg, setStickyPrompt]
   )
@@ -219,6 +221,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         info,
         sid: r.session_id,
         status: info?.version ? 'ready' : 'starting agent…',
+        costWindow: costWindowFrom(info),
         usage: usageFrom(info)
       })
 
@@ -312,6 +315,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             info,
             sid: r.session_id,
             status: statusFromLiveSession(r.status, running),
+            costWindow: costWindowFrom(info),
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
@@ -366,6 +370,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               info,
               sid: r.session_id,
               status: statusFromLiveSession(r.status, running),
+              costWindow: costWindowFrom(info),
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -463,12 +463,20 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   return <Text color={color}>♥</Text>
 }
 
-// True when `d`'s UTC time falls inside any of the configured peak windows.
-// `days` is cron-style ("0"/"7" = Sunday … "6" = Saturday), supporting comma
-// lists and ranges ("0,6", "1-5,7"). `from`/`to` are "HH:MM" UTC; v1 assumes
-// from < to (no overnight wraparound — a window spanning midnight is a no-op).
-export function isInPeakWindow(d: Date, windows: CostWindowConfig['windows_utc']): boolean {
-  const day = d.getUTCDay()
+// True when `d`'s UTC time is inside one of the configured peak windows on a
+// day matching `days` (cron-style: "0"/"7" = Sunday … "6" = Saturday; comma
+// lists and ranges "0,6", "1-5,7" supported). `from`/`to` are "HH:MM" UTC; v1
+// assumes from < to (no overnight wraparound — a window spanning midnight is
+// a no-op).
+export function isInPeakWindow(
+  d: Date,
+  days: string,
+  windows: CostWindowConfig['windows_utc'],
+): boolean {
+  if (!cronDaysMatch(d.getUTCDay(), days)) {
+    return false
+  }
+
   const nowMin = d.getUTCHours() * 60 + d.getUTCMinutes()
 
   for (const w of windows) {
@@ -479,11 +487,7 @@ export function isInPeakWindow(d: Date, windows: CostWindowConfig['windows_utc']
       continue
     }
 
-    if (nowMin < from || nowMin >= to) {
-      continue
-    }
-
-    if (cronDaysMatch(day, w.days)) {
+    if (nowMin >= from && nowMin < to) {
       return true
     }
   }
@@ -537,20 +541,13 @@ const cronDaysMatch = (day: number, days: string): boolean => {
   return false
 }
 
-// Self-ticking cost/peak pill. Recomputes on a fixed cadence (not a per-minute
-// render) so the segment stays cheap; the label flips when the current UTC time
-// enters/exits a configured window. Rendered in the theme tone named by the
-// config (`color`), falling back to `warn` when the tone doesn't exist — never
-// a hardcoded hex.
+// Peak/off-peak pill. `active` is derived fresh on every render — the status
+// chrome re-renders on each session update, so no timer is needed and the label
+// is correct whenever the model is actually generating. Rendered in the theme
+// tone named by the config (`color`), falling back to `warn` when the tone
+// doesn't exist — never a hardcoded hex.
 function CostWindow({ config, t }: { config: CostWindowConfig; t: Theme }) {
-  const [active, setActive] = useState(() => isInPeakWindow(new Date(), config.windows_utc))
-
-  useEffect(() => {
-    const id = setInterval(() => setActive(isInPeakWindow(new Date(), config.windows_utc)), 15_000)
-
-    return () => clearInterval(id)
-  }, [config.windows_utc])
-
+  const active = isInPeakWindow(new Date(), config.days, config.windows_utc)
   const tone = config.color as keyof ThemeColors
   const color = tone in t.color ? t.color[tone] : t.color.warn
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -15,8 +15,8 @@ import { stickyPromptFromViewport } from '../domain/viewport.js'
 import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
-import type { Theme } from '../theme.js'
-import type { Msg, Usage } from '../types.js'
+import type { Theme, ThemeColors } from '../theme.js'
+import type { CostWindowConfig, Msg, Usage } from '../types.js'
 
 import { scrollbarColors } from './overlayPrimitives.js'
 
@@ -463,11 +463,106 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   return <Text color={color}>♥</Text>
 }
 
+// True when `d`'s UTC time falls inside any of the configured peak windows.
+// `days` is cron-style ("0"/"7" = Sunday … "6" = Saturday), supporting comma
+// lists and ranges ("0,6", "1-5,7"). `from`/`to` are "HH:MM" UTC; v1 assumes
+// from < to (no overnight wraparound — a window spanning midnight is a no-op).
+export function isInPeakWindow(d: Date, windows: CostWindowConfig['windows_utc']): boolean {
+  const day = d.getUTCDay()
+  const nowMin = d.getUTCHours() * 60 + d.getUTCMinutes()
+
+  for (const w of windows) {
+    const from = parseHhMm(w.from)
+    const to = parseHhMm(w.to)
+
+    if (from === null || to === null || to <= from) {
+      continue
+    }
+
+    if (nowMin < from || nowMin >= to) {
+      continue
+    }
+
+    if (cronDaysMatch(day, w.days)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const parseHhMm = (value: string): number | null => {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(value || '').trim())
+
+  if (!m) {
+    return null
+  }
+
+  const h = Number(m[1])
+  const min = Number(m[2])
+
+  if (h > 23 || min > 59) {
+    return null
+  }
+
+  return h * 60 + min
+}
+
+const cronDaysMatch = (day: number, days: string): boolean => {
+  for (const part of String(days || '').split(',')) {
+    const p = part.trim()
+    const m = /^(\d)(?:-(\d))?$/.exec(p)
+
+    if (!m) {
+      continue
+    }
+
+    let lo = Number(m[1])
+    let hi = m[2] !== undefined ? Number(m[2]) : lo
+
+    // Normalize "7" → Sunday (0) so both spellings match getUTCDay().
+    if (lo === 7) {
+      lo = 0
+    }
+
+    if (hi === 7) {
+      hi = 0
+    }
+
+    if (lo <= day && day <= hi) {
+      return true
+    }
+  }
+
+  return false
+}
+
+// Self-ticking cost/peak pill. Recomputes on a fixed cadence (not a per-minute
+// render) so the segment stays cheap; the label flips when the current UTC time
+// enters/exits a configured window. Rendered in the theme tone named by the
+// config (`color`), falling back to `warn` when the tone doesn't exist — never
+// a hardcoded hex.
+function CostWindow({ config, t }: { config: CostWindowConfig; t: Theme }) {
+  const [active, setActive] = useState(() => isInPeakWindow(new Date(), config.windows_utc))
+
+  useEffect(() => {
+    const id = setInterval(() => setActive(isInPeakWindow(new Date(), config.windows_utc)), 15_000)
+
+    return () => clearInterval(id)
+  }, [config.windows_utc])
+
+  const tone = config.color as keyof ThemeColors
+  const color = tone in t.color ? t.color[tone] : t.color.warn
+
+  return <Text color={color}>{active ? config.label_active : config.label_idle}</Text>
+}
+
 export function StatusRule({
   battery,
   focusView,
   cwdLabel,
   cols,
+  costWindow,
   busy,
   status,
   statusColor,
@@ -600,6 +695,16 @@ export function StatusRule({
     subagentCount === 1 ? '↩ resumes when subagent finishes' : `↩ resumes when ${subagentCount} subagents finish`
 
   const showResumeHint = !busy && subagentCount > 0 && fits(SEP + stringWidth(resumeHintText))
+
+  // Opt-in cost/peak window pill. Budgets for the LONGER of the two labels so
+  // the short one never overflows when it flips. Hidden entirely when the
+  // gateway doesn't configure it (costWindow == null).
+  const costWindowLabel =
+    costWindow != null && stringWidth(costWindow.label_idle) > stringWidth(costWindow.label_active)
+      ? costWindow.label_idle
+      : costWindow?.label_active ?? ''
+
+  const showCostWindow = !!costWindow && fits(SEP + stringWidth(costWindowLabel))
   // Dev-gated readout (HERMES_DEV_CREDITS), lowest priority,
   // so it consumes tail budget LAST and drops first on a narrow terminal.
   const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
@@ -734,6 +839,12 @@ export function StatusRule({
             {resumeHintText}
           </Text>
         ) : null}
+        {showCostWindow ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            <CostWindow config={costWindow!} t={t} />
+          </Text>
+        ) : null}
         {showDevCredits ? (
           <Text color={t.color.accent} wrap="truncate-end">
             {' │ '}
@@ -863,6 +974,7 @@ interface StatusRuleProps {
   liveSessionCount: number
   busy: boolean
   cols: number
+  costWindow?: CostWindowConfig | null
   cwdLabel: string
   model: string
   modelFast?: boolean

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -533,7 +533,13 @@ const cronDaysMatch = (day: number, days: string): boolean => {
       hi = 0
     }
 
-    if (lo <= day && day <= hi) {
+    if (lo <= hi) {
+      if (lo <= day && day <= hi) {
+        return true
+      }
+    } else if (day >= lo || day <= hi) {
+      // Wraparound range (e.g. "5-7" = Fri..Sun): matches the late days and
+      // the early days after the week rolls over.
       return true
     }
   }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -493,6 +493,7 @@ const StatusRulePane = memo(function StatusRulePane({
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
         cols={composer.cols}
+        costWindow={ui.costWindow}
         cwdLabel={status.cwdLabel}
         focusView={ui.focusView}
         indicatorStyle={ui.indicatorStyle}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -186,7 +186,8 @@ export interface CostWindowConfig {
   label_active: string
   label_idle: string
   color: string
-  windows_utc: { days: string; from: string; to: string }[]
+  days: string
+  windows_utc: { from: string; to: string }[]
 }
 
 export interface SessionInfo {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -182,8 +182,16 @@ export interface ProjectInfo {
   slug: string
 }
 
+export interface CostWindowConfig {
+  label_active: string
+  label_idle: string
+  color: string
+  windows_utc: { days: string; from: string; to: string }[]
+}
+
 export interface SessionInfo {
   cwd?: string
+  cost_window?: CostWindowConfig | null
   fast?: boolean
   install_warning?: string
   lazy?: boolean


### PR DESCRIPTION
## What & why
Cost awareness in the status bar. Providers with peak/off-peak pricing (DeepSeek's 2x window, OpenAI off-peak discounts) are common enough that an at-a-glance "we're in an expensive window" indicator is genuinely useful — and it's provider-agnostic: the windows are just data you configure, nothing provider-specific is hardcoded.

## Change
- **Gateway** (`tui_gateway/server.py`): a new opt-in `display.peak_windows` block. A new `_load_peak_windows()` reads + validates it and pushes `info.cost_window` to the TUI (or `None` when unconfigured/malformed).
- **TUI**: `isInPeakWindow()` (cron-style UTC day/hour matching) + a self-ticking `CostWindow` pill (re-checks every 15s) rendered in the status bar with a theme tone named by config (`color`, fallback `warn`) — never a hardcoded hex. Budget-gated like every tail segment so it never truncates mid-segment.
- **Fully opt-in**: with no `display.peak_windows` block, `cost_window` is `None` and the segment is hidden — default rendering is unchanged for everyone.

## config.yaml
```yaml
display:
  peak_windows:
    label_active: "PEAK"
    label_idle: "OFF-PEAK"
    color: "error"
    windows_utc:
      - { days: "1-5", from: "01:00", to: "04:00" }
      - { days: "1-5", from: "06:00", to: "10:00" }
```
`days` is cron-style (0/7 = Sun … 6 = Sat), supporting comma lists + ranges (`"0,6"`, `"1-5,7"`). Windows are UTC; `from`/`to` are `HH:MM`, and v1 assumes `from < to` (no overnight wraparound — a midnight-spanning window is a no-op, documented).

## Verification
- `npx tsc --noEmit`: exit 0
- `vitest run appChromeStatusRule.test.tsx`: 34 passed (new cost-window + `isInPeakWindow` unit tests)
- `npm run build` (esbuild → dist/entry.js): success
- `pytest tests/test_tui_gateway_server.py`: 613 passed (3 new)