### PR TITLE
dashboard auth: allow exact configured native app callbacks

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1721,6 +1721,11 @@ DEFAULT_CONFIG = {
         "oauth": {
             "client_id": "",  # agent:{instance_id} — Portal provisions this
             "portal_url": "",  # blank → use plugin default (production Portal)
+            # Exact installed-app callbacks accepted in addition to RFC 8252
+            # literal-loopback redirects by /auth/native/authorize. Entries
+            # must use a dotted private-use scheme and an absolute path, with
+            # no authority, query, or fragment. Empty preserves loopback-only.
+            "native_redirect_uris": [],
         },
         # Username/password gate configuration — read by the bundled
         # ``dashboard_auth/basic`` plugin (a self-hosted "just put a

--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -56,6 +56,15 @@ class AuditEvent(enum.Enum):
     NATIVE_TOKEN_FAILURE = "native_token_failure"
 
 
+def client_ip(request: Any) -> str:
+    """Return Uvicorn's trusted request peer for audit/rate-limit identity.
+
+    Proxy-header trust is resolved before the ASGI request is built. Reading
+    raw forwarded headers here would let a direct client forge its identity.
+    """
+    return request.client.host if request.client else ""
+
+
 def _resolve_log_path() -> Path:
     """``$HERMES_HOME/logs/dashboard-auth.log``.
 

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -52,6 +52,7 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/auth/native/authorize",
     "/auth/native/token",
     "/auth/native/refresh",
+    "/auth/native/logout",
     "/auth/password-login",
     "/auth/logout",
     "/login",

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -16,6 +16,7 @@ binds.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Awaitable, Callable
 
@@ -23,7 +24,11 @@ from fastapi import Request
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 from hermes_cli.dashboard_auth import list_session_providers
-from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
+from hermes_cli.dashboard_auth.audit import (
+    AuditEvent,
+    audit_log,
+    client_ip as _client_ip,
+)
 from hermes_cli.dashboard_auth.base import (
     DashboardAuthProvider,
     ProviderError,
@@ -85,13 +90,6 @@ def _path_is_public(path: str) -> bool:
         path == prefix or path.startswith(prefix)
         for prefix in _GATE_PUBLIC_PREFIXES
     )
-
-
-def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
 
 
 def _ordered_session_providers(
@@ -288,7 +286,7 @@ def _extract_bearer(request: Request) -> str:
     return ""
 
 
-def _verify_bearer(request: Request, *, access_token: str):
+async def _verify_bearer(request: Request, *, access_token: str):
     """Verify a native-app bearer access token via the session-provider stack.
 
     Returns the :class:`Session` on success, or ``None`` if no provider
@@ -302,7 +300,10 @@ def _verify_bearer(request: Request, *, access_token: str):
     unreachable_provider: str | None = None
     for provider in list_session_providers():
         try:
-            session = provider.verify_session(access_token=access_token)
+            session = await asyncio.to_thread(
+                provider.verify_session,
+                access_token=access_token,
+            )
         except ProviderError as e:
             _log.warning(
                 "dashboard-auth: provider %r unreachable during bearer verify: %s",
@@ -357,7 +358,10 @@ async def gated_auth_middleware(
     bearer = _extract_bearer(request)
     if bearer:
         try:
-            bearer_session = _verify_bearer(request, access_token=bearer)
+            bearer_session = await _verify_bearer(
+                request,
+                access_token=bearer,
+            )
         except ProviderError as e:
             # At least one provider's IDP/JWKS was unreachable and none
             # verified the token — transient outage, not bad credentials.
@@ -422,7 +426,10 @@ async def gated_auth_middleware(
         unreachable_provider: str | None = None
         for provider in _ordered_session_providers(provider_hint):
             try:
-                session = provider.verify_session(access_token=at)
+                session = await asyncio.to_thread(
+                    provider.verify_session,
+                    access_token=at,
+                )
             except ProviderError as e:
                 _log.warning(
                     "dashboard-auth: provider %r unreachable during verify: %s",
@@ -455,7 +462,7 @@ async def gated_auth_middleware(
         # serve the request transparently; only after every provider rejects
         # the RT do we fall through to clear-and-relogin.
         try:
-            refreshed = _attempt_refresh(
+            refreshed = await _attempt_refresh(
                 request,
                 refresh_token=_rt,
                 provider_hint=provider_hint,
@@ -545,7 +552,12 @@ def _expires_in_seconds(session) -> int:
     return max(60, int(session.expires_at) - int(time.time()))
 
 
-def _attempt_refresh(request: Request, *, refresh_token, provider_hint: str | None = None):
+async def _attempt_refresh(
+    request: Request,
+    *,
+    refresh_token,
+    provider_hint: str | None = None,
+):
     """Try to rotate an expired session via the refresh token.
 
     The provider hint only changes candidate order. ``RefreshExpiredError``
@@ -562,7 +574,10 @@ def _attempt_refresh(request: Request, *, refresh_token, provider_hint: str | No
     unavailable_provider: str | None = None
     for provider in _ordered_session_providers(provider_hint):
         try:
-            new_session = provider.refresh_session(refresh_token=refresh_token)
+            new_session = await asyncio.to_thread(
+                provider.refresh_session,
+                refresh_token=refresh_token,
+            )
         except RefreshExpiredError:
             audit_log(
                 AuditEvent.REFRESH_FAILURE,

--- a/hermes_cli/dashboard_auth/native_redirects.py
+++ b/hermes_cli/dashboard_auth/native_redirects.py
@@ -1,0 +1,114 @@
+"""Native-app redirect policy for the dashboard OAuth broker.
+
+Loopback redirects remain available for desktop clients. Operators may also
+configure exact private-use callback URIs for installed apps. Configuration is
+parsed once by ``start_server`` and stored as an immutable set on app state;
+request validation never reloads or normalises configured values.
+"""
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
+_FORBIDDEN_PRIVATE_SCHEMES = frozenset(
+    {"http", "https", "file", "data", "javascript"}
+)
+
+
+class NativeRedirectConfigurationError(ValueError):
+    """Raised when an operator-configured native callback is unsafe."""
+
+
+def parse_native_redirect_uris(raw: object) -> frozenset[str]:
+    """Validate an operator callback list and return an exact-match set.
+
+    Empty/unset configuration returns an empty set, preserving the historical
+    loopback-only policy. Strings are rejected instead of being treated as an
+    iterable of characters so a YAML scalar cannot silently broaden policy.
+    """
+    if raw is None or raw == []:
+        return frozenset()
+    if not isinstance(raw, list):
+        raise NativeRedirectConfigurationError(
+            "dashboard.oauth.native_redirect_uris must be a YAML list"
+        )
+
+    callbacks: set[str] = set()
+    for index, value in enumerate(raw):
+        if not isinstance(value, str) or not value:
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries must be "
+                f"non-empty strings (entry {index})"
+            )
+        if value != value.strip() or any(
+            ord(char) <= 0x20 or ord(char) == 0x7F for char in value
+        ):
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries must not "
+                f"contain whitespace or control characters (entry {index})"
+            )
+
+        parsed = urlsplit(value)
+        scheme = parsed.scheme
+        if (
+            not _SCHEME_RE.fullmatch(scheme)
+            or "." not in scheme
+            or scheme.lower() in _FORBIDDEN_PRIVATE_SCHEMES
+        ):
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries require a "
+                f"dotted private-use scheme (entry {index})"
+            )
+        if parsed.netloc:
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries must not "
+                f"contain an authority or userinfo (entry {index})"
+            )
+        if not parsed.path.startswith("/"):
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries require an "
+                f"absolute path (entry {index})"
+            )
+        if parsed.query or parsed.fragment:
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries must not "
+                f"contain a query or fragment (entry {index})"
+            )
+        callbacks.add(value)
+    return frozenset(callbacks)
+
+
+def configured_native_redirect_uris(config: object) -> frozenset[str]:
+    """Extract and validate ``dashboard.oauth.native_redirect_uris``."""
+    if not isinstance(config, dict):
+        return frozenset()
+    dashboard = config.get("dashboard")
+    if not isinstance(dashboard, dict):
+        return frozenset()
+    oauth = dashboard.get("oauth")
+    if not isinstance(oauth, dict):
+        return frozenset()
+    return parse_native_redirect_uris(oauth.get("native_redirect_uris"))
+
+
+def is_loopback_redirect_uri(raw: str) -> bool:
+    """Return whether ``raw`` is an RFC 8252 literal-loopback callback."""
+    if not raw:
+        return False
+    parsed = urlsplit(raw)
+    if parsed.scheme != "http":
+        return False
+    try:
+        host = (parsed.hostname or "").lower()
+        parsed.port
+    except ValueError:
+        return False
+    return host in {"127.0.0.1", "::1"}
+
+
+def is_allowed_native_redirect_uri(
+    raw: str, configured: frozenset[str]
+) -> bool:
+    """Apply loopback policy plus exact configured private-use matching."""
+    return is_loopback_redirect_uri(raw) or raw in configured

--- a/hermes_cli/dashboard_auth/native_redirects.py
+++ b/hermes_cli/dashboard_auth/native_redirects.py
@@ -14,10 +14,21 @@ _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
 _FORBIDDEN_PRIVATE_SCHEMES = frozenset(
     {"http", "https", "file", "data", "javascript"}
 )
+_UNSAFE_URI_CHARACTERS = frozenset('\\"<>^`{|}')
 
 
 class NativeRedirectConfigurationError(ValueError):
     """Raised when an operator-configured native callback is unsafe."""
+
+
+def _contains_unsafe_uri_character(value: str) -> bool:
+    """Reject parser-differential and non-printing URI characters."""
+    return any(
+        char in _UNSAFE_URI_CHARACTERS
+        or ord(char) <= 0x20
+        or ord(char) == 0x7F
+        for char in value
+    )
 
 
 def parse_native_redirect_uris(raw: object) -> frozenset[str]:
@@ -41,15 +52,20 @@ def parse_native_redirect_uris(raw: object) -> frozenset[str]:
                 "dashboard.oauth.native_redirect_uris entries must be "
                 f"non-empty strings (entry {index})"
             )
-        if value != value.strip() or any(
-            ord(char) <= 0x20 or ord(char) == 0x7F for char in value
-        ):
+        if value != value.strip() or _contains_unsafe_uri_character(value):
             raise NativeRedirectConfigurationError(
                 "dashboard.oauth.native_redirect_uris entries must not "
-                f"contain whitespace or control characters (entry {index})"
+                "contain whitespace, control characters, backslashes, or "
+                f"unsafe delimiters (entry {index})"
             )
 
-        parsed = urlsplit(value)
+        try:
+            parsed = urlsplit(value)
+        except ValueError as exc:
+            raise NativeRedirectConfigurationError(
+                "dashboard.oauth.native_redirect_uris entries must be valid "
+                f"URIs (entry {index})"
+            ) from exc
         scheme = parsed.scheme
         if (
             not _SCHEME_RE.fullmatch(scheme)
@@ -94,17 +110,25 @@ def configured_native_redirect_uris(config: object) -> frozenset[str]:
 
 def is_loopback_redirect_uri(raw: str) -> bool:
     """Return whether ``raw`` is an RFC 8252 literal-loopback callback."""
-    if not raw:
-        return False
-    parsed = urlsplit(raw)
-    if parsed.scheme != "http":
+    if (
+        not raw
+        or raw != raw.strip()
+        or _contains_unsafe_uri_character(raw)
+    ):
         return False
     try:
+        parsed = urlsplit(raw)
         host = (parsed.hostname or "").lower()
         parsed.port
     except ValueError:
         return False
-    return host in {"127.0.0.1", "::1"}
+    return (
+        parsed.scheme == "http"
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+        and host in {"127.0.0.1", "::1"}
+    )
 
 
 def is_allowed_native_redirect_uri(

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -251,8 +251,8 @@ async def auth_login(request: Request, provider: str, next: str = ""):
 # ---------------------------------------------------------------------------
 
 
-def _validate_loopback_redirect_uri(raw: str) -> str:
-    """Return ``raw`` if it is a safe loopback redirect_uri, else raise.
+def _validate_native_redirect_uri(request: Request, raw: str) -> str:
+    """Return ``raw`` if it is an accepted native redirect, else raise.
 
     RFC 8252 §7.3 restricts native-app redirects to the loopback interface.
     We accept only ``http://127.0.0.1[:port]/...`` and ``http://[::1][:port]/...``
@@ -264,27 +264,29 @@ def _validate_loopback_redirect_uri(raw: str) -> str:
     authorize`` (a public route) turn the gateway's authenticated callback
     into an open redirect that leaks a live authorization code to an
     arbitrary origin — so this check is a security boundary, not ergonomics.
+    Operators may additionally configure exact private-use installed-app
+    callbacks. Those values are validated once before the server starts and
+    kept as an immutable set on app state. Request matching is byte-for-byte;
+    no scheme-only, prefix, suffix, or normalised matching is permitted.
     """
-    from urllib.parse import urlparse
-
     if not raw:
         raise HTTPException(status_code=400, detail="redirect_uri required")
-    parsed = urlparse(raw)
-    if parsed.scheme != "http":
-        raise HTTPException(
-            status_code=400,
-            detail="native redirect_uri must be http:// on the loopback interface",
-        )
-    host = (parsed.hostname or "").lower()
-    if host not in ("127.0.0.1", "::1"):
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "native redirect_uri host must be a loopback IP literal "
-                "(127.0.0.1 / ::1)"
-            ),
-        )
-    return raw
+    from hermes_cli.dashboard_auth.native_redirects import (
+        is_allowed_native_redirect_uri,
+    )
+
+    configured = getattr(
+        request.app.state, "native_redirect_uris", frozenset()
+    )
+    if is_allowed_native_redirect_uri(raw, configured):
+        return raw
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "native redirect_uri must use a loopback IP literal "
+            "(127.0.0.1 / ::1) or an exact configured private-use callback"
+        ),
+    )
 
 
 @router.get("/auth/native/authorize", name="auth_native_authorize")
@@ -323,7 +325,7 @@ async def auth_native_authorize(
         )
     if not code_challenge:
         raise HTTPException(status_code=400, detail="code_challenge required")
-    _validate_loopback_redirect_uri(redirect_uri)
+    _validate_native_redirect_uri(request, redirect_uri)
 
     # Resolve the provider. With exactly one brokerable session provider
     # registered (the common hosted case) an empty ``provider`` selects it,
@@ -1021,7 +1023,7 @@ async def auth_native_token(request: Request, body: _NativeTokenBody):
 
 class _NativeRefreshBody(BaseModel):
     refresh_token: str
-    provider: str = ""
+    provider: str
 
 
 @router.post("/auth/native/refresh", name="auth_native_refresh")
@@ -1030,39 +1032,39 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
 
     The desktop owns its refresh token (OS keychain) rather than a cookie, so
     it rotates here instead of relying on the gate's transparent cookie
-    rotation. Mirrors the middleware's ``_attempt_refresh`` provider stacking:
-    tries each session provider until one rotates the token, returning the new
-    access/refresh pair **in the JSON body**.
+    rotation. The provider returned by token redemption is authoritative: the
+    refresh token is sent to that provider only and never probed against other
+    configured providers.
 
     Failure modes:
-      * every provider rejects the RT (dead/expired/reuse-detected) → 401
+      * the named provider rejects the RT (dead/expired/reuse-detected) → 401
         ``session_expired`` so the desktop starts a fresh native login;
-      * a provider's IDP is unreachable and none rotated → 503.
+      * the named provider's IDP is unreachable → 503.
     """
-    from hermes_cli.dashboard_auth import list_session_providers
     from hermes_cli.dashboard_auth.base import RefreshExpiredError
 
     if not body.refresh_token:
         raise HTTPException(status_code=400, detail="refresh_token required")
+    if not body.provider:
+        raise HTTPException(status_code=400, detail="provider required")
 
-    providers = list_session_providers()
-    if body.provider:
-        providers.sort(key=lambda p: p.name != body.provider)
-
-    unreachable: str | None = None
-    for provider in providers:
-        try:
-            session = provider.refresh_session(refresh_token=body.refresh_token)
-        except RefreshExpiredError:
-            continue
-        except ProviderError as e:
-            if unreachable is None:
-                unreachable = provider.name
-            _log.warning(
-                "dashboard-auth: provider %r unreachable during native refresh: %s",
-                provider.name, e,
-            )
-            continue
+    provider = get_provider(body.provider)
+    if provider is None or not getattr(provider, "supports_session", True):
+        raise HTTPException(status_code=400, detail="Unknown session provider")
+    try:
+        session = provider.refresh_session(refresh_token=body.refresh_token)
+    except RefreshExpiredError:
+        session = None
+    except ProviderError as e:
+        _log.warning(
+            "dashboard-auth: provider %r unreachable during native refresh: %s",
+            provider.name, e,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=f"Auth provider {provider.name!r} unreachable",
+        )
+    if session is not None:
         audit_log(
             AuditEvent.REFRESH_SUCCESS,
             provider=session.provider,
@@ -1078,14 +1080,10 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
             "user_id": session.user_id,
         }
 
-    if unreachable is not None:
-        raise HTTPException(
-            status_code=503,
-            detail=f"Auth provider {unreachable!r} unreachable",
-        )
     audit_log(
         AuditEvent.REFRESH_FAILURE,
-        reason="all_providers_rejected_rt",
+        provider=provider.name,
+        reason="provider_rejected_rt",
         ip=_client_ip(request),
     )
     return JSONResponse(
@@ -1095,3 +1093,45 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
         },
         status_code=401,
     )
+
+
+class _NativeLogoutBody(BaseModel):
+    refresh_token: str
+    provider: str
+
+
+@router.post("/auth/native/logout", name="auth_native_logout")
+async def auth_native_logout(request: Request, body: _NativeLogoutBody):
+    """Best-effort revocation for a native-app-owned refresh token.
+
+    Access-token authentication is intentionally not required: logout must
+    remain possible after access-token expiry. Possession authorises revocation
+    of the supplied token only. The token is sent solely to the named provider,
+    and provider or network failure never prevents the app from clearing its
+    local credential.
+    """
+    if not body.refresh_token:
+        raise HTTPException(status_code=400, detail="refresh_token required")
+    if not body.provider:
+        raise HTTPException(status_code=400, detail="provider required")
+    provider = get_provider(body.provider)
+    if provider is None or not getattr(provider, "supports_session", True):
+        raise HTTPException(status_code=400, detail="Unknown session provider")
+
+    outcome = "attempted"
+    try:
+        provider.revoke_session(refresh_token=body.refresh_token)
+    except Exception as exc:  # noqa: BLE001 — revocation is best-effort
+        outcome = "provider_error"
+        _log.warning(
+            "dashboard-auth: provider %r native revocation failed: %s",
+            provider.name,
+            type(exc).__name__,
+        )
+    audit_log(
+        AuditEvent.REVOKE,
+        provider=provider.name,
+        reason=outcome,
+        ip=_client_ip(request),
+    )
+    return {"ok": True}

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -15,11 +15,12 @@ The routes:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
-from collections import defaultdict, deque
-from typing import Any, Deque, Dict
+from collections import OrderedDict, deque
+from typing import Any, Deque
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -30,7 +31,11 @@ from hermes_cli.dashboard_auth import (
     list_providers,
     list_session_providers,
 )
-from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
+from hermes_cli.dashboard_auth.audit import (
+    AuditEvent,
+    audit_log,
+    client_ip as _client_ip,
+)
 from hermes_cli.dashboard_auth.base import (
     InvalidCodeError,
     InvalidCredentialsError,
@@ -104,13 +109,6 @@ def _redirect_uri(request: Request) -> str:
         return base
     parsed = urlparse(base)
     return urlunparse(parsed._replace(path=f"{prefix}{parsed.path}"))
-
-
-def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
 
 
 def _prefix(request: Request) -> str:
@@ -203,7 +201,10 @@ async def auth_login(request: Request, provider: str, next: str = ""):
         return RedirectResponse(url=login_url, status_code=302)
 
     try:
-        ls = p.start_login(redirect_uri=_redirect_uri(request))
+        ls = await asyncio.to_thread(
+            p.start_login,
+            redirect_uri=_redirect_uri(request),
+        )
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,
@@ -400,7 +401,10 @@ async def auth_native_authorize(
         return resp
 
     try:
-        ls = p.start_login(redirect_uri=_redirect_uri(request))
+        ls = await asyncio.to_thread(
+            p.start_login,
+            redirect_uri=_redirect_uri(request),
+        )
     except ProviderError as e:
         raise HTTPException(status_code=503, detail=f"Provider unreachable: {e}")
 
@@ -501,7 +505,8 @@ async def auth_callback(
         )
 
     try:
-        session = p.complete_login(
+        session = await asyncio.to_thread(
+            p.complete_login,
             code=code,
             state=state,
             code_verifier=verifier,
@@ -652,37 +657,58 @@ def _validate_post_login_target(raw: str) -> str:
 # password we verify locally, so it's a credential-stuffing target. A
 # simple in-process sliding-window limiter per client IP raises the cost
 # of online guessing without any external dependency. It is intentionally
-# best-effort: process-local (resets on restart), and behind a trusting
-# proxy the IP is the proxy's unless X-Forwarded-For is set — which is why
-# this is defence-in-depth on top of the provider's own constant-time
-# verify, not the only line of defence.
+# best-effort and process-local (resets on restart), so it is defence-in-depth
+# on top of the provider's own constant-time verify, not the only line of
+# defence.
 
+_RATE_LIMIT_MAX_CLIENTS = 4096
 _PW_RATE_MAX_ATTEMPTS = 10
 _PW_RATE_WINDOW_SEC = 60.0
-_pw_attempts: Dict[str, Deque[float]] = defaultdict(deque)
+_pw_attempts: OrderedDict[str, Deque[float]] = OrderedDict()
 _pw_attempts_lock = threading.Lock()
+
+
+def _sliding_window_rate_limited(
+    ip: str,
+    *,
+    attempts: OrderedDict[str, Deque[float]],
+    lock: Any,
+    max_attempts: int,
+    window_sec: float,
+) -> bool:
+    """Record an attempt in a bounded per-IP sliding-window map."""
+    now = time.monotonic()
+    cutoff = now - window_sec
+    key = ip or "_unknown_"
+    with lock:
+        # Pop/reinsert gives O(1) least-recently-used ordering. The cap prevents
+        # a stream of unique client addresses from growing process memory
+        # without bound.
+        bucket = attempts.pop(key, deque())
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        limited = len(bucket) >= max_attempts
+        if not limited:
+            bucket.append(now)
+        attempts[key] = bucket
+        while len(attempts) > _RATE_LIMIT_MAX_CLIENTS:
+            attempts.popitem(last=False)
+        return limited
 
 
 def _password_rate_limited(ip: str) -> bool:
     """True if ``ip`` has exceeded the password-login attempt budget.
 
-    Sliding window: prune attempts older than the window, then check the
-    count. Records the attempt timestamp when allowed. An empty IP (no
-    discernible client) shares a single bucket — fail-safe toward
-    throttling rather than letting unattributable traffic through
-    unmetered.
+    An empty IP (no discernible client) shares a single bucket — fail-safe
+    toward throttling rather than letting unattributable traffic through.
     """
-    now = time.monotonic()
-    cutoff = now - _PW_RATE_WINDOW_SEC
-    key = ip or "_unknown_"
-    with _pw_attempts_lock:
-        bucket = _pw_attempts[key]
-        while bucket and bucket[0] < cutoff:
-            bucket.popleft()
-        if len(bucket) >= _PW_RATE_MAX_ATTEMPTS:
-            return True
-        bucket.append(now)
-        return False
+    return _sliding_window_rate_limited(
+        ip,
+        attempts=_pw_attempts,
+        lock=_pw_attempts_lock,
+        max_attempts=_PW_RATE_MAX_ATTEMPTS,
+        window_sec=_PW_RATE_WINDOW_SEC,
+    )
 
 
 def _reset_password_rate_limit() -> None:
@@ -783,8 +809,10 @@ async def auth_password_login(request: Request, body: _PasswordLoginBody):
         )
 
     try:
-        session = p.complete_password_login(
-            username=body.username, password=body.password
+        session = await asyncio.to_thread(
+            p.complete_password_login,
+            username=body.username,
+            password=body.password,
         )
     except InvalidCredentialsError:
         audit_log(
@@ -883,7 +911,10 @@ async def auth_logout(request: Request):
         # logged but never raised.
         for provider in list_providers():
             try:
-                provider.revoke_session(refresh_token=rt)
+                await asyncio.to_thread(
+                    provider.revoke_session,
+                    refresh_token=rt,
+                )
             except Exception as e:  # noqa: BLE001 — best-effort
                 _log.warning(
                     "dashboard-auth: revoke on %r failed: %s",
@@ -1021,9 +1052,51 @@ async def auth_native_token(request: Request, body: _NativeTokenBody):
     }
 
 
+_NATIVE_REFRESH_RATE_MAX_ATTEMPTS = 10
+_NATIVE_REFRESH_RATE_WINDOW_SEC = 60.0
+_native_refresh_attempts: OrderedDict[str, Deque[float]] = OrderedDict()
+_native_refresh_attempts_lock = threading.Lock()
+
+
+def _native_refresh_rate_limited(ip: str) -> bool:
+    """True if ``ip`` has exhausted the native-refresh attempt budget."""
+    return _sliding_window_rate_limited(
+        ip,
+        attempts=_native_refresh_attempts,
+        lock=_native_refresh_attempts_lock,
+        max_attempts=_NATIVE_REFRESH_RATE_MAX_ATTEMPTS,
+        window_sec=_NATIVE_REFRESH_RATE_WINDOW_SEC,
+    )
+
+
+def _reset_native_refresh_rate_limit() -> None:
+    """Test-only: clear all native-refresh rate-limit buckets."""
+    with _native_refresh_attempts_lock:
+        _native_refresh_attempts.clear()
+
+
+def _native_refresh_expired_response(
+    request: Request, *, provider: str, reason: str
+) -> JSONResponse:
+    """Return the terminal response that makes native clients reauthenticate."""
+    audit_log(
+        AuditEvent.REFRESH_FAILURE,
+        provider=provider,
+        reason=reason,
+        ip=_client_ip(request),
+    )
+    return JSONResponse(
+        {
+            "error": "session_expired",
+            "detail": "Refresh token expired or invalid; start a new sign-in.",
+        },
+        status_code=401,
+    )
+
+
 class _NativeRefreshBody(BaseModel):
     refresh_token: str
-    provider: str
+    provider: str = ""
 
 
 @router.post("/auth/native/refresh", name="auth_native_refresh")
@@ -1037,22 +1110,53 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
     configured providers.
 
     Failure modes:
+      * a missing or unknown provider → 401 ``session_expired`` so an older
+        native client clears stale credentials instead of retrying forever;
       * the named provider rejects the RT (dead/expired/reuse-detected) → 401
         ``session_expired`` so the desktop starts a fresh native login;
+      * too many attempts from the trusted client address → 429;
       * the named provider's IDP is unreachable → 503.
     """
     from hermes_cli.dashboard_auth.base import RefreshExpiredError
 
     if not body.refresh_token:
         raise HTTPException(status_code=400, detail="refresh_token required")
+
+    ip = _client_ip(request)
+    if _native_refresh_rate_limited(ip):
+        audit_log(
+            AuditEvent.REFRESH_FAILURE,
+            provider=body.provider,
+            reason="rate_limited",
+            ip=ip,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Too many refresh attempts. Try again shortly.",
+            headers={
+                "Retry-After": str(int(_NATIVE_REFRESH_RATE_WINDOW_SEC))
+            },
+        )
+
     if not body.provider:
-        raise HTTPException(status_code=400, detail="provider required")
+        return _native_refresh_expired_response(
+            request,
+            provider="",
+            reason="provider_missing",
+        )
 
     provider = get_provider(body.provider)
     if provider is None or not getattr(provider, "supports_session", True):
-        raise HTTPException(status_code=400, detail="Unknown session provider")
+        return _native_refresh_expired_response(
+            request,
+            provider=body.provider,
+            reason="unknown_provider",
+        )
     try:
-        session = provider.refresh_session(refresh_token=body.refresh_token)
+        session = await asyncio.to_thread(
+            provider.refresh_session,
+            refresh_token=body.refresh_token,
+        )
     except RefreshExpiredError:
         session = None
     except ProviderError as e:
@@ -1069,7 +1173,7 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
             AuditEvent.REFRESH_SUCCESS,
             provider=session.provider,
             user_id=session.user_id,
-            ip=_client_ip(request),
+            ip=ip,
         )
         return {
             "access_token": session.access_token,
@@ -1080,19 +1184,34 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
             "user_id": session.user_id,
         }
 
-    audit_log(
-        AuditEvent.REFRESH_FAILURE,
+    return _native_refresh_expired_response(
+        request,
         provider=provider.name,
         reason="provider_rejected_rt",
-        ip=_client_ip(request),
     )
-    return JSONResponse(
-        {
-            "error": "session_expired",
-            "detail": "Refresh token expired or invalid; start a new sign-in.",
-        },
-        status_code=401,
+
+
+_NATIVE_LOGOUT_RATE_MAX_ATTEMPTS = 10
+_NATIVE_LOGOUT_RATE_WINDOW_SEC = 60.0
+_native_logout_attempts: OrderedDict[str, Deque[float]] = OrderedDict()
+_native_logout_attempts_lock = threading.Lock()
+
+
+def _native_logout_rate_limited(ip: str) -> bool:
+    """True if ``ip`` has exhausted the native-revocation attempt budget."""
+    return _sliding_window_rate_limited(
+        ip,
+        attempts=_native_logout_attempts,
+        lock=_native_logout_attempts_lock,
+        max_attempts=_NATIVE_LOGOUT_RATE_MAX_ATTEMPTS,
+        window_sec=_NATIVE_LOGOUT_RATE_WINDOW_SEC,
     )
+
+
+def _reset_native_logout_rate_limit() -> None:
+    """Test-only: clear all native-logout rate-limit buckets."""
+    with _native_logout_attempts_lock:
+        _native_logout_attempts.clear()
 
 
 class _NativeLogoutBody(BaseModel):
@@ -1118,9 +1237,28 @@ async def auth_native_logout(request: Request, body: _NativeLogoutBody):
     if provider is None or not getattr(provider, "supports_session", True):
         raise HTTPException(status_code=400, detail="Unknown session provider")
 
+    ip = _client_ip(request)
+    if _native_logout_rate_limited(ip):
+        audit_log(
+            AuditEvent.REVOKE,
+            provider=provider.name,
+            reason="rate_limited",
+            ip=ip,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Too many logout attempts. Try again shortly.",
+            headers={
+                "Retry-After": str(int(_NATIVE_LOGOUT_RATE_WINDOW_SEC))
+            },
+        )
+
     outcome = "attempted"
     try:
-        provider.revoke_session(refresh_token=body.refresh_token)
+        await asyncio.to_thread(
+            provider.revoke_session,
+            refresh_token=body.refresh_token,
+        )
     except Exception as exc:  # noqa: BLE001 — revocation is best-effort
         outcome = "provider_error"
         _log.warning(
@@ -1132,6 +1270,6 @@ async def auth_native_logout(request: Request, body: _NativeLogoutBody):
         AuditEvent.REVOKE,
         provider=provider.name,
         reason=outcome,
-        ip=_client_ip(request),
+        ip=ip,
     )
     return {"ok": True}

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -46,7 +46,11 @@ from fastapi import Request
 from fastapi.responses import JSONResponse, Response
 
 from hermes_cli.dashboard_auth import list_token_providers
-from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
+from hermes_cli.dashboard_auth.audit import (
+    AuditEvent,
+    audit_log,
+    client_ip as _client_ip,
+)
 from hermes_cli.dashboard_auth.base import ProviderError, TokenPrincipal
 
 _log = logging.getLogger(__name__)
@@ -78,13 +82,6 @@ def clear_token_routes() -> None:
     """Test-only: drop all registered token routes."""
     with _lock:
         _token_routes.clear()
-
-
-def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
 
 
 def extract_bearer_token(request: Request) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19491,9 +19491,10 @@ def start_server(
         configured_native_redirect_uris,
     )
 
+    server_config = load_config()
     try:
         app.state.native_redirect_uris = configured_native_redirect_uris(
-            load_config()
+            server_config
         )
     except NativeRedirectConfigurationError as exc:
         raise SystemExit(f"Invalid native redirect configuration: {exc}") from exc
@@ -19667,10 +19668,7 @@ def start_server(
     # Non-loopback ping cadence is config-driven (dashboard.ws_ping_interval /
     # dashboard.ws_ping_timeout, #79635); the 20/20 defaults keep the
     # Cloudflare-Tunnel-friendly behaviour when unset or invalid.
-    try:
-        _dash_cfg = load_config().get("dashboard") or {}
-    except Exception:
-        _dash_cfg = {}
+    _dash_cfg = server_config.get("dashboard") or {}
 
     def _ws_ping_setting(key: str, default: float = 20.0) -> float:
         try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19483,6 +19483,21 @@ def start_server(
         host, app.state.trusted_public_hosts
     )
 
+    # Parse installed-app callbacks once before the listener is started. An
+    # invalid allowlist is an operator configuration error and must fail closed
+    # rather than being discovered only after an authorization attempt.
+    from hermes_cli.dashboard_auth.native_redirects import (
+        NativeRedirectConfigurationError,
+        configured_native_redirect_uris,
+    )
+
+    try:
+        app.state.native_redirect_uris = configured_native_redirect_uris(
+            load_config()
+        )
+    except NativeRedirectConfigurationError as exc:
+        raise SystemExit(f"Invalid native redirect configuration: {exc}") from exc
+
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:
     # the hermes-0day MCP-persistence campaign abused unauthenticated public
     # dashboards). If a caller still passes it, warn that it is now a no-op

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -611,14 +611,27 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
     def _verify_id_token(self, id_token: str) -> Dict[str, Any]:
         import jwt  # lazy import — keeps startup fast for the ungated path
 
+        # Reject tokens that are not even structurally valid JWTs before any
+        # discovery/JWKS I/O. PyJWKClient otherwise reports some malformed
+        # inputs as lookup failures, which makes middleware misclassify a bad
+        # bearer as a retryable provider outage (503 instead of 401).
+        try:
+            header = jwt.get_unverified_header(id_token)
+        except jwt.InvalidTokenError as exc:
+            raise InvalidCodeError("ID token is malformed") from exc
+        if header.get("alg") not in _ALLOWED_ID_TOKEN_ALGS:
+            raise InvalidCodeError("ID token uses an unsupported algorithm")
+
         disco = self._get_discovery()
 
         try:
             signing_key = self._get_jwks_client().get_signing_key_from_jwt(
                 id_token
             )
-        except jwt.PyJWKClientError as exc:
+        except jwt.PyJWKClientConnectionError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.PyJWKClientError as exc:
+            raise InvalidCodeError("ID token signing key is unknown") from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 
@@ -653,7 +666,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 )
             except Exception:
                 pass
-            raise ProviderError(
+            raise InvalidCodeError(
                 f"ID token verification failed: {exc}{details}"
             ) from exc
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -210,6 +210,7 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         self._discovery_fetched_at: float = 0.0
         self._discovery_lock = threading.Lock()
         self._jwks_client: Any = None
+        self._jwks_client_lock = threading.Lock()
 
     # ---- public API (DashboardAuthProvider) -------------------------------
 
@@ -307,8 +308,11 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         # unreachable.
         try:
             claims = self._verify_id_token(access_token)
-        except InvalidCodeError:
+        except InvalidCodeError as exc:
             # Expired / invalid token — protocol says return None, not raise.
+            # Keep claim/config drift diagnosable without turning attacker-
+            # controlled invalid tokens into warning-level log spam.
+            logger.debug("self-hosted OIDC: session token invalid: %s", exc)
             return None
         except ProviderError:
             raise
@@ -594,18 +598,20 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
 
     def _get_jwks_client(self) -> Any:
         if self._jwks_client is None:
-            from jwt import PyJWKClient  # lazy import
+            with self._jwks_client_lock:
+                if self._jwks_client is None:
+                    from jwt import PyJWKClient  # lazy import
 
-            disco = self._get_discovery()
-            self._jwks_client = PyJWKClient(
-                disco["jwks_uri"],
-                cache_keys=True,
-                lifespan=_JWKS_CACHE_SECONDS,
-                headers={
-                    "Accept": "application/json",
-                    "User-Agent": "HermesAgent/1.0",
-                },
-            )
+                    disco = self._get_discovery()
+                    self._jwks_client = PyJWKClient(
+                        disco["jwks_uri"],
+                        cache_keys=True,
+                        lifespan=_JWKS_CACHE_SECONDS,
+                        headers={
+                            "Accept": "application/json",
+                            "User-Agent": "HermesAgent/1.0",
+                        },
+                    )
         return self._jwks_client
 
     def _verify_id_token(self, id_token: str) -> Dict[str, Any]:
@@ -625,13 +631,37 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         disco = self._get_discovery()
 
         try:
-            signing_key = self._get_jwks_client().get_signing_key_from_jwt(
-                id_token
-            )
+            jwks_client = self._get_jwks_client()
+            # Use PyJWKClient's per-key LRU on the normal path. Its generic
+            # PyJWKClientError also represents an unknown ``kid``, so inspect
+            # the cached, successfully parsed set below before classifying the
+            # token as invalid rather than treating an unusable JWKS as 401.
+            signing_key = jwks_client.get_signing_key(header.get("kid"))
         except jwt.PyJWKClientConnectionError as exc:
             raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except jwt.PyJWKSetError as exc:
+            raise ProviderError(f"JWKS is unusable: {exc}") from exc
         except jwt.PyJWKClientError as exc:
-            raise InvalidCodeError("ID token signing key is unknown") from exc
+            try:
+                signing_keys = jwks_client.get_signing_keys()
+                signing_key = jwks_client.match_kid(
+                    signing_keys, header.get("kid")
+                )
+            except jwt.PyJWKClientConnectionError as lookup_exc:
+                raise ProviderError(
+                    f"JWKS lookup failed: {lookup_exc}"
+                ) from lookup_exc
+            except (jwt.PyJWKClientError, jwt.PyJWKSetError) as lookup_exc:
+                # A malformed/empty JWKS document is an IDP outage, not
+                # evidence that the caller's token is invalid. Preserve the
+                # session so middleware returns 503 instead of forcing logout.
+                raise ProviderError(
+                    f"JWKS is unusable: {lookup_exc}"
+                ) from lookup_exc
+            if signing_key is None:
+                raise InvalidCodeError(
+                    "ID token signing key is unknown"
+                ) from exc
         except Exception as exc:  # pragma: no cover - defensive
             raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
 

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -167,6 +167,28 @@ def test_start_server_loopback_sets_auth_required_false(monkeypatch):
     assert web_server.app.state.auth_required is False
 
 
+def test_start_server_invalid_native_redirect_configuration_fails_closed(monkeypatch):
+    _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(monkeypatch, "native_redirect_uris")
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {
+            "dashboard": {
+                "oauth": {"native_redirect_uris": ["com.example://[bad"]}
+            }
+        },
+    )
+
+    with pytest.raises(SystemExit, match="Invalid native redirect configuration"):
+        web_server.start_server(
+            host="127.0.0.1",
+            port=9119,
+            open_browser=False,
+            allow_public=False,
+        )
+
+
 def test_start_server_insecure_public_no_longer_bypasses_gate(monkeypatch):
     """``--insecure`` (allow_public=True) on a public host: gate now ENGAGES.
 

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -30,7 +30,7 @@ from hermes_cli.dashboard_auth import (
     clear_providers,
     register_provider,
 )
-from hermes_cli.dashboard_auth import native_flow
+from hermes_cli.dashboard_auth import native_flow, routes
 from hermes_cli.dashboard_auth.base import RefreshExpiredError, Session
 from hermes_cli.dashboard_auth.native_redirects import (
     NativeRedirectConfigurationError,
@@ -90,6 +90,8 @@ class _SecondStubProvider(StubAuthProvider):
 @pytest.fixture(autouse=True)
 def _reset_broker():
     native_flow._reset_for_tests()
+    routes._reset_native_refresh_rate_limit()
+    routes._reset_native_logout_rate_limit()
     # Snapshot the shared app.state auth fields + provider registry so a test
     # that flips auth_required / registers a stub provider can't leak into a
     # later test file (e.g. the MCP dashboard-oauth suite shares web_server.app).
@@ -101,6 +103,8 @@ def _reset_broker():
     )
     yield
     native_flow._reset_for_tests()
+    routes._reset_native_refresh_rate_limit()
+    routes._reset_native_logout_rate_limit()
     clear_providers()
     web_server.app.state.auth_required = prev_required
     web_server.app.state.bound_host = prev_host
@@ -165,6 +169,15 @@ def gated_client():
     web_server.app.state.native_redirect_uris = prev_redirects
 
 
+def _gated_client_from_ip(ip: str) -> TestClient:
+    return TestClient(
+        web_server.app,
+        base_url="https://fly-app.fly.dev",
+        follow_redirects=False,
+        client=(ip, 50000),
+    )
+
+
 def _walk_native_login(client, *, redirect_uri, challenge, state="cli-state"):
     """Drive authorize → (stub redirects to callback) → loopback code.
 
@@ -196,9 +209,9 @@ def _walk_native_login(client, *, redirect_uri, challenge, state="cli-state"):
     )
     assert r2.status_code == 302, r2.text
     # 3. The callback 302s to the desktop's loopback redirect_uri.
-    loop = urlparse(r2.headers["location"])
-    assert f"{loop.scheme}://{loop.netloc}" == redirect_uri.rsplit("/", 1)[0] or \
-        loop.netloc in redirect_uri
+    location = r2.headers["location"]
+    assert location.startswith(f"{redirect_uri}?")
+    loop = urlparse(location)
     loop_qs = parse_qs(loop.query)
     # No session cookie must be set on the native callback response.
     set_cookie = r2.headers.get("set-cookie", "")
@@ -224,6 +237,33 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
     )
     assert r.status_code == 400
     assert "loopback" in r.json()["detail"].lower()
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        r"http://evil.example\@127.0.0.1/callback",
+        "http://[::1/callback",
+        "http://127.0.0.1/callback#fragment",
+    ],
+)
+def test_native_authorize_rejects_unsafe_loopback_before_state(
+    gated_client, redirect_uri
+):
+    _verifier, challenge = _make_pkce()
+    before = len(native_flow._pending)
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "provider": "stub",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": redirect_uri,
+            "state": "unsafe-loopback",
+        },
+    )
+    assert response.status_code == 400
+    assert len(native_flow._pending) == before
 
 
 @pytest.mark.parametrize(
@@ -293,6 +333,8 @@ def test_native_authorize_rejects_private_callback_lookalikes_before_state(
         "com.example:relative",
         "com.example:/callback?query=yes",
         "com.example:/callback#fragment",
+        r"com.example:/callback\unsafe",
+        "com.example://[bad",
         "comexample:/callback",
         " com.example:/callback",
     ],
@@ -318,6 +360,26 @@ def test_native_redirect_configuration_is_immutable_and_empty_by_default():
         }
     )
     assert configured == frozenset({"com.example.hermex:/oauth/callback"})
