### PR TITLE
feat(display): mid-session /model cache-rebuild notice + revert hint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11170,6 +11170,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             save_config_value("model.context_length", None)
 
+    def _print_cache_switch_notice(
+        self,
+        *,
+        old_model_display: str,
+        new_model_display: str,
+        pre_switch_tokens: int,
+        new_provider: str,
+        include_revert_hint: bool = True,
+    ) -> None:
+        """Print the mid-session cache-rebuild notice (shared by both /model
+        apply paths). Uses the PRE-switch token snapshot — switch_model()
+        already zeroed the live counters by the time this runs.
+        Informational only, never blocks."""
+        try:
+            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
+
+            _cache_notice = cache_switch_notice_for_agent(
+                old_model_display=old_model_display,
+                new_model_display=new_model_display,
+                est_context_tokens=pre_switch_tokens,
+                old_provider=self.provider if self.provider == new_provider else "",
+                new_provider=new_provider,
+                include_revert_hint=include_revert_hint,
+            )
+            if _cache_notice:
+                for _line in _cache_notice.splitlines():
+                    _cprint(f"  {_line}")
+        except Exception as exc:
+            logger.debug("cache-switch notice failed: %s", exc)
+
     def _apply_model_switch_result(
         self, result, persist_global: bool, custom_providers=None
     ) -> None:
@@ -11229,11 +11259,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if result.api_mode:
             self.api_mode = result.api_mode
 
+        # Snapshot the context estimate BEFORE switch_model() — that call
+        # zeroes compressor.last_prompt_tokens and clears the cached system
+        # prompt, so estimating afterwards under-reports (P0, PR #94753).
+        _pre_switch_tokens = 0
         if self.agent is not None:
-            # Snapshot the context estimate BEFORE switch_model() — that call
-            # zeroes compressor.last_prompt_tokens and clears the cached
-            # system prompt, so estimating afterwards under-reports (P0, PR
-            # #94753 review).
             try:
                 from hermes_cli.cache_switch_notice import snapshot_pre_switch_state
 
@@ -11278,21 +11308,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Mid-session cache-rebuild notice (display.cache_switch_notice).
         # Uses the PRE-switch token snapshot — switch_model() already zeroed
         # the live counters above. Informational only, never blocks.
-        try:
-            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
-
-            _cache_notice = cache_switch_notice_for_agent(
-                old_model_display=_display_old,
-                new_model_display=_display_new,
-                est_context_tokens=_pre_switch_tokens,
-                old_provider=self.provider if self.provider == result.target_provider else "",
-                new_provider=result.target_provider,
-            )
-            if _cache_notice:
-                for _line in _cache_notice.splitlines():
-                    _cprint(f"  {_line}")
-        except Exception as exc:
-            logger.debug("cache-switch notice failed: %s", exc)
+        self._print_cache_switch_notice(
+            old_model_display=_display_old,
+            new_model_display=_display_new,
+            pre_switch_tokens=_pre_switch_tokens,
+            new_provider=result.target_provider,
+        )
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
@@ -11648,11 +11669,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.api_mode = result.api_mode
 
         # Apply to running agent (in-place swap)
+        # Snapshot the context estimate BEFORE switch_model() — that call
+        # zeroes compressor.last_prompt_tokens and clears the cached system
+        # prompt, so estimating afterwards under-reports (P0, PR #94753).
+        _pre_switch_tokens = 0
         if self.agent is not None:
-            # Snapshot the context estimate BEFORE switch_model() — that call
-            # zeroes compressor.last_prompt_tokens and clears the cached
-            # system prompt, so estimating afterwards under-reports (P0, PR
-            # #94753 review).
             try:
                 from hermes_cli.cache_switch_notice import snapshot_pre_switch_state
 
@@ -11702,24 +11723,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cprint(f"    Provider: {provider_label}")
 
         # Mid-session cache-rebuild notice (display.cache_switch_notice).
-        # Informational only — never blocks the switch. Silent when the
-        # estimated context is below the noise threshold or the toggle is off.
-        try:
-            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
-
-            _cache_notice = cache_switch_notice_for_agent(
-                old_model_display=_display_old,
-                new_model_display=_display_new,
-                est_context_tokens=_pre_switch_tokens,
-                old_provider=self.provider if self.provider == result.target_provider else "",
-                new_provider=result.target_provider,
-                include_revert_hint=not one_turn,
-            )
-            if _cache_notice:
-                for _line in _cache_notice.splitlines():
-                    _cprint(f"  {_line}")
-        except Exception as exc:
-            logger.debug("cache-switch notice failed: %s", exc)
+        # Uses the PRE-switch token snapshot — see shared helper.
+        self._print_cache_switch_notice(
+            old_model_display=_display_old,
+            new_model_display=_display_new,
+            pre_switch_tokens=_pre_switch_tokens,
+            new_provider=result.target_provider,
+            include_revert_hint=not one_turn,
+        )
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry

--- a/cli.py
+++ b/cli.py
@@ -11230,6 +11230,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.api_mode = result.api_mode
 
         if self.agent is not None:
