### PR TITLE
fix(gateway): deliver background-process completions to secondary profiles under multiplexing

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from gateway.config import Platform
 from gateway.session import SessionSource
+from gateway.transport_provenance import TransportProvenance
 from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
@@ -258,32 +259,39 @@ class GatewayAuthorizationMixin:
             return str(value) if value else None
         return None
 
-    def _adapter_for_transport_slot(self, transport_slot, transport_profile):
-        """Re-resolve the live adapter for a recorded owner + slot pair.
+    def _capture_transport_provenance(self, source) -> Optional[TransportProvenance]:
+        """Record the exact ingress adapter of *source* as one atomic pair.
+
+        The two dimensions are read behind a single failure boundary and only
+        a complete pair is returned: half a return address would later be
+        replayed as a guessed transport, so an incomplete read records nothing
+        and the completion takes the legacy path instead.
+        """
+        try:
+            profile = (self._transport_owner_profile(source) or "").strip()
+            slot = (self._ingress_transport_slot(source) or "").strip()
+        except Exception:
+            return None
+        if not profile or not slot:
+            return None
+        return TransportProvenance(profile, slot)
+
+    def _adapter_for_provenance(self, provenance: TransportProvenance):
+        """Re-resolve the live adapter a recorded provenance pair names.
 
         Exact provenance, so the lookup is the recorded slot rather than the
         logical platform: no alias resolution, and a miss means the ingress
-        transport is gone and the caller must fail closed.
+        transport is gone and the caller must fail closed. An adapter object
+        captured at commissioning time cannot be held across a completion —
+        the reconnect path may have replaced it, or the process may have
+        restarted — so provenance is a name, turned back here into whatever
+        adapter is live now.
         """
-        if not transport_slot:
-            return None
         try:
-            platform = Platform(str(transport_slot))
+            platform = Platform(str(provenance.slot))
         except (ValueError, KeyError):
             return None
-        return self._authorization_adapter(platform, transport_profile or None)
-
-    def _adapter_for_transport_profile(self, platform, transport_profile):
-        """Re-resolve the currently live adapter for a recorded provenance token.
-
-        An adapter object captured at commissioning time cannot be held across a
-        completion: the reconnect path may have replaced it, or the process may
-        have restarted. Provenance is a name, and this turns it back into
-        whatever adapter is live now.
-        """
-        if not transport_profile:
-            return None
-        return self._authorization_adapter(platform, transport_profile)
+        return self._authorization_adapter(platform, provenance.profile or None)
 
     def _adapter_authorization_is_upstream(
         self,

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -246,13 +246,16 @@ class GatewayAuthorizationMixin:
         (``GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS``). ``None`` means no live
         transport provenance, so the caller keeps alias resolution.
         """
+        # relay ingress is the authoritative fact and is checked first: the
+        # adapter sits under ``Platform.RELAY``, so a native adapter serving
+        # the same logical platform must never claim the slot.
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            return Platform.RELAY.value
         if self._registered_transport_adapter(source) is not None:
             # Registration was found under the source's own platform key.
             platform = getattr(source, "platform", None)
             value = getattr(platform, "value", platform)
             return str(value) if value else None
-        if getattr(source, "delivered_via_upstream_relay", False) is True:
-            return Platform.RELAY.value
         return None
 
     def _adapter_for_transport_slot(self, transport_slot, transport_profile):

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,6 +28,12 @@ from gateway.whatsapp_identity import (
 )
 
 
+# Provenance token for "the process-default adapter map" (``self.adapters``).
+# Deliberately the same string ``_authorization_adapter`` already treats as the
+# default map, so a recorded provenance token can be handed straight back to it.
+TRANSPORT_PROFILE_DEFAULT = "default"
+
+
 def _platform_gate_env(name: str, default: str = "") -> str:
     """Read a platform allow/deny gate env var with per-profile isolation.
 
@@ -187,6 +193,63 @@ class GatewayAuthorizationMixin:
                 if adapter is profile_adapters.get(platform):
                     return profile
         return getattr(source, "profile", None)
+
+    def _transport_owner_profile(self, source) -> Optional[str]:
+        """Return DURABLE transport provenance for the turn *source* arrived on.
+
+        ``source.profile`` is the runtime namespace — which agent config,
+        credentials and session lane the turn is routed to. It is NOT the
+        transport owner: one shared credential (a single Matrix bot, say) can
+        serve several routed runtimes, so a completion resolved from the
+        runtime namespace is either dropped (that runtime registers no adapter
+        for the platform) or answered from a different bot than the one the
+        user spoke to.
+
+        This returns the profile that OWNS the receiving adapter, as a token
+        that survives serialization onto a durable record:
+
+        * ``"default"`` — the process-default adapter map (``self.adapters``).
+        * ``"<name>"``  — ``_profile_adapters["<name>"]``.
+        * ``None``      — no live transport provenance on this source (a
+          restored or hand-built source), i.e. legacy: the caller must fall
+          back to the runtime profile.
+
+        The token is deliberately the same vocabulary
+        :meth:`_authorization_adapter` already accepts, so re-resolving the
+        CURRENT LIVE adapter at completion time is a single call with no new
+        lookup rules — and no new fail-open path.
+        """
+        adapter = self._registered_transport_adapter(source)
+        if adapter is None:
+            return None
+        # #89860's ownership API is the adapter's own declaration of which
+        # profile's credentials it holds. Prefer it; it is set by
+        # ``_configure_profile_adapter`` before any inbound event is handled.
+        owner = getattr(adapter, "_owner_profile", None)
+        if isinstance(owner, str) and owner.strip():
+            return owner.strip()
+        platform = getattr(source, "platform", None)
+        if adapter is (getattr(self, "adapters", None) or {}).get(platform):
+            return TRANSPORT_PROFILE_DEFAULT
+        for profile, profile_adapters in (
+            getattr(self, "_profile_adapters", None) or {}
+        ).items():
+            if adapter is profile_adapters.get(platform):
+                return profile
+        return None
+
+    def _adapter_for_transport_profile(self, platform, transport_profile):
+        """Re-resolve the CURRENT LIVE adapter for a recorded provenance token.
+
+        The adapter object captured at commissioning time must never be held
+        across a completion: it may have been disconnected and replaced by the
+        reconnect path (``_run_secondary_profile_reconnect``), or the whole
+        process may have restarted. Provenance is recorded as a *name*; this
+        turns the name back into whatever adapter is live NOW.
+        """
+        if not transport_profile:
+            return None
+        return self._authorization_adapter(platform, transport_profile)
 
     def _adapter_authorization_is_upstream(
         self,

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,9 +28,9 @@ from gateway.whatsapp_identity import (
 )
 
 
-# Provenance token for "the process-default adapter map" (``self.adapters``).
-# Deliberately the same string ``_authorization_adapter`` already treats as the
-# default map, so a recorded provenance token can be handed straight back to it.
+# Provenance token for the process-default adapter map (``self.adapters``).
+# Same string ``_authorization_adapter`` already treats as the default map, so a
+# recorded token can be handed straight back to it.
 TRANSPORT_PROFILE_DEFAULT = "default"
 
 
@@ -195,50 +195,33 @@ class GatewayAuthorizationMixin:
         return getattr(source, "profile", None)
 
     def _transport_owner_profile(self, source) -> Optional[str]:
-        """Return DURABLE transport provenance for the turn *source* arrived on.
+        """Return durable transport provenance for the turn *source* arrived on.
 
-        ``source.profile`` is the runtime namespace — which agent config,
-        credentials and session lane the turn is routed to. It is NOT the
-        transport owner: one shared credential (a single Matrix bot, say) can
-        serve several routed runtimes, so a completion resolved from the
-        runtime namespace is either dropped (that runtime registers no adapter
-        for the platform) or answered from a different bot than the one the
-        user spoke to.
-
-        This returns the profile that OWNS the receiving adapter, as a token
+        Unlike ``source.profile`` — the runtime namespace the turn is routed to
+        — this names the profile that owns the receiving adapter, as a token
         that survives serialization onto a durable record:
 
         * ``"default"`` — the process-default adapter map (``self.adapters``),
-          which is also the answer for relay ingress: one process-level
-          RelayAdapter fronts every multiplexed profile.
+          also the answer for relay ingress.
         * ``"<name>"``  — ``_profile_adapters["<name>"]``.
-        * ``None``      — no live transport provenance on this source (a
-          restored or hand-built source), i.e. legacy: the caller must fall
-          back to the runtime profile.
+        * ``None``      — no live transport provenance on this source, so the
+          caller must fall back to the runtime profile.
 
-        The token is deliberately the same vocabulary
-        :meth:`_authorization_adapter` already accepts, so re-resolving the
-        CURRENT LIVE adapter at completion time is a single call with no new
-        lookup rules — and no new fail-open path.
+        The token is the vocabulary :meth:`_authorization_adapter` already
+        accepts, so re-resolving the live adapter later is a single call.
         """
         adapter = self._registered_transport_adapter(source)
         if adapter is None:
-            # Relay ingress: the receiving adapter is registered under
-            # ``Platform.RELAY`` while the source keeps the logical platform,
-            # so the registry check above cannot see it. ONE process-level
-            # RelayAdapter owns the connector socket for every multiplexed
-            # profile (secondary profiles deliberately register no relay
-            # adapter), so the process-default map IS the owner — the same rule
-            # :meth:`_adapter_for_source` applies. Without this a relayed turn
-            # records no provenance at all and its completion falls back to
-            # runtime-profile resolution, which is the wrong-bot delivery this
-            # method exists to prevent.
+            # Relay ingress registers the adapter under ``Platform.RELAY`` while
+            # the source keeps the logical platform, so the check above misses
+            # it. One process-level RelayAdapter serves every profile, so the
+            # default map owns it (the rule :meth:`_adapter_for_source` applies).
             if getattr(source, "delivered_via_upstream_relay", False) is True:
                 return TRANSPORT_PROFILE_DEFAULT
             return None
-        # #89860's ownership API is the adapter's own declaration of which
-        # profile's credentials it holds. Prefer it; it is set by
-        # ``_configure_profile_adapter`` before any inbound event is handled.
+        # The adapter's own declaration of which profile's credentials it holds
+        # (see #89860), set by ``_configure_profile_adapter`` before any inbound
+        # event is handled, so prefer it over the registry scans below.
         owner = getattr(adapter, "_owner_profile", None)
         if isinstance(owner, str) and owner.strip():
             return owner.strip()
@@ -253,13 +236,12 @@ class GatewayAuthorizationMixin:
         return None
 
     def _adapter_for_transport_profile(self, platform, transport_profile):
-        """Re-resolve the CURRENT LIVE adapter for a recorded provenance token.
+        """Re-resolve the currently live adapter for a recorded provenance token.
 
-        The adapter object captured at commissioning time must never be held
-        across a completion: it may have been disconnected and replaced by the
-        reconnect path (``_run_secondary_profile_reconnect``), or the whole
-        process may have restarted. Provenance is recorded as a *name*; this
-        turns the name back into whatever adapter is live NOW.
+        An adapter object captured at commissioning time cannot be held across a
+        completion: the reconnect path may have replaced it, or the process may
+        have restarted. Provenance is a name, and this turns it back into
+        whatever adapter is live now.
         """
         if not transport_profile:
             return None

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -208,7 +208,9 @@ class GatewayAuthorizationMixin:
         This returns the profile that OWNS the receiving adapter, as a token
         that survives serialization onto a durable record:
 
-        * ``"default"`` — the process-default adapter map (``self.adapters``).
+        * ``"default"`` — the process-default adapter map (``self.adapters``),
+          which is also the answer for relay ingress: one process-level
+          RelayAdapter fronts every multiplexed profile.
         * ``"<name>"``  — ``_profile_adapters["<name>"]``.
         * ``None``      — no live transport provenance on this source (a
           restored or hand-built source), i.e. legacy: the caller must fall
@@ -221,6 +223,18 @@ class GatewayAuthorizationMixin:
         """
         adapter = self._registered_transport_adapter(source)
         if adapter is None:
+            # Relay ingress: the receiving adapter is registered under
+            # ``Platform.RELAY`` while the source keeps the logical platform,
+            # so the registry check above cannot see it. ONE process-level
+            # RelayAdapter owns the connector socket for every multiplexed
+            # profile (secondary profiles deliberately register no relay
+            # adapter), so the process-default map IS the owner — the same rule
+            # :meth:`_adapter_for_source` applies. Without this a relayed turn
+            # records no provenance at all and its completion falls back to
+            # runtime-profile resolution, which is the wrong-bot delivery this
+            # method exists to prevent.
+            if getattr(source, "delivered_via_upstream_relay", False) is True:
+                return TRANSPORT_PROFILE_DEFAULT
             return None
         # #89860's ownership API is the adapter's own declaration of which
         # profile's credentials it holds. Prefer it; it is set by

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -235,6 +235,41 @@ class GatewayAuthorizationMixin:
                 return profile
         return None
 
+    def _ingress_transport_slot(self, source) -> Optional[str]:
+        """Return the adapter-map key the turn's receiving adapter sits under.
+
+        ``_transport_owner_profile`` names which map owns the adapter; this
+        names which slot inside that map received the turn. The two are
+        separate dimensions wherever an alias exists: a Slack turn arriving
+        over Relay is registered under ``Platform.RELAY`` while the source
+        keeps ``slack`` as its logical platform, and a deployment may run both
+        (``GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS``). ``None`` means no live
+        transport provenance, so the caller keeps alias resolution.
+        """
+        if self._registered_transport_adapter(source) is not None:
+            # Registration was found under the source's own platform key.
+            platform = getattr(source, "platform", None)
+            value = getattr(platform, "value", platform)
+            return str(value) if value else None
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            return Platform.RELAY.value
+        return None
+
+    def _adapter_for_transport_slot(self, transport_slot, transport_profile):
+        """Re-resolve the live adapter for a recorded owner + slot pair.
+
+        Exact provenance, so the lookup is the recorded slot rather than the
+        logical platform: no alias resolution, and a miss means the ingress
+        transport is gone and the caller must fail closed.
+        """
+        if not transport_slot:
+            return None
+        try:
+            platform = Platform(str(transport_slot))
+        except (ValueError, KeyError):
+            return None
+        return self._authorization_adapter(platform, transport_profile or None)
+
     def _adapter_for_transport_profile(self, platform, transport_profile):
         """Re-resolve the currently live adapter for a recorded provenance token.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3858,9 +3858,22 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
-    Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
-    optionally ``thread_id`` keys, or None if the key doesn't match.
+    ``agent:{namespace}:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    Returns a dict with ``platform``, ``chat_type``, ``chat_id``, ``profile``,
+    and optionally ``thread_id`` keys, or None if the key doesn't match.
+
+    ``parts[1]`` is the profile namespace produced by
+    :func:`gateway.session._session_key_namespace`: the default profile emits
+    the historical literal ``main`` (``profile`` is then ``None``), and a named
+    profile ``alpha`` emits ``agent:alpha`` (``profile`` is then
+    ``"alpha"``). Under
+    ``gateway.multiplex_profiles`` every secondary profile's sessions use the
+    latter form, so requiring ``parts[1] == "main"`` here made this parser
+    blind to them: keys like ``agent:alpha:matrix:group:!room:@user`` returned
+    ``None`` and their completions lost their routing metadata (or, worse,
+    were misclassified as raw api_server session ids by
+    ``_inject_watch_notification``). The positional layout is identical for
+    both forms, so accepting any namespace is safe for existing callers.
 
     The 6th element is only returned as ``thread_id`` for chat types where
     it is unambiguous (``dm`` and ``thread``).  For group/channel sessions
@@ -3868,11 +3881,16 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
+        namespace = parts[1]
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
+            # ``main`` is the default profile's static namespace literal, not
+            # a profile name — normalise it to None so callers can pass this
+            # straight to profile-aware resolvers.
+            "profile": None if namespace == "main" else namespace,
         }
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
@@ -25197,6 +25215,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         derived_platform = ""
         derived_chat_type = ""
         derived_chat_id = ""
+        derived_profile = None
 
         if session_key:
             try:
@@ -25220,6 +25239,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 derived_platform = _parsed["platform"]
                 derived_chat_type = _parsed["chat_type"]
                 derived_chat_id = _parsed["chat_id"]
+                derived_profile = _parsed.get("profile")
 
         platform_name = str(evt.get("platform") or derived_platform or "").strip().lower()
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
@@ -25268,6 +25288,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "the connector's tenant guard (user_id fallback only).",
                 platform_name, chat_id, chat_type,
             )
+        # Carry the profile through. A reconstructed source that drops it
+        # resolves against the DEFAULT profile's adapter map, which under
+        # multiplexing is the wrong bot (or, commonly, no adapter at all for
+        # that platform) — see _inject_watch_notification's profile-aware
+        # resolution.
+        profile = str(evt.get("profile") or "").strip() or derived_profile
         return SessionSource(
             platform=platform,
             chat_id=chat_id,
@@ -25276,6 +25302,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
             scope_id=scope_id,
+            profile=profile,
         )
 
     async def _drain_watch_notifications(self, completion_queue) -> None:
@@ -25363,20 +25390,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # the shared transport resolver — native adapter wins; relay is
         # eligible only when it advertises fronting the logical platform.
         adapter = None
+        # Profile-aware resolution FIRST (multiplex plane): under
+        # ``gateway.multiplex_profiles`` one gateway process serves the
+        # default profile plus every named profile, and only the default
+        # profile's adapters live in ``self.adapters`` — each secondary
+        # profile's adapters live in ``_profile_adapters[profile]``. Both
+        # scans below read ``self.adapters`` only, so a completion for a
+        # secondary profile (``@alpha-bot:example.org``'s dedicated Matrix
+        # connection, say) found no adapter and hit the bare ``return None``
+        # under this block: no
+        # delivery, no synthetic turn, and no log line to say so. Reuse
+        # ``_adapter_for_source``, the resolver the kanban notifier already
+        # trusts for exactly this (gateway/authz_mixin.py), which consults
+        # the stamped ``source.profile`` and fails closed rather than
+        # replying out of the default profile's bot.
         try:
-            _platform_enum = Platform(platform_name)
-        except (ValueError, KeyError):
-            _platform_enum = None
-        if _platform_enum is not None:
+            adapter = self._adapter_for_source(source)
+        except Exception as exc:
+            logger.debug(
+                "Profile-aware adapter resolution failed for %s (profile=%r): %s",
+                platform_name, getattr(source, "profile", None), exc,
+            )
+            adapter = None
+        # Whether the ``self.adapters`` fallbacks below are allowed to answer.
+        # They read the DEFAULT profile's map, so for a source stamped with a
+        # secondary profile that owns a registry entry they would deliver out
+        # of the wrong bot. ``_authorization_adapter`` fails closed in exactly
+        # that case; mirror its rule here instead of undoing it. A profile
+        # with no registry entry at all (relay-fronted deployments, where
+        # secondary profiles deliberately register no adapters) keeps the
+        # historical fallback behaviour.
+        _profile_name = (getattr(source, "profile", None) or "").strip() or None
+        _fallback_ok = not (
+            _profile_name
+            and _profile_name != "default"
+            and _profile_name in (getattr(self, "_profile_adapters", None) or {})
+        )
+        if adapter is None and _fallback_ok:
             try:
-                _transport = resolve_delivery_transport(
-                    _platform_enum, self.config, self.adapters,
-                )
-            except Exception:
-                _transport = None
-            if _transport is not None:
-                adapter = _transport.adapter
-        if adapter is None:
+                _platform_enum = Platform(platform_name)
+            except (ValueError, KeyError):
+                _platform_enum = None
+            if _platform_enum is not None:
+                try:
+                    _transport = resolve_delivery_transport(
+                        _platform_enum, self.config, self.adapters,
+                    )
+                except Exception:
+                    _transport = None
+                if _transport is not None:
+                    adapter = _transport.adapter
+        if adapter is None and _fallback_ok:
             # Legacy literal scan — still correct for native adapters, and
             # keeps minimal runner stubs (tests) and exotic platform strings
             # working when the resolver can't run.
@@ -25385,6 +25449,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter = a
                     break
         if not adapter:
+            # Previously a bare ``return None``. This is the last silent drop
+            # on the completion path (the two above it already log), and it
+            # is the one a multiplexed deployment actually hits, so say which
+            # platform/profile could not be resolved.
+            logger.warning(
+                "Dropping watch notification for process %s: no adapter for "
+                "platform=%s profile=%r (multiplex profiles registered: %s)",
+                evt.get("session_id", "unknown"),
+                platform_name,
+                getattr(source, "profile", None),
+                sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
+            )
             return None
         from gateway.wake import adapter_supports_push as _wake_push_ok
         if not _wake_push_ok(adapter):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2650,6 +2650,7 @@ from gateway.session import (
     build_channel_continuity_note,
     build_session_key,
     is_shared_multi_user_session,
+    parse_session_key,
     neutralize_untrusted_inline_text,
 )
 from gateway.delivery import (
@@ -2668,7 +2669,7 @@ from gateway.session_state import (
     legacy_dict_property,
     legacy_lease_token_property,
 )
-from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.authz_mixin import GatewayAuthorizationMixin, TRANSPORT_PROFILE_DEFAULT
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
@@ -3855,47 +3856,27 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
 
 
 def _parse_session_key(session_key: str) -> "dict | None":
-    """Parse a session key into its component parts.
+    """Thin alias for :func:`gateway.session.parse_session_key`.
 
-    Session keys follow the format
-    ``agent:{namespace}:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
-    Returns a dict with ``platform``, ``chat_type``, ``chat_id``, ``profile``,
-    and optionally ``thread_id`` keys, or None if the key doesn't match.
+    A session key is an OPAQUE identifier, not a return address. Routing must
+    come from the structured fields captured when the background work was
+    commissioned (platform / chat_type / chat_id / thread_id / runtime profile
+    / transport provenance) and carried on the durable record. This parser is
+    the legacy fallback for records that predate that capture, and the
+    "is this a structured agent key at all?" test that
+    ``_inject_watch_notification`` uses to tell a gateway session key from a
+    raw ``api_server`` session id.
 
-    ``parts[1]`` is the profile namespace produced by
-    :func:`gateway.session._session_key_namespace`: the default profile emits
-    the historical literal ``main`` (``profile`` is then ``None``), and a named
-    profile ``alpha`` emits ``agent:alpha`` (``profile`` is then
-    ``"alpha"``). Under
-    ``gateway.multiplex_profiles`` every secondary profile's sessions use the
-    latter form, so requiring ``parts[1] == "main"`` here made this parser
-    blind to them: keys like ``agent:alpha:matrix:group:!room:@user`` returned
-    ``None`` and their completions lost their routing metadata (or, worse,
-    were misclassified as raw api_server session ids by
-    ``_inject_watch_notification``). The positional layout is identical for
-    both forms, so accepting any namespace is safe for existing callers.
-
-    The 6th element is only returned as ``thread_id`` for chat types where
-    it is unambiguous (``dm`` and ``thread``).  For group/channel sessions
-    the suffix may be a user_id (per-user isolation) rather than a
-    thread_id, so we leave ``thread_id`` out to avoid mis-routing.
+    It used to be a positional ``split(":")`` here, which was lossy for real
+    session-key grammar: a Matrix room id is ``!room:server``, so
+    ``agent:main:matrix:group:!room:example.org`` parsed ``chat_id ==
+    "!room"`` and discarded the homeserver, and a Slack key carries the
+    workspace id between the chat-type slot and the chat id, so the chat-id
+    slot held the workspace. The canonical parser mirrors
+    ``build_session_key``'s per-platform grammar instead; see its docstring for
+    what remains ambiguous by construction.
     """
-    parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
-        namespace = parts[1]
-        result = {
-            "platform": parts[2],
-            "chat_type": parts[3],
-            "chat_id": parts[4],
-            # ``main`` is the default profile's static namespace literal, not
-            # a profile name — normalise it to None so callers can pass this
-            # straight to profile-aware resolvers.
-            "profile": None if namespace == "main" else namespace,
-        }
-        if len(parts) > 5 and parts[3] in {"dm", "thread"}:
-            result["thread_id"] = parts[5]
-        return result
-    return None
+    return parse_session_key(session_key)
 
 
 def _shorten_command_for_display(command: str, limit: int = 80) -> str:
@@ -24718,6 +24699,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        # TRANSPORT PROVENANCE (see _transport_owner_profile). Captured here,
+        # on the commissioning turn, because this is the only point where the
+        # receiving adapter is still reachable from the source: anything the
+        # turn commissions (a background process, an async delegation) records
+        # this token and re-resolves the CURRENT LIVE adapter from it when the
+        # work completes. Resolving the completion from the runtime profile
+        # instead is what drops it, or answers from the wrong bot, whenever one
+        # shared transport serves several routed runtimes.
+        try:
+            _transport_profile = self._transport_owner_profile(context.source) or ""
+        except Exception:
+            _transport_profile = ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24733,6 +24726,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            transport_profile=_transport_profile,
             async_delivery=_async_delivery,
             cron_session="",
         )
@@ -25382,51 +25376,112 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return None
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        # Alias-aware resolution (relay-plane): a relay-fronted gateway
-        # registers ONE adapter under Platform.RELAY fronting N logical
-        # platforms, so a literal ``p.value == platform_name`` scan misses
-        # "slack" and silently drops the completion as "no gateway route"
-        # (staging incident 2026-08-09, second occurrence). Resolve through
-        # the shared transport resolver — native adapter wins; relay is
-        # eligible only when it advertises fronting the logical platform.
         adapter = None
