### PR TITLE
fix(gateway): keep liveness heartbeats alive from gateway startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2705,8 +2705,6 @@ from gateway.restart import (
     parse_restart_drain_timeout,
     resolve_cron_drain_budget,
 )
-
-
 from gateway.whatsapp_identity import (
     canonical_whatsapp_identifier as _canonical_whatsapp_identifier,  # noqa: F401
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
@@ -2715,6 +2713,10 @@ from gateway.whatsapp_identity import (
 
 
 logger = logging.getLogger(__name__)
+
+
+_LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S = 1.0
+_LOOP_HEARTBEAT_RESTART_MAX_DELAY_S = 60.0
 
 
 _OWN_POLICY_OPEN_ENV = {
@@ -6845,6 +6847,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # real values are set in __init__ / start() / stop().
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
     _loop_heartbeat_restart_handle: Optional[Any] = None
+    _loop_heartbeat_restart_delay_s: float = _LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S
     _loop_floor_timer_handle: Optional[Any] = None
     _loop_liveness_watchdog: Optional[Any] = None
     _gateway_started_at: float = 0.0
@@ -7263,6 +7266,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._gateway_started_at: float = time.time()
         self._loop_heartbeat_task: Optional[asyncio.Task] = None
         self._loop_heartbeat_restart_handle = None
+        self._loop_heartbeat_restart_delay_s = _LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S
         self._loop_floor_timer_handle = None
         self._loop_liveness_watchdog = None
 
@@ -12488,6 +12492,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     start_time=getattr(self, "_gateway_started_at", 0.0),
                 )
             )
+            self._loop_heartbeat_task._hermes_heartbeat_started_at = (  # type: ignore[attr-defined]
+                self._loop_heartbeat_task.get_loop().time()
+            )
             # PERMANENT for the process lifetime, same as a
             # _spawn_supervised watcher — tag it so
             # _scale_to_zero_has_live_background_work() doesn't treat an
@@ -12513,12 +12520,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ):
             return
 
+        loop = task.get_loop()
+        started_at = getattr(task, "_hermes_heartbeat_started_at", loop.time())
+        if loop.time() - started_at >= DEFAULT_HEARTBEAT_INTERVAL_S:
+            self._loop_heartbeat_restart_delay_s = (
+                _LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S
+            )
+        restart_delay = min(
+            max(
+                float(
+                    getattr(
+                        self,
+                        "_loop_heartbeat_restart_delay_s",
+                        _LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S,
+                    )
+                ),
+                _LOOP_HEARTBEAT_RESTART_INITIAL_DELAY_S,
+            ),
+            _LOOP_HEARTBEAT_RESTART_MAX_DELAY_S,
+        )
+        self._loop_heartbeat_restart_delay_s = min(
+            restart_delay * 2,
+            _LOOP_HEARTBEAT_RESTART_MAX_DELAY_S,
+        )
+
         exc = task.exception()
         if exc is None:
-            logger.warning("Gateway loop heartbeat stopped unexpectedly; restarting")
+            logger.warning(
+                "Gateway loop heartbeat stopped unexpectedly; restarting in %.0fs",
+                restart_delay,
+            )
         else:
             logger.warning(
-                "Gateway loop heartbeat failed; restarting",
+                "Gateway loop heartbeat failed; restarting in %.0fs",
+                restart_delay,
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
         self._loop_heartbeat_task = None
@@ -12532,7 +12567,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             self._start_loop_heartbeat_task()
 
-        self._loop_heartbeat_restart_handle = task.get_loop().call_later(1.0, _restart)
+        self._loop_heartbeat_restart_handle = loop.call_later(restart_delay, _restart)
 
     async def start(self) -> bool:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6844,6 +6844,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # defaults so partial construction in tests doesn't blow up on access; the
     # real values are set in __init__ / start() / stop().
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
+    _loop_heartbeat_restart_handle: Optional[Any] = None
     _loop_floor_timer_handle: Optional[Any] = None
     _loop_liveness_watchdog: Optional[Any] = None
     _gateway_started_at: float = 0.0
@@ -7261,6 +7262,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # updated_at to distinguish "process alive" from "loop frozen".
         self._gateway_started_at: float = time.time()
         self._loop_heartbeat_task: Optional[asyncio.Task] = None
+        self._loop_heartbeat_restart_handle = None
         self._loop_floor_timer_handle = None
         self._loop_liveness_watchdog = None
 
@@ -12413,6 +12415,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _stop_loop_liveness_guards(self) -> None:
         """Disarm lifetime liveness guards before shutdown can load the loop."""
+        restart_handle = getattr(self, "_loop_heartbeat_restart_handle", None)
+        self._loop_heartbeat_restart_handle = None
+        if restart_handle is not None:
+            restart_handle.cancel()
+
         watchdog = getattr(self, "_loop_liveness_watchdog", None)
         self._loop_liveness_watchdog = None
         if watchdog is not None:
@@ -12465,10 +12472,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         An asyncio task so a frozen loop stops refreshing
         ``state/gateway.heartbeat``. Cancelled with the other background
-        tasks during stop(). Best-effort — a liveness probe must never be
-        able to abort startup.
+        tasks during stop(). Unexpected task exits are restarted after a short
+        delay so monitoring cannot silently disappear for the process lifetime.
         """
         try:
+            _pending_restart = getattr(self, "_loop_heartbeat_restart_handle", None)
+            if _pending_restart is not None and not _pending_restart.cancelled():
+                return
             _existing_hb = getattr(self, "_loop_heartbeat_task", None)
             if _existing_hb is not None and not _existing_hb.done():
                 return
@@ -12487,8 +12497,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _bg is not None:
                 _bg.add(self._loop_heartbeat_task)
                 self._loop_heartbeat_task.add_done_callback(_bg.discard)
+            self._loop_heartbeat_task.add_done_callback(
+                self._restart_loop_heartbeat_after_failure
+            )
         except Exception:
-            logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
+            logger.warning("Failed to start gateway loop heartbeat", exc_info=True)
+
+    def _restart_loop_heartbeat_after_failure(self, task: "asyncio.Task") -> None:
+        """Log and replace an unexpectedly dead loop-heartbeat task."""
+        if task.cancelled() or getattr(self, "_loop_heartbeat_task", None) is not task:
+            return
+        shutdown_event = getattr(self, "_shutdown_event", None)
+        if getattr(self, "_draining", False) or (
+            shutdown_event is not None and shutdown_event.is_set()
+        ):
+            return
+
+        exc = task.exception()
+        if exc is None:
+            logger.warning("Gateway loop heartbeat stopped unexpectedly; restarting")
+        else:
+            logger.warning(
+                "Gateway loop heartbeat failed; restarting",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+        self._loop_heartbeat_task = None
+
+        def _restart() -> None:
+            self._loop_heartbeat_restart_handle = None
+            current_shutdown_event = getattr(self, "_shutdown_event", None)
+            if getattr(self, "_draining", False) or (
+                current_shutdown_event is not None and current_shutdown_event.is_set()
+            ):
+                return
+            self._start_loop_heartbeat_task()
+
+        self._loop_heartbeat_restart_handle = task.get_loop().call_later(1.0, _restart)
 
     async def start(self) -> bool:
         """
@@ -12497,6 +12541,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
+        try:
+            self._gateway_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._gateway_loop = None
+        if self._gateway_loop is not None:
+            self._start_loop_liveness_guards(self._gateway_loop)
+        self._start_loop_heartbeat_task()
+
         # Enable faulthandler for stack dumps on freezes/crashes (#70344).
         # Falls back to a log file when sys.stderr is None (Windows VBS /
         # pythonw / detached service) — otherwise the gateway would die
@@ -12540,12 +12592,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Could not set up faulthandler file logging", exc_info=True)
 
-        try:
-            self._gateway_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._gateway_loop = None
-        if self._gateway_loop is not None:
-            self._start_loop_liveness_guards(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
 
         # Sanity-check that systemd's TimeoutStopSec covers our drain
@@ -13258,8 +13304,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running = True
         self._install_plugin_message_injector()
         self._update_runtime_status("running")
-
-        self._start_loop_heartbeat_task()
 
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)

--- a/tests/gateway/test_loop_heartbeat_lifecycle.py
+++ b/tests/gateway/test_loop_heartbeat_lifecycle.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_start_arms_heartbeat_before_startup_diagnostics():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._background_tasks = set()
+    runner._gateway_started_at = 123.0
+    runner._loop_heartbeat_task = None
+    runner._start_loop_liveness_guards = lambda _loop: None
+
+    with patch("gateway.run.faulthandler.enable", side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            await runner.start()
+
+    task = runner._loop_heartbeat_task
+    assert task is not None
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_failed_heartbeat_is_logged_and_restarted(monkeypatch, caplog):
+    calls = 0
+    replacement_started = asyncio.Event()
+    hold_replacement = asyncio.Event()
+
+    async def flaky_heartbeat(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("heartbeat write failed")
+        replacement_started.set()
+        await hold_replacement.wait()
+
+    monkeypatch.setattr("gateway.run.loop_heartbeat_forever", flaky_heartbeat)
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._background_tasks = set()
+    runner._gateway_started_at = 123.0
+    runner._loop_heartbeat_task = None
+    runner._draining = False
+    runner._shutdown_event = asyncio.Event()
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        runner._start_loop_heartbeat_task()
+        failed_task = runner._loop_heartbeat_task
+        await asyncio.wait_for(replacement_started.wait(), timeout=2.5)
+
+    replacement_task = runner._loop_heartbeat_task
+    assert replacement_task is not failed_task
+    assert "Gateway loop heartbeat failed; restarting" in caplog.text
+    replacement_task.cancel()
+    await asyncio.gather(replacement_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_pending_heartbeat_restart(monkeypatch):
+    calls = 0
+
+    async def failed_heartbeat(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("heartbeat write failed")
+
+    monkeypatch.setattr("gateway.run.loop_heartbeat_forever", failed_heartbeat)
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._background_tasks = set()
+    runner._gateway_started_at = 123.0
+    runner._loop_heartbeat_task = None
+    runner._loop_heartbeat_restart_handle = None
+    runner._loop_floor_timer_handle = None
+    runner._loop_liveness_watchdog = None
+    runner._draining = False
+    runner._shutdown_event = asyncio.Event()
+
+    runner._start_loop_heartbeat_task()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    restart_handle = runner._loop_heartbeat_restart_handle
+    assert restart_handle is not None
+
+    runner._stop_loop_liveness_guards()
+
+    assert restart_handle.cancelled()
+    await asyncio.sleep(1.1)
+    assert calls == 1

--- a/tests/gateway/test_loop_heartbeat_lifecycle.py
+++ b/tests/gateway/test_loop_heartbeat_lifecycle.py
@@ -23,6 +23,7 @@ async def test_start_arms_heartbeat_before_startup_diagnostics():
 
     task = runner._loop_heartbeat_task
     assert task is not None
+    assert not task.done()
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
@@ -59,6 +60,44 @@ async def test_failed_heartbeat_is_logged_and_restarted(monkeypatch, caplog):
     assert "Gateway loop heartbeat failed; restarting" in caplog.text
     replacement_task.cancel()
     await asyncio.gather(replacement_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_repeated_heartbeat_failures_back_off_and_stable_run_resets(monkeypatch):
+    loop = asyncio.get_running_loop()
+    scheduled_delays = []
+
+    class RestartHandle:
+        def cancelled(self):
+            return False
+
+    def capture_call_later(delay, _callback):
+        scheduled_delays.append(delay)
+        return RestartHandle()
+
+    monkeypatch.setattr(loop, "call_later", capture_call_later)
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._draining = False
+    runner._shutdown_event = asyncio.Event()
+    runner._loop_heartbeat_restart_delay_s = 1.0
+
+    async def fail():
+        raise RuntimeError("heartbeat failed")
+
+    for _ in range(8):
+        task = loop.create_task(fail())
+        task._hermes_heartbeat_started_at = loop.time()
+        await asyncio.sleep(0)
+        runner._loop_heartbeat_task = task
+        runner._restart_loop_heartbeat_after_failure(task)
+
+    stable_task = loop.create_task(fail())
+    stable_task._hermes_heartbeat_started_at = loop.time() - 10_000
+    await asyncio.sleep(0)
+    runner._loop_heartbeat_task = stable_task
+    runner._restart_loop_heartbeat_after_failure(stable_task)
+
+    assert scheduled_delays == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0, 60.0, 1.0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Keeps the gateway loop-liveness heartbeat active from the beginning of gateway startup and replaces it if the task later crashes. Without this fix, startup work can fail or wedge before the heartbeat task exists, and an unexpected heartbeat-task exception silently removes the external liveness signal for the rest of the process lifetime.

### Symptom

`state/gateway.heartbeat` can retain a timestamp from a previous gateway life even while the current process remains partially operational. External supervisors then cannot distinguish the current event loop from a process that never established its liveness signal.

### Impact

Operators can receive stale health information for a live gateway process. The reported incident observed a seven-hour gateway life with no heartbeat writes; the broader blast radius is unknown.

### Bug Cause

**Trigger:** `gateway/run.py` / `GatewayRunner.start()` and `_start_loop_heartbeat_task()`

**Causal chain:**
1. Gateway startup performs diagnostics, adapter bring-up, plugin discovery, and hook setup before reaching the existing heartbeat start call.
2. An exception or wedge in that earlier work leaves the process without a heartbeat task. Separately, a heartbeat task that raises is only discarded from `_background_tasks`.
3. `state/gateway.heartbeat` remains stale with no warning or recovery, so external health checks report an invalid liveness state.

**Why it is wrong:** The heartbeat is the process-wide event-loop liveness witness, but its lifecycle was shorter and less supervised than the gateway lifecycle it represents.

**Working sibling / contrast:** The selector-floor timer and out-of-loop liveness watchdog are armed before adapters and have explicit shutdown cleanup. The heartbeat was started only after adapters connected and had no equivalent failure owner.

**Ruled out:** Heartbeat file-write exceptions alone do not terminate the task because `write_loop_heartbeat()` already handles write failures internally. The uncovered failure class is task startup timing and unexpected task-level death.

### Fix

- Arm the heartbeat alongside the other loop-liveness guards at the top of `GatewayRunner.start()`.
- Log unexpected task completion at warning level and restart it after a bounded delay.
- Cancel any pending restart handle before shutdown teardown so cleanup cannot recreate the task.
- Add lifecycle regressions for early startup failure, task-level failure recovery, and shutdown cancellation.

## Related Issue

Closes #94758

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - start and supervise the loop heartbeat for the full gateway lifecycle.
- `tests/gateway/test_loop_heartbeat_lifecycle.py` - cover early startup, failure recovery, and shutdown behavior.

## How to Test

1. Run the heartbeat, startup, adapter, plugin, watchdog, scale-to-zero, and delivery regression files.
2. Confirm all 73 tests pass.

```bash
scripts/run_tests.sh tests/gateway/test_loop_heartbeat_lifecycle.py tests/gateway/test_shutdown_watchdog.py tests/gateway/test_scale_to_zero_watcher.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_startup_restart_race.py tests/gateway/test_runner_fatal_adapter.py tests/gateway/test_plugin_message_injection.py tests/gateway/test_delivery.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A
- [x] Config example updates are N/A
- [x] Contributor guide updates are N/A
- [x] I've considered cross-platform impact; the change uses asyncio lifecycle primitives available on all supported hosts
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

N/A - automated lifecycle tests cover the behavior.