+
+
+def test_private_callback_is_disabled_when_route_has_no_configuration(
+    gated_client
+):
+    del web_server.app.state.native_redirect_uris
+    _verifier, challenge = _make_pkce()
+    before = len(native_flow._pending)
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "provider": "stub",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "com.uzairansar.hermesmobile:/oauth/callback",
+            "state": "no-config",
+        },
+    )
+    assert response.status_code == 400
+    assert len(native_flow._pending) == before
 
 
 # ---------------------------------------------------------------------------
@@ -743,6 +805,13 @@ class _UntargetedProvider(StubAuthProvider):
         self.revoke_calls += 1
 
 
+class _FailingRevocationProvider(_RejectingRecipientProvider):
+    name = "recipient-failing"
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        raise RuntimeError("simulated IDP failure")
+
+
 def test_native_refresh_routes_only_to_named_provider(gated_client):
     clear_providers()
     target = _RejectingRecipientProvider()
@@ -757,6 +826,65 @@ def test_native_refresh_routes_only_to_named_provider(gated_client):
     assert response.status_code == 401
     assert target.refresh_tokens == ["recipient-secret"]
     assert other.refresh_calls == 0
+
+
+def test_native_refresh_rate_limits_peer_before_provider_forwarding(
+    gated_client, monkeypatch
+):
+    clear_providers()
+    target = _RejectingRecipientProvider()
+    register_provider(target)
+    monkeypatch.setattr(routes, "_NATIVE_REFRESH_RATE_MAX_ATTEMPTS", 1)
+    client_one = _gated_client_from_ip("203.0.113.10")
+    client_two = _gated_client_from_ip("203.0.113.11")
+    try:
+        first = client_one.post(
+            "/auth/native/refresh",
+            json={"refresh_token": "recipient-one", "provider": target.name},
+            headers={"X-Forwarded-For": "198.51.100.1"},
+        )
+        blocked = client_one.post(
+            "/auth/native/refresh",
+            json={"refresh_token": "recipient-two", "provider": target.name},
+            headers={"X-Forwarded-For": "198.51.100.2"},
+        )
+        other_client = client_two.post(
+            "/auth/native/refresh",
+            json={
+                "refresh_token": "recipient-three",
+                "provider": target.name,
+            },
+        )
+    finally:
+        client_one.close()
+        client_two.close()
+
+    assert first.status_code == 401
+    assert blocked.status_code == 429
+    assert int(blocked.headers["retry-after"]) > 0
+    assert other_client.status_code == 401
+    assert target.refresh_tokens == ["recipient-one", "recipient-three"]
+
+
+def test_native_refresh_rate_limits_unknown_provider_requests(
+    gated_client, monkeypatch
+):
+    monkeypatch.setattr(routes, "_NATIVE_REFRESH_RATE_MAX_ATTEMPTS", 1)
+    client = _gated_client_from_ip("203.0.113.12")
+    try:
+        first = client.post(
+            "/auth/native/refresh",
+            json={"refresh_token": "bogus-one", "provider": "unknown"},
+        )
+        blocked = client.post(
+            "/auth/native/refresh",
+            json={"refresh_token": "bogus-two", "provider": "unknown"},
+        )
+    finally:
+        client.close()
+
+    assert first.status_code == 401
+    assert blocked.status_code == 429
 
 
 def test_native_logout_is_public_and_routes_only_to_named_provider(gated_client):