-        # Profile-aware resolution FIRST (multiplex plane): under
-        # ``gateway.multiplex_profiles`` one gateway process serves the
-        # default profile plus every named profile, and only the default
-        # profile's adapters live in ``self.adapters`` — each secondary
-        # profile's adapters live in ``_profile_adapters[profile]``. Both
-        # scans below read ``self.adapters`` only, so a completion for a
-        # secondary profile (``@alpha-bot:example.org``'s dedicated Matrix
-        # connection, say) found no adapter and hit the bare ``return None``
-        # under this block: no
-        # delivery, no synthetic turn, and no log line to say so. Reuse
-        # ``_adapter_for_source``, the resolver the kanban notifier already
-        # trusts for exactly this (gateway/authz_mixin.py), which consults
-        # the stamped ``source.profile`` and fails closed rather than
-        # replying out of the default profile's bot.
-        try:
-            adapter = self._adapter_for_source(source)
-        except Exception as exc:
-            logger.debug(
-                "Profile-aware adapter resolution failed for %s (profile=%r): %s",
-                platform_name, getattr(source, "profile", None), exc,
+        # The full return address, for every log line on this path.
+        _return_address = (
+            "platform=%s chat_type=%s chat_id=%s thread=%s scope=%s "
+            "runtime profile=%r transport provenance=%r "
+            "(multiplex profiles registered: %s)" % (
+                platform_name,
+                getattr(source, "chat_type", None),
+                getattr(source, "chat_id", None),
+                getattr(source, "thread_id", None),
+                getattr(source, "scope_id", None),
+                getattr(source, "profile", None),
+                str(evt.get("transport_profile") or "") or None,
+                sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
             )
-            adapter = None
+        )
+        # ---- TRANSPORT PROVENANCE FIRST ----------------------------------
+        # ``source.profile`` is the RUNTIME namespace, not the transport owner.
+        # One shared credential (a single Matrix bot, say) can serve several
+        # routed runtimes, and then resolving a completion from the runtime
+        # namespace is wrong in both directions: the runtime may register no
+        # adapter for the platform (completion dropped although the originating
+        # transport is live), or it may own its OWN adapter for that platform
+        # (completion delivered from a different bot than the user spoke to).
+        # So the commissioning turn records WHICH TRANSPORT it arrived on — as
+        # a name, never an adapter object — and we re-resolve whatever adapter
+        # is live for that name NOW. See
+        # GatewayAuthorizationMixin._transport_owner_profile and, upstream of
+        # it, BasePlatformAdapter.set_owner_profile.
+        _transport_profile = str(evt.get("transport_profile") or "").strip() or None
+        _provenance_is_default = _transport_profile == TRANSPORT_PROFILE_DEFAULT
+        if _transport_profile and not _provenance_is_default:
+            # A named profile owns the transport: its map is the only correct
+            # answer. Fail closed on a miss rather than delivering out of some
+            # other profile's bot.
+            try:
+                adapter = self._adapter_for_transport_profile(
+                    source.platform, _transport_profile,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Transport-provenance adapter resolution failed for %s: %s",
+                    _transport_profile, exc,
+                )
+                adapter = None
+            if adapter is None:
+                logger.warning(
+                    "Dropping watch notification for process %s: transport "
+                    "provenance %r has no live adapter — %s",
+                    evt.get("session_id", "unknown"),
+                    _transport_profile,
+                    _return_address,
+                )
+                return None
+        elif not _provenance_is_default:
+            # Legacy record with NO provenance (queued before it was captured,
+            # or restored from a pre-upgrade checkpoint): fall back to the
+            # runtime profile's own adapter, which is correct for the
+            # dedicated-adapter-per-profile topology and is what this path did
+            # before provenance existed.
+            #
+            # Profile-aware resolution (multiplex plane): under
+            # ``gateway.multiplex_profiles`` one gateway process serves the
+            # default profile plus every named profile, and only the default
+            # profile's adapters live in ``self.adapters`` — each secondary
+            # profile's adapters live in ``_profile_adapters[profile]``. Both
+            # scans below read ``self.adapters`` only, so a completion for a
+            # secondary profile found no adapter and hit a bare ``return None``:
+            # no delivery, no synthetic turn, and no log line to say so. Reuse
+            # ``_adapter_for_source``, the resolver the kanban notifier already
+            # trusts for exactly this (gateway/authz_mixin.py), which consults
+            # the stamped ``source.profile`` and fails closed rather than
+            # replying out of the default profile's bot.
+            try:
+                adapter = self._adapter_for_source(source)
+            except Exception as exc:
+                logger.debug(
+                    "Profile-aware adapter resolution failed for %s (profile=%r): %s",
+                    platform_name, getattr(source, "profile", None), exc,
+                )
+                adapter = None
         # Whether the ``self.adapters`` fallbacks below are allowed to answer.
-        # They read the DEFAULT profile's map, so for a source stamped with a
-        # secondary profile that owns a registry entry they would deliver out
-        # of the wrong bot. ``_authorization_adapter`` fails closed in exactly
-        # that case; mirror its rule here instead of undoing it. A profile
-        # with no registry entry at all (relay-fronted deployments, where
-        # secondary profiles deliberately register no adapters) keeps the
-        # historical fallback behaviour.
+        # They read the DEFAULT profile's map. Provenance of ``default`` says
+        # exactly that map is the right one — including for relay-fronted
+        # platforms, whose adapter only ``resolve_delivery_transport`` can find.
+        # Without provenance, a source stamped with a secondary profile that
+        # owns a registry entry must NOT reach them: that delivers out of the
+        # wrong bot. ``_authorization_adapter`` fails closed in exactly that
+        # case; mirror its rule instead of undoing it. A profile with no
+        # registry entry at all (relay-fronted deployments, where secondary
+        # profiles deliberately register no adapters) keeps the historical
+        # fallback behaviour.
         _profile_name = (getattr(source, "profile", None) or "").strip() or None
-        _fallback_ok = not (
+        _fallback_ok = _provenance_is_default or not (
             _profile_name
             and _profile_name != "default"
             and _profile_name in (getattr(self, "_profile_adapters", None) or {})
         )
         if adapter is None and _fallback_ok:
+            # Alias-aware resolution (relay plane): a relay-fronted gateway
+            # registers ONE adapter under Platform.RELAY fronting N logical
+            # platforms, so a literal ``p.value == platform_name`` scan misses
+            # "slack" and silently drops the completion as "no gateway route"
+            # (staging incident 2026-08-09, second occurrence). Resolve through
+            # the shared transport resolver — native adapter wins; relay is
+            # eligible only when it advertises fronting the logical platform.
             try:
                 _platform_enum = Platform(platform_name)
             except (ValueError, KeyError):
@@ -25451,15 +25506,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter:
             # Previously a bare ``return None``. This is the last silent drop
             # on the completion path (the two above it already log), and it
-            # is the one a multiplexed deployment actually hits, so say which
-            # platform/profile could not be resolved.
+            # is the one a multiplexed deployment actually hits, so name the
+            # whole return address that could not be resolved.
             logger.warning(
-                "Dropping watch notification for process %s: no adapter for "
-                "platform=%s profile=%r (multiplex profiles registered: %s)",
+                "Dropping watch notification for process %s: no adapter for %s",
                 evt.get("session_id", "unknown"),
-                platform_name,
-                getattr(source, "profile", None),
-                sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
+                _return_address,
             )
             return None
         from gateway.wake import adapter_supports_push as _wake_push_ok
@@ -26263,10 +26315,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "platform": platform_name,
                         "chat_type": watcher.get("chat_type", ""),
                         "chat_id": chat_id,
+                        "scope_id": watcher.get("scope_id", ""),
                         "thread_id": thread_id,
                         "user_id": user_id,
                         "user_name": user_name,
                         "message_id": message_id,
+                        # Runtime namespace and, separately, the transport this
+                        # process's commissioning turn actually arrived on. The
+                        # completion is delivered through the LIVE adapter
+                        # re-resolved from the latter — see
+                        # _inject_watch_notification.
+                        "profile": watcher.get("profile", ""),
+                        "transport_profile": watcher.get("transport_profile", ""),
                         "started_at": getattr(session, "started_at", None),
                         "command": _command,
                         "exit_code": session.exit_code,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3858,23 +3858,10 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
 def _parse_session_key(session_key: str) -> "dict | None":
     """Thin alias for :func:`gateway.session.parse_session_key`.
 
-    A session key is an OPAQUE identifier, not a return address. Routing must
-    come from the structured fields captured when the background work was
-    commissioned (platform / chat_type / chat_id / thread_id / runtime profile
-    / transport provenance) and carried on the durable record. This parser is
-    the legacy fallback for records that predate that capture, and the
-    "is this a structured agent key at all?" test that
-    ``_inject_watch_notification`` uses to tell a gateway session key from a
-    raw ``api_server`` session id.
-
-    It used to be a positional ``split(":")`` here, which was lossy for real
-    session-key grammar: a Matrix room id is ``!room:server``, so
-    ``agent:main:matrix:group:!room:example.org`` parsed ``chat_id ==
-    "!room"`` and discarded the homeserver, and a Slack key carries the
-    workspace id between the chat-type slot and the chat id, so the chat-id
-    slot held the workspace. The canonical parser mirrors
-    ``build_session_key``'s per-platform grammar instead; see its docstring for
-    what remains ambiguous by construction.
+    A session key is not a return address: routing comes from the structured
+    fields carried on the durable record. This stays as the fallback for
+    records that predate that capture, and as the "is this a structured agent
+    key at all?" test ``_inject_watch_notification`` uses.
     """
     return parse_session_key(session_key)
 
@@ -24699,14 +24686,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
-        # TRANSPORT PROVENANCE (see _transport_owner_profile). Captured here,
-        # on the commissioning turn, because this is the only point where the
-        # receiving adapter is still reachable from the source: anything the
-        # turn commissions (a background process, an async delegation) records
-        # this token and re-resolves the CURRENT LIVE adapter from it when the
-        # work completes. Resolving the completion from the runtime profile
-        # instead is what drops it, or answers from the wrong bot, whenever one
-        # shared transport serves several routed runtimes.
+        # The only point where the receiving adapter is still reachable from
+        # the source (see _transport_owner_profile).
         try:
             _transport_profile = self._transport_owner_profile(context.source) or ""
         except Exception:
@@ -25282,11 +25263,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "the connector's tenant guard (user_id fallback only).",
                 platform_name, chat_id, chat_type,
             )
-        # Carry the profile through. A reconstructed source that drops it
-        # resolves against the DEFAULT profile's adapter map, which under
-        # multiplexing is the wrong bot (or, commonly, no adapter at all for
-        # that platform) — see _inject_watch_notification's profile-aware
-        # resolution.
+        # A reconstructed source that drops the profile resolves against the
+        # default profile's map: under multiplexing, the wrong bot or none.
         profile = str(evt.get("profile") or "").strip() or derived_profile
         return SessionSource(
             platform=platform,
@@ -25377,7 +25355,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         adapter = None
-        # The full return address, for every log line on this path.
         _return_address = (
             "platform=%s chat_type=%s chat_id=%s thread=%s scope=%s "
             "runtime profile=%r transport provenance=%r "
@@ -25392,25 +25369,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
             )
         )
-        # ---- TRANSPORT PROVENANCE FIRST ----------------------------------
-        # ``source.profile`` is the RUNTIME namespace, not the transport owner.
-        # One shared credential (a single Matrix bot, say) can serve several
-        # routed runtimes, and then resolving a completion from the runtime
-        # namespace is wrong in both directions: the runtime may register no
-        # adapter for the platform (completion dropped although the originating
-        # transport is live), or it may own its OWN adapter for that platform
-        # (completion delivered from a different bot than the user spoke to).
-        # So the commissioning turn records WHICH TRANSPORT it arrived on — as
-        # a name, never an adapter object — and we re-resolve whatever adapter
-        # is live for that name NOW. See
-        # GatewayAuthorizationMixin._transport_owner_profile and, upstream of
-        # it, BasePlatformAdapter.set_owner_profile.
+        # Provenance wins over ``source.profile``, the runtime namespace: one
+        # credential can serve several runtimes, so resolving from the runtime
+        # drops the completion or answers from another bot.
         _transport_profile = str(evt.get("transport_profile") or "").strip() or None
         _provenance_is_default = _transport_profile == TRANSPORT_PROFILE_DEFAULT
         if _transport_profile and not _provenance_is_default:
-            # A named profile owns the transport: its map is the only correct
-            # answer. Fail closed on a miss rather than delivering out of some
-            # other profile's bot.
+            # A named profile owns the transport, so fail closed on a miss
+            # rather than delivering out of another profile's bot.
             try:
                 adapter = self._adapter_for_transport_profile(
                     source.platform, _transport_profile,
@@ -25431,24 +25397,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
         elif not _provenance_is_default:
-            # Legacy record with NO provenance (queued before it was captured,
-            # or restored from a pre-upgrade checkpoint): fall back to the
-            # runtime profile's own adapter, which is correct for the
-            # dedicated-adapter-per-profile topology and is what this path did
-            # before provenance existed.
-            #
-            # Profile-aware resolution (multiplex plane): under
-            # ``gateway.multiplex_profiles`` one gateway process serves the
-            # default profile plus every named profile, and only the default
-            # profile's adapters live in ``self.adapters`` — each secondary
-            # profile's adapters live in ``_profile_adapters[profile]``. Both
-            # scans below read ``self.adapters`` only, so a completion for a
-            # secondary profile found no adapter and hit a bare ``return None``:
-            # no delivery, no synthetic turn, and no log line to say so. Reuse
-            # ``_adapter_for_source``, the resolver the kanban notifier already
-            # trusts for exactly this (gateway/authz_mixin.py), which consults
-            # the stamped ``source.profile`` and fails closed rather than
-            # replying out of the default profile's bot.
+            # No provenance recorded: resolve from the runtime profile, which
+            # is correct for the dedicated-adapter-per-profile topology and
+            # fails closed on an unknown profile.
             try:
                 adapter = self._adapter_for_source(source)
             except Exception as exc:
@@ -25457,17 +25408,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform_name, getattr(source, "profile", None), exc,
                 )
                 adapter = None
-        # Whether the ``self.adapters`` fallbacks below are allowed to answer.
-        # They read the DEFAULT profile's map. Provenance of ``default`` says
-        # exactly that map is the right one — including for relay-fronted
-        # platforms, whose adapter only ``resolve_delivery_transport`` can find.
-        # Without provenance, a source stamped with a secondary profile that
-        # owns a registry entry must NOT reach them: that delivers out of the
-        # wrong bot. ``_authorization_adapter`` fails closed in exactly that
-        # case; mirror its rule instead of undoing it. A profile with no
-        # registry entry at all (relay-fronted deployments, where secondary
-        # profiles deliberately register no adapters) keeps the historical
-        # fallback behaviour.
+        # The fallbacks below read the default profile's map, so without
+        # provenance a source stamped with a secondary profile that owns a
+        # registry entry must not reach them (as ``_authorization_adapter``).
         _profile_name = (getattr(source, "profile", None) or "").strip() or None
         _fallback_ok = _provenance_is_default or not (
             _profile_name
@@ -25475,13 +25418,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and _profile_name in (getattr(self, "_profile_adapters", None) or {})
         )
         if adapter is None and _fallback_ok:
-            # Alias-aware resolution (relay plane): a relay-fronted gateway
-            # registers ONE adapter under Platform.RELAY fronting N logical
-            # platforms, so a literal ``p.value == platform_name`` scan misses
-            # "slack" and silently drops the completion as "no gateway route"
-            # (staging incident 2026-08-09, second occurrence). Resolve through
-            # the shared transport resolver — native adapter wins; relay is
-            # eligible only when it advertises fronting the logical platform.
+            # Alias-aware: a relay-fronted gateway registers one adapter under
+            # Platform.RELAY fronting several logical platforms, which the
+            # literal scan below misses. Native adapter wins over relay.
             try:
                 _platform_enum = Platform(platform_name)
             except (ValueError, KeyError):
@@ -25504,9 +25443,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter = a
                     break
         if not adapter:
-            # Previously a bare ``return None``. This is the last silent drop
-            # on the completion path (the two above it already log), and it
-            # is the one a multiplexed deployment actually hits, so name the
+            # The drop a multiplexed deployment actually hits, so name the
             # whole return address that could not be resolved.
             logger.warning(
                 "Dropping watch notification for process %s: no adapter for %s",
@@ -26320,11 +26257,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "user_id": user_id,
                         "user_name": user_name,
                         "message_id": message_id,
-                        # Runtime namespace and, separately, the transport this
-                        # process's commissioning turn actually arrived on. The
-                        # completion is delivered through the LIVE adapter
-                        # re-resolved from the latter — see
-                        # _inject_watch_notification.
+                        # Runtime namespace and, separately, the transport the
+                        # turn arrived on; delivery re-resolves the latter.
                         "profile": watcher.get("profile", ""),
                         "transport_profile": watcher.get("transport_profile", ""),
                         "started_at": getattr(session, "started_at", None),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25381,11 +25381,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _transport_profile = str(evt.get("transport_profile") or "").strip() or None
         _provenance_is_default = _transport_profile == TRANSPORT_PROFILE_DEFAULT
         # Owner map plus slot is exact: it names the one adapter the turn
-        # arrived on, so no alias resolution runs. Without the slot, a default
-        # owner and a relay-fronted platform are indistinguishable from a
-        # native one, and resolve_delivery_transport picks the native adapter
-        # by contract — a completion out of a different bot and credential.
+        # arrived on, so no alias resolution runs. Without it a default owner
+        # cannot tell a relay-fronted platform from a native one, and
+        # resolve_delivery_transport answers out of the native bot by contract.
         _transport_slot = str(evt.get("transport_slot") or "").strip() or None
+        if _transport_slot and _transport_slot not in (
+            platform_name, Platform.RELAY.value,
+        ):
+            # Capture only ever records the logical platform's own slot or
+            # relay, so a third value is a damaged record: fall back to the
+            # chain below instead of delivering out of an unrelated platform.
+            logger.debug(
+                "Ignoring transport slot %r: not a slot the %s turn could "
+                "have arrived on",
+                _transport_slot, platform_name,
+            )
+            _transport_slot = None
         if _transport_slot:
             try:
                 adapter = self._adapter_for_transport_slot(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2669,7 +2669,14 @@ from gateway.session_state import (
     legacy_dict_property,
     legacy_lease_token_property,
 )
-from gateway.authz_mixin import GatewayAuthorizationMixin, TRANSPORT_PROFILE_DEFAULT
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.transport_provenance import (
+    EXACT,
+    MALFORMED,
+    classify_provenance,
+    provenance_fields,
+    read_provenance,
+)
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
@@ -24687,15 +24694,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
         # The only point where the receiving adapter is still reachable from
-        # the source (see _transport_owner_profile).
-        try:
-            _transport_profile = self._transport_owner_profile(context.source) or ""
-        except Exception:
-            _transport_profile = ""
-        try:
-            _transport_slot = self._ingress_transport_slot(context.source) or ""
-        except Exception:
-            _transport_slot = ""
+        # the source (see _capture_transport_provenance).
+        _provenance = self._capture_transport_provenance(context.source)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24711,8 +24711,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
-            transport_profile=_transport_profile,
-            transport_slot=_transport_slot,
+            **provenance_fields(_provenance),
             async_delivery=_async_delivery,
             cron_session="",
         )
@@ -25360,6 +25359,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         adapter = None
+        _provenance = read_provenance(evt)
         _return_address = (
             "platform=%s chat_type=%s chat_id=%s thread=%s scope=%s "
             "runtime profile=%r transport provenance=%r slot=%r "
@@ -25370,42 +25370,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 getattr(source, "thread_id", None),
                 getattr(source, "scope_id", None),
                 getattr(source, "profile", None),
-                str(evt.get("transport_profile") or "") or None,
-                str(evt.get("transport_slot") or "") or None,
+                _provenance.profile or None,
+                _provenance.slot or None,
                 sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
             )
         )
-        # Provenance wins over ``source.profile``, the runtime namespace: one
-        # credential can serve several runtimes, so resolving from the runtime
-        # drops the completion or answers from another bot.
-        _transport_profile = str(evt.get("transport_profile") or "").strip() or None
-        _provenance_is_default = _transport_profile == TRANSPORT_PROFILE_DEFAULT
-        # Owner map plus slot is exact: it names the one adapter the turn
-        # arrived on, so no alias resolution runs. Without it a default owner
-        # cannot tell a relay-fronted platform from a native one, and
-        # resolve_delivery_transport answers out of the native bot by contract.
-        _transport_slot = str(evt.get("transport_slot") or "").strip() or None
-        if _transport_slot and _transport_slot not in (
-            platform_name, Platform.RELAY.value,
-        ):
-            # Capture only ever records the logical platform's own slot or
-            # relay, so a third value is a damaged record: fall back to the
-            # chain below instead of delivering out of an unrelated platform.
-            logger.debug(
-                "Ignoring transport slot %r: not a slot the %s turn could "
-                "have arrived on",
-                _transport_slot, platform_name,
+        # owner map plus slot names the one adapter the turn arrived on, so no
+        # alias resolution runs. either dimension alone is a guess — a default
+        # owner cannot tell a relay-fronted platform from a native one — so a
+        # partial or contradictory pair is dropped rather than resolved.
+        _record_class = classify_provenance(_provenance, platform_name)
+        if _record_class == MALFORMED:
+            logger.warning(
+                "Dropping watch notification for process %s: incomplete or "
+                "contradictory transport provenance — %s",
+                evt.get("session_id", "unknown"),
+                _return_address,
             )
-            _transport_slot = None
-        if _transport_slot:
+            return None
+        if _record_class == EXACT:
             try:
-                adapter = self._adapter_for_transport_slot(
-                    _transport_slot, _transport_profile,
-                )
+                adapter = self._adapter_for_provenance(_provenance)
             except Exception as exc:
                 logger.debug(
-                    "Transport-slot adapter resolution failed for %s/%s: %s",
-                    _transport_profile, _transport_slot, exc,
+                    "Transport-provenance adapter resolution failed for %s/%s: %s",
+                    _provenance.profile, _provenance.slot, exc,
                 )
                 adapter = None
             if adapter is None:
@@ -25413,37 +25402,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Dropping watch notification for process %s: ingress "
                     "transport %r/%r is no longer live — %s",
                     evt.get("session_id", "unknown"),
-                    _transport_profile,
-                    _transport_slot,
+                    _provenance.profile,
+                    _provenance.slot,
                     _return_address,
                 )
                 return None
-        elif _transport_profile and not _provenance_is_default:
-            # A named profile owns the transport, so fail closed on a miss
-            # rather than delivering out of another profile's bot.
-            try:
-                adapter = self._adapter_for_transport_profile(
-                    source.platform, _transport_profile,
-                )
-            except Exception as exc:
-                logger.debug(
-                    "Transport-provenance adapter resolution failed for %s: %s",
-                    _transport_profile, exc,
-                )
-                adapter = None
-            if adapter is None:
-                logger.warning(
-                    "Dropping watch notification for process %s: transport "
-                    "provenance %r has no live adapter — %s",
-                    evt.get("session_id", "unknown"),
-                    _transport_profile,
-                    _return_address,
-                )
-                return None
-        elif not _provenance_is_default:
-            # No provenance recorded: resolve from the runtime profile, which
-            # is correct for the dedicated-adapter-per-profile topology and
-            # fails closed on an unknown profile.
+        else:
+            # Legacy record, from before provenance was recorded: resolve from
+            # the runtime profile, which is correct for the
+            # dedicated-adapter-per-profile topology and fails closed on an
+            # unknown profile.
             try:
                 adapter = self._adapter_for_source(source)
             except Exception as exc:
@@ -25452,11 +25420,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform_name, getattr(source, "profile", None), exc,
                 )
                 adapter = None
-        # The fallbacks below read the default profile's map, so without
-        # provenance a source stamped with a secondary profile that owns a
-        # registry entry must not reach them (as ``_authorization_adapter``).
+        # The fallbacks below read the default profile's map, so a legacy source
+        # stamped with a secondary profile that owns a registry entry must not
+        # reach them (as ``_authorization_adapter``).
         _profile_name = (getattr(source, "profile", None) or "").strip() or None
