### PR TITLE
fix(kanban): reject malformed decomposition parents

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -135,6 +135,44 @@ BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
+def validate_decomposition_parents(
+    parents: object,
+    *,
+    child_index: int,
+    child_count: int,
+) -> list[int]:
+    """Validate and normalize sibling-parent indices for a decomposition.
+
+    The decomposer contract uses exact JSON integers as zero-based indices into
+    the same children list. Python's ``bool`` is an ``int`` subclass, so an
+    ``isinstance(value, int)`` check would incorrectly turn JSON ``true`` and
+    ``false`` into sibling links. Keep this validator shared by the parser and
+    the DB ingest boundary so malformed graphs cannot reach persistence.
+    """
+    if not isinstance(parents, list):
+        raise ValueError(f"child[{child_index}].parents must be a list")
+
+    validated: list[int] = []
+    for parent_position, parent in enumerate(parents):
+        if type(parent) is not int:
+            if isinstance(parent, bool):
+                detail = "bool is not a valid integer index"
+            else:
+                detail = "must be an integer index"
+            raise ValueError(
+                f"child[{child_index}].parents[{parent_position}] {detail}"
+            )
+        if parent < 0 or parent >= child_count:
+            raise ValueError(
+                f"child[{child_index}].parents[{parent_position}]={parent!r} "
+                "is not a valid index into children"
+            )
+        if parent == child_index:
+            raise ValueError(f"child[{child_index}] cannot list itself as a parent")
+        validated.append(parent)
+    return validated
+
+
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
 