@@ -778,10 +906,100 @@ def test_native_logout_is_public_and_routes_only_to_named_provider(gated_client)
     assert "recipient-secret" not in response.text
 
 
-@pytest.mark.parametrize("path", ["/auth/native/refresh", "/auth/native/logout"])
-def test_native_credential_lifecycle_rejects_unknown_provider(gated_client, path):
+def test_native_logout_stays_successful_when_provider_raises(
+    gated_client, monkeypatch
+):
+    clear_providers()
+    target = _FailingRevocationProvider()
+    register_provider(target)
+    audited = []
+    monkeypatch.setattr(
+        routes,
+        "audit_log",
+        lambda event, **fields: audited.append((event, fields)),
+    )
+
     response = gated_client.post(
-        path,
+        "/auth/native/logout",
+        json={"refresh_token": "recipient-secret", "provider": target.name},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert audited[-1][1]["reason"] == "provider_error"
+
+
+def test_native_logout_rate_limits_each_client_before_provider_forwarding(
+    gated_client, monkeypatch
+):
+    clear_providers()
+    target = _RejectingRecipientProvider()
+    register_provider(target)
+    monkeypatch.setattr(routes, "_NATIVE_LOGOUT_RATE_MAX_ATTEMPTS", 1)
+    client_one = _gated_client_from_ip("203.0.113.10")
+    client_two = _gated_client_from_ip("203.0.113.11")
+    try:
+        first = client_one.post(
+            "/auth/native/logout",
+            json={"refresh_token": "recipient-one", "provider": target.name},
+            headers={"X-Forwarded-For": "198.51.100.1"},
+        )
+        blocked = client_one.post(
+            "/auth/native/logout",
+            json={"refresh_token": "recipient-two", "provider": target.name},
+            headers={"X-Forwarded-For": "198.51.100.2"},
+        )
+        other_client = client_two.post(
+            "/auth/native/logout",
+            json={
+                "refresh_token": "recipient-three",
+                "provider": target.name,
+            },
+        )
+    finally:
+        client_one.close()
+        client_two.close()
+
+    assert first.status_code == 200
+    assert blocked.status_code == 429
+    assert int(blocked.headers["retry-after"]) > 0
+    assert other_client.status_code == 200
+    assert target.revoked_tokens == ["recipient-one", "recipient-three"]
+
+
+def test_native_rate_limit_client_map_is_bounded(gated_client, monkeypatch):
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAX_CLIENTS", 2)
+    for index in range(3):
+        routes._native_logout_rate_limited(f"203.0.113.{index}")
+    assert len(routes._native_logout_attempts) <= routes._RATE_LIMIT_MAX_CLIENTS
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"refresh_token": "recipient-secret"},
+        {"refresh_token": "recipient-secret", "provider": "missing"},
+    ],
+)
+def test_native_refresh_unroutable_provider_forces_reauthentication(
+    gated_client, payload
+):
+    clear_providers()
+    other = _UntargetedProvider()
+    register_provider(other)
+    response = gated_client.post(
+        "/auth/native/refresh",
+        json=payload,
+    )
+    assert response.status_code == 401
+    assert response.json()["error"] == "session_expired"
+    assert other.refresh_calls == 0
+    assert "recipient-secret" not in response.text
+
+
+def test_native_logout_rejects_unknown_provider(gated_client):
+    response = gated_client.post(
+        "/auth/native/logout",
         json={"refresh_token": "recipient-secret", "provider": "missing"},
     )
     assert response.status_code == 400

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -31,7 +31,12 @@ from hermes_cli.dashboard_auth import (
     register_provider,
 )
 from hermes_cli.dashboard_auth import native_flow