-        _fallback_ok = _provenance_is_default or not (
+        _fallback_ok = not (
             _profile_name
             and _profile_name != "default"
             and _profile_name in (getattr(self, "_profile_adapters", None) or {})
@@ -26304,8 +26272,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # Runtime namespace and, separately, the transport the
                         # turn arrived on; delivery re-resolves the latter.
                         "profile": watcher.get("profile", ""),
-                        "transport_profile": watcher.get("transport_profile", ""),
-                        "transport_slot": watcher.get("transport_slot", ""),
+                        **provenance_fields(read_provenance(watcher)),
                         "started_at": getattr(session, "started_at", None),
                         "command": _command,
                         "exit_code": session.exit_code,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24692,6 +24692,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _transport_profile = self._transport_owner_profile(context.source) or ""
         except Exception:
             _transport_profile = ""
+        try:
+            _transport_slot = self._ingress_transport_slot(context.source) or ""
+        except Exception:
+            _transport_slot = ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24708,6 +24712,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             transport_profile=_transport_profile,
+            transport_slot=_transport_slot,
             async_delivery=_async_delivery,
             cron_session="",
         )
@@ -25357,7 +25362,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = None
         _return_address = (
             "platform=%s chat_type=%s chat_id=%s thread=%s scope=%s "
-            "runtime profile=%r transport provenance=%r "
+            "runtime profile=%r transport provenance=%r slot=%r "
             "(multiplex profiles registered: %s)" % (
                 platform_name,
                 getattr(source, "chat_type", None),
@@ -25366,6 +25371,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 getattr(source, "scope_id", None),
                 getattr(source, "profile", None),
                 str(evt.get("transport_profile") or "") or None,
+                str(evt.get("transport_slot") or "") or None,
                 sorted(getattr(self, "_profile_adapters", None) or {}) or "none",
             )
         )
@@ -25374,7 +25380,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # drops the completion or answers from another bot.
         _transport_profile = str(evt.get("transport_profile") or "").strip() or None
         _provenance_is_default = _transport_profile == TRANSPORT_PROFILE_DEFAULT
-        if _transport_profile and not _provenance_is_default:
+        # Owner map plus slot is exact: it names the one adapter the turn
+        # arrived on, so no alias resolution runs. Without the slot, a default
+        # owner and a relay-fronted platform are indistinguishable from a
+        # native one, and resolve_delivery_transport picks the native adapter
+        # by contract — a completion out of a different bot and credential.
+        _transport_slot = str(evt.get("transport_slot") or "").strip() or None
+        if _transport_slot:
+            try:
+                adapter = self._adapter_for_transport_slot(
+                    _transport_slot, _transport_profile,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Transport-slot adapter resolution failed for %s/%s: %s",
+                    _transport_profile, _transport_slot, exc,
+                )
+                adapter = None
+            if adapter is None:
+                logger.warning(
+                    "Dropping watch notification for process %s: ingress "
+                    "transport %r/%r is no longer live — %s",
+                    evt.get("session_id", "unknown"),
+                    _transport_profile,
+                    _transport_slot,
+                    _return_address,
+                )
+                return None
+        elif _transport_profile and not _provenance_is_default:
             # A named profile owns the transport, so fail closed on a miss
             # rather than delivering out of another profile's bot.
             try:
@@ -26261,6 +26294,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # turn arrived on; delivery re-resolves the latter.
                         "profile": watcher.get("profile", ""),
                         "transport_profile": watcher.get("transport_profile", ""),
+                        "transport_slot": watcher.get("transport_slot", ""),
                         "started_at": getattr(session, "started_at", None),
                         "command": _command,
                         "exit_code": session.exit_code,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -10,6 +10,7 @@ Handles:
 
 import asyncio
 import hashlib
+import re
 import logging
 import os
 import json
@@ -1209,6 +1210,111 @@ def build_session_key(
         key_parts.append(str(participant_id))
 
     return ":".join(str(part) for part in key_parts)
+
+
+# ---------------------------------------------------------------------------
+# Session-key parsing — the inverse of build_session_key
+# ---------------------------------------------------------------------------
+
+# Platforms whose identifiers are THEMSELVES colon-delimited. A Matrix room is
+# ``!localpart:homeserver`` and a Matrix user is ``@localpart:homeserver``, so a
+# positional ``split(":")`` over a Matrix key shears the id in half: the key
+# ``agent:main:matrix:group:!room:example.org`` yields ``parts[4] == "!room"``
+# and silently discards ``:example.org``. Delivering to ``!room`` is delivering
+# to a room that does not exist.
+_COLON_ID_PLATFORMS = frozenset({"matrix"})
+# Matrix sigils: rooms ``!``, users ``@``, aliases ``#``, events ``$``. A Matrix
+# id that carries a server name has exactly one ``:`` separating localpart from
+# it, so re-joining exactly two tokens is exact, not heuristic — and the next
+# token is never itself sigil-prefixed (that would be the NEXT id in the key),
+# which is what keeps a sigil-only id such as a room-v4 event ``$hash`` from
+# swallowing the participant id that follows it.
+_COLON_ID_SIGILS = ("!", "@", "#", "$")
+
+# Slack workspace/team ids are ``T…`` (classic) or ``E…`` (Enterprise Grid);
+# conversation ids are ``C``/``G``/``D``/``im``/``mpim`` and user ids ``U``/``W``.
+# ``build_session_key`` inserts the workspace id BETWEEN the chat-type slot and
+# the chat id (and only when ``source.scope_id`` is set), so the slot after the
+# chat type is the scope on a scoped key and the chat id on an unscoped one.
+# The two are told apart by Slack's own id grammar.
+_SLACK_SCOPE_ID_RE = re.compile(r"^[TE][A-Z0-9]{2,}$")
+
+
+def _take_key_id(tokens: List[str], platform: str) -> tuple:
+    """Consume one identifier from *tokens*, honouring colon-bearing ids."""
+    if not tokens:
+        return "", tokens
+    head = tokens[0]
+    if (
+        platform in _COLON_ID_PLATFORMS
+        and len(tokens) >= 2
+        and head[:1] in _COLON_ID_SIGILS
+        and tokens[1][:1] not in _COLON_ID_SIGILS
+    ):
+        return f"{head}:{tokens[1]}", tokens[2:]
+    return head, tokens[1:]
+
+
+def parse_session_key(session_key: str) -> Optional[Dict[str, Any]]:
+    """Parse a session key back into routing fields — the inverse of
+    :func:`build_session_key`.
+
+    Returns ``platform``, ``chat_type``, ``chat_id``, ``profile`` and
+    (when present) ``scope_id`` / ``thread_id``, or ``None`` when *session_key*
+    is not a structured agent key at all (a raw ``api_server`` session id, say).
+
+    This mirrors the grammar ``build_session_key`` emits, per platform, instead
+    of indexing a flat ``split(":")``:
+
+    * ``parts[1]`` is the namespace slot :func:`_session_key_namespace` writes —
+      the literal ``main`` for the default profile (reported as ``profile=None``
+      so it can be handed straight to the profile-aware resolvers) and the
+      profile name for every other profile.
+    * Matrix ids are re-joined (see ``_COLON_ID_PLATFORMS``).
+    * A Slack workspace id is consumed from the scope slot ``build_session_key``
+      writes it into (see ``_SLACK_SCOPE_ID_RE``).
+
+    **A session key is not a return address.** Even inverted exactly, the tail
+    of a group key is ambiguous by construction — ``build_session_key`` appends
+    a bare participant id after the chat id with no delimiter change, so a
+    6th token may be a thread or a user (which is why ``thread_id`` is reported
+    only for the ``dm``/``thread`` shapes, where the grammar is unambiguous).
+    Callers that need a route must carry the structured routing fields from the
+    commissioning turn; this parser exists for legacy records that predate that
+    capture, and for the "is this a structured key at all?" test.
+    """
+    if not session_key:
+        return None
+    parts = session_key.split(":")
+    if len(parts) < 5 or parts[0] != "agent" or not parts[1]:
+        return None
+    namespace = parts[1]
+    platform = parts[2]
+    chat_type = parts[3]
+    rest = parts[4:]
+
+    scope_id = None
+    if platform == "slack" and len(rest) >= 2 and _SLACK_SCOPE_ID_RE.match(rest[0]):
+        scope_id = rest[0]
+        rest = rest[1:]
+
+    chat_id, rest = _take_key_id(rest, platform)
+
+    result: Dict[str, Any] = {
+        "platform": platform,
+        "chat_type": chat_type,
+        "chat_id": chat_id,
+        # ``main`` is the default profile's static namespace literal, not a
+        # profile name — normalise it to None.
+        "profile": None if namespace == "main" else namespace,
+    }
+    if scope_id:
+        result["scope_id"] = scope_id
+    if chat_type in {"dm", "thread"} and rest:
+        thread_id, rest = _take_key_id(rest, platform)
+        if thread_id:
+            result["thread_id"] = thread_id
+    return result
 
 
 class _SessionFlight:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1249,7 +1249,7 @@ def parse_session_key(session_key: str) -> Optional[Dict[str, Any]]:
 
     Returns ``platform``, ``chat_type``, ``chat_id``, ``profile`` and, when
     present, ``scope_id`` / ``thread_id``; ``None`` when *session_key* is not a
-    structured agent key (a raw ``api_server`` session id, say).
+    structured agent key, e.g. a raw ``api_server`` session id.
 
     Follows the per-platform grammar rather than a flat ``split(":")``:
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1212,31 +1212,20 @@ def build_session_key(
     return ":".join(str(part) for part in key_parts)
 
 
-# ---------------------------------------------------------------------------
-# Session-key parsing — the inverse of build_session_key
-# ---------------------------------------------------------------------------
-
-# Platforms whose identifiers are THEMSELVES colon-delimited. A Matrix room is
-# ``!localpart:homeserver`` and a Matrix user is ``@localpart:homeserver``, so a
-# positional ``split(":")`` over a Matrix key shears the id in half: the key
-# ``agent:main:matrix:group:!room:example.org`` yields ``parts[4] == "!room"``
-# and silently discards ``:example.org``. Delivering to ``!room`` is delivering
-# to a room that does not exist.
+# Platforms whose identifiers are themselves colon-delimited: a Matrix room is
+# ``!localpart:homeserver``, so a positional ``split(":")`` shears the id in half
+# and yields a room that does not exist.
 _COLON_ID_PLATFORMS = frozenset({"matrix"})
-# Matrix sigils: rooms ``!``, users ``@``, aliases ``#``, events ``$``. A Matrix
-# id that carries a server name has exactly one ``:`` separating localpart from
-# it, so re-joining exactly two tokens is exact, not heuristic — and the next
-# token is never itself sigil-prefixed (that would be the NEXT id in the key),
-# which is what keeps a sigil-only id such as a room-v4 event ``$hash`` from
-# swallowing the participant id that follows it.
+# Matrix sigils: rooms ``!``, users ``@``, aliases ``#``, events ``$``. A server
+# name is separated by exactly one ``:``, so re-joining two tokens is exact; the
+# following token is never sigil-prefixed unless it is the next id in the key,
+# which keeps a sigil-only id from swallowing the participant id after it.
 _COLON_ID_SIGILS = ("!", "@", "#", "$")
 
-# Slack workspace/team ids are ``T…`` (classic) or ``E…`` (Enterprise Grid);
-# conversation ids are ``C``/``G``/``D``/``im``/``mpim`` and user ids ``U``/``W``.
-# ``build_session_key`` inserts the workspace id BETWEEN the chat-type slot and
-# the chat id (and only when ``source.scope_id`` is set), so the slot after the
-# chat type is the scope on a scoped key and the chat id on an unscoped one.
-# The two are told apart by Slack's own id grammar.
+# Slack workspace ids are ``T…`` (classic) or ``E…`` (Enterprise Grid), which is
+# what distinguishes them from conversation ids. ``build_session_key`` writes
+# one between the chat-type slot and the chat id, and only when
+# ``source.scope_id`` is set, so the slot after the chat type is ambiguous.
 _SLACK_SCOPE_ID_RE = re.compile(r"^[TE][A-Z0-9]{2,}$")
 
 
@@ -1256,32 +1245,25 @@ def _take_key_id(tokens: List[str], platform: str) -> tuple:
 
 
 def parse_session_key(session_key: str) -> Optional[Dict[str, Any]]:
-    """Parse a session key back into routing fields — the inverse of
-    :func:`build_session_key`.
+    """Parse a session key into routing fields, inverting :func:`build_session_key`.
 
-    Returns ``platform``, ``chat_type``, ``chat_id``, ``profile`` and
-    (when present) ``scope_id`` / ``thread_id``, or ``None`` when *session_key*
-    is not a structured agent key at all (a raw ``api_server`` session id, say).
+    Returns ``platform``, ``chat_type``, ``chat_id``, ``profile`` and, when
+    present, ``scope_id`` / ``thread_id``; ``None`` when *session_key* is not a
+    structured agent key (a raw ``api_server`` session id, say).
 
-    This mirrors the grammar ``build_session_key`` emits, per platform, instead
-    of indexing a flat ``split(":")``:
+    Follows the per-platform grammar rather than a flat ``split(":")``:
 
-    * ``parts[1]`` is the namespace slot :func:`_session_key_namespace` writes —
-      the literal ``main`` for the default profile (reported as ``profile=None``
-      so it can be handed straight to the profile-aware resolvers) and the
-      profile name for every other profile.
+    * ``parts[1]`` is the namespace slot — the literal ``main`` for the default
+      profile (reported as ``profile=None``), else the profile name.
     * Matrix ids are re-joined (see ``_COLON_ID_PLATFORMS``).
     * A Slack workspace id is consumed from the scope slot ``build_session_key``
       writes it into (see ``_SLACK_SCOPE_ID_RE``).
 
-    **A session key is not a return address.** Even inverted exactly, the tail
-    of a group key is ambiguous by construction — ``build_session_key`` appends
-    a bare participant id after the chat id with no delimiter change, so a
-    6th token may be a thread or a user (which is why ``thread_id`` is reported
-    only for the ``dm``/``thread`` shapes, where the grammar is unambiguous).
-    Callers that need a route must carry the structured routing fields from the
-    commissioning turn; this parser exists for legacy records that predate that
-    capture, and for the "is this a structured key at all?" test.
+    A session key is not a return address: a group key's tail is ambiguous by
+    construction, since a bare participant id follows the chat id with no
+    delimiter change, so ``thread_id`` is reported only for ``dm``/``thread``.
+    Callers that need a route carry structured fields from the commissioning
+    turn instead.
     """
     if not session_key:
         return None
@@ -1304,8 +1286,8 @@ def parse_session_key(session_key: str) -> Optional[Dict[str, Any]]:
         "platform": platform,
         "chat_type": chat_type,
         "chat_id": chat_id,
-        # ``main`` is the default profile's static namespace literal, not a
-        # profile name — normalise it to None.
+        # ``main`` is the default profile's namespace literal, not a profile
+        # name, so normalise it to None.
         "profile": None if namespace == "main" else namespace,
     }
     if scope_id:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -109,6 +109,13 @@ _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNS
 _SESSION_TRANSPORT_PROFILE: ContextVar = ContextVar(
     "HERMES_SESSION_TRANSPORT_PROFILE", default=_UNSET
 )
+# Which adapter slot inside that profile's map received the turn, as a platform
+# value. Distinct from ``_SESSION_PLATFORM``, the logical platform used for the
+# send: a Slack turn arriving over Relay is ``relay`` here and ``slack`` there.
+# "" means the ingress transport was not identifiable.
+_SESSION_TRANSPORT_SLOT: ContextVar = ContextVar(
+    "HERMES_SESSION_TRANSPORT_SLOT", default=_UNSET
+)
 _BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
     "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
 )
@@ -165,6 +172,7 @@ _VAR_MAP = {
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
     "HERMES_SESSION_TRANSPORT_PROFILE": _SESSION_TRANSPORT_PROFILE,
+    "HERMES_SESSION_TRANSPORT_SLOT": _SESSION_TRANSPORT_SLOT,
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
@@ -245,6 +253,7 @@ def set_session_vars(
     message_id: str = "",
     profile: str = "",
     transport_profile: str = "",
+    transport_slot: str = "",
     browser_control_principal: str = "",
     browser_control_transport_family: str = "",
     cwd: str = "",
@@ -293,6 +302,7 @@ def set_session_vars(
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
         _SESSION_TRANSPORT_PROFILE.set(transport_profile),
+        _SESSION_TRANSPORT_SLOT.set(transport_slot),
         _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
         _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
         _CRON_SESSION.set(cron_session),
@@ -335,6 +345,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
         _SESSION_TRANSPORT_PROFILE,
+        _SESSION_TRANSPORT_SLOT,
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -102,12 +102,10 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
-# TRANSPORT PROVENANCE — which profile owns the ADAPTER this turn arrived on,
-# as opposed to ``_SESSION_PROFILE``, which is the runtime namespace the turn is
-# routed to. The two differ whenever one shared credential serves several
-# routed runtimes, and only this one identifies the bot that must answer.
-# Values: ``"default"`` (the process-default adapter map), a profile name, or
-# ``""``/unset when the transport could not be identified (legacy).
+# Which profile owns the adapter this turn arrived on, as opposed to
+# ``_SESSION_PROFILE``, the runtime namespace it is routed to: the two differ
+# when one shared credential serves several routed runtimes, and only this one
+# identifies the bot that must answer. ``""`` means unidentified transport.
 _SESSION_TRANSPORT_PROFILE: ContextVar = ContextVar(
     "HERMES_SESSION_TRANSPORT_PROFILE", default=_UNSET
 )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -102,6 +102,15 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+# TRANSPORT PROVENANCE — which profile owns the ADAPTER this turn arrived on,
+# as opposed to ``_SESSION_PROFILE``, which is the runtime namespace the turn is
+# routed to. The two differ whenever one shared credential serves several
+# routed runtimes, and only this one identifies the bot that must answer.
+# Values: ``"default"`` (the process-default adapter map), a profile name, or
+# ``""``/unset when the transport could not be identified (legacy).
+_SESSION_TRANSPORT_PROFILE: ContextVar = ContextVar(
+    "HERMES_SESSION_TRANSPORT_PROFILE", default=_UNSET
+)
 _BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
     "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
 )
@@ -157,6 +166,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_SESSION_TRANSPORT_PROFILE": _SESSION_TRANSPORT_PROFILE,
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
@@ -236,6 +246,7 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     profile: str = "",
+    transport_profile: str = "",
     browser_control_principal: str = "",
     browser_control_transport_family: str = "",
     cwd: str = "",
@@ -283,6 +294,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _SESSION_TRANSPORT_PROFILE.set(transport_profile),
         _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
         _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
         _CRON_SESSION.set(cron_session),
@@ -324,6 +336,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _SESSION_TRANSPORT_PROFILE,
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,

--- a/gateway/transport_provenance.py
+++ b/gateway/transport_provenance.py
@@ -1,0 +1,97 @@
+"""The exact ingress adapter a turn arrived on, as one indivisible record.
+
+The owner map (``transport_profile``) and the adapter slot inside it
+(``transport_slot``) only identify a transport together: an owner alone cannot
+tell a relay-fronted platform from a native one, and a slot alone does not say
+whose credentials hold it. Capture, serialization and decoding all run through
+this module so no site can emit half a return address, and a damaged or
+contradictory one is dropped rather than resolved to a guess.
+
+A recorded pair is exactly one of three classes (see :func:`classify_provenance`):
+``LEGACY`` — both fields absent, from before provenance was recorded, which
+keeps the runtime/alias fallback; ``EXACT`` — both present and the slot is one
+the turn could have arrived on, which resolves that adapter directly; and
+``MALFORMED`` — anything else, which is dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple, Optional
+
+PROFILE_FIELD = "transport_profile"
+SLOT_FIELD = "transport_slot"
+PROVENANCE_KEYS = (PROFILE_FIELD, SLOT_FIELD)
+
+PROFILE_ENV = "HERMES_SESSION_TRANSPORT_PROFILE"
+SLOT_ENV = "HERMES_SESSION_TRANSPORT_SLOT"
+
+LEGACY = "legacy"
+EXACT = "exact"
+MALFORMED = "malformed"
+
+
+class TransportProvenance(NamedTuple):
+    """The owner map and adapter slot the commissioning turn arrived on."""
+
+    profile: str
+    slot: str
+
+
+def _field(record: Any, name: str) -> str:
+    """Read *name* off a mapping or an attribute-bearing record."""
+    value = record.get(name, "") if hasattr(record, "get") else getattr(record, name, "")
+    return str(value or "").strip()
+
+
+def read_provenance(record: Any, prefix: str = "") -> TransportProvenance:
+    """Read a recorded pair back verbatim, damage included.
+
+    Classification is :func:`classify_provenance`'s job: this reader never
+    repairs, defaults or drops a field, so a half-record stays visibly half.
+    """
+    return TransportProvenance(
+        _field(record, f"{prefix}{PROFILE_FIELD}"),
+        _field(record, f"{prefix}{SLOT_FIELD}"),
+    )
+
+
+def provenance_from_session_env(get_env) -> TransportProvenance:
+    """Read the pair from the session context via *get_env*, damage included."""
+    return TransportProvenance(
+        str(get_env(PROFILE_ENV, "") or "").strip(),
+        str(get_env(SLOT_ENV, "") or "").strip(),
+    )
+
+
+def provenance_fields(
+    provenance: Optional[TransportProvenance], prefix: str = ""
+) -> dict:
+    """Both fields as a mapping, so no writer can persist one without the other."""
+    profile, slot = provenance if provenance is not None else ("", "")
+    return {f"{prefix}{PROFILE_FIELD}": profile, f"{prefix}{SLOT_FIELD}": slot}
+
+
+def stamp_provenance(
+    target: Any, provenance: Optional[TransportProvenance], prefix: str = ""
+) -> None:
+    """Write both fields onto *target*'s attributes in one call."""
+    for name, value in provenance_fields(provenance, prefix).items():
+        setattr(target, name, value)
+
+
+def classify_provenance(provenance: TransportProvenance, platform_name: Any) -> str:
+    """Return ``LEGACY``, ``EXACT`` or ``MALFORMED`` for a recorded pair.
+
+    A slot is only credible for the two adapter maps a turn on *platform_name*
+    can arrive through: that platform's own slot, or the relay fronting it.
+    """
+    from gateway.config import Platform
+
+    profile, slot = provenance
+    if not profile and not slot:
+        return LEGACY
+    if not profile or not slot:
+        return MALFORMED
+    if slot not in (str(platform_name), Platform.RELAY.value):
+        return MALFORMED
+    return EXACT

--- a/gateway/transport_provenance.py
+++ b/gateway/transport_provenance.py
@@ -85,6 +85,8 @@ def classify_provenance(provenance: TransportProvenance, platform_name: Any) -> 
     A slot is only credible for the two adapter maps a turn on *platform_name*
     can arrive through: that platform's own slot, or the relay fronting it.
     """
+    # deferred: keeps this module importable from tools/ without pulling
+    # gateway.config in at import time.
     from gateway.config import Platform
 
     profile, slot = provenance

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -512,24 +512,13 @@ def test_parse_session_key_with_extra_parts():
         "platform": "discord",
         "chat_type": "group",
         "chat_id": "chan123",
-        # ``main`` is the default profile's namespace literal, not a profile.
+        # ``main`` is a namespace literal, not a profile name.
         "profile": None,
     }
 
 
 def test_parse_session_key_accepts_profile_namespace():
-    """A named profile's key (``agent:alpha:...``) must parse, report the
-    profile, and keep the WHOLE Matrix room id.
-
-    ``_session_key_namespace`` reuses ``parts[1]`` to carry the profile under
-    ``gateway.multiplex_profiles``. Requiring the literal ``main`` here made
-    every secondary profile's session unparseable, which stripped the routing
-    metadata off its completions.
-
-    And a Matrix room id is ``!localpart:homeserver``, so the positional
-    ``split(":")`` this parser used to be returned ``chat_id == "!room"`` —
-    a room that does not exist. See gateway.session.parse_session_key.
-    """
+    """A named profile's key parses, reports the profile, and keeps the whole room id."""
     result = _parse_session_key("agent:alpha:matrix:group:!room:example.org")
     assert result == {
         "platform": "matrix",
@@ -540,8 +529,7 @@ def test_parse_session_key_accepts_profile_namespace():
 
 
 def test_parse_session_key_rejects_non_agent_and_short_keys():
-    """Control: raw api_server session ids still return None, so the
-    self-post recovery path in _inject_watch_notification is unaffected."""
+    """Control: raw api_server session ids still return None."""
     assert _parse_session_key("sess_abc123") is None
     assert _parse_session_key("agent:main:matrix:dm") is None
     assert _parse_session_key("agent::matrix:dm:!room") is None

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -518,19 +518,23 @@ def test_parse_session_key_with_extra_parts():
 
 
 def test_parse_session_key_accepts_profile_namespace():
-    """A named profile's key (``agent:alpha:...``) must parse, and report the
-    profile.
+    """A named profile's key (``agent:alpha:...``) must parse, report the
+    profile, and keep the WHOLE Matrix room id.
 
     ``_session_key_namespace`` reuses ``parts[1]`` to carry the profile under
     ``gateway.multiplex_profiles``. Requiring the literal ``main`` here made
     every secondary profile's session unparseable, which stripped the routing
     metadata off its completions.
+
+    And a Matrix room id is ``!localpart:homeserver``, so the positional
+    ``split(":")`` this parser used to be returned ``chat_id == "!room"`` —
+    a room that does not exist. See gateway.session.parse_session_key.
     """
     result = _parse_session_key("agent:alpha:matrix:group:!room:example.org")
     assert result == {
         "platform": "matrix",
         "chat_type": "group",
-        "chat_id": "!room",
+        "chat_id": "!room:example.org",
         "profile": "alpha",
     }
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -508,7 +508,39 @@ async def test_concise_mode_no_interim_output_updates(monkeypatch, tmp_path):
 def test_parse_session_key_with_extra_parts():
     """6th part in a group key may be a user_id, not a thread_id — omit it."""
     result = _parse_session_key("agent:main:discord:group:chan123:thread456")
-    assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
+    assert result == {
+        "platform": "discord",
+        "chat_type": "group",
+        "chat_id": "chan123",
+        # ``main`` is the default profile's namespace literal, not a profile.
+        "profile": None,
+    }
+
+
+def test_parse_session_key_accepts_profile_namespace():
+    """A named profile's key (``agent:alpha:...``) must parse, and report the
+    profile.
+
+    ``_session_key_namespace`` reuses ``parts[1]`` to carry the profile under
+    ``gateway.multiplex_profiles``. Requiring the literal ``main`` here made
+    every secondary profile's session unparseable, which stripped the routing
+    metadata off its completions.
+    """
+    result = _parse_session_key("agent:alpha:matrix:group:!room:example.org")
+    assert result == {
+        "platform": "matrix",
+        "chat_type": "group",
+        "chat_id": "!room",
+        "profile": "alpha",
+    }
+
+
+def test_parse_session_key_rejects_non_agent_and_short_keys():
+    """Control: raw api_server session ids still return None, so the
+    self-post recovery path in _inject_watch_notification is unaffected."""
+    assert _parse_session_key("sess_abc123") is None
+    assert _parse_session_key("agent:main:matrix:dm") is None
+    assert _parse_session_key("agent::matrix:dm:!room") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -410,11 +410,20 @@ async def test_relay_ingress_records_default_provenance():
         "a relayed turn recorded no transport provenance, so its completion "
         "would fall back to the runtime profile's own adapter"
     )
+    assert runner._ingress_transport_slot(source) == "relay", (
+        "the owner map alone cannot tell relay ingress from native ingress "
+        "when both front the same logical platform"
+    )
 
 
 @pytest.mark.asyncio
-async def test_relay_completion_is_not_answered_by_a_secondary_bot():
-    """That provenance sends the completion back out the relay chain."""
+async def test_relay_completion_is_delivered_through_the_relay():
+    """That provenance sends the completion back out the relay chain.
+
+    The relay stub deliberately does not advertise ``fronts_platform``: the
+    recorded slot is exact provenance, so delivery must not depend on the
+    alias resolver being able to re-derive it.
+    """
     relay = _Adapter("relay")
     alpha_slack = _Adapter("slack-alpha")
     runner = _runner(
@@ -430,11 +439,19 @@ async def test_relay_completion_is_not_answered_by_a_secondary_bot():
         "scope_id": "T0WORKSPACE",
         "profile": "alpha",
         "transport_profile": "default",
+        "transport_slot": "relay",
         "status": "completed",
     }
 
-    await runner._inject_watch_notification("[task finished]", evt)
+    result = await runner._inject_watch_notification("[task finished]", evt)
 
+    assert result is True, (
+        f"injection returned {result!r} — the completion was dropped, which a "
+        "'not the other bot' assertion alone would have passed"
+    )
+    assert relay.handle_message.await_count == 1, (
+        "the completion did not leave through the relay the turn arrived on"
+    )
     assert alpha_slack.handle_message.await_count == 0, (
         "delivered through the secondary profile's own Slack bot although the "
         "originating turn arrived over the shared relay transport"

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -22,6 +22,7 @@ genuine miss is logged rather than swallowed.
 """
 
 import logging
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -126,3 +127,311 @@ async def test_unresolvable_adapter_is_logged_not_silent(caplog):
         "no adapter for" in r.getMessage() and "alpha" in r.getMessage()
         for r in caplog.records
     ), f"expected a WARNING naming platform+profile, got: {[r.getMessage() for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Transport provenance vs runtime namespace
+#
+# ``source.profile`` is the RUNTIME namespace, not the transport owner. When one
+# shared credential serves several routed runtimes, resolving a completion from
+# the runtime namespace is wrong in both directions:
+#
+#   (a) the runtime registers no adapter for the platform -> the completion is
+#       dropped although the originating transport is live;
+#   (b) the runtime owns its OWN adapter for that platform -> the completion is
+#       delivered from a different bot than the one the user spoke to.
+#
+# So the commissioning turn records WHICH TRANSPORT it arrived on, as a name,
+# and the completion re-resolves whatever adapter is live for that name now.
+# ---------------------------------------------------------------------------
+
+
+def _shared_primary_event(**overrides):
+    """A completion commissioned on the SHARED PRIMARY Matrix transport by a
+    turn routed into the secondary runtime ``alpha``.
+
+    ``profile`` (runtime) and ``transport_profile`` (transport owner) disagree —
+    which is the whole point.
+    """
+    evt = _alpha_event()
+    evt["profile"] = "alpha"
+    evt["transport_profile"] = "default"
+    evt.update(overrides)
+    return evt
+
+
+@pytest.mark.asyncio
+async def test_shared_primary_transport_into_runtime_with_no_adapter():
+    """(a) Routed runtime ``alpha`` owns NO Matrix adapter, but the turn arrived
+    on the shared primary transport, which is live. Deliver on it."""
+    primary_matrix = _Adapter("matrix-primary")
+    runner = _runner({Platform.MATRIX: primary_matrix}, {"alpha": {}})
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _shared_primary_event()
+    )
+
+    assert result is True, (
+        "resolving from the runtime namespace finds _profile_adapters['alpha'] "
+        "== {} and drops the completion, although the transport it was "
+        "commissioned on is live"
+    )
+    assert primary_matrix.handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_shared_primary_transport_is_not_switched_for_a_secondary_bot():
+    """(b) Same route, but ``alpha`` ALSO owns its own Matrix adapter. The
+    completion must go back out the ORIGINATING (primary) transport — answering
+    from ``alpha``'s bot is a wrong-credential delivery to a user who never
+    spoke to it."""
+    primary_matrix = _Adapter("matrix-primary")
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner(
+        {Platform.MATRIX: primary_matrix},
+        {"alpha": {Platform.MATRIX: alpha_matrix}},
+    )
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _shared_primary_event()
+    )
+
+    assert result is True
+    assert primary_matrix.handle_message.await_count == 1
+    assert alpha_matrix.handle_message.await_count == 0, (
+        "delivered through the secondary bot although the originating turn "
+        "arrived through the shared primary bot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dedicated_per_profile_transport_still_uses_the_secondary_bot():
+    """(c) Control — the original topology. ``alpha`` owns the transport it was
+    commissioned on, so provenance names ``alpha`` and delivery is unchanged."""
+    primary_matrix = _Adapter("matrix-primary")
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner(
+        {Platform.MATRIX: primary_matrix},
+        {"alpha": {Platform.MATRIX: alpha_matrix}},
+    )
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _shared_primary_event(transport_profile="alpha")
+    )
+
+    assert result is True
+    assert alpha_matrix.handle_message.await_count == 1
+    assert primary_matrix.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provenance_is_re_resolved_to_the_current_live_adapter():
+    """Provenance is a NAME, never the adapter object captured at commissioning
+    time. An adapter that reconnected (or a whole restarted process) must be
+    picked up as-is."""
+    stale_alpha = _Adapter("matrix-alpha-stale")
+    live_alpha = _Adapter("matrix-alpha-live")
+    profile_adapters = {"alpha": {Platform.MATRIX: stale_alpha}}
+    runner = _runner({}, profile_adapters)
+    # Reconnect swaps the registry entry underneath us.
+    profile_adapters["alpha"][Platform.MATRIX] = live_alpha
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _shared_primary_event(transport_profile="alpha")
+    )
+
+    assert result is True
+    assert live_alpha.handle_message.await_count == 1
+    assert stale_alpha.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_provenance_fails_closed_with_the_return_address(caplog):
+    """A named provenance with no live adapter must drop — never silently, and
+    never by falling through to some other profile's bot."""
+    primary_matrix = _Adapter("matrix-primary")
+    runner = _runner({Platform.MATRIX: primary_matrix}, {"alpha": {}})
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification(
+            "[x]", _shared_primary_event(transport_profile="alpha")
+        )
+
+    assert result is None
+    assert primary_matrix.handle_message.await_count == 0
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "transport provenance" in m and "'alpha'" in m and "!room:example.org" in m
+        for m in messages
+    ), f"expected a WARNING naming the provenance and the return address, got: {messages}"
+
+
+# ---------------------------------------------------------------------------
+# Restart / recovery leg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, monkeypatch):
+    """(f) Serialize the watcher record, drop ALL in-memory state, reload from
+    the checkpoint, and complete: the provenance must survive and still select
+    the originating transport."""
+    import json
+
+    from tools import process_registry as pr_mod
+
+    registry = pr_mod.ProcessRegistry()
+    session = pr_mod.ProcessSession(
+        id="proc_restart_1",
+        command="sleep 1",
+        session_key="agent:alpha:matrix:group:!room:example.org",
+        pid=os.getpid(),
+        started_at=1.0,
+        watcher_platform="matrix",
+        watcher_chat_id="!room:example.org",
+        watcher_chat_type="group",
+        watcher_user_id="@user:example.org",
+        watcher_thread_id="",
+        watcher_message_id="$evt",
+        watcher_profile="alpha",
+        watcher_transport_profile="default",
+        watcher_interval=5,
+        notify_on_complete=True,
+    )
+    session.host_start_time = registry._safe_host_start_time(os.getpid())
+    registry._running[session.id] = session
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr_mod, "CHECKPOINT_PATH", checkpoint)
+    registry._write_checkpoint()
+    assert json.loads(checkpoint.read_text())[0]["watcher_transport_profile"] == "default"
+
+    # --- restart: nothing in memory survives ---
+    restarted = pr_mod.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 1
+    watcher = next(
+        w for w in restarted.pending_watchers if w["session_id"] == "proc_restart_1"
+    )
+    assert watcher["transport_profile"] == "default"
+    assert watcher["chat_type"] == "group"
+    assert watcher["chat_id"] == "!room:example.org"
+
+    # --- the completion, built the way _run_process_watcher builds it ---
+    primary_matrix = _Adapter("matrix-primary")
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner(
+        {Platform.MATRIX: primary_matrix},
+        {"alpha": {Platform.MATRIX: alpha_matrix}},
+    )
+    evt = {
+        "type": "completion",
+        "session_id": watcher["session_id"],
+        "session_key": watcher["session_key"],
+        "platform": watcher["platform"],
+        "chat_type": watcher["chat_type"],
+        "chat_id": watcher["chat_id"],
+        "scope_id": watcher["scope_id"],
+        "thread_id": watcher["thread_id"],
+        "user_id": watcher["user_id"],
+        "profile": watcher["profile"],
+        "transport_profile": watcher["transport_profile"],
+        "status": "completed",
+    }
+
+    assert await runner._inject_watch_notification("[task finished]", evt) is True
+    assert primary_matrix.handle_message.await_count == 1
+    assert alpha_matrix.handle_message.await_count == 0
+
+    delivered = primary_matrix.handle_message.await_args[0][0]
+    assert delivered.source.chat_id == "!room:example.org"
+    assert delivered.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_legacy_record_without_provenance_keeps_runtime_resolution():
+    """Records queued before provenance was captured (or restored from a
+    pre-upgrade checkpoint) must keep the runtime-profile behaviour."""
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
+
+    evt = _alpha_event()          # no transport_profile at all
+    assert "transport_profile" not in evt
+
+    assert await runner._inject_watch_notification("[task finished]", evt) is True
+    assert alpha_matrix.handle_message.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Async-delegation completions, end to end on the injection path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_matrix_colon_room_id_routes_to_the_full_id():
+    """(d) The captured address is used verbatim: the completion goes to
+    ``!room:example.org``, not to the ``!room`` a positional key split yields."""
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "del_1",
+        "session_key": "agent:alpha:matrix:group:!room:example.org",
+        "platform": "matrix",
+        "chat_type": "group",
+        "chat_id": "!room:example.org",
+        "user_id": "@user:example.org",
+        "profile": "alpha",
+        "transport_profile": "alpha",
+        "status": "completed",
+    }
+
+    assert await runner._inject_watch_notification("[delegation done]", evt) is True
+    delivered = alpha_matrix.handle_message.await_args[0][0]
+    assert delivered.source.chat_id == "!room:example.org"
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_slack_scoped_session_routes_to_the_channel():
+    """(e) The workspace scope stays the scope and the channel stays the chat."""
+    slack = _Adapter("slack-default")
+    runner = _runner({Platform.SLACK: slack}, {})
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "del_2",
+        "session_key": "agent:main:slack:group:T0WORKSPACE:C0CHANNEL:U0USER",
+        "platform": "slack",
+        "chat_type": "group",
+        "chat_id": "C0CHANNEL",
+        "scope_id": "T0WORKSPACE",
+        "user_id": "U0USER",
+        "transport_profile": "default",
+        "status": "completed",
+    }
+
+    assert await runner._inject_watch_notification("[delegation done]", evt) is True
+    delivered = slack.handle_message.await_args[0][0]
+    assert delivered.source.chat_id == "C0CHANNEL"
+    assert delivered.source.scope_id == "T0WORKSPACE"
+
+
+@pytest.mark.asyncio
+async def test_legacy_async_delegation_enrichment_uses_the_canonical_parser():
+    """A legacy event with only a session_key is enriched through the canonical
+    parser, so even the fallback keeps the whole Matrix room id."""
+    alpha_matrix = _Adapter("matrix-alpha")
+    runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "del_legacy",
+        "session_key": "agent:alpha:matrix:group:!room:example.org",
+        "status": "completed",
+    }
+    runner._enrich_async_delegation_routing(evt)
+    assert evt["chat_id"] == "!room:example.org"
+
+    assert await runner._inject_watch_notification("[delegation done]", evt) is True
+    delivered = alpha_matrix.handle_message.await_args[0][0]
+    assert delivered.source.chat_id == "!room:example.org"

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -119,7 +119,9 @@ def _shared_primary_event(**overrides):
     """A shared-primary Matrix completion whose runtime and transport disagree."""
     evt = _alpha_event()
     evt["profile"] = "alpha"
