### PR TITLE
fix(gateway): honor launchd respawn throttle

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5461,11 +5461,13 @@ def launchd_restart():
         _clear_launchd_unsupported_marker()
 
 
-# launchd will not relaunch a KeepAlive job more than about once per 10s.  A
+# Hermes generates its launchd plist with ``ThrottleInterval=30``.  A
 # self-restart that exits promptly therefore leaves the label registered with
-# NO pid for most of that window, so any verification budget shorter than the
-# throttle reports a healthy restart as a failure.
-LAUNCHD_SUPERVISION_VERIFY_TIMEOUT = 20.0
+# NO pid for nearly that full window.  Keep verification comfortably beyond
+# the configured throttle so a healthy, supervised respawn is not reported as
+# an incomplete update and the Desktop hand-off does not reopen without its
+# backend.
+LAUNCHD_SUPERVISION_VERIFY_TIMEOUT = 45.0
 
 
 def wait_for_launchd_gateway_supervision(

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -96,23 +96,24 @@ class TestWaitForLaunchdGatewaySupervision:
         assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
         assert clock.slept == []
 
-    def test_waits_out_the_launchd_respawn_throttle(self, monkeypatch, clock):
-        """A pid that only appears after ~10s is a SUCCESS, not a failure.
+    def test_waits_out_the_generated_launchd_respawn_throttle(
+        self, monkeypatch, clock
+    ):
+        """A pid delayed by our 30s plist throttle is a success, not a failure.
 
-        launchd will not relaunch a KeepAlive job more than about once per 10
-        seconds, so a gateway that exits promptly leaves the label registered
-        with no pid for most of that window.  A one-shot check - or any budget
-        shorter than the throttle - would report a perfectly healthy restart as
-        a silent failure, which is a worse bug than the one being fixed.
+        Hermes generates the gateway LaunchAgent with ``ThrottleInterval=30``.
+        The verifier must therefore stay alive beyond that full interval; using
+        launchd's 10s default here makes a healthy update fail before the plist's
+        configured respawn is even eligible to occur.
         """
-        # 0.5s poll interval: 20 misses is ~10s of throttle, then the pid lands.
-        probe = _supervision_returning(*([False] * 20 + [True]))
+        # 0.5s poll interval: 60 misses is ~30s of throttle, then the pid lands.
+        probe = _supervision_returning(*([False] * 60 + [True]))
         monkeypatch.setattr(
             gateway_cli, "_launchctl_label_supervising_process", probe
         )
 
         assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
-        assert sum(clock.slept) == pytest.approx(10.0)
+        assert sum(clock.slept) == pytest.approx(30.0)
 
     def test_gives_up_at_the_deadline(self, monkeypatch, clock):
         """A job that never comes back must fail, and must fail bounded."""


### PR DESCRIPTION
## What does this PR do?

Fixes a deterministic timeout mismatch in the macOS launchd gateway restart verification used by `hermes update` and the Desktop update hand-off.

Hermes generates the gateway LaunchAgent with `ThrottleInterval=30`, but `wait_for_launchd_gateway_supervision()` gave launchd only 20 seconds to produce a supervised replacement PID. A normal throttled respawn could therefore be labeled failed ten seconds before it was eligible to occur. The POSIX Desktop updater would then retry against the already-current checkout and reopen Desktop while its gateway backend was still unavailable.

This raises the bounded supervision-verification budget to 45 seconds: the configured 30-second throttle plus 15 seconds of startup/scheduling headroom.

## Reproduction and root cause

Observed on macOS 26.5.2 during an in-app Desktop update:

- old gateway exited during the restart phase;
- updater exhausted the 20-second supervision check and reported the gateway `DOWN`;
- Desktop relaunched at 08:53:40;
- launchd started the replacement gateway at 08:54:02, consistent with the generated 30-second throttle;
- the app appeared to have failed its restart because its backend was unavailable when it reopened.

The mismatch is in the shipped source itself:

- generated plist: `ThrottleInterval=30`;
- verifier default before this PR: `LAUNCHD_SUPERVISION_VERIFY_TIMEOUT=20.0`.

Related context: #62128 and the verification work closed in #88848. This PR addresses the remaining configured-throttle budget mismatch rather than adding another restart mechanism.

## Changes

- Raise `LAUNCHD_SUPERVISION_VERIFY_TIMEOUT` from 20 to 45 seconds.
- Update the fake-clock regression to simulate a replacement PID appearing at the generated 30-second throttle boundary.
- Document why the verifier must exceed the generated plist value.

## Validation

- Regression test failed before the production change because the verifier returned `False` at 20 seconds.
- `27 passed` across:
  - `tests/hermes_cli/test_update_launchd_restart_verification.py`
  - `tests/hermes_cli/test_fleet_matrix_down_state.py`
  - `tests/hermes_cli/test_update_gateway_restart_aborted.py`
- `ruff check` passed on both changed files.
- `git diff --check` passed.
- Independent code review: approved; no logic or security concerns.
- Live post-fix probe on the affected Mac reports `verification_timeout=45.0`, launchd supervision active, Desktop running, and gateway health `ok=true`.

## Risk and rollback

Low risk and macOS-specific in effect. Healthy restarts still return immediately on the first successful supervision probe. Only failure detection can wait longer. Rollback is the single commit in this PR.
