### PR TITLE
feat(sessions): add taxonomy backend and sidebar slices

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -337,6 +337,13 @@ class SessionRename(BaseModel):
     # session explicitly unread, False marks it read up to now. Mirrored from
     # the Desktop sidebar's "Mark as unread"/"Mark as read". None = leave alone.
     unread: Optional[bool] = None
+    # Session taxonomy (disposition = project / archive / transient / junk,
+    # plus project_group category and named project). Classification is
+    # written only when disposition is non-None; project_group/project may be
+    # set alongside it. None on any field leaves it untouched.
+    disposition: Optional[str] = None
+    project_group: Optional[str] = None
+    project: Optional[str] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -435,8 +435,6 @@ def get_profiles_sessions_sidebar(
     messaging_exclude: str = None,
     projects_limit: int = 300,
     archives_limit: int = 300,
-    recents_exclude_dispositions: str = None,
-    messaging_exclude_dispositions: str = None,
 ):
     """Batched sidebar session slices — one profile-DB open per refresh.
 
@@ -458,7 +456,9 @@ def get_profiles_sessions_sidebar(
     ``messaging_exclude`` CSV, ``source=cron`` is implicit) so this stays
     taxonomy-agnostic like the per-slice endpoint. All three slices use
     ``min_messages=1`` / ``archived=exclude`` / recency order, matching the
-    desktop's per-slice calls.
+    desktop's per-slice calls. Transient and junk are operational noise
+    (probes, cron echoes, tool runs) and are always excluded from the recents
+    and messaging slices server-side — they never surface in the sidebar.
     """
     from hermes_cli import profiles as profiles_mod
 
@@ -473,15 +473,12 @@ def get_profiles_sessions_sidebar(
         targets.append(("default", profiles_mod.get_profile_dir("default")))
 
     recents_scope = (recents_profile or "all").strip() or "all"
-    _validate_dispositions(recents_exclude_dispositions, messaging_exclude_dispositions)
     recents_exclude_list = _parse_csv_param(recents_exclude, "recents_exclude")
     messaging_exclude_list = _parse_csv_param(messaging_exclude, "messaging_exclude")
-    recents_exclude_disp_list = _parse_csv_param(
-        recents_exclude_dispositions, "recents_exclude_dispositions"
-    )
-    messaging_exclude_disp_list = _parse_csv_param(
-        messaging_exclude_dispositions, "messaging_exclude_dispositions"
-    )
+    # Transient + junk are operational noise and never surface in the sidebar
+    # (review #11: hardcode server-side instead of two always-constant request
+    # fields). Projects/archives slices are disposition-filtered by design.
+    _SIDEBAR_HIDDEN_DISPOSITIONS = ("transient", "junk")
 
     recents_cap = min(max(recents_limit, 1), 500)
     cron_cap = min(max(cron_limit, 1), 500)
@@ -548,8 +545,6 @@ def get_profiles_sessions_sidebar(
             tuple(messaging_exclude_list),
             projects_cap,
             archives_cap,
-            tuple(recents_exclude_disp_list),
-            tuple(messaging_exclude_disp_list),
         )
         slices = _sidebar_profile_cache_get(profile_cache_key)
         if slices is None:
@@ -568,7 +563,7 @@ def get_profiles_sessions_sidebar(
                         db,
                         exclude=recents_exclude_list,
                         cap=recents_cap,
-                        exclude_dispositions=recents_exclude_disp_list,
+                        exclude_dispositions=list(_SIDEBAR_HIDDEN_DISPOSITIONS),
                     ),
                     # Aggregated in SQL rather than over the recents window: the
                     # window is a page, and a total that shrank when you scrolled
@@ -579,7 +574,7 @@ def get_profiles_sessions_sidebar(
                         db,
                         exclude=messaging_exclude_list,
                         cap=messaging_cap,
-                        exclude_dispositions=messaging_exclude_disp_list,
+                        exclude_dispositions=list(_SIDEBAR_HIDDEN_DISPOSITIONS),
                     ),
                     # Taxonomy slices: active PROJECT sessions (grouped
                     # client-side by project_group -> project) and finished

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -43,6 +43,53 @@ from hermes_cli.web_models import (
     SessionPrScanBody,
 )
 
+# Session taxonomy allowlist (must match hermes_state.SessionDB
+# set_session_disposition). Unknown dispositions silently vanish from every
+# sidebar bucket, so reject them at the boundary instead.
+_DISPOSITION_ALLOWLIST = {"project", "archive", "transient", "junk"}
+_MAX_CSV_ENTRIES = 8
+
+
+def _parse_csv_param(value: Optional[str], param_name: str) -> List[str]:
+    """Parse a comma-separated query param into a stripped, bounded list.
+
+    Filters on the stripped value but stores the stripped value (the old
+    behavior filtered untrimmed entries yet kept the raw string, so a caller
+    passing ``a , b`` would filter on ``a``/``b`` but store ``a ``/`` b``).
+    Bounds the list so a hostile query can't explode the WHERE clause.
+    """
+    if not value:
+        return []
+    items = [s.strip() for s in value.split(",") if s.strip()]
+    if len(items) > _MAX_CSV_ENTRIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{param_name}: at most {_MAX_CSV_ENTRIES} comma-separated values",
+        )
+    return items
+
+
+def _validate_dispositions(
+    disposition: Optional[str], exclude_dispositions: Optional[str]
+) -> None:
+    """400 on unknown disposition values (single or CSV)."""
+    for raw, param_name in (
+        (disposition, "disposition"),
+        (exclude_dispositions, "exclude_dispositions"),
+    ):
+        if not raw:
+            continue
+        values = _parse_csv_param(raw, param_name)
+        unknown = [v for v in values if v not in _DISPOSITION_ALLOWLIST]
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"{param_name}: unknown disposition(s) {', '.join(unknown)}; "
+                    f"must be one of project/archive/transient/junk"
+                ),
+            )
+
 # Same logger the handlers used before extraction (identical logger object).
 _log = logging.getLogger("hermes_cli.web_server")
 