+    # Capture always stamps the pair, so every well-formed record carries both.
     evt["transport_profile"] = "default"
+    evt["transport_slot"] = "matrix"
     evt.update(overrides)
     return evt
 
@@ -247,6 +249,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
         watcher_message_id="$evt",
         watcher_profile="alpha",
         watcher_transport_profile="default",
+        watcher_transport_slot="matrix",
         watcher_interval=5,
         notify_on_complete=True,
     )
@@ -265,6 +268,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
         w for w in restarted.pending_watchers if w["session_id"] == "proc_restart_1"
     )
     assert watcher["transport_profile"] == "default"
+    assert watcher["transport_slot"] == "matrix"
     assert watcher["chat_type"] == "group"
     assert watcher["chat_id"] == "!room:example.org"
 
@@ -287,6 +291,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
         "user_id": watcher["user_id"],
         "profile": watcher["profile"],
         "transport_profile": watcher["transport_profile"],
+        "transport_slot": watcher["transport_slot"],
         "status": "completed",
     }
 
@@ -331,6 +336,7 @@ async def test_async_delegation_matrix_colon_room_id_routes_to_the_full_id():
         "user_id": "@user:example.org",
         "profile": "alpha",
         "transport_profile": "alpha",
+        "transport_slot": "matrix",
         "status": "completed",
     }
 
@@ -355,6 +361,7 @@ async def test_async_delegation_slack_scoped_session_routes_to_the_channel():
         "scope_id": "T0WORKSPACE",
         "user_id": "U0USER",
         "transport_profile": "default",
+        "transport_slot": "slack",
         "status": "completed",
     }
 
@@ -413,6 +420,10 @@ async def test_relay_ingress_records_default_provenance():
     assert runner._ingress_transport_slot(source) == "relay", (
         "the owner map alone cannot tell relay ingress from native ingress "
         "when both front the same logical platform"
+    )
+    assert runner._capture_transport_provenance(source) == ("default", "relay"), (
+        "the pair must be captured atomically — a half record is dropped at "
+        "delivery, not resolved"
     )
 
 

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -435,3 +435,66 @@ async def test_legacy_async_delegation_enrichment_uses_the_canonical_parser():
     assert await runner._inject_watch_notification("[delegation done]", evt) is True
     delivered = alpha_matrix.handle_message.await_args[0][0]
     assert delivered.source.chat_id == "!room:example.org"
+
+
+# ---------------------------------------------------------------------------
+# Relay ingress — the receiving adapter is registered under Platform.RELAY
+# while the source keeps the logical platform, so the registry check in
+# ``_registered_transport_adapter`` cannot see it. Provenance must still be
+# recorded, or a relayed turn's completion falls back to runtime-profile
+# resolution and answers out of a secondary profile's own bot.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_relay_ingress_records_default_provenance():
+    """A relayed turn routed into runtime ``alpha`` records ``default``
+    provenance, not nothing."""
+    import weakref
+
+    relay = _Adapter("relay")
+    alpha_slack = _Adapter("slack-alpha")
+    runner = _runner(
+        {Platform.RELAY: relay}, {"alpha": {Platform.SLACK: alpha_slack}},
+    )
+    source = SimpleNamespace(
+        platform=Platform.SLACK,
+        profile="alpha",
+        delivered_via_upstream_relay=True,
+    )
+    source._transport_adapter_ref = weakref.ref(relay)
+
+    assert runner._transport_owner_profile(source) == "default", (
+        "a relayed turn recorded no transport provenance, so its completion "
+        "would fall back to the runtime profile's own adapter"
+    )
+
+
+@pytest.mark.asyncio
+async def test_relay_completion_is_not_answered_by_a_secondary_bot():
+    """With that provenance the completion goes back out the relay chain, not
+    out ``alpha``'s native Slack bot."""
+    relay = _Adapter("relay")
+    alpha_slack = _Adapter("slack-alpha")
+    runner = _runner(
+        {Platform.RELAY: relay}, {"alpha": {Platform.SLACK: alpha_slack}},
+    )
+    evt = {
+        "type": "process_completed",
+        "session_id": "proc_relay_1",
+        "session_key": "agent:alpha:slack:group:T0WORKSPACE:C0CHANNEL",
+        "platform": "slack",
+        "chat_type": "group",
+        "chat_id": "C0CHANNEL",
+        "scope_id": "T0WORKSPACE",
+        "profile": "alpha",
+        "transport_profile": "default",
+        "status": "completed",
+    }
+
+    await runner._inject_watch_notification("[task finished]", evt)
+
+    assert alpha_slack.handle_message.await_count == 0, (
+        "delivered through the secondary profile's own Slack bot although the "
+        "originating turn arrived over the shared relay transport"
+    )

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -1,24 +1,10 @@
-"""Regression: completion injection must resolve a SECONDARY profile's adapter.
+"""Regression: completion injection must resolve a secondary profile's adapter.
 
