### PR TITLE
Configurable session-title prompt (auxiliary.title_generation.prompt)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -167,6 +167,25 @@ def _title_language() -> str:
         return ""
 
 
+def _title_prompt_override() -> str:
+    """Return a user-supplied titling prompt, or empty for the built-in.
+
+    Mirrors _title_language(): read-only loader so agent code paths never
+    trigger config-migration writes, and fail open — a broken config must
+    fall back to the built-in template, not disable titling.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return str(
+            ((load_config_readonly() or {}).get("auxiliary") or {})
+            .get("title_generation", {})
+            .get("prompt", "")
+        ).strip()
+    except Exception:
+        return ""
+
+
 def _auto_title_enabled() -> bool:
     """Return whether automatic session title generation is enabled."""
     try:
@@ -390,9 +409,22 @@ def generate_title(
         if language
         else _LANGUAGE_RULE_MATCH_USER
     )
-    # Placeholder substitution, not str.format: the prompt embeds literal JSON
-    # braces as few-shot examples, which format() would try to interpolate.
-    prompt = _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
+    custom_prompt = _title_prompt_override()
+    if custom_prompt:
+        # The user owns the prompt, but the language pin is a config-level
+        # contract, not template decoration — append it so `language` still
+        # wins over whatever the custom text says. A leftover placeholder
+        # from copy-pasting the built-in template is dropped first.
+        prompt = (
+            custom_prompt.replace("__LANGUAGE_RULE__", "").strip()
+            + "\n"
+            + language_rule
+        )
+    else:
+        # Placeholder substitution, not str.format: the prompt embeds literal
+        # JSON braces as few-shot examples, which format() would try to
+        # interpolate.
+        prompt = _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
 
     messages = [
         {"role": "system", "content": prompt},

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1163,6 +1163,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "language": "",
+            "prompt": "",  # custom titling system prompt; empty = built-in template
         },
         "memory_query_rewrite": {
             "provider": "auto",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _title_prompt_override,
 )
 from hermes_state import SessionDB
 
@@ -29,6 +30,101 @@ class TestGenerateTitle:
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("bad config")), \
          patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("bad config")):
             assert _title_language() == ""
+
+    def test_title_prompt_override_reads_config(self):
+        cfg = {"auxiliary": {"title_generation": {"prompt": "  My custom titler.  "}}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _title_prompt_override() == "My custom titler."
+        with patch("hermes_cli.config.load_config", return_value={}), patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert _title_prompt_override() == ""
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("bad config")), \
+         patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("bad config")):
+            assert _title_prompt_override() == ""
+
+    def test_custom_prompt_is_used_as_system_message(self):
+        """A configured prompt replaces the built-in template, verbatim, as
+        the system message — that is the whole point of the knob."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Custom Titler Output"
+            return resp
+
+        cfg = {"auxiliary": {"title_generation": {"prompt": "Name it like a filing cabinet. 3-5 words."}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("fix the flaky test") == "Custom Titler Output"
+
+        system_message = captured["messages"][0]["content"]
+        assert system_message.startswith("Name it like a filing cabinet. 3-5 words.")
+        assert "You name chat sessions" not in system_message  # built-in not in play
+
+    def test_custom_prompt_keeps_language_match_rule(self):
+        """With no pinned language, the match-user rule is appended to a
+        custom prompt so language handling doesn't silently regress."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Some Title"
+            return resp
+
+        cfg = {"auxiliary": {"title_generation": {"prompt": "My custom titler."}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("hello")
+
+        assert "same language as the user's message" in captured["messages"][0]["content"]
+
+    def test_custom_prompt_respects_pinned_language(self):
+        """A pinned language overrides the match-user rule, even with a
+        custom prompt — the pin is a config-level contract."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Titre en Français"
+            return resp
+
+        cfg = {"auxiliary": {"title_generation": {"prompt": "My custom titler.", "language": "French"}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("fix the bug")
+
+        system_message = captured["messages"][0]["content"]
+        assert "Write the title in French." in system_message
+        assert "same language as the user's message" not in system_message
+
+    def test_custom_prompt_strips_leftover_placeholder(self):
+        """Copy-pasting the built-in template into config leaves a bare
+        __LANGUAGE_RULE__ line behind; it must not ship to the model."""
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Some Title"
+            return resp
+
+        cfg = {"auxiliary": {"title_generation": {"prompt": "Custom rules.\n__LANGUAGE_RULE__"}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("hello")
+
+        assert "__LANGUAGE_RULE__" not in captured["messages"][0]["content"]
 
     def test_default_timeout_delegates_to_auxiliary_config(self):
         captured_kwargs = {}

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -44,6 +44,8 @@ def test_title_generation_present_in_default_config():
     assert tg["prefer_fast_model"] is False
     assert tg["timeout"] > 0
     assert tg["extra_body"] == {}
+    assert tg["language"] == ""
+    assert tg["prompt"] == ""
 
 
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -165,6 +165,21 @@ auxiliary:
 
 When `fallback_chain` is absent, `auto` uses the top-level `fallback_providers` chain before the built-in auxiliary discovery chain.
 
+### Customizing the session-title prompt
+
+By default titles are produced with a built-in prompt tuned for short, findable, sentence-case names. If you want your titles to follow a house style (a different length, tone, or naming convention), set a custom system prompt for the task. It fully replaces the built-in text as the titling model's system message:
+
+```yaml
+auxiliary:
+  title_generation:
+    prompt: |
+      You name chat sessions. Keep titles under 4 words, title case, and
+      lead with the project or component name when the message names one.
+      Reply with JSON only: {"title": "..."}
+```
+
+Leave `prompt` empty (the default) to keep the built-in template. The pinned `language` still applies on top of a custom prompt — set `auxiliary.title_generation.language` to force a language, or leave it empty to match the user's message. A custom prompt that forgets the `{"title": "..."}` JSON contract will still work via the parser's fallbacks, but the cleanest results come from keeping the "reply with JSON only" instruction.
+
 ## Per-provider request options
 
 Provider entries (`providers.<name>` in the `providers:` dict, or items in the legacy `custom_providers` list) accept two knobs that shape how Hermes talks to the endpoint:


### PR DESCRIPTION
## What

You can configure everything about session-title generation except the one thing that actually shapes the output: the prompt. Provider, model, timeout, language — all knobs. The prompt itself was hardcoded in `title_generator.py`.

So if your titles follow a house style (shorter names, title case, "lead with the project name", whatever you do in other tools), there was no way to say that. This adds `auxiliary.title_generation.prompt`.

```yaml
auxiliary:
  title_generation:
    prompt: |
      You name chat sessions. Keep titles under 4 words, title case, and
      lead with the project name when the message names one.
      Reply with JSON only: {"title": "..."}
```

Empty (the default) = built-in template. No behavior change unless you set it.

## Why this came up

I run Hermes desktop for a lot of different work and the sidebar titles are how I find sessions later. The built-in prompt is genuinely well-made — but "3-7 words, sentence case" is a style opinion, and I have my own. The natural thing was to copy the template out of the source and edit it, and then I realized that edit would be silently clobbered on the next update, and nobody else without source access has that lever at all.

## Design choices, since the small ones matter here

- **The `language` pin still wins over a custom prompt.** It's a config-level contract, not template decoration — a custom prompt shouldn't be able to silently regress language handling. When no language is pinned, the match-user rule gets appended to the custom text.
- **Fail open to the built-in.** Read through `load_config_readonly` with the same pattern as `_title_language()` / `_auto_title_enabled()`: a broken config falls back to the default template instead of killing titling.
- **Placeholder hygiene.** If someone copy-pastes the built-in template into config, a bare `__LANGUAGE_RULE__` line can survive. It gets stripped before the prompt ships, so the model never sees a raw placeholder.

I deliberately did *not* try to make the custom prompt support the `__LANGUAGE_RULE__` placeholder for insertion — append-only is simpler and the pin-wins rule above already covers the contract.

## Tests

6 new, all in `tests/agent/test_title_generator.py` (plus the `prompt` key asserted in the default-config test):

- config read / empty / broken-config fallback
- custom prompt arrives verbatim as the system message, built-in not in play
- match-user language rule appended when no pin
- pinned language overrides match-user with a custom prompt
- leftover `__LANGUAGE_RULE__` stripped

Full title + aux-config suite: **48 passed**.

## Docs

One section in `configuring-models.md`, right after the existing `title_generation` fallback-chain example.