+            # Snapshot the context estimate BEFORE switch_model() — that call
+            # zeroes compressor.last_prompt_tokens and clears the cached
+            # system prompt, so estimating afterwards under-reports (P0, PR
+            # #94753 review).
+            try:
+                from hermes_cli.cache_switch_notice import snapshot_pre_switch_state
+
+                _pre_switch_tokens = snapshot_pre_switch_state(self.agent)
+            except Exception:
+                _pre_switch_tokens = 0
             try:
                 self.agent.switch_model(
                     new_model=result.new_model,
@@ -11266,15 +11276,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cprint(f"    Provider: {provider_label}")
 
         # Mid-session cache-rebuild notice (display.cache_switch_notice).
-        # Informational only — never blocks the switch. Silent when the
-        # estimated context is below the noise threshold or the toggle is off.
+        # Uses the PRE-switch token snapshot — switch_model() already zeroed
+        # the live counters above. Informational only, never blocks.
         try:
             from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
 
             _cache_notice = cache_switch_notice_for_agent(
-                agent=self.agent,
                 old_model_display=_display_old,
                 new_model_display=_display_new,
+                est_context_tokens=_pre_switch_tokens,
+                old_provider=self.provider if self.provider == result.target_provider else "",
+                new_provider=result.target_provider,
             )
             if _cache_notice:
                 for _line in _cache_notice.splitlines():
@@ -11637,6 +11649,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Apply to running agent (in-place swap)
         if self.agent is not None:
+            # Snapshot the context estimate BEFORE switch_model() — that call
+            # zeroes compressor.last_prompt_tokens and clears the cached
+            # system prompt, so estimating afterwards under-reports (P0, PR
+            # #94753 review).
+            try:
+                from hermes_cli.cache_switch_notice import snapshot_pre_switch_state
+
+                _pre_switch_tokens = snapshot_pre_switch_state(self.agent)
+            except Exception:
+                _pre_switch_tokens = 0
             try:
                 self.agent.switch_model(
                     new_model=result.new_model,
@@ -11686,9 +11708,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
 
             _cache_notice = cache_switch_notice_for_agent(
-                agent=self.agent,
                 old_model_display=_display_old,
                 new_model_display=_display_new,
+                est_context_tokens=_pre_switch_tokens,
+                old_provider=self.provider if self.provider == result.target_provider else "",
+                new_provider=result.target_provider,
+                include_revert_hint=not one_turn,
             )
             if _cache_notice:
                 for _line in _cache_notice.splitlines():

--- a/cli.py
+++ b/cli.py
@@ -11265,6 +11265,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cprint(f"  ✓ Model switched: {_display_new}")
         _cprint(f"    Provider: {provider_label}")
 
+        # Mid-session cache-rebuild notice (display.cache_switch_notice).
+        # Informational only — never blocks the switch. Silent when the
+        # estimated context is below the noise threshold or the toggle is off.
+        try:
+            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
+
+            _cache_notice = cache_switch_notice_for_agent(
+                agent=self.agent,
+                old_model_display=_display_old,
+                new_model_display=_display_new,
+            )
+            if _cache_notice:
+                for _line in _cache_notice.splitlines():
+                    _cprint(f"  {_line}")
+        except Exception as exc:
+            logger.debug("cache-switch notice failed: %s", exc)
+
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
@@ -11661,6 +11678,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         provider_label = result.provider_label or result.target_provider
         _cprint(f"  ✓ Model switched: {_display_new}")
         _cprint(f"    Provider: {provider_label}")
+
+        # Mid-session cache-rebuild notice (display.cache_switch_notice).
+        # Informational only — never blocks the switch. Silent when the
+        # estimated context is below the noise threshold or the toggle is off.
+        try:
+            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
+
+            _cache_notice = cache_switch_notice_for_agent(
+                agent=self.agent,
+                old_model_display=_display_old,
+                new_model_display=_display_new,
+            )
+            if _cache_notice:
+                for _line in _cache_notice.splitlines():
+                    _cprint(f"  {_line}")
+        except Exception as exc:
+            logger.debug("cache-switch notice failed: %s", exc)
 
         # Context: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1756,29 +1756,29 @@ class GatewaySlashCommandsMixin:
         old_model_display: str,
         new_model_display: str,
         agent=None,
+        est_context_tokens: Optional[int] = None,
+        old_provider: str = "",
+        new_provider: str = "",
+        include_revert_hint: bool = True,
     ) -> None:
         """Append the mid-session cache-rebuild notice if it applies.
 
-        Prefer a live agent when one is handed in (or found in the agent
-        cache); fall back to a silent no-op when neither is available so a
-        cold gateway still switches cleanly without a noisy estimate of 0.
+        ``est_context_tokens`` must come from ``snapshot_pre_switch_state()``
+        called BEFORE the in-place switch — afterwards the counters are zeroed
+        (P0, PR #94753 review). Falls back to estimating from ``agent`` only
+        when no snapshot was provided.
         """
         try:
             from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
 
-            live_agent = agent
-            if live_agent is None:
-                _cache_lock = getattr(self, "_agent_cache_lock", None)
-                _cache = getattr(self, "_agent_cache", None)
-                if _cache_lock is not None and _cache is not None:
-                    with _cache_lock:
-                        _entry = _cache.get(session_key)
-                    if _entry and _entry[0] is not None:
-                        live_agent = _entry[0]
             notice = cache_switch_notice_for_agent(
-                agent=live_agent,
+                agent=agent,
                 old_model_display=old_model_display,
                 new_model_display=new_model_display,
+                est_context_tokens=est_context_tokens,
+                old_provider=old_provider,
+                new_provider=new_provider,
+                include_revert_hint=include_revert_hint,
             )
             if notice:
                 lines.extend(notice.splitlines())
@@ -1975,12 +1975,25 @@ class GatewaySlashCommandsMixin:
                         # Update cached agent in-place
                         cached_entry = None
                         _switched_agent = None
+                        _pre_switch_tokens = 0
                         _cache_lock = getattr(_self, "_agent_cache_lock", None)
                         _cache = getattr(_self, "_agent_cache", None)
                         if _cache_lock and _cache is not None:
                             with _cache_lock:
                                 cached_entry = _cache.get(_session_key)
                         if cached_entry and cached_entry[0] is not None:
+                            # Snapshot the context estimate BEFORE switch_model()
+                            # — that call zeroes the live counters (P0 review).
+                            try:
+                                from hermes_cli.cache_switch_notice import (
+                                    snapshot_pre_switch_state,
+                                )
+
+                                _pre_switch_tokens = snapshot_pre_switch_state(
+                                    cached_entry[0]
+                                )
+                            except Exception:
+                                _pre_switch_tokens = 0
                             try:
                                 cached_entry[0].switch_model(
                                     new_model=result.new_model,
@@ -2173,14 +2186,18 @@ class GatewaySlashCommandsMixin:
                                 lines.append(t("gateway.model.max_output_label", tokens=f"{mi.max_output:,}"))
                             lines.append(t("gateway.model.capabilities_label", capabilities=mi.format_capabilities()))
                         # Mid-session cache-rebuild notice (display.cache_switch_notice).
-                        # Uses the agent we switched in-place above — the cache
-                        # has already been evicted by this point.
+                        # Uses the PRE-switch token snapshot — the in-place
+                        # switch above already zeroed the live counters, and
+                        # the agent cache has been evicted by this point.
                         _self._append_cache_switch_notice(
                             lines,
                             session_key=_session_key,
                             old_model_display=_display_cur,
                             new_model_display=_display_new,
                             agent=_switched_agent,
+                            est_context_tokens=_pre_switch_tokens,
+                            old_provider=_cur_provider,
+                            new_provider=result.target_provider,
                         )
                         if result.warning_message:
                             lines.append(t("gateway.model.warning_prefix", warning=result.warning_message))
@@ -2301,6 +2318,7 @@ class GatewaySlashCommandsMixin:
             # If there's a cached agent, update it in-place
             cached_entry = None
             _switched_agent = None
+            _pre_switch_tokens = 0
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
             if _cache_lock and _cache is not None:
@@ -2308,6 +2326,16 @@ class GatewaySlashCommandsMixin:
                     cached_entry = _cache.get(session_key)
 
             if cached_entry and cached_entry[0] is not None:
+                # Snapshot the context estimate BEFORE switch_model() — that
+                # call zeroes compressor.last_prompt_tokens and clears the
+                # cached system prompt, so estimating afterwards under-reports
+                # (P0, PR #94753 review).
+                try:
+                    from hermes_cli.cache_switch_notice import snapshot_pre_switch_state
+
+                    _pre_switch_tokens = snapshot_pre_switch_state(cached_entry[0])
+                except Exception:
+                    _pre_switch_tokens = 0
                 try:
                     cached_entry[0].switch_model(
                         new_model=result.new_model,
@@ -2523,15 +2551,19 @@ class GatewaySlashCommandsMixin:
                 lines.append(t("gateway.model.prompt_caching_enabled"))
 
             # Mid-session cache-rebuild notice (display.cache_switch_notice).
-            # Informational only — never blocks. Silent below the noise threshold.
-            # Pass the agent we switched in-place above — the cache has already
-            # been evicted by this point so a cache lookup would miss.
+            # Uses the PRE-switch token snapshot — the in-place switch above
+            # already zeroed the live counters, and the agent cache has been
+            # evicted by this point.
             self._append_cache_switch_notice(
                 lines,
                 session_key=session_key,
                 old_model_display=format_model_for_display(current_model),
                 new_model_display=format_model_for_display(result.new_model),
                 agent=_switched_agent,
+                est_context_tokens=_pre_switch_tokens,
+                old_provider=current_provider,
+                new_provider=result.target_provider,
+                include_revert_hint=not one_turn,
             )
 
             if result.warning_message:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1748,6 +1748,43 @@ class GatewaySlashCommandsMixin:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
+    def _append_cache_switch_notice(
+        self,
+        lines: list,
+        *,
+        session_key: str,
+        old_model_display: str,
+        new_model_display: str,
+        agent=None,
+    ) -> None:
+        """Append the mid-session cache-rebuild notice if it applies.
+
+        Prefer a live agent when one is handed in (or found in the agent
+        cache); fall back to a silent no-op when neither is available so a
+        cold gateway still switches cleanly without a noisy estimate of 0.
+        """
+        try:
+            from hermes_cli.cache_switch_notice import cache_switch_notice_for_agent
+
+            live_agent = agent
+            if live_agent is None:
+                _cache_lock = getattr(self, "_agent_cache_lock", None)
+                _cache = getattr(self, "_agent_cache", None)
+                if _cache_lock is not None and _cache is not None:
+                    with _cache_lock:
+                        _entry = _cache.get(session_key)
+                    if _entry and _entry[0] is not None:
+                        live_agent = _entry[0]
+            notice = cache_switch_notice_for_agent(
+                agent=live_agent,
+                old_model_display=old_model_display,
+                new_model_display=new_model_display,
+            )
+            if notice:
+                lines.extend(notice.splitlines())
+        except Exception as exc:
+            logger.debug("cache-switch notice failed: %s", exc)
+
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model.
 
@@ -1937,6 +1974,7 @@ class GatewaySlashCommandsMixin:
 
                         # Update cached agent in-place
                         cached_entry = None
+                        _switched_agent = None
                         _cache_lock = getattr(_self, "_agent_cache_lock", None)
                         _cache = getattr(_self, "_agent_cache", None)
                         if _cache_lock and _cache is not None:
@@ -1951,6 +1989,9 @@ class GatewaySlashCommandsMixin:
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
                                 )
+                                # Hold the live agent so the cache-rebuild notice
+                                # can still estimate context after we evict below.
+                                _switched_agent = cached_entry[0]
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
                                 # OLD working model/client and re-raised.  Abort
@@ -2131,6 +2172,16 @@ class GatewaySlashCommandsMixin:
                             if mi.max_output:
                                 lines.append(t("gateway.model.max_output_label", tokens=f"{mi.max_output:,}"))
                             lines.append(t("gateway.model.capabilities_label", capabilities=mi.format_capabilities()))
+                        # Mid-session cache-rebuild notice (display.cache_switch_notice).
+                        # Uses the agent we switched in-place above — the cache
+                        # has already been evicted by this point.
+                        _self._append_cache_switch_notice(
+                            lines,
+                            session_key=_session_key,
+                            old_model_display=_display_cur,
+                            new_model_display=_display_new,
+                            agent=_switched_agent,
+                        )
                         if result.warning_message:
                             lines.append(t("gateway.model.warning_prefix", warning=result.warning_message))
                         if persist_global:
@@ -2249,6 +2300,7 @@ class GatewaySlashCommandsMixin:
             """Apply the resolved switch (agent, session, config) and build the reply."""
             # If there's a cached agent, update it in-place
             cached_entry = None
+            _switched_agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
             if _cache_lock and _cache is not None:
@@ -2264,6 +2316,9 @@ class GatewaySlashCommandsMixin:
                         base_url=result.base_url,
                         api_mode=result.api_mode,
                     )
+                    # Hold the live agent so the cache-rebuild notice can still
+                    # estimate context after we evict the cache entry below.
+                    _switched_agent = cached_entry[0]
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working
                     # model/client and re-raised.  Abort the commit: skip DB
@@ -2466,6 +2521,18 @@ class GatewaySlashCommandsMixin:
             )
             if cache_enabled:
                 lines.append(t("gateway.model.prompt_caching_enabled"))
