### PR TITLE
fix(sandbox): restore npm installer trust and exact-head E2E

### DIFF
--- a/.github/workflows/install-e2e-acceptance.yml
+++ b/.github/workflows/install-e2e-acceptance.yml
@@ -1,10 +1,10 @@
 name: Installer E2E Change Acceptance
 
 # The scheduled Install & Update E2E matrix is the release-shaped authority,
-# but relevant pull-request heads also need one exact-object installer witness.
-# Generic CI cannot prove the sandboxed real-network install path. This focused
-# lane samples the newest release and exercises Node/npm/browser installation
-# plus the installer re-run whenever the governed surface changes.
+# but relevant pull-request heads also need exact-object installer and updater
+# witnesses. Generic CI cannot prove the sandboxed real-network install path.
+# This focused lane samples the newest release, executes both update routes, and
+# keeps Node/npm/browser installation in scope for the installer route.
 
 on:
   workflow_dispatch:
@@ -68,19 +68,20 @@ jobs:
           expected='${{ github.event.pull_request.head.sha || github.sha }}'
           test "$actual" = "$expected"
           tags="$(scripts/sandbox/pick-release-tags.sh --count 1)"
-          echo "Testing installer path from: $tags"
+          echo "Testing installer paths from: $tags"
           echo "Candidate object: $actual"
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
-  installer:
-    name: Installer exact-head witness
+  acceptance:
+    name: Exact-head install/update witness
     needs: pick-release
     strategy:
       fail-fast: false
       matrix:
         install-ref: ${{ fromJSON(needs.pick-release.outputs.tags) }}
+        route: [installer, update]
     uses: ./.github/workflows/install-e2e-run.yml
     with:
-      route: installer
+      route: ${{ matrix.route }}
       install-ref: ${{ matrix.install-ref }}
-      include-browser: true
+      include-browser: ${{ matrix.route == 'installer' }}

--- a/.github/workflows/install-e2e-acceptance.yml
+++ b/.github/workflows/install-e2e-acceptance.yml
@@ -59,6 +59,11 @@ jobs:
       - id: pick
         run: |
           set -euo pipefail
+          # The candidate may live in a fork whose tags are stale. Release
+          # selection belongs to the canonical base repository, while code
+          # execution remains bound to the submitted head.
+          git fetch --force --tags --no-recurse-submodules \
+            "https://github.com/${GITHUB_REPOSITORY}.git"
           actual="$(git rev-parse HEAD)"
           expected='${{ github.event.pull_request.head.sha || github.sha }}'
           test "$actual" = "$expected"

--- a/.github/workflows/install-e2e-acceptance.yml
+++ b/.github/workflows/install-e2e-acceptance.yml
@@ -3,8 +3,8 @@ name: Installer E2E Change Acceptance
 # The scheduled Install & Update E2E matrix is the release-shaped authority,
 # but relevant pull-request heads also need one exact-object installer witness.
 # Generic CI cannot prove the sandboxed real-network install path. This focused
-# lane samples the newest release and exercises the installer re-run whenever
-# the installer, sandbox, test harness, or its workflow wiring changes.
+# lane samples the newest release and exercises Node/npm/browser installation
+# plus the installer re-run whenever the governed surface changes.
 
 on:
   workflow_dispatch:
@@ -14,19 +14,23 @@ on:
     paths:
       - '.github/workflows/install-e2e-acceptance.yml'
       - '.github/workflows/install-e2e-run.yml'
+      - '.github/workflows/install-e2e.yml'
       - 'scripts/dev-sandbox.sh'
       - 'scripts/install.sh'
       - 'scripts/sandbox/**'
       - 'tests/install/**'
+      - 'tests/test_install_e2e_contract.py'
       - 'tests/test_sandbox_stage2_node_ca.py'
   pull_request:
     paths:
       - '.github/workflows/install-e2e-acceptance.yml'
       - '.github/workflows/install-e2e-run.yml'
+      - '.github/workflows/install-e2e.yml'
       - 'scripts/dev-sandbox.sh'
       - 'scripts/install.sh'
       - 'scripts/sandbox/**'
       - 'tests/install/**'
+      - 'tests/test_install_e2e_contract.py'
       - 'tests/test_sandbox_stage2_node_ca.py'
 
 permissions:
@@ -46,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           filter: blob:none
           fetch-tags: true
           sparse-checkout: scripts/sandbox/pick-release-tags.sh
@@ -53,8 +59,12 @@ jobs:
       - id: pick
         run: |
           set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          expected='${{ github.event.pull_request.head.sha || github.sha }}'
+          test "$actual" = "$expected"
           tags="$(scripts/sandbox/pick-release-tags.sh --count 1)"
           echo "Testing installer path from: $tags"
