### PR TITLE
fix(cron): microsecond stamp for per-job output files

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3901,7 +3901,7 @@ def save_job_output(job_id: str, output: str):
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
 
-    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
+    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S_%f")
     output_file = job_output_dir / f"{timestamp}.md"
 
     fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')


### PR DESCRIPTION
## Problem

`save_job_output()` wrote per-run output as `<job_id>/<YYYY-MM-DD_%H-%M-%S>.md` — **second resolution**. A misfire catch-up landing in the same wall-clock second as the scheduled fire (or a rapid manual re-run) produced an identical filename, and `atomic_replace` **silently overwrote the earlier run's saved output**. This is the `cron/jobs.py` sibling of the `gateway/delivery.py` collision fixed earlier; only that file was scoped at the time.

## Fix

Stamp gains `%f` microseconds (`YYYY-MM-DD_%H-%M-%S_%f`), matching the convention already used across the repo (`gateway/delivery.py`, `tui_gateway/methods_session.py`, `agent_runtime_helpers`). The atomic tmp+replace write path, pruning (`_prune_job_output` counts files, not names), and the returned `output_file` path semantics are unchanged.

## Verification

`tests/cron` output/save selection: 21 passed with the change; the `test_monitor_kind` failures are pre-existing on clean `main` on this Windows host (reproduced with the change stashed).