### PR TITLE
fix(agent): show billing errors for exhausted Desktop provider picks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -104,6 +104,51 @@ def _ra():
     return run_agent
 
 
+def _credential_pool_billing_error(provider: str, pool: Any) -> Optional[str]:
+    """Describe a confirmed exhausted billing pool without exposing its payload."""
+    if not provider or pool is None:
+        return None
+    if str(getattr(pool, "provider", "") or "").strip().lower() != provider:
+        return None
+    try:
+        entries = pool.entries()
+    except Exception:
+        return None
+    if not entries or any(
+        getattr(entry, "last_status", None) != "exhausted" for entry in entries
+    ):
+        return None
+
+    billing_entries = [
+        entry
+        for entry in entries
+        if getattr(entry, "last_error_code", None) == 402
+        or str(getattr(entry, "last_error_reason", "") or "").strip().lower()
+        == "billing"
+    ]
+    if not billing_entries:
+        return None
+
+    status_codes = sorted(
+        {
+            code
+            for entry in billing_entries
+            if isinstance((code := getattr(entry, "last_error_code", None)), int)
+        }
+    )
+    status_hint = (
+        f" (HTTP {', '.join(str(code) for code in status_codes)})"
+        if status_codes
+        else ""
+    )
+    return (
+        f"Provider '{provider}' has no usable credentials because its credential "
+        f"pool is exhausted by a billing or credit error{status_hint}. Add credits "
+        "or update billing with that provider, then retry; alternatively select a "
+        "different provider with `hermes model`."
+    )
+
+
 def _moa_reference_output_allowed(agent: Any) -> bool:
     """Keep MoA display events off only the machine-readable ``-Q`` surface."""
     return not (
@@ -1388,6 +1433,9 @@ def init_agent(
                 # but no credentials were found, fail fast with a clear
                 # message instead of silently routing through OpenRouter.
                 _explicit = (agent.provider or "").strip().lower()
+                _pool_billing_error = _credential_pool_billing_error(
+                    _explicit, agent._credential_pool
+                )
                 if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
                     # Look up the actual env var name from the provider
                     # config — some providers use non-standard names
@@ -1445,12 +1493,16 @@ def init_agent(
                             _fb_resolved = True
                             break
                     if not _fb_resolved:
+                        if _pool_billing_error:
+                            raise RuntimeError(_pool_billing_error)
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
                             f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                 if not getattr(agent, "_fallback_activated", False):
+                    if _pool_billing_error:
+                        raise RuntimeError(_pool_billing_error)
                     # No provider configured — reject with a clear message.
                     raise RuntimeError(
                         "No LLM provider configured. Run `hermes model` to "

--- a/tests/agent/test_provider_init_billing_error.py
+++ b/tests/agent/test_provider_init_billing_error.py
@@ -1,0 +1,66 @@
+"""Regression coverage for provider-specific init failures (#94785)."""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.credential_pool import CredentialPool, PooledCredential
+
+
+def test_exhausted_openrouter_pool_surfaces_billing_error_without_raw_details() -> None:
+    from agent.agent_init import init_agent
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._base_url = ""
+    agent._base_url_lower = ""
+    agent._base_url_hostname = ""
+    pool = CredentialPool(
+        "openrouter",
+        [
+            PooledCredential(
+                provider="openrouter",
+                id="or-billing",
+                label="desktop override",
+                auth_type="api_key",
+                priority=0,
+                source="manual",
+                access_token="sk-secret-must-not-leak",
+                last_status="exhausted",
+                last_status_at=time.time(),
+                last_error_code=402,
+                last_error_reason="billing",
+                last_error_message="account owner secret@example.com can only afford 4282 tokens",
+            )
+        ],
+    )
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.get_compatible_custom_providers", return_value=[]),
+        patch("agent.iteration_budget.IterationBudget"),
+        patch("hermes_cli.config.cfg_get", return_value=None),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        init_agent(
+            agent,
+            provider="openrouter",
+            requested_provider="openrouter",
+            model="z-ai/glm-5.3",
+            credential_pool=pool,
+            skip_context_files=True,
+            skip_memory=True,
+            quiet_mode=True,
+        )
+
+    message = str(exc_info.value)
+    assert "openrouter" in message.lower()
+    assert "billing" in message.lower() or "credit" in message.lower()
+    assert "402" in message
+    assert "No LLM provider configured" not in message
+    assert "sk-secret-must-not-leak" not in message
+    assert "secret@example.com" not in message


### PR DESCRIPTION
## What does this PR do?

Desktop sessions with a sticky provider override now report a confirmed billing or credit exhaustion for that provider instead of claiming that no LLM provider is configured. The diagnostic uses only structured pool status and HTTP code metadata, so stored credential tokens and provider response text are not exposed.

### Symptom

A Desktop composer pick routed through an exhausted OpenRouter account fails during agent initialization with "No LLM provider configured", even when the profile's configured default provider works.

### Impact

Affected users are directed to rerun model setup instead of fixing credits for the explicitly selected provider, obscuring the actual failed route and delaying recovery.

### Bug Cause

**Trigger:** `agent/agent_init.py` / the no-routed-client branch for an explicit OpenRouter provider

**Causal chain:**
1. A persisted Desktop model choice selects OpenRouter and its credential pool has a confirmed 402 billing exhaustion.
2. Credential resolution correctly returns no usable client, but OpenRouter bypasses the explicit-provider missing-key diagnostic.
3. Agent initialization falls through to the generic no-provider error and discards the structured billing state.

**Why it is wrong:** A configured but exhausted explicit provider is different from a profile with no provider configuration. Replacing both states with the same setup error hides the actionable cause.

**Working sibling / contrast:** Explicit non-OpenRouter providers already receive provider-specific missing-key diagnostics; the generic message remains correct only when no provider-specific exhausted billing pool is attached.

**Ruled out:** The profile default provider is not the failing route. The issue evidence shows it works in CLI/TUI while the Desktop session carries an OpenRouter override.

### Fix

Inspect the already attached, provider-matched credential pool only after routing returns no client. When every pool entry is exhausted and structured status confirms billing through HTTP 402 or the billing reason code, raise sanitized provider-specific guidance. Preserve existing fallback, missing-key, and truly unconfigured-provider behavior.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` - preserve confirmed exhausted-pool billing context in init errors without exposing raw credential error payloads.
- `tests/agent/test_provider_init_billing_error.py` - reproduce the Desktop override path and assert provider, billing, and HTTP status context while guarding secrets and raw messages.

## How to Test

1. Run the focused agent initialization and fallback regression files:

```bash
scripts/run_tests.sh tests/agent/test_provider_init_billing_error.py tests/run_agent/test_init_fallback_on_exhausted_pool.py tests/run_agent/test_63425_credential_pool_auto_detect.py -q
```

2. Confirm all 4 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing contract or configuration changed
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change is platform-neutral Python logic
- [x] Tool descriptions/schemas: N/A - no tool behavior changed

## Screenshots / Logs

N/A - automated regression coverage exercises the failing initialization path.
