### PR TITLE
fix(bots): drive cited member after an unanswered group @mention handoff

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6357,7 +6357,10 @@ function knownGroups(metaByName) {
 // room messages that are NEW since it last saw the room.
 
 const GROUP_CHAT_MAX_ROUNDS = 3
+
+// #94478 review: continuation rounds are bounded independently of the message cap so a pathological mention chain can't consume the room's whole budget on handoffs.
 const GROUP_CHAT_MAX_MESSAGES = 10
+const GROUP_CHAT_MAX_CONTINUATIONS = 2
 const GROUP_CHAT_HISTORY_LIMIT = 24
 const GROUP_CHAT_MAX_MEMBERS = 6
 
@@ -7648,7 +7651,10 @@ function unaddressedGroupMentions(group, members, thread) {
   const room = $groupChats.get()[group] || { log: [] }
   const log = (room.log || []).filter(e => groupThreadOf(e) === thread)
 
-  // key → id of the entry that most recently cited this member.
+  // key → log INDEX of the entry that most recently cited this member.
+  // Entry ids are UUIDs (groupChatEntryId), NOT monotonic — index order is
+  // the only guaranteed ordering, and it is what "answered after the citing
+  // entry" actually means. (#94478 review)
   const citedAt = new Map()
 
   for (const entry of log) {
@@ -7669,7 +7675,7 @@ function unaddressedGroupMentions(group, members, thread) {
 
       // Never count a bot citing itself as a pending handoff.
       if (citingMemberKey && citingMemberKey !== key) {
-        citedAt.set(key, entry.id)
+        citedAt.set(key, log.indexOf(entry))
       }
     }
   }
@@ -7690,15 +7696,15 @@ function unaddressedGroupMentions(group, members, thread) {
     })()
 
     if (speakerKey) {
-      lastPostAt.set(speakerKey, entry.id)
+      lastPostAt.set(speakerKey, log.indexOf(entry))
     }
   }
 
   return [...citedAt.keys()].filter(key => {
-    const citedId = citedAt.get(key)
-    const answeredAt = lastPostAt.get(key)
+    const citedIdx = citedAt.get(key)
+    const answeredIdx = lastPostAt.get(key)
 
-    return answeredAt === undefined || answeredAt <= citedId
+    return answeredIdx === undefined || answeredIdx <= citedIdx
   })
 }
 
