### PR TITLE
fix(auxiliary): drop the dead provider's model from the vision auto fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9498,9 +9498,15 @@ def _call_llm_impl(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
             )
+            # Do NOT forward resolved_model here: it was configured for the
+            # provider that just failed to resolve, and the auto chain may
+            # land on a different provider (e.g. the main one) whose model
+            # namespace it does not belong to — a bare slug then reaches the
+            # wire and the wrong provider rejects it with a cryptic format
+            # error that masks the dead provider (#94780). Auto derives its
+            # own vision model per selected backend.
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
-                model=resolved_model,
                 async_mode=False,
                 main_runtime=main_runtime,
             )
@@ -10321,9 +10327,10 @@ async def _async_call_llm_impl(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
             )
+            # Same rationale as the sync twin: the failed provider's model
+            # must not travel into the auto chain (#94780).
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
-                model=resolved_model,
                 async_mode=True,
                 main_runtime=main_runtime,
             )

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -313,3 +313,58 @@ auxiliary:
         assert all(m is None for m in captured["auto_models"]), (
             "the dead provider's model must not be forwarded into the auto chain"
         )
+
+    def _run_async_call_llm(self, isolated_home, monkeypatch):
+        import asyncio
+
+        from unittest.mock import patch
+
+        import agent.auxiliary_client as ac
+
+        _write_config(isolated_home, """
+model:
+  provider: openrouter
+  default: anthropic/claude-sonnet-4
+auxiliary:
+  vision:
+    provider: opencode-go
+    model: kimi-k3
+""")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        captured = {"auto_models": []}
+
+        class _FakeClient:
+            base_url = "https://openrouter.ai/api/v1"
+
+        def fake_resolve(provider=None, model=None, *, base_url=None,
+                         api_key=None, async_mode=False, main_runtime=None):
+            if provider == "opencode-go":
+                return "opencode-go", None, None
+            if provider == "auto":
+                captured["auto_models"].append(model)
+                return "openrouter", _FakeClient(), "anthropic/claude-sonnet-4"
+            return provider, _FakeClient(), model
+
+        async def fake_relay(*a, **k):
+            return {"ok": True}
+
+        with patch.object(ac, "resolve_vision_provider_client", side_effect=fake_resolve), \
+             patch.object(ac, "_set_relay_auxiliary_route"), \
+             patch.object(ac, "_build_call_kwargs", return_value={"model": "x", "messages": []}), \
+             patch.object(ac, "_relay_async_completion", side_effect=fake_relay), \
+             patch.object(ac, "_validate_llm_response", return_value={"ok": True}):
+            asyncio.run(ac._async_call_llm_impl(
+                "vision",
+                messages=[{"role": "user", "content": [{"type": "image_url"}]}],
+            ))
+        return captured
+
+    def test_async_auto_fallback_carries_no_model(self, isolated_home, monkeypatch):
+        # The async twin has the same fix but different control flow; a
+        # regression there would not be caught by the sync test above.
+        captured = self._run_async_call_llm(isolated_home, monkeypatch)
+        assert captured["auto_models"], "async auto fallback must fire"
+        assert all(m is None for m in captured["auto_models"]), (
+            "the dead provider's model must not be forwarded into the async auto chain"
+        )

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -256,3 +256,60 @@ model:
         import tools.browser_tool
         with patch.object(tools.browser_tool, "check_browser_requirements", return_value=True):
             assert tools.browser_tool.check_browser_vision_requirements() is True
