### PR TITLE
fix(sessions): stop timed-out workers from losing session history

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5543,6 +5543,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _defer_cron_worker_teardown = False
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -6228,6 +6229,24 @@ def run_job(
                 _cur_tool or "none",
             )
             request_hard_interrupt(agent, "Cron job timed out (inactivity)")
+            if not _cron_future.done():
+                # The worker is intentionally abandoned so a stuck provider or
+                # tool cannot wedge the scheduler. Its AIAgent and SessionDB
+                # must not be torn down while run_conversation is still using
+                # them, though: that turns the eventual flush into
+                # ``NoneType.execute`` and destroys the transcript. Transfer
+                # cleanup to the worker future's completion boundary instead.
+                _defer_cron_worker_teardown = True
+                _cron_future.add_done_callback(
+                    lambda future: _teardown_detached_cron_worker(
+                        future,
+                        session_db=_session_db,
+                        agent=agent,
+                        cron_session_id=_cron_session_id,
+                        job_id=job_id,
+                        job_name=job_name,
+                    )
+                )
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -6436,7 +6455,7 @@ def run_job(
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and not _defer_cron_worker_teardown:
             # The agent turn has already returned. Bound every subsequent DB
             # operation so storage failure cannot hold the dispatch guard.
             _session_db = _BoundedCronSessionDB(_session_db, job_id)
@@ -6517,11 +6536,75 @@ def run_job(
         # When the caller opted to defer teardown (passed a list), hand the live
         # agent back instead of closing it here — delivery must run against a
         # live async client, and the caller tears down afterwards (#58720).
-        if defer_agent_teardown is not None:
+        if _defer_cron_worker_teardown:
+            pass
+        elif defer_agent_teardown is not None:
             if agent is not None:
                 defer_agent_teardown.append(agent)
         else:
             _teardown_cron_agent(agent, job_id)
+
+
+def _teardown_detached_cron_worker(
+    future,
+    *,
+    session_db,
+    agent,
+    cron_session_id: str,
+    job_id: str,
+    job_name: str,
+) -> None:
+    """Finalize resources only after an abandoned cron worker has exited."""
+    try:
+        future.result()
+    except BaseException:
+        logger.debug(
+            "Job '%s': detached cron worker exited with an error",
+            job_id,
+            exc_info=True,
+        )
+
+    if session_db is not None:
+        bounded_db = _BoundedCronSessionDB(session_db, job_id)
+        final_session_id = getattr(agent, "session_id", None) or cron_session_id
+        try:
+            compression_tip = bounded_db.get_compression_tip(cron_session_id)
+            if compression_tip:
+                final_session_id = compression_tip
+        except (Exception, KeyboardInterrupt):
+            logger.debug(
+                "Job '%s': detached cleanup could not resolve compression tip",
+                job_id,
+                exc_info=True,
+            )
+        try:
+            title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+            title = f"{title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
+            _set_cron_session_title(bounded_db, final_session_id, title)
+        except (Exception, KeyboardInterrupt):
+            logger.debug(
+                "Job '%s': detached cleanup could not title cron session",
+                job_id,
+                exc_info=True,
+            )
+        try:
+            bounded_db.end_session(final_session_id, "cron_timeout")
+        except (Exception, KeyboardInterrupt):
+            logger.debug(
+                "Job '%s': detached cleanup could not end cron session",
+                job_id,
+                exc_info=True,
+            )
+        try:
+            bounded_db.close()
+        except (Exception, KeyboardInterrupt):
+            logger.debug(
+                "Job '%s': detached cleanup could not close session store",
+                job_id,
+                exc_info=True,
+            )
+
+    _teardown_cron_agent(agent, job_id)
 
 
 def _teardown_cron_agent(

--- a/tests/cron/test_cleanup_timeout.py
+++ b/tests/cron/test_cleanup_timeout.py
@@ -48,6 +48,39 @@ class HangingAgent:
         self.release.wait()
 
 
+class BlockingCronAgent:
+    def __init__(self, release: threading.Event, db):
+        self.release = release
+        self.db = db
+        self.worker_started = threading.Event()
+        self.worker_finished = threading.Event()
+        self.closed = threading.Event()
+        self.session_id = "cron-timeout-session"
+
+    def run_conversation(self, _prompt):
+        self.worker_started.set()
+        self.release.wait()
+        assert not self.db.close.called
+        self.db.append_message("cron-timeout-session", "assistant", "late")
+        self.worker_finished.set()
+        return {"final_response": "late", "messages": []}
+
+    def get_activity_summary(self):
+        return {
+            "seconds_since_activity": 60.0,
+            "last_activity_desc": "blocked provider call",
+            "api_call_count": 3,
+            "max_iterations": 250,
+            "current_tool": None,
+        }
+
+    def interrupt(self, *_args, **_kwargs):
+        return None
+
+    def close(self):
+        self.closed.set()
+
+
 def test_run_job_bounds_sessiondb_finalization(tmp_path):
     release = threading.Event()
     fake_db = HangingSessionDB(release)
@@ -90,6 +123,45 @@ def test_agent_teardown_is_bounded():
 
         assert agent.entered.wait(timeout=0.5)
         assert elapsed < 0.5
+    finally:
+        release.set()
+
+
+def test_inactivity_timeout_defers_session_cleanup_until_worker_exits(tmp_path):
+    release = threading.Event()
+    fake_db = MagicMock()
+    db_closed = threading.Event()
+    fake_db.close.side_effect = db_closed.set
+    agent = BlockingCronAgent(release, fake_db)
+    job = {
+        "id": "cron-timeout-worker",
+        "name": "cron timeout worker",
+        "prompt": "hello",
+        "model": "test-model",
+    }
+
+    try:
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler._cron_inactivity_seconds", return_value=0.01), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=_RUNTIME), \
+             patch("run_agent.AIAgent", return_value=agent):
+            success, _output, final_response, error = run_job(job)
+
+        assert agent.worker_started.is_set()
+        assert success is False
+        assert final_response == ""
+        assert "idle for" in error
+        assert not db_closed.is_set()
+        assert not agent.closed.is_set()
+
+        release.set()
+        assert agent.worker_finished.wait(timeout=2.0)
+        assert db_closed.wait(timeout=2.0)
+        assert agent.closed.wait(timeout=2.0)
     finally:
         release.set()
 

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -211,6 +211,23 @@ class TestRunSingleChildTimeoutDump:
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
 
+    def test_timeout_defers_child_close_until_worker_exits(self, hermes_home, monkeypatch):
+        """A detached worker must keep its persistence handle until it stops."""
+        child = _StubChild(api_call_count=1, hang_seconds=10.0)
+        child.interrupt = lambda *args, **kwargs: None
+        child.close = MagicMock()
+
+        result = self._invoke_with_short_timeout(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert not child.close.called
+
+        child._hang.set()
+        deadline = time.monotonic() + 2.0
+        while not child.close.called and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert child.close.call_count == 1
+
 
     # ── explicit timeout metadata (#51690, salvaged from PR #60378) ────
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2653,6 +2653,7 @@ def _run_single_child(
     # Worktree-isolation state: populated inside the try once the child's
     # task id is known; the default no-op keeps every early error path safe.
     _worktree_info: Optional[Dict[str, str]] = None
+    _defer_child_close_to_worker = False
 
     def _attach_worktree(entry_dict: Dict[str, Any]) -> None:
         """Inspect + prune the child worktree, reporting into the entry."""
@@ -2845,6 +2846,25 @@ def _run_single_child(
                 pass
 
             is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            if is_timeout and not _child_future.done():
+                # The timeout owner abandons this daemon worker by design, but
+                # closing the child here also closes its dedicated SessionDB
+                # while run_conversation may still be flushing on that worker.
+                # Keep ownership with the worker until it actually exits; a
+                # future callback is race-safe even if completion happens
+                # between done() and add_done_callback().
+                _defer_child_close_to_worker = True
+
+                def _close_detached_child(_future) -> None:
+                    try:
+                        child.close()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close detached child agent after worker exit",
+                            exc_info=True,
+                        )
+
+                _child_future.add_done_callback(_close_detached_child)
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -3367,11 +3387,12 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        if not _defer_child_close_to_worker:
+            try:
+                if hasattr(child, "close"):
+                    child.close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop


### PR DESCRIPTION
## What does this PR do?

Timed-out subagent and cron workers now retain their agent and SessionDB resources until the worker thread actually exits. This prevents a still-unwinding turn from losing its SQLite connection, failing the next transcript flush with `NoneType object has no attribute execute`, and silently dropping the remaining work. Cron inactivity timeouts continue to return an explicit failure instead of being recorded as a successful empty run.

### Symptom

Long-running subagent or cron turns can end with `reason=session_persistence_failed`, `response_len=0`, and `Session DB append_message failed: NoneType object has no attribute execute` while the worker is still active.

### Impact

The affected child stops before returning its result, its remaining transcript is not persisted, and unattended cron work can appear to finish without the expected output.

### Bug Cause

**Trigger:** `tools/delegate_tool.py:_run_single_child` and `cron/scheduler.py:run_job` when their timeout owners abandon a worker that has not exited.

**Causal chain:**
1. A subagent hard timeout or cron inactivity timeout stops waiting for a daemon worker.
2. The owner immediately closes the child or shared cron SessionDB while `run_conversation` is still unwinding.
3. `SessionDB.close()` clears `_conn`; the worker next flush fails on `_conn.execute()`.
4. The turn terminates as `session_persistence_failed` with no usable response.

**Why it is wrong:** Resource ownership moved back to the waiting thread before the worker crossed its completion boundary.

**Working sibling / contrast:** Normal completion waits for `run_conversation` to return before cleanup, so the final persistence flush finishes first.

**Ruled out:** Provider response handling and SQLite lock contention cannot produce this exact closed-handle state. Deterministic timeout tests reproduce cleanup while the worker remains blocked.

### Fix

- Transfer timed-out subagent cleanup to a Future completion callback.
- Transfer cron SessionDB finalization and agent teardown to the cron worker future.
- Preserve explicit cron timeout failure reporting and finalize the eventual session with `cron_timeout`.
- Add deterministic concurrency regressions that prove late persistence runs before close and resources close once afterward.

## Related Issue

Closes #94736

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - defer timed-out child cleanup to the child worker future.
- `cron/scheduler.py` - defer timed-out cron session and agent cleanup until the worker exits.
- `tests/tools/test_delegate_subagent_timeout_diagnostic.py` - cover child timeout resource ownership.
- `tests/cron/test_cleanup_timeout.py` - cover cron timeout failure status and late persistence before cleanup.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_delegate_subagent_timeout_diagnostic.py -q`.
2. Run `scripts/run_tests.sh tests/cron/test_cleanup_timeout.py tests/cron/test_cron_inactivity_timeout.py -q`.
3. Temporarily restore immediate cleanup and confirm the new regression tests fail before the blocked worker is released.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs to avoid duplicates
- [x] PR contains only related changes
- [x] Repository test entrypoint passed on all affected suites (84 tests)
- [x] Added regression tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update - N/A, no user-facing configuration or API changed
- [x] Config example update - N/A
- [x] Architecture guide update - N/A
- [x] Considered cross-platform impact
- [x] Tool schema update - N/A

## Screenshots / Logs

N/A. Deterministic tests cover the thread lifecycle and persistence ordering failure.