-from hermes_cli.dashboard_auth.base import Session
+from hermes_cli.dashboard_auth.base import RefreshExpiredError, Session
+from hermes_cli.dashboard_auth.native_redirects import (
+    NativeRedirectConfigurationError,
+    configured_native_redirect_uris,
+    parse_native_redirect_uris,
+)
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
 
@@ -91,12 +96,16 @@ def _reset_broker():
     prev_required = getattr(web_server.app.state, "auth_required", None)
     prev_host = getattr(web_server.app.state, "bound_host", None)
     prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_redirects = getattr(
+        web_server.app.state, "native_redirect_uris", frozenset()
+    )
     yield
     native_flow._reset_for_tests()
     clear_providers()
     web_server.app.state.auth_required = prev_required
     web_server.app.state.bound_host = prev_host
     web_server.app.state.bound_port = prev_port
+    web_server.app.state.native_redirect_uris = prev_redirects
 
 
 def _stub_session(exp_offset: int = 3600) -> Session:
@@ -131,9 +140,18 @@ def gated_client():
     prev_host = getattr(web_server.app.state, "bound_host", None)
     prev_port = getattr(web_server.app.state, "bound_port", None)
     prev_required = getattr(web_server.app.state, "auth_required", None)
+    prev_redirects = getattr(
+        web_server.app.state, "native_redirect_uris", frozenset()
+    )
     web_server.app.state.bound_host = "fly-app.fly.dev"
     web_server.app.state.bound_port = 443
     web_server.app.state.auth_required = True