+
+
+class TestVisionFallbackDropsDeadProviderModel:
+    """#94780: when the configured auxiliary.vision provider cannot be
+    resolved and call_llm falls back to the auto chain, the failed
+    provider's model must NOT travel with it. The bare slug reaches the
+    main provider's endpoint, which rejects the format and masks the dead
+    provider behind a cryptic 400. Mirrors the non-vision auto fallback,
+    which already passes no model for exactly this reason."""
+
+    def _run_call_llm(self, isolated_home, monkeypatch):
+        from unittest.mock import patch
+
+        import agent.auxiliary_client as ac
+
+        _write_config(isolated_home, """
+model:
+  provider: openrouter
+  default: anthropic/claude-sonnet-4
+auxiliary:
+  vision:
+    provider: opencode-go
+    model: kimi-k3
+""")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        captured = {"auto_models": []}
+
+        class _FakeClient:
+            base_url = "https://openrouter.ai/api/v1"
+
+        def fake_resolve(provider=None, model=None, *, base_url=None,
+                         api_key=None, async_mode=False, main_runtime=None):
+            if provider == "opencode-go":
+                return "opencode-go", None, None
+            if provider == "auto":
+                captured["auto_models"].append(model)
+                return "openrouter", _FakeClient(), "anthropic/claude-sonnet-4"
+            return provider, _FakeClient(), model
+
+        with patch.object(ac, "resolve_vision_provider_client", side_effect=fake_resolve), \
+             patch.object(ac, "_set_relay_auxiliary_route"), \
+             patch.object(ac, "_build_call_kwargs", return_value={"model": "x", "messages": []}), \
+             patch.object(ac, "_relay_sync_completion", return_value={"ok": True}), \
+             patch.object(ac, "_validate_llm_response", return_value={"ok": True}):
+            ac._call_llm_impl(
+                "vision",
+                messages=[{"role": "user", "content": [{"type": "image_url"}]}],
+            )
+        return captured
+
+    def test_auto_fallback_carries_no_model(self, isolated_home, monkeypatch):
+        captured = self._run_call_llm(isolated_home, monkeypatch)
+        assert captured["auto_models"], "auto fallback must fire"
+        assert all(m is None for m in captured["auto_models"]), (
+            "the dead provider's model must not be forwarded into the auto chain"
+        )


### PR DESCRIPTION
## What does this PR do?

When `auxiliary.vision.provider` cannot be resolved (e.g. a stale provider left in config after its credentials were removed), `call_llm(task="vision")` logs "falling back to auto vision backends" and retries with `provider="auto"` — but it forwarded the failed provider's **model** alongside. The auto chain can land on the main provider, whose model namespace that slug does not belong to: a bare `kimi-k3` configured for a dead `opencode-go` reached the main provider's endpoint and was rejected with a wire-format 400 (`invalid model format. Expected format: modelType/model`) that masked the dead provider entirely (#94780).

The fix drops `model=resolved_model` from both the sync and async fallback call sites. The **non-vision** auto fallback already passes no model for exactly this reason — its own comment says *"resolved_model may be an OpenRouter-format slug that doesn't work on other providers"* — so this aligns the vision fallback with the same established rule. Auto derives its own vision model per selected backend (provider vision defaults, then the main model); a model configured for a provider that failed to resolve is cross-namespace noise.

This is the sibling of the text-only-fallback family (#51220/#82534/#51513): those assume the fallback model name is correct, while here the name itself was malformed before the payload question arose.

## Related Issue

Fixes #94780

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — the sync and async `resolve_vision_provider_client(provider="auto", ...)` fallback calls no longer forward `resolved_model`, with a comment naming the cross-namespace mechanism (#94780) and pointing at the non-vision precedent.
- `tests/agent/test_vision_routing_31179.py` — new regression: with a dead configured vision provider (no client) and a resolvable auto chain, the auto retry is observed with `model=None` (captured at the resolver boundary), while the fallback itself still fires.

## How to Test

1. `pytest tests/agent/test_vision_routing_31179.py -q` — the new test passes; one pre-existing failure (`test_vision_capable_main_used`) is environment-dependent and fails identically on clean main (verified by stash-control), unrelated to this diff. Adjacent suites (`test_vision_resolved_args.py`, `test_auxiliary_main_first.py`) pass 19/19.
2. Observed result: with this PR's source reverted, the new test fails — the auto retry arrives with `model="kimi-k3"`; with the change it arrives with `model=None` and the selected backend derives its own vision model.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue (before): the gateway log showed the main provider rejecting the **model string** of the dead provider —

```
ERROR tools.vision_tools: Error analyzing image:
Error code: 400 - {'error': 'invalid model format. Expected format: modelType/model'}
```

— with `kimi-k3` sent bare to the cline endpoint. After this fix the auto fallback uses the selected backend's own vision model, and if none is vision-capable the original resolution failure surfaces instead.