+          echo "Candidate object: $actual"
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
   installer:
@@ -68,3 +78,4 @@ jobs:
     with:
       route: installer
       install-ref: ${{ matrix.install-ref }}
+      include-browser: true

--- a/.github/workflows/install-e2e-acceptance.yml
+++ b/.github/workflows/install-e2e-acceptance.yml
@@ -1,0 +1,70 @@
+name: Installer E2E Change Acceptance
+
+# The scheduled Install & Update E2E matrix is the release-shaped authority,
+# but relevant pull-request heads also need one exact-object installer witness.
+# Generic CI cannot prove the sandboxed real-network install path. This focused
+# lane samples the newest release and exercises the installer re-run whenever
+# the installer, sandbox, test harness, or its workflow wiring changes.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/install-e2e-acceptance.yml'
+      - '.github/workflows/install-e2e-run.yml'
+      - 'scripts/dev-sandbox.sh'
+      - 'scripts/install.sh'
+      - 'scripts/sandbox/**'
+      - 'tests/install/**'
+      - 'tests/test_sandbox_stage2_node_ca.py'
+  pull_request:
+    paths:
+      - '.github/workflows/install-e2e-acceptance.yml'
+      - '.github/workflows/install-e2e-run.yml'
+      - 'scripts/dev-sandbox.sh'
+      - 'scripts/install.sh'
+      - 'scripts/sandbox/**'
+      - 'tests/install/**'
+      - 'tests/test_sandbox_stage2_node_ca.py'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: installer-e2e-acceptance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pick-release:
+    name: Pick newest release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tags: ${{ steps.pick.outputs.tags }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: blob:none
+          fetch-tags: true
+          sparse-checkout: scripts/sandbox/pick-release-tags.sh
+          sparse-checkout-cone-mode: false
+      - id: pick
+        run: |
+          set -euo pipefail
+          tags="$(scripts/sandbox/pick-release-tags.sh --count 1)"
+          echo "Testing installer path from: $tags"
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+
+  installer:
+    name: Installer exact-head witness
+    needs: pick-release
+    strategy:
+      fail-fast: false
+      matrix:
+        install-ref: ${{ fromJSON(needs.pick-release.outputs.tags) }}
+    uses: ./.github/workflows/install-e2e-run.yml
+    with:
+      route: installer
+      install-ref: ${{ matrix.install-ref }}

--- a/.github/workflows/install-e2e-run.yml
+++ b/.github/workflows/install-e2e-run.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: refs/heads/main
+      include-browser:
+        description: 'Exercise Node/npm/browser installation instead of passing --skip-browser.'
+        required: false
+        type: boolean
+        default: false
       runner:
         description: 'Runner label.'
         required: false
@@ -50,11 +55,28 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
 
     steps:
-      # Full history: the sandbox fetches the starting commit and the test
-      # compares against this commit, so a shallow clone is not enough.
+      # Pull-request workflows normally check out GitHub's synthetic merge ref.
+      # Acceptance evidence must bind to the submitted object itself, so fetch
+      # the fork repository and exact head SHA when the caller is a PR.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+
+      - name: Bind exact candidate object
+        id: candidate
+        env:
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          if [ "$actual" != "$EXPECTED_SHA" ]; then
+            echo "checkout mismatch: got $actual, expected $EXPECTED_SHA" >&2
+            exit 1
+          fi
+          echo "sha=$actual" >> "$GITHUB_OUTPUT"
+          echo "Installer acceptance is bound to $actual"
 
       # bubblewrap + slirp4netns are what the sandbox is built on; util-linux
       # supplies the `unshare` that builds the multi-uid userns for the
@@ -84,9 +106,14 @@ jobs:
       - name: Run install + update E2E
         run: |
           set -euo pipefail
-          tests/install/install-update-e2e.sh \
-            --route '${{ inputs.route }}' \
+          args=(
+            --route '${{ inputs.route }}'
             --install-ref '${{ inputs.install-ref }}'
+          )
+          if [ '${{ inputs.include-browser }}' = 'true' ]; then
+            args+=(--include-browser)
+          fi
+          tests/install/install-update-e2e.sh "${args[@]}"
         env:
           # Outside the workspace on purpose: the script creates this directory
           # up front, and an untracked dir inside the repo makes the worktree
@@ -114,9 +141,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Unique per leg: a matrix over releases runs this workflow several
-          # times per route, and same-named artifacts collide.
-          name: ${{ steps.artifact.outputs.name }}-${{ github.sha }}
+          # Unique per leg and bound to the checked-out candidate, not a PR
+          # merge ref: same-named artifacts must never masquerade as head proof.
+          name: ${{ steps.artifact.outputs.name }}-${{ steps.candidate.outputs.sha }}
           path: ${{ runner.temp }}/e2e-logs
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -19,9 +19,9 @@ name: Install & Update E2E
 #     update FROM changes, and the moment a broken updater would strand them;
 #   * manually, where you can pick the route and how many releases to sample.
 #
-# Deliberately NOT on pull_request: a leg takes ~11 minutes of real toolchain
-# installation, and the matrix multiplies that. Updating is release-shaped work,
-# so it is gated on releases and the clock instead.
+# Deliberately NOT on pull_request: the full release matrix takes ~11 minutes
+# per leg and multiplies across releases. A separate path-filtered acceptance
+# workflow runs one exact-head installer witness for relevant pull requests.
 
 on:
   workflow_dispatch:
@@ -95,7 +95,9 @@ jobs:
       install-ref: ${{ matrix.install-ref }}
 
   # Re-running the curl one-liner over an existing checkout: autostash + pull
-  # rather than the updater's own git handling.
+  # rather than the updater's own git handling. Browser/npm installation stays
+  # explicit here: this scheduled installer surface is the authority for the
+  # Node trust and proxy keep-alive boundary.
   installer:
     if: github.event_name != 'workflow_dispatch' || inputs.route != 'update'
     needs: pick-releases
@@ -108,3 +110,4 @@ jobs:
     with:
       route: installer
       install-ref: ${{ matrix.install-ref }}
+      include-browser: true

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -24,14 +24,27 @@ import ssl
 import subprocess
 import sys
 import threading
+import time
 from urllib.parse import unquote, urlsplit
 
 ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
 
 LISTEN_ADDRESS = ('127.0.0.1', 8080)
 MAX_REQUEST_BYTES = 65536
-UPSTREAM_TIMEOUT_SECONDS = 30
+# Cap on a single upstream connect; generous because it now also bounds the
+# idle time between keep-alive requests on a reused connection.
+UPSTREAM_IDLE_SECONDS = 30
 CERT_VALIDITY_DAYS = 2
+
+
+def strip_proxy_headers(request):
+    """Drop hop-by-hop proxy headers from an inner (tunneled) request."""
+    headers, separator, body = request.partition(b'\r\n\r\n')
+    lines = [
+        line for line in headers.split(b'\r\n')
+        if not line.lower().startswith((b'proxy-', b'proxy-connection:'))
+    ]
+    return b'\r\n'.join(lines) + separator + body
 
 
 def read_request(conn):
@@ -151,11 +164,64 @@ def relay(source, destination):
 
 
 def forward_https(conn, host, port, request):
+    # Keep the tunnel open for as long as BOTH peers want it: npm reuses
+    # keep-alive sockets aggressively, and serving a single request per
+    # CONNECT turns every reused socket into a dead tunnel (client sees
+    # unexpected EOF / SSLEOF; retries exhaust; install fails).
+    #
+    # Two pumps run concurrently: client->upstream (new requests) and
+    # upstream->client (responses). Each ends when its peer EOFs or errors;
+    # when either side finishes, the whole tunnel is torn down.
     context = ssl.create_default_context(cafile=str(REAL_CA))
-    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as raw:
-        with context.wrap_socket(raw, server_hostname=host) as upstream:
-            upstream.sendall(close_request(request))
-            relay(upstream, conn)
+    upstream = None
+    # A transient upstream connect/TLS failure looks like "empty reply" to the
+    # client, which reads as a broken installer rather than a network blip.
+    # Retry the handshake a few times before giving up on this tunnel.
+    for attempt in range(3):
+        try:
+            raw = socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS)
+            upstream = context.wrap_socket(raw, server_hostname=host)
+            break
+        except OSError:
+            if attempt == 2:
+                return
+            time.sleep(1)
+
+    def c2u():
+        # Client requests: forward verbatim (minus hop-by-hop headers).
+        # `request` is the first one, already read by handle_connect.
+        try:
+            upstream.sendall(strip_proxy_headers(request))
+            while True:
+                req = read_request(conn)
+                if not req:
+                    break
+                upstream.sendall(strip_proxy_headers(req))
+        except OSError:
+            pass
+        finally:
+            try:
+                upstream.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+    t = threading.Thread(target=c2u, daemon=True)
+    t.start()
+    try:
+        while True:
+            chunk = upstream.recv(65536)
+            if not chunk:
+                break
+            conn.sendall(chunk)
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        t.join(timeout=5)
+        upstream.close()
 
 
 def forward_http(conn, host, port, request, target):
