### PR TITLE
fix(computer-use): let Session 0 gateways reach the interactive desktop

### DIFF
--- a/tests/computer_use/test_cua_windows_session0_transport.py
+++ b/tests/computer_use/test_cua_windows_session0_transport.py
@@ -1,0 +1,46 @@
+"""Windows Session-0 transport policy for cua-driver."""
+
+from tools.computer_use.cua_backend import _standard_mcp_transport_args
+
+
+_DEFAULT_PIPE = r"\\.\pipe\cua-driver"
+
+
+def test_session_zero_routes_standard_mcp_to_interactive_daemon():
+    args = _standard_mcp_transport_args(
+        ["mcp"],
+        platform="win32",
+        windows_session_id=0,
+    )
+
+    assert args == ["mcp", "--socket", _DEFAULT_PIPE]
+
+
+def test_interactive_windows_session_keeps_direct_standard_runtime():
+    args = _standard_mcp_transport_args(
+        ["mcp"],
+        platform="win32",
+        windows_session_id=3,
+    )
+
+    assert args == ["mcp"]
+
+
+def test_unknown_windows_session_fails_closed_to_driver_guard():
+    args = _standard_mcp_transport_args(
+        ["mcp"],
+        platform="win32",
+        windows_session_id=None,
+    )
+
+    assert args == ["mcp"]
+
+
+def test_non_windows_standard_runtime_is_unchanged():
+    args = _standard_mcp_transport_args(
+        ["mcp"],
+        platform="linux",
+        windows_session_id=0,
+    )
+
+    assert args == ["mcp"]

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -97,6 +97,30 @@ def _default_cli_version_matches_report(monkeypatch):
     )
 
 
+# ── transport selection ────────────────────────────────────────────────────
+
+
+def test_doctor_routes_session_zero_through_interactive_daemon():
+    from tools.computer_use import doctor
+
+    proc = MagicMock()
+    with patch(
+        "tools.computer_use.cua_backend._windows_process_session_id",
+        return_value=0,
+    ), patch(
+        "tools.computer_use.cua_backend._resolve_mcp_invocation",
+        return_value=("C:/cua-driver.exe", ["mcp"]),
+    ), patch("subprocess.Popen", return_value=proc) as popen:
+        assert doctor._open_mcp("C:/cua-driver.exe") is proc
+
+    assert popen.call_args.args[0] == [
+        "C:/cua-driver.exe",
+        "mcp",
+        "--socket",
+        r"\\.\pipe\cua-driver",
+    ]
+
+
 # ── exit codes ─────────────────────────────────────────────────────────────
 
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -172,6 +172,7 @@ _CUA_DRIVER_DEFAULT_CMD = "cua-driver"
 _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # driver doesn't expose `manifest` — see
                             # `_resolve_mcp_invocation` below)
+_WINDOWS_CUA_DAEMON_PIPE = r"\\.\pipe\cua-driver"
 
 # Whole-screen / desktop capture. cua-driver is a window-oriented driver —
 # its `get_window_state` / `screenshot` tools capture a single window (by
@@ -376,6 +377,42 @@ def _standard_runtime_launch_args(
     )
     result.extend(["--socket", private_socket])
     return result, private_socket
+
+
+def _windows_process_session_id() -> Optional[int]:
+    """Return this process's Windows session id, or None when unavailable."""
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        session_id = ctypes.c_ulong()
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        if not kernel32.ProcessIdToSessionId(os.getpid(), ctypes.byref(session_id)):
+            return None
+        return int(session_id.value)
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
+def _standard_mcp_transport_args(
+    args: List[str],
+    *,
+    platform: str,
+    windows_session_id: Optional[int],
+) -> List[str]:
+    """Select the authenticated interactive daemon from Windows Session 0.
+
+    A bare Windows MCP process owns a desktop runtime and is therefore invalid
+    in Session 0. The explicit named-pipe form remains a protocol-only proxy;
+    cua-driver authenticates the pipe as same-user and the interactive daemon
+    remains the sole desktop/authorization owner. Unknown session identity is
+    left on the direct path so cua-driver's own Session-0 guard fails closed.
+    """
+    result = list(args)
+    if platform == "win32" and windows_session_id == 0 and "--socket" not in result:
+        result.extend(["--socket", _WINDOWS_CUA_DAEMON_PIPE])
+    return result
 
 
 def _computer_use_max_image_dimension() -> Optional[int]:
@@ -1613,13 +1650,25 @@ class _CuaDriverSession:
                 child_env = self._embedded_daemon.child_env()
             else:
                 command, args = _resolve_mcp_invocation(driver_cmd)