+    web_server.app.state.native_redirect_uris = frozenset(
+        {
+            "com.uzairansar.hermesmobile:/oauth/callback",
+            "com.uzairansar.hermesmobile.branch:/oauth/callback",
+        }
+    )
     # follow_redirects=False so we can inspect each 302 leg of the flow.
     client = TestClient(
         web_server.app, base_url="https://fly-app.fly.dev",
@@ -144,6 +162,7 @@ def gated_client():
     web_server.app.state.bound_host = prev_host
     web_server.app.state.bound_port = prev_port
     web_server.app.state.auth_required = prev_required
+    web_server.app.state.native_redirect_uris = prev_redirects
 
 
 def _walk_native_login(client, *, redirect_uri, challenge, state="cli-state"):
@@ -205,6 +224,100 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
     )
     assert r.status_code == 400
     assert "loopback" in r.json()["detail"].lower()
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "com.uzairansar.hermesmobile:/oauth/callback",
+        "com.uzairansar.hermesmobile.branch:/oauth/callback",
+    ],
+)
+def test_native_authorize_accepts_exact_configured_private_callback(
+    gated_client, redirect_uri
+):
+    verifier, challenge = _make_pkce()
+    code, state = _walk_native_login(
+        gated_client,
+        redirect_uri=redirect_uri,
+        challenge=challenge,
+        state="ios-state",
+    )
+    callback = gated_client.post(
+        "/auth/native/token",
+        json={"code": code, "code_verifier": verifier},
+    )
+    assert callback.status_code == 200, callback.text
+    assert callback.json()["provider"] == "stub"
+    assert state == "ios-state"
+    assert "set-cookie" not in callback.headers
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "com.uzairansar.hermesmobile:/oauth/callback/extra",
+        "com.uzairansar.hermesmobile:/oauth/callback?next=evil",
+        "com.uzairansar.hermesmobile:/oauth/callback#fragment",
+        "COM.UZAIRANSAR.HERMESMOBILE:/oauth/callback",
+        "com.uzairansar.hermesmobile:/oauth/%63allback",
+        "hermes-agent:/oauth/callback",
+    ],
+)
+def test_native_authorize_rejects_private_callback_lookalikes_before_state(
+    gated_client, redirect_uri
+):
+    _verifier, challenge = _make_pkce()
+    before = len(native_flow._pending)
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "provider": "stub",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": redirect_uri,
+            "state": "ios-state",
+        },
+    )
+    assert response.status_code == 400
+    assert len(native_flow._pending) == before
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://app.example/callback",
+        "file:/callback",
+        "javascript:/callback",
+        "com.example://authority/callback",
+        "com.example:relative",
+        "com.example:/callback?query=yes",
+        "com.example:/callback#fragment",
+        "comexample:/callback",
+        " com.example:/callback",
+    ],
+)
+def test_native_redirect_configuration_rejects_unsafe_entries(value):
+    with pytest.raises(NativeRedirectConfigurationError):
+        parse_native_redirect_uris([value])
+
+
+def test_native_redirect_configuration_is_immutable_and_empty_by_default():
+    assert configured_native_redirect_uris({}) == frozenset()
+    with pytest.raises(NativeRedirectConfigurationError, match="YAML list"):
+        parse_native_redirect_uris("com.example.hermex:/oauth/callback")
+    configured = configured_native_redirect_uris(
+        {
+            "dashboard": {
+                "oauth": {
+                    "native_redirect_uris": [
+                        "com.example.hermex:/oauth/callback"
+                    ]
+                }
+            }
+        }
+    )
+    assert configured == frozenset({"com.example.hermex:/oauth/callback"})
 
 
 # ---------------------------------------------------------------------------
