### PR TITLE
fix(tools): anchor session_search timestamps to the configured timezone

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -11,9 +11,11 @@ All run zero LLM calls.
 import inspect
 import json
 import time
+from datetime import datetime
 
 import pytest
 
+import hermes_time
 from hermes_state import SessionDB
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
@@ -22,6 +24,7 @@ from tools.session_search_tool import (
     _is_compression_ended,
     _resolve_to_parent,
     _session_link,
+    _shape_message,
     session_search,
 )
 
@@ -107,6 +110,81 @@ class TestFormatTimestamp:
         assert "2023" in _format_timestamp(1700000000)
         assert _format_timestamp(None) == "unknown"
         assert _format_timestamp("not-a-number-string") == "not-a-number-string"
+
+
+class TestTimestampsAreTimezoneAnchored:
+    """Regression tests for #75751 — timestamps reached the model unanchored.
+
+    Session timestamps are stored as absolute epoch floats, but the tool used
+    to render them through a naive ``datetime.fromtimestamp()``: the wall clock
+    came from the *server's* zone rather than the configured one, and the
+    output carried no zone marker. The system prompt separately tells the model
+    which zone the user is in, so an unlabelled wall clock gets read as UTC and
+    shifted by the offset a second time — the reported symptom was timestamps
+    exactly one UTC offset away.
+    """
+
+    # 2026-08-01 02:35 EEST (+03:00) == 2026-07-31 23:35 UTC — the hour the
+    # reporter asked "list all commands you executed in the last 4 hours".
+    RIGA_EPOCH = 1785540900.0
+
+    def setup_method(self):
+        hermes_time.reset_cache()
+
+    def teardown_method(self):
+        hermes_time.reset_cache()
+
+    def test_renders_the_configured_zone_not_the_server_zone(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Europe/Riga")
+        hermes_time.reset_cache()
+
+        rendered = _format_timestamp(self.RIGA_EPOCH)
+
+        # Riga wall clock. Under the suite's pinned TZ=UTC the naive render
+        # produced "July 31, 2026 at 11:35 PM" instead.
+        assert "August 01, 2026" in rendered
+        assert "02:35 AM" in rendered
+
+    def test_labels_the_zone_so_the_model_need_not_guess(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Europe/Riga")
+        hermes_time.reset_cache()
+
+        assert "EEST" in _format_timestamp(self.RIGA_EPOCH)
+
+    def test_unconfigured_timezone_still_renders_and_labels(self):
+        # No HERMES_TIMEZONE — fall back to server-local, but stay labelled.
+        # The host decides what to call that zone ("UTC" on the POSIX lanes,
+        # "Coordinated Universal Time" on Windows), so assert the shape of the
+        # output rather than a literal zone name.
+        bare = datetime.fromtimestamp(self.RIGA_EPOCH).astimezone().strftime(
+            "%B %d, %Y at %I:%M %p"
+        )
+
+        rendered = _format_timestamp(self.RIGA_EPOCH)
+
+        assert rendered.startswith(bare)
+        assert rendered[len(bare):].strip(), "server-local render carries no zone label"
+
+    def test_shaped_message_carries_an_offset_bearing_timestamp(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Europe/Riga")
+        hermes_time.reset_cache()
+
+        shaped = _shape_message({
+            "id": 1,
+            "role": "assistant",
+            "content": "ran the command",
+            "timestamp": self.RIGA_EPOCH,
+        })
+
+        # The raw epoch stays put for anything that measures durations...
+        assert shaped["timestamp"] == self.RIGA_EPOCH
+        # ...and the model gets a time it can read without converting.
+        assert shaped["timestamp_iso"] == "2026-08-01T02:35:00+03:00"
+
+    def test_shaped_message_without_a_timestamp_omits_the_iso_field(self):
+        shaped = _shape_message({"id": 1, "role": "user", "content": "hi"})
+
+        assert "timestamp_iso" not in shaped
 
 
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -35,6 +35,7 @@ support.
 
 import json
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_state_common import _RESET_END_REASONS
@@ -96,23 +97,37 @@ _COMPACTION_PREFIXES = (
 _FRESH_RESET_END_REASONS = frozenset(_RESET_END_REASONS) | {"new_session"}
 
 
+def _local_datetime(ts: float) -> datetime:
+    """Convert an epoch timestamp to an aware datetime in the user's timezone.
+
+    Mirrors ``hermes_time.now()``: the configured IANA zone when one is set,
+    the server's local zone otherwise. Always returns an *aware* datetime so
+    callers can stamp a zone marker onto whatever they render — an unlabelled
+    wall clock reaches the model as an unanchored number and gets shifted by
+    the offset a second time (#75751).
+    """
+    from hermes_time import get_timezone
+
+    tz = get_timezone()
+    if tz is not None:
+        return datetime.fromtimestamp(ts, tz=tz)
+    return datetime.fromtimestamp(ts).astimezone()
+
+
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
     """Convert a Unix timestamp (float/int) or ISO string to a human-readable date.
 
+    Rendered in the user's configured timezone and always zone-labelled.
     Returns "unknown" for None, str(ts) if conversion fails.
     """
     if ts is None:
         return "unknown"
     try:
         if isinstance(ts, (int, float)):
-            from datetime import datetime
-            dt = datetime.fromtimestamp(ts)
-            return dt.strftime("%B %d, %Y at %I:%M %p")
+            return _local_datetime(ts).strftime("%B %d, %Y at %I:%M %p %Z")
         if isinstance(ts, str):
             if ts.replace(".", "").replace("-", "").isdigit():
-                from datetime import datetime
-                dt = datetime.fromtimestamp(float(ts))
-                return dt.strftime("%B %d, %Y at %I:%M %p")
+                return _local_datetime(float(ts)).strftime("%B %d, %Y at %I:%M %p %Z")
             return ts
     except (ValueError, OSError, OverflowError) as e:
         logging.debug("Failed to format timestamp %s: %s", ts, e, exc_info=True)
@@ -327,6 +342,15 @@ def _shape_message(
         "content": content,
         "timestamp": m.get("timestamp"),
     }
+    # A bare epoch forces the model to do the epoch→wall-clock conversion
+    # itself, and it defaults to UTC even when the user is in another zone
+    # (#75751). Hand it an offset-bearing time it can just read.
+    raw_ts = m.get("timestamp")
+    if isinstance(raw_ts, (int, float)):
+        try:
+            entry["timestamp_iso"] = _local_datetime(raw_ts).isoformat(timespec="seconds")
+        except (ValueError, OSError, OverflowError) as e:
+            logging.debug("Failed to render timestamp %s: %s", raw_ts, e, exc_info=True)
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
     if m.get("tool_calls"):


### PR DESCRIPTION
## What does this PR do?

`session_search` handed the model timestamps with nothing to anchor them to, so the model shifted them by the user's UTC offset a second time.

Two renderers were involved, both in `tools/session_search_tool.py`:

- `_format_timestamp()` built its output from a naive `datetime.fromtimestamp()`. The wall clock therefore came from the **server's** zone rather than the user's configured one, and the format string (`"%B %d, %Y at %I:%M %p"`) carried **no zone marker at all**.
- `_shape_message()` passed each message's `timestamp` straight through as a bare epoch float, leaving the epoch→wall-clock conversion to the model.

The system prompt separately tells the model which timezone the user is in (`agent/system_prompt.py:888-896` emits the IANA key, the abbreviation and a `UTC±HH:MM` offset). So the model receives an unlabelled wall clock plus a stated offset, reads the unlabelled value as UTC, and applies the offset — landing exactly one UTC offset away from the truth. That matches the report: asked at 02:35 local for "commands executed in the last 4 hours", it answered with times three hours in the future on a `UTC+03:00` machine.

The storage layer is not at fault — `messages.timestamp` is a `REAL` epoch (`hermes_state_common.py:439`), i.e. an unambiguous absolute instant. Only the rendering was lossy, so the fix stays in the renderers.

**Approach.** `_local_datetime()` mirrors `hermes_time.now()`'s own branch (configured `ZoneInfo` when one is set, `.astimezone()` otherwise) and always returns an *aware* datetime, so every caller can stamp a zone label. `_format_timestamp()` gains `%Z`; `_shape_message()` gains an offset-bearing `timestamp_iso` next to the untouched raw epoch.

The raw `timestamp` field is deliberately left alone — it is additive, so nothing that measures durations off it changes behaviour.

## Related Issue

Fixes #75751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py` — new `_local_datetime()` helper: epoch → aware datetime in the configured zone, falling back to server-local exactly as `hermes_time.now()` does.
- `tools/session_search_tool.py` — `_format_timestamp()` renders through `_local_datetime()` and appends `%Z`, so the four `"when"` fields (lines 492, 688, 759, 905) are zone-labelled.
- `tools/session_search_tool.py` — `_shape_message()` adds `timestamp_iso` (offset-bearing ISO-8601) beside the existing raw `timestamp`. Omitted when the row has no usable timestamp.
- `tools/session_search_tool.py` — `datetime` moved to a module-level import; it is already resident via the module-level `hermes_state_common` import, so this costs nothing and lets the new helper carry a return annotation like its neighbours.
- `tests/tools/test_session_search.py` — five regression tests under `TestTimestampsAreTimezoneAnchored`.

## How to Test

**Reproduction** — a server on UTC (any container, or a VPS left on UTC) with the user's timezone configured as `Europe/Riga`, and a message stored at epoch `1785540900.0` (= `2026-08-01 02:35 EEST`, the hour in the report):

```python
import os, time
os.environ["TZ"] = "UTC"; os.environ["HERMES_TIMEZONE"] = "Europe/Riga"; time.tzset()

import json, tempfile
from pathlib import Path
from hermes_state import SessionDB
from tools.session_search_tool import session_search

with tempfile.TemporaryDirectory() as tmp:
    db = SessionDB(Path(tmp) / "s.db"); db.create_session("s1", source="cli")
    db._conn.execute("UPDATE sessions SET started_at=?,title=? WHERE id=?",
                     (1785540900.0, "Perms", "s1"))
    db.append_message("s1", role="assistant", content="sudo chown root:root /home")
    db._conn.execute("UPDATE messages SET timestamp=? WHERE session_id=?",
                     (1785540900.0, "s1"))
    db._conn.commit()
    r = json.loads(session_search(db=db, session_id="s1"))
    print(r["session_meta"]["when"], "|", r["messages"][0].get("timestamp_iso"))
```

Before / after on that script:

| field | before | after |
| --- | --- | --- |
| `session_meta.when` | `July 31, 2026 at 11:35 PM` — server's zone, wrong day, no marker | `August 01, 2026 at 02:35 AM EEST` |
| `messages[].timestamp` | `1785540900.0` | `1785540900.0` (unchanged) |
| `messages[].timestamp_iso` | *(absent)* | `2026-08-01T02:35:00+03:00` |

**Automated:**

1. `scripts/run_tests.sh tests/tools/test_session_search.py` → 58 passed (5 new, 53 pre-existing).
2. `scripts/run_tests.sh tests/test_timezone.py` → 11 passed.
3. The four assertions that pin a zone name go through `ZoneInfo("Europe/Riga")`, which is platform-independent (`tzdata` is a declared Windows dependency, `pyproject.toml:102`). The server-local fallback test asserts the *shape* of the output rather than a literal zone name, because Windows reports `Coordinated Universal Time` where POSIX reports `UTC`.

**Why this was not caught earlier:** `tests/conftest.py` pins `TZ=UTC` (line 519) and clears `HERMES_TIMEZONE` (line 298), so "server zone ≠ configured zone" — the only configuration in which this misbehaves — was never exercised. The new tests set `HERMES_TIMEZONE` explicitly against that pinned UTC clock.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the suite via `scripts/run_tests.sh` (per `AGENTS.md:1580`) — see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64), Python 3.11.15

> Full-suite note, in the interest of precision: `scripts/run_tests.sh` gives **38082 passed / 47 failed** on this machine. All 47 are local environment gaps rather than regressions — macOS has no systemd (`tests/gateway/test_systemd_notify.py:17: FileNotFoundError`), no local whisper build, no browser/computer-use environment, and the MCP OAuth tests need network. None of the 18 failing files reference `session_search`, `hermes_time`, `_format_timestamp` or `_shape_message`; the single grep hit in `tests/test_hermes_state.py` is a prose comment on line 3183, and that file's one failure (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`) reproduces identically on a clean `main` with this branch's changes stashed. `_format_timestamp` and `_shape_message` have no importers outside `tools/session_search_tool.py`, so the blast radius is contained to that module.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both touched functions updated; no user-facing docs describe this output shape
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — see the `%Z` / `tzdata` note under *How to Test*; `ruff check .` and `scripts/check-windows-footguns.py --all` (1013 files) both pass
- [x] N/A — the tool's parameter schema is unchanged; `timestamp_iso` is an additive, self-describing response field

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_session_search.py tests/test_timezone.py
=== Summary: 2 files, 69 tests passed, 0 failed (100% complete) in 2.9s (28 workers) ===

$ ruff check .
All checks passed!

$ python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (1013 file(s) scanned).
```