@@ -253,6 +300,7 @@ def get_profiles_sessions(
         raise HTTPException(status_code=400, detail="archived must be one of: exclude, only, include")
     if order not in ("created", "recent"):
         raise HTTPException(status_code=400, detail="order must be one of: created, recent")
+    _validate_dispositions(disposition, exclude_dispositions)
 
     from hermes_cli import profiles as profiles_mod
 
@@ -278,12 +326,10 @@ def get_profiles_sessions(
     # the cron-jobs section passes source=cron — two independent lists so
     # newest cron sessions can't starve the recents page.
     source_filter = source or None
-    source_list = [s.strip() for s in (sources or "").split(",") if s.strip()]
-    exclude_list = [s.strip() for s in (exclude_sources or "").split(",") if s.strip()]
+    source_list = _parse_csv_param(sources, "sources")
+    exclude_list = _parse_csv_param(exclude_sources, "exclude_sources")
     disposition_filter = disposition.strip() if disposition else None
-    exclude_dispositions_list = [
-        s.strip() for s in (exclude_dispositions or "").split(",") if s.strip()
-    ]
+    exclude_dispositions_list = _parse_csv_param(exclude_dispositions, "exclude_dispositions")
     # Over-fetch per profile so the merged+sorted window is correct for the
     # requested page. Capped so a huge profile can't blow up the response.
     per_profile = min(max(limit + offset, limit), 500)
@@ -336,6 +382,7 @@ def get_profiles_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 exclude_children=True,
+                include_pinned=True,
                 disposition=disposition_filter,
                 exclude_dispositions=exclude_dispositions_list or None,
             )
@@ -426,14 +473,15 @@ def get_profiles_sessions_sidebar(
         targets.append(("default", profiles_mod.get_profile_dir("default")))
 
     recents_scope = (recents_profile or "all").strip() or "all"
-    recents_exclude_list = [s for s in (recents_exclude or "").split(",") if s.strip()]
-    messaging_exclude_list = [s for s in (messaging_exclude or "").split(",") if s.strip()]
-    recents_exclude_disp_list = [
-        s for s in (recents_exclude_dispositions or "").split(",") if s.strip()
-    ]
-    messaging_exclude_disp_list = [
-        s for s in (messaging_exclude_dispositions or "").split(",") if s.strip()
-    ]
+    _validate_dispositions(recents_exclude_dispositions, messaging_exclude_dispositions)
+    recents_exclude_list = _parse_csv_param(recents_exclude, "recents_exclude")
+    messaging_exclude_list = _parse_csv_param(messaging_exclude, "messaging_exclude")
+    recents_exclude_disp_list = _parse_csv_param(
+        recents_exclude_dispositions, "recents_exclude_dispositions"
+    )
+    messaging_exclude_disp_list = _parse_csv_param(
+        messaging_exclude_dispositions, "messaging_exclude_dispositions"
+    )
 
     recents_cap = min(max(recents_limit, 1), 500)
     cron_cap = min(max(cron_limit, 1), 500)

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -234,6 +234,8 @@ def get_profiles_sessions(
     sources: str = None,
     exclude_sources: str = None,
     full: bool = False,
+    disposition: str = None,
+    exclude_dispositions: str = None,
 ):
     """Unified, read-only session list aggregated across ALL profiles.
 
@@ -278,6 +280,10 @@ def get_profiles_sessions(
     source_filter = source or None
     source_list = [s.strip() for s in (sources or "").split(",") if s.strip()]
     exclude_list = [s.strip() for s in (exclude_sources or "").split(",") if s.strip()]
+    disposition_filter = disposition.strip() if disposition else None
+    exclude_dispositions_list = [
+        s.strip() for s in (exclude_dispositions or "").split(",") if s.strip()
+    ]
     # Over-fetch per profile so the merged+sorted window is correct for the
     # requested page. Capped so a huge profile can't blow up the response.
     per_profile = min(max(limit + offset, limit), 500)
@@ -319,6 +325,8 @@ def get_profiles_sessions(
                 # Same SQL-level blob skip as /api/sessions (see above).
                 compact_rows=not full,
                 include_pinned=True,
+                disposition=disposition_filter,
+                exclude_dispositions=exclude_dispositions_list or None,
             )
             profile_total = db.session_count(
                 source=source_filter,
@@ -328,6 +336,8 @@ def get_profiles_sessions(
                 include_archived=include_archived,
                 archived_only=archived_only,
                 exclude_children=True,
+                disposition=disposition_filter,
+                exclude_dispositions=exclude_dispositions_list or None,
             )
             total += profile_total
             profile_totals[name] = profile_total
@@ -376,6 +386,10 @@ def get_profiles_sessions_sidebar(
     cron_limit: int = 50,
     messaging_limit: int = 100,
     messaging_exclude: str = None,
+    projects_limit: int = 300,
+    archives_limit: int = 300,
+    recents_exclude_dispositions: str = None,
+    messaging_exclude_dispositions: str = None,
 ):
     """Batched sidebar session slices — one profile-DB open per refresh.
 
@@ -414,14 +428,24 @@ def get_profiles_sessions_sidebar(
     recents_scope = (recents_profile or "all").strip() or "all"
     recents_exclude_list = [s for s in (recents_exclude or "").split(",") if s.strip()]
     messaging_exclude_list = [s for s in (messaging_exclude or "").split(",") if s.strip()]
+    recents_exclude_disp_list = [
+        s for s in (recents_exclude_dispositions or "").split(",") if s.strip()
+    ]
+    messaging_exclude_disp_list = [
+        s for s in (messaging_exclude_dispositions or "").split(",") if s.strip()
+    ]
 
     recents_cap = min(max(recents_limit, 1), 500)
     cron_cap = min(max(cron_limit, 1), 500)
     messaging_cap = min(max(messaging_limit, 1), 500)
+    projects_cap = min(max(projects_limit, 1), 500)
+    archives_cap = min(max(archives_limit, 1), 500)
 
     recents_rows: List[Dict[str, Any]] = []
     cron_rows: List[Dict[str, Any]] = []
     messaging_rows: List[Dict[str, Any]] = []
+    projects_rows: List[Dict[str, Any]] = []
+    archives_rows: List[Dict[str, Any]] = []
     recents_truncated: Dict[str, bool] = {}
     profile_totals: Dict[str, Dict[str, float]] = {}
     errors: List[Dict[str, str]] = []
@@ -441,7 +465,7 @@ def get_profiles_sessions_sidebar(
             s["pinned"] = bool(s.get("pinned"))
         return rows
 
-    def _slice(db, *, source=None, exclude=None, cap):
+    def _slice(db, *, source=None, exclude=None, cap, disposition=None, exclude_dispositions=None):
         return db.list_sessions_rich(
             source=source,
             exclude_sources=exclude or None,
@@ -455,6 +479,8 @@ def get_profiles_sessions_sidebar(
             # A pinned conversation must reach the sidebar even when it has
             # aged past the window — otherwise its Pinned row renders empty.
             include_pinned=True,
+            disposition=disposition,
+            exclude_dispositions=exclude_dispositions or None,
         )
 
     for name, home in targets:
@@ -472,6 +498,10 @@ def get_profiles_sessions_sidebar(
             cron_cap,
             messaging_cap,
             tuple(messaging_exclude_list),
+            projects_cap,
+            archives_cap,
+            tuple(recents_exclude_disp_list),
+            tuple(messaging_exclude_disp_list),
         )
         slices = _sidebar_profile_cache_get(profile_cache_key)
         if slices is None:
@@ -486,7 +516,12 @@ def get_profiles_sessions_sidebar(
                 continue
             try:
                 slices = {
-                    "recents": _slice(db, exclude=recents_exclude_list, cap=recents_cap),
+                    "recents": _slice(
+                        db,
+                        exclude=recents_exclude_list,
+                        cap=recents_cap,
+                        exclude_dispositions=recents_exclude_disp_list,
+                    ),
                     # Aggregated in SQL rather than over the recents window: the
                     # window is a page, and a total that shrank when you scrolled
                     # would be worse than no total at all.
@@ -496,7 +531,16 @@ def get_profiles_sessions_sidebar(
                         db,
                         exclude=messaging_exclude_list,
                         cap=messaging_cap,
+                        exclude_dispositions=messaging_exclude_disp_list,
                     ),
+                    # Taxonomy slices: active PROJECT sessions (grouped
+                    # client-side by project_group -> project) and finished
+                    # ARCHIVE sessions. TRANSIENT/JUNK never surface here —
+                    # they are hidden from the sidebar by the caller passing
+                    # them as exclusions on recents/messaging, and never
+                    # requested as their own slice.
+                    "projects": _slice(db, cap=projects_cap, disposition="project"),
+                    "archives": _slice(db, cap=archives_cap, disposition="archive"),
                 }
                 _sidebar_profile_cache_put(profile_cache_key, slices)
             except Exception as exc:
@@ -518,6 +562,8 @@ def get_profiles_sessions_sidebar(
         profile_totals[name] = slices["usage"]
         cron_rows.extend(_tag(slices["cron"], name))
         messaging_rows.extend(_tag(slices["messaging"], name))
+        projects_rows.extend(_tag(slices.get("projects", []), name))
+        archives_rows.extend(_tag(slices.get("archives", []), name))
 
     def _window(rows: List[Dict[str, Any]], cap: int) -> List[Dict[str, Any]]:
         rows.sort(key=lambda s: s.get("last_active") or s.get("started_at") or 0, reverse=True)
@@ -542,6 +588,8 @@ def get_profiles_sessions_sidebar(
             "sessions": _window(messaging_rows, messaging_cap),
             "total": len(messaging_rows),
         },
+        "projects": {"sessions": _window(projects_rows, projects_cap)},
+        "archives": {"sessions": _window(archives_rows, archives_cap)},
         "errors": errors,
     }
 

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -690,8 +690,10 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
     restores the session; ``pinned`` sets the durable keep flag (exempts the
     session from the auto-archive sweep); ``unread`` toggles the read-state
     watermark (True = explicitly unread, False = read up to now — see
-    ``SessionDB.set_session_read``). Any field may be omitted. ``profile``
-    targets another profile's session.
+    ``SessionDB.set_session_read``); ``disposition`` / ``project_group`` /
+    ``project`` assign the session taxonomy (see
+    ``SessionDB.set_session_disposition``). Any field may be omitted.
+    ``profile`` targets another profile's session.
     """
     db = _open_session_db_for_profile(body.profile, read_only=False)
     try:
@@ -703,10 +705,13 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             and body.archived is None
             and body.pinned is None
             and body.unread is None
+            and body.disposition is None
+            and body.project_group is None
+            and body.project is None
         ):
             raise HTTPException(
                 status_code=400,
-                detail="Nothing to update; provide 'title', 'archived', 'pinned', and/or 'unread'.",
+                detail="Nothing to update; provide 'title', 'archived', 'pinned', 'unread', 'disposition', 'project_group', and/or 'project'.",
             )
         if body.title is not None:
             try:
@@ -720,6 +725,22 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             db.set_session_pinned(sid, body.pinned)
         if body.unread is not None:
             db.set_session_read(sid, read=not body.unread)
+        if (
+            body.disposition is not None
+            or body.project_group is not None
+            or body.project is not None
+        ):
+            try:
+                db.set_session_disposition(
+                    sid,
+                    body.disposition,
+                    body.project_group,
+                    body.project,
+                )
+            except ValueError as e:
+                # Invalid disposition, oversized fields, or project_group/
+                # project without a disposition.
+                raise HTTPException(status_code=400, detail=str(e))
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:
             result["archived"] = bool(body.archived)
@@ -727,6 +748,14 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             result["pinned"] = bool(body.pinned)
         if body.unread is not None:
             result["unread"] = bool(body.unread)
+        if (
+            body.disposition is not None
+            or body.project_group is not None
+            or body.project is not None
+        ):
+            result["disposition"] = body.disposition
+            result["project_group"] = body.project_group
+            result["project"] = body.project
         return result
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8391,6 +8391,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
+    def set_session_disposition(
+        self,
+        session_id: str,
+        disposition: str = None,
+        project_group: str = None,
+        project: str = None,
+        *,
+        clear: bool = False,
+    ) -> bool:
+        """Assign the taxonomy disposition for a session (and its lineage).
+
+        ``disposition`` is one of ``project`` / ``archive`` / ``transient`` /
+        ``junk`` per the approved session taxonomy; ``project_group`` is the
+        category bucket (e.g. ``Hermes Community Extensions``) and ``project``
+        the named project (e.g. ``Fusion Router``). Passing ``clear=True``
+        resets all three fields to NULL (unclassified) for the lineage.
+
+        Like :meth:`set_session_archived` / :meth:`set_session_pinned` the
+        whole compression chain is stamped as a unit, so classifying the
+        surfaced tip classifies the root (and vice-versa) no matter which id
+        the caller holds. Returns True when at least one row changed.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                UPDATE sessions
+                SET disposition = ?,
+                    project_group = ?,
+                    project = ?
+                WHERE id IN (SELECT id FROM lineage)
+                """,
+                (
+                    session_id,
+                    session_id,
+                    None if clear else disposition,
+                    None if clear else project_group,
+                    None if clear else project,
+                ),
+            )
+            rowcount = cursor.rowcount
+            if rowcount is None or rowcount < 0:
+                rowcount = conn.execute("SELECT changes()").fetchone()[0]
+            return rowcount
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
     def set_session_read(self, session_id: str, read: bool = True) -> bool:
         """Mark a session read or unread (and its whole compression lineage).
 
@@ -8663,6 +8733,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_pinned: bool = False,
         session_key: str = None,
         include_hidden: bool = False,
+        disposition: str = None,
+        exclude_dispositions: List[str] = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -8767,6 +8839,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 0")
         if not include_hidden:
             where_clauses.append("s.hidden = 0")
+        # Disposition clauses are DERIVED taxonomy. A pin is an explicit user
+        # statement ("always reachable"), so the pinned back-fill must ignore
+        # them: a pinned transient/junk session still belongs in the Pinned
+        # section even though the taxonomy would hide it from Projects/Archives.
+        # Record where the disposition clauses start so the back-fill can build
+        # a WHERE without them.
+        disposition_clause_start = len(where_clauses)
+        disposition_param_start = len(params)
+        if disposition:
+            where_clauses.append("s.disposition = ?")
+            params.append(disposition)
+        if exclude_dispositions:
+            placeholders = ",".join("?" for _ in exclude_dispositions)
+            where_clauses.append(f"COALESCE(s.disposition, '') NOT IN ({placeholders})")
+            params.extend(exclude_dispositions)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         # Snapshot the filter params before the query builders below extend
@@ -8930,8 +9017,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # number of pins (a handful), never N+1 per pin.
         if include_pinned:
             seen_ids = {s["id"] for s in sessions}
+            # Pins override derived taxonomy: build the pinned WHERE from the
+            # same clauses MINUS the disposition filters, so a pinned
+            # transient/junk session stays in the Pinned section even when the
+            # page excludes those dispositions. The param slice matches.
+            pinned_clauses = where_clauses[:disposition_clause_start]
+            pinned_params = params[:disposition_param_start]
             pinned_where = (
-                f"{where_sql} AND s.pinned = 1" if where_sql else "WHERE s.pinned = 1"
+                f"WHERE {' AND '.join(pinned_clauses)} AND s.pinned = 1"
+                if pinned_clauses
+                else "WHERE s.pinned = 1"
             )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             pinned_query = f"""
@@ -8953,7 +9048,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY s.started_at DESC
             """
             with self._read_ctx() as conn:
-                pinned_cursor = conn.execute(pinned_query, base_where_params)
+                pinned_cursor = conn.execute(pinned_query, pinned_params)
                 pinned_rows = pinned_cursor.fetchall()
             for row in pinned_rows:
                 s = self._session_row_dict(row)
@@ -11103,6 +11198,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived_only: bool = False,
         exclude_children: bool = False,
         exclude_sources: List[str] = None,
+        disposition: str = None,
+        exclude_dispositions: List[str] = None,
     ) -> int:
         """Count sessions, optionally filtered by source.
 
@@ -11147,6 +11244,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 1")
         elif not include_archived:
             where_clauses.append("s.archived = 0")
+        if disposition:
+            where_clauses.append("s.disposition = ?")
+            params.append(disposition)
+        if exclude_dispositions:
+            placeholders = ",".join("?" for _ in exclude_dispositions)
+            where_clauses.append(f"COALESCE(s.disposition, '') NOT IN ({placeholders})")
+            params.extend(exclude_dispositions)
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8408,11 +8408,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the named project (e.g. ``Fusion Router``). Passing ``clear=True``
         resets all three fields to NULL (unclassified) for the lineage.
 
+        Validation: an unknown ``disposition``, ``project_group`` /
+        ``project`` longer than 120 characters, or ``project_group`` /
+        ``project`` supplied without a ``disposition`` (and not clearing)
+        raise :class:`ValueError`.
+
         Like :meth:`set_session_archived` / :meth:`set_session_pinned` the
         whole compression chain is stamped as a unit, so classifying the
         surfaced tip classifies the root (and vice-versa) no matter which id
         the caller holds. Returns True when at least one row changed.
         """
+        if not clear:
+            if disposition is not None and disposition not in (
+                "project",
+                "archive",
+                "transient",
+                "junk",
+            ):
+                raise ValueError(
+                    "disposition must be one of project/archive/transient/junk"
+                )
+            if disposition is None and (project_group or project):
+                raise ValueError(
+                    "project_group/project require a disposition"
+                )
+            for label, value in (
+                ("project_group", project_group),
+                ("project", project),
+            ):
+                if value is not None and len(value) > 120:
+                    raise ValueError(f"{label} must be at most 120 characters")
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -11200,6 +11226,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         exclude_sources: List[str] = None,
         disposition: str = None,
         exclude_dispositions: List[str] = None,
+        include_pinned: bool = False,
     ) -> int:
         """Count sessions, optionally filtered by source.
 
@@ -11214,6 +11241,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (e.g. ``["cron"]`` so the recents "load more" total matches a
         cron-excluded ``list_sessions_rich`` page and doesn't keep "load more"
         stuck on for buried scheduler sessions).
+
+        Pass ``include_pinned=True`` to mirror ``list_sessions_rich``'s pinned
+        back-fill: pins override derived taxonomy, so pinned rows that the
+        disposition filters would have excluded still count. Keeps the count
+        consistent with the rows the matching list call returns (filter and
+        total never disagree).
         """
         where_clauses = []
         params = []
@@ -11226,11 +11259,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
         include_sources = [source] if source else list(sources or [])
         if include_sources:
-            placeholders = ",".join("?" for _ in include_sources)
+            placeholders = ", ".join("?" for _ in include_sources)
             where_clauses.append(f"s.source IN ({placeholders})")
             params.extend(include_sources)
         if exclude_sources:
-            placeholders = ",".join("?" for _ in exclude_sources)
+            placeholders = ", ".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
         if cwd_prefix:
@@ -11248,15 +11281,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.disposition = ?")
             params.append(disposition)
         if exclude_dispositions:
-            placeholders = ",".join("?" for _ in exclude_dispositions)
+            placeholders = ", ".join("?" for _ in exclude_dispositions)
             where_clauses.append(f"COALESCE(s.disposition, '') NOT IN ({placeholders})")
             params.extend(exclude_dispositions)
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
-        with self._lock:
-            cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
-            return cursor.fetchone()[0]
+        def _count(clauses: list, count_params: list) -> int:
+            sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+            with self._lock:
+                cursor = self._conn.execute(
+                    f"SELECT COUNT(*) FROM sessions s{sql}", count_params
+                )
+                return cursor.fetchone()[0]
+
+        total = _count(where_clauses, params)
+        if not include_pinned:
+            return total
+
+        # Mirror list_sessions_rich's pinned back-fill: pinned rows the
+        # disposition filters would have excluded still count (pins override
+        # derived taxonomy), and rows already counted by the filtered query are
+        # not double-counted.
+        disposition_clause_start = len(where_clauses) - (
+            1 if disposition else 0
+        ) - (1 if exclude_dispositions else 0)
+        disposition_param_start = len(params) - (
+            1 if disposition else 0
+        ) - len(exclude_dispositions or [])
+        pinned_clauses = where_clauses[:disposition_clause_start] + ["s.pinned = 1"]
+        pinned_params = params[:disposition_param_start]
+        pinned_total = _count(pinned_clauses, pinned_params)
+        overlap_clauses = where_clauses + ["s.pinned = 1"]
+        overlap_params = params[:]
+        overlap = _count(overlap_clauses, overlap_params)
+        return total + pinned_total - overlap
 
     def session_count_ge(self, n: int = 1) -> bool:
         """Check if at least N sessions exist (archived included).

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -312,6 +312,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     archived INTEGER NOT NULL DEFAULT 0,
     pinned INTEGER NOT NULL DEFAULT 0,
     hidden INTEGER NOT NULL DEFAULT 0,
+    disposition TEXT,
+    project_group TEXT,
+    project TEXT,
     last_read_at REAL,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)

--- a/scripts/backfill_session_dispositions.py
+++ b/scripts/backfill_session_dispositions.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Idempotent rules-based session taxonomy classifier.
+
+Assigns ``disposition`` (project / archive / transient / junk) plus
+``project_group`` / ``project`` to sessions that have none yet, so the Desktop
+sidebar's Projects / Archives sections have data to render.
+
+Rules (deliberately generic — no user-specific data, no absolute paths):
+- Source-based noise: cron, tool, subagent, kanban, hermes_browser and
+  speed-test* sources are operational noise -> transient (junk for speed-test).
+- Content-based pass for cli/desktop/api_server/tui/webui/acp sources:
+  probe/echo sessions -> transient; otherwise project with project_group /
+  project inferred from a small keyword table.
+
+Idempotent: only writes rows whose disposition is NULL, so manual
+classifications are never clobbered. Writes through SessionDB so the whole
+compression lineage is stamped as a unit (like archive/pin).
+
+Usage:
+    python3 scripts/backfill_session_dispositions.py [--dry-run] [--db PATH] [--home HERMES_HOME]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Source classes that are operational noise, never user project work.
+NOISE_SOURCES = {
+    "cron",
+    "tool",
+    "subagent",
+    "kanban",
+    "hermes_browser",
+}
+
+# Keyword table: (project_group, project) candidates matched against the
+# session title. First match wins; keys are lowercased.
+PROJECT_KEYWORDS: List[Tuple[Tuple[str, ...], str, str]] = [
+    (("fusion", "router"), "Hermes", "Fusion Router"),
+    (("sidebar", "taxonomy"), "Hermes", "Sidebar Taxonomy"),
+    (("new tab", "newtab", "new-tab"), "Hermes", "New Tab"),
+    (("agora", "share", "session share"), "Hermes", "Agora"),
+    (("plugin",), "Hermes", "Plugin Dev"),
+    (("skill",), "Hermes", "Skill Dev"),
+    (("kanban",), "Hermes", "Kanban"),
+]
+
+# Titles that are clearly throwaway probes/echoes.
+PROBE_TITLES = {"probe", "echo", "test", "ping", "smoke test", "hello"}
+
+
+def classify(session_meta: Dict[str, object]) -> Optional[Dict[str, str]]:
+    """Return ``{disposition, project_group, project}`` or None (leave alone).
+
+    Pure function — importable and unit-testable, no side effects on import.
+    Only sessions with no existing disposition are passed in by the caller.
+    """
+    source = str(session_meta.get("source") or "").lower()
+    title = str(session_meta.get("title") or "").lower().strip()
+
+    if source.startswith("speed-test"):
+        return {"disposition": "junk", "project_group": None, "project": None}
+    if source in NOISE_SOURCES:
+        return {"disposition": "transient", "project_group": None, "project": None}
+
+    if source in {"cli", "desktop", "api_server", "tui", "webui", "acp"}:
+        if title in PROBE_TITLES or title.startswith("probe "):
+            return {"disposition": "transient", "project_group": None, "project": None}
+        for keywords, group, project in PROJECT_KEYWORDS:
+            if all(k in title for k in keywords):
+                return {
+                    "disposition": "project",
+                    "project_group": group,
+                    "project": project,
+                }
+        return {"disposition": "project", "project_group": None, "project": None}
+
+    return None
+
+
+def _open_db(home: Optional[str], db_path: Optional[str]):
+    from hermes_state import SessionDB
+
+    if db_path:
+        return SessionDB(db_path=Path(db_path).expanduser())
+    home_path = Path(home).expanduser() if home else Path.home() / ".hermes"
+    return SessionDB(db_path=home_path / "state.db")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="print changes without writing")
+    parser.add_argument("--db", help="explicit path to state.db")
+    parser.add_argument("--home", help="HERMES_HOME (defaults to ~/.hermes)")
+    args = parser.parse_args(argv)
+
+    db = _open_db(args.home, args.db)
+
+    # Only rows with no disposition yet — never clobber manual classification.
+    unclassified = db.list_sessions_rich(
+        limit=100000,
+        include_archived=True,
+        exclude_dispositions=[],
+    )
+    candidates = [s for s in unclassified if not s.get("disposition")]
+
+    changed = 0
+    for session in candidates:
+        result = classify(session)
+        if not result:
+            continue
+        if not args.dry_run:
+            db.set_session_disposition(
+                session["id"],
+                result["disposition"],
+                result.get("project_group"),
+                result.get("project"),
+            )
+        changed += 1
+        print(
+            f"{'[dry-run] ' if args.dry_run else ''}{session['id'][:12]} "
+            f"source={session.get('source')} disposition={result['disposition']} "
+            f"group={result.get('project_group') or '-'} project={result.get('project') or '-'}"
+        )
+    print(f"{'Would classify' if args.dry_run else 'Classified'} {changed} session(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -477,6 +477,59 @@ class TestWebServerEndpoints:
             "sidebar-stale"
         ]
 
+    def test_profiles_sidebar_returns_taxonomy_slices(self):
+        """The batched sidebar route returns projects + archives slices.
+
+        The taxonomy-driven sidebar renders Projects (disposition=project) and
+        Archives (disposition=archive) as the primary organization; transient
+        and junk never surface as their own slice, and recents/messaging can
+        exclude them via the disposition exclusion params.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session("proj-a", source="cli")
+            seed.append_message(session_id="proj-a", role="user", content="Build the fusion router plugin")
+            seed.set_session_disposition("proj-a", "project", "Hermes Community Extensions", "Fusion Router")
+
+            seed.create_session("proj-b", source="telegram")
+            seed.append_message(session_id="proj-b", role="user", content="Thin remote PWA grid")
+            seed.set_session_disposition("proj-b", "project", "Hermes Community Extensions", "Thin Remote")
+
+            seed.create_session("arch-a", source="cli")
+            seed.append_message(session_id="arch-a", role="user", content="Old finished work")
+            seed.set_session_disposition("arch-a", "archive", "Hermes infra", None)
+
+            seed.create_session("noise-a", source="cron")
+            seed.append_message(session_id="noise-a", role="user", content="scheduled run")
+            seed.set_session_disposition("noise-a", "transient", None, None)
+        finally:
+            seed.close()
+
+        # Recents without exclusions still carries everything (back-compat).
+        response = self.client.get("/api/profiles/sessions/sidebar?recents_limit=50")
+        assert response.status_code == 200
+        payload = response.json()
+        assert {row["id"] for row in payload["projects"]["sessions"]} == {"proj-a", "proj-b"}
+        assert [row["id"] for row in payload["archives"]["sessions"]] == ["arch-a"]
+        # Taxonomy rows carry the grouping fields to the renderer.
+        proj = next(row for row in payload["projects"]["sessions"] if row["id"] == "proj-a")
+        assert proj["project_group"] == "Hermes Community Extensions"
+        assert proj["project"] == "Fusion Router"
+        assert proj["disposition"] == "project"
+
+        # With exclusions, transient/junk disappear from recents.
+        response = self.client.get(
+            "/api/profiles/sessions/sidebar?recents_limit=50&recents_exclude_dispositions=transient,junk"
+        )
+        assert response.status_code == 200
+        recents_ids = {row["id"] for row in response.json()["recents"]["sessions"]}
+        assert "noise-a" not in recents_ids
+        assert "proj-a" in recents_ids
+
     def test_startup_eager_reconcile_heals_stale_store(self):
         """The lifespan's eager reconcile brings a stale store current.
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4987,3 +4987,154 @@ class TestSessionPatchUnread:
         # a string outside the accepted set to prove validation rejects it.
         resp = self.auth_client.patch("/api/sessions/s1", json={"unread": "maybe"})
         assert resp.status_code == 422  # pydantic validation
+
+
+class TestSessionPatchDisposition:
+    """PATCH /api/sessions/{id} taxonomy writer (disposition/project_group/project)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+
+        self.client = TestClient(app)
+        self.auth_client = TestClient(app)
+        self.auth_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="hi")
+        finally:
+            db.close()
+
+    def _rows(self):
+        return self.auth_client.get("/api/sessions?limit=100").json()["sessions"]
+
+    def test_patch_classifies_session(self):
+        resp = self.auth_client.patch(
+            "/api/sessions/s1",
+            json={
+                "disposition": "project",
+                "project_group": "Hermes Community Extensions",
+                "project": "Fusion Router",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["disposition"] == "project"
+        assert body["project_group"] == "Hermes Community Extensions"
+        assert body["project"] == "Fusion Router"
+
+        row = next(s for s in self._rows() if s["id"] == "s1")
+        assert row["disposition"] == "project"
+        assert row["project_group"] == "Hermes Community Extensions"
+        assert row["project"] == "Fusion Router"
+
+    def test_patch_rejects_unknown_disposition(self):
+        resp = self.auth_client.patch("/api/sessions/s1", json={"disposition": "banana"})
+        assert resp.status_code == 400
+
+    def test_patch_rejects_project_without_disposition(self):
+        resp = self.auth_client.patch(
+            "/api/sessions/s1", json={"project_group": "Hermes"}
+        )
+        assert resp.status_code == 400
+
+    def test_patch_disposition_alone_accepted(self):
+        resp = self.auth_client.patch("/api/sessions/s1", json={"disposition": "archive"})
+        assert resp.status_code == 200
+        assert resp.json()["disposition"] == "archive"
+        assert resp.json()["project_group"] is None
+
+    def test_patch_disposition_only_writes_when_set(self):
+        """A PATCH with only title must not touch disposition (leave-alone)."""
+        self.auth_client.patch(
+            "/api/sessions/s1",
+            json={
+                "disposition": "project",
+                "project_group": "Hermes",
+                "project": "Agora",
+            },
+        )
+        resp = self.auth_client.patch("/api/sessions/s1", json={"title": "renamed"})
+        assert resp.status_code == 200
+        row = next(s for s in self._rows() if s["id"] == "s1")
+        assert row["disposition"] == "project"
+        assert row["project"] == "Agora"
+        assert row["title"] == "renamed"
+
+    def test_patch_rejects_oversized_project(self):
+        resp = self.auth_client.patch(
+            "/api/sessions/s1", json={"disposition": "project", "project": "y" * 121}
+        )
+        assert resp.status_code == 400
+
+
+class TestProfilesSessionsDispositionValidation:
+    """GET /api/profiles/sessions disposition param validation."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+
+        self.client = TestClient(app)
+        self.auth_client = TestClient(app)
+        self.auth_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="hi")
+        finally:
+            db.close()
+
+    def test_unknown_disposition_400(self):
+        resp = self.auth_client.get(
+            "/api/profiles/sessions?disposition=banana&profile=default"
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_exclude_disposition_400(self):
+        resp = self.auth_client.get(
+            "/api/profiles/sessions?exclude_dispositions=transient,nope&profile=default"
+        )
+        assert resp.status_code == 400
+
+    def test_oversized_csv_400(self):
+        values = ",".join(f"v{i}" for i in range(9))
+        resp = self.auth_client.get(
+            f"/api/profiles/sessions?exclude_sources={values}&profile=default"
+        )
+        assert resp.status_code == 400
+
+    def test_valid_disposition_ok(self):
+        resp = self.auth_client.get(
+            "/api/profiles/sessions?disposition=project&profile=default"
+        )
+        assert resp.status_code == 200

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -509,7 +509,7 @@ class TestWebServerEndpoints:
         finally:
             seed.close()
 
-        # Recents without exclusions still carries everything (back-compat).
+        # Recents: transient/junk are always excluded server-side (review #11).
         response = self.client.get("/api/profiles/sessions/sidebar?recents_limit=50")
         assert response.status_code == 200
         payload = response.json()
@@ -520,13 +520,7 @@ class TestWebServerEndpoints:
         assert proj["project_group"] == "Hermes Community Extensions"
         assert proj["project"] == "Fusion Router"
         assert proj["disposition"] == "project"
-
-        # With exclusions, transient/junk disappear from recents.
-        response = self.client.get(
-            "/api/profiles/sessions/sidebar?recents_limit=50&recents_exclude_dispositions=transient,junk"
-        )
-        assert response.status_code == 200
-        recents_ids = {row["id"] for row in response.json()["recents"]["sessions"]}
+        recents_ids = {row["id"] for row in payload["recents"]["sessions"]}
         assert "noise-a" not in recents_ids
         assert "proj-a" in recents_ids
 

--- a/tests/test_backfill_dispositions.py
+++ b/tests/test_backfill_dispositions.py
@@ -1,0 +1,123 @@
+"""Tests for scripts/backfill_session_dispositions.py.
+
+Covers the pure classify() rules, idempotency, and dry-run semantics.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from backfill_session_dispositions import classify  # noqa: E402
+
+
+class TestClassifyRules:
+    def test_speed_test_is_junk(self):
+        assert classify({"source": "speed-test-a", "title": "ping"}) == {
+            "disposition": "junk",
+            "project_group": None,
+            "project": None,
+        }
+
+    def test_noise_sources_are_transient(self):
+        for source in ["cron", "tool", "subagent", "kanban", "hermes_browser"]:
+            assert classify({"source": source, "title": "anything"}) == {
+                "disposition": "transient",
+                "project_group": None,
+                "project": None,
+            }
+
+    def test_probe_title_is_transient(self):
+        for title in ["probe", "echo", "ping", "smoke test"]:
+            assert classify({"source": "cli", "title": title})["disposition"] == "transient"
+
+    def test_keyword_inference_sets_project_group_and_project(self):
+        result = classify(
+            {"source": "cli", "title": "Build the Fusion Router plugin"}
+        )
+        assert result == {
+            "disposition": "project",
+            "project_group": "Hermes",
+            "project": "Fusion Router",
+        }
+
+    def test_plain_cli_session_is_project_unfiled(self):
+        assert classify({"source": "desktop", "title": "random work"}) == {
+            "disposition": "project",
+            "project_group": None,
+            "project": None,
+        }
+
+    def test_unknown_source_returns_none(self):
+        assert classify({"source": "telegram", "title": "chat"}) is None
+
+
+class TestBackfillIdempotency:
+    def test_rerun_changes_nothing(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="Build the Fusion Router plugin")
+            db.set_session_title("s1", "Build the Fusion Router plugin")
+            db.create_session(session_id="s2", source="cron")
+            db.append_message(session_id="s2", role="user", content="scheduled run")
+            # Manual classification must survive a backfill run.
+            db.create_session(session_id="s3", source="cli")
+            db.append_message(session_id="s3", role="user", content="manual one")
+            db.set_session_disposition("s3", "archive", "Manual", None)
+        finally:
+            db.close()
+
+        from backfill_session_dispositions import main
+
+        assert main(["--db", str(db_path)]) == 0
+        db = SessionDB(db_path=db_path)
+        try:
+            rows = db.list_sessions_rich(limit=100, include_archived=True)
+            by_id = {r["id"]: r for r in rows}
+            assert by_id["s1"]["disposition"] == "project"
+            assert by_id["s1"]["project"] == "Fusion Router"
+            assert by_id["s2"]["disposition"] == "transient"
+            # Manual archive disposition untouched.
+            assert by_id["s3"]["disposition"] == "archive"
+            assert by_id["s3"]["project_group"] == "Manual"
+        finally:
+            db.close()
+
+        # Re-run: idempotent, nothing changes, exit 0.
+        assert main(["--db", str(db_path)]) == 0
+        db = SessionDB(db_path=db_path)
+        try:
+            rows = db.list_sessions_rich(limit=100, include_archived=True)
+            by_id = {r["id"]: r for r in rows}
+            assert by_id["s1"]["disposition"] == "project"
+            assert by_id["s2"]["disposition"] == "transient"
+            assert by_id["s3"]["disposition"] == "archive"
+        finally:
+            db.close()
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="Build the Fusion Router plugin")
+        finally:
+            db.close()
+
+        from backfill_session_dispositions import main
+
+        assert main(["--db", str(db_path), "--dry-run"]) == 0
+        db = SessionDB(db_path=db_path)
+        try:
+            rows = db.list_sessions_rich(limit=100, include_archived=True)
+            assert rows[0]["disposition"] is None
+        finally:
+            db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3805,6 +3805,92 @@ class TestSessionPinAndStaleArchive:
 
 
 
+class TestSessionDisposition:
+    """Taxonomy disposition: setter + list/count filters (schema columns)."""
+
+    def test_set_disposition_roundtrip(self, db):
+        db.create_session(session_id="s1", source="cli")
+        assert db.set_session_disposition("s1", "project", "Hermes Community Extensions", "Fusion Router") is True
+        rows = db.list_sessions_rich(disposition="project", limit=10)
+        assert len(rows) == 1
+        assert rows[0]["disposition"] == "project"
+        assert rows[0]["project_group"] == "Hermes Community Extensions"
+        assert rows[0]["project"] == "Fusion Router"
+
+    def test_clear_disposition(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_session_disposition("s1", "archive", "Hermes infra", None)
+        assert db.set_session_disposition("s1", clear=True) is True
+        rows = db.list_sessions_rich(disposition="archive", limit=10)
+        assert rows == []
+        # Row still exists, just unclassified.
+        assert db.get_session("s1")["disposition"] is None
+
+    def test_list_filters_by_disposition(self, db):
+        for sid, disp in [("a", "project"), ("b", "archive"), ("c", "transient"), ("d", "junk")]:
+            db.create_session(session_id=sid, source="cli")
+            db.set_session_disposition(sid, disp, None, None)
+
+        assert [s["id"] for s in db.list_sessions_rich(disposition="project", limit=10)] == ["a"]
+        # Unclassified rows (disposition NULL) survive the exclusion filter.
+        db.create_session(session_id="e", source="cli")
+        assert [s["id"] for s in db.list_sessions_rich(exclude_dispositions=["transient", "junk"], limit=10)] == ["e", "b", "a"]
+
+    def test_count_matches_list_filters(self, db):
+        for sid, disp in [("a", "project"), ("b", "archive"), ("c", "transient"), ("d", "junk")]:
+            db.create_session(session_id=sid, source="cli")
+            db.set_session_disposition(sid, disp, None, None)
+
+        assert db.session_count(disposition="project") == 1
+        assert db.session_count(exclude_dispositions=["transient", "junk"]) == 2
+
+    def test_disposition_flows_through_compact_rows(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.set_session_disposition("s1", "project", "Hermes infra", None)
+        rows = db.list_sessions_rich(compact_rows=True, disposition="project", limit=10)
+        assert rows[0]["disposition"] == "project"
+        assert rows[0]["project_group"] == "Hermes infra"
+
+    def test_pinned_transient_survives_disposition_exclusion(self, db):
+        """A pin is explicit user intent and overrides derived taxonomy.
+
+        The sidebar fetches recents excluding transient/junk; a session the
+        user pinned MUST still reach the Pinned section even when its
+        disposition would hide it from Projects/Archives.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="probe")
+        db.set_session_disposition("s1", "transient", None, None)
+        db.set_session_pinned("s1", True)
+
+        rows = db.list_sessions_rich(
+            limit=3,
+            min_message_count=1,
+            order_by_last_active=True,
+            exclude_dispositions=["transient", "junk"],
+            include_pinned=True,
+        )
+        ids = [s["id"] for s in rows]
+        assert "s1" in ids, "pinned transient session must survive the exclusion"
+        assert rows[0]["pinned"] is True or any(s["pinned"] for s in rows)
+
+    def test_pinned_transient_still_excluded_without_backfill(self, db):
+        """Without include_pinned, the disposition exclusion applies normally."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="probe")
+        db.set_session_disposition("s1", "transient", None, None)
+        db.set_session_pinned("s1", True)
+
+        rows = db.list_sessions_rich(
+            limit=3,
+            min_message_count=1,
+            order_by_last_active=True,
+            exclude_dispositions=["transient", "junk"],
+            include_pinned=False,
+        )
+        assert all(s["id"] != "s1" for s in rows)
+
+
 class TestSessionIdSearch:
     """Session id search backs Desktop's Search Sessions UX."""
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3890,6 +3890,71 @@ class TestSessionDisposition:
         )
         assert all(s["id"] != "s1" for s in rows)
 
+    def test_set_disposition_validates_allowlist(self, db):
+        """Unknown dispositions are rejected at the setter, not stored."""
+        db.create_session(session_id="s1", source="cli")
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", "banana", None, None)
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", "PROJECT", None, None)
+
+    def test_set_disposition_rejects_project_without_disposition(self, db):
+        """project_group/project require a disposition (unless clearing)."""
+        db.create_session(session_id="s1", source="cli")
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", None, "Hermes", None)
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", None, None, "Fusion Router")
+
+    def test_set_disposition_rejects_oversized_fields(self, db):
+        """project_group/project are bounded to 120 chars."""
+        db.create_session(session_id="s1", source="cli")
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", "project", "x" * 121, None)
+        with pytest.raises(ValueError):
+            db.set_session_disposition("s1", "project", None, "y" * 121)
+
+    def test_set_disposition_clear_ignores_validation(self, db):
+        """clear=True resets to NULL and must not trip field validation."""
+        db.create_session(session_id="s1", source="cli")
+        db.set_session_disposition("s1", "project", "Hermes", "Fusion Router")
+        assert db.set_session_disposition("s1", clear=True) is True
+        assert db.get_session("s1")["disposition"] is None
+
+    def test_count_include_pinned_mirrors_list_backfill(self, db):
+        """session_count(include_pinned=True) agrees with list_sessions_rich.
+
+        A pinned transient session survives the exclusion in both the list
+        back-fill and the count, so the sidebar total never disagrees with the
+        rows it renders.
+        """
+        db.create_session(session_id="pinned_transient", source="cli")
+        db.append_message(session_id="pinned_transient", role="user", content="probe")
+        db.set_session_disposition("pinned_transient", "transient", None, None)
+        db.set_session_pinned("pinned_transient", True)
+
+        db.create_session(session_id="normal_project", source="cli")
+        db.append_message(session_id="normal_project", role="user", content="real work")
+        db.set_session_disposition("normal_project", "project", "Hermes", None)
+
+        rows = db.list_sessions_rich(
+            limit=10,
+            min_message_count=1,
+            order_by_last_active=True,
+            disposition="project",
+            include_pinned=True,
+        )
+        ids = [s["id"] for s in rows]
+        assert set(ids) == {"pinned_transient", "normal_project"}, (
+            "pinned back-fill must surface the pinned transient row"
+        )
+        assert db.session_count(
+            disposition="project", include_pinned=True, exclude_children=True
+        ) == 2, "count must include the pinned back-filled row"
+        assert db.session_count(
+            disposition="project", include_pinned=False, exclude_children=True
+        ) == 1
+
 
 class TestSessionIdSearch:
     """Session id search backs Desktop's Search Sessions UX."""


### PR DESCRIPTION
# PR A — Session taxonomy backend: disposition columns, sidebar project/archive slices, production classifier

**What changed and why**

Hermes Desktop's sidebar has no semantic organization: every session lands in one flat
recents list, and there is no way to group work by project or to hide operational noise.
This PR adds the backend for a session taxonomy (`disposition` = project / archive /
transient / junk, plus `project_group` and `project`), so the sidebar can render
Pinned → Projects (category → named project) → Archives, with transient/junk hidden and
an unclassified Recent fallback (the renderer lands in a follow-up PR).

- **Schema:** three nullable columns on `sessions` — `disposition`, `project_group`,
  `project`. The declarative schema reconciler auto-adds them to existing databases;
  no manual migration step.
- **Setters:** `SessionDB.set_session_disposition()` stamps the whole compression
  lineage as a unit (like archive/pin), with validation (enum allowlist, length caps,
  no orphan project_group/project without a disposition).
- **Writers:**
  - `PATCH /api/sessions/{id}` now accepts `disposition` / `project_group` / `project`
    (same endpoint as title/archive/pin/unread), with 400s on invalid values.
  - New `scripts/backfill_session_dispositions.py` — an idempotent, rules-based
    classifier any install can run to classify existing sessions (noise sources →
    transient/junk; content-based keyword inference → project). Only writes rows whose
    disposition is NULL, so it never clobbers manual classification.
- **Reads:** `list_sessions_rich()` and `session_count()` gain `disposition` /
  `exclude_dispositions` filters. The batched sidebar endpoint
  (`GET /api/profiles/sessions/sidebar`) returns new `projects` and `archives` slices;
  recents/messaging always exclude transient and junk server-side. Pins override
  taxonomy: the pinned back-fill ignores disposition filters, and `session_count()` mirrors the
  back-fill so filter/total stay consistent for the sidebar feed.

Ships as a no-op: no user-visible behavior changes until the renderer PR lands.

**How to test**
- `python -m pytest tests/hermes_cli/test_web_server.py tests/test_hermes_state.py -k "disposition or taxonomy or sidebar" -q` (9 tests)
- `python -m pytest tests/hermes_cli/test_web_server.py -q` (full file, no regressions)
- `python -m pytest tests/test_backfill_dispositions.py -q`
- Manual: `curl -X PATCH .../api/sessions/{id}` with `{"disposition":"project","project_group":"X","project":"Y"}` → 200 and echoed values; invalid disposition → 400.

**What platforms tested on**
- Linux (VPS) — Python 3.12.

**Related**
- Follow-up PR B: Desktop sidebar renderer (Projects/Archives UI).