@@ -596,3 +709,80 @@ def test_native_refresh_dead_token_returns_401(gated_client):
     )
     assert r.status_code == 401
     assert r.json()["error"] == "session_expired"
+
+
+class _RejectingRecipientProvider(StubAuthProvider):
+    name = "recipient-a"
+
+    def __init__(self):
+        super().__init__()
+        self.refresh_tokens: list[str] = []
+        self.revoked_tokens: list[str] = []
+
+    def refresh_session(self, *, refresh_token: str) -> Session:
+        self.refresh_tokens.append(refresh_token)
+        raise RefreshExpiredError("rejected")
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        self.revoked_tokens.append(refresh_token)
+
+
+class _UntargetedProvider(StubAuthProvider):
+    name = "recipient-b"
+
+    def __init__(self):
+        super().__init__()
+        self.refresh_calls = 0
+        self.revoke_calls = 0
+
+    def refresh_session(self, *, refresh_token: str) -> Session:
+        self.refresh_calls += 1
+        return super().refresh_session(refresh_token=refresh_token)
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        self.revoke_calls += 1
+
+
+def test_native_refresh_routes_only_to_named_provider(gated_client):
+    clear_providers()
+    target = _RejectingRecipientProvider()
+    other = _UntargetedProvider()
+    register_provider(target)
+    register_provider(other)
+
+    response = gated_client.post(
+        "/auth/native/refresh",
+        json={"refresh_token": "recipient-secret", "provider": target.name},
+    )
+    assert response.status_code == 401
+    assert target.refresh_tokens == ["recipient-secret"]
+    assert other.refresh_calls == 0
+
+
+def test_native_logout_is_public_and_routes_only_to_named_provider(gated_client):
+    clear_providers()
+    target = _RejectingRecipientProvider()
+    other = _UntargetedProvider()
+    register_provider(target)
+    register_provider(other)
+
+    response = gated_client.post(
+        "/auth/native/logout",
+        json={"refresh_token": "recipient-secret", "provider": target.name},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert target.revoked_tokens == ["recipient-secret"]
+    assert other.revoke_calls == 0
+    assert "set-cookie" not in response.headers
+    assert "recipient-secret" not in response.text
+
+
+@pytest.mark.parametrize("path", ["/auth/native/refresh", "/auth/native/logout"])
+def test_native_credential_lifecycle_rejects_unknown_provider(gated_client, path):
+    response = gated_client.post(
+        path,
+        json={"refresh_token": "recipient-secret", "provider": "missing"},
+    )
+    assert response.status_code == 400
+    assert "recipient-secret" not in response.text

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -548,24 +548,29 @@ class TestVerifySession:
 
     def test_wrong_audience_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair, aud="some-other-client")