-Under ``gateway.multiplex_profiles`` one gateway process serves the default
-profile plus every named profile under ``~/.hermes/profiles/``. Only the
-default profile's adapters live in ``GatewayRunner.adapters``; each secondary
-profile's adapters live in ``_profile_adapters[profile]``.
-
-``_inject_watch_notification`` — the single funnel every background-process and
-async-delegation completion passes through — resolved its adapter from
-``self.adapters`` only (the alias-aware ``resolve_delivery_transport`` call and
-the legacy literal scan both read that one map). For a secondary profile that
-map has no entry for the profile's platform, so resolution fell through to a
-bare ``return None``: registration proven, drain proven, and then no delivery,
-no synthetic turn, and no log line naming the drop.
-
-The kanban notifier already resolves the same problem correctly via
-``_adapter_for_source``/``_authorization_adapter``
-(``gateway/authz_mixin.py``), which reads ``source.profile`` and fails closed
-rather than replying out of the default profile's bot. Contract under test:
-the injection path resolves through that same profile-aware resolver, and a
-genuine miss is logged rather than swallowed.
+Under ``gateway.multiplex_profiles`` only the default profile's adapters live in
+``GatewayRunner.adapters``; a secondary profile's live in
+``_profile_adapters[profile]``. Contract under test: ``_inject_watch_notification``
+resolves through the profile-aware resolver rather than ``self.adapters`` alone,
+and logs a genuine miss rather than swallowing it.
 """
 
 import logging
@@ -50,8 +36,7 @@ def _runner(default_adapters, profile_adapters):
 
 
 def _alpha_event():
-    """A completion for the alpha profile's Matrix room (served by its own
-    ``@alpha-bot:example.org`` connection), as the watcher queues it."""
+    """A completion for the alpha profile's Matrix room, as the watcher queues it."""
     return {
         "type": "process_completed",
         "session_id": "proc_alpha_1",
@@ -65,8 +50,7 @@ def _alpha_event():
 
 @pytest.mark.asyncio
 async def test_injection_resolves_secondary_profile_adapter():
-    """The alpha profile's Matrix adapter must receive the completion, even
-    though ``self.adapters`` (the default profile's map) has no Matrix entry."""
+    """Alpha's Matrix adapter is used although the default map has no Matrix entry."""
     alpha_adapter = _Adapter("matrix-alpha")
     telegram = _Adapter("telegram-default")
     runner = _runner(
@@ -86,9 +70,7 @@ async def test_injection_resolves_secondary_profile_adapter():
 
 @pytest.mark.asyncio
 async def test_injection_does_not_leak_to_default_profile_adapter():
-    """Fail closed: when the alpha profile has no Matrix adapter, the default
-    profile's Matrix adapter must NOT be used — that answers out of the wrong
-    bot."""
+    """Fail closed rather than answering out of the default profile's bot."""
     default_matrix = _Adapter("matrix-default")
     runner = _runner({Platform.MATRIX: default_matrix}, {"alpha": {}})
 
@@ -100,8 +82,7 @@ async def test_injection_does_not_leak_to_default_profile_adapter():
 
 @pytest.mark.asyncio
 async def test_default_profile_injection_unchanged():
-    """Control: a default-profile (``agent:main``) completion still resolves
-    through ``self.adapters`` exactly as before."""
+    """Control: an ``agent:main`` completion still resolves through ``self.adapters``."""
     matrix = _Adapter("matrix-default")
     runner = _runner({Platform.MATRIX: matrix}, {})
     evt = _alpha_event()
@@ -115,8 +96,7 @@ async def test_default_profile_injection_unchanged():
 
 @pytest.mark.asyncio
 async def test_unresolvable_adapter_is_logged_not_silent(caplog):
-    """The drop that used to be a bare ``return None`` must name the platform
-    and profile it could not resolve."""
+    """An unresolvable drop names the platform and profile it could not resolve."""
     runner = _runner({}, {"alpha": {}})
 
     with caplog.at_level(logging.WARNING, logger="gateway.run"):
@@ -129,30 +109,14 @@ async def test_unresolvable_adapter_is_logged_not_silent(caplog):
     ), f"expected a WARNING naming platform+profile, got: {[r.getMessage() for r in caplog.records]}"
 
 
-# ---------------------------------------------------------------------------
-# Transport provenance vs runtime namespace
-#
-# ``source.profile`` is the RUNTIME namespace, not the transport owner. When one
-# shared credential serves several routed runtimes, resolving a completion from
-# the runtime namespace is wrong in both directions:
-#
-#   (a) the runtime registers no adapter for the platform -> the completion is
-#       dropped although the originating transport is live;
-#   (b) the runtime owns its OWN adapter for that platform -> the completion is
-#       delivered from a different bot than the one the user spoke to.
-#
-# So the commissioning turn records WHICH TRANSPORT it arrived on, as a name,
-# and the completion re-resolves whatever adapter is live for that name now.
-# ---------------------------------------------------------------------------
+# Transport provenance vs runtime namespace: when one shared credential serves
+# several routed runtimes, resolving from ``source.profile`` either drops a
+# completion whose transport is live, or answers from a different bot than the
+# user spoke to.
 
 
 def _shared_primary_event(**overrides):
-    """A completion commissioned on the SHARED PRIMARY Matrix transport by a
-    turn routed into the secondary runtime ``alpha``.
-
-    ``profile`` (runtime) and ``transport_profile`` (transport owner) disagree —
-    which is the whole point.
-    """
+    """A shared-primary Matrix completion whose runtime and transport disagree."""
     evt = _alpha_event()
     evt["profile"] = "alpha"
     evt["transport_profile"] = "default"
@@ -162,8 +126,7 @@ def _shared_primary_event(**overrides):
 
 @pytest.mark.asyncio
 async def test_shared_primary_transport_into_runtime_with_no_adapter():
-    """(a) Routed runtime ``alpha`` owns NO Matrix adapter, but the turn arrived
-    on the shared primary transport, which is live. Deliver on it."""
+    """Runtime ``alpha`` owns no Matrix adapter; deliver on the live transport."""
     primary_matrix = _Adapter("matrix-primary")
     runner = _runner({Platform.MATRIX: primary_matrix}, {"alpha": {}})
 
@@ -181,10 +144,7 @@ async def test_shared_primary_transport_into_runtime_with_no_adapter():
 
 @pytest.mark.asyncio
 async def test_shared_primary_transport_is_not_switched_for_a_secondary_bot():
-    """(b) Same route, but ``alpha`` ALSO owns its own Matrix adapter. The
-    completion must go back out the ORIGINATING (primary) transport — answering
-    from ``alpha``'s bot is a wrong-credential delivery to a user who never
-    spoke to it."""
+    """With ``alpha`` also owning a Matrix adapter, the originating one still wins."""
     primary_matrix = _Adapter("matrix-primary")
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner(
@@ -206,8 +166,7 @@ async def test_shared_primary_transport_is_not_switched_for_a_secondary_bot():
 
 @pytest.mark.asyncio
 async def test_dedicated_per_profile_transport_still_uses_the_secondary_bot():
-    """(c) Control — the original topology. ``alpha`` owns the transport it was
-    commissioned on, so provenance names ``alpha`` and delivery is unchanged."""
+    """Control: ``alpha`` owns the transport it was commissioned on."""
     primary_matrix = _Adapter("matrix-primary")
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner(
@@ -226,14 +185,12 @@ async def test_dedicated_per_profile_transport_still_uses_the_secondary_bot():
 
 @pytest.mark.asyncio
 async def test_provenance_is_re_resolved_to_the_current_live_adapter():
-    """Provenance is a NAME, never the adapter object captured at commissioning
-    time. An adapter that reconnected (or a whole restarted process) must be
-    picked up as-is."""
+    """Provenance is a name, so a reconnected adapter is picked up as-is."""
     stale_alpha = _Adapter("matrix-alpha-stale")
     live_alpha = _Adapter("matrix-alpha-live")
     profile_adapters = {"alpha": {Platform.MATRIX: stale_alpha}}
     runner = _runner({}, profile_adapters)
-    # Reconnect swaps the registry entry underneath us.
+    # Reconnect swaps the registry entry after commissioning.
     profile_adapters["alpha"][Platform.MATRIX] = live_alpha
 
     result = await runner._inject_watch_notification(
@@ -247,8 +204,7 @@ async def test_provenance_is_re_resolved_to_the_current_live_adapter():
 
 @pytest.mark.asyncio
 async def test_unresolvable_provenance_fails_closed_with_the_return_address(caplog):
-    """A named provenance with no live adapter must drop — never silently, and
-    never by falling through to some other profile's bot."""
+    """A named provenance with no live adapter drops loudly, without falling through."""
     primary_matrix = _Adapter("matrix-primary")
     runner = _runner({Platform.MATRIX: primary_matrix}, {"alpha": {}})
 
@@ -266,16 +222,12 @@ async def test_unresolvable_provenance_fails_closed_with_the_return_address(capl
     ), f"expected a WARNING naming the provenance and the return address, got: {messages}"
 
 
-# ---------------------------------------------------------------------------
-# Restart / recovery leg
-# ---------------------------------------------------------------------------
+# Restart / recovery leg.
 
 
 @pytest.mark.asyncio
 async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, monkeypatch):
-    """(f) Serialize the watcher record, drop ALL in-memory state, reload from
-    the checkpoint, and complete: the provenance must survive and still select
-    the originating transport."""
+    """Provenance survives a checkpoint round-trip and still selects the transport."""
     import json
 
     from tools import process_registry as pr_mod
@@ -306,7 +258,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
     registry._write_checkpoint()
     assert json.loads(checkpoint.read_text())[0]["watcher_transport_profile"] == "default"
 
-    # --- restart: nothing in memory survives ---
+    # Restart: nothing in memory survives.
     restarted = pr_mod.ProcessRegistry()
     assert restarted.recover_from_checkpoint() == 1
     watcher = next(
@@ -316,7 +268,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
     assert watcher["chat_type"] == "group"
     assert watcher["chat_id"] == "!room:example.org"
 
-    # --- the completion, built the way _run_process_watcher builds it ---
+    # The completion, built the way _run_process_watcher builds it.
     primary_matrix = _Adapter("matrix-primary")
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner(
@@ -349,8 +301,7 @@ async def test_completion_routes_correctly_after_a_gateway_restart(tmp_path, mon
 
 @pytest.mark.asyncio
 async def test_legacy_record_without_provenance_keeps_runtime_resolution():
-    """Records queued before provenance was captured (or restored from a
-    pre-upgrade checkpoint) must keep the runtime-profile behaviour."""
+    """Records without provenance keep the runtime-profile behaviour."""
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
 
@@ -361,15 +312,12 @@ async def test_legacy_record_without_provenance_keeps_runtime_resolution():
     assert alpha_matrix.handle_message.await_count == 1
 
 
-# ---------------------------------------------------------------------------
-# Async-delegation completions, end to end on the injection path
-# ---------------------------------------------------------------------------
+# Async-delegation completions, end to end on the injection path.
 
 
 @pytest.mark.asyncio
 async def test_async_delegation_matrix_colon_room_id_routes_to_the_full_id():
-    """(d) The captured address is used verbatim: the completion goes to
-    ``!room:example.org``, not to the ``!room`` a positional key split yields."""
+    """The captured address is used verbatim, keeping the whole Matrix room id."""
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
 
@@ -393,7 +341,7 @@ async def test_async_delegation_matrix_colon_room_id_routes_to_the_full_id():
 
 @pytest.mark.asyncio
 async def test_async_delegation_slack_scoped_session_routes_to_the_channel():
-    """(e) The workspace scope stays the scope and the channel stays the chat."""
+    """The workspace scope stays the scope and the channel stays the chat."""
     slack = _Adapter("slack-default")
     runner = _runner({Platform.SLACK: slack}, {})
 
@@ -418,8 +366,7 @@ async def test_async_delegation_slack_scoped_session_routes_to_the_channel():
 
 @pytest.mark.asyncio
 async def test_legacy_async_delegation_enrichment_uses_the_canonical_parser():
-    """A legacy event with only a session_key is enriched through the canonical
-    parser, so even the fallback keeps the whole Matrix room id."""
+    """Session-key-only enrichment goes through the canonical parser."""
     alpha_matrix = _Adapter("matrix-alpha")
     runner = _runner({}, {"alpha": {Platform.MATRIX: alpha_matrix}})
 
@@ -437,19 +384,14 @@ async def test_legacy_async_delegation_enrichment_uses_the_canonical_parser():
     assert delivered.source.chat_id == "!room:example.org"
 
 
-# ---------------------------------------------------------------------------
-# Relay ingress — the receiving adapter is registered under Platform.RELAY
-# while the source keeps the logical platform, so the registry check in
-# ``_registered_transport_adapter`` cannot see it. Provenance must still be
-# recorded, or a relayed turn's completion falls back to runtime-profile
-# resolution and answers out of a secondary profile's own bot.
-# ---------------------------------------------------------------------------
+# Relay ingress registers the adapter under ``Platform.RELAY`` while the source
+# keeps the logical platform, so ``_registered_transport_adapter`` cannot see it
+# and provenance has to be recorded another way.
 
 
 @pytest.mark.asyncio
 async def test_relay_ingress_records_default_provenance():
-    """A relayed turn routed into runtime ``alpha`` records ``default``
-    provenance, not nothing."""
+    """A relayed turn routed into runtime ``alpha`` records ``default`` provenance."""
     import weakref
 
     relay = _Adapter("relay")
@@ -472,8 +414,7 @@ async def test_relay_ingress_records_default_provenance():
 
 @pytest.mark.asyncio
 async def test_relay_completion_is_not_answered_by_a_secondary_bot():
-    """With that provenance the completion goes back out the relay chain, not
-    out ``alpha``'s native Slack bot."""
+    """That provenance sends the completion back out the relay chain."""
     relay = _Adapter("relay")
     alpha_slack = _Adapter("slack-alpha")
     runner = _runner(

--- a/tests/gateway/test_multiplex_completion_injection_routing.py
+++ b/tests/gateway/test_multiplex_completion_injection_routing.py
@@ -1,0 +1,128 @@
+"""Regression: completion injection must resolve a SECONDARY profile's adapter.
+
+Under ``gateway.multiplex_profiles`` one gateway process serves the default
+profile plus every named profile under ``~/.hermes/profiles/``. Only the
+default profile's adapters live in ``GatewayRunner.adapters``; each secondary
+profile's adapters live in ``_profile_adapters[profile]``.
+
+``_inject_watch_notification`` — the single funnel every background-process and
+async-delegation completion passes through — resolved its adapter from
+``self.adapters`` only (the alias-aware ``resolve_delivery_transport`` call and
+the legacy literal scan both read that one map). For a secondary profile that
+map has no entry for the profile's platform, so resolution fell through to a
+bare ``return None``: registration proven, drain proven, and then no delivery,
+no synthetic turn, and no log line naming the drop.
+
+The kanban notifier already resolves the same problem correctly via
+``_adapter_for_source``/``_authorization_adapter``
+(``gateway/authz_mixin.py``), which reads ``source.profile`` and fails closed
+rather than replying out of the default profile's bot. Contract under test:
+the injection path resolves through that same profile-aware resolver, and a
+genuine miss is logged rather than swallowed.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+class _Adapter:
+    """Minimal push-capable adapter stub."""
+
+    def __init__(self, name):
+        self.name = name
+        self.handle_message = AsyncMock()
+
+
+def _runner(default_adapters, profile_adapters):
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = default_adapters
+    runner._profile_adapters = profile_adapters
+    runner.config = SimpleNamespace(platforms={})
+    return runner
+
+
+def _alpha_event():
+    """A completion for the alpha profile's Matrix room (served by its own
+    ``@alpha-bot:example.org`` connection), as the watcher queues it."""
+    return {
+        "type": "process_completed",
+        "session_id": "proc_alpha_1",
+        "session_key": "agent:alpha:matrix:group:!room:example.org",
+        "platform": "matrix",
+        "chat_type": "group",
+        "chat_id": "!room:example.org",
+        "status": "completed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_injection_resolves_secondary_profile_adapter():
+    """The alpha profile's Matrix adapter must receive the completion, even
+    though ``self.adapters`` (the default profile's map) has no Matrix entry."""
+    alpha_adapter = _Adapter("matrix-alpha")
+    telegram = _Adapter("telegram-default")
+    runner = _runner(
+        {Platform.TELEGRAM: telegram},
+        {"alpha": {Platform.MATRIX: alpha_adapter}},
+    )
+
+    result = await runner._inject_watch_notification("[task finished]", _alpha_event())
+
+    assert result is True, (
+        f"injection returned {result!r} — the alpha completion was dropped at the "
+        "bare `return None`, exactly the multiplex symptom this fixes"
+    )
+    assert alpha_adapter.handle_message.await_count == 1
+    assert telegram.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_injection_does_not_leak_to_default_profile_adapter():
+    """Fail closed: when the alpha profile has no Matrix adapter, the default
+    profile's Matrix adapter must NOT be used — that answers out of the wrong
+    bot."""
+    default_matrix = _Adapter("matrix-default")
+    runner = _runner({Platform.MATRIX: default_matrix}, {"alpha": {}})
+
+    result = await runner._inject_watch_notification("[task finished]", _alpha_event())
+
+    assert result is None
+    assert default_matrix.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_default_profile_injection_unchanged():
+    """Control: a default-profile (``agent:main``) completion still resolves
+    through ``self.adapters`` exactly as before."""
+    matrix = _Adapter("matrix-default")
+    runner = _runner({Platform.MATRIX: matrix}, {})
+    evt = _alpha_event()
+    evt["session_key"] = "agent:main:matrix:group:!room:example.org"
+
+    result = await runner._inject_watch_notification("[task finished]", evt)
+
+    assert result is True
+    assert matrix.handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_adapter_is_logged_not_silent(caplog):
+    """The drop that used to be a bare ``return None`` must name the platform
+    and profile it could not resolve."""
+    runner = _runner({}, {"alpha": {}})
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification("[x]", _alpha_event())
+
+    assert result is None
+    assert any(
+        "no adapter for" in r.getMessage() and "alpha" in r.getMessage()
+        for r in caplog.records
+    ), f"expected a WARNING naming platform+profile, got: {[r.getMessage() for r in caplog.records]}"

--- a/tests/gateway/test_relay_transport_slot_routing.py
+++ b/tests/gateway/test_relay_transport_slot_routing.py
@@ -8,7 +8,9 @@ provenance alone therefore sends the completion through
 ``resolve_delivery_transport``, whose documented contract is native-wins, so a
 turn that arrived over Relay is answered by a different bot and credential.
 Contract under test: the commissioning turn also records which adapter slot
-received it, and completion resolves that slot directly or fails closed.
+received it as one atomic pair with the owner map, and completion either
+resolves that exact adapter, falls back for a record carrying neither field, or
+drops a record carrying a partial or contradictory pair.
 """
 
 import json
@@ -52,6 +54,16 @@ def _runner(default_adapters, profile_adapters=None):
     return runner
 
 
+def _dropped_with_the_return_address(caplog):
+    """Whether a drop WARNING named the damaged provenance and the return address."""
+    return any(
+        "incomplete or contradictory" in r.getMessage()
+        and "C0CHANNEL" in r.getMessage()
+        and "transport provenance" in r.getMessage()
+        for r in caplog.records
+    )
+
+
 def _slack_event(**overrides):
     """A Slack completion as the watcher queues it."""
     evt = {
@@ -63,11 +75,17 @@ def _slack_event(**overrides):
         "chat_id": "C0CHANNEL",
         "scope_id": "T0WORKSPACE",
         "profile": "",
-        "transport_profile": "default",
         "status": "completed",
     }
     evt.update(overrides)
     return evt
+
+
+def _relayed_event(**overrides):
+    """The same completion carrying exact relay provenance."""
+    return _slack_event(
+        transport_profile="default", transport_slot="relay", **overrides
+    )
 
 
 # Capture side: the slot is read off the receiving adapter.
@@ -86,6 +104,7 @@ def test_relay_ingress_records_the_relay_slot():
 
     assert runner._ingress_transport_slot(source) == "relay"
     assert runner._transport_owner_profile(source) == "default"
+    assert runner._capture_transport_provenance(source) == ("default", "relay")
 
 
 def test_native_ingress_records_its_own_slot():
@@ -100,6 +119,7 @@ def test_native_ingress_records_its_own_slot():
     source._transport_adapter_ref = weakref.ref(native)
 
     assert runner._ingress_transport_slot(source) == "slack"
+    assert runner._capture_transport_provenance(source) == ("default", "slack")
 
 
 def test_no_provenance_source_records_no_slot():
@@ -108,6 +128,10 @@ def test_no_provenance_source_records_no_slot():
     source = SimpleNamespace(platform=Platform.SLACK, profile="")
 
     assert runner._ingress_transport_slot(source) is None
+    assert runner._capture_transport_provenance(source) is None, (
+        "an unidentifiable transport must record neither field, so the "
+        "completion is classified legacy rather than partial"
+    )
 
 
 # Completion side.
@@ -120,7 +144,7 @@ async def test_relay_only_completion_is_delivered_through_the_relay():
     runner = _runner({Platform.RELAY: relay})
 
     result = await runner._inject_watch_notification(
-        "[task finished]", _slack_event(transport_slot="relay")
+        "[task finished]", _relayed_event()
     )
 
     assert result is True, (
@@ -142,7 +166,7 @@ async def test_mixed_map_relay_ingress_is_not_answered_by_the_native_adapter():
     runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
 
     result = await runner._inject_watch_notification(
-        "[task finished]", _slack_event(transport_slot="relay")
+        "[task finished]", _relayed_event()
     )
 
     assert result is True
@@ -161,7 +185,8 @@ async def test_mixed_map_native_ingress_is_not_answered_by_the_relay():
     runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
 
     result = await runner._inject_watch_notification(
-        "[task finished]", _slack_event(transport_slot="slack")
+        "[task finished]",
+        _slack_event(transport_profile="default", transport_slot="slack"),
     )
 
     assert result is True
@@ -177,7 +202,7 @@ async def test_dead_ingress_transport_fails_closed_with_the_return_address(caplo
 
     with caplog.at_level(logging.WARNING, logger="gateway.run"):
         result = await runner._inject_watch_notification(
-            "[x]", _slack_event(transport_slot="relay")
+            "[x]", _relayed_event()
         )
 
     assert result is None
@@ -190,8 +215,8 @@ async def test_dead_ingress_transport_fails_closed_with_the_return_address(caplo
 
 
 @pytest.mark.asyncio
-async def test_legacy_record_without_a_slot_keeps_alias_resolution():
-    """Control: a pre-existing record still resolves through the alias router."""
+async def test_legacy_record_without_provenance_keeps_alias_resolution():
+    """Control: a record carrying neither field still uses the alias router."""
     relay = _RelayAdapter()
     runner = _runner({Platform.RELAY: relay})
 
@@ -256,23 +281,177 @@ async def test_relay_slot_survives_a_gateway_restart(tmp_path, monkeypatch):
     assert native.handle_message.await_count == 0
 
 
+# Malformed records: exactly one field present, or a slot the turn could not
+# have arrived on. Owner and slot only identify a transport together, so a
+# damaged pair is a return address that cannot be trusted, not a legacy record.
+
+
 @pytest.mark.asyncio
-async def test_a_slot_the_turn_could_not_have_arrived_on_is_ignored():
-    """A damaged record must not deliver through an unrelated platform."""
-    discord = _Adapter("discord")
+async def test_a_contradictory_slot_drops_without_touching_either_adapter(caplog):
+    """A slot the Slack turn could not have arrived on is dropped, not re-guessed."""
+    relay = _RelayAdapter()
     native = _Adapter("slack-native")
-    runner = _runner({Platform.SLACK: native, Platform.DISCORD: discord})
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
 
-    result = await runner._inject_watch_notification(
-        "[task finished]", _slack_event(transport_slot="discord")
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification(
+            "[task finished]",
+            _slack_event(transport_profile="default", transport_slot="discord"),
+        )
+
+    assert result is None, (
+        "exact provenance was contradicted, yet another transport was chosen "
+        "and the completion delivered"
+    )
+    assert native.handle_message.await_count == 0
+    assert relay.handle_message.await_count == 0
+    assert _dropped_with_the_return_address(caplog)
+
+
+@pytest.mark.asyncio
+async def test_a_slot_without_an_owner_drops_and_never_reaches_a_default_bot(caplog):
+    """A slot with no owner must not be resolved against the default map."""
+    default_slack = _Adapter("slack-default")
+    alpha_slack = _Adapter("slack-alpha")
+    runner = _runner(
+        {Platform.SLACK: default_slack}, {"alpha": {Platform.SLACK: alpha_slack}}
     )
 
-    assert result is True
-    assert discord.handle_message.await_count == 0, (
-        "a Slack completion left through the Discord adapter because the "
-        "recorded slot was taken on trust"
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification(
+            "[task finished]", _slack_event(profile="alpha", transport_slot="slack")
+        )
+
+    assert result is None, (
+        "a partial record resolved to owner=default and answered through the "
+        "default bot"
     )
-    assert native.handle_message.await_count == 1
+    assert default_slack.handle_message.await_count == 0
+    assert alpha_slack.handle_message.await_count == 0
+    assert _dropped_with_the_return_address(caplog)
+
+
+@pytest.mark.asyncio
+async def test_an_owner_without_a_slot_drops_and_never_reaches_alias_resolution(caplog):
+    """An owner with no slot is incomplete, not a legacy record."""
+    default_slack = _Adapter("slack-default")
+    alpha_slack = _Adapter("slack-alpha")
+    runner = _runner(
+        {Platform.SLACK: default_slack}, {"alpha": {Platform.SLACK: alpha_slack}}
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification(
+            "[task finished]", _slack_event(profile="alpha", transport_profile="default")
+        )
+
+    assert result is None
+    assert default_slack.handle_message.await_count == 0
+    assert alpha_slack.handle_message.await_count == 0
+    assert _dropped_with_the_return_address(caplog)
+
+
+@pytest.mark.asyncio
+async def test_a_damaged_record_still_drops_after_a_process_restart(
+    tmp_path, monkeypatch, caplog
+):
+    """A checkpoint holding half a pair is dropped once it is replayed."""
+    from tools import process_registry as pr_mod
+
+    registry = pr_mod.ProcessRegistry()
+    session = pr_mod.ProcessSession(
+        id="proc_slot_damaged",
+        command="sleep 1",
+        session_key="agent:main:slack:group:T0WORKSPACE:C0CHANNEL",
+        pid=os.getpid(),
+        started_at=1.0,
+        watcher_platform="slack",
+        watcher_chat_id="C0CHANNEL",
+        watcher_chat_type="group",
+        watcher_scope_id="T0WORKSPACE",
+        watcher_profile="",
+        watcher_transport_profile="default",
+        watcher_interval=5,
+        notify_on_complete=True,
+    )
+    session.host_start_time = registry._safe_host_start_time(os.getpid())
+    registry._running[session.id] = session
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr_mod, "CHECKPOINT_PATH", checkpoint)
+    registry._write_checkpoint()
+
+    restarted = pr_mod.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 1
+    watcher = next(
+        w for w in restarted.pending_watchers if w["session_id"] == "proc_slot_damaged"
+    )
+
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+    evt = _slack_event(
+        session_id=watcher["session_id"],
+        transport_profile=watcher["transport_profile"],
+        transport_slot=watcher["transport_slot"],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification("[task finished]", evt)
+
+    assert result is None
+    assert native.handle_message.await_count == 0
+    assert relay.handle_message.await_count == 0
+    assert _dropped_with_the_return_address(caplog)
+
+
+@pytest.mark.asyncio
+async def test_a_damaged_delegation_record_still_drops_after_a_restart(
+    tmp_path, monkeypatch, caplog
+):
+    """The async-delegation replay leg carries the damage through, and it drops."""
+    from tools import async_delegation as ad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+
+    record = {
+        "delegation_id": "del_damaged",
+        "session_key": "agent:main:slack:group:T0WORKSPACE:C0CHANNEL",
+        "goal": "g",
+        "dispatched_at": 1.0,
+        "platform": "slack",
+        "chat_type": "group",
+        "chat_id": "C0CHANNEL",
+        "scope_id": "T0WORKSPACE",
+        "transport_slot": "relay",
+    }
+    ad._persist_dispatch(record)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+    assert ad.recover_abandoned_delegations() >= 1
+
+    with ad._connect() as conn:
+        event_json = conn.execute(
+            "SELECT event_json FROM async_delegations WHERE delegation_id=?",
+            ("del_damaged",),
+        ).fetchone()[0]
+    evt = json.loads(event_json)
+    assert evt["transport_slot"] == "relay"
+    assert not evt.get("transport_profile"), (
+        "the replay invented an owner for a record that never carried one"
+    )
+
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification("[delegation done]", evt)
+
+    assert result is None
+    assert relay.handle_message.await_count == 0
+    assert native.handle_message.await_count == 0
+    assert _dropped_with_the_return_address(caplog)
 
 
 def test_relay_ingress_outranks_a_native_registration_on_the_same_source():

--- a/tests/gateway/test_relay_transport_slot_routing.py
+++ b/tests/gateway/test_relay_transport_slot_routing.py
@@ -1,0 +1,256 @@
+"""Regression: the ingress transport identity, not only its owner map.
+
+``transport_profile`` names which adapter map owned the receiving adapter.
+Inside one map a logical platform can be served by two live transports: a
+native adapter and a Relay adapter that fronts the same platform (a supported
+mixed deployment — ``GATEWAY_RELAY_ALLOW_DIRECT_PLATFORMS``). ``default``
+provenance alone therefore sends the completion through
+``resolve_delivery_transport``, whose documented contract is native-wins, so a
+turn that arrived over Relay is answered by a different bot and credential.
+Contract under test: the commissioning turn also records which adapter slot
+received it, and completion resolves that slot directly or fails closed.
+"""
+
+import json
+import logging
+import os
+import weakref
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+class _Adapter:
+    """Minimal push-capable adapter stub."""
+
+    def __init__(self, name):
+        self.name = name
+        self.handle_message = AsyncMock()
+
+
+class _RelayAdapter(_Adapter):
+    """Relay stub that advertises a logical platform, as the real one does."""
+
+    def __init__(self, name="relay", fronted=(Platform.SLACK,)):
+        super().__init__(name)
+        self._fronted = tuple(fronted)
+
+    def fronts_platform(self, platform):
+        return platform in self._fronted
+
+
+def _runner(default_adapters, profile_adapters=None):
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = default_adapters
+    runner._profile_adapters = profile_adapters or {}
+    runner.config = SimpleNamespace(platforms={})
+    return runner
+
+
+def _slack_event(**overrides):
+    """A Slack completion as the watcher queues it."""
+    evt = {
+        "type": "process_completed",
+        "session_id": "proc_slot_1",
+        "session_key": "agent:main:slack:group:T0WORKSPACE:C0CHANNEL",
+        "platform": "slack",
+        "chat_type": "group",
+        "chat_id": "C0CHANNEL",
+        "scope_id": "T0WORKSPACE",
+        "profile": "",
+        "transport_profile": "default",
+        "status": "completed",
+    }
+    evt.update(overrides)
+    return evt
+
+
+# Capture side: the slot is read off the receiving adapter.
+
+
+def test_relay_ingress_records_the_relay_slot():
+    """A Slack turn arriving over Relay records ``relay``, not ``slack``."""
+    relay = _RelayAdapter()
+    runner = _runner({Platform.SLACK: _Adapter("slack-native"), Platform.RELAY: relay})
+    source = SimpleNamespace(
+        platform=Platform.SLACK,
+        profile="",
+        delivered_via_upstream_relay=True,
+    )
+    source._transport_adapter_ref = weakref.ref(relay)
+
+    assert runner._ingress_transport_slot(source) == "relay"
+    assert runner._transport_owner_profile(source) == "default"
+
+
+def test_native_ingress_records_its_own_slot():
+    """A turn on the native adapter records that platform's slot."""
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: _RelayAdapter()})
+    source = SimpleNamespace(
+        platform=Platform.SLACK,
+        profile="",
+        delivered_via_upstream_relay=False,
+    )
+    source._transport_adapter_ref = weakref.ref(native)
+
+    assert runner._ingress_transport_slot(source) == "slack"
+
+
+def test_no_provenance_source_records_no_slot():
+    """A hand-built or restored source keeps legacy alias resolution."""
+    runner = _runner({Platform.SLACK: _Adapter("slack-native")})
+    source = SimpleNamespace(platform=Platform.SLACK, profile="")
+
+    assert runner._ingress_transport_slot(source) is None
+
+
+# Completion side.
+
+
+@pytest.mark.asyncio
+async def test_relay_only_completion_is_delivered_through_the_relay():
+    """Relay is the only transport: the completion succeeds through it."""
+    relay = _RelayAdapter()
+    runner = _runner({Platform.RELAY: relay})
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _slack_event(transport_slot="relay")
+    )
+
+    assert result is True, (
+        f"injection returned {result!r} — the completion was dropped although "
+        "the recorded ingress transport is live"
+    )
+    assert relay.handle_message.await_count == 1
+    delivered = relay.handle_message.await_args[0][0]
+    assert delivered.source.platform == Platform.SLACK, (
+        "the logical platform must survive: the relay sends for slack"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_map_relay_ingress_is_not_answered_by_the_native_adapter():
+    """Both transports front Slack; a relayed turn returns over the relay."""
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _slack_event(transport_slot="relay")
+    )
+
+    assert result is True
+    assert relay.handle_message.await_count == 1
+    assert native.handle_message.await_count == 0, (
+        "answered out of the native Slack bot although the originating turn "
+        "arrived over the relay — a different credential than the user spoke to"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_map_native_ingress_is_not_answered_by_the_relay():
+    """Same topology, native-origin turn: the native adapter stays the route."""
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _slack_event(transport_slot="slack")
+    )
+
+    assert result is True
+    assert native.handle_message.await_count == 1
+    assert relay.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dead_ingress_transport_fails_closed_with_the_return_address(caplog):
+    """The recorded slot is gone: drop loudly rather than pick the survivor."""
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native})
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        result = await runner._inject_watch_notification(
+            "[x]", _slack_event(transport_slot="relay")
+        )
+
+    assert result is None
+    assert native.handle_message.await_count == 0
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "no longer live" in m and "'relay'" in m and "C0CHANNEL" in m
+        for m in messages
+    ), f"expected a WARNING naming the slot and the return address, got: {messages}"
+
+
+@pytest.mark.asyncio
+async def test_legacy_record_without_a_slot_keeps_alias_resolution():
+    """Control: a pre-existing record still resolves through the alias router."""
+    relay = _RelayAdapter()
+    runner = _runner({Platform.RELAY: relay})
+
+    result = await runner._inject_watch_notification("[task finished]", _slack_event())
+
+    assert result is True
+    assert relay.handle_message.await_count == 1
+
+
+# Restart / recovery leg: the discriminator is durable.
+
+
+@pytest.mark.asyncio
+async def test_relay_slot_survives_a_gateway_restart(tmp_path, monkeypatch):
+    """Checkpoint round-trip keeps the slot, so the relay still answers."""
+    from tools import process_registry as pr_mod
+
+    registry = pr_mod.ProcessRegistry()
+    session = pr_mod.ProcessSession(
+        id="proc_slot_restart",
+        command="sleep 1",
+        session_key="agent:main:slack:group:T0WORKSPACE:C0CHANNEL",
+        pid=os.getpid(),
+        started_at=1.0,
+        watcher_platform="slack",
+        watcher_chat_id="C0CHANNEL",
+        watcher_chat_type="group",
+        watcher_scope_id="T0WORKSPACE",
+        watcher_profile="",
+        watcher_transport_profile="default",
+        watcher_transport_slot="relay",
+        watcher_interval=5,
+        notify_on_complete=True,
+    )
+    session.host_start_time = registry._safe_host_start_time(os.getpid())
+    registry._running[session.id] = session
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr_mod, "CHECKPOINT_PATH", checkpoint)
+    registry._write_checkpoint()
+    assert json.loads(checkpoint.read_text())[0]["watcher_transport_slot"] == "relay"
+
+    restarted = pr_mod.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 1
+    watcher = next(
+        w for w in restarted.pending_watchers if w["session_id"] == "proc_slot_restart"
+    )
+    assert watcher["transport_slot"] == "relay"
+
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+    evt = _slack_event(
+        session_id=watcher["session_id"],
+        session_key=watcher["session_key"],
+        transport_profile=watcher["transport_profile"],
+        transport_slot=watcher["transport_slot"],
+    )
+
+    assert await runner._inject_watch_notification("[task finished]", evt) is True
+    assert relay.handle_message.await_count == 1
+    assert native.handle_message.await_count == 0

--- a/tests/gateway/test_relay_transport_slot_routing.py
+++ b/tests/gateway/test_relay_transport_slot_routing.py
@@ -254,3 +254,37 @@ async def test_relay_slot_survives_a_gateway_restart(tmp_path, monkeypatch):
     assert await runner._inject_watch_notification("[task finished]", evt) is True
     assert relay.handle_message.await_count == 1
     assert native.handle_message.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_slot_the_turn_could_not_have_arrived_on_is_ignored():
+    """A damaged record must not deliver through an unrelated platform."""
+    discord = _Adapter("discord")
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.DISCORD: discord})
+
+    result = await runner._inject_watch_notification(
+        "[task finished]", _slack_event(transport_slot="discord")
+    )
+
+    assert result is True
+    assert discord.handle_message.await_count == 0, (
+        "a Slack completion left through the Discord adapter because the "
+        "recorded slot was taken on trust"
+    )
+    assert native.handle_message.await_count == 1
+
+
+def test_relay_ingress_outranks_a_native_registration_on_the_same_source():
+    """The relay flag decides the slot, not the order of the lookups."""
+    relay = _RelayAdapter()
+    native = _Adapter("slack-native")
+    runner = _runner({Platform.SLACK: native, Platform.RELAY: relay})
+    source = SimpleNamespace(
+        platform=Platform.SLACK,
+        profile="",
+        delivered_via_upstream_relay=True,
+    )
+    source._transport_adapter_ref = weakref.ref(native)
+
+    assert runner._ingress_transport_slot(source) == "relay"