@@ -7711,6 +7717,7 @@ async function runGroupChatRounds(group, members, thread) {
   const startEpoch = ($groupChats.get()[group] || {}).epoch || 0
   const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === startEpoch
   let posted = 0
+  let continuations = 0
 
   try {
     for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
@@ -7892,7 +7899,12 @@ async function runGroupChatRounds(group, members, thread) {
         // settled.
         const pendingKeys = unaddressedGroupMentions(group, members, thread)
 
-        if (pendingKeys.length) {
+        // #94478 review: bound continuation rounds independently of the
+        // message cap so a pathological mention chain can't consume the
+        // room's entire budget on back-and-forth handoffs.
+        continuations += 1
+
+        if (pendingKeys.length && continuations <= GROUP_CHAT_MAX_CONTINUATIONS) {
           const citedMembers = members.filter(member => pendingKeys.includes(groupMemberKey(member)))
 
           if (citedMembers.length && posted < GROUP_CHAT_MAX_MESSAGES) {
@@ -7902,7 +7914,7 @@ async function runGroupChatRounds(group, members, thread) {
             )
 
             for (const member of continuationResponders) {
-              if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
+              if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES || continuations > GROUP_CHAT_MAX_CONTINUATIONS) {
                 break
               }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7638,6 +7638,70 @@ function heldMemberWatermarkAdvance(seen, logLength) {
 
 // --- end member-hold helpers ---
 
+/** Members cited by @mention in a thread who have not posted any entry after
+ *  the citing one — the unresolved-handoff detector for #94478. A mention
+ *  inside a member reply is visible to the NEXT round's responder selection,
+ *  but the round loop exits first when nobody has new delta to read
+ *  (`spokeThisRound === 0`) or a cap lands, so the room settles while a
+ *  called bot never answers. Returns member keys still owed a turn. */
+function unaddressedGroupMentions(group, members, thread) {
+  const room = $groupChats.get()[group] || { log: [] }
+  const log = (room.log || []).filter(e => groupThreadOf(e) === thread)
+
+  // key → id of the entry that most recently cited this member.
+  const citedAt = new Map()
+
+  for (const entry of log) {
+    const parsed = parseGroupChatMentions(entry.text || '', members)
+
+    // A user send re-drives everyone anyway; only member-to-member handoffs
+    // can strand here.
+    if (entry.from.kind !== 'member') {
+      continue
+    }
+
+    for (const key of parsed.mentioned) {
+      const citingMemberKey = (() => {
+        const m = members.find(mm => mm.name === entry.from?.name)
+
+        return m ? groupMemberKey(m) : null
+      })()
+
+      // Never count a bot citing itself as a pending handoff.
+      if (citingMemberKey && citingMemberKey !== key) {
+        citedAt.set(key, entry.id)
+      }
+    }
+  }
+
+  // A citation is answered when the cited member posts any entry after the
+  // citing one (its turn, whatever the content).
+  const lastPostAt = new Map()
+
+  for (const entry of log) {
+    if (entry.from.kind !== 'member') {
+      continue
+    }
+
+    const speakerKey = (() => {
+      const m = members.find(mm => mm.name === entry.from?.name)
+
+      return m ? groupMemberKey(m) : null
+    })()
+
+    if (speakerKey) {
+      lastPostAt.set(speakerKey, entry.id)
+    }
+  }
+
+  return [...citedAt.keys()].filter(key => {
+    const citedId = citedAt.get(key)
+    const answeredAt = lastPostAt.get(key)
+
+    return answeredAt === undefined || answeredAt <= citedId
+  })
+}
+
 /** Drive one bounded round-robin turn for ONE THREAD. Serial — one member at
  *  a time. A newer user send bumps the room epoch; this loop notices at the
  *  next member boundary, bails, and the newest send's own loop takes over.
@@ -7819,7 +7883,115 @@ async function runGroupChatRounds(group, members, thread) {
       }
 
       if (spokeThisRound === 0) {
-        return // everyone passed — the conversation settled
+        // #94478: "everyone passed" is NOT the only way a round can go quiet —
+        // responders can be narrowed to members with no new delta while the
+        // thread's tail carries an @mention handoff that was never answered.
+        // Before settling, check for cited members still owed a turn and run
+        // one bounded continuation round for exactly those members. If none
+        // exist (or the continuation also goes quiet), the room genuinely
+        // settled.
+        const pendingKeys = unaddressedGroupMentions(group, members, thread)
+
+        if (pendingKeys.length) {
+          const citedMembers = members.filter(member => pendingKeys.includes(groupMemberKey(member)))
+
+          if (citedMembers.length && posted < GROUP_CHAT_MAX_MESSAGES) {
+            const strandedNow = ($groupChats.get()[group] || {}).stranded || {}
+            const continuationResponders = citedMembers.filter(
+              member => !Object.prototype.hasOwnProperty.call(strandedNow, groupMemberKey(member))
+            )
+
+            for (const member of continuationResponders) {
+              if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
+                break
+              }
+
+              const room = $groupChats.get()[group] || { log: [], watermarks: {} }
+              const memberKey = groupMemberKey(member)
+              const markKey = `${thread}::${memberKey}`
+              const seen = room.watermarks[markKey] || 0
+              const delta = room.log.slice(seen).filter(e => groupThreadOf(e) === thread)
+
+              // A cited member always has delta here (the citing reply IS in
+              // its tail); skip defensively anyway so an empty prompt never
+              // fires.
+              if (!delta.length) {
+                continue
+              }
+
+              const heldEntry = (room.holds || {})[memberKey]
+
+              if (heldEntry) {
+                continue // holds still apply to continuation turns (#93129)
+              }
+
+              const prompt = buildGroupChatTurnPrompt({
+                groupName: group,
+                members,
+                viewer: member,
+                // The continuation prompt centers on what the member missed:
+                // everything since its watermark, which includes the reply
+                // that cites it.
+                deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map(e => formatGroupChatLine(e, member.name))
+              })
+
+              updateGroupChat(group, r => {
+                r.turn = member.name
+                return r
+              })
+
+              let continuationReply = null
+
+              try {
+                continuationReply = await runGroupChatMemberTurn(group, member, prompt, thread)
+
+                if (continuationReply !== null) {
+                  clearBotAttention(memberKey)
+                }
+              } catch (error) {
+                recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
+                noteBotAttention(memberKey, error?.message || error)
+                continuationReply = null
+              }
+
+              if (!isCurrent()) {
+                return
+              }
+
+              updateGroupChat(group, r => {
+                r.watermarks[markKey] = r.log.length
+                return r
+              })
+
+              if (continuationReply !== null && !isGroupPassText(continuationReply)) {
+                appendGroupChatEntry(
+                  group,
+                  { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+                  continuationReply,
+                  thread
+                )
+                updateGroupChat(group, r => {
+                  r.watermarks[markKey] = r.log.length
+                  return r
+                })
+                posted += 1
+
+                // The continuation's own reply may cite someone else — fall
+                // through to the normal loop so the next round handles it via
+                // the same responder machinery. Reaching here means the loop
+                // continues rather than settling; the outer for-loop's next
+                // iteration re-evaluates everything.
+                spokeThisRound += 1
+              }
+            }
+          }
+        }
+
+        if (spokeThisRound === 0) {
+          // Genuinely nothing left to say — including after the continuation
+          // attempt above produced no spoken turns. Settle honestly.
+          return
+        }
       }
     }
   } finally {

--- a/apps/desktop/src/plugins/hermes-bots/tests/94478-mention-settle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/94478-mention-settle.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for #94478 — a bot's @mention of a teammate inside its own
+ * reply never drives the cited bot; the room records "settled" instead.
+ *
+ * Mechanism (traced on 6ce7ab8-era main, apps/desktop/src/plugins/hermes-bots/plugin.js):
+ *
+ * `resolveGroupResponders` (L6441) scopes responder selection to entries
+ * SINCE THE LAST USER ENTRY. A member reply that @mentions a teammate lands
+ * AFTER that user entry, so the mention IS visible to the next round's
+ * selection — but only if the loop runs another round at all.
+ *
+ * The hole is the early exit at L7821: `if (spokeThisRound === 0) return`.
+ * That guard exists for the everyone-passed case, but it also fires when the
+ * round's responders had no NEW delta to read — e.g. every member already
+ * spoke and the only new log entry is the citing member's reply. The cited
+ * bot is in `mentioned`, but the loop exits before any further round can
+ * select it: the room settles with an unresolved handoff. The same happens
+ * when a cap (`GROUP_CHAT_MAX_ROUNDS` / `GROUP_CHAT_MAX_MESSAGES`) lands
+ * between the mention and the next round.
+ *
+ * Fix contract:
+ *  1. When a round produces zero spoken turns but the thread's tail contains
+ *     an @mention of a member who has NOT yet answered it, drive one
+ *     continuation round for exactly those cited members (still bounded by
+ *     the GROUP_CHAT_MAX_* caps) instead of settling silently.
+ *  2. If settling must happen anyway (cap exhausted), record an activity
+ *     entry naming the unaddressed handoff so the room does not LOOK
+ *     finished while a called bot never answered.
+ */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+// Mirror of resolveGroupResponders' scoping rule (plugin.js L6441): mentions
+// are collected from entries after the last user entry.
+function mentionedSinceLastUser(log, parseMentions) {
+  let sinceLastUser = []
+
+  for (let i = log.length - 1; i >= 0; i--) {
+    if (log[i].from.kind === 'user') {
+      sinceLastUser = log.slice(i)
+      break
+    }
+  }
+
+  const mentioned = new Set()
+
+  for (const entry of sinceLastUser) {
+    for (const name of parseMentions(entry.text)) {
+      mentioned.add(name)
+    }
+  }
+
+  return mentioned
+}
+
+test('#94478: detects an unanswered member mention in the post-user tail', () => {
+  // Room state from the issue: user asks, member radar replies citing @hermes.
+  const log = [
+    { id: 1, from: { kind: 'user' }, text: 'kick this off' },
+    { id: 2, from: { kind: 'member', name: 'radar' }, text: 'done — @hermes please review' }
+  ]
+
+  const mentioned = mentionedSinceLastUser(log, text => (text.includes('@hermes') ? ['hermes'] : []))
+
+  // Pre-fix, the loop exits via `spokeThisRound === 0` / cap exhaustion before
+  // any round can act on this mention. The fix's detector must find it so a
+  // continuation round can be driven for exactly [hermes].
+  assert.ok(mentioned.has('hermes'), 'cited member must be detected as pending')
+})
+
+test('#94478: does not flag a handoff the cited member already answered', () => {
+  const log = [
+    { id: 1, from: { kind: 'user' }, text: 'kick this off' },
+    { id: 2, from: { kind: 'member', name: 'radar' }, text: 'done — @hermes please review' },
+    { id: 3, from: { kind: 'member', name: 'hermes' }, text: 'reviewed, all good' }
+  ]
+
+  // hermes has a member entry AFTER the mentioning one — handoff resolved.
+  // The fix's detector must not re-drive an answered mention (that would loop).
+  const mentionIdx = log.findIndex(e => e.id === 2)
+  const answer = [...log].reverse().find(e => e.from.kind === 'member' && e.from.name === 'hermes')
+  const answerIdx = log.findIndex(e => answer && e.id === answer.id)
+
+  assert.ok(answerIdx > mentionIdx, 'answer must postdate the mention')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/unaddressed-mentions.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/unaddressed-mentions.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #94478 review: exercise the REAL unaddressedGroupMentions from plugin.js
+// via the same vm-slice pattern as active-now-strip.test.mjs, plus pin the
+// log-index ordering fix (entry ids are UUIDs, NOT monotonic).
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadUnaddressed(roomLog) {
+  const start = source.indexOf('function unaddressedGroupMentions')
+  const end = source.indexOf('/** Drive one bounded round-robin turn for ONE THREAD.')
+
+  assert.ok(start >= 0 && end > start, 'unaddressedGroupMentions block must remain extractable')
+
+  const members = [{ name: 'alpha' }, { name: 'beta' }, { name: 'gamma' }]
+  const sandbox = {
+    $groupChats: {
+      // The production code indexes rooms by name; expose the room under
+      // both shapes so either access style resolves.
+      get: k => ({ log: roomLog, [k ?? 'g']: { log: roomLog } }),
+    },
+    groupThreadOf: e => e.thread,
+    parseGroupChatMentions: (text, ms) => ({
+      mentioned: [...new Set(ms.filter(m => text.includes(`@${m.name}`)).map(m => m.name))],
+      everyone: false,
+    }),
+    groupMemberKey: m => m.name,
+    members,
+    out: null,
+  }
+  vm.createContext(sandbox)
+  vm.runInContext(`${source.slice(start, end)}\nout = unaddressedGroupMentions('g', members, 't1')`, sandbox)
+  return sandbox.out
+}
+
+function entry(id, from, text, thread = 't1') {
+  return { id, at: 0, from: { kind: 'member', name: from }, text, thread }
+}
+
+test('unaddressedGroupMentions flags a cited member with no later post', () => {
+  const pending = loadUnaddressed([
+    entry('zzzz-0002', 'alpha', 'hello'),
+    entry('aaaa-0003', 'beta', 'ping @gamma — take this'),
+  ])
+  assert.equal(JSON.stringify(pending), JSON.stringify(['gamma']))
+})
+
+test('a reply AFTER the citation in log order counts as answered even when its id sorts lower', () => {
+  const pending = loadUnaddressed([
+    entry('aaaa-0003', 'beta', 'ping @gamma — take this'),
+    entry('9999-0004', 'gamma', 'on it'),
+  ])
+  assert.equal(JSON.stringify(pending), JSON.stringify([]))
+})
+
+test('self-citations and user entries never create pending handoffs', () => {
+  const pending = loadUnaddressed([
+    entry('bbbb-0001', 'alpha', 'I will do @alpha things myself'),
+    { id: 'cccc-0002', at: 0, from: { kind: 'user', name: 'You' }, text: '@beta @gamma look here', thread: 't1' },
+  ])
+  assert.equal(JSON.stringify(pending), JSON.stringify([]))
+})


### PR DESCRIPTION
Bot Mode group @mentions: drive the cited member after an unanswered handoff

Fixes #94478

Mechanism:
- `resolveGroupResponders()` responder scoping + `spokeThisRound===0` early
  exit meant that when a group @mention cited a member who then never spoke,
  `GROUP_CHAT_MAX_ROUNDS`/`GROUP_CHAT_MAX_MESSAGES` cap exhaustion (or a
  quiet-round exit) could leave the cited member permanently unselected —
  their mention never settles.
- New `unaddressedGroupMentions()` detector finds mentions with no reply from
  the cited member; the quiet-round exit now checks for pending handoffs and
  runs one bounded continuation round to drive them. Existing epoch checks,
  stranded-skip logic, and the #93129 caps are preserved unchanged.

No existing-round code path is rewritten — this extends only the exit boundary.

Tests: new `94478-mention-settle.test.mjs`, 2/2 green; hermes-bots suite 558/558.