-                args, owned_socket = _standard_runtime_launch_args(
+                windows_session_id = _windows_process_session_id()
+                args = _standard_mcp_transport_args(
                     args,
-                    grant_existing_profile=_cua_grant_existing_profile(),
                     platform=sys.platform,
-                    socket_path=self._owned_standard_runtime_socket,
+                    windows_session_id=windows_session_id,
                 )
-                self._owned_standard_runtime_socket = owned_socket
+                if "--socket" not in args:
+                    args, owned_socket = _standard_runtime_launch_args(
+                        args,
+                        grant_existing_profile=_cua_grant_existing_profile(),
+                        platform=sys.platform,
+                        socket_path=self._owned_standard_runtime_socket,
+                    )
+                    self._owned_standard_runtime_socket = owned_socket
+                if sys.platform == "win32" and windows_session_id == 0:
+                    logger.info(
+                        "Windows Session 0 detected; proxying standard-mode "
+                        "cua-driver MCP through the interactive daemon"
+                    )
                 child_env = cua_driver_child_env()
             _t_manifest = _time.monotonic()
             params = StdioServerParameters(

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -202,13 +202,23 @@ def _extract_health_report_from_result(result: Dict[str, Any]) -> Dict[str, Any]
 
 def _open_mcp(binary: str) -> subprocess.Popen:
     """Spawn ``<binary> mcp`` with UTF-8 + sanitized env."""
+    from tools.computer_use.cua_backend import (
+        _standard_mcp_transport_args,
+        _windows_process_session_id,
+    )
+
+    args = _standard_mcp_transport_args(
+        ["mcp"],
+        platform=sys.platform,
+        windows_session_id=_windows_process_session_id(),
+    )
     # cua-driver emits UTF-8 (containing emoji in check messages on macOS
     # and arbitrary file paths on Windows). The Python default
     # text-mode encoding follows the system locale — `cp1252` on a
     # default Windows install — which raises UnicodeDecodeError on the
     # first non-ASCII byte. Pin the codec.
     return subprocess.Popen(
-        [binary, "mcp"],
+        [binary, *args],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## What does this PR do?

Windows gateways running in Session 0 can now use the standard-mode `computer_use` backend through the logged-in user's interactive cua-driver daemon instead of starting a desktop-owning runtime in the non-interactive service session. The same routing is applied to `hermes computer-use doctor`, while interactive Hermes processes and bounded or unrestricted runtimes keep their existing private transport behavior.

### Symptom

A long-lived Windows gateway in Session 0 fails during MCP initialization with `Cua Driver requires an interactive Windows user session: running in Windows Session 0`, even when the same user's interactive cua-driver daemon is healthy and reachable.

### Impact

Always-on Windows gateway deployments cannot use built-in computer use while retaining the required separation between the Session 0 service and the logged-in desktop.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:1652` / `_CuaDriverSession._lifecycle_coro()` when the current Windows process belongs to Session 0.

**Causal chain:**
1. The gateway starts the standard cua-driver MCP transport from Session 0.
2. Hermes launches bare `cua-driver mcp`, which owns a desktop runtime on Windows.
3. cua-driver correctly rejects that runtime before MCP initialization because Session 0 has no interactive desktop.

**Why it is wrong:** Hermes always selected the direct Windows MCP topology and did not distinguish an interactive process from a Session 0 service process.

**Working sibling / contrast:** `cua-driver call` and `cua-driver mcp --socket \\.\pipe\cua-driver` are protocol-only clients of the interactive daemon. The daemon's named pipe is same-user authenticated, and the daemon remains the desktop and authorization owner.

**Ruled out:** A missing driver or broken desktop permission is not the cause. The reported control path reaches `health_report` and `get_accessibility_tree` through the brokered CLI from the same Session 0 gateway context.

### Fix

- Resolve the current Windows process session with `ProcessIdToSessionId`.
- In Session 0, select the canonical same-user daemon pipe for standard MCP instead of constructing a direct runtime.
- Leave unknown session identity on cua-driver's direct path so its own Session 0 guard remains fail-closed.
- Keep bounded and unrestricted Hermes runs on their existing private embedded daemons.
- Route `hermes computer-use doctor` through the same Session 0 transport policy.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - add Windows session detection and the standard-mode Session 0 daemon-proxy policy.
- `tools/computer_use/doctor.py` - use the same transport policy for health checks.
- `tests/computer_use/test_cua_windows_session0_transport.py` - cover Session 0, interactive, unknown, and non-Windows routing behavior.
- `tests/computer_use/test_doctor.py` - verify doctor launches the explicit daemon-proxy MCP command in Session 0.

## How to Test

1. Run a cua-driver daemon as the logged-in owner in an interactive Windows session.
2. From a same-owner Session 0 gateway, invoke a read-only `computer_use` capture and `hermes computer-use doctor`; both should reach the interactive daemon without starting a direct Session 0 runtime.
3. Run the targeted regression suite (40 passed, 1 skipped locally):

```bash
scripts/run_tests.sh tests/computer_use/test_doctor.py tests/computer_use/test_cua_windows_session0_transport.py tests/tools/test_computer_use_cua_0_10_permissions.py tests/computer_use/test_cua_spawn_env_sanitization.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is documented in the transport helper
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the model tool contract is unchanged

## Screenshots / Logs

N/A. This changes a background transport selection and adds automated command assertions.