+
+            # Mid-session cache-rebuild notice (display.cache_switch_notice).
+            # Informational only — never blocks. Silent below the noise threshold.
+            # Pass the agent we switched in-place above — the cache has already
+            # been evicted by this point so a cache lookup would miss.
+            self._append_cache_switch_notice(
+                lines,
+                session_key=session_key,
+                old_model_display=format_model_for_display(current_model),
+                new_model_display=format_model_for_display(result.new_model),
+                agent=_switched_agent,
+            )
 
             if result.warning_message:
                 lines.append(t("gateway.model.warning_prefix", warning=result.warning_message))

--- a/hermes_cli/cache_switch_notice.py
+++ b/hermes_cli/cache_switch_notice.py
@@ -1,0 +1,164 @@
+"""Cache-rebuild notice for mid-session model switches.
+
+Switching models mid-conversation invalidates the prompt cache the new
+model would otherwise hit: providers key prompt caches per model, so the
+first call after a switch re-reads the entire context fully uncached —
+every tool result, file read, and web page in the session, billed at full
+input price once. On a short session that costs pennies; on a long one it
+is real money, and users have no way to see it coming.
+
+This module builds a single informational line appended to the ``/model``
+switch confirmation on every surface (CLI, TUI, gateway). It is NOT a
+confirmation gate — the switch already happened; the notice only makes the
+one-time cost visible and offers the session-scoped revert command.
+
+Design constraints honored here (see AGENTS.md):
+
+- Informational only. Never blocks, never prompts, never mutates context —
+  the note is display output, so prompt caching and message alternation are
+  untouched.
+- Fires only when it matters: below ``MIN_CONTEXT_TOKENS`` the re-read cost
+  is negligible and the line would be noise, so nothing is emitted. Empty
+  and near-empty sessions stay silent.
+- Gated by ``display.cache_switch_notice`` in config.yaml (never env vars).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+# Below this estimated context size, the uncached re-read after a switch is
+# cheap enough that warning about it is pure noise. ~30k tokens ≈ several
+# substantial exchanges (or one long document read).
+MIN_CONTEXT_TOKENS = 30_000
+
+
+def cache_switch_notice_enabled() -> bool:
+    """Read ``display.cache_switch_notice`` (default: enabled).
+
+    Config failures degrade to "enabled" — a broken config.yaml should not
+    silently suppress a cost signal.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        display = (load_config_readonly() or {}).get("display") or {}
+        value = display.get("cache_switch_notice")
+        if value is None:
+            return True
+        return bool(value)
+    except Exception:
+        return True
+
+
+def _compressor_reported_tokens(agent: Any) -> int:
+    """Provider-reported prompt tokens from the agent's context engine.
+
+    Returns 0 when unknown. ``last_prompt_tokens`` parks at a -1 sentinel
+    right after a compression (awaiting real usage) — clamp it to 0, the
+    same treatment the status bar applies (cli.py snapshot path).
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return 0
+    try:
+        tokens = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+    return tokens if tokens > 0 else 0
+
+
+def _rough_estimate_tokens(agent: Any) -> int:
+    """Rough token estimate over the live conversation as a fallback.
+
+    Used when no provider-reported count exists yet (fresh session, or the
+    first turn before any usage came back). Mirrors the payload buckets
+    Hermes actually sends: system prompt, messages, tool schemas.
+    """
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    messages: List[dict] = [
+        m
+        for m in (getattr(agent, "conversation_history", None) or [])
+        if isinstance(m, dict)
+    ]
+    system_prompt = str(getattr(agent, "system_prompt", "") or "")
+    tools = getattr(agent, "tools", None)
+    try:
+        return int(
+            estimate_request_tokens_rough(messages, system_prompt=system_prompt, tools=tools)
+        )
+    except Exception:
+        return 0
+
+
+def estimate_context_tokens(agent: Any) -> int:
+    """Best-effort context size for the cache-notice decision.
+
+    Prefers the provider-reported prompt token count from the last real API
+    call; falls back to a rough structural estimate. Returns 0 when neither
+    is available (bare/test agents) — callers treat 0 as "below threshold".
+    """
+    if agent is None:
+        return 0
+    reported = _compressor_reported_tokens(agent)
+    if reported > 0:
+        return reported
+    return _rough_estimate_tokens(agent)
+
+
+def build_cache_switch_notice(
+    *,
+    old_model_display: str,
+    new_model_display: str,
+    est_context_tokens: int,
+) -> Optional[str]:
+    """Build the user-facing notice, or None when it should stay silent.
+
+    Silent when:
+    - the "switch" didn't change the model (same-model re-select keeps the
+      cache warm — there is nothing to warn about),
+    - the estimated context is below :data:`MIN_CONTEXT_TOKENS`,
+    - the config toggle is off.
+    """
+    if not old_model_display or not new_model_display:
+        return None
+    if old_model_display == new_model_display:
+        return None
+    if est_context_tokens < MIN_CONTEXT_TOKENS:
+        return None
+
+    from agent.i18n import t
+
+    # Round to nearest thousand with half-up (not banker's), so 30_500 → 31k.
+    k = max(1, int((est_context_tokens + 500) // 1000))
+    return "\n".join(
+        [
+            t(
+                "gateway.model.cache_switch_notice",
+                model=new_model_display,
+                tokens=f"{k}k",
+            ),
+            t("gateway.model.cache_switch_revert_hint", model=old_model_display),
+        ]
+    )
+
+
+def cache_switch_notice_for_agent(
+    *,
+    agent: Any,
+    old_model_display: str,
+    new_model_display: str,
+) -> Optional[str]:
+    """Convenience wrapper: gate on config, estimate, and build in one call.
+
+    All three surfaces (CLI apply path, gateway typed-command path, gateway
+    picker callback) call this with their live agent reference.
+    """
+    if not cache_switch_notice_enabled():
+        return None
+    return build_cache_switch_notice(
+        old_model_display=old_model_display,
+        new_model_display=new_model_display,
+        est_context_tokens=estimate_context_tokens(agent),
+    )

--- a/hermes_cli/cache_switch_notice.py
+++ b/hermes_cli/cache_switch_notice.py
@@ -8,9 +8,9 @@ input price once. On a short session that costs pennies; on a long one it
 is real money, and users have no way to see it coming.
 
 This module builds a single informational line appended to the ``/model``
-switch confirmation on every surface (CLI, TUI, gateway). It is NOT a
-confirmation gate — the switch already happened; the notice only makes the
-one-time cost visible and offers the session-scoped revert command.
+switch confirmation on every wired surface. It is NOT a confirmation gate
+— the switch already happened; the notice only makes the one-time cost
+visible and offers the session-scoped revert command.
 
 Design constraints honored here (see AGENTS.md):
 
@@ -21,6 +21,13 @@ Design constraints honored here (see AGENTS.md):
   is negligible and the line would be noise, so nothing is emitted. Empty
   and near-empty sessions stay silent.
 - Gated by ``display.cache_switch_notice`` in config.yaml (never env vars).
+
+CRITICAL CALL ORDER (see PR #94753 review): ``agent.switch_model()`` calls
+``context_compressor.update_model()``, which zeroes ``last_prompt_tokens``
+and clears ``_cached_system_prompt`` by design. Every caller MUST snapshot
+the estimate (and any fields it wants) BEFORE calling ``switch_model()`` —
+afterwards the agent looks like an empty session and the notice goes
+silent exactly when it matters most.
 """
 
 from __future__ import annotations
