### PR TITLE
fix(desktop): linux relaunch gate accepts ARM64 unpacked build dir

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -307,10 +307,20 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 # Outcomes mirror decideRelaunchOutcome: relaunch | skew | manual.
 GATE="" GATE_MSG=""
 linux_gate() {
-  local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
+  # electron-builder emits an arch-suffixed unpacked dir on ARM64
+  # (linux-arm64-unpacked) but a bare linux-unpacked on x64. Accept BOTH
+  # anchored under THIS checkout's release dir (same trust domain, still
+  # path-segment-aware), then derive the target's own base for the
+  # chrome-sandbox checks (#94703).
+  local release_dir="$INSTALL_ROOT/apps/desktop/release"
+  local unpacked sb arg
   case "$RELAUNCH_TARGET" in
-    "$unpacked"/*) ;;
-    *) GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;
+    "$release_dir/linux-arm64-unpacked"/*)
+      unpacked="$release_dir/linux-arm64-unpacked" ;;
+    "$release_dir/linux-unpacked"/*)
+      unpacked="$release_dir/linux-unpacked" ;;
+    *)
+      GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;
   esac
 
   sb="$unpacked/chrome-sandbox"


### PR DESCRIPTION
Fixes #94703

## Problem

`electron-builder` emits an arch-suffixed output dir on ARM64 (`release/linux-arm64-unpacked`) but a bare `linux-unpacked` on x64. The Linux relaunch gate in `scripts/desktop-update/posix.sh` hard-coded the x64 path:

```bash
local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked"
```

so on Linux ARM64 every successful `hermes update` — backend updated, Desktop rebuilt, executable sitting in the new dir — failed the anchored-prefix check and reported **"Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed"**, then re-nagged on every launch.

## Fix

The gate now accepts **either** unpacked dir, still anchored under *this checkout's* `apps/desktop/release` (path-segment-aware, same trust domain), and derives the target's own base directory for the `chrome-sandbox` ownership/sandbox checks. x64 behavior is byte-identical.

## Verification

Ran the script's own `--self-test-gate` matrix:

| Target | Result |
|---|---|
| `linux-arm64-unpacked/Hermes` | `relaunch` (**was** `skew` — the bug) |
| `linux-unpacked/Hermes` | `relaunch` (unchanged) |
| `/opt/impostor/linux-unpacked/Hermes` | `skew` (trust property preserved) |