### PR TITLE
fix(desktop): isolate private backend auth

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19447,7 +19447,21 @@ def start_server(
     # request middleware never reloads config. Any non-loopback public hostname
     # engages the auth gate even when the backend itself remains on loopback;
     # otherwise the SPA's local session token would become remotely reachable.
-    app.state.trusted_public_hosts = _dashboard_public_hosts()
+    #
+    # Desktop's private headless backend is a separate loopback-only surface. It
+    # inherits the user's environment (including public-dashboard OAuth config),
+    # but is contacted directly by the native shell with its process-minted
+    # session token — never through the public reverse proxy. Do not let an
+    # unrelated dashboard.public_url switch that private child into cookie/OAuth
+    # mode, and do not trust the public hostname on the child's loopback bind.
+    _desktop_loopback_backend = (
+        headless
+        and os.environ.get("HERMES_DESKTOP") == "1"
+        and host in _LOOPBACK_HOST_VALUES
+    )
+    app.state.trusted_public_hosts = (
+        frozenset() if _desktop_loopback_backend else _dashboard_public_hosts()
+    )
     # Stash the auth-gate flag on app.state so middleware / SPA-token injection /
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -315,6 +315,41 @@ def test_start_server_loopback_public_url_without_provider_fails_closed(monkeypa
     assert web_server.app.state.auth_required is True
 
 
+def test_desktop_headless_loopback_ignores_external_dashboard_public_url(monkeypatch):
+    """Desktop's private backend must not inherit the public dashboard gate."""
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    register_provider(StubAuthProvider())
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+    try:
+        web_server.start_server(
+            host="127.0.0.1",
+            port=9119,
+            open_browser=False,
+            allow_public=False,
+            headless=True,
+        )
+        assert web_server.app.state.auth_required is False
+        assert web_server.app.state.trusted_public_hosts == frozenset()
+        assert captured["kwargs"].get("proxy_headers") is False
+    finally:
+        clear_providers()
+
+
 def test_loopback_public_url_fail_closed_message_is_actionable(monkeypatch):
     """The refusal must name public_url, print its value, and give both exits.
 


### PR DESCRIPTION
## What does this PR do?

Keeps Hermes Desktop's private headless loopback backend in its intended session-token authentication mode when the user also configured an external authenticated dashboard URL.

## Problem

Desktop starts a private backend with:

- `headless=True`
- `HERMES_DESKTOP=1`
- a loopback bind
- a process-minted `HERMES_DASHBOARD_SESSION_TOKEN`

That child inherits the user's dashboard configuration. When `dashboard.public_url` (or its environment equivalent) names an external host, `start_server()` currently treats the private Desktop child like the public dashboard, enables the OAuth/cookie gate, and rejects Desktop's `/api/ws?token=...` session token.

The HTTP readiness endpoint still succeeds, so Desktop reports:

> Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token

## Fix

For the narrowly defined Desktop-private path only — `headless`, `HERMES_DESKTOP=1`, and loopback — use an empty trusted-public-host snapshot before computing `auth_required`.

All other behavior remains unchanged:

- normal loopback dashboards with an external public URL remain authenticated;
- non-loopback binds remain authenticated;
- public host-header trust remains intact;
- the exception does not apply without the Desktop marker or without headless mode.

## Regression coverage

The added test verifies that a Desktop headless loopback child ignores an unrelated external public-dashboard URL, stays out of OAuth/cookie mode, trusts no public hostname, and keeps `proxy_headers` disabled.

## Verification

```text
30 passed, 1 deselected in 2.23s
All checks passed!  (Ruff)
git diff --check: clean
```

The one deselected existing test binds fixed port 9119, which the live Hermes gateway owns on the verification machine; CI can run the complete module in an isolated environment.

A real Desktop-style backend was also started with `HERMES_DESKTOP=1` and a session token:

- `/api/status`: `overall=ok`, `auth_required=false`
- `/api/ws?token=...`: opened and delivered a gateway event

The actual macOS Desktop app was then restarted and reached `Hermes backend is ready. Finalizing desktop startup` with a healthy private backend.