@@ -31,6 +38,17 @@ from typing import Any, List, Optional
 # cheap enough that warning about it is pure noise. ~30k tokens ≈ several
 # substantial exchanges (or one long document read).
 MIN_CONTEXT_TOKENS = 30_000
+
+
+def _parse_bool(value: Any) -> bool:
+    """Config-truthy parse: real booleans plus common string spellings.
+
+    ``"false"``, ``"no"``, ``"0"``, ``"off"`` are False — a bare ``bool()``
+    would treat every non-empty string (including "false") as True.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() not in {"false", "no", "0", "off", ""}
+    return bool(value)
 
 
 def cache_switch_notice_enabled() -> bool:
@@ -46,7 +64,7 @@ def cache_switch_notice_enabled() -> bool:
         value = display.get("cache_switch_notice")
         if value is None:
             return True
-        return bool(value)
+        return _parse_bool(value)
     except Exception:
         return True
 
@@ -68,6 +86,43 @@ def _compressor_reported_tokens(agent: Any) -> int:
     return tokens if tokens > 0 else 0
 
 
+def _agent_messages_and_prompt(agent: Any) -> tuple[List[dict], str]:
+    """Read conversation history + system prompt off either agent shape.
+
+    ``AIAgent`` keeps them in ``_session_messages`` / ``_cached_system_prompt``;
+    the classic CLI object exposes ``conversation_history`` / ``system_prompt``.
+    Probe the AIAgent names FIRST — ``switch_model()`` clears
+    ``_cached_system_prompt``, which is exactly why callers must snapshot
+    before switching (module docstring).
+    """
+    messages: List[dict] = []
+    for source_name in ("_session_messages", "conversation_history"):
+        raw = getattr(agent, source_name, None)
+        if raw:
+            messages = [m for m in raw if isinstance(m, dict)]
+            break
+    system_prompt = ""
+    for prompt_name in ("_cached_system_prompt", "system_prompt"):
+        raw = getattr(agent, prompt_name, None)
+        if raw:
+            system_prompt = str(raw)
+            break
+    return messages, system_prompt
+
+
+def _agent_tools(agent: Any) -> Optional[List[dict]]:
+    """Best-effort tool-schema list for the rough estimator.
+
+    Prefers the live resolved schemas; ``tools`` may be names/strings on
+    some shapes, in which case the estimator just counts less accurately.
+    """
+    for name in ("_tool_definitions", "tool_definitions", "tools"):
+        raw = getattr(agent, name, None)
+        if isinstance(raw, list) and raw:
+            return raw
+    return None
+
+
 def _rough_estimate_tokens(agent: Any) -> int:
     """Rough token estimate over the live conversation as a fallback.
 
@@ -75,15 +130,13 @@ def _rough_estimate_tokens(agent: Any) -> int:
     first turn before any usage came back). Mirrors the payload buckets
     Hermes actually sends: system prompt, messages, tool schemas.
     """
-    from agent.model_metadata import estimate_request_tokens_rough
+    try:
+        from agent.model_metadata import estimate_request_tokens_rough
+    except Exception:
+        return 0
 
-    messages: List[dict] = [
-        m
-        for m in (getattr(agent, "conversation_history", None) or [])
-        if isinstance(m, dict)
-    ]
-    system_prompt = str(getattr(agent, "system_prompt", "") or "")
-    tools = getattr(agent, "tools", None)
+    messages, system_prompt = _agent_messages_and_prompt(agent)
+    tools = _agent_tools(agent)
     try:
         return int(
             estimate_request_tokens_rough(messages, system_prompt=system_prompt, tools=tools)
@@ -96,8 +149,11 @@ def estimate_context_tokens(agent: Any) -> int:
     """Best-effort context size for the cache-notice decision.
 
     Prefers the provider-reported prompt token count from the last real API
-    call; falls back to a rough structural estimate. Returns 0 when neither
-    is available (bare/test agents) — callers treat 0 as "below threshold".
+    call; falls back to a rough structural estimate over whatever message /
+    prompt / tool attributes this agent shape carries. Returns 0 when
+    neither is available — callers treat 0 as "below threshold".
+
+    MUST be called BEFORE ``agent.switch_model()`` — see module docstring.
     """
     if agent is None:
         return 0
@@ -107,23 +163,58 @@ def estimate_context_tokens(agent: Any) -> int:
     return _rough_estimate_tokens(agent)
 
 
+def same_model_reselect(
+    *,
+    old_model: str,
+    old_provider: str = "",
+    new_model: str,
+    new_provider: str = "",
+) -> bool:
+    """True when the switch is a no-op for caching purposes.
+
+    Prompt caches are keyed per (provider, model). Same display string with
+    a different provider IS a real cache miss (e.g. grok-4.6 xAI-OAuth →
+    grok-4.6 OpenRouter), so identity requires BOTH to match. Unknown
+    providers compare on the model alone.
+    """
+    om = (old_model or "").strip()
+    nm = (new_model or "").strip()
+    op = (old_provider or "").strip().lower()
+    np_ = (new_provider or "").strip().lower()
+    if not om or not nm:
+        return False
+    if om != nm:
+        return False
+    # Model IDs match: it's a re-select unless the providers differ AND we
+    # know both of them.
+    if op and np_ and op != np_:
+        return False
+    return True
+
+
 def build_cache_switch_notice(
     *,
     old_model_display: str,
     new_model_display: str,
     est_context_tokens: int,
+    is_reselect: bool = False,
+    include_revert_hint: bool = True,
 ) -> Optional[str]:
     """Build the user-facing notice, or None when it should stay silent.
 
     Silent when:
-    - the "switch" didn't change the model (same-model re-select keeps the
-      cache warm — there is nothing to warn about),
+    - ``is_reselect`` — same (provider, model) re-select keeps the cache
+      warm, there is nothing to warn about,
     - the estimated context is below :data:`MIN_CONTEXT_TOKENS`,
