### PR TITLE
fix(custom): allow model names with spaces for custom providers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6372,7 +6372,12 @@ def validate_requested_model(
                 "message": f"Could not read MoA presets: {exc}",
             }
 
-    if any(ch.isspace() for ch in requested):
+    # Custom providers may legitimately expose model IDs with spaces
+    # (e.g. Frankonia returns "Qwen 3.8 27B", "Gemma 4 26B").
+    # For known built-in providers the space check still applies.
+    if normalized == "custom" or normalized.startswith("custom:"):
+        pass
+    elif any(ch.isspace() for ch in requested):
         return {
             "accepted": False,
             "persist": False,


### PR DESCRIPTION
## Problem

Custom providers (e.g. frankonia.ai) may legitimately expose model IDs with spaces like "Qwen 3.8 27B" or "Gemma 4 26B". The blanket whitespace check in `validate_requested_model` rejected all providers, blocking valid model IDs from custom endpoints.

This caused the error:

    Model names cannot contain spaces.

when trying to switch to any model from a custom endpoint whose API returns space-containing model IDs.

## Fix

Skip the whitespace validation for `custom` and `custom:` providers, letting the provider's own model listing serve as the source of truth. Built-in providers still enforce the space check.

## Verification

Tested against frankonia.ai API, which returns models like:
- Qwen 3.8 27B -> accepted, recognized
- Gemma 4 26B -> accepted, recognized
- Z Image Turbo -> accepted, recognized
- Nemotron 3 Nano 30B -> accepted, recognized
- Qwen 3.6 27B -> still works (no regression)

## Changes

Single file changed: `hermes_cli/models.py`
- Added provider-type check before the space validation (5 lines added, 1 line modified)