-        with pytest.raises(ProviderError, match="verification failed"):
-            provider.verify_session(access_token=token)
+        assert provider.verify_session(access_token=token) is None
 
 
     def test_failure_message_surfaces_claims(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair, iss="https://evil.example")
-        with pytest.raises(ProviderError) as excinfo:
-            provider.verify_session(access_token=token)
-        msg = str(excinfo.value)
-        assert "'https://evil.example'" in msg
-        assert f"'{_ISSUER}'" in msg
+        assert provider.verify_session(access_token=token) is None
+
+    def test_malformed_token_is_invalid_without_discovery(self, rsa_keypair):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID
+        )
+        with patch.object(provider, "_get_discovery") as discovery:
+            assert provider.verify_session(access_token="not-a-jwt") is None
+        discovery.assert_not_called()
 
 
     def test_jwks_unreachable_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair)
         bad_client = MagicMock()
-        bad_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
+        bad_client.get_signing_key_from_jwt.side_effect = (
+            jwt.PyJWKClientConnectionError(
             "fetch failed"
+            )
         )
         provider._jwks_client = bad_client
         with pytest.raises(ProviderError, match="JWKS"):
@@ -726,4 +731,3 @@ class TestPluginRegister:
         oidc_plugin.register(ctx)
         registered = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert registered._client_secret == "cfg-secret"
-

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import time
 import urllib.parse
 from typing import Any, Dict
@@ -161,10 +162,24 @@ def _make_provider(
     fake_key.key = serialization.load_pem_private_key(
         rsa_keypair["private_pem"].encode(), password=None
     ).public_key()
+    fake_key.key_id = rsa_keypair["kid"]
     fake_client = MagicMock()
-    fake_client.get_signing_key_from_jwt.return_value = fake_key
+    fake_client.get_signing_key.return_value = fake_key
     p._jwks_client = fake_client
     return p
+
+
+def _real_jwks_client(jwk_set: Dict[str, Any]) -> jwt.PyJWKClient:
+    """Use PyJWT's real parser/key lookup with only network fetch stubbed."""
+    client = jwt.PyJWKClient("https://unused.example/jwks", cache_keys=True)
+
+    def _fetch_data():
+        # Mirror PyJWKClient.fetch_data's cache write while avoiding network.
+        client.jwk_set_cache.put(jwk_set)
+        return jwk_set
+
+    client.fetch_data = MagicMock(side_effect=_fetch_data)
+    return client
 
 
 def _mock_post(status_code: int, body: Any, *, ctype: str = "application/json"):
@@ -551,9 +566,12 @@ class TestVerifySession:
         assert provider.verify_session(access_token=token) is None
 
 
-    def test_failure_message_surfaces_claims(self, provider, rsa_keypair):
+    def test_failure_message_surfaces_claims(self, provider, rsa_keypair, caplog):
         token = _mint_id_token(rsa_keypair, iss="https://evil.example")
-        assert provider.verify_session(access_token=token) is None
+        with caplog.at_level(logging.DEBUG, logger=oidc_plugin.logger.name):
+            assert provider.verify_session(access_token=token) is None
+        assert "'https://evil.example'" in caplog.text
+        assert f"'{_ISSUER}'" in caplog.text
 
     def test_malformed_token_is_invalid_without_discovery(self, rsa_keypair):
         provider = oidc_plugin.SelfHostedOIDCProvider(
@@ -563,18 +581,121 @@ class TestVerifySession:
             assert provider.verify_session(access_token="not-a-jwt") is None
         discovery.assert_not_called()
 
+    @pytest.mark.parametrize("algorithm", ["none", "HS256"])
+    def test_unsupported_token_algorithm_is_invalid_without_discovery(
+        self, algorithm
+    ):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID
+        )
+        header = base64.urlsafe_b64encode(
+            json.dumps(
+                {"alg": algorithm, "typ": "JWT"}, separators=(",", ":")
+            ).encode()
+        ).rstrip(b"=").decode()
+        signature = "" if algorithm == "none" else "c2ln"
+        token = f"{header}.e30.{signature}"
+
+        with patch.object(provider, "_get_discovery") as discovery:
+            assert provider.verify_session(access_token=token) is None
+        discovery.assert_not_called()
+
 
     def test_jwks_unreachable_raises(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair)
         bad_client = MagicMock()
-        bad_client.get_signing_key_from_jwt.side_effect = (
-            jwt.PyJWKClientConnectionError(
+        bad_client.get_signing_key.side_effect = jwt.PyJWKClientConnectionError(
             "fetch failed"
-            )
         )
         provider._jwks_client = bad_client
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
+
+    def test_unusable_jwks_is_provider_error(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair)
+        bad_client = MagicMock()
+        bad_client.get_signing_key.side_effect = jwt.PyJWKSetError(
+            "The JWK Set did not contain any keys"
+        )
+        provider._jwks_client = bad_client
+
+        with pytest.raises(ProviderError, match="unusable"):
+            provider.verify_session(access_token=token)
+
+    def test_unknown_signing_key_is_invalid(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair)
+        unknown_key_client = MagicMock()
+        unknown_key_client.get_signing_key.side_effect = jwt.PyJWKClientError(
+            'Unable to find a signing key that matches: "test-key-1"'
+        )
+        unknown_key_client.get_signing_keys.return_value = [MagicMock()]
+        unknown_key_client.match_kid.return_value = None
+        provider._jwks_client = unknown_key_client
+
+        assert provider.verify_session(access_token=token) is None
+        unknown_key_client.get_signing_keys.assert_called_once_with()
+
+    def test_real_pyjwkclient_verifies_fixture(self, rsa_keypair):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+        )
+        provider._discovery = dict(_DISCOVERY_DOC)
+        provider._discovery_fetched_at = time.time()
+        jwks_client = _real_jwks_client(
+            {"keys": [rsa_keypair["jwk"]]}
+        )
+        provider._jwks_client = jwks_client
+
+        session = provider.verify_session(
+            access_token=_mint_id_token(rsa_keypair)
+        )
+
+        assert session is not None
+        assert session.user_id == "usr_abc"
+        jwks_client.fetch_data.assert_called_once_with()
+
+    def test_real_pyjwkclient_unknown_key_is_invalid(self, rsa_keypair):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+        )
+        provider._discovery = dict(_DISCOVERY_DOC)
+        provider._discovery_fetched_at = time.time()
+        jwks_client = _real_jwks_client(
+            {"keys": [rsa_keypair["jwk"]]}
+        )
+        provider._jwks_client = jwks_client
+        token = jwt.encode(
+            {
+                "iss": _ISSUER,
+                "aud": _CLIENT_ID,
+                "sub": "usr_abc",
+                "iat": int(time.time()),
+                "exp": int(time.time()) + 900,
+            },
+            rsa_keypair["private_pem"],
+            algorithm="RS256",
+            headers={"kid": "unknown-key"},
+        )
+
+        assert provider.verify_session(access_token=token) is None
+        assert jwks_client.fetch_data.call_count == 2
+
+    def test_real_pyjwkclient_empty_set_is_provider_error(self, rsa_keypair):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+        )
+        provider._discovery = dict(_DISCOVERY_DOC)
+        provider._discovery_fetched_at = time.time()
+        jwks_client = _real_jwks_client({"keys": []})
+        provider._jwks_client = jwks_client
+
+        with pytest.raises(ProviderError, match="unusable"):
+            provider.verify_session(
+                access_token=_mint_id_token(rsa_keypair)
+            )
 
     def test_jwks_client_sends_explicit_http_headers(self):
         provider = oidc_plugin.SelfHostedOIDCProvider(

--- a/tests/test_ws_keepalive_config.py
+++ b/tests/test_ws_keepalive_config.py
@@ -50,6 +50,36 @@ def test_dashboard_ws_values_propagate_from_yaml(_temp_home):
     assert dash.get("theme") == "default"
 
 
+def test_dashboard_auth_security_values_propagate_from_yaml(_temp_home):
+    from hermes_cli.config import load_config
+    from hermes_cli.dashboard_auth.native_redirects import (
+        configured_native_redirect_uris,
+    )
+    from hermes_cli.web_server import _dashboard_forwarded_allow_ips
+
+    _write_config(
+        _temp_home,
+        """
+        dashboard:
+          trusted_proxies:
+            - 172.18.0.0/16
+          oauth:
+            native_redirect_uris:
+              - com.example.hermes:/oauth/callback
+        """,
+    )
+    cfg = load_config()
+
+    assert _dashboard_forwarded_allow_ips(cfg["dashboard"]) == [
+        "127.0.0.1",
+        "::1",
+        "172.18.0.0/16",
+    ]
+    assert configured_native_redirect_uris(cfg) == frozenset(
+        {"com.example.hermes:/oauth/callback"}
+    )
+
+
 def test_ws_orphan_reap_grace_reads_config(_temp_home):
     from tui_gateway import server
 

--- a/website/docs/guides/desktop-native-signin.md
+++ b/website/docs/guides/desktop-native-signin.md
@@ -111,12 +111,43 @@ Passwords, etc.) autofill the form, something no embedded desktop webview can
 offer. Token-only credentials (e.g. drain) are not interactive sign-ins and do
 not advertise `native_pkce`.
 