-    - the config toggle is off.
+    - the config toggle is off (checked by :func:`cache_switch_notice_enabled`).
+
+    ``include_revert_hint=False`` for ``--once`` switches: those auto-restore
+    after one turn, so telling the user to type ``/model <old>`` would be
+    wrong.
     """
     if not old_model_display or not new_model_display:
         return None
-    if old_model_display == new_model_display:
+    if is_reselect:
         return None
     if est_context_tokens < MIN_CONTEXT_TOKENS:
         return None
@@ -132,33 +223,60 @@ def build_cache_switch_notice(
 
     # Round to nearest thousand with half-up (not banker's), so 30_500 → 31k.
     k = max(1, int((est_context_tokens + 500) // 1000))
-    return "\n".join(
-        [
-            t(
-                "gateway.model.cache_switch_notice",
-                model=new_model_display,
-                tokens=f"{k}k",
-            ),
-            t("gateway.model.cache_switch_revert_hint", model=old_model_display),
-        ]
-    )
+    lines = [
+        t(
+            "gateway.model.cache_switch_notice",
+            model=new_model_display,
+            tokens=f"{k}k",
+        ),
+    ]
+    if include_revert_hint:
+        lines.append(t("gateway.model.cache_switch_revert_hint", model=old_model_display))
+    return "\n".join(lines)
+
+
+def snapshot_pre_switch_state(agent: Any) -> int:
+    """Capture the context-token estimate BEFORE ``switch_model()`` runs.
+
+    The single integration point every surface must call pre-switch;
+    ``switch_model()`` zeroes the compressor counters and clears the cached
+    system prompt, so anything captured afterwards under-reports (PR
+    #94753 review, P0).
+    """
+    return estimate_context_tokens(agent)
 
 
 def cache_switch_notice_for_agent(
     *,
-    agent: Any,
+    agent: Any = None,
     old_model_display: str,
     new_model_display: str,
+    est_context_tokens: Optional[int] = None,
+    old_provider: str = "",
+    new_provider: str = "",
+    include_revert_hint: bool = True,
 ) -> Optional[str]:
-    """Convenience wrapper: gate on config, estimate, and build in one call.
+    """Compose config gate + reselect check + builder in one call.
 
-    All three surfaces (CLI apply path, gateway typed-command path, gateway
-    picker callback) call this with their live agent reference.
+    ``est_context_tokens`` should come from :func:`snapshot_pre_switch_state`
+    called BEFORE ``switch_model()``. When omitted, falls back to estimating
+    from ``agent`` right now — only correct for surfaces that have not yet
+    switched (or tests). ``agent`` may be None when only a pre-captured
+    token count is available.
     """
     if not cache_switch_notice_enabled():
         return None
+    if est_context_tokens is None:
+        est_context_tokens = estimate_context_tokens(agent)
     return build_cache_switch_notice(
         old_model_display=old_model_display,
         new_model_display=new_model_display,
-        est_context_tokens=estimate_context_tokens(agent),
+        est_context_tokens=est_context_tokens,
+        is_reselect=same_model_reselect(
+            old_model=old_model_display,
+            old_provider=old_provider,
+            new_model=new_model_display,
+            new_provider=new_provider,
+        ),
+        include_revert_hint=include_revert_hint,
     )

--- a/hermes_cli/cache_switch_notice.py
+++ b/hermes_cli/cache_switch_notice.py
@@ -154,6 +154,15 @@ def estimate_context_tokens(agent: Any) -> int:
     neither is available — callers treat 0 as "below threshold".
 
     MUST be called BEFORE ``agent.switch_model()`` — see module docstring.
+
+    Approximation note (PR #94753 review): the provider-reported count comes
+    from the OLD model's last API call. The NEW model may tokenize the same
+    conversation differently, so this is an upper-bound estimate of what it
+    will re-read, not an exact figure — hence the "up to ~Nk" wording in
+    the notice. This is inherent: the new model has no call history yet, so
+    a pre-switch estimate under the old tokenizer is the best signal
+    available. The rough fallback (system + messages + tools) is
+    model-agnostic and slightly more conservative.
     """
     if agent is None:
         return 0

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1322,6 +1322,12 @@ DEFAULT_CONFIG = {
     "display": {
         "compact": False,
         "personality": "",
+        # When True (default), a mid-session /model switch appends an
+        # informational line to the confirmation showing the estimated
+        # uncached re-read cost of the new model's first reply, plus the
+        # session-scoped revert command. Sessions below the noise threshold
+        # (~30k context tokens) stay silent regardless of this toggle.
+        "cache_switch_notice": True,
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the
         # historical hardcoded values; expose them as config so power users can

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -37,7 +37,7 @@ gateway:
     capabilities_label:     "Fähigkeiten: {capabilities}"
     prompt_caching_enabled: "Prompt-Caching: aktiviert"
     cache_switch_notice:    "⚡ Mitten in der Session zu `{model}` gewechselt — die nächste Antwort liest ~{tokens} Kontext uncached neu (einmalig)"
-    cache_switch_revert_hint: "  ↩ `/model {model}` tippen, um zurückzuwechseln — gleiche Unterhaltung, kein erneutes Einlesen"
+    cache_switch_revert_hint: "↩ `/model {model}` tippen, um zurückzuwechseln — gleiche Unterhaltung, kein erneutes Einlesen"
     warning_prefix:         "Warnung: {warning}"
     saved_global:           "In config.yaml gespeichert (`--global`)"
     session_only_hint:      "_(nur für diese Sitzung — `--global` ergänzen, um zu speichern)_"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -36,6 +36,8 @@ gateway:
     cost_label:             "Kosten: {cost}"
     capabilities_label:     "Fähigkeiten: {capabilities}"
     prompt_caching_enabled: "Prompt-Caching: aktiviert"
+    cache_switch_notice:    "⚡ Mitten in der Session zu `{model}` gewechselt — die nächste Antwort liest ~{tokens} Kontext uncached neu (einmalig)"
+    cache_switch_revert_hint: "  ↩ `/model {model}` tippen, um zurückzuwechseln — gleiche Unterhaltung, kein erneutes Einlesen"
     warning_prefix:         "Warnung: {warning}"
     saved_global:           "In config.yaml gespeichert (`--global`)"
     session_only_hint:      "_(nur für diese Sitzung — `--global` ergänzen, um zu speichern)_"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -36,7 +36,7 @@ gateway:
     cost_label:             "Kosten: {cost}"
     capabilities_label:     "Fähigkeiten: {capabilities}"
     prompt_caching_enabled: "Prompt-Caching: aktiviert"
-    cache_switch_notice:    "⚡ Mitten in der Session zu `{model}` gewechselt — die nächste Antwort liest ~{tokens} Kontext uncached neu (einmalig)"
+    cache_switch_notice:    "⚡ Mitten in der Session zu `{model}` gewechselt — die nächste Antwort liest bis zu ~{tokens} Kontext uncached neu (einmalig; je nach Cache-Verhalten des Anbieters)"
     cache_switch_revert_hint: "↩ `/model {model}` tippen, um zurückzuwechseln — gleiche Unterhaltung, kein erneutes Einlesen"
     warning_prefix:         "Warnung: {warning}"
     saved_global:           "In config.yaml gespeichert (`--global`)"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -51,7 +51,7 @@ gateway:
     cost_label:             "Cost: {cost}"
     capabilities_label:     "Capabilities: {capabilities}"
     prompt_caching_enabled: "Prompt caching: enabled"
-    cache_switch_notice:    "⚡ Switched mid-session to `{model}` — its next reply re-reads ~{tokens} of context uncached (one-time cost)"
+    cache_switch_notice:    "⚡ Switched mid-session to `{model}` — its next reply re-reads up to ~{tokens} of context uncached (one-time cost; actual amount depends on the provider's caching)"
     cache_switch_revert_hint: "↩ Type `/model {model}` to go back — same conversation, no re-reading on the way back"
     warning_prefix:         "Warning: {warning}"
     saved_global:           "Saved to config.yaml (`--global`)"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -52,7 +52,7 @@ gateway:
     capabilities_label:     "Capabilities: {capabilities}"
     prompt_caching_enabled: "Prompt caching: enabled"
     cache_switch_notice:    "⚡ Switched mid-session to `{model}` — its next reply re-reads ~{tokens} of context uncached (one-time cost)"
-    cache_switch_revert_hint: "  ↩ Type `/model {model}` to go back — same conversation, no re-reading on the way back"
+    cache_switch_revert_hint: "↩ Type `/model {model}` to go back — same conversation, no re-reading on the way back"
     warning_prefix:         "Warning: {warning}"
     saved_global:           "Saved to config.yaml (`--global`)"
     session_only_hint:      "_(session only — add `--global` to persist)_"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -51,6 +51,8 @@ gateway:
     cost_label:             "Cost: {cost}"
     capabilities_label:     "Capabilities: {capabilities}"
     prompt_caching_enabled: "Prompt caching: enabled"
+    cache_switch_notice:    "⚡ Switched mid-session to `{model}` — its next reply re-reads ~{tokens} of context uncached (one-time cost)"
+    cache_switch_revert_hint: "  ↩ Type `/model {model}` to go back — same conversation, no re-reading on the way back"
     warning_prefix:         "Warning: {warning}"
     saved_global:           "Saved to config.yaml (`--global`)"
     session_only_hint:      "_(session only — add `--global` to persist)_"

--- a/tests/hermes_cli/test_cache_switch_notice.py
+++ b/tests/hermes_cli/test_cache_switch_notice.py
@@ -1,10 +1,15 @@
-"""Unit tests for the mid-session cache-rebuild notice.
+"""Unit + integration tests for the mid-session cache-rebuild notice.
 
 Pins the gate and message-builder behaviour of
 ``hermes_cli.cache_switch_notice`` so a future refactor cannot silently
-regress the cost signal. The integration paths (CLI apply + gateway
-finish/picker) just call the same helpers — if these unit tests hold,
-the surfaces emit the same shape of text.
+regress the cost signal.
+
+Regression guard (PR #94753 review, P0): the real ``AIAgent`` stores
+history in ``_session_messages`` / prompt in ``_cached_system_prompt``, and
+``agent.switch_model()`` zeroes ``compressor.last_prompt_tokens`` and
+clears the cached prompt. Tests therefore cover BOTH agent shapes and the
+post-switch (zeroed) shape — a helper that only understands the CLI shape
+or estimates after the switch must fail here.
 """
 
 from __future__ import annotations
@@ -16,8 +21,11 @@ import pytest
 from hermes_cli.cache_switch_notice import (
     MIN_CONTEXT_TOKENS,
     build_cache_switch_notice,
+    cache_switch_notice_enabled,
     cache_switch_notice_for_agent,
     estimate_context_tokens,
+    same_model_reselect,
+    snapshot_pre_switch_state,
 )
 
 
@@ -26,15 +34,10 @@ class _FakeCompressor:
         self.last_prompt_tokens = last_prompt_tokens
 
 
-class _FakeAgent:
-    def __init__(
-        self,
-        *,
-        last_prompt_tokens: int = 0,
-        messages=None,
-        system_prompt: str = "",
-        tools=None,
-    ):
+class _CLIShapeAgent:
+    """The classic HermesCLI object shape: public attribute names."""
+
+    def __init__(self, *, last_prompt_tokens=0, messages=None, system_prompt="", tools=None):
         self.context_compressor = (
             _FakeCompressor(last_prompt_tokens) if last_prompt_tokens is not None else None
         )
@@ -43,35 +46,108 @@ class _FakeAgent:
         self.tools = tools
 
 
+class _AIAgentShape:
+    """The real AIAgent shape: underscore-private attributes only.
+
+    Mirrors what the reviewer probed on a live agent: no
+    ``conversation_history``, no ``system_prompt``, history lives in
+    ``_session_messages``.
+    """
+
+    def __init__(self, *, last_prompt_tokens=0, messages=None, system_prompt="", tools=None):
+        self.context_compressor = (
+            _FakeCompressor(last_prompt_tokens) if last_prompt_tokens is not None else None
+        )
+        self._session_messages = list(messages or [])
+        self._cached_system_prompt = system_prompt
+        if tools is not None:
+            self._tool_definitions = tools
+
+
+def _post_switch_ai_agent(tools=None):
+    """An AIAgent-shaped object AFTER switch_model() ran.
+
+    update_model() zeroed last_prompt_tokens and cleared the cached prompt —
+    this is the state every wired surface is in when it builds its reply.
+    """
+    return _AIAgentShape(
+        last_prompt_tokens=0,
+        messages=[{"role": "user", "content": "hi"}],
+        system_prompt="",
+        tools=tools,
+    )
+
+
 # ---------------------------------------------------------------------------
-# estimate_context_tokens
+# estimate_context_tokens — both shapes
 # ---------------------------------------------------------------------------
 
 
 def test_estimate_prefers_provider_reported_tokens():
-    agent = _FakeAgent(last_prompt_tokens=84_000)
-    assert estimate_context_tokens(agent) == 84_000
+    for agent in (
+        _CLIShapeAgent(last_prompt_tokens=84_000),
+        _AIAgentShape(last_prompt_tokens=84_000),
+    ):
+        assert estimate_context_tokens(agent) == 84_000
 
 
 def test_estimate_clamps_compression_sentinel():
     # last_prompt_tokens parks at -1 right after a compression until the next
     # real API call reports usage — treat that as "unknown" (0).
-    agent = _FakeAgent(last_prompt_tokens=-1)
-    assert estimate_context_tokens(agent) == 0
+    for agent in (
+        _CLIShapeAgent(last_prompt_tokens=-1),
+        _AIAgentShape(last_prompt_tokens=-1),
+    ):
+        assert estimate_context_tokens(agent) == 0
 
 
 def test_estimate_returns_zero_for_none_agent():
     assert estimate_context_tokens(None) == 0
 
 
-def test_estimate_falls_back_to_rough_count_when_no_provider_report(monkeypatch):
-    # No provider-reported tokens; force the rough estimator to a known value.
-    agent = _FakeAgent(last_prompt_tokens=0, messages=[{"role": "user", "content": "hi"}])
+def test_estimate_reads_underscored_fields_on_real_agent_shape(monkeypatch):
+    """P0 regression: AIAgent keeps history/prompt under private names."""
     monkeypatch.setattr(
         "agent.model_metadata.estimate_request_tokens_rough",
-        lambda *a, **kw: 42_000,
+        lambda messages, system_prompt="", tools=None: (
+            70_000 if messages and system_prompt else 0
+        ),
     )
-    assert estimate_context_tokens(agent) == 42_000
+    agent = _AIAgentShape(
+        last_prompt_tokens=0,
+        messages=[{"role": "user", "content": "hi"}],
+        system_prompt="You are Hermes.",
+    )
+    assert estimate_context_tokens(agent) == 70_000
+
+
+def test_post_switch_agent_shape_does_not_look_like_empty_session(monkeypatch):
+    """After switch_model() zeroes counters, the rough fallback must still
+    count _session_messages content — not collapse to tools-only ~19k."""
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_request_tokens_rough",
+        lambda messages, system_prompt="", tools=None: sum(
+            len(str(m.get("content", ""))) // 4 for m in messages
+        ),
+    )
+    agent = _post_switch_ai_agent()
+    agent._session_messages = [
+        {"role": "user", "content": "x" * 160_000},
+        {"role": "assistant", "content": "y" * 40_000},
+    ]
+    # 50k tokens of conversation → well above threshold even with the
+    # provider-reported path dead.
+    assert estimate_context_tokens(agent) >= MIN_CONTEXT_TOKENS
+
+
+# ---------------------------------------------------------------------------
+# snapshot_pre_switch_state
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_returns_reported_tokens_before_switch():
+    agent = _AIAgentShape(last_prompt_tokens=84_000)
+    assert snapshot_pre_switch_state(agent) == 84_000
 
 
 # ---------------------------------------------------------------------------
@@ -90,13 +166,13 @@ def test_build_silent_below_threshold():
     )
 
 