--- a/tests/gateway/test_session_key_roundtrip.py
+++ b/tests/gateway/test_session_key_roundtrip.py
@@ -1,19 +1,8 @@
 """Regression: ``parse_session_key`` must be the inverse of ``build_session_key``.
 
-A session key is colon-delimited and its grammar is platform-specific, so a
-positional ``split(":")`` is lossy on real keys:
-
-* a Matrix room id is ``!localpart:homeserver``, so
-  ``agent:main:matrix:group:!room:example.org`` split positionally yields
-  ``chat_id == "!room"`` — a room that does not exist — and silently discards
-  the homeserver;
-* ``build_session_key`` inserts the Slack workspace id BETWEEN the chat-type
-  slot and the chat id, so on a scoped Slack key the chat-id slot holds the
-  workspace.
-
-The contract these tests pin: for every shape ``build_session_key`` emits,
-parsing the key it built recovers the platform, chat type, chat id, workspace
-scope and profile it was built from.
+Session-key grammar is platform-specific, so a positional ``split(":")`` is lossy
+on real keys. For every shape ``build_session_key`` emits, parsing the key it
+built must recover the platform, chat type, chat id, workspace scope and profile.
 """
 
 import pytest
@@ -118,8 +107,7 @@ def test_parse_is_the_inverse_of_build(source, profile):
         f"{key!r} -> chat_id {parsed['chat_id']!r}; delivering there is "
         "delivering to the wrong chat"
     )
-    # ``main`` is a namespace literal, not a profile — it is reported as None so
-    # it can be handed straight to the profile-aware resolvers.
+    # ``main`` is a namespace literal, not a profile, so it is reported as None.
     assert parsed["profile"] == profile
     if source.scope_id:
         assert parsed.get("scope_id") == source.scope_id
@@ -127,15 +115,13 @@ def test_parse_is_the_inverse_of_build(source, profile):
 
 @pytest.mark.parametrize("source,profile", ROUND_TRIPS)
 def test_chat_type_slot_round_trips(source, profile):
-    """The chat-type slot survives, including Discord's prospective-thread
-    rewrite of ``group`` to ``thread``."""
+    """The chat-type slot survives, including Discord's ``group``/``thread`` rewrite."""
     key = build_session_key(source, profile=profile)
     assert parse_session_key(key)["chat_type"] == key.split(":")[2 + 1]
 
 
 def test_thread_id_only_where_the_grammar_is_unambiguous():
-    """A 6th token in a GROUP key may be a participant id, not a thread — so
-    ``thread_id`` is reported only for ``dm``/``thread``."""
+    """A group key's 6th token may be a participant, so no ``thread_id`` is reported."""
     group = build_session_key(
         _source(platform=Platform.DISCORD, chat_id="chan", chat_type="group", user_id="u1")
     )
@@ -163,6 +149,5 @@ def test_thread_id_only_where_the_grammar_is_unambiguous():
     ],
 )
 def test_non_keys_return_none(not_a_key):
-    """``_inject_watch_notification`` uses ``None`` here to tell a gateway
-    session key from a raw api_server session id it must self-post to."""
+    """``None`` is how ``_inject_watch_notification`` spots a non-gateway session id."""
     assert parse_session_key(not_a_key) is None

--- a/tests/gateway/test_session_key_roundtrip.py
+++ b/tests/gateway/test_session_key_roundtrip.py
@@ -1,0 +1,168 @@
+"""Regression: ``parse_session_key`` must be the inverse of ``build_session_key``.
+
+A session key is colon-delimited and its grammar is platform-specific, so a
+positional ``split(":")`` is lossy on real keys:
+
+* a Matrix room id is ``!localpart:homeserver``, so
+  ``agent:main:matrix:group:!room:example.org`` split positionally yields
+  ``chat_id == "!room"`` — a room that does not exist — and silently discards
+  the homeserver;
+* ``build_session_key`` inserts the Slack workspace id BETWEEN the chat-type
+  slot and the chat id, so on a scoped Slack key the chat-id slot holds the
+  workspace.
+
+The contract these tests pin: for every shape ``build_session_key`` emits,
+parsing the key it built recovers the platform, chat type, chat id, workspace
+scope and profile it was built from.
+"""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource, build_session_key, parse_session_key
+
+
+def _source(**kwargs) -> SessionSource:
+    kwargs.setdefault("chat_type", "group")
+    return SessionSource(**kwargs)
+
+
+ROUND_TRIPS = [
+    pytest.param(
+        _source(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_type="group",
+            user_id="@user:example.org",
+        ),
+        "alpha",
+        id="matrix-group-colon-room-id-and-colon-user-id",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_type="dm",
+            user_id="@user:example.org",
+        ),
+        None,
+        id="matrix-dm-colon-room-id",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_type="thread",
+            thread_id="$event:example.org",
+        ),
+        "alpha",
+        id="matrix-thread-colon-room-and-colon-thread-id",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.SLACK,
+            chat_id="C0CHANNEL",
+            chat_type="group",
+            scope_id="T0WORKSPACE",
+            user_id="U0USER",
+        ),
+        None,
+        id="slack-scoped-group",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.SLACK,
+            chat_id="D0DIRECT",
+            chat_type="dm",
+            scope_id="T0WORKSPACE",
+        ),
+        "alpha",
+        id="slack-scoped-dm",
+    ),
+    pytest.param(
+        _source(platform=Platform.SLACK, chat_id="D0DIRECT", chat_type="dm"),
+        None,
+        id="slack-unscoped-dm",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.DISCORD,
+            chat_id="123456",
+            chat_type="group",
+            user_id="789",
+        ),
+        None,
+        id="discord-group-per-user",
+    ),
+    pytest.param(
+        _source(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_type="thread",
+            thread_id="42",
+        ),
+        "alpha",
+        id="telegram-forum-topic",
+    ),
+]
+
+
+@pytest.mark.parametrize("source,profile", ROUND_TRIPS)
+def test_parse_is_the_inverse_of_build(source, profile):
+    key = build_session_key(source, profile=profile)
+    parsed = parse_session_key(key)
+
+    assert parsed is not None, f"{key!r} did not parse"
+    assert parsed["platform"] == source.platform.value
+    assert parsed["chat_id"] == source.chat_id, (
+        f"{key!r} -> chat_id {parsed['chat_id']!r}; delivering there is "
+        "delivering to the wrong chat"
+    )
+    # ``main`` is a namespace literal, not a profile — it is reported as None so
+    # it can be handed straight to the profile-aware resolvers.
+    assert parsed["profile"] == profile
+    if source.scope_id:
+        assert parsed.get("scope_id") == source.scope_id
+
+
+@pytest.mark.parametrize("source,profile", ROUND_TRIPS)
+def test_chat_type_slot_round_trips(source, profile):
+    """The chat-type slot survives, including Discord's prospective-thread
+    rewrite of ``group`` to ``thread``."""
+    key = build_session_key(source, profile=profile)
+    assert parse_session_key(key)["chat_type"] == key.split(":")[2 + 1]
+
+
+def test_thread_id_only_where_the_grammar_is_unambiguous():
+    """A 6th token in a GROUP key may be a participant id, not a thread — so
+    ``thread_id`` is reported only for ``dm``/``thread``."""
+    group = build_session_key(
+        _source(platform=Platform.DISCORD, chat_id="chan", chat_type="group", user_id="u1")
+    )
+    assert "thread_id" not in parse_session_key(group)
+
+    thread = build_session_key(
+        _source(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_type="thread",
+            thread_id="$evt:example.org",
+        )
+    )
+    assert parse_session_key(thread)["thread_id"] == "$evt:example.org"
+
+
+@pytest.mark.parametrize(
+    "not_a_key",
+    [
+        "",
+        "sess_abc123",                    # raw api_server session id
+        "agent:main:matrix:dm",           # too short
+        "agent::matrix:dm:!room",         # empty namespace slot
+        "chatcmpl-xyz",
+    ],
+)
+def test_non_keys_return_none(not_a_key):
+    """``_inject_watch_notification`` uses ``None`` here to tell a gateway
+    session key from a raw api_server session id it must self-post to."""
+    assert parse_session_key(not_a_key) is None

--- a/tests/tools/test_async_delegation_routing_capture.py
+++ b/tests/tools/test_async_delegation_routing_capture.py
@@ -1,0 +1,206 @@
+"""Regression: async delegation must carry a STRUCTURED return address.
+
+``tools/async_delegation.py`` persisted ``session_key`` plus a few origin fields
+(scope_id / user_id / user_name) and nothing else, so a completion had to be
+reconstructed by splitting the session key on ``":"``. That grammar is
+platform-specific and lossy — a Matrix room id is ``!room:server``, and a Slack
+key carries the workspace id between the chat-type slot and the chat id — so the
+completion could target the wrong chat even with the adapter lookup fixed.
+
+And ``profile`` (the runtime namespace) is not the transport owner: one shared
+credential can serve several routed runtimes. ``transport_profile`` is carried
+separately, and is what the gateway re-resolves the delivering adapter from.
+
+These tests pin the capture at dispatch, its replay onto the completion event,
+and its survival across a restart (durable record -> recovery -> event).
+"""
+
+import json
+import os
+
+import pytest
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools import async_delegation as ad
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point the durable state.db at a temp dir — no network, no shared state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    return tmp_path
+
+
+@pytest.fixture
+def matrix_turn():
+    """A turn that arrived on the SHARED PRIMARY Matrix transport but is routed
+    into the secondary runtime ``alpha`` — the topology where the runtime
+    namespace and the transport owner disagree."""
+    tokens = set_session_vars(
+        platform="matrix",
+        chat_id="!room:example.org",
+        chat_type="group",
+        thread_id="",
+        user_id="@user:example.org",
+        user_name="user",
+        session_key="agent:alpha:matrix:group:!room:example.org",
+        profile="alpha",
+        transport_profile="default",
+    )
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+@pytest.fixture
+def slack_turn():
+    """A Slack turn in a scoped (workspace-qualified) channel."""
+    tokens = set_session_vars(
+        platform="slack",
+        chat_id="C0CHANNEL",
+        chat_type="group",
+        scope_id="T0WORKSPACE",
+        user_id="U0USER",
+        session_key="agent:main:slack:group:T0WORKSPACE:C0CHANNEL:U0USER",
+        profile="",
+        transport_profile="default",
+    )
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_capture_records_the_full_return_address_matrix(matrix_turn):
+    """(d) The colon-bearing Matrix room id is captured whole — not recovered
+    later by splitting the key, which would yield ``!room``."""
+    origin = ad._capture_routing_origin()
+
+    assert origin["platform"] == "matrix"
+    assert origin["chat_type"] == "group"
+    assert origin["chat_id"] == "!room:example.org"
+    assert origin["profile"] == "alpha"
+    assert origin["transport_profile"] == "default"
+
+
+def test_capture_records_the_slack_workspace_scope(slack_turn):
+    """(e) The workspace scope and the channel are separate captured fields, so
+    neither can end up in the other's slot."""
+    origin = ad._capture_routing_origin()
+
+    assert origin["platform"] == "slack"
+    assert origin["scope_id"] == "T0WORKSPACE"
+    assert origin["chat_id"] == "C0CHANNEL"
+    assert origin["transport_profile"] == "default"
+
+
+def test_capture_outside_a_gateway_turn_is_empty():
+    """CLI / contextvar-unaware paths persist nothing new."""
+    tokens = set_session_vars()
+    try:
+        assert ad._capture_routing_origin() == {}
+    finally:
+        clear_session_vars(tokens)
+
+
+def _pushed_event(monkeypatch, record):
+    """Run _push_completion_event against a stub queue and return the event."""
+    pushed = []
+
+    class _Q:
+        @staticmethod
+        def put(evt):
+            pushed.append(evt)
+
+    class _Registry:
+        completion_queue = _Q()
+
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr, "process_registry", _Registry)
+    monkeypatch.setattr(ad, "_persist_completion", lambda *a, **k: None)
+    ad._push_completion_event(record, {"status": "completed", "summary": "done"}, "completed")
+    assert pushed, "no completion event was queued"
+    return pushed[0]
+
+
+def test_completion_event_carries_the_captured_address(monkeypatch, matrix_turn):
+    """The completion the gateway consumes is fully addressed — no session-key
+    parsing needed on the delivery path."""
+    record = {
+        "delegation_id": "del_1",
+        "session_key": "agent:alpha:matrix:group:!room:example.org",
+        "goal": "g",
+        "dispatched_at": 1.0,
+        "completed_at": 2.0,
+        **ad._capture_routing_origin(),
+    }
+
+    evt = _pushed_event(monkeypatch, record)
+
+    assert evt["platform"] == "matrix"
+    assert evt["chat_type"] == "group"
+    assert evt["chat_id"] == "!room:example.org"
+    assert evt["profile"] == "alpha"
+    assert evt["transport_profile"] == "default"
+
+
+def test_slack_completion_event_routes_to_the_right_chat(monkeypatch, slack_turn):
+    """(e) end to end: the channel is the chat id and the workspace is the
+    scope, on the event the gateway delivers from."""
+    record = {
+        "delegation_id": "del_slack",
+        "session_key": "agent:main:slack:group:T0WORKSPACE:C0CHANNEL:U0USER",
+        "goal": "g",
+        "dispatched_at": 1.0,
+        "completed_at": 2.0,
+        **ad._capture_routing_origin(),
+    }
+
+    evt = _pushed_event(monkeypatch, record)
+
+    assert evt["chat_id"] == "C0CHANNEL"
+    assert evt["scope_id"] == "T0WORKSPACE"
+
+
+def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatch):
+    """(f) Durable leg: persist the dispatch, then recover it as an owner-died
+    record in a fresh process. The replayed event must carry the same address
+    and the same transport provenance."""
+    record = {
+        "delegation_id": "del_restart",
+        "session_key": "agent:alpha:matrix:group:!room:example.org",
+        "goal": "g",
+        "dispatched_at": 1.0,
+        # An owner pid that cannot be alive, so recovery classifies it.
+        **ad._capture_routing_origin(),
+    }
+    ad._persist_dispatch(record)
+
+    # The address is on disk, not merely in memory.
+    with ad._connect() as conn:
+        task_json = conn.execute(
+            "SELECT task_json FROM async_delegations WHERE delegation_id=?",
+            ("del_restart",),
+        ).fetchone()[0]
+    persisted = json.loads(task_json)
+    assert persisted["chat_id"] == "!room:example.org"
+    assert persisted["transport_profile"] == "default"
+
+    # --- restart: the owning process is gone ---
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+    assert ad.recover_abandoned_delegations() >= 1
+
+    with ad._connect() as conn:
+        event_json = conn.execute(
+            "SELECT event_json FROM async_delegations WHERE delegation_id=?",
+            ("del_restart",),
+        ).fetchone()[0]
+    event = json.loads(event_json)
+
+    assert event["platform"] == "matrix"
+    assert event["chat_type"] == "group"
+    assert event["chat_id"] == "!room:example.org"
+    assert event["profile"] == "alpha"
+    assert event["transport_profile"] == "default"

--- a/tests/tools/test_async_delegation_routing_capture.py
+++ b/tests/tools/test_async_delegation_routing_capture.py
@@ -1,18 +1,9 @@
-"""Regression: async delegation must carry a STRUCTURED return address.
+"""Regression: async delegation must carry a structured return address.
 
-``tools/async_delegation.py`` persisted ``session_key`` plus a few origin fields
-(scope_id / user_id / user_name) and nothing else, so a completion had to be
-reconstructed by splitting the session key on ``":"``. That grammar is
-platform-specific and lossy — a Matrix room id is ``!room:server``, and a Slack
-key carries the workspace id between the chat-type slot and the chat id — so the
-completion could target the wrong chat even with the adapter lookup fixed.
-
-And ``profile`` (the runtime namespace) is not the transport owner: one shared
-credential can serve several routed runtimes. ``transport_profile`` is carried
-separately, and is what the gateway re-resolves the delivering adapter from.
-
-These tests pin the capture at dispatch, its replay onto the completion event,
-and its survival across a restart (durable record -> recovery -> event).
+Session-key grammar is platform-specific and lossy to split, and the runtime
+namespace ``profile`` is not the transport owner. These tests pin the capture at
+dispatch, its replay onto the completion event, and its survival across a
+restart (durable record -> recovery -> event).
 """
 
 import json
@@ -26,7 +17,7 @@ from tools import async_delegation as ad
 
 @pytest.fixture
 def hermes_home(tmp_path, monkeypatch):
-    """Point the durable state.db at a temp dir — no network, no shared state."""
+    """Point the durable state.db at a temp dir."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
     return tmp_path
@@ -34,9 +25,7 @@ def hermes_home(tmp_path, monkeypatch):
 
 @pytest.fixture
 def matrix_turn():
