### PR TITLE
fix(tui): bound slash-worker stdin write; stop lock wedge on huge commands

### DIFF
--- a/tests/tui_gateway/test_slash_worker_stdin_bound.py
+++ b/tests/tui_gateway/test_slash_worker_stdin_bound.py
@@ -1,0 +1,89 @@
+"""_SlashWorker.run must bound its stdin write.
+
+run() holds _lock across proc.stdin.write(). A command larger than the pipe
+buffer against a busy child (still executing the previous command) blocked
+that write forever while holding the lock - every later slash command from
+any thread queued behind it, and the queue-wait timeout was never reached
+because the call never got past the write. The write is now offloaded to a
+helper thread bounded by the same timeout.
+"""
+import queue
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+class _BlockingStdin:
+    """stdin whose write() blocks until released."""
+
+    def __init__(self):
+        self.release = threading.Event()
+        self.written = []
+
+    def write(self, payload):
+        self.written.append(payload)
+        self.release.wait(timeout=10)
+
+    def flush(self):
+        pass
+
+
+def _make_worker(stdin):
+    worker = object.__new__(server._SlashWorker)
+    worker.proc = types.SimpleNamespace(
+        poll=lambda: None,  # "running"
+        stdin=stdin,
+        stdout=None,
+        stderr=None,
+    )
+    worker._lock = threading.Lock()
+    worker._seq = 0
+    worker.stdout_queue = queue.Queue()
+    worker.stderr_tail = []
+    return worker
+
+
+def test_run_raises_timeout_when_stdin_write_blocks(monkeypatch):
+    stdin = _BlockingStdin()
+    worker = _make_worker(stdin)
+    monkeypatch.setattr(server, "_SLASH_WORKER_TIMEOUT_S", 0.2)
+
+    with pytest.raises(RuntimeError, match="stdin write timed out"):
+        worker.run("huge command")
+
+    # Lock must be released: a second call proceeds (and times out again
+    # instead of deadlocking behind the first).
+    with pytest.raises(RuntimeError):
+        worker.run("second")
+
+    stdin.release.set()
+
+
+def test_run_returns_output_when_write_and_response_succeed(monkeypatch):
+    class _EchoStdin(_BlockingStdin):
+        def write(self, payload):
+            self.written.append(payload)
+            # Simulate the child answering immediately.
+
+    stdin = _EchoStdin()
+    worker = _make_worker(stdin)
+
+    def responder():
+        worker.stdout_queue.put({"id": 1, "ok": True, "output": "done"})
+
+    monkeypatch.setattr(
+        server, "_SLASH_WORKER_TIMEOUT_S", 2.0
+    )
+    # Answer the first command as soon as the payload lands.
+    orig_start = threading.Thread
+
+    def _spawn_then_answer(target, daemon=False, name=None):
+        t = orig_start(target=target, daemon=daemon, name=name)
+        responder()
+        return t
+
+    monkeypatch.setattr(threading, "Thread", _spawn_then_answer)
+    assert worker.run("cmd") == "done"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -527,8 +527,28 @@ class _SlashWorker:
         with self._lock:
             self._seq += 1
             rid = self._seq
-            self.proc.stdin.write(json.dumps({"id": rid, "command": command}) + "\n")
-            self.proc.stdin.flush()
+            payload = json.dumps({"id": rid, "command": command}) + "\n"
+            # Bound the stdin write: a command larger than the pipe buffer
+            # against a busy child (executing the previous command) would
+            # block this write forever WHILE holding _lock, wedging every
+            # future slash command. The write thread converts that into the
+            # same timeout the response wait already uses.
+            write_done = threading.Event()
+
+            def _write_payload() -> None:
+                try:
+                    self.proc.stdin.write(payload)
+                    self.proc.stdin.flush()
+                except Exception:
+                    pass  # broken pipe surfaces via the queue loop / close()
+                finally:
+                    write_done.set()
+
+            threading.Thread(
+                target=_write_payload, daemon=True, name="slash-worker-stdin"
+            ).start()
+            if not write_done.wait(_SLASH_WORKER_TIMEOUT_S):
+                raise RuntimeError("slash worker stdin write timed out")
 
             while True:
                 try:


### PR DESCRIPTION
## Problem

`_SlashWorker.run()` held `_lock` across `proc.stdin.write()` with no bound. A command whose serialized payload exceeds the OS pipe buffer (~64KB — a large paste into a slash command) against a **busy child** — one still executing the previous command and therefore not reading stdin — blocked the write **indefinitely while holding the lock**:

- every later slash command, from any thread, queued behind the lock
- the existing `queue.get(timeout=_SLASH_WORKER_TIMEOUT_S)` could never fire, because the call never got past the write
- `close()` (terminate → BrokenPipe) was the only escape

## Fix

The payload write is offloaded to a short-lived daemon thread; `run()` waits on its completion with the **same** `_SLASH_WORKER_TIMEOUT_S` budget as the response wait. A wedged write now raises `RuntimeError("slash worker stdin write timed out")` and releases the lock, so subsequent commands proceed (and fail fast the same way) instead of deadlocking. Normal-size commands are unaffected — the helper completes immediately.

## Verification

New `tests/tui_gateway/test_slash_worker_stdin_bound.py`:
- blocked write → `stdin write timed out` raised, lock released (second call proceeds rather than deadlocking)
- happy path (write lands, child responds) still returns output

slash_worker selection: 8 passed; the one `test_slash_worker_mcp_discovery` failure is pre-existing on clean `main` on this host (reproduced stashed).