-def test_build_silent_on_same_model():
-    # Re-selecting the same model keeps the cache warm — nothing to warn about.
+def test_build_silent_on_reselect_flag():
     assert (
         build_cache_switch_notice(
             old_model_display="Grok 4.6",
             new_model_display="Grok 4.6",
             est_context_tokens=100_000,
+            is_reselect=True,
         )
         is None
     )
@@ -122,40 +198,116 @@ def test_build_emits_notice_and_revert_hint_above_threshold():
     assert notice is not None
     lines = notice.splitlines()
     assert len(lines) == 2
-    # Notice names the new model and rounds the estimate to ~Nk.
     assert "Grok 4.5" in lines[0]
     assert "~84k" in lines[0]
     assert "uncached" in lines[0].lower() or "uncached" in lines[0]
-    # Revert hint names the OLD model and gives the /model command.
     assert "Ox Alpha" in lines[1]
     assert "/model Ox Alpha" in lines[1]
 
 
-def test_build_rounds_tokens_to_nearest_k():
+def test_build_can_omit_revert_hint_for_once_switches():
     notice = build_cache_switch_notice(
-        old_model_display="A",
-        new_model_display="B",
-        est_context_tokens=30_499,  # rounds to 30k
+        old_model_display="Ox Alpha",
+        new_model_display="Grok 4.5",
+        est_context_tokens=84_000,
+        include_revert_hint=False,
     )
     assert notice is not None
-    assert "~30k" in notice
+    assert "/model" not in notice
+    assert "~84k" in notice
+
+
+def test_build_rounds_tokens_half_up():
+    notice = build_cache_switch_notice(
+        old_model_display="A", new_model_display="B", est_context_tokens=30_499
+    )
+    assert notice is not None and "~30k" in notice
 
     notice = build_cache_switch_notice(
-        old_model_display="A",
-        new_model_display="B",
-        est_context_tokens=30_500,  # rounds to 31k
+        old_model_display="A", new_model_display="B", est_context_tokens=30_500
     )
-    assert notice is not None
-    assert "~31k" in notice
+    assert notice is not None and "~31k" in notice
 
 
 # ---------------------------------------------------------------------------