-    """A turn that arrived on the SHARED PRIMARY Matrix transport but is routed
-    into the secondary runtime ``alpha`` — the topology where the runtime
-    namespace and the transport owner disagree."""
+    """A shared-primary Matrix turn routed into the secondary runtime ``alpha``."""
     tokens = set_session_vars(
         platform="matrix",
         chat_id="!room:example.org",
@@ -74,8 +63,7 @@ def slack_turn():
 
 
 def test_capture_records_the_full_return_address_matrix(matrix_turn):
-    """(d) The colon-bearing Matrix room id is captured whole — not recovered
-    later by splitting the key, which would yield ``!room``."""
+    """The colon-bearing Matrix room id is captured whole."""
     origin = ad._capture_routing_origin()
 
     assert origin["platform"] == "matrix"
@@ -86,8 +74,7 @@ def test_capture_records_the_full_return_address_matrix(matrix_turn):
 
 
 def test_capture_records_the_slack_workspace_scope(slack_turn):
-    """(e) The workspace scope and the channel are separate captured fields, so
-    neither can end up in the other's slot."""
+    """The workspace scope and the channel are captured as separate fields."""
     origin = ad._capture_routing_origin()
 
     assert origin["platform"] == "slack"
@@ -126,8 +113,7 @@ def _pushed_event(monkeypatch, record):
 
 
 def test_completion_event_carries_the_captured_address(monkeypatch, matrix_turn):
-    """The completion the gateway consumes is fully addressed — no session-key
-    parsing needed on the delivery path."""
+    """The completion the gateway consumes is fully addressed."""
     record = {
         "delegation_id": "del_1",
         "session_key": "agent:alpha:matrix:group:!room:example.org",
@@ -147,8 +133,7 @@ def test_completion_event_carries_the_captured_address(monkeypatch, matrix_turn)
 
 
 def test_slack_completion_event_routes_to_the_right_chat(monkeypatch, slack_turn):
-    """(e) end to end: the channel is the chat id and the workspace is the
-    scope, on the event the gateway delivers from."""
+    """On the delivered event the channel is the chat id and the workspace the scope."""
     record = {
         "delegation_id": "del_slack",
         "session_key": "agent:main:slack:group:T0WORKSPACE:C0CHANNEL:U0USER",
@@ -165,9 +150,7 @@ def test_slack_completion_event_routes_to_the_right_chat(monkeypatch, slack_turn
 
 
 def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatch):
-    """(f) Durable leg: persist the dispatch, then recover it as an owner-died
-    record in a fresh process. The replayed event must carry the same address
-    and the same transport provenance."""
+    """A dispatch recovered as an owner-died record replays the same address."""
     record = {
         "delegation_id": "del_restart",
         "session_key": "agent:alpha:matrix:group:!room:example.org",
@@ -188,7 +171,7 @@ def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatc
     assert persisted["chat_id"] == "!room:example.org"
     assert persisted["transport_profile"] == "default"
 
-    # --- restart: the owning process is gone ---
+    # Restart: the owning process is gone.
     monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
     assert ad.recover_abandoned_delegations() >= 1
 

--- a/tests/tools/test_async_delegation_routing_capture.py
+++ b/tests/tools/test_async_delegation_routing_capture.py
@@ -87,6 +87,26 @@ def test_capture_records_the_slack_workspace_scope(slack_turn):
     assert origin["transport_slot"] == "relay"
 
 
+def test_a_damaged_context_is_captured_as_a_pair_not_completed():
+    """A half provenance context stays visibly half, so delivery can drop it."""
+    tokens = set_session_vars(
+        platform="slack",
+        chat_id="C0CHANNEL",
+        session_key="agent:main:slack:group:C0CHANNEL",
+        transport_profile="default",
+    )
+    try:
+        origin = ad._capture_routing_origin()
+    finally:
+        clear_session_vars(tokens)
+
+    assert origin["transport_profile"] == "default"
+    assert origin["transport_slot"] == "", (
+        "the missing half was omitted instead of recorded, so the completion "
+        "would be replayed as a legacy record and alias-resolved"
+    )
+
+
 def test_capture_outside_a_gateway_turn_is_empty():
     """CLI / contextvar-unaware paths persist nothing new."""
     tokens = set_session_vars()

--- a/tests/tools/test_async_delegation_routing_capture.py
+++ b/tests/tools/test_async_delegation_routing_capture.py
@@ -36,6 +36,7 @@ def matrix_turn():
         session_key="agent:alpha:matrix:group:!room:example.org",
         profile="alpha",
         transport_profile="default",
+        transport_slot="matrix",
     )
     try:
         yield
@@ -55,6 +56,8 @@ def slack_turn():
         session_key="agent:main:slack:group:T0WORKSPACE:C0CHANNEL:U0USER",
         profile="",
         transport_profile="default",
+        # Relay ingress: the owner map is the default one, the slot is not.
+        transport_slot="relay",
     )
     try:
         yield
@@ -81,6 +84,7 @@ def test_capture_records_the_slack_workspace_scope(slack_turn):
     assert origin["scope_id"] == "T0WORKSPACE"
     assert origin["chat_id"] == "C0CHANNEL"
     assert origin["transport_profile"] == "default"
+    assert origin["transport_slot"] == "relay"
 
 
 def test_capture_outside_a_gateway_turn_is_empty():
@@ -147,6 +151,10 @@ def test_slack_completion_event_routes_to_the_right_chat(monkeypatch, slack_turn
 
     assert evt["chat_id"] == "C0CHANNEL"
     assert evt["scope_id"] == "T0WORKSPACE"
+    assert evt["transport_slot"] == "relay", (
+        "the completion would be resolved by the native-wins alias router and "
+        "leave through a different Slack transport than the turn arrived on"
+    )
 
 
 def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatch):
@@ -170,6 +178,7 @@ def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatc
     persisted = json.loads(task_json)
     assert persisted["chat_id"] == "!room:example.org"
     assert persisted["transport_profile"] == "default"
+    assert persisted["transport_slot"] == "matrix"
 
     # Restart: the owning process is gone.
     monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
@@ -187,3 +196,4 @@ def test_routing_address_survives_a_restart(hermes_home, matrix_turn, monkeypatc
     assert event["chat_id"] == "!room:example.org"
     assert event["profile"] == "alpha"
     assert event["transport_profile"] == "default"
+    assert event["transport_slot"] == "matrix"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -49,6 +49,12 @@ from typing import Any, Callable, Dict, Iterator, List, Optional
 from hermes_constants import get_hermes_home
 from tools.daemon_pool import DaemonThreadPoolExecutor
 from tools.thread_context import propagate_context_to_thread
+from gateway.transport_provenance import (
+    PROVENANCE_KEYS,
+    provenance_fields,
+    provenance_from_session_env,
+    read_provenance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -213,11 +219,22 @@ _ROUTING_ORIGIN_FIELDS = (
     ("user_id", "HERMES_SESSION_USER_ID"),
     ("user_name", "HERMES_SESSION_USER_NAME"),
     ("profile", "HERMES_SESSION_PROFILE"),
-    ("transport_profile", "HERMES_SESSION_TRANSPORT_PROFILE"),
-    ("transport_slot", "HERMES_SESSION_TRANSPORT_SLOT"),
 )
 
-_ROUTING_ORIGIN_KEYS = tuple(key for key, _ in _ROUTING_ORIGIN_FIELDS)
+# The transport provenance pair is deliberately not in the tuple above: it is
+# captured, persisted and replayed as one unit (see gateway.transport_provenance)
+# so no leg of this path can emit half a return address.
+_ROUTING_ORIGIN_KEYS = tuple(key for key, _ in _ROUTING_ORIGIN_FIELDS) + PROVENANCE_KEYS
+
+
+def _copy_routing_origin(source: Any, event: Dict[str, Any]) -> None:
+    """Replay a recorded return address from *source* onto *event*."""
+    for key, _ in _ROUTING_ORIGIN_FIELDS:
+        if source.get(key):
+            event[key] = source[key]
+    provenance = read_provenance(source)
+    if any(provenance):
+        event.update(provenance_fields(provenance))
 
 
 def _capture_routing_origin() -> Dict[str, Any]:
@@ -242,6 +259,9 @@ def _capture_routing_origin() -> Dict[str, Any]:
             value = get_session_env(env_name, "")
             if value:
                 origin[evt_key] = value
+        provenance = provenance_from_session_env(get_session_env)
+        if any(provenance):
+            origin.update(provenance_fields(provenance))
     except Exception:  # noqa: BLE001 - routing origin is additive, never fatal
         pass
     return origin
@@ -384,9 +404,7 @@ def recover_abandoned_delegations() -> int:
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            for _k in _ROUTING_ORIGIN_KEYS:
-                if task.get(_k):
-                    event[_k] = task[_k]
+            _copy_routing_origin(task, event)
             result = {"status": "unknown", "summary": None, "error": event["error"]}
             conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
@@ -995,9 +1013,7 @@ def _push_completion_event(
         "exit_reason": result.get("exit_reason"),
     }
     # Routing origin captured at dispatch (see _capture_routing_origin).
-    for _k in _ROUTING_ORIGIN_KEYS:
-        if record.get(_k):
-            evt[_k] = record[_k]
+    _copy_routing_origin(record, evt)
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
     for _k in (
@@ -1209,9 +1225,7 @@ def _push_batch_completion_event(
         "completed_at": completed_at,
     }
     # Routing origin captured at dispatch (see _capture_routing_origin).
-    for _k in _ROUTING_ORIGIN_KEYS:
-        if event_record.get(_k):
-            evt[_k] = event_record[_k]
+    _copy_routing_origin(event_record, evt)
     # Structured stall metadata (#51690) — additive, present only on
     # stall-monitor finalizations.
     for _k in (

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -202,6 +202,35 @@ def _transaction() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
+# The STRUCTURED return address an async delegation must carry from the
+# commissioning turn to its completion, mapped to the session contextvar that
+# holds each field.
+#
+# ``session_key`` alone is not a return address: it is colon-delimited and its
+# grammar is platform-specific (a Matrix room id is ``!room:server``; a Slack
+# key carries the workspace id between the chat-type slot and the chat id), so
+# a completion reconstructed by splitting it can target the wrong chat. And
+# ``profile`` — the runtime namespace — is not the transport owner: one shared
+# credential can serve several routed runtimes, so ``transport_profile`` is
+# carried separately and is what the gateway re-resolves the delivering adapter
+# from (see GatewayAuthorizationMixin._transport_owner_profile).
+_ROUTING_ORIGIN_FIELDS = (
+    ("platform", "HERMES_SESSION_PLATFORM"),
+    ("chat_type", "HERMES_SESSION_CHAT_TYPE"),
+    ("chat_id", "HERMES_SESSION_CHAT_ID"),
+    ("thread_id", "HERMES_SESSION_THREAD_ID"),
+    ("scope_id", "HERMES_SESSION_SCOPE_ID"),
+    ("user_id", "HERMES_SESSION_USER_ID"),
+    ("user_name", "HERMES_SESSION_USER_NAME"),
+    ("profile", "HERMES_SESSION_PROFILE"),
+    ("transport_profile", "HERMES_SESSION_TRANSPORT_PROFILE"),
+)
+
+#: The keys :func:`_capture_routing_origin` can produce — persisted with the
+#: durable record and replayed onto the completion event.
+_ROUTING_ORIGIN_KEYS = tuple(key for key, _ in _ROUTING_ORIGIN_FIELDS)
+
+
 def _capture_routing_origin() -> Dict[str, Any]:
     """Snapshot the dispatching turn's routing origin for the completion event.
 
@@ -220,11 +249,7 @@ def _capture_routing_origin() -> Dict[str, Any]:
     try:
         from gateway.session_context import get_session_env
 
-        for evt_key, env_name in (
-            ("scope_id", "HERMES_SESSION_SCOPE_ID"),
-            ("user_id", "HERMES_SESSION_USER_ID"),
-            ("user_name", "HERMES_SESSION_USER_NAME"),
-        ):
+        for evt_key, env_name in _ROUTING_ORIGIN_FIELDS:
             value = get_session_env(env_name, "")
             if value:
                 origin[evt_key] = value
@@ -244,10 +269,12 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         key: record.get(key)
         for key in (
             "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
-            # Routing origin (scope_id/user_id/user_name): persisted so a
-            # restart-recovered completion can reconstruct a full
-            # SessionSource — see _capture_routing_origin.
-            "scope_id", "user_id", "user_name",
+            # Structured return address + transport provenance: persisted so
+            # a restart-recovered completion reconstructs the SAME
+            # SessionSource and delivers through the SAME transport, without
+            # re-deriving either from the session key — see
+            # _capture_routing_origin.
+            *_ROUTING_ORIGIN_KEYS,
         )
         if key in record
     }
@@ -373,9 +400,10 @@ def recover_abandoned_delegations() -> int:
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
             # Routing origin persisted at dispatch (see _capture_routing_origin):
-            # restores scope_id/user_id for the reconstructed SessionSource so
-            # relay egress priming works after a restart.
-            for _k in ("scope_id", "user_id", "user_name"):
+            # restores the full structured return address AND the transport
+            # provenance, so a completion replayed after a restart routes to
+            # the same chat through the same bot.
+            for _k in _ROUTING_ORIGIN_KEYS:
                 if task.get(_k):
                     event[_k] = task[_k]
             result = {"status": "unknown", "summary": None, "error": event["error"]}
@@ -986,9 +1014,9 @@ def _push_completion_event(
         "exit_reason": result.get("exit_reason"),
     }
     # Routing origin captured at dispatch (see _capture_routing_origin):
-    # additive, lets the gateway reconstruct a full SessionSource (incl.
-    # scope_id for relay tenant egress) when its own caches are cold.
-    for _k in ("scope_id", "user_id", "user_name"):
+    # the full structured return address plus transport provenance, so the
+    # gateway never has to re-derive either from the session key.
+    for _k in _ROUTING_ORIGIN_KEYS:
         if record.get(_k):
             evt[_k] = record[_k]
     # Structured stall metadata (#51690) — additive, present only on
@@ -1202,7 +1230,7 @@ def _push_batch_completion_event(
         "completed_at": completed_at,
     }
     # Routing origin captured at dispatch (see _capture_routing_origin).
-    for _k in ("scope_id", "user_id", "user_name"):
+    for _k in _ROUTING_ORIGIN_KEYS:
         if event_record.get(_k):
             evt[_k] = event_record[_k]
     # Structured stall metadata (#51690) — additive, present only on

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -214,6 +214,7 @@ _ROUTING_ORIGIN_FIELDS = (
     ("user_name", "HERMES_SESSION_USER_NAME"),
     ("profile", "HERMES_SESSION_PROFILE"),
     ("transport_profile", "HERMES_SESSION_TRANSPORT_PROFILE"),
+    ("transport_slot", "HERMES_SESSION_TRANSPORT_SLOT"),
 )
 
 _ROUTING_ORIGIN_KEYS = tuple(key for key, _ in _ROUTING_ORIGIN_FIELDS)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -202,18 +202,8 @@ def _transaction() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-# The STRUCTURED return address an async delegation must carry from the
-# commissioning turn to its completion, mapped to the session contextvar that
-# holds each field.
-#
-# ``session_key`` alone is not a return address: it is colon-delimited and its
-# grammar is platform-specific (a Matrix room id is ``!room:server``; a Slack
-# key carries the workspace id between the chat-type slot and the chat id), so
-# a completion reconstructed by splitting it can target the wrong chat. And
-# ``profile`` — the runtime namespace — is not the transport owner: one shared
-# credential can serve several routed runtimes, so ``transport_profile`` is
-# carried separately and is what the gateway re-resolves the delivering adapter
-# from (see GatewayAuthorizationMixin._transport_owner_profile).
+# The return address carried from the commissioning turn to the completion:
+# session_key is lossy to split, and the runtime profile is not the transport.
 _ROUTING_ORIGIN_FIELDS = (
     ("platform", "HERMES_SESSION_PLATFORM"),
     ("chat_type", "HERMES_SESSION_CHAT_TYPE"),
@@ -226,8 +216,6 @@ _ROUTING_ORIGIN_FIELDS = (
     ("transport_profile", "HERMES_SESSION_TRANSPORT_PROFILE"),
 )
 
-#: The keys :func:`_capture_routing_origin` can produce — persisted with the
-#: durable record and replayed onto the completion event.
 _ROUTING_ORIGIN_KEYS = tuple(key for key, _ in _ROUTING_ORIGIN_FIELDS)
 
 
@@ -269,11 +257,7 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         key: record.get(key)
         for key in (
             "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
-            # Structured return address + transport provenance: persisted so
-            # a restart-recovered completion reconstructs the SAME
-            # SessionSource and delivers through the SAME transport, without
-            # re-deriving either from the session key — see
-            # _capture_routing_origin.
+            # Routing origin persisted at dispatch (see _capture_routing_origin).
             *_ROUTING_ORIGIN_KEYS,
         )
         if key in record
@@ -399,10 +383,6 @@ def recover_abandoned_delegations() -> int:
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            # Routing origin persisted at dispatch (see _capture_routing_origin):
-            # restores the full structured return address AND the transport
-            # provenance, so a completion replayed after a restart routes to
-            # the same chat through the same bot.
             for _k in _ROUTING_ORIGIN_KEYS:
                 if task.get(_k):
                     event[_k] = task[_k]
@@ -1013,9 +993,7 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
-    # Routing origin captured at dispatch (see _capture_routing_origin):
-    # the full structured return address plus transport provenance, so the
-    # gateway never has to re-derive either from the session key.
+    # Routing origin captured at dispatch (see _capture_routing_origin).
     for _k in _ROUTING_ORIGIN_KEYS:
         if record.get(_k):
             evt[_k] = record[_k]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -373,6 +373,27 @@ def format_uptime_short(seconds: int) -> str:
     return f"{hours}h {mins}m"
 
 
+def _watcher_return_address(session: "ProcessSession") -> Dict[str, Any]:
+    """The structured return address recorded when *session* was commissioned.
+
+    One place, so every event this registry queues carries the same complete
+    address — including the transport provenance the gateway re-resolves the
+    delivering adapter from.
+    """
+    return {
+        "platform": session.watcher_platform,
+        "chat_id": session.watcher_chat_id,
+        "chat_type": session.watcher_chat_type,
+        "scope_id": session.watcher_scope_id,
+        "user_id": session.watcher_user_id,
+        "user_name": session.watcher_user_name,
+        "thread_id": session.watcher_thread_id,
+        "message_id": session.watcher_message_id,
+        "profile": session.watcher_profile,
+        "transport_profile": session.watcher_transport_profile,
+    }
+
+
 @dataclass
 class ProcessSession:
     """A tracked background process with output buffering."""
@@ -398,6 +419,23 @@ class ProcessSession:
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
+    # The rest of the STRUCTURED return address, captured when the process was
+    # commissioned (tools/terminal_tool.py). Before these existed the gateway
+    # had to recover chat_type/scope_id/profile by splitting the session_key on
+    # ":", which is lossy for real key grammar (Matrix ids are ``!room:server``;
+    # Slack keys carry the workspace id before the chat id) — see
+    # gateway.session.parse_session_key.
+    watcher_chat_type: str = ""
+    watcher_scope_id: str = ""
+    # Runtime namespace this process's turn was routed to.
+    watcher_profile: str = ""
+    # TRANSPORT PROVENANCE: the profile that owns the ADAPTER the commissioning
+    # turn arrived on ("default" for the process-default adapter map). Distinct
+    # from watcher_profile: one shared credential can serve several routed
+    # runtimes, and only this identifies the bot that must answer. Recorded as a
+    # NAME, never an adapter object, so it survives reconnects and restarts and
+    # is re-resolved to whatever adapter is live at completion time.
+    watcher_transport_profile: str = ""
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
@@ -625,12 +663,7 @@ class ProcessRegistry:
                     "command": session.command,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
-                    "platform": session.watcher_platform,
-                    "chat_id": session.watcher_chat_id,
-                    "user_id": session.watcher_user_id,
-                    "user_name": session.watcher_user_name,
-                    "thread_id": session.watcher_thread_id,
-                    "message_id": session.watcher_message_id,
+                    **_watcher_return_address(session),
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -665,12 +698,7 @@ class ProcessRegistry:
             "pattern": matched_pattern,
             "output": output,
             "suppressed": suppressed,
-            "platform": session.watcher_platform,
-            "chat_id": session.watcher_chat_id,
-            "user_id": session.watcher_user_id,
-            "user_name": session.watcher_user_name,
-            "thread_id": session.watcher_thread_id,
-            "message_id": session.watcher_message_id,
+            **_watcher_return_address(session),
         }
         _redact_process_result(notification)
         self.completion_queue.put(notification)
@@ -688,12 +716,7 @@ class ProcessRegistry:
             "command": session.command,
             "type": "watch_disabled",
             "suppressed": 0,
-            "platform": session.watcher_platform,
-            "chat_id": session.watcher_chat_id,
-            "user_id": session.watcher_user_id,
-            "user_name": session.watcher_user_name,
-            "thread_id": session.watcher_thread_id,
-            "message_id": session.watcher_message_id,
+            **_watcher_return_address(session),
             "message": (
                 f"Watch patterns disabled for process {session.id} — "
                 f"reached the lifetime cap of {WATCH_LIFETIME_MAX_HITS} delivered "
@@ -2756,6 +2779,15 @@ class ProcessRegistry:
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
+                            # Structured return address + transport provenance:
+                            # persisted so a completion that lands AFTER a
+                            # gateway restart still re-resolves the originating
+                            # transport instead of falling back to the runtime
+                            # profile's adapter map (or to a session_key split).
+                            "watcher_chat_type": s.watcher_chat_type,
+                            "watcher_scope_id": s.watcher_scope_id,
+                            "watcher_profile": s.watcher_profile,
+                            "watcher_transport_profile": s.watcher_transport_profile,
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
@@ -2853,6 +2885,13 @@ class ProcessRegistry:
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
                 watcher_chat_id=entry.get("watcher_chat_id", ""),
+                # Absent on pre-existing checkpoints — an empty transport
+                # provenance is the documented "legacy record" signal and the
+                # gateway falls back to runtime-profile resolution for it.
+                watcher_chat_type=entry.get("watcher_chat_type", ""),
+                watcher_scope_id=entry.get("watcher_scope_id", ""),
+                watcher_profile=entry.get("watcher_profile", ""),
+                watcher_transport_profile=entry.get("watcher_transport_profile", ""),
                 watcher_user_id=entry.get("watcher_user_id", ""),
                 watcher_user_name=entry.get("watcher_user_name", ""),
                 watcher_thread_id=entry.get("watcher_thread_id", ""),
@@ -2873,12 +2912,7 @@ class ProcessRegistry:
                     "session_id": session.id,
                     "check_interval": session.watcher_interval,
                     "session_key": session.session_key,
-                    "platform": session.watcher_platform,
-                    "chat_id": session.watcher_chat_id,
-                    "user_id": session.watcher_user_id,
-                    "user_name": session.watcher_user_name,
-                    "thread_id": session.watcher_thread_id,
-                    "message_id": session.watcher_message_id,
+                    **_watcher_return_address(session),
                     "notify_on_complete": session.notify_on_complete,
                     "parent_session_id": session.parent_session_id,
                 })

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2884,11 +2884,11 @@ class ProcessRegistry:
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
                 watcher_chat_id=entry.get("watcher_chat_id", ""),
-                # Absent on pre-existing checkpoints: empty provenance is the
-                # legacy-record signal the gateway falls back on.
                 watcher_chat_type=entry.get("watcher_chat_type", ""),
                 watcher_scope_id=entry.get("watcher_scope_id", ""),
                 watcher_profile=entry.get("watcher_profile", ""),
+                # absent on pre-existing checkpoints: an empty pair is the
+                # legacy-record signal the gateway falls back on.
                 **provenance_fields(
                     read_provenance(entry, prefix="watcher_"), prefix="watcher_"
                 ),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -51,6 +51,7 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.config import get_hermes_home
 
 from agent.redact import redact_sensitive_text
+from gateway.transport_provenance import provenance_fields, read_provenance
 
 logger = logging.getLogger(__name__)
 
@@ -389,8 +390,7 @@ def _watcher_return_address(session: "ProcessSession") -> Dict[str, Any]:
         "thread_id": session.watcher_thread_id,
         "message_id": session.watcher_message_id,
         "profile": session.watcher_profile,
-        "transport_profile": session.watcher_transport_profile,
-        "transport_slot": session.watcher_transport_slot,
+        **provenance_fields(read_provenance(session, prefix="watcher_")),
     }
 
 
@@ -427,14 +427,11 @@ class ProcessSession:
     watcher_scope_id: str = ""
     # Runtime namespace this process's turn was routed to.
     watcher_profile: str = ""
-    # The profile owning the adapter the commissioning turn arrived on, which is
-    # distinct from watcher_profile when one credential serves several routed
-    # runtimes. A name, never an adapter object, so it survives reconnects and
-    # restarts and is re-resolved to whatever adapter is live at completion.
+    # One atomic pair — never written apart (see gateway.transport_provenance):
+    # the profile owning the adapter the commissioning turn arrived on, and the
+    # slot in that map which received it. Names, never adapter objects, so they
+    # survive reconnects and are re-resolved to whatever is live at completion.
     watcher_transport_profile: str = ""
-    # Which adapter slot in that map received it, as a platform value: "relay"
-    # for relay ingress, the platform's own value for native ingress. Owner
-    # alone cannot tell the two apart when both front the same platform.
     watcher_transport_slot: str = ""
     watcher_user_id: str = ""
     watcher_user_name: str = ""
@@ -2786,8 +2783,10 @@ class ProcessRegistry:
                             "watcher_chat_type": s.watcher_chat_type,
                             "watcher_scope_id": s.watcher_scope_id,
                             "watcher_profile": s.watcher_profile,
-                            "watcher_transport_profile": s.watcher_transport_profile,
-                            "watcher_transport_slot": s.watcher_transport_slot,
+                            **provenance_fields(
+                                read_provenance(s, prefix="watcher_"),
+                                prefix="watcher_",
+                            ),
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
@@ -2890,8 +2889,9 @@ class ProcessRegistry:
                 watcher_chat_type=entry.get("watcher_chat_type", ""),
                 watcher_scope_id=entry.get("watcher_scope_id", ""),
                 watcher_profile=entry.get("watcher_profile", ""),
-                watcher_transport_profile=entry.get("watcher_transport_profile", ""),
-                watcher_transport_slot=entry.get("watcher_transport_slot", ""),
+                **provenance_fields(
+                    read_provenance(entry, prefix="watcher_"), prefix="watcher_"
+                ),
                 watcher_user_id=entry.get("watcher_user_id", ""),
                 watcher_user_name=entry.get("watcher_user_name", ""),
                 watcher_thread_id=entry.get("watcher_thread_id", ""),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -374,11 +374,10 @@ def format_uptime_short(seconds: int) -> str:
 
 
 def _watcher_return_address(session: "ProcessSession") -> Dict[str, Any]:
-    """The structured return address recorded when *session* was commissioned.
+    """The return address recorded when *session* was commissioned.
 
-    One place, so every event this registry queues carries the same complete
-    address — including the transport provenance the gateway re-resolves the
-    delivering adapter from.
+    One place, so every event this registry queues carries the same fields,
+    including the transport provenance delivery re-resolves an adapter from.
     """
     return {
         "platform": session.watcher_platform,
@@ -419,22 +418,18 @@ class ProcessSession:
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
-    # The rest of the STRUCTURED return address, captured when the process was
-    # commissioned (tools/terminal_tool.py). Before these existed the gateway
-    # had to recover chat_type/scope_id/profile by splitting the session_key on
-    # ":", which is lossy for real key grammar (Matrix ids are ``!room:server``;
-    # Slack keys carry the workspace id before the chat id) — see
-    # gateway.session.parse_session_key.
+    # The rest of the return address, captured when the process was
+    # commissioned (tools/terminal_tool.py). Without these the gateway can only
+    # recover chat_type/scope_id/profile by splitting the session_key, which is
+    # lossy for real key grammar (see gateway.session.parse_session_key).
     watcher_chat_type: str = ""
     watcher_scope_id: str = ""
     # Runtime namespace this process's turn was routed to.
     watcher_profile: str = ""
-    # TRANSPORT PROVENANCE: the profile that owns the ADAPTER the commissioning
-    # turn arrived on ("default" for the process-default adapter map). Distinct
-    # from watcher_profile: one shared credential can serve several routed
-    # runtimes, and only this identifies the bot that must answer. Recorded as a
-    # NAME, never an adapter object, so it survives reconnects and restarts and
-    # is re-resolved to whatever adapter is live at completion time.
+    # The profile owning the adapter the commissioning turn arrived on, which is
+    # distinct from watcher_profile when one credential serves several routed
+    # runtimes. A name, never an adapter object, so it survives reconnects and
+    # restarts and is re-resolved to whatever adapter is live at completion.
     watcher_transport_profile: str = ""
     watcher_user_id: str = ""
     watcher_user_name: str = ""
@@ -2779,11 +2774,10 @@ class ProcessRegistry:
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
-                            # Structured return address + transport provenance:
-                            # persisted so a completion that lands AFTER a
-                            # gateway restart still re-resolves the originating
-                            # transport instead of falling back to the runtime
-                            # profile's adapter map (or to a session_key split).
+                            # Persisted so a completion landing after a gateway
+                            # restart still re-resolves the originating
+                            # transport, rather than falling back to the runtime
+                            # profile's adapter map or to a session_key split.
                             "watcher_chat_type": s.watcher_chat_type,
                             "watcher_scope_id": s.watcher_scope_id,
                             "watcher_profile": s.watcher_profile,
@@ -2885,9 +2879,8 @@ class ProcessRegistry:
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
                 watcher_chat_id=entry.get("watcher_chat_id", ""),
-                # Absent on pre-existing checkpoints — an empty transport
-                # provenance is the documented "legacy record" signal and the
-                # gateway falls back to runtime-profile resolution for it.
+                # Absent on pre-existing checkpoints: empty provenance is the
+                # legacy-record signal the gateway falls back on.
                 watcher_chat_type=entry.get("watcher_chat_type", ""),
                 watcher_scope_id=entry.get("watcher_scope_id", ""),
                 watcher_profile=entry.get("watcher_profile", ""),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -390,6 +390,7 @@ def _watcher_return_address(session: "ProcessSession") -> Dict[str, Any]:
         "message_id": session.watcher_message_id,
         "profile": session.watcher_profile,
         "transport_profile": session.watcher_transport_profile,
+        "transport_slot": session.watcher_transport_slot,
     }
 
 
@@ -431,6 +432,10 @@ class ProcessSession:
     # runtimes. A name, never an adapter object, so it survives reconnects and
     # restarts and is re-resolved to whatever adapter is live at completion.
     watcher_transport_profile: str = ""
+    # Which adapter slot in that map received it, as a platform value: "relay"
+    # for relay ingress, the platform's own value for native ingress. Owner
+    # alone cannot tell the two apart when both front the same platform.
+    watcher_transport_slot: str = ""
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
@@ -2782,6 +2787,7 @@ class ProcessRegistry:
                             "watcher_scope_id": s.watcher_scope_id,
                             "watcher_profile": s.watcher_profile,
                             "watcher_transport_profile": s.watcher_transport_profile,
+                            "watcher_transport_slot": s.watcher_transport_slot,
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
@@ -2885,6 +2891,7 @@ class ProcessRegistry:
                 watcher_scope_id=entry.get("watcher_scope_id", ""),
                 watcher_profile=entry.get("watcher_profile", ""),
                 watcher_transport_profile=entry.get("watcher_transport_profile", ""),
+                watcher_transport_slot=entry.get("watcher_transport_slot", ""),
                 watcher_user_id=entry.get("watcher_user_id", ""),
                 watcher_user_name=entry.get("watcher_user_name", ""),
                 watcher_thread_id=entry.get("watcher_thread_id", ""),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3478,30 +3478,19 @@ def terminal_tool(
                             proc_session.watcher_user_name = _gw_user_name
                             proc_session.watcher_thread_id = _gw_thread_id
                             proc_session.watcher_message_id = _gw_message_id
-                            # The rest of the structured return address. Until
-                            # these were captured here, a completion had to be
-                            # reconstructed by splitting the session_key on
-                            # ":" — which is lossy for real key grammar (a
-                            # Matrix room id is ``!room:server``; a Slack key
-                            # carries the workspace id before the chat id) —
-                            # and the chat_type slot was simply left empty.
+                            # The rest of the return address; a session_key split recovers it lossily.
                             proc_session.watcher_chat_type = _gse(
                                 "HERMES_SESSION_CHAT_TYPE", ""
                             )
                             proc_session.watcher_scope_id = _gse(
                                 "HERMES_SESSION_SCOPE_ID", ""
                             )
-                            # Runtime namespace...
+                            # Runtime namespace the turn was routed to...
                             proc_session.watcher_profile = _gse(
                                 "HERMES_SESSION_PROFILE", ""
                             )
-                            # ...and, separately, TRANSPORT PROVENANCE: which
-                            # profile owns the adapter this turn arrived on.
-                            # The two differ whenever one shared credential
-                            # serves several routed runtimes, and only this one
-                            # identifies the bot that must deliver the
-                            # completion (see
-                            # GatewayAuthorizationMixin._transport_owner_profile).
+                            # ...and the profile owning the adapter it arrived
+                            # on, which is the bot that must answer.
                             proc_session.watcher_transport_profile = _gse(
                                 "HERMES_SESSION_TRANSPORT_PROFILE", ""
                             )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3478,6 +3478,33 @@ def terminal_tool(
                             proc_session.watcher_user_name = _gw_user_name
                             proc_session.watcher_thread_id = _gw_thread_id
                             proc_session.watcher_message_id = _gw_message_id
+                            # The rest of the structured return address. Until
+                            # these were captured here, a completion had to be
+                            # reconstructed by splitting the session_key on
+                            # ":" — which is lossy for real key grammar (a
+                            # Matrix room id is ``!room:server``; a Slack key
+                            # carries the workspace id before the chat id) —
+                            # and the chat_type slot was simply left empty.
+                            proc_session.watcher_chat_type = _gse(
+                                "HERMES_SESSION_CHAT_TYPE", ""
+                            )
+                            proc_session.watcher_scope_id = _gse(
+                                "HERMES_SESSION_SCOPE_ID", ""
+                            )
+                            # Runtime namespace...
+                            proc_session.watcher_profile = _gse(
+                                "HERMES_SESSION_PROFILE", ""
+                            )
+                            # ...and, separately, TRANSPORT PROVENANCE: which
+                            # profile owns the adapter this turn arrived on.
+                            # The two differ whenever one shared credential
+                            # serves several routed runtimes, and only this one
+                            # identifies the bot that must deliver the
+                            # completion (see
+                            # GatewayAuthorizationMixin._transport_owner_profile).
+                            proc_session.watcher_transport_profile = _gse(
+                                "HERMES_SESSION_TRANSPORT_PROFILE", ""
+                            )
                             # Stamp the spawning conversation's session-db id
                             # so the gateway's completion pre-flight
                             # (_classify_completion_target) can drop the
@@ -3520,10 +3547,14 @@ def terminal_tool(
                             "session_key": session_key,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
+                            "chat_type": proc_session.watcher_chat_type,
+                            "scope_id": proc_session.watcher_scope_id,
                             "user_id": proc_session.watcher_user_id,
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,
                             "message_id": proc_session.watcher_message_id,
+                            "profile": proc_session.watcher_profile,
+                            "transport_profile": proc_session.watcher_transport_profile,
                             "notify_on_complete": True,
                             "parent_session_id": proc_session.parent_session_id,
                         })

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3494,6 +3494,12 @@ def terminal_tool(
                             proc_session.watcher_transport_profile = _gse(
                                 "HERMES_SESSION_TRANSPORT_PROFILE", ""
                             )
+                            # ...and which of that profile's adapter slots
+                            # received it, so a relay-fronted platform is not
+                            # answered by a native adapter for the same one.
+                            proc_session.watcher_transport_slot = _gse(
+                                "HERMES_SESSION_TRANSPORT_SLOT", ""
+                            )
                             # Stamp the spawning conversation's session-db id
                             # so the gateway's completion pre-flight
                             # (_classify_completion_target) can drop the
@@ -3544,6 +3550,7 @@ def terminal_tool(
                             "message_id": proc_session.watcher_message_id,
                             "profile": proc_session.watcher_profile,
                             "transport_profile": proc_session.watcher_transport_profile,
+                            "transport_slot": proc_session.watcher_transport_slot,
                             "notify_on_complete": True,
                             "parent_session_id": proc_session.parent_session_id,
                         })

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -50,6 +50,12 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
+from gateway.transport_provenance import (
+    provenance_fields,
+    provenance_from_session_env,
+    read_provenance,
+    stamp_provenance,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -3489,16 +3495,14 @@ def terminal_tool(
                             proc_session.watcher_profile = _gse(
                                 "HERMES_SESSION_PROFILE", ""
                             )
-                            # ...and the profile owning the adapter it arrived
-                            # on, which is the bot that must answer.
-                            proc_session.watcher_transport_profile = _gse(
-                                "HERMES_SESSION_TRANSPORT_PROFILE", ""
-                            )
-                            # ...and which of that profile's adapter slots
-                            # received it, so a relay-fronted platform is not
+                            # ...and the exact adapter it arrived on: the
+                            # owning profile plus that map's slot, stamped as
+                            # one pair so a relay-fronted platform is never
                             # answered by a native adapter for the same one.
-                            proc_session.watcher_transport_slot = _gse(
-                                "HERMES_SESSION_TRANSPORT_SLOT", ""
+                            stamp_provenance(
+                                proc_session,
+                                provenance_from_session_env(_gse),
+                                prefix="watcher_",
                             )
                             # Stamp the spawning conversation's session-db id
                             # so the gateway's completion pre-flight
@@ -3549,8 +3553,9 @@ def terminal_tool(
                             "thread_id": proc_session.watcher_thread_id,
                             "message_id": proc_session.watcher_message_id,
                             "profile": proc_session.watcher_profile,
-                            "transport_profile": proc_session.watcher_transport_profile,
-                            "transport_slot": proc_session.watcher_transport_slot,
+                            **provenance_fields(
+                                read_provenance(proc_session, prefix="watcher_")
+                            ),
                             "notify_on_complete": True,
                             "parent_session_id": proc_session.parent_session_id,
                         })


### PR DESCRIPTION
## Symptom

On a gateway running `gateway.multiplex_profiles: true`, background-process and
async-delegation completions for a **secondary** profile are delivered nowhere and logged
nowhere.

The forensics come from a multiplexed deployment with dedicated per-profile Matrix adapters
(several secondary profiles, each owning its own Matrix connection, alongside a
default-profile bot on another platform). First observed **2026-08-14**, re-confirmed against
upstream `main` on **2026-08-22** and again on **2026-08-25** — the same result every time:

- watcher **registration** proven,
- queue **drain** proven (`_drain_watch_notifications` runs, `synth_text` is non-empty),
- then nothing. No adapter send, no synthetic turn, no retry, and **none of the logging drop
  paths fire**.

`notify_on_complete` and background `delegate_task` are therefore unusable for every profile
except the default one, which is the whole fleet in a multiplex deployment.

## Root cause

`GatewayRunner` keeps two adapter registries: `self.adapters` is the **default/active
profile's** map, and `_profile_adapters[profile]` holds each **secondary** profile's adapters
(populated by `_start_secondary_profile_adapters`).

`_inject_watch_notification` — the single funnel every completion passes through — resolved
its adapter from `self.adapters` only, via both the alias-aware `resolve_delivery_transport`
call and the legacy `p.value == platform_name` scan. Neither consults `_profile_adapters`, so
for a secondary profile with its own adapter neither can find it, and control reaches:

```python
if not adapter:
    return None
```

That is the one drop path in the function with **no log statement** — the two sibling paths
above it (`"Dropping watch notification with no routing metadata"`,
`"Synthetic event source unresolvable"`) both log, which is why the failure presents as a
completely silent loss rather than a warning.

A second, compounding bug: `_parse_session_key` required `parts[1] == "main"`. But `parts[1]`
is the namespace slot that `_session_key_namespace` deliberately reuses to carry the profile
(`agent:main:…` for the default profile, `agent:<profile>:…` for a named profile). So every
secondary profile's session key parsed as `None`, which stripped derived routing off
async-delegation events and — worse — made `_inject_watch_notification` misclassify a Matrix
session key as a **raw api_server session id**
(`if _sk and _parse_session_key(_sk) is None: raw_sid = _sk`) and route the completion down
the api_server self-post branch.

Notably, the **kanban notifier in this same tree already solves this correctly**: it resolves
via `_authorization_adapter(plat, sub_profile)` / `_adapter_for_source` in
`gateway/authz_mixin.py`, which reads `source.profile`, consults `_profile_adapters`, and
deliberately fails closed rather than falling back to the default profile's adapter. The
process-completion path was simply never taught about multiplexing.

## Addressing review

@andrexibiza's two blockers are both fixed on this head, and the earlier "Scope and known
limits" caveat is retired: the shared-primary topology is now handled, tested, and covered
across restart.

The reviewer's thesis restated: *the runtime namespace is not the transport owner, and the
session key is not a return address.* Both are the same mistake — inferring a route from
something that only usually implies it. The fix in both cases is to record the fact while it
is still known (the commissioning turn) and re-resolve from the recorded fact at completion.

### Blocker 1 — durable transport provenance, re-resolved live

| Ask | What changed | Regression |
|---|---|---|
| Identify the transport a turn actually arrived on, via #89860's ownership API | `gateway/authz_mixin.py` — new `_transport_owner_profile()` reads `_registered_transport_adapter(source)`, prefers the adapter's own `_owner_profile` (`BasePlatformAdapter.set_owner_profile`), falls back to a scan of the live maps. Returns a **name** (`TRANSPORT_PROFILE_DEFAULT`, a profile name, or `None`), never a held adapter object. | `test_dedicated_per_profile_transport_still_uses_the_secondary_bot` (control: green on both trees) |
| Capture it at commissioning | New `HERMES_SESSION_TRANSPORT_PROFILE` contextvar (`gateway/session_context.py`, `set_session_vars`), stamped once per turn in `GatewayRunner._set_session_env`. Deliberately **separate** from `HERMES_SESSION_PROFILE` — runtime profile and transport claimant are two fields end to end, and only the transport one selects an adapter. | `test_capture_records_the_full_return_address_matrix` |
| Persist it — terminal background | `tools/terminal_tool.py` stamps `proc_session.watcher_transport_profile`; the field lives on `ProcessSession` in `tools/process_registry.py`, and `_watcher_return_address()` is the single place every queued event gets its address from. | `test_completion_routes_correctly_after_a_gateway_restart` |
| Persist it — async delegation | `tools/async_delegation.py` `_ROUTING_ORIGIN_FIELDS` / `_ROUTING_ORIGIN_KEYS`, consumed by `_capture_routing_origin`, `_persist_dispatch` (`task_json`), `recover_abandoned_delegations`, `_push_completion_event`, `_push_batch_completion_event`. | `test_routing_address_survives_a_restart` |
| Re-resolve the **current live** transport at completion | `_inject_watch_notification` (`gateway/run.py`): a named provenance goes to `_adapter_for_transport_profile()` (`_authorization_adapter` with the *recorded name*) and **fails closed** on a miss; `"default"` provenance takes the `self.adapters` chain unconditionally, so relay-fronted platforms still resolve through `resolve_delivery_transport`. | `test_provenance_is_re_resolved_to_the_current_live_adapter` — swaps the registry entry *under* the runner between commissioning and completion |
| Runtime-profile fallback only when provenance is absent | The `elif not _provenance_is_default` branch — the pre-existing `_adapter_for_source` path, unchanged, for legacy records. | `test_legacy_record_without_provenance_keeps_runtime_resolution` |
| Never a silent `None` | `_return_address` is built once (platform, chat_type, chat_id, thread, scope, runtime profile, provenance, registered profiles) and named in **both** WARNING drop paths. | `test_unresolvable_provenance_fails_closed_with_the_return_address` |

**The two required regressions**, both failing on the parent commit for the right reason:

- **(a) shared primary → secondary runtime with no same-platform adapter** —
  `test_shared_primary_transport_into_runtime_with_no_adapter`. Parent: dropped.
- **(b) same route, secondary *also* owns a same-platform adapter** —
  `test_shared_primary_transport_is_not_switched_for_a_secondary_bot`; asserts the secondary
  bot's `handle_message` await count is **0**. Parent: answered from the wrong bot.

**Restart/recovery leg** (asked for because the provenance is persisted) —
`test_completion_routes_correctly_after_a_gateway_restart` writes a real checkpoint to
`tmp_path`, builds a **second** `ProcessRegistry`, recovers from disk and drives the recovered
watcher through `_inject_watch_notification`. Fails on the parent.

A self-review pass on the rework caught one more instance of the same bug and fixed it:
**relay ingress recorded no provenance at all**. Relay ingress registers one process-level
`RelayAdapter` under `Platform.RELAY` while the source keeps its logical platform, so
`_registered_transport_adapter` found nothing and every relayed turn recorded the legacy
empty signal — landing back on blocker 1(ii) for relay-fronted deployments.
`_transport_owner_profile` now mirrors the rule `_adapter_for_source` already applies: a
source carrying `delivered_via_upstream_relay` is owned by the process-default map.
Regressions `test_relay_ingress_records_default_provenance` (fails without the fix) and
`test_relay_completion_is_not_answered_by_a_secondary_bot`.

### Blocker 2 — structured routing fields, not a parsed key

Both halves of the required fix were done, in the reviewer's order of authority.

**Structured fields are now the route.** `tools/terminal_tool.py` also captures
`HERMES_SESSION_CHAT_TYPE` and `HERMES_SESSION_SCOPE_ID` — `chat_type` was previously never
set at all, so `_run_process_watcher` always emitted `chat_type: ""` and the gateway fell back
to the key split. New `ProcessSession` fields carry platform / chat_type / chat_id / thread_id
/ scope_id / profile / transport_profile onto the watcher dict and every queued event via
`_watcher_return_address`; `tools/async_delegation.py` carries the same set through capture,
`task_json`, recovery and both completion pushes; the checkpoint writes and restores them,
defaulting to `""` = legacy record. `_parse_session_key` in `gateway/run.py` is demoted to a
documented thin alias — its only remaining structural use is the "is this a gateway key at
all?" test that distinguishes a raw api_server session id.

**And the parser was made a real inverse.** `gateway/session.py` `parse_session_key()` mirrors
the grammar `build_session_key` emits instead of indexing a flat split: Matrix ids are
re-joined by sigil (`_take_key_id`, `! @ # $`), so
`agent:alpha:matrix:group:!room:example.org` yields `chat_id == "!room:example.org"`, not
`"!room"`; the Slack workspace segment is consumed from the slot `build_session_key` writes it
into, told from a conversation id by Slack's own id grammar, and reported as `scope_id`;
`thread_id` is reported only for `dm`/`thread`, because a 6th token in a group key may be a
participant id — documented in the docstring as the part of the grammar that is ambiguous *by
construction*, which is exactly why the structured fields above are the authority.
`tests/gateway/test_session_key_roundtrip.py` round-trips eight shapes built by
`build_session_key` (Matrix group/dm/thread with colon-bearing room, user and event ids; Slack
scoped group, scoped dm, unscoped dm; Discord per-user group; Telegram forum topic), with and
without a profile namespace.

**The two required async-delegation regressions**, plus the replay leg:

- **Matrix room with a colon-bearing id** —
  `test_async_delegation_matrix_colon_room_id_routes_to_the_full_id` (delivery goes to the
  full id) and `test_capture_records_the_full_return_address_matrix` (captured whole at
  dispatch, not recovered later).
- **Slack scoped session** — `test_async_delegation_slack_scoped_session_routes_to_the_channel`
  (chat is the channel, scope is the workspace) and
  `test_capture_records_the_slack_workspace_scope`.
- **durable replay/restart** — `test_routing_address_survives_a_restart` persists a dispatch to
  a temp `state.db`, reads `task_json` back **off disk**, classifies the owner dead, and
  asserts the recovered `event_json` carries the same address and provenance.

Complementary to #89860 as asked: this consumes `set_owner_profile` /
`_registered_transport_adapter` rather than duplicating them, and introduces no assumption
that runtime profile == transport claimant.

### Blocker 3 (review of 2026-08-25 14:47Z) — transport *identity*, not only the owner map

Head for this section: **`6ccd90aef1`** (`a31b52c248` + verification follow-ups).

The blocker restated: `transport_profile="default"` records **which adapter map owns the
adapter**, not **which slot inside that map received the turn**. Owner and transport identity
are separate dimensions wherever an alias exists, and #91237 makes native + Relay fronting the
same platform a supported topology, so the alias is not hypothetical. Agreed, and fixed by
recording the slot as a second durable fact.

| Ask | What changed | Regression |
|---|---|---|
| Durable provenance sufficient to re-resolve the **exact** ingress transport | `gateway/authz_mixin.py` — new `_ingress_transport_slot()` records the adapter-map key as a platform value: relay ingress → `Platform.RELAY.value`, native ingress → the source's own platform. Stamped in `GatewayRunner._set_session_env` beside the existing `_transport_owner_profile()` call. | `test_relay_ingress_records_the_relay_slot`, `test_native_ingress_records_its_own_slot` |
| Keep the logical platform separate for the send | New contextvar `HERMES_SESSION_TRANSPORT_SLOT` (`gateway/session_context.py`, `set_session_vars(transport_slot=…)`), distinct from `HERMES_SESSION_PLATFORM`, which still drives the session key and the send. | `test_relay_only_completion_is_delivered_through_the_relay` asserts `delivered.source.platform == Platform.SLACK` while Relay is the adapter |
| Exact provenance resolves that transport directly, no alias step | `_inject_watch_notification` (`gateway/run.py`) gains a slot branch **before** both existing branches; `_adapter_for_transport_slot()` = `_authorization_adapter(Platform(slot), owner)`. `fronts_platform()` is deliberately not consulted — that answers the alias question, and exact provenance already answers "which adapter received this turn?". | `test_mixed_map_relay_ingress_is_not_answered_by_the_native_adapter` |
| Fail closed when the recorded transport is gone | Same block: `return None` after a WARNING naming owner, slot and the full return address; `_return_address` now carries `slot=`. | `test_dead_ingress_transport_fails_closed_with_the_return_address` |
| Native-first alias resolution only for legacy / no-provenance | The `elif` chain is untouched and is reached only by records with no slot. | `test_legacy_record_without_a_slot_keeps_alias_resolution`, `test_no_provenance_source_records_no_slot` |

**The four required regressions** (new file `tests/gateway/test_relay_transport_slot_routing.py`, 11 tests):

1. **relay-only, Relay actually invoked** — `test_relay_only_completion_is_delivered_through_the_relay`: relay-capable stub advertising Slack, asserts the injection returned `True` **and** `relay.handle_message.await_count == 1`. This is also the fix to the weak test you named: `test_relay_completion_is_not_answered_by_a_secondary_bot` is renamed `test_relay_completion_is_delivered_through_the_relay` and now asserts delivery through Relay rather than only the absence of a secondary call. Its relay stub still has no `fronts_platform`, which is the point — exact provenance must not depend on the alias router re-deriving it; on the parent it drops outright.
2. **mixed default map, relay ingress** — `test_mixed_map_relay_ingress_is_not_answered_by_the_native_adapter`: Relay receives the completion, `native_slack.handle_message.await_count == 0`. This is the case that distinguishes the trees; on the parent the completion leaves through the native bot.
3. **mixed map, native-origin turn** — `test_mixed_map_native_ingress_is_not_answered_by_the_relay`: native adapter remains the return transport, Relay zero calls. Passes on the parent too, and is reported as a control rather than a regression; likewise (1), which was asked for assertion strength.
4. **restart/recovery legs** — the slot is persisted alongside `transport_profile` on both: process side `ProcessSession.watcher_transport_slot`, `_watcher_return_address`, checkpoint write and restore (absent key → `""` = legacy), stamped in `tools/terminal_tool.py` and carried on the watcher dict and the completion event; delegation side one entry in `_ROUTING_ORIGIN_FIELDS`, so capture, `task_json`, `recover_abandoned_delegations` and both push paths carry it by construction. `test_relay_slot_survives_a_gateway_restart` writes a real checkpoint, builds a second `ProcessRegistry`, recovers from disk and drives the recovered watcher; `test_routing_address_survives_a_restart`, `test_capture_records_the_slack_workspace_scope` and `test_slack_completion_event_routes_to_the_right_chat` carry slot assertions for the delegation leg.

A verification pass over the rework fixed two further LOW issues in `6ccd90aef1`, each with a
regression that fails on `a31b52c248`: a slot outside {logical platform, `relay`} is now
ignored rather than trusted, so a damaged checkpoint cannot deliver a Slack completion through
a Discord adapter (`test_a_slot_the_turn_could_not_have_arrived_on_is_ignored`); and
`_ingress_transport_slot` checks the relay flag before the registered-adapter lookup, so the
deciding fact is consulted first (`test_relay_ingress_outranks_a_native_registration_on_the_same_source`).

**One intentional behaviour change worth naming.** With a slot recorded, a completion whose
ingress transport has since disappeared is dropped even when another live adapter could have
carried it (native Slack gone, Relay fronting Slack still up); previously the alias router
would have delivered it. That is the fail-closed semantics asked for — losing a notification
beats answering from a different credential — but it is a delivery-rate change under adapter
churn, not only a routing correctness fix.

### Blocker 4 (review of 2026-08-25 15:41Z) — the pair must be atomic

Head for this section: **`e988ae672c`** (`38c53005c1` + verification follow-ups).

The blocker restated: `(transport_profile, transport_slot)` was *contractually* the exact
ingress adapter, but nothing made it one fact. The two halves were computed in separate `try`
blocks, stored in independent contextvars, serialized as independent optional fields in both
`ProcessSession` checkpoints and async-delegation `task_json`, and replayed independently — so
a half-record was representable, and a contradictory slot was downgraded to DEBUG and then
routed through the ordinary fallback chain (native-wins in a mixed default map). Agreed on
both legs: after exact provenance is contradicted, selecting another transport is not
fail-closed.

**Three record classes, all decided in one place** (`_inject_watch_notification`,
`gateway/run.py`):

| class | condition | behaviour |
|---|---|---|
| `LEGACY` | **both** fields absent | existing runtime/alias fallback, untouched |
| `EXACT` | both present, slot ∈ {logical platform, `relay`} | resolve that adapter directly; WARNING + drop if it is no longer live |
| `MALFORMED` | exactly one present, or slot invalid for the platform | WARNING with the full return address, `return None`, **zero** adapter lookups — never alias resolution, never `owner=default` |

**One carrier, one capture boundary, one stamper, one decoder.**

| Ask | What changed |
|---|---|
| One typed carrier | New module `gateway/transport_provenance.py`: `TransportProvenance(NamedTuple)` is the single home of the pair, the field and env names, the three class constants and every read/write helper. |
| ONE capture helper with ONE failure boundary | `gateway/authz_mixin.py` `_capture_transport_provenance()` — a single `try` reading both dimensions, returning the pair only when both halves are non-empty, else `None`. It replaces the two `try` blocks in `_set_session_env`, which is now one call. Capture is total: there is no input on which it writes one field. |
| ONE stamper | `provenance_fields()` / `stamp_provenance()` at every write site — contextvars, completion event, `ProcessSession` stamp and watcher dict, the return address, checkpoint write and restore, delegation capture and replay. The only literal `transport_profile` / `transport_slot` occurrences left outside the module are the two `ProcessSession` field declarations and the `session_context` contextvar plumbing. |
| ONE decoder | `classify_provenance()`, with exactly one call site, off the single `read_provenance(evt)`. The named-owner `elif` and the debug-and-ignore invalid-slot branch are gone; owner-only is no longer a routing input. |
| Serialization cannot produce a half-record | `_ROUTING_ORIGIN_FIELDS` no longer carries the pair; the new `_copy_routing_origin()` is the single replay path for all three call sites and moves both fields or neither. |
| Owner-only records: **not** versioned | `transport_profile` does not exist anywhere on `main` (merge base `1bbb6e5bce`, `git grep` → no hits) — both fields were introduced on this branch, so no persisted record on the release line carries an owner without a slot. Owner-only is therefore treated as `MALFORMED`, which is the alternative the review allows in that case. |

**The required regressions** (`tests/gateway/test_relay_transport_slot_routing.py`, now 16 tests):

- **Replacement for the invalid-slot test** — `test_a_contradictory_slot_drops_without_touching_either_adapter`: mixed native-Slack + Relay map, event slot `discord`, asserts `result is None` and **both** await counts `0`. The old `test_a_slot_the_turn_could_not_have_arrived_on_is_ignored`, which codified `True` + native delivery, is deleted.
- **Valid slot, missing owner** — `test_a_slot_without_an_owner_drops_and_never_reaches_a_default_bot`: a default `slack` adapter **and** a secondary `alpha` Slack adapter, source stamped `profile="alpha"`; neither is invoked and the WARNING carries the return address.
- **Reverse partial (owner-only)** — `test_an_owner_without_a_slot_drops_and_never_reaches_alias_resolution`, same two-adapter topology.
- **Both restart legs** — `test_a_damaged_record_still_drops_after_a_process_restart` writes a real checkpoint, builds a second `ProcessRegistry` and recovers from disk; `test_a_damaged_delegation_record_still_drops_after_a_restart` persists a real sqlite dispatch, runs `recover_abandoned_delegations()` and asserts the replay did not invent the missing half. Both then drop.
- **Atomic capture** — `test_a_damaged_context_is_captured_as_a_pair_not_completed`
  (`tests/tools/test_async_delegation_routing_capture.py`): the missing half is recorded as
  `""`, never silently completed.
- **Legacy still delivers** — `test_legacy_record_without_provenance_keeps_alias_resolution`
  and `test_legacy_record_without_provenance_keeps_runtime_resolution`, both now carrying
  neither field.

Six pre-existing test events carried an owner with no slot — a shape real capture can never
emit and which is malformed under the new contract; each was completed to the pair capture
would produce. Their intent (owner-map routing) is unchanged, and
`test_unresolvable_provenance_fails_closed_with_the_return_address` still asserts the same
WARNING content.

Fails-on-parent check for this rework (source stashed, tests kept):

```
uv run pytest tests/gateway/test_relay_transport_slot_routing.py -q -p no:randomly -p no:cacheprovider
  → 8 failed, 7 passed in 0.57s
```

All three drop cases and both restart legs fail there for the stated reason: the parent
returns `True` through the native Slack adapter, resolves `transport_profile or None` to the
default map, or enters alias resolution; the three capture assertions fail as
`AttributeError: _capture_transport_provenance`.

**Behaviour change worth naming**, in addition to the fail-closed one already disclosed above:
a record carrying half a return address, or a slot the turn could not have arrived on, is now
dropped rather than delivered. That state is only reachable from a damaged or hand-edited
durable record, since capture is atomic.

## Tests

`tests/gateway/test_relay_transport_slot_routing.py` (new, 16 tests),
`tests/gateway/test_multiplex_completion_injection_routing.py` (extended),
`tests/gateway/test_session_key_roundtrip.py` (new),
`tests/tools/test_async_delegation_routing_capture.py` (new),
`tests/gateway/test_background_process_notifications.py` (extended).

All numbers below are for head `e988ae672c`.

```
uv run pytest tests/gateway -q -p no:randomly -p no:cacheprovider
  → 7 failed, 6277 passed, 36 skipped, 1 xfailed in 315s

# same command with source+tests stashed to the merge base:
  → 7 failed, 6228 passed, 36 skipped, 1 xfailed in 315.53s
```

The **same 7** on both runs are pre-existing order-dependent failures unrelated to this branch
(`test_discord_send.py` ×3, `test_send_multiple_images.py`, `test_session_store_prune.py`,
`test_teams_dotenv_isolation.py`, `test_telegram_polling_health_confirmation.py`); each passes
when its file is run alone, on both trees.

```
uv run pytest tests/tools/test_async_delegation.py tests/tools/test_async_delegation_fd_leak.py \
  tests/tools/test_async_delegation_routing_capture.py tests/tools/test_process_registry.py \
  tests/tools/test_process_registry_write_stdin_surrogates.py -q -p no:cacheprovider
  → 119 passed, 4 skipped in 14.05s

uv run pytest tests/gateway/test_relay_transport_slot_routing.py \
  tests/gateway/test_multiplex_completion_injection_routing.py \
  tests/gateway/test_relay_completion_injection_routing.py \
  tests/tools/test_async_delegation_routing_capture.py -q -p no:randomly -p no:cacheprovider
  → 40 passed in 1.04s

uv run ruff check <changed source + test files>
  → All checks passed!
```

New-tests-fail-on-old-code check for the slot work (source files stashed to `6b80861539`,
tests kept):

```
uv run pytest tests/gateway/test_relay_transport_slot_routing.py \
  tests/gateway/test_multiplex_completion_injection_routing.py \
  tests/tools/test_async_delegation_routing_capture.py -q -p no:randomly -p no:cacheprovider
  → 8 failed, 18 passed, 5 errors in 0.97s
```

The mixed-map relay-ingress regression and the renamed relay delivery test fail there for the
stated reason (the latter dropped outright: `Dropping watch notification … no adapter for
platform=slack … transport provenance='default'`); capture, fail-closed and restart tests fail
as missing field / missing kwarg. The earlier blocker-1/2 check is unchanged:
`tests/gateway/test_multiplex_completion_injection_routing.py` → `4 failed, 7 passed`.

## Notes for reviewers

- CI / Nix / Docker runs for this head still sit at `action_required` with zero jobs — they
  need maintainer approval to execute, so there is still no exact-head CI receipt from my side.
  Every number above is local.
- Marked **ready for review**: all four blockers are addressed with regressions that fail on the
  parent for the stated reason. Still no live end-to-end multiplex drill against a paid model
  turn, so the in-production repair remains argued from tests and code reading rather than
  demonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