@@ -163,7 +229,7 @@ def forward_http(conn, host, port, request, target):
     path = parsed.path or '/'
     if parsed.query:
         path += f'?{parsed.query}'
-    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as upstream:
+    with socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS) as upstream:
         upstream.sendall(close_request(request, path))
         relay(upstream, conn)
 

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,20 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# Every payload TLS client must trust the SANDBOX CA: all HTTP(S) goes
+# through the MITM proxy, which terminates each connection with a
+# sandbox-CA-minted cert and re-validates upstream against the real CA
+# bundle itself (real-ca.pem, passed to proxy.py below). Node reads
+# NODE_EXTRA_CA_CERTS instead of SSL_CERT_FILE, so it gets ca.pem too --
+# pointing it at the real bundle made npm reject the proxy's certs
+# (UNABLE_TO_VERIFY_LEAF_SIGNATURE) and the proxy log the abort as an
+# SSLEOFError. curl/git/openssl get the same ca.pem via their own vars.
+# One asymmetry to note: the *_FILE vars replace the trust store, but
+# NODE_EXTRA_CA_CERTS is additive -- Node keeps its built-in bundle --
+# so a Node process that somehow bypassed the proxy could still reach
+# public CAs directly. The *_PROXY vars are the enforcement; the CA
+# vars are only the trust plumbing.
+
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -216,7 +230,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \

--- a/tests/install/install-update-e2e.sh
+++ b/tests/install/install-update-e2e.sh
@@ -21,14 +21,18 @@
 #
 # Usage:
 #   tests/install/install-update-e2e.sh --route update|installer
-#                                       [--install-ref REF] [--keep]
+#                                       [--install-ref REF]
+#                                       [--include-browser] [--keep]
 #
-#   --route         which update path to exercise (required):
-#                     update     `hermes update`
-#                     installer  re-running the curl one-liner over the checkout
-#   --install-ref   what to install first; anything git resolves (a branch, a
-#                   tag like v2026.7.7, or a SHA reachable from main).
-#                   Default: refs/heads/main.
+#   --route           which update path to exercise (required):
+#                       update     `hermes update`
+#                       installer  re-running the curl one-liner over the checkout
+#   --install-ref     what to install first; anything git resolves (a branch, a
+#                     tag like v2026.7.7, or a SHA reachable from main).
+#                     Default: refs/heads/main.
+#   --include-browser keep Node/npm/browser installation in scope even when the
+#                     sampled installer supports --skip-browser. The specialized
+#                     installer acceptance lanes use this to exercise npm trust.
 #
 # Requires a CLEAN worktree: every dev-sandbox invocation re-derives fake main
 # from the working copy, so uncommitted changes move the update target between
@@ -38,6 +42,7 @@ set -euo pipefail
 
 ROUTE=""
 INSTALL_REF="refs/heads/main"
+INCLUDE_BROWSER=false
 KEEP=false
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -47,8 +52,9 @@ while [ "$#" -gt 0 ]; do
     --install-ref)
       [ "$#" -ge 2 ] || { echo 'error: --install-ref needs a value' >&2; exit 1; }
       INSTALL_REF="$2"; shift 2 ;;
+    --include-browser) INCLUDE_BROWSER=true; shift ;;
     --keep) KEEP=true; shift ;;
-    -h|--help) sed -n '2,35p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -154,7 +160,12 @@ rm -rf -- "$SANDBOX_ROOT"
 # and argparse prints every option it accepts.
 update_supports() {
   local flag="$1"
-  in_sandbox "hermes update --help 2>&1" | grep -qF -- "$flag"
+  local help=""
+  help="$(in_sandbox "hermes update --help 2>&1")" || return 1
+  # Do not pipe a producer into grep -q under pipefail: grep exits as soon as it
+  # finds FLAG, the producer can receive SIGPIPE, and a supported flag is then
+  # misreported as absent.
+  grep -qF -- "$flag" <<<"$help"
 }
 
 # Does the installer at REF accept FLAG? Read it out of that ref's own
@@ -174,7 +185,9 @@ installer_supports() {
     git fetch -q --depth 1 "$UPSTREAM_URL" "$ref" 2>/dev/null || return 1
     script="$(git show FETCH_HEAD:scripts/install.sh 2>/dev/null)" || return 1
   }
-  printf '%s' "$script" | grep -qF -- "$flag"
+  # A here-string keeps grep's early success from SIGPIPE-ing a pipeline
+  # producer under `set -o pipefail`.
+  grep -qF -- "$flag" <<<"$script"
 }
 
 # Run the real install one-liner inside the sandbox. `ref` non-empty installs