-# cache_switch_notice_for_agent (config + estimate composition)
+# same_model_reselect — provider-aware identity (P2)
+# ---------------------------------------------------------------------------
+
+
+def test_reselect_same_model_same_provider():
+    assert same_model_reselect(
+        old_model="grok-4.6", old_provider="xai-oauth",
+        new_model="grok-4.6", new_provider="xai-oauth",
+    ) is True
+
+
+def test_cross_provider_same_model_is_not_reselect():
+    """grok-4.6 xAI-OAuth → grok-4.6 OpenRouter IS a real cache miss."""
+    assert same_model_reselect(
+        old_model="grok-4.6", old_provider="xai-oauth",
+        new_model="grok-4.6", new_provider="openrouter",
+    ) is False
+
+
+def test_reselect_with_unknown_providers_falls_back_to_model_only():
+    assert same_model_reselect(
+        old_model="grok-4.6", old_provider="",
+        new_model="grok-4.6", new_provider="",
+    ) is True
+
+
+def test_different_models_never_reselect():
+    assert same_model_reselect(
+        old_model="a", old_provider="p",
+        new_model="b", new_provider="p",
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# cache_switch_notice_enabled — toggle parsing
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_defaults_true_on_config_error(monkeypatch):
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+    assert cache_switch_notice_enabled() is True
+
+
+def test_enabled_respects_false(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"display": {"cache_switch_notice": False}},
+    )
+    assert cache_switch_notice_enabled() is False
+
+
+def test_enabled_parses_string_false_as_off(monkeypatch):
+    """bool("false") is True — YAML users may quote the value."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"display": {"cache_switch_notice": "false"}},
+    )
+    assert cache_switch_notice_enabled() is False
+
+
+def test_enabled_parses_string_true_as_on(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"display": {"cache_switch_notice": "true"}},
+    )
+    assert cache_switch_notice_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# cache_switch_notice_for_agent — composition
 # ---------------------------------------------------------------------------
 
 
 def test_for_agent_respects_config_toggle_off(monkeypatch):
-    agent = _FakeAgent(last_prompt_tokens=100_000)
+    agent = _AIAgentShape(last_prompt_tokens=100_000)
     monkeypatch.setattr(
         "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
         lambda: False,
@@ -170,12 +322,8 @@ def test_for_agent_respects_config_toggle_off(monkeypatch):
     )
 
 
-def test_for_agent_emits_when_enabled_and_above_threshold(monkeypatch):
-    agent = _FakeAgent(last_prompt_tokens=100_000)
-    monkeypatch.setattr(
-        "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
-        lambda: True,
-    )
+def test_for_agent_emits_when_enabled_and_above_threshold():
+    agent = _AIAgentShape(last_prompt_tokens=100_000)
     notice = cache_switch_notice_for_agent(
         agent=agent,
         old_model_display="A",
@@ -186,44 +334,74 @@ def test_for_agent_emits_when_enabled_and_above_threshold(monkeypatch):
     assert "/model A" in notice
 
 
-def test_for_agent_silent_on_empty_session(monkeypatch):
-    agent = _FakeAgent(last_prompt_tokens=0)
-    monkeypatch.setattr(
-        "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
-        lambda: True,
+def test_for_agent_accepts_pre_captured_token_count_without_agent():
+    """The production pattern: tokens captured BEFORE switch_model(), agent
+    already swapped/evicted by the time the reply is built."""
+    notice = cache_switch_notice_for_agent(
+        agent=None,
+        old_model_display="A",
+        new_model_display="B",
+        est_context_tokens=84_000,
     )
-    # Force the rough estimate too, so we don't accidentally trip on a
-    # non-zero structural estimate of system prompt + tools.
-    monkeypatch.setattr(
-        "agent.model_metadata.estimate_request_tokens_rough",
-        lambda *a, **kw: 1_000,
+    assert notice is not None
+    assert "~84k" in notice
+
+
+def test_for_agent_silent_on_empty_session():
+    agent = _AIAgentShape(last_prompt_tokens=0)
+    notice = cache_switch_notice_for_agent(
+        agent=agent,
+        old_model_display="A",
+        new_model_display="B",
     )
-    assert (
-        cache_switch_notice_for_agent(
-            agent=agent,
-            old_model_display="A",
-            new_model_display="B",
-        )
-        is None
+    assert notice is None
+
+
+def test_for_agent_silent_on_cross_provider_same_model_is_wrong():
+    """Cross-provider same-model must NOT be treated as reselect."""
+    notice = cache_switch_notice_for_agent(
+        agent=None,
+        old_model_display="grok-4.6",
+        new_model_display="grok-4.6",
+        est_context_tokens=100_000,
+        old_provider="xai-oauth",
+        new_provider="openrouter",
+    )
+    assert notice is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration: gateway apply-path shape (mirrors _finish_switch flow)
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_flow_snapshot_before_zeroing(monkeypatch):
+    """Simulate the exact _finish_switch sequence: capture pre-switch tokens,
+    then run switch_model() (zeroes counters), then build the reply from the
+    snapshot. The confirmation must contain ~84k."""
+    agent = _AIAgentShape(
+        last_prompt_tokens=84_000,
+        messages=[{"role": "user", "content": "big"}],
+        system_prompt="sys",
     )
 
+    def _fake_switch_model():
+        # Mirror context_compressor.update_model(): zero the live counters.
+        agent.context_compressor.last_prompt_tokens = 0
+        agent._cached_system_prompt = ""
 
-def test_cache_switch_notice_enabled_defaults_true_on_config_error(monkeypatch):
-    # A broken config.yaml must not silently suppress the cost signal.
-    def _boom():
-        raise RuntimeError("config unreadable")
+    captured = snapshot_pre_switch_state(agent)
+    _fake_switch_model()
 
-    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
-    from hermes_cli.cache_switch_notice import cache_switch_notice_enabled
-
-    assert cache_switch_notice_enabled() is True
-
-
-def test_cache_switch_notice_enabled_reads_false(monkeypatch):
-    monkeypatch.setattr(
-        "hermes_cli.config.load_config_readonly",
-        lambda: {"display": {"cache_switch_notice": False}},
+    lines: list[str] = []
+    notice = cache_switch_notice_for_agent(
+        agent=agent,
+        old_model_display="old-model",
+        new_model_display="new-model",
+        est_context_tokens=captured,
     )
-    from hermes_cli.cache_switch_notice import cache_switch_notice_enabled
+    if notice:
+        lines.extend(notice.splitlines())
 
-    assert cache_switch_notice_enabled() is False
+    assert any("~84k" in line for line in lines)
+    assert any("/model old-model" in line for line in lines)

--- a/tests/hermes_cli/test_cache_switch_notice.py
+++ b/tests/hermes_cli/test_cache_switch_notice.py
@@ -1,0 +1,229 @@
+"""Unit tests for the mid-session cache-rebuild notice.
+
+Pins the gate and message-builder behaviour of
+``hermes_cli.cache_switch_notice`` so a future refactor cannot silently
+regress the cost signal. The integration paths (CLI apply + gateway
+finish/picker) just call the same helpers — if these unit tests hold,
+the surfaces emit the same shape of text.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.cache_switch_notice import (
+    MIN_CONTEXT_TOKENS,
+    build_cache_switch_notice,
+    cache_switch_notice_for_agent,
+    estimate_context_tokens,
+)
+
+
+class _FakeCompressor:
+    def __init__(self, last_prompt_tokens: int):
+        self.last_prompt_tokens = last_prompt_tokens
+
+
+class _FakeAgent:
+    def __init__(
+        self,
+        *,
+        last_prompt_tokens: int = 0,
+        messages=None,
+        system_prompt: str = "",
+        tools=None,
+    ):
+        self.context_compressor = (
+            _FakeCompressor(last_prompt_tokens) if last_prompt_tokens is not None else None
+        )
+        self.conversation_history = list(messages or [])
+        self.system_prompt = system_prompt
+        self.tools = tools
+
+
+# ---------------------------------------------------------------------------
+# estimate_context_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_prefers_provider_reported_tokens():
+    agent = _FakeAgent(last_prompt_tokens=84_000)
+    assert estimate_context_tokens(agent) == 84_000
+
+
+def test_estimate_clamps_compression_sentinel():
+    # last_prompt_tokens parks at -1 right after a compression until the next
+    # real API call reports usage — treat that as "unknown" (0).
+    agent = _FakeAgent(last_prompt_tokens=-1)
+    assert estimate_context_tokens(agent) == 0
+
+
+def test_estimate_returns_zero_for_none_agent():
+    assert estimate_context_tokens(None) == 0
+
+
+def test_estimate_falls_back_to_rough_count_when_no_provider_report(monkeypatch):
+    # No provider-reported tokens; force the rough estimator to a known value.
+    agent = _FakeAgent(last_prompt_tokens=0, messages=[{"role": "user", "content": "hi"}])
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_request_tokens_rough",
+        lambda *a, **kw: 42_000,
+    )
+    assert estimate_context_tokens(agent) == 42_000
+
+
+# ---------------------------------------------------------------------------
+# build_cache_switch_notice
+# ---------------------------------------------------------------------------
+
+
+def test_build_silent_below_threshold():
+    assert (
+        build_cache_switch_notice(
+            old_model_display="Grok 4.6",
+            new_model_display="Grok 4.5",
+            est_context_tokens=MIN_CONTEXT_TOKENS - 1,
+        )
+        is None
+    )
+
+
+def test_build_silent_on_same_model():
+    # Re-selecting the same model keeps the cache warm — nothing to warn about.
+    assert (
+        build_cache_switch_notice(
+            old_model_display="Grok 4.6",
+            new_model_display="Grok 4.6",
+            est_context_tokens=100_000,
+        )
+        is None
+    )
+
+
+def test_build_silent_on_empty_names():
+    assert (
+        build_cache_switch_notice(
+            old_model_display="",
+            new_model_display="Grok 4.5",
+            est_context_tokens=100_000,
+        )
+        is None
+    )
+
+
+def test_build_emits_notice_and_revert_hint_above_threshold():
+    notice = build_cache_switch_notice(
+        old_model_display="Ox Alpha",
+        new_model_display="Grok 4.5",
+        est_context_tokens=84_000,
+    )
+    assert notice is not None
+    lines = notice.splitlines()
+    assert len(lines) == 2
+    # Notice names the new model and rounds the estimate to ~Nk.
+    assert "Grok 4.5" in lines[0]
+    assert "~84k" in lines[0]
+    assert "uncached" in lines[0].lower() or "uncached" in lines[0]
+    # Revert hint names the OLD model and gives the /model command.
+    assert "Ox Alpha" in lines[1]
+    assert "/model Ox Alpha" in lines[1]
+
+
+def test_build_rounds_tokens_to_nearest_k():
+    notice = build_cache_switch_notice(
+        old_model_display="A",
+        new_model_display="B",
+        est_context_tokens=30_499,  # rounds to 30k
+    )
+    assert notice is not None
+    assert "~30k" in notice
+
+    notice = build_cache_switch_notice(
+        old_model_display="A",
+        new_model_display="B",
+        est_context_tokens=30_500,  # rounds to 31k
+    )
+    assert notice is not None
+    assert "~31k" in notice
+
+
+# ---------------------------------------------------------------------------
+# cache_switch_notice_for_agent (config + estimate composition)
+# ---------------------------------------------------------------------------
+
+
+def test_for_agent_respects_config_toggle_off(monkeypatch):
+    agent = _FakeAgent(last_prompt_tokens=100_000)
+    monkeypatch.setattr(
+        "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
+        lambda: False,
+    )
+    assert (
+        cache_switch_notice_for_agent(
+            agent=agent,
+            old_model_display="A",
+            new_model_display="B",
+        )
+        is None
+    )
+
+
+def test_for_agent_emits_when_enabled_and_above_threshold(monkeypatch):
+    agent = _FakeAgent(last_prompt_tokens=100_000)
+    monkeypatch.setattr(
+        "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
+        lambda: True,
+    )
+    notice = cache_switch_notice_for_agent(
+        agent=agent,
+        old_model_display="A",
+        new_model_display="B",
+    )
+    assert notice is not None
+    assert "B" in notice
+    assert "/model A" in notice
+
+
+def test_for_agent_silent_on_empty_session(monkeypatch):
+    agent = _FakeAgent(last_prompt_tokens=0)
+    monkeypatch.setattr(
+        "hermes_cli.cache_switch_notice.cache_switch_notice_enabled",
+        lambda: True,
+    )
+    # Force the rough estimate too, so we don't accidentally trip on a
+    # non-zero structural estimate of system prompt + tools.
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_request_tokens_rough",
+        lambda *a, **kw: 1_000,
+    )
+    assert (
+        cache_switch_notice_for_agent(
+            agent=agent,
+            old_model_display="A",
+            new_model_display="B",
+        )
+        is None
+    )
+
+
+def test_cache_switch_notice_enabled_defaults_true_on_config_error(monkeypatch):
+    # A broken config.yaml must not silently suppress the cost signal.
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+    from hermes_cli.cache_switch_notice import cache_switch_notice_enabled
+
+    assert cache_switch_notice_enabled() is True
+
+
+def test_cache_switch_notice_enabled_reads_false(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"display": {"cache_switch_notice": False}},
+    )
+    from hermes_cli.cache_switch_notice import cache_switch_notice_enabled
+
+    assert cache_switch_notice_enabled() is False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1806,6 +1806,7 @@ display:
   compact: false          # Compact output mode (less whitespace)
   cli_multiline_shortcuts: true  # CLI: Ctrl+J, \ + Enter, and supported Shift+Enter insert newlines (false = legacy c-j submit fallback)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