+Desktop uses a literal loopback callback by default. Installed mobile apps may
+instead use an exact operator-approved private-use callback configured in
+`~/.hermes/config.yaml`:
+
+```yaml
+dashboard:
+  # Required when a reverse proxy reaches Hermes from a non-loopback address.
+  # List only the proxy IP/CIDR; never use a wildcard on a public backend.
+  trusted_proxies:
+    - 172.18.0.0/16
+  oauth:
+    native_redirect_uris:
+      - com.example.hermes:/oauth/callback
+```
+
+Each entry must use a dotted private-use scheme and an absolute path, with no
+authority, userinfo, query, fragment, whitespace, backslash, or unsafe URI
+delimiter. Matching is byte-for-byte: there are no wildcard, prefix, suffix, or
+case-normalized matches. Restart the gateway after changing this startup-only
+allowlist. The upstream identity provider still redirects only to the gateway's
+HTTPS callback; the private-use scheme is registered with the installed app,
+not the identity provider.
+
+Hermes takes the native endpoint rate-limit identity from Uvicorn's trusted
+connection metadata, never directly from `X-Forwarded-For`. If a reverse proxy
+connects from outside loopback, include its exact address or bounded CIDR in
+`dashboard.trusted_proxies`; otherwise every proxied client appears to come
+from the proxy itself and shares its rate-limit budget. Loopback remains trusted
+automatically; wildcards and `/0` networks are rejected.
+
 The relevant endpoints (all public, pre-auth bootstrap, same as the existing
 `/auth/*` OAuth routes):
 
 - `GET /auth/native/authorize` — starts the brokered PKCE login
 - `POST /auth/native/token` — exchanges the loopback code + verifier for tokens
 - `POST /auth/native/refresh` — rotates tokens from the app's refresh token
+- `POST /auth/native/logout` — best-effort, provider-scoped token revocation
 
 ## See also
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2692,6 +2692,7 @@ dashboard:
   oauth:                      # Portal OAuth gate (engaged with --host and not --insecure)
     client_id: ""             # agent:{instance_id} — Portal provisions this
     portal_url: ""            # blank → plugin default (production Portal)
+    native_redirect_uris: []  # Exact private-use callback URIs for installed mobile apps
   basic_auth:                 # Self-hosted username/password gate (dashboard_auth/basic plugin)
     username: ""              # blank → plugin no-op
     password_hash: ""         # scrypt$... (preferred — no plaintext at rest)
@@ -2712,6 +2713,7 @@ dashboard:
 - `public_url` — when set, this is the complete authority (scheme + host + optional path prefix) the OAuth `redirect_uri` is built from. Set it for deploys behind reverse proxies that don't reliably forward `X-Forwarded-*` headers. Leave empty to use proxy-header reconstruction.
 - `trusted_proxies` — IP addresses or bounded CIDR networks allowed to supply `X-Forwarded-Proto` and `X-Forwarded-For`. Loopback remains trusted automatically. Configure this when the TLS reverse proxy connects from another container or host. Prefer the proxy's exact IP; use a small dedicated network only when its address is dynamic. Wildcards and `/0` networks are rejected.
 - `oauth` / `basic_auth` / `drain_auth` — auth provider config read by the bundled dashboard-auth plugins. The drain secret itself is **not** set here; it's provisioned via the `HERMES_DASHBOARD_DRAIN_SECRET` env var. See [Web Dashboard](/user-guide/features/web-dashboard) for full auth setup.
+- `oauth.native_redirect_uris` — exact operator-approved private-use callback URIs for installed apps. Literal loopback callbacks remain available without configuration; see [Desktop Native Sign-In](/guides/desktop-native-signin).
 - `ws_ping_interval` / `ws_ping_timeout` — WebSocket keepalive tuning for non-loopback binds (loopback connections never ping). Raise these on high-latency links (Tailscale, distant SSH tunnels) where the 20 s defaults can manufacture spurious 1006 disconnects.
 - `ws_orphan_reap_grace_s` — how long a WS-detached session waits before the orphan reaper collects it. Raise alongside the keepalive values if clients reconnect slowly. (`HERMES_TUI_WS_ORPHAN_REAP_GRACE_S` remains as an internal override.)
 - `startup_orphan_sweep` (default `true`) — the WS-orphan reap timer above is in-process, so a gateway restart (update, crash, systemd) before it fires leaves the session row open forever — phantom "active" work in `/resume` and dashboards. On every gateway boot — both the stdio TUI (`entry.main`) and the desktop/dashboard WebSocket sidecar (`handle_ws`) — rows with source `tui` / `desktop` / `subagent` whose start time **and** newest message are both older than the session TTL (`HERMES_TUI_SESSION_TTL_S`, default 6 hours) are closed with `end_reason: startup_orphan_reap`. Messaging-platform sessions (Telegram, Discord, …) are never touched, live in-memory sessions (a client that already resumed) are excluded, and swept sessions remain resumable.


### PR DESCRIPTION
## Summary

- preserve RFC 8252 literal-loopback callbacks and add an exact, startup-validated allowlist for private-use installed-app callbacks
- make native refresh provider-authoritative and add public, best-effort provider-scoped native logout
- classify malformed/invalid self-hosted OIDC bearer tokens as invalid credentials while retaining 503 for genuine JWKS connection failures

The motivating deployment uses these operator-configured callbacks:

```yaml
dashboard:
  oauth:
    native_redirect_uris:
      - com.uzairansar.hermesmobile:/oauth/callback
      - com.uzairansar.hermesmobile.branch:/oauth/callback
```

Keycloak continues to redirect only to the gateway HTTPS callback. App schemes are never registered with the IdP.

Closes #94733.

## Security properties

- S256 and existing one-time gateway-code semantics are unchanged.
- Private callbacks use complete-string equality after fail-closed configuration validation; no wildcard, prefix, suffix, scheme-only, or normalization match exists.
- Callback policy is checked before pending broker state is registered.
- Refresh and logout never disclose a refresh token to an unrelated provider.
- Native logout requires no live access token and cannot trigger global IdP logout.
- Tests cover exact callbacks, lookalikes, unsafe config, state-store ordering, single-recipient refresh/logout, no-cookie responses, malformed bearer handling, and loopback/browser compatibility.

## Tests

```text
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/hermes_cli/test_dashboard_auth_native_flow.py tests/hermes_cli/test_dashboard_auth_plugin_hook.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_dashboard_token_auth.py tests/plugins/dashboard_auth/ --file-timeout 240
197 passed

scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_flow.py tests/plugins/dashboard_auth/test_self_hosted_provider.py tests/hermes_cli/test_dashboard_auth_middleware.py --file-timeout 180
85 passed

ruff check <affected files>
All checks passed
```