@@ -188,13 +201,21 @@ install_in_sandbox() {
   local log="$LOG_DIR/$tag.log"
   local args=(install --persistent)
   [ -n "$ref" ] && args+=(--install-ref "$ref")
+  # astral.sh and its release mirrors intermittently return empty replies to
+  # GitHub runner egress IPs. Serve a runner-prefetched fixture through the same
+  # sandbox proxy so external bootstrap availability cannot prevent the test
+  # from reaching the Hermes-owned npm trust and keep-alive boundary.
+  if [ -n "$UV_INSTALLER_FIXTURE" ]; then
+    args+=(--http-root "$UV_INSTALLER_FIXTURE")
+  fi
 
   # Installer flags have to match the installer being run, not this checkout's.
   # Older releases reject options added later ("Unknown option: --skip-browser"),
   # and this test deliberately installs releases from months back. --skip-setup
   # goes back further than any tag we sample; anything newer is probed for.
   local installer_flags=(--skip-setup)
-  if [ -z "$ref" ] || installer_supports "$ref" --skip-browser; then
+  if [ "$INCLUDE_BROWSER" = false ] \
+      && { [ -z "$ref" ] || installer_supports "$ref" --skip-browser; }; then
     installer_flags+=(--skip-browser)
   fi
   # Sandbox flags must precede `--`; the rest goes to install.sh.
@@ -247,6 +268,56 @@ require_hermes_works() {
 }
 
 # ── install the earlier Hermes ─────────────────────────────────────────────
+# Prefetch the uv installer and binary so the sandbox can serve stable fixtures
+# for third-party bootstrap bytes. This keeps the Hermes acceptance lane focused
+# on Hermes-owned behavior while install.sh still performs a real uv/Python/Node
+# and venv installation. Best-effort: if prefetching fails, the in-sandbox curl
+# still attempts the public endpoints and the transcript remains authoritative.
+UV_INSTALLER_FIXTURE=""
+if command -v curl >/dev/null 2>&1; then
+  UV_FIXTURE_DIR="$LOG_DIR/http-fixture"
+  UV_SCRIPT="$UV_FIXTURE_DIR/astral.sh/uv/install.sh"
+  mkdir -p "$UV_FIXTURE_DIR/astral.sh/uv"
+  for _attempt in 1 2 3 4 5; do
+    if curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 \
+        https://astral.sh/uv/install.sh -o "$UV_SCRIPT" 2>/dev/null \
+        && [ -s "$UV_SCRIPT" ]; then
+      UV_INSTALLER_FIXTURE="$UV_FIXTURE_DIR"
+      break
+    fi
+    sleep 3
+  done
+fi
+
+# Cache the architecture-matched uv tarball for both download hosts the
+# installer tries. Unknown architectures retain only the script fixture and
+# exercise the binary download upstream rather than serving the wrong artifact.
+if [ -n "$UV_INSTALLER_FIXTURE" ]; then
+  UV_VER="$(grep -om1 'releases/download/[0-9][0-9.]*' "$UV_SCRIPT" | cut -d/ -f3)"
+  case "$(uname -m)" in
+    x86_64|amd64) UV_TARGET="x86_64-unknown-linux-gnu" ;;
+    aarch64|arm64) UV_TARGET="aarch64-unknown-linux-gnu" ;;
+    *) UV_TARGET="" ;;
+  esac
+  if [ -n "$UV_VER" ] && [ -n "$UV_TARGET" ]; then
+    _uv_rel="github/uv/releases/download/$UV_VER/uv-$UV_TARGET.tar.gz"
+    mkdir -p "$UV_FIXTURE_DIR/releases.astral.sh/$(dirname "$_uv_rel")" \
+             "$UV_FIXTURE_DIR/github.com/astral-sh/$(dirname "${_uv_rel#github/}")"
+    if curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 \
+        "https://releases.astral.sh/$_uv_rel" \
+        -o "$UV_FIXTURE_DIR/releases.astral.sh/$_uv_rel" 2>/dev/null; then
+      cp "$UV_FIXTURE_DIR/releases.astral.sh/$_uv_rel" \
+         "$UV_FIXTURE_DIR/github.com/astral-sh/${_uv_rel#github/}"
+    else
+      rm -f "$UV_FIXTURE_DIR/releases.astral.sh/$_uv_rel"
+      echo "⚠ could not prefetch uv $UV_VER tarball; binary will fetch upstream" >&2
+    fi
+  fi
+  ok "prefetched uv installer for sandbox fixture"
+else
+  echo "⚠ could not prefetch uv installer; install will fetch astral.sh directly" >&2
+fi
+
 step "installing upstream $INSTALL_REF (real curl | install.sh: uv, Python, Node, venv)"
 install_in_sandbox "install of upstream $INSTALL_REF" "$INSTALL_REF" install
 

--- a/tests/test_install_e2e_contract.py
+++ b/tests/test_install_e2e_contract.py
@@ -51,6 +51,7 @@ def test_pull_request_acceptance_executes_both_flag_probe_routes() -> None:
 
     assert "route: [installer, update]" in acceptance
     assert "route: ${{ matrix.route }}" in acceptance
+    assert "install-ref: ${{ matrix.install-ref }}" in acceptance
     assert "include-browser: ${{ matrix.route == 'installer' }}" in acceptance
     assert "include-browser: true" not in acceptance
 

--- a/tests/test_install_e2e_contract.py
+++ b/tests/test_install_e2e_contract.py
@@ -43,7 +43,16 @@ def test_installer_authorities_keep_browser_and_npm_in_scope() -> None:
     assert "include-browser:" in reusable
     assert "args+=(--include-browser)" in reusable
     assert "include-browser: true" in scheduled
-    assert "include-browser: true" in acceptance
+    assert "include-browser: ${{ matrix.route == 'installer' }}" in acceptance
+
+
+def test_pull_request_acceptance_executes_both_flag_probe_routes() -> None:
+    acceptance = ACCEPTANCE.read_text()
+
+    assert "route: [installer, update]" in acceptance
+    assert "route: ${{ matrix.route }}" in acceptance
+    assert "include-browser: ${{ matrix.route == 'installer' }}" in acceptance
+    assert "include-browser: true" not in acceptance
 
 
 def test_pull_request_receipt_binds_to_the_submitted_head() -> None:

--- a/tests/test_install_e2e_contract.py
+++ b/tests/test_install_e2e_contract.py
@@ -57,6 +57,11 @@ def test_pull_request_receipt_binds_to_the_submitted_head() -> None:
     assert f"EXPECTED_SHA: {head_expression}" in reusable
     assert "steps.candidate.outputs.sha" in reusable
     assert f"ref: {head_expression}" in acceptance
+    assert (
+        'git fetch --force --tags --no-recurse-submodules \\\n'
+        '            "https://github.com/${GITHUB_REPOSITORY}.git"'
+        in acceptance
+    )
 
 
 def test_uv_fixture_does_not_hardcode_the_runner_architecture() -> None:

--- a/tests/test_install_e2e_contract.py
+++ b/tests/test_install_e2e_contract.py
@@ -1,0 +1,69 @@
+"""Regression contract for specialized Install & Update E2E acceptance."""
+
+from pathlib import Path
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HARNESS = REPO_ROOT / "tests" / "install" / "install-update-e2e.sh"
+REUSABLE = REPO_ROOT / ".github" / "workflows" / "install-e2e-run.yml"
+SCHEDULED = REPO_ROOT / ".github" / "workflows" / "install-e2e.yml"
+ACCEPTANCE = REPO_ROOT / ".github" / "workflows" / "install-e2e-acceptance.yml"
+
+
+def test_harness_exposes_explicit_browser_acceptance_mode() -> None:
+    result = subprocess.run(
+        ["bash", str(HARNESS), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "--include-browser" in result.stdout
+    text = HARNESS.read_text()
+    assert "--include-browser) INCLUDE_BROWSER=true" in text
+    assert '[ "$INCLUDE_BROWSER" = false ]' in text
+
+
+def test_flag_probes_cannot_false_negative_via_pipefail_sigpipe() -> None:
+    text = HARNESS.read_text()
+
+    # `grep -q` exits after the first match. With `set -o pipefail`, piping a
+    # large producer into it can report the producer's SIGPIPE instead of the
+    # successful match and silently change which installer flags are exercised.
+    assert "| grep -qF" not in text
+    assert 'grep -qF -- "$flag" <<<"$help"' in text
+    assert 'grep -qF -- "$flag" <<<"$script"' in text
+
+
+def test_installer_authorities_keep_browser_and_npm_in_scope() -> None:
+    reusable = REUSABLE.read_text()
+    scheduled = SCHEDULED.read_text()
+    acceptance = ACCEPTANCE.read_text()
+
+    assert "include-browser:" in reusable
+    assert "args+=(--include-browser)" in reusable
+    assert "include-browser: true" in scheduled
+    assert "include-browser: true" in acceptance
+
+
+def test_pull_request_receipt_binds_to_the_submitted_head() -> None:
+    reusable = REUSABLE.read_text()
+    acceptance = ACCEPTANCE.read_text()
+    head_expression = (
+        "${{ github.event.pull_request.head.sha || github.sha }}"
+    )
+
+    assert f"ref: {head_expression}" in reusable
+    assert f"EXPECTED_SHA: {head_expression}" in reusable
+    assert "steps.candidate.outputs.sha" in reusable
+    assert f"ref: {head_expression}" in acceptance
+
+
+def test_uv_fixture_does_not_hardcode_the_runner_architecture() -> None:
+    text = HARNESS.read_text()
+
+    assert 'case "$(uname -m)" in' in text
+    assert 'UV_TARGET="x86_64-unknown-linux-gnu"' in text
+    assert 'UV_TARGET="aarch64-unknown-linux-gnu"' in text
+    assert '_uv_rel="github/uv/releases/download/$UV_VER/uv-$UV_TARGET.tar.gz"' in text
+    assert "uv-x86_64-unknown-linux-gnu.tar.gz" not in text

--- a/tests/test_sandbox_stage2_node_ca.py
+++ b/tests/test_sandbox_stage2_node_ca.py
@@ -1,0 +1,43 @@
+"""The sandbox payload must trust the sandbox CA, not the real bundle.
+
+Every TLS client inside the sandbox talks to the MITM proxy, which
+terminates HTTPS with a cert minted by the sandbox CA and validates
+upstream against the real CA bundle itself. Node is the one payload
+client that reads NODE_EXTRA_CA_CERTS instead of SSL_CERT_FILE; pointing
+it at the real bundle made npm reject the proxy's minted certs
+(UNABLE_TO_VERIFY_LEAF_SIGNATURE) while curl/git/uv kept working, which
+surfaced as npm-install failures in the Install & Update E2E workflow
+and as the proxy logging each aborted handshake as an SSLEOFError
+(#87093).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGE2 = REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh"
+
+
+def test_payload_clients_trust_the_sandbox_ca() -> None:
+    text = STAGE2.read_text()
+
+    # Every payload-side CA variable points at the sandbox CA...
+    assert "--setenv CURL_CA_BUNDLE /work/certs/ca.pem \\" in text
+    assert "--setenv SSL_CERT_FILE /work/certs/ca.pem \\" in text
+    assert "--setenv GIT_SSL_CAINFO /work/certs/ca.pem \\" in text
+    # ...including Node's, which reads NODE_EXTRA_CA_CERTS instead of
+    # SSL_CERT_FILE.
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \\" in text
+    # The real bundle must never be handed to a payload client as its
+    # trust anchor.
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in text
+
+
+def test_proxy_still_validates_upstream_against_the_real_ca() -> None:
+    """The trust split: payload trusts the sandbox CA, proxy trusts real CAs."""
+    text = STAGE2.read_text()
+
+    # proxy.py's third argument is the real CA bundle.
+    assert (
+        "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem"
+        in text
+    )


### PR DESCRIPTION
## Summary

Repairs the specialized sandboxed **Install & Update E2E** surface end-to-end and makes that surface attest the submitted candidate object rather than borrowing generic CI or GitHub's synthetic PR merge ref.

The live submitted head is **`08b1c2d54cd21ed62208c85600fe73814c206b50`**. The product repair was rooted at current-main base `1bbb6e5bce56e721ab685af4cd87df21bbff4d35`; that historical base is provenance, not current-main certification.

## Root-cause chain

Exact-head execution separated four independent defects rather than laundering them into one network flake:

1. **Wrong payload trust authority.** Sandbox processes see a MITM leaf signed by `/work/certs/ca.pem`; the proxy alone validates public upstreams with `/work/certs/real-ca.pem`. Node now consumes the sandbox CA without weakening upstream verification.
2. **One-response CONNECT lifetime.** Once Node trusted the leaf, Node 26 reused its tunnel while `proxy.py` closed it after one response. The proxy now pumps both directions for the tunnel lifetime, strips hop-by-hop proxy headers, and bounds transient upstream connection retries.
3. **Third-party bootstrap availability masked the owned boundary.** The harness now prefetches the uv installer and architecture-matched release archive with retries, serves them through the sandbox fixture root, and still executes the real uv/Python/Node/venv installation. Unknown architectures fall back to upstream rather than receiving a wrong artifact.
4. **Acceptance scope could silently shrink.** `printf ... | grep -q` under `set -o pipefail` could false-negative feature probes through SIGPIPE. Both probes now capture output and query it through here-strings, and browser/npm coverage is an explicit reusable-workflow contract.

The final exact-head correction separates **candidate authority from release-tag authority**: fork PR execution stays bound to the submitted fork SHA while release selection comes from canonical `NousResearch/hermes-agent` tags. HEAD is re-attested before selecting the shared release sample.

## Acceptance-gap closure

- `8a6dfef43d417fa2784a6e6957b66f0ec2fbc7e2` runs the path-filtered lane as a matrix over `installer` and `update` against the same newest canonical release.
- Browser/npm installation remains explicit on the installer leg.
- The update leg exercises `installer_supports --skip-browser` and `update_supports --yes` at the mutation edge.
- `08b1c2d54cd21ed62208c85600fe73814c206b50` pins the shared `matrix.install-ref` contract so the two witnesses cannot silently sample different releases.

## Exact-object acceptance contract

The reusable installer workflow:

- checks out `${{ github.event.pull_request.head.repo.full_name }}` at `${{ github.event.pull_request.head.sha }}` for PR events;
- fails unless `git rev-parse HEAD` equals the expected submitted SHA;
- prints the bound candidate SHA;
- names retained installer artifacts with that candidate SHA;
- fetches canonical release tags without moving the candidate HEAD.

Generic CI, Docker, Nix, a historical installer run, a synthetic merge ref, or a nearby branch cannot substitute for this specialized receipt.

## Changed paths

Exactly eight paths are in scope:

- `.github/workflows/install-e2e-acceptance.yml`
- `.github/workflows/install-e2e-run.yml`
- `.github/workflows/install-e2e.yml`
- `scripts/sandbox/proxy.py`
- `scripts/sandbox/stage2-run.sh`
- `tests/install/install-update-e2e.sh`
- `tests/test_install_e2e_contract.py`
- `tests/test_sandbox_stage2_node_ca.py`

No product installer semantics, dependency pins, retry policy, or TLS verification floor are weakened.

## Regression coverage

Executable checks cover payload-side CA authority, proxy upstream trust, explicit browser/npm acceptance mode, pipefail-safe flag probes, installer/update shared-release identity, submitted-head checkout and artifact identity, canonical tag fetch without HEAD movement, and architecture-aware uv fixture selection.

Focused pre-publication validation on the exact head: `pytest -q tests/test_install_e2e_contract.py` → **6 passed**. Hosted execution below remains the acceptance authority.

## Evidence-driven iterations

- `32849051861` on `718417471dd3e3f3e16abbf1ec4d95f4576ea32a`: CA-only candidate reached npm, then failed on reused CONNECT tunnels.
- `32849836997` on `4bbc1c71ebc3ab0b3dac3238af7c5c52acd2910f`: transport candidate exposed the independent `astral.sh` bootstrap-fixture failure.
- `32851768915` on `ecaf68f01a82be686bb46c6b4487ade1ad70d865`: installer acceptance reached the release-selection authority mismatch.
- `32852261920` on `1807e7489eb140ea32299641e05d125073deedd1`: installer-route exact-head witness succeeded and exposed the remaining update-route evidence gap.

These runs are provenance for the root-cause chain; none substitutes for the live head.

## Current exact-head verification — 2026-08-27 14:09 CDT

Live head: **`08b1c2d54cd21ed62208c85600fe73814c206b50`**.

Exact-head hosted receipts now exist on the submitted SHA:

- **Installer E2E Change Acceptance `32990893400` — SUCCESS.** Both installer and update witnesses consume the same matrix-selected canonical release.
- **Docker `32990892166` — SUCCESS.**
- **Nix `32990893304` — SUCCESS.**
- **CI `32990894899` — aggregate FAILURE only at `Review label gate / Review label gate` → `Fail on missing label`.** Every substantive product/test job in that run succeeded or was an expected skip. This is therefore strong exact-head product evidence, but the aggregate CI object is not green and must not be described as green.

The old temporary witness carriers `#95698` / `#95710` are closed unmerged. They are historical execution routes, not implementation or landing owners.

The external `duplicate` label remains a **topology assertion, not closure proof**. It was applied by `alt-glitch` on 2026-08-25. This reconciliation has not established a canonical replacement that owns this exact eight-path trust/transport/acceptance contract, so the label must not be converted into completion truth without that proof.

## Canonicalization and contributor credit

- **#87635 / Jason Crabtree** supplied the canonical minimal CA split and focused regression. Commit `7184174` preserves co-authorship.
- **#94259 / Jesse Casco** supplied the keep-alive transport and uv-fixture direction. Commits `4bbc1c7` and `ecaf68f` preserve co-authorship after exact-head failures demonstrated each requirement.
- **#94622** was an exact duplicate of the CA correction and remains superseded by #87635.

This PR is the current consolidation carrier unless and until a live canonical replacement is proved. It does not erase original authorities or collapse distinct trust, transport, bootstrap, and acceptance defects into one undocumented fix.

## Required exact-head receipts

- [x] focused six-test acceptance contract green on `08b1c2d54cd21ed62208c85600fe73814c206b50`
- [x] hosted installer **and update** witnesses green on that exact head — run `32990893400`
- [x] all substantive product/test jobs in CI run `32990894899` green or expected skip
- [x] Docker green on that exact head — run `32990892166`
- [x] Nix green on that exact head — run `32990893304`
- [x] no historical or adjacent-object receipt substituted
- [ ] aggregate CI green — currently blocked only by the independent review-label gate
- [ ] independent `ci-reviewed` acceptance authority
- [ ] every submitted commit carries the required exact-object proof for its material state
- [ ] `duplicate` topology resolved only after a canonical replacement owning this exact contract is proved

Closes #94613
Supersedes #87635 as its current-main materialization and absorbs the demonstrated portions of #94259 with attribution preserved.