### PR TITLE
fix(langfuse): pin SDK install to v3 — plugin targets the v3 API

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2070,17 +2070,38 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Run manually: hermes auth spotify")
 
     elif post_setup_key == "langfuse":
-        # Install the langfuse SDK.
+        # Install the langfuse SDK. The bundled observability/langfuse plugin
+        # targets the SDK v3 API (update_trace); v4 removed those methods and
+        # the plugin fails open silently, so the install is pinned to 3.x
+        # and an existing v4 is downgraded rather than accepted (#94710).
+        _LANGFUSE_PIN = "langfuse>=3,<4"
         try:
-            __import__("langfuse")
-            _print_success("    langfuse SDK already installed")
+            import importlib.metadata as _md
+
+            _lf_ver = _md.version("langfuse")
+            if _lf_ver.startswith("3"):
+                _print_success("    langfuse SDK already installed")
+            else:
+                _print_warning(
+                    f"    langfuse SDK {_lf_ver} is incompatible with the "
+                    "bundled plugin (targets v3 update_trace API); "
+                    f"installing {_LANGFUSE_PIN}..."
+                )
+                result = _pip_install([_LANGFUSE_PIN, "--quiet"], timeout=120)
+                if result.returncode == 0:
+                    _print_success(f"    langfuse SDK pinned to {_LANGFUSE_PIN}")
+                else:
+                    _print_warning(
+                        "    langfuse SDK downgrade failed - run manually: "
+                        f"uv pip install '{_LANGFUSE_PIN}'"
+                    )
         except ImportError:
             _print_info("    Installing langfuse SDK...")
-            result = _pip_install(["langfuse", "--quiet"], timeout=120)
+            result = _pip_install([_LANGFUSE_PIN, "--quiet"], timeout=120)
             if result.returncode == 0:
                 _print_success("    langfuse SDK installed")
             else:
-                _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+                _print_warning("    langfuse SDK install failed — run manually: uv pip install 'langfuse>=3,<4'")
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -12,7 +12,7 @@ Pick one:
 hermes tools  # → Langfuse Observability
 
 # Manual
-pip install langfuse
+pip install "langfuse>=3,<4"
 hermes plugins enable observability/langfuse
 ```
 


### PR DESCRIPTION
Fixes #94710

## Problem

The bundled `observability/langfuse` plugin calls `root_span.update_trace(...)` — the **SDK v3** API, removed in v4 — and fails open when those calls raise. Meanwhile the `hermes tools` setup path:

- installed **unbounded** `langfuse` (v4.14.5 today)
- accepted any already-installed version because `__import__("langfuse")` succeeded

Net effect: a fresh setup produces a plugin that loads, starts traces, and **silently drops every trace-level input/output update** (`'LangfuseChain' object has no attribute 'update_trace'`), visible only with `HERMES_LANGFUSE_DEBUG=true`. The README's manual-install line had the same unbounded pin.

## Fix

- Fresh installs: `langfuse>=3,<4`
- Existing install: version checked via `importlib.metadata`; a non-3.x version is **downgraded with a warning** instead of accepted
- Failure messages updated to quote the pinned specifier
- README manual line: `pip install "langfuse>=3,<4"`

## Verification

`tests/plugins/test_langfuse_plugin.py` + `tests/hermes_cli/test_plugins_cmd.py`: 134 passed; the one `TestResolveSubdirWithin::test_rejects_symlink_escape` failure is pre-existing on clean `main` on this Windows host (symlink-privilege dependent — reproduced with the change stashed).