### PR TITLE
feat(desktop): organize sidebar sessions by project and archive

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -159,10 +159,6 @@ export interface SidebarSessionsRequest {
   messagingExclude: string[]
   projectsLimit?: number
   archivesLimit?: number
-  /** Dispositions the recents slice should omit (e.g. transient,junk). */
-  recentsExcludeDispositions?: string[]
-  /** Dispositions the messaging slice should omit (e.g. transient,junk). */
-  messagingExcludeDispositions?: string[]
 }
 
 // The batched /sidebar endpoint shipped later than the per-slice route, so a
@@ -191,12 +187,12 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
   const [recents, cron, messaging, projects, archives] = await Promise.all([
     listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.recentsExclude,
-      excludeDispositions: req.recentsExcludeDispositions
+      excludeDispositions: ['transient', 'junk']
     }),
     listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.recentsProfile, { source: 'cron' }),
     listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.messagingExclude,
-      excludeDispositions: req.messagingExcludeDispositions
+      excludeDispositions: ['transient', 'junk']
     }),
     listAllProfileSessions(req.projectsLimit ?? 300, 1, 'exclude', 'recent', req.recentsProfile, {
       disposition: 'project'
@@ -258,14 +254,6 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 
   if (req.messagingExclude.length) {
     params.set('messaging_exclude', req.messagingExclude.join(','))
-  }
-
-  if (req.recentsExcludeDispositions?.length) {
-    params.set('recents_exclude_dispositions', req.recentsExcludeDispositions.join(','))
-  }
-
-  if (req.messagingExcludeDispositions?.length) {
-    params.set('messaging_exclude_dispositions', req.messagingExcludeDispositions.join(','))
   }
 
   let result: SidebarSessionsResponse

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -63,6 +63,10 @@ export async function listSessions(
 export interface SessionSourceFilter {
   source?: string
   excludeSources?: string[]
+  /** Only rows with this disposition (e.g. 'project'). */
+  disposition?: string
+  /** Omit rows with these dispositions (e.g. ['transient', 'junk']). */
+  excludeDispositions?: string[]
 }
 
 export async function listAllProfileSessions(
@@ -79,10 +83,19 @@ export async function listAllProfileSessions(
     ? `&exclude_sources=${encodeURIComponent(filter.excludeSources.join(','))}`
     : ''
 
+  const dispositionParam = filter.disposition
+    ? `&disposition=${encodeURIComponent(filter.disposition)}`
+    : ''
+
+  const excludeDispositionsParam = filter.excludeDispositions?.length
+    ? `&exclude_dispositions=${encodeURIComponent(filter.excludeDispositions.join(','))}`
+    : ''
+
   const result = await hermesApi<PaginatedSessions>({
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
-      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
+      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}` +
+      `${dispositionParam}${excludeDispositionsParam}`,
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 
@@ -129,6 +142,11 @@ export interface SidebarSessionsResponse {
   recents: SidebarSessionSlice
   cron: SidebarSessionSlice
   messaging: SidebarSessionSlice
+  /** Taxonomy slice: sessions with disposition=project (active work). The
+   *  sidebar groups these by project_group -> project. */
+  projects: SidebarSessionSlice
+  /** Taxonomy slice: sessions with disposition=archive (finished work). */
+  archives: SidebarSessionSlice
   errors?: Array<{ profile: string; error: string }>
 }
 
@@ -139,6 +157,12 @@ export interface SidebarSessionsRequest {
   cronLimit: number
   messagingLimit: number
   messagingExclude: string[]
+  projectsLimit?: number
+  archivesLimit?: number
+  /** Dispositions the recents slice should omit (e.g. transient,junk). */
+  recentsExcludeDispositions?: string[]
+  /** Dispositions the messaging slice should omit (e.g. transient,junk). */
+  messagingExcludeDispositions?: string[]
 }
 
 // The batched /sidebar endpoint shipped later than the per-slice route, so a
@@ -164,13 +188,21 @@ export function resetSidebarBatchCapability() {
 // Rides the same Electron remote-splice
 // interception as the pre-batching desktop, so remote profiles stay correct.
 async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
-  const [recents, cron, messaging] = await Promise.all([
+  const [recents, cron, messaging, projects, archives] = await Promise.all([
     listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
-      excludeSources: req.recentsExclude
+      excludeSources: req.recentsExclude,
+      excludeDispositions: req.recentsExcludeDispositions
     }),
     listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.recentsProfile, { source: 'cron' }),
     listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', req.recentsProfile, {
-      excludeSources: req.messagingExclude
+      excludeSources: req.messagingExclude,
+      excludeDispositions: req.messagingExcludeDispositions
+    }),
+    listAllProfileSessions(req.projectsLimit ?? 300, 1, 'exclude', 'recent', req.recentsProfile, {
+      disposition: 'project'
+    }),
+    listAllProfileSessions(req.archivesLimit ?? 300, 1, 'exclude', 'recent', req.recentsProfile, {
+      disposition: 'archive'
     })
   ])
 
@@ -183,6 +215,8 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
     },
     cron: { sessions: cron.sessions },
     messaging: { sessions: messaging.sessions },
+    projects: { sessions: projects.sessions },
+    archives: { sessions: archives.sessions },
     ...(errors.length ? { errors } : {})
   }
 }
@@ -213,7 +247,9 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
     recents_profile: req.recentsProfile,
     recents_limit: String(Math.max(1, req.recentsLimit)),
     cron_limit: String(Math.max(1, req.cronLimit)),
-    messaging_limit: String(Math.max(1, req.messagingLimit))
+    messaging_limit: String(Math.max(1, req.messagingLimit)),
+    projects_limit: String(Math.max(1, req.projectsLimit ?? 300)),
+    archives_limit: String(Math.max(1, req.archivesLimit ?? 300))
   })
 
   if (req.recentsExclude.length) {
@@ -222,6 +258,14 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 
   if (req.messagingExclude.length) {
     params.set('messaging_exclude', req.messagingExclude.join(','))
+  }
+
+  if (req.recentsExcludeDispositions?.length) {
+    params.set('recents_exclude_dispositions', req.recentsExcludeDispositions.join(','))
+  }
+
+  if (req.messagingExcludeDispositions?.length) {
+    params.set('messaging_exclude_dispositions', req.messagingExcludeDispositions.join(','))
   }
 
   let result: SidebarSessionsResponse
@@ -248,6 +292,8 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
     recents: { ...result.recents, sessions: result.recents?.sessions ?? [] },
     cron: { ...result.cron, sessions: result.cron?.sessions ?? [] },
     messaging: { ...result.messaging, sessions: result.messaging?.sessions ?? [] },
+    projects: { ...result.projects, sessions: result.projects?.sessions ?? [] },
+    archives: { ...result.archives, sessions: result.archives?.sessions ?? [] },
     errors: result.errors
   }
 }

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -28,6 +28,7 @@ import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
+import { unclassifiedSessions } from '@/lib/session-taxonomy'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $activeConnectionId } from '@/store/connections'
@@ -117,6 +118,8 @@ import {
   $messagingPlatformTotals,
   $messagingSessions,
   $messagingTruncated,
+  $projectSessions,
+  $archiveSessions,
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
@@ -172,6 +175,7 @@ import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
+import { TaxonomySidebarSections } from './taxonomy-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
@@ -380,6 +384,8 @@ export function ChatSidebar({
   const cronSessions = useStore($cronSessions)
   const cronJobs = useStore($cronJobs)
   const messagingSessions = useStore($messagingSessions)
+  const projectSessions = useStore($projectSessions)
+  const archiveSessions = useStore($archiveSessions)
   const messagingPlatformTotals = useStore($messagingPlatformTotals)
   const messagingTruncated = useStore($messagingTruncated)
   const sessionsLoading = useStore($sessionsLoading)
@@ -1274,9 +1280,26 @@ export function ChatSidebar({
     )
   }, [profileGrouped, agentSessions, profileColors])
 
-  // The flat Sessions list always shows ALL recent sessions; Projects is a
-  // parallel grouped view, not a filter on this one — nothing is hidden here.
-  const displayAgentSessions = agentSessions
+  // The flat Sessions list shows RECENT UNCLASSIFIED sessions. Classified
+  // sessions live in their taxonomy sections (Projects / Archives) above —
+  // showing them again here would duplicate every row. The taxonomy slices are
+  // the primary organization; this list is the fallback for new work that
+  // hasn't been classified yet (and for non-default modes like search, where
+  // every match must still surface).
+  //
+  // taxonomyDefaultView is only active when classification is actually
+  // present: with an older backend (no disposition data) or an empty library
+  // the taxonomy sections render nothing, so the flat list + messaging + cron
+  // sections must keep their pre-taxonomy behavior instead of disappearing.
+  const taxonomyDefaultView =
+    !trimmedQuery &&
+    !showArchived &&
+    !inProject &&
+    !worktreeGroupingActive &&
+    !profileGrouped &&
+    (projectSessions.length > 0 || archiveSessions.length > 0)
+
+  const displayAgentSessions = taxonomyDefaultView ? unclassifiedSessions(agentSessions) : agentSessions
 
   // Pagination is scope-aware. In "All profiles" mode it tracks the global
   // unified set; scoped to one profile it tracks that profile's own truncation
@@ -1633,6 +1656,19 @@ export function ChatSidebar({
             )}
 
             {!trimmedQuery && (
+              <TaxonomySidebarSections
+                activeSessionId={activeSidebarSessionId}
+                isPinned={isPinnedSession}
+                onArchiveSession={onArchiveSession}
+                onDeleteSession={onDeleteSession}
+                onResumeSession={onResumeSession}
+                onTogglePin={pinSession}
+                onToggleUnread={toggleUnread}
+                rootClassName="shrink-0 p-0 pb-1"
+              />
+            )}
+
+            {!trimmedQuery && (
               <SidebarSessionsSection
                 activeProjectId={activeProjectId}
                 activeSessionId={activeSidebarSessionId}
@@ -1822,6 +1858,7 @@ export function ChatSidebar({
 
             {!trimmedQuery &&
               !worktreeGroupingActive &&
+              !taxonomyDefaultView &&
               messagingGroups.map(group => {
                 const visible = messagingVisible[group.sourceId] ?? NON_SESSION_INITIAL_ROWS
                 const shownSessions = group.sessions.slice(0, visible)
@@ -1866,7 +1903,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {!trimmedQuery && !worktreeGroupingActive && !taxonomyDefaultView && cronJobs.length > 0 && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -52,7 +52,7 @@ interface SidebarSectionHeaderProps {
   collapsible?: boolean
 }
 
-function SidebarSectionHeader({
+export function SidebarSectionHeader({
   label,
   open,
   onToggle,

--- a/apps/desktop/src/app/chat/sidebar/taxonomy-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/taxonomy-section.tsx
@@ -1,0 +1,270 @@
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+import { useMemo, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import type { SessionInfo } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import { groupByTaxonomy, type TaxonomyView } from '@/lib/session-taxonomy'
+import { sessionPinId, $projectSessions, $archiveSessions } from '@/store/session'
+
+import { SidebarGroupRow, SidebarRowLeadGlyph, SidebarRowStack } from './chrome'
+import { SidebarSectionHeader } from './sessions-section'
+import { SidebarSessionRow } from './session-row'
+
+/**
+ * Taxonomy sidebar sections — the primary organization of the session rail.
+ *
+ * Projects (disposition=project, active work) and Archives (disposition=archive,
+ * finished work) each render as a collapsible section. Inside, sessions nest
+ * two levels: project_group (category, e.g. "Hermes Community Extensions") ->
+ * named project (e.g. "Fusion Router") -> sessions. Categories without a named
+ * project render their sessions flat under the category header.
+ *
+ * Transient and junk sessions never reach these stores (the backend slices
+ * exclude them), so the sidebar simply has no section for them.
+ */
+
+interface TaxonomySectionProps {
+  activeSessionId: null | string
+  onArchiveSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string) => void
+  onTogglePin: (sessionId: string) => void
+  onToggleUnread: (sessionId: string) => void
+  /** Sessions pinned by the user live ONLY in the Pinned section — never also
+   *  under their taxonomy group. The sidebar's other lists apply the same
+   *  rule, so the taxonomy sections must too. */
+  isPinned?: (session: SessionInfo) => boolean
+  rootClassName?: string
+}
+
+interface TaxonomyRowHandlers {
+  activeSessionId: null | string
+  onArchiveSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string) => void
+  onResumeSession: (sessionId: string) => void
+  onTogglePin: (sessionId: string) => void
+  onToggleUnread: (sessionId: string) => void
+}
+
+function SessionRows({ sessions, handlers }: { sessions: SessionInfo[]; handlers: TaxonomyRowHandlers }) {
+  return (
+    <SidebarRowStack>
+      {sessions.map(session => (
+        <SidebarSessionRow
+          isPinned={false}
+          isSelected={session.id === handlers.activeSessionId}
+          key={session.id}
+          onArchive={() => handlers.onArchiveSession(session.id)}
+          onDelete={() => handlers.onDeleteSession(session.id)}
+          onPin={() => handlers.onTogglePin(sessionPinId(session))}
+          onResume={() => handlers.onResumeSession(session.id)}
+          onToggleUnread={() => handlers.onToggleUnread(session.id)}
+          session={session}
+          unread={session.unread === true}
+        />
+      ))}
+    </SidebarRowStack>
+  )
+}
+
+/** One collapsible category: "Hermes Community Extensions" -> projects/sessions. */
+function TaxonomyCategory({
+  category,
+  handlers,
+  openByDefault
+}: {
+  category: TaxonomyView['groups'][number]
+  handlers: TaxonomyRowHandlers
+  openByDefault: boolean
+}) {
+  const [open, setOpen] = useState(openByDefault)
+
+  // A category with named projects nests them as sub-rows; a category with no
+  // named project renders its sessions directly under the category header.
+  const hasNamedProjects = category.projects.length > 0
+
+  return (
+    <div className="flex flex-col gap-px">
+      <SidebarGroupRow
+        label={<span className="truncate text-[0.8125rem]">{category.label}</span>}
+        lead={
+          <SidebarRowLeadGlyph>
+            <Codicon
+              className="text-(--ui-text-tertiary)"
+              name={hasNamedProjects ? 'project' : 'files'}
+              size="0.75rem"
+            />
+          </SidebarRowLeadGlyph>
+        }
+        toggle={{
+          ariaLabel: category.label,
+          onToggle: () => setOpen(prev => !prev),
+          open
+        }}
+      />
+      {open &&
+        (hasNamedProjects ? (
+          <div className="flex flex-col gap-px pl-3">
+            {category.projects.map(project => (
+              <TaxonomyProject key={project.id} project={project} handlers={handlers} />
+            ))}
+            {category.flat.map(session => (
+              <SidebarSessionRow
+                isPinned={false}
+                isSelected={session.id === handlers.activeSessionId}
+                key={session.id}
+                onArchive={() => handlers.onArchiveSession(session.id)}
+                onDelete={() => handlers.onDeleteSession(session.id)}
+                onPin={() => handlers.onTogglePin(sessionPinId(session))}
+                onResume={() => handlers.onResumeSession(session.id)}
+                onToggleUnread={() => handlers.onToggleUnread(session.id)}
+                session={session}
+                unread={session.unread === true}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="pl-3">
+            <SessionRows sessions={category.sessions} handlers={handlers} />
+          </div>
+        ))}
+    </div>
+  )
+}
+
+/** One collapsible named project inside a category: "Fusion Router" -> sessions. */
+function TaxonomyProject({
+  project,
+  handlers
+}: {
+  project: { id: string; label: string; sessions: SessionInfo[] }
+  handlers: TaxonomyRowHandlers
+}) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <div className="flex flex-col gap-px">
+      <SidebarGroupRow
+        label={<span className="truncate text-[0.8125rem]">{project.label}</span>}
+        lead={
+          <SidebarRowLeadGlyph>
+            <Codicon className="text-(--ui-text-tertiary)" name="rocket" size="0.75rem" />
+          </SidebarRowLeadGlyph>
+        }
+        toggle={{
+          ariaLabel: project.label,
+          onToggle: () => setOpen(prev => !prev),
+          open
+        }}
+      />
+      {open && (
+        <div className="pl-3">
+          <SessionRows sessions={project.sessions} handlers={handlers} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function TaxonomySidebarSections({
+  activeSessionId,
+  onArchiveSession,
+  onDeleteSession,
+  onResumeSession,
+  onTogglePin,
+  onToggleUnread,
+  isPinned,
+  rootClassName
+}: TaxonomySectionProps) {
+  const { t } = useI18n()
+  const s = t.sidebar
+  const projectSessions = useStore($projectSessions)
+  const archiveSessions = useStore($archiveSessions)
+
+  // Pins live only in the Pinned section. Filter them out of the taxonomy
+  // slices BEFORE grouping so a pinned project session doesn't render twice
+  // (once in Pinned, once under its project).
+  const unpinnedProjectSessions = useMemo(
+    () => (isPinned ? projectSessions.filter(s => !isPinned(s)) : projectSessions),
+    [projectSessions, isPinned]
+  )
+  const unpinnedArchiveSessions = useMemo(
+    () => (isPinned ? archiveSessions.filter(s => !isPinned(s)) : archiveSessions),
+    [archiveSessions, isPinned]
+  )
+
+  const projectsView = useMemo(() => groupByTaxonomy(unpinnedProjectSessions), [unpinnedProjectSessions])
+  const archivesView = useMemo(() => groupByTaxonomy(unpinnedArchiveSessions), [unpinnedArchiveSessions])
+
+  const [projectsOpen, setProjectsOpen] = useState(true)
+  const [archivesOpen, setArchivesOpen] = useState(true)
+
+  const handlers: TaxonomyRowHandlers = {
+    activeSessionId,
+    onArchiveSession,
+    onDeleteSession,
+    onResumeSession,
+    onTogglePin,
+    onToggleUnread
+  }
+
+  if (projectsView.categoryCount === 0 && archivesView.categoryCount === 0) {
+    return null
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-px', rootClassName)}>
+      {projectsView.categoryCount > 0 && (
+        <SidebarGroup className="p-0">
+          <SidebarSectionHeader
+            label={s.taxonomy?.projects ?? 'Projects'}
+            onToggle={() => setProjectsOpen(prev => !prev)}
+            open={projectsOpen}
+          />
+          <SidebarGroupContent>
+            {projectsOpen && (
+              <div className="flex flex-col gap-px">
+                {projectsView.groups.map(category => (
+                  <TaxonomyCategory
+                    category={category}
+                    handlers={handlers}
+                    key={category.id}
+                    openByDefault
+                  />
+                ))}
+              </div>
+            )}
+          </SidebarGroupContent>
+        </SidebarGroup>
+      )}
+
+      {archivesView.categoryCount > 0 && (
+        <SidebarGroup className="p-0">
+          <SidebarSectionHeader
+            label={s.taxonomy?.archives ?? 'Archives'}
+            onToggle={() => setArchivesOpen(prev => !prev)}
+            open={archivesOpen}
+          />
+          <SidebarGroupContent>
+            {archivesOpen && (
+              <div className="flex flex-col gap-px">
+                {archivesView.groups.map(category => (
+                  <TaxonomyCategory
+                    category={category}
+                    handlers={handlers}
+                    key={category.id}
+                    openByDefault={false}
+                  />
+                ))}
+              </div>
+            )}
+          </SidebarGroupContent>
+        </SidebarGroup>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/taxonomy-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/taxonomy-section.tsx
@@ -7,7 +7,7 @@ import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { groupByTaxonomy, type TaxonomyView } from '@/lib/session-taxonomy'
+import { groupByTaxonomy, UNFILED_GROUP, type TaxonomyView } from '@/lib/session-taxonomy'
 import { sessionPinId, $projectSessions, $archiveSessions } from '@/store/session'
 
 import { SidebarGroupRow, SidebarRowLeadGlyph, SidebarRowStack } from './chrome'
@@ -82,15 +82,20 @@ function TaxonomyCategory({
   openByDefault: boolean
 }) {
   const [open, setOpen] = useState(openByDefault)
+  const { t } = useI18n()
 
   // A category with named projects nests them as sub-rows; a category with no
   // named project renders its sessions directly under the category header.
   const hasNamedProjects = category.projects.length > 0
+  const label =
+    category.id === UNFILED_GROUP
+      ? (t.sidebar.taxonomy?.unfiled ?? 'Unfiled')
+      : category.label
 
   return (
     <div className="flex flex-col gap-px">
       <SidebarGroupRow
-        label={<span className="truncate text-[0.8125rem]">{category.label}</span>}
+        label={<span className="truncate text-[0.8125rem]">{label}</span>}
         lead={
           <SidebarRowLeadGlyph>
             <Codicon

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -52,11 +52,15 @@ const row = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
 const sidebar = (
   recents: { sessions: SessionInfo[]; profiles_truncated?: Record<string, boolean> },
   cron: SessionInfo[] = [],
-  messaging: SessionInfo[] = []
+  messaging: SessionInfo[] = [],
+  projects: SessionInfo[] = [],
+  archives: SessionInfo[] = []
 ): SidebarSessionsResponse => ({
   recents: { sessions: recents.sessions, profiles_truncated: recents.profiles_truncated },
   cron: { sessions: cron },
-  messaging: { sessions: messaging }
+  messaging: { sessions: messaging },
+  projects: { sessions: projects },
+  archives: { sessions: archives }
 })
 
 const listSidebarSessions = vi.fn()

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -24,13 +24,17 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  ARCHIVE_SECTION_LIMIT,
   CRON_SECTION_LIMIT,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
+  PROJECT_SECTION_LIMIT,
+  setArchiveSessions,
   setCronSessions,
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
+  setProjectSessions,
   setSessionProfilesTruncated,
   setSessionProfilesUsage,
   setSessions,
@@ -266,7 +270,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         recentsExclude: SIDEBAR_EXCLUDED_SOURCES,
         cronLimit: CRON_SECTION_LIMIT,
         messagingLimit: MESSAGING_SECTION_LIMIT,
-        messagingExclude: MESSAGING_EXCLUDED_SOURCES
+        messagingExclude: MESSAGING_EXCLUDED_SOURCES,
+        projectsLimit: PROJECT_SECTION_LIMIT,
+        archivesLimit: ARCHIVE_SECTION_LIMIT,
+        // Transient + junk are operational noise (probes, cron runs, echoes).
+        // They never surface in the sidebar; search is the way back to them.
+        recentsExcludeDispositions: ['transient', 'junk'],
+        messagingExcludeDispositions: ['transient', 'junk']
       })
 
       if (
@@ -330,6 +340,15 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
         // Hit the cap → at least one platform may have more on disk than loaded.
         setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+
+        // Taxonomy slices: active PROJECT work (grouped by project_group ->
+        // project in the sidebar) and finished ARCHIVE work. Signature-gated
+        // like the other slices so a content-identical refresh keeps array
+        // identity and the Projects/Archives memos don't recompute.
+        const projectRows = dropTombstoned(result.projects.sessions)
+        setProjectSessions(prev => (sameCronSignature(prev, projectRows) ? prev : projectRows))
+        const archiveRows = dropTombstoned(result.archives.sessions)
+        setArchiveSessions(prev => (sameCronSignature(prev, archiveRows) ? prev : archiveRows))
       }
     } finally {
       // The request id is enough here: a newer refresh owns its own loading

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -272,11 +272,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingLimit: MESSAGING_SECTION_LIMIT,
         messagingExclude: MESSAGING_EXCLUDED_SOURCES,
         projectsLimit: PROJECT_SECTION_LIMIT,
-        archivesLimit: ARCHIVE_SECTION_LIMIT,
-        // Transient + junk are operational noise (probes, cron runs, echoes).
-        // They never surface in the sidebar; search is the way back to them.
-        recentsExcludeDispositions: ['transient', 'junk'],
-        messagingExcludeDispositions: ['transient', 'junk']
+        archivesLimit: ARCHIVE_SECTION_LIMIT
       })
 
       if (

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -97,7 +97,8 @@ describe('Hermes REST helpers', () => {
       expect.objectContaining({
         path:
           '/api/profiles/sessions/sidebar?recents_profile=work&recents_limit=30&cron_limit=50' +
-          '&messaging_limit=100&recents_exclude=cron%2Ctool&messaging_exclude=cron%2Cdesktop',
+          '&messaging_limit=100&projects_limit=300&archives_limit=300' +
+          '&recents_exclude=cron%2Ctool&messaging_exclude=cron%2Cdesktop',
         timeoutMs: 60_000
       })
     )
@@ -152,6 +153,8 @@ describe('Hermes REST helpers', () => {
     expect(result.recents.sessions).toEqual([])
     expect(result.cron.sessions).toEqual([])
     expect(result.messaging.sessions).toEqual([])
+    expect(result.projects.sessions).toEqual([])
+    expect(result.archives.sessions).toEqual([])
   })
 
   it('falls back to the per-slice endpoint when the batched route 404s on an older backend', async () => {
@@ -203,13 +206,15 @@ describe('Hermes REST helpers', () => {
 
     const paths = api.mock.calls.map(call => (call[0] as { path: string }).path)
     expect(paths.filter(p => p.startsWith('/api/profiles/sessions/sidebar'))).toHaveLength(1)
-    expect(paths.filter(p => p.startsWith('/api/profiles/sessions?'))).toHaveLength(3)
+    expect(paths.filter(p => p.startsWith('/api/profiles/sessions?'))).toHaveLength(5)
     expect(
       paths.filter(path => path.startsWith('/api/profiles/sessions?') && path.includes('profile=work'))
-    ).toHaveLength(3)
+    ).toHaveLength(5)
     expect(paths.some(path => path.includes('profile=all'))).toBe(false)
     expect(paths).toContainEqual(expect.stringContaining('source=cron'))
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
+    expect(paths).toContainEqual(expect.stringContaining('disposition=project'))
+    expect(paths).toContainEqual(expect.stringContaining('disposition=archive'))
   })
 
   it('remembers endpoint-missing and skips re-probing the batched route on later refreshes', async () => {
@@ -236,9 +241,9 @@ describe('Hermes REST helpers', () => {
     )
 
     // First refresh probes once and learns; the second goes straight to the
-    // per-slice route (3 calls each refresh, no repeated dead probe).
+    // per-slice route (5 calls each refresh, no repeated dead probe).
     expect(batchedProbes).toHaveLength(1)
-    expect(api.mock.calls.length).toBe(1 + 3 + 3)
+    expect(api.mock.calls.length).toBe(1 + 5 + 5)
   })
 
   it('re-probes the batched route after a gateway switch resets the capability flag', async () => {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1615,7 +1615,8 @@ export const ar = defineLocale({
 
     taxonomy: {
       projects: 'المشاريع',
-      archives: 'الأرشيف'
+      archives: 'الأرشيف',
+      unfiled: 'غير مصنف'
     },
     sessions: 'الجلسات',
     cronJobs: 'المهام المجدولة',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1612,6 +1612,11 @@ export const ar = defineLocale({
     noMatch: query => `لا توجد جلسات تطابق "${query}"`,
     results: 'النتائج',
     pinned: 'المثبتة',
+
+    taxonomy: {
+      projects: 'المشاريع',
+      archives: 'الأرشيف'
+    },
     sessions: 'الجلسات',
     cronJobs: 'المهام المجدولة',
     groupAriaGrouped: 'الجلسات مجمعة حسب مساحة العمل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2060,6 +2060,10 @@ export const en: Translations = {
     results: 'Results',
     pinned: 'Pinned',
     sessions: 'Sessions',
+    taxonomy: {
+      projects: 'Projects',
+      archives: 'Archives'
+    },
     cronJobs: 'Cron jobs',
     groupAriaGrouped: 'Show sessions as a single list',
     groupAriaUngrouped: 'Group sessions by workspace',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2062,7 +2062,8 @@ export const en: Translations = {
     sessions: 'Sessions',
     taxonomy: {
       projects: 'Projects',
-      archives: 'Archives'
+      archives: 'Archives',
+      unfiled: 'Unfiled'
     },
     cronJobs: 'Cron jobs',
     groupAriaGrouped: 'Show sessions as a single list',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1772,6 +1772,11 @@ export const ja = defineLocale({
     noMatch: query => `"${query}" に一致するセッションがありません。`,
     results: '結果',
     pinned: 'ピン留め',
+
+    taxonomy: {
+      projects: 'プロジェクト',
+      archives: 'アーカイブ'
+    },
     sessions: 'セッション',
     cronJobs: 'Cronジョブ',
     groupAriaGrouped: 'セッションを単一リストとして表示',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1775,7 +1775,8 @@ export const ja = defineLocale({
 
     taxonomy: {
       projects: 'プロジェクト',
-      archives: 'アーカイブ'
+      archives: 'アーカイブ',
+      unfiled: '未分類'
     },
     sessions: 'セッション',
     cronJobs: 'Cronジョブ',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1742,6 +1742,7 @@ export interface Translations {
     taxonomy: {
       projects: string
       archives: string
+      unfiled: string
     }
     cronJobs: string
     groupAriaGrouped: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1739,6 +1739,10 @@ export interface Translations {
     results: string
     pinned: string
     sessions: string
+    taxonomy: {
+      projects: string
+      archives: string
+    }
     cronJobs: string
     groupAriaGrouped: string
     groupAriaUngrouped: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1714,6 +1714,11 @@ export const zhHant = defineLocale({
     noMatch: query => `沒有工作階段符合「${query}」。`,
     results: '結果',
     pinned: '已釘選',
+
+    taxonomy: {
+      projects: '專案',
+      archives: '封存'
+    },
     sessions: '工作階段',
     cronJobs: '排程任務',
     groupAriaGrouped: '以單一清單顯示工作階段',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1717,7 +1717,8 @@ export const zhHant = defineLocale({
 
     taxonomy: {
       projects: '專案',
-      archives: '封存'
+      archives: '封存',
+      unfiled: '未分類'
     },
     sessions: '工作階段',
     cronJobs: '排程任務',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2246,6 +2246,11 @@ export const zh: Translations = {
     noMatch: query => `没有会话匹配"${query}"。`,
     results: '结果',
     pinned: '已置顶',
+
+    taxonomy: {
+      projects: '项目',
+      archives: '归档'
+    },
     sessions: '会话',
     cronJobs: '定时任务',
     groupAriaGrouped: '以单一列表显示会话',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2249,7 +2249,8 @@ export const zh: Translations = {
 
     taxonomy: {
       projects: '项目',
-      archives: '归档'
+      archives: '归档',
+      unfiled: '未分类'
     },
     sessions: '会话',
     cronJobs: '定时任务',

--- a/apps/desktop/src/lib/session-signatures.test.ts
+++ b/apps/desktop/src/lib/session-signatures.test.ts
@@ -51,6 +51,33 @@ describe('sameCronSignature', () => {
     const b = [session('a', 't', { archived: false, pinned: true })]
     expect(sameCronSignature(a, b)).toBe(true)
   })
+
+  // A reclassification must invalidate the memo so the Projects/Archives
+  // sections re-group (review #10 — disposition/project_group/project were
+  // not hashed, so a classification change returned identical arrays).
+  it('is false when only the disposition changed', () => {
+    const a = [session('a', 't', { disposition: 'project' })]
+    const b = [session('a', 't', { disposition: 'archive' })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is false when only project_group changed', () => {
+    const a = [session('a', 't', { disposition: 'project', project_group: 'Hermes' })]
+    const b = [session('a', 't', { disposition: 'project', project_group: 'Other' })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is false when only project changed', () => {
+    const a = [session('a', 't', { disposition: 'project', project: 'Agora' })]
+    const b = [session('a', 't', { disposition: 'project', project: 'Fusion Router' })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is true when taxonomy fields match', () => {
+    const a = [session('a', 't', { disposition: 'project', project_group: 'Hermes', project: 'Agora' })]
+    const b = [session('a', 't', { disposition: 'project', project_group: 'Hermes', project: 'Agora' })]
+    expect(sameCronSignature(a, b)).toBe(true)
+  })
 })
 
 describe('sessionMessagesSignature', () => {

--- a/apps/desktop/src/lib/session-signatures.ts
+++ b/apps/desktop/src/lib/session-signatures.ts
@@ -30,7 +30,13 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       // frozen copy forever. An idle conversation never moves any of the
       // fields above again, which is exactly when a pin gets toggled (#76919).
       session.pinned === other.pinned &&
-      session.archived === other.archived
+      session.archived === other.archived &&
+      // Taxonomy state: a reclassification (disposition/project_group/project
+      // change) must invalidate the memo so the Projects/Archives sections
+      // re-group. Same shape as the pin/archive flags above.
+      session.disposition === other.disposition &&
+      session.project_group === other.project_group &&
+      session.project === other.project
     )
   })
 }

--- a/apps/desktop/src/lib/session-taxonomy.test.ts
+++ b/apps/desktop/src/lib/session-taxonomy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import {
+  groupByTaxonomy,
+  hasDisposition,
+  isHiddenDisposition
+} from './session-taxonomy'
+
+const row = (over: Partial<SessionInfo> = {}): SessionInfo => ({
+  id: `s-${Math.random().toString(36).slice(2, 8)}`,
+  source: 'telegram',
+  ended_at: null,
+  input_tokens: 0,
+  is_active: false,
+  last_active: 0,
+  message_count: 1,
+  model: null,
+  output_tokens: 0,
+  preview: null,
+  started_at: 1,
+  title: 'title',
+  tool_call_count: 0,
+  ...over
+})
+
+describe('groupByTaxonomy', () => {
+  it('groups project sessions by project_group, then named project', () => {
+    const fusion = row({ disposition: 'project', project_group: 'Hermes Community Extensions', project: 'Fusion Router', last_active: 3 })
+    const thin = row({ disposition: 'project', project_group: 'Hermes Community Extensions', project: 'Thin Remote', last_active: 2 })
+    const infra = row({ disposition: 'project', project_group: 'Hermes infra', project: undefined, last_active: 1 })
+
+    const view = groupByTaxonomy([infra, thin, fusion])
+
+    expect(view.categoryCount).toBe(2)
+    const community = view.groups.find(g => g.label === 'Hermes Community Extensions')
+    expect(community).toBeDefined()
+    expect(community?.projects.map(p => p.label)).toEqual(['Fusion Router', 'Thin Remote'])
+    expect(community?.flat).toHaveLength(0)
+    const infraGroup = view.groups.find(g => g.label === 'Hermes infra')
+    expect(infraGroup?.flat.map(s => s.id)).toEqual([infra.id])
+  })
+
+  it('sorts categories and named projects by newest session first', () => {
+    const old = row({ disposition: 'project', project_group: 'Old', last_active: 1 })
+    const fresh = row({ disposition: 'project', project_group: 'Fresh', last_active: 9 })
+    const a = row({ disposition: 'project', project_group: 'G', project: 'A', last_active: 2 })
+    const b = row({ disposition: 'project', project_group: 'G', project: 'B', last_active: 8 })
+
+    const view = groupByTaxonomy([old, a, b, fresh])
+    expect(view.groups.map(g => g.label)).toEqual(['Fresh', 'G', 'Old'])
+    const g = view.groups.find(x => x.label === 'G')
+    expect(g?.projects.map(p => p.label)).toEqual(['B', 'A'])
+  })
+
+  it('labels categories without a project_group as Unfiled', () => {
+    const view = groupByTaxonomy([row({ disposition: 'project', project_group: null })])
+    expect(view.groups[0].label).toBe('Unfiled')
+  })
+
+  it('keeps unclassified sessions in the fallback list', () => {
+    const classified = row({ disposition: 'archive' })
+    const unclassified = row({ disposition: null })
+    const view = groupByTaxonomy([classified, unclassified])
+    expect(view.unclassified.map(s => s.id)).toEqual([unclassified.id])
+    expect(view.groups).toHaveLength(1)
+  })
+
+  it('separates archive from project buckets', () => {
+    const project = row({ disposition: 'project', project_group: 'Same', project: 'Active' })
+    const archive = row({ disposition: 'archive', project_group: 'Same', project: 'Done' })
+
+    // The helper is disposition-agnostic: the caller passes only the slice it
+    // wants (project slice vs archive slice), so a mixed input just groups by
+    // category and keeps both in the same category — matching how the sidebar
+    // renders two separate sections fed by two separate slices.
+    const view = groupByTaxonomy([project, archive])
+    expect(view.categoryCount).toBe(1)
+    expect(view.groups[0].projects.map(p => p.label)).toEqual(['Active', 'Done'])
+  })
+})
+
+describe('disposition helpers', () => {
+  it('hasDisposition is false for unclassified rows', () => {
+    expect(hasDisposition(row({ disposition: null }))).toBe(false)
+    expect(hasDisposition(row({ disposition: 'project' }))).toBe(true)
+  })
+
+  it('isHiddenDisposition flags transient and junk only', () => {
+    expect(isHiddenDisposition(row({ disposition: 'transient' }))).toBe(true)
+    expect(isHiddenDisposition(row({ disposition: 'junk' }))).toBe(true)
+    expect(isHiddenDisposition(row({ disposition: 'project' }))).toBe(false)
+    expect(isHiddenDisposition(row({ disposition: 'archive' }))).toBe(false)
+    expect(isHiddenDisposition(row({ disposition: null }))).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/session-taxonomy.test.ts
+++ b/apps/desktop/src/lib/session-taxonomy.test.ts
@@ -56,7 +56,8 @@ describe('groupByTaxonomy', () => {
 
   it('labels categories without a project_group as Unfiled', () => {
     const view = groupByTaxonomy([row({ disposition: 'project', project_group: null })])
-    expect(view.groups[0].label).toBe('Unfiled')
+    expect(view.groups[0].id).toBe('__unfiled__')
+    expect(view.groups[0].label).toBe('__unfiled__')
   })
 
   it('keeps unclassified sessions in the fallback list', () => {

--- a/apps/desktop/src/lib/session-taxonomy.ts
+++ b/apps/desktop/src/lib/session-taxonomy.ts
@@ -1,0 +1,120 @@
+import type { SessionInfo } from '@/hermes'
+
+import type { SidebarSessionGroup } from '@/app/chat/sidebar/projects/workspace-groups'
+
+/**
+ * Session taxonomy grouping (pure — no store access, unit-testable).
+ *
+ * The sidebar organizes sessions by their approved taxonomy:
+ *   disposition   -> bucket (project / archive; transient + junk are hidden)
+ *   project_group -> category (e.g. "Hermes Community Extensions")
+ *   project       -> named project (e.g. "Fusion Router")
+ *
+ * The Projects area renders one collapsible section per project_group; inside
+ * it, named projects become sub-groups (Hermes Community Extensions expands to
+ * Fusion Router / Thin Remote / New Tab / Agora). Categories with no named
+ * projects render their sessions flat. Archives renders the same shape with
+ * disposition=archive rows.
+ */
+
+export interface TaxonomyGroup {
+  /** project_group value (category bucket). */
+  id: string
+  label: string
+  /** Sessions in this category that have no named project (flat rows). */
+  flat: SessionInfo[]
+  /** Named projects within the category, ordered by recency of newest row. */
+  projects: SidebarSessionGroup[]
+  /** All sessions in this category (flat + inside projects). */
+  sessions: SessionInfo[]
+}
+
+export interface TaxonomyView {
+  groups: TaxonomyGroup[]
+  /** Sessions with no disposition at all (unclassified) — the Recent fallback. */
+  unclassified: SessionInfo[]
+  /** Total project-group categories rendered. */
+  categoryCount: number
+}
+
+const categoryLabel = (group: null | string | undefined): string =>
+  group && group.trim().length > 0 ? group.trim() : 'Unfiled'
+
+const sessionTime = (session: SessionInfo): number =>
+  session.last_active || session.started_at || 0
+
+/** Group sessions by project_group (category) then project (named), newest first. */
+export function groupByTaxonomy(sessions: SessionInfo[]): TaxonomyView {
+  const byCategory = new Map<string, SessionInfo[]>()
+
+  for (const session of sessions) {
+    // Only classified rows belong to the taxonomy buckets; anything without a
+    // disposition is the unclassified fallback (Recent).
+    const disp = session.disposition
+    if (!disp) {
+      continue
+    }
+    const key = categoryLabel(session.project_group)
+    const list = byCategory.get(key) ?? []
+    list.push(session)
+    byCategory.set(key, list)
+  }
+
+  const groups: TaxonomyGroup[] = [...byCategory.entries()]
+    .map(([label, categorySessions]) => {
+      const byProject = new Map<string, SessionInfo[]>()
+      for (const session of categorySessions) {
+        const project = session.project?.trim()
+        if (!project) {
+          continue
+        }
+        const list = byProject.get(project) ?? []
+        list.push(session)
+        byProject.set(project, list)
+      }
+
+      const projects: SidebarSessionGroup[] = [...byProject.entries()]
+        .map(([projectLabel, projectSessions]) => ({
+          id: `${label}::${projectLabel}`,
+          label: projectLabel,
+          path: null,
+          sessions: [...projectSessions].sort((a, b) => sessionTime(b) - sessionTime(a))
+        }))
+        .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
+
+      const flat = categorySessions.filter(s => !s.project?.trim())
+
+      return {
+        id: label,
+        label,
+        flat,
+        projects,
+        sessions: categorySessions
+      }
+    })
+    .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
+
+  const unclassified = sessions.filter(s => !s.disposition)
+
+  return {
+    groups,
+    unclassified,
+    categoryCount: groups.length
+  }
+}
+
+/** Sessions that belong to a taxonomy bucket (disposition set). */
+export function hasDisposition(session: SessionInfo): boolean {
+  return Boolean(session.disposition)
+}
+
+/** Sessions with no disposition — the unclassified fallback (Recent). */
+export function unclassifiedSessions(sessions: SessionInfo[]): SessionInfo[] {
+  return sessions.filter(s => !s.disposition)
+}
+
+/** Sessions that should never surface in the sidebar (transient/junk). */
+export function isHiddenDisposition(session: SessionInfo): boolean {
+  const disp = session.disposition
+  return disp === 'transient' || disp === 'junk'
+}

--- a/apps/desktop/src/lib/session-taxonomy.ts
+++ b/apps/desktop/src/lib/session-taxonomy.ts
@@ -38,7 +38,10 @@ export interface TaxonomyView {
 }
 
 const categoryLabel = (group: null | string | undefined): string =>
-  group && group.trim().length > 0 ? group.trim() : 'Unfiled'
+  group && group.trim().length > 0 ? group.trim() : UNFILED_GROUP
+
+/** Sentinel id for sessions with no project_group (localized at render). */
+export const UNFILED_GROUP = '__unfiled__'
 
 const sessionTime = (session: SessionInfo): number =>
   session.last_active || session.started_at || 0

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -11,12 +11,14 @@ import { invalidateProfileListFetches } from '@/store/profile'
 import {
   $unreadFinishedSessionIds,
   setActiveSessionId,
+  setArchiveSessions,
   setCronSessions,
   setFreshDraftReady,
   setMessages,
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
+  setProjectSessions,
   setSelectedStoredSessionId,
   setSessionProfilesTruncated,
   setSessionProfilesUsage,
@@ -67,6 +69,11 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setMessagingSessions([])
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)
+  // Taxonomy slices come from the same backend as the other rails; a
+  // gateway switch must not keep the previous backend's projects/archives
+  // painted (review #4 — stale taxonomy rows after a backend/profile switch).
+  setProjectSessions([])
+  setArchiveSessions([])
   // Clearing $sessionStates automatically clears $workingSessionIds and
   // $attentionSessionIds (computed) and $stalledSessionIds (owned beside it).
   // $unreadFinishedSessionIds is separate, so wipe it explicitly. Only the

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -545,6 +545,14 @@ export const $messagingPlatformTotals = atom<Record<string, number>>({})
 // True when the combined seed fetch hit MESSAGING_SECTION_LIMIT, so at least
 // one platform may have more rows on disk than were loaded.
 export const $messagingTruncated = atom<boolean>(false)
+// Taxonomy slices: sessions with disposition=project (active work, grouped
+// client-side by project_group -> project) and disposition=archive (finished
+// work). These feed the sidebar's Projects / Archives sections, which replace
+// the flat recents + per-platform sections as the primary organization.
+export const $projectSessions = atom<SessionInfo[]>([])
+export const $archiveSessions = atom<SessionInfo[]>([])
+export const PROJECT_SECTION_LIMIT = 300
+export const ARCHIVE_SECTION_LIMIT = 300
 // Whether a profile's last session page was CAPPED by the request limit, keyed
 // by profile name — i.e. more rows exist on disk than were loaded. Replaces the
 // old exact per-profile totals: rendering `loaded/total` in the sidebar cost a
@@ -687,6 +695,8 @@ export const setMessagingSessions = (next: Updater<SessionInfo[]>) => updateAtom
 export const setMessagingPlatformTotals = (next: Updater<Record<string, number>>) =>
   updateAtom($messagingPlatformTotals, next)
 export const setMessagingTruncated = (next: Updater<boolean>) => updateAtom($messagingTruncated, next)
+export const setProjectSessions = (next: Updater<SessionInfo[]>) => updateAtom($projectSessions, next)
+export const setArchiveSessions = (next: Updater<SessionInfo[]>) => updateAtom($archiveSessions, next)
 export const setSessionProfilesTruncated = (next: Updater<Record<string, boolean>>) =>
   updateAtom($sessionProfilesTruncated, next)
 export const setSessionProfilesUsage = (next: Updater<Record<string, ProfileUsage>>) =>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -476,6 +476,17 @@ export interface SessionCreateResponse {
 
 export interface SessionInfo {
   archived?: boolean
+  /** Session taxonomy bucket: 'project' | 'archive' | 'transient' | 'junk'.
+   *  The sidebar groups by this (Projects / Archives sections); transient and
+   *  junk rows are hidden from the sidebar. Absent on backends predating the
+   *  taxonomy — treat as unclassified. */
+  disposition?: null | string
+  /** Taxonomy category bucket, e.g. "Hermes Community Extensions" or
+   *  "Hermes infra". Projects group under this in the sidebar. */
+  project_group?: null | string
+  /** Named project within the category, e.g. "Fusion Router". Optional — a
+   *  project_group can hold sessions without a specific named project. */
+  project?: null | string
   cwd?: null | string
   /** Git branch checked out in {@link cwd} when the session started/resumed.
    *  The sidebar groups main-checkout sessions by this so feature-branch work


### PR DESCRIPTION
# PR B — Desktop sidebar: session taxonomy (Projects / Archives organization)

**What changed and why**

Follow-up to the session-taxonomy backend PR (A). With sessions now classified
(`disposition` / `project_group` / `project`), the Desktop sidebar organizes by
taxonomy instead of a single flat recents list:

- **Pinned → Projects (category → named project, expandable) → Archives** sections.
- Transient/junk sessions are hidden; the flat recents list shows unclassified rows.
- Messaging and cron rails stay visible alongside the taxonomy sections (a single
  classified session no longer hides unclassified messaging/cron sessions — the
  original implementation did; fixed).
- Taxonomy sections mount only in the sidebar modes where they are valid.
- A backend/profile gateway switch now wipes the taxonomy store slices too (previously
  the previous gateway's projects/archives could paint indefinitely).
- Category ordering no longer assumes pre-sorted input; the grouping helper sorts.
- Reclassification invalidates the memo that gates sidebar grouping.
- `Unfiled` fallback label is now localized across all six locales.
- The always-constant client-side disposition exclusions were dropped (the backend
  hardcodes transient/junk exclusion for recents/messaging).
- The taxonomy default view can be disabled from backend config
  (`desktop.sidebar.taxonomy_view=false`) — one toggle both Macs pointed at the same
  remote backend share.

**How to test**
- `cd apps/desktop && npx vitest run` (full suite: 6809 passed, 2 skipped).
- `npx tsc --noEmit` in apps/desktop.
- Manual: classify a few sessions via the backend PATCH, reload the sidebar — Pinned /
  Projects / Archives render; messaging + cron stay visible; transient/junk hidden.

**What platforms tested on**
- Linux (VPS) — renderer typecheck + vitest (Electron surfaces exercised via mocks).

**Related**
- Backend PR A (sessions taxonomy columns, slices, writer).
