### PR TITLE
fix(terminal): refresh profile-scoped environment

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -262,6 +262,61 @@ class TestTerminalIntegration:
         assert result["output"] == "token-for-profile-b"
         assert missing["output"] == "unset"
 
+    def test_shared_local_snapshot_re_resolves_profile_runtime_home(
+        self, monkeypatch, tmp_path
+    ):
+        """A routed profile must not inherit another profile's Hermes home."""
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.environments.local import LocalEnvironment
+
+        real_home_a = tmp_path / "real-home-a"
+        real_home_b = tmp_path / "real-home-b"
+        profile_a = tmp_path / "profiles" / "a"
+        profile_b = tmp_path / "profiles" / "b"
+        real_home_a.mkdir()
+        real_home_b.mkdir()
+        (profile_a / "home").mkdir(parents=True)
+        (profile_b / "home").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(real_home_a))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home_a))
+        monkeypatch.setenv("HERMES_HOME", str(profile_a))
+        monkeypatch.setenv("TERMINAL_HOME_MODE", "real")
+        ss.set_multiplex_active(True)
+        env = LocalEnvironment(cwd=str(tmp_path))
+        first = env.execute(
+            "printf '%s\\n%s\\n%s\\n%s\\n' "
+            '"$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME" "$TERMINAL_HOME_MODE"'
+        )
+        monkeypatch.setenv("HOME", str(real_home_b))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home_b))
+        monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+        token = set_hermes_home_override(str(profile_b))
+        try:
+            result = env.execute(
+                "printf '%s\\n%s\\n%s\\n%s\\n' "
+                '"$HOME" "$HERMES_HOME" "$HERMES_REAL_HOME" "$TERMINAL_HOME_MODE"'
+            )
+        finally:
+            reset_hermes_home_override(token)
+            ss.set_multiplex_active(False)
+            env.cleanup()
+
+        assert first["output"].splitlines() == [
+            str(real_home_a),
+            str(profile_a),
+            str(real_home_a),
+            "real",
+        ]
+        assert result["output"].splitlines() == [
+            str(profile_b / "home"),
+            str(profile_b),
+            str(real_home_b),
+            "profile",
+        ]
+
     def test_blocklisted_var_blocked_by_default(self):
         from tools.environments.local import _sanitize_subprocess_env, _HERMES_PROVIDER_ENV_BLOCKLIST
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1746,6 +1746,15 @@ class LocalEnvironment(BaseEnvironment):
 
     _profile_scoped_passthrough = True
 
+    def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
+        """Keep routed profile HOME state out of a shared shell snapshot."""
+        return (
+            "HOME",
+            "HERMES_HOME",
+            "HERMES_REAL_HOME",
+            "TERMINAL_HOME_MODE",
+        )
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)


### PR DESCRIPTION
## What does this PR do?

Prevents a shared local terminal snapshot from leaking one routed Hermes profile's HOME state into another profile.

In multiplexed processes, `LocalEnvironment` snapshots the shell environment once and reuses it. The active profile can change between commands, but `HOME`, `HERMES_HOME`, `HERMES_REAL_HOME`, and `TERMINAL_HOME_MODE` were not part of the backend-specific profile-scoped passthrough set. Sourcing the snapshot could therefore restore the profile that initialized the shell instead of the profile handling the current request.

This change uses the existing profile-scoped snapshot exclusion/restoration mechanism for those four variables. Their current values are saved before the snapshot is sourced, restored immediately afterward, and excluded from the next snapshot write.

## Reproduction

The regression test initializes and executes a shared local shell under profile A, then switches the runtime Hermes-home override, real-home value, and home mode to profile B before executing through the same `LocalEnvironment`.

- Before: the second command retains profile A's HOME-routing state
- After: `$HOME`, `$HERMES_HOME`, `$HERMES_REAL_HOME`, and `$TERMINAL_HOME_MODE` all resolve to profile B's current runtime state

## Changes

- Declare local HOME-routing variables as additional profile-scoped passthrough names.
- Add a multiplexed shared-snapshot regression test.

## Duplicate search

No open or closed PR/issue was found for profile-scoped HOME leakage in shared local terminal snapshots. Container mount detection is intentionally not included because the separate host false-positive is already addressed by #65060.

## Validation

```text
scripts/run_tests.sh tests/tools/test_env_passthrough.py
24 passed, 0 failed

git diff --check origin/main...HEAD
clean
```

## Type of change

- [x] Bug fix
- [x] Security hardening / profile isolation
- [x] Tests added
- [x] Backward compatible
