### PR TITLE
fix(gateway): size TimeoutStopSec from the full stop budget incl. the cron floor

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -140,10 +140,12 @@ def resolve_cron_drain_budget(
 
     The configured floor is clamped to what this process can actually honour.
     The shutdown watchdog hard-exits at ``watchdog_delay`` and the service
-    manager's ``TimeoutStopSec`` is sized from the same drain timeout, so
-    waiting past that leash (minus ``cleanup_reserve_s`` for the teardown that
-    follows the drain) would swap a cleanly-interrupted job for a SIGKILL that
-    leaves it wedged mid-run — strictly worse than the bug being fixed.
+    manager's ``TimeoutStopSec`` is sized from the full stop budget (the max
+    of the restart drain and this floor, plus cleanup reserve — see
+    ``generate_systemd_unit``), so waiting past that leash (minus
+    ``cleanup_reserve_s`` for the teardown that follows the drain) would swap
+    a cleanly-interrupted job for a SIGKILL that leaves it wedged mid-run —
+    strictly worse than the bug being fixed.
 
     Never returns less than ``drain_timeout``: the cron floor only ever
     extends the wait, so an operator who deliberately configured a long

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -33,12 +33,14 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 from gateway.config import coerce_systemd_watchdog_seconds, load_gateway_config
 from gateway.status import terminate_pid
 from gateway.restart import (
+    CRON_DRAIN_CLEANUP_RESERVE_S,
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     EXTERNAL_GATEWAY_SUPERVISOR_ENV,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     is_gateway_supervisor_process,
+    parse_cron_drain_timeout,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
     resolve_restart_exit_wait_budget,
@@ -3527,8 +3529,18 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     # 60s minimum for installs that use the default immediate drain. Positive
     # drain values extend the deadline directly instead of inheriting a second
     # 60s floor, so a configured 45s drain yields 75s rather than 90s.
+    # The leash must cover the FULL stop budget: the shutdown drain may also
+    # hold for the cron floor — agent.cron_drain_timeout plus the cleanup
+    # reserve — on top of (as a max of) the restart drain, exactly as
+    # resolve_cron_drain_budget() sizes it at runtime. Sizing from the
+    # restart drain alone let TimeoutStopSec cut an in-flight cron drain
+    # mid-budget and turn every stop with active cron work into an unclean
+    # SIGKILL exit (#94759).
     _drain_timeout = int(_get_restart_drain_timeout() or 0)
-    restart_timeout = max(60, _drain_timeout + 30)
+    _cron_floor = int(
+        _get_cron_drain_timeout() + CRON_DRAIN_CLEANUP_RESERVE_S
+    )
+    restart_timeout = max(60, max(_drain_timeout, _cron_floor) + 30)
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -3947,6 +3959,21 @@ def _get_restart_drain_timeout() -> float:
             )
         )
     return parse_restart_drain_timeout(raw)
+
+
+def _get_cron_drain_timeout() -> float:
+    """Return the configured cron-only drain floor in seconds (#82161).
+
+    Mirrors the gateway runtime reader (env HERMES_CRON_DRAIN_TIMEOUT over
+    agent.cron_drain_timeout) so the generated systemd unit sizes
+    TimeoutStopSec against the same floor the live shutdown drain can wait.
+    """
+    raw = os.getenv("HERMES_CRON_DRAIN_TIMEOUT", "").strip()
+    if not raw:
+        cfg = read_raw_config()
+        agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+        raw = str(agent_cfg.get("cron_drain_timeout", ""))
+    return parse_cron_drain_timeout(raw if raw.strip() else None)
 
 
 def _get_restart_after_turn_timeout() -> float:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -185,12 +185,6 @@ class TestRequireServiceInstalled:
 
 
 class TestGeneratedSystemdUnits:
-    def _expected_timeout_stop_sec(self) -> str:
-        timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30))
-        return f"TimeoutStopSec={timeout}"
-
-
-
     def test_user_unit_does_not_leak_profile_node_symlink_target(self, tmp_path, monkeypatch):
         # Regression for the multi-profile gateway restart-loop flap (#48700):
         # ~/.local/bin/node is often a symlink into a *specific* profile's node
@@ -2343,8 +2337,11 @@ class TestTimeoutStopSecCoversCronFloor:
             monkeypatch,
             "agent:\n  restart_drain_timeout: 60\n",
         )