@@ -7319,22 +7357,21 @@ def decompose_triage_task(
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
+    validated_parent_indices: list[list[int]] = []
     for idx, child in enumerate(children):
         if not isinstance(child, dict):
             raise ValueError(f"child[{idx}] is not a dict")
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
-        parents_idx = child.get("parents") or []
-        if not isinstance(parents_idx, list):
-            raise ValueError(f"child[{idx}].parents must be a list")
-        for p in parents_idx:
-            if not isinstance(p, int) or p < 0 or p >= len(children):
-                raise ValueError(
-                    f"child[{idx}].parents[{p}] is not a valid index into children"
-                )
-            if p == idx:
-                raise ValueError(f"child[{idx}] cannot list itself as a parent")
+        raw_parents = child["parents"] if "parents" in child else []
+        validated_parent_indices.append(
+            validate_decomposition_parents(
+                raw_parents,
+                child_index=idx,
+                child_count=len(children),
+            )
+        )
 
     # Detect cycles in the sibling parent graph (Kahn's topological sort).
     # link_tasks() calls _would_cycle() for every new edge; here we check
@@ -7343,8 +7380,8 @@ def decompose_triage_task(
     # can never promote them.
     _in_deg = [0] * len(children)
     _adj: list[list[int]] = [[] for _ in range(len(children))]
-    for _i, _c in enumerate(children):
-        for _p in (_c.get("parents") or []):
+    for _i, _parents in enumerate(validated_parent_indices):
+        for _p in _parents:
             _adj[_p].append(_i)
             _in_deg[_i] += 1
     _queue = [_i for _i in range(len(children)) if _in_deg[_i] == 0]
@@ -7441,8 +7478,8 @@ def decompose_triage_task(
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).
-        for idx, child in enumerate(children):
-            for p_idx in child.get("parents") or []:
+        for idx, p_indices in enumerate(validated_parent_indices):
+            for p_idx in p_indices:
                 parent_id = child_ids[p_idx]
                 child_id = child_ids[idx]
                 conn.execute(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -417,11 +417,15 @@ def decompose_task(
                 "routing to default_assignee %r",
                 task_id, idx, assignee, default_assignee,
             )
-        parents = entry.get("parents") or []
-        if not isinstance(parents, list):
-            parents = []
-        # Clean parent indices: drop non-int and out-of-range.
-        clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        raw_parents = entry["parents"] if "parents" in entry else []
+        try:
+            clean_parents = kb.validate_decomposition_parents(
+                raw_parents,
+                child_index=idx,
+                child_count=len(raw_tasks),
+            )
+        except ValueError as exc:
+            return DecomposeOutcome(task_id, False, f"invalid parents: {exc}")
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,85 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+@pytest.mark.parametrize(
+    ("parents", "child_index", "child_count"),
+    [
+        ([-1], 1, 2),
+        ([2], 1, 2),
+        ([True], 2, 3),
+        ([False], 1, 2),
+        ([0, True], 2, 3),
+    ],
+    ids=["negative", "out-of-range", "true", "false", "mixed"],
+)
+def test_decompose_rejects_malformed_parent_indices_from_llm(
+    kanban_home, parents, child_index, child_count
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    tasks = [
+        {"title": f"child {idx}", "body": "", "assignee": None, "parents": []}
+        for idx in range(child_count)
+    ]
+    tasks[child_index]["parents"] = parents
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "reject malformed graph",
+        "tasks": tasks,
+    })
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "parents" in outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        task_count = conn.execute("SELECT COUNT(*) AS count FROM tasks").fetchone()["count"]
+        link_count = conn.execute("SELECT COUNT(*) AS count FROM task_links").fetchone()["count"]
+    assert root is not None
+    assert root.status == "triage"
+    assert task_count == 1
+    assert link_count == 0
+
+
+@pytest.mark.parametrize("parents", [True, False, None], ids=["true", "false", "null"])
+def test_decompose_rejects_present_non_list_parents_from_llm(kanban_home, parents):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "reject non-list parents",
+        "tasks": [
+            {"title": "parallel", "body": "", "assignee": None},
+            {"title": "invalid", "body": "", "assignee": None, "parents": parents},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "parents" in outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+    assert root is not None
+    assert root.status == "triage"
+
+

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,85 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_missing_parents_is_parallel(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[{"title": "parallel task"}],
+            author="alice",
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    assert child is not None
+    assert child.status == "ready"
+
+
+@pytest.mark.parametrize(
+    ("parents", "child_index", "child_count"),
+    [
+        ([-1], 1, 2),
+        ([2], 1, 2),
+        ([True], 2, 3),
+        ([False], 1, 2),
+        ([0, True], 2, 3),
+    ],
+    ids=["negative", "out-of-range", "true", "false", "mixed"],
+)
+def test_decompose_rejects_invalid_parent_indices_atomically(
+    kanban_home, parents, child_index, child_count
+):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+
+    children = [
+        {"title": f"child {idx}", "parents": []}
+        for idx in range(child_count)
+    ]
+    children[child_index]["parents"] = parents
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="parents"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=children,
+                author="alice",
+            )
+
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        task_count = conn.execute("SELECT COUNT(*) AS count FROM tasks").fetchone()["count"]
+        link_count = conn.execute("SELECT COUNT(*) AS count FROM task_links").fetchone()["count"]
+    assert root is not None
+    assert root.status == "triage"
+    assert task_count == 1
+    assert link_count == 0
+
+
+@pytest.mark.parametrize("parents", [True, False, None], ids=["true", "false", "null"])
+def test_decompose_rejects_present_non_list_parents(kanban_home, parents):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="parents must be a list"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orch",
+                children=[
+                    {"title": "parallel"},
+                    {"title": "invalid", "parents": parents},
+                ],
+                author="alice",
+            )
+
+
 
 


### PR DESCRIPTION
## Summary
- Validate decomposition `parents` at the LLM parsing and DB ingestion boundaries.
- Accept only exact integer sibling indices; reject booleans, non-lists, non-integers, negative/out-of-range/self indices before any writes.
- Preserve missing/empty parents as parallel execution and keep valid dependency scheduling unchanged.

## Acceptance evidence
- `parents` is required to be a list when present; missing and `[]` normalize to no parents.
- `type(value) is int` rejects Python/JSON booleans and all non-exact integer values.
- All indices are range/self validated before the DB transaction, and the normalized graph is reused for cycle detection and link insertion.
- Focused regressions verify LLM and DB boundaries, atomic rejection, missing-parent parallel scheduling, and bool/scalar/null cases.

## Baseline drift resolution
The reviewed four-file patch was independently compared with the source candidate, then cherry-picked cleanly onto the current upstream `main` baseline `1bbb6e5bce56e721ab685af4cd87df21bbff4d35`. The resulting PR contains only the four requested files; final commit is `7792649a3c5c796ff52e6a17da82afc09b4cc990`.

## Verification
- RED: `HERMES_PYTHON=/root/.hermes/hermes-agent/venv-sqlite-3.51.3/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py -q -k "rejects_malformed or rejects_present or missing_parents"` — 10 expected failures before production changes.
- GREEN on final upstream base: focused decomposition files — 22 passed.
- Final-upstream-base Kanban suite: `HERMES_PYTHON=/root/.hermes/hermes-agent/venv-sqlite-3.51.3/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q` — 311 passed, 1 skipped.
- Ruff on all four changed files — passed.
- Compileall on all four changed files and scoped `git diff --check` — passed.
- `uv lock --check` — passed; dependency manifests unchanged.
- `ty check` on changed Python/test files — 19 diagnostics; the detached final-upstream-base baseline reports the same 19 pre-existing diagnostics, all outside the new validator/assertions.
- Added-line security scan — passed.

## Full-suite baseline evidence
The full Python suite was run at the pre-rebase baseline and at the corresponding pre-rebase implementation head. Both runs had the same 27 failing files / 88 failed tests, all unrelated to these four files (optional dependencies, provider/runtime environment, and existing integration/flaky cases). `npm run check` remains blocked by pre-existing missing JS workspace dependencies; this PR changes no JS files.

No merge or deployment is authorized by the originating task.