+  cache_switch_notice: true  # Show one-time uncached re-read cost after a mid-session /model switch (silent below ~30k context tokens)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)


### PR DESCRIPTION
## Summary

Switching models mid-conversation invalidates the prompt cache the new model would otherwise hit — providers key caches per model, so the first call after a switch re-reads the entire context fully uncached. On a long session that is real money; on a short one it is noise. Today Hermes gives the user no signal either way.

This PR appends a single informational line to the `/model` confirmation on every surface (CLI apply path, gateway typed command, gateway picker):

```
⚡ Switched mid-session to `Grok 4.5` — its next reply re-reads ~84k of context uncached (one-time cost)
  ↩ Type `/model Ox Alpha` to go back — same conversation, no re-reading on the way back
```

### Design choices

- **Informational only.** Never blocks, never prompts, never mutates conversation context — pure display output, so prompt caching and message alternation are untouched (AGENTS.md invariants hold).
- **Silent when it doesn't matter.** Below ~30k estimated context tokens the re-read costs pennies and the line would be noise. Empty / near-empty sessions stay quiet. Same-model re-selects also stay silent (cache stays warm).
- **Config toggle, not env var.** `display.cache_switch_notice` (default `true`) in `config.yaml` — secrets stay in `.env`, behavioral settings stay in config.
- **Desktop/CLI/gateway share one helper.** `hermes_cli/cache_switch_notice.py` owns the gate + message builder; surfaces just call it. Desktop gets the slash-command revert hint (no new renderer work); gateway platforms that already support inline buttons can grow a real ↩ button later riding the existing `slash_confirm` rail without changing the core helper.
- **Honest token estimate.** Prefer the provider-reported `compressor.last_prompt_tokens` (same source the status bar uses, with the -1 compression-sentinel clamp); fall back to `estimate_request_tokens_rough` (system + messages + tools) when no provider report exists yet.

### Surfaces wired

| Surface | Path |
|---------|------|
| CLI picker apply | `cli.py` `_apply_model_switch_result` |
| CLI typed `/model` | `cli.py` typed-command apply path |
| Gateway picker | `gateway/slash_commands.py` `_on_model_selected_scoped` |
| Gateway typed `/model` | `gateway/slash_commands.py` `_finish_switch` |

Both gateway paths capture the live agent *before* `_evict_cached_agent` so the estimate still works after the cache is cleared.

### Config

```yaml
display:
  cache_switch_notice: true   # default; set false to silence
```

### i18n

- `locales/en.yaml` + `locales/de.yaml` keys under `gateway.model.cache_switch_notice` / `cache_switch_revert_hint`
- Other locales fall through to English (existing `t()` behaviour)

## Test plan

- [x] Unit tests: `tests/hermes_cli/test_cache_switch_notice.py` — 14 cases covering threshold, same-model silence, empty-name silence, rounding, config toggle on/off, config-error fail-open, provider-reported vs rough estimate, compression-sentinel clamp
- [ ] Manual: long session (>30k context) → `/model other` → notice appears with correct ~Nk and old-model revert command
- [ ] Manual: fresh/empty session → `/model other` → no notice
- [ ] Manual: `display.cache_switch_notice: false` → no notice even on a long session
- [ ] Manual: same-model re-select → no notice
- [ ] Manual: `/model <old>` after the notice → switch succeeds, conversation intact

## Notes for reviewers

- Smallest-footprint path: new module + thin display-path call sites. No new core tools, no system-prompt changes, no message-history mutation.
- The "↩ Type `/model …`" form is deliberate for desktop/CLI v1 (messages are plain markdown there). A real gateway button can ride `send_slash_confirm` later without changing the helper.