-        # Default cron floor (30 + 10 = 40) < 60: unchanged from the old
-        # formula — no regression for restart-drain-dominated installs.
+        # An explicit restart drain above the default cron floor (30+10=40)
+        # keeps the old formula's result — no regression for
+        # restart-drain-dominated installs. (Default installs differ from
+        # main: restart_drain_timeout defaults to 0, so the cron floor 40+30
+        # raises the leash from 60 to 70 — see the PR description.)
         assert "TimeoutStopSec=90" in unit
 
     def test_env_override_extends_the_leash(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2303,3 +2303,55 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
+
+
+class TestTimeoutStopSecCoversCronFloor:
+    """#94759: TimeoutStopSec must cover the FULL stop budget.
+
+    resolve_cron_drain_budget() can hold the shutdown drain for
+    agent.cron_drain_timeout plus CRON_DRAIN_CLEANUP_RESERVE_S on top of
+    (as a max of) the restart drain, so the unit leash is sized from
+    max(restart_drain, cron_floor) + 30 — not the restart drain alone."""
+
+    def _unit_with_config(self, tmp_path, monkeypatch, config_yaml, env=None):
+        hermes = tmp_path / "home" / ".hermes"
+        hermes.mkdir(parents=True)
+        (hermes / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes))
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths", lambda home, existing: []
+        )
+        for key, value in (env or {}).items():
+            monkeypatch.setenv(key, value)
+        return gateway_cli.generate_systemd_unit(system=False)
+
+    def test_cron_floor_dominates_when_larger(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 0\n  cron_drain_timeout: 120\n",
+        )
+        # cron floor 120 + reserve 10 + cleanup 30 = 160 > the old formula's 60.
+        assert "TimeoutStopSec=160" in unit
+
+    def test_restart_drain_still_dominates_when_larger(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 60\n",
+        )
+        # Default cron floor (30 + 10 = 40) < 60: unchanged from the old
+        # formula — no regression for restart-drain-dominated installs.
+        assert "TimeoutStopSec=90" in unit
+
+    def test_env_override_extends_the_leash(self, tmp_path, monkeypatch):
+        unit = self._unit_with_config(
+            tmp_path,
+            monkeypatch,
+            "agent:\n  restart_drain_timeout: 0\n",
+            env={"HERMES_CRON_DRAIN_TIMEOUT": "200"},
+        )
+        assert "TimeoutStopSec=240" in unit


### PR DESCRIPTION
## What does this PR do?

`generate_systemd_unit()` sized the systemd stop leash (`TimeoutStopSec`) from the restart drain alone: `max(60, agent.restart_drain_timeout + 30)`. But the stop path may legally wait longer — `resolve_cron_drain_budget()` can hold the shutdown drain for `agent.cron_drain_timeout` (default 30s) **plus** `CRON_DRAIN_CLEANUP_RESERVE_S` (10s) on top of (as a max of) the restart drain when in-flight cron work exists. That function's own docstring states "the service manager's TimeoutStopSec is sized from the same drain timeout" — the unit generator just never accounted for the cron half. With active cron work, systemd cut the drain mid-budget and every restart became an unclean SIGKILL exit (#94759).

The fix sizes the leash from the full stop budget:

```python
_cron_floor = int(_get_cron_drain_timeout() + CRON_DRAIN_CLEANUP_RESERVE_S)
restart_timeout = max(60, max(_drain_timeout, _cron_floor) + 30)
```

`_get_cron_drain_timeout()` is a new reader in the CLI that mirrors the gateway runtime reader (env `HERMES_CRON_DRAIN_TIMEOUT` over `agent.cron_drain_timeout`), so the generated unit and the live drain agree on the same floor.

**Default installs change by +10s**: `agent.restart_drain_timeout` defaults to `0`, so the cron floor (30+10=40s) now governs — `TimeoutStopSec` moves from 60 (old formula) to 70 on a default install, which correctly covers the ~40s default worst-case stop the old leash did not. Installs whose restart drain exceeds the cron floor keep identical values (the pre-existing `TimeoutStopSec=210` regression for a 180s drain still passes untouched); only installs where the cron floor can outlast the restart drain get a longer leash.

## Related Issue

Fixes #94759

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — `generate_systemd_unit()` now takes `max(restart_drain, cron_drain_timeout + CRON_DRAIN_CLEANUP_RESERVE_S)` as the drain term; new `_get_cron_drain_timeout()` reader (env-over-config, mirroring the runtime reader); imports `CRON_DRAIN_CLEANUP_RESERVE_S`/`parse_cron_drain_timeout` from `gateway.restart`.
- `tests/hermes_cli/test_gateway_service.py` — new `TestTimeoutStopSecCoversCronFloor`: a 120s cron floor with zero restart drain yields 160 (old formula gave 60); a 60s restart drain with the default cron floor still yields 90 (no regression for drain-dominated installs); `HERMES_CRON_DRAIN_TIMEOUT` env override extends the leash.

## How to Test

1. `pytest tests/hermes_cli/test_gateway_service.py -q` — should pass (92 passed, 1 skipped).
2. Observed result: with this PR's source reverted (plain main), the cron-floor and env-override tests fail — the unit sizes from the restart drain alone; with the change, `TimeoutStopSec` covers the full budget while drain-dominated installs are byte-identical.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue (before): every gateway restart with an active agent turn became an unclean SIGKILL exit — journal showed `Stopping...` → `Gateway drain timed out af[ter...]` → SIGKILL, because TimeoutStopSec (sized from the restart drain alone) expired before the cron drain budget it was supposed to leash.

