### PR TITLE
fix(vision): send keyless opencode-free headers on the async (vision) path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6259,6 +6259,24 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
+    # OpenCode Zen free tier: the keyless placeholder must never reach the
+    # wire on the async (vision) path either — the Zen relay serves free
+    # models anonymously but 401s any unrecognized bearer. Mirror
+    # _create_openai_client: override the SDK's Authorization header with an
+    # empty value whenever the sync client carries the keyless placeholder.
+    # This runs AFTER the base_url host matching above so the keyless headers
+    # win over any provider/attribution fallback that set default_headers.
+    try:
+        from hermes_cli.models import (
+            OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER,
+            opencode_zen_free_headers,
+        )
+        if sync_client.api_key == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER:
+            _keyless = dict(async_kwargs.get("default_headers") or {})
+            _keyless.update(opencode_zen_free_headers())
+            async_kwargs["default_headers"] = _keyless
+    except Exception:
+        pass
     _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"))
     if _merged_async:
         async_kwargs["default_headers"] = _merged_async

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4636,3 +4636,90 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+class TestOpenCodeFreeAsyncVisionClientKeyless:
+    """Regression for #94748: the async (vision) client for the keyless
+    opencode-free placeholder must blank the Authorization header so the SDK
+    never sends ``Bearer opencode-zen-free-keyless`` (the Zen relay 401s any
+    unrecognized bearer). The sync chokepoint (_create_openai_client) already
+    handled this; the async path (_to_async_client) did not.
+    """
+
+    ZEN_V1 = "https://opencode.ai/zen/v1"
+
+    def _fake_sync_client(self, api_key):
+        """A minimal OpenAI-shaped sync client, like the one
+        _create_openai_client returns (exposes .api_key and .base_url)."""
+        from openai import OpenAI
+
+        return OpenAI(api_key=api_key, base_url=self.ZEN_V1, max_retries=0)
+
+    def test_keyless_async_client_blanks_authorization(self):
+        """The AsyncOpenAI built from a keyless sync client carries an empty
+        Authorization default header, so the placeholder never reaches the
+        wire as a bearer."""
+        from agent import auxiliary_client as ac
+        from hermes_cli.models import OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+
+        captured: dict = {}
+
+        def _capture_async(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        sync_client = self._fake_sync_client(OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER)
+        # _to_async_client imports AsyncOpenAI locally (`from openai import
+        # AsyncOpenAI`), so patch the source module, not the aux module.
+        with patch("openai.AsyncOpenAI", side_effect=_capture_async):
+            async_client, model = ac._to_async_client(sync_client, "x-preview-f-free", is_vision=True)
+
+        headers = dict(captured.get("default_headers") or {})
+        assert headers.get("Authorization") == "", (
+            "async opencode-free keyless client must blank Authorization "
+            "so the SDK never sends 'Bearer opencode-zen-free-keyless'; "
+            f"got default_headers={headers!r}"
+        )
+
+    def test_keyless_async_client_still_attributable(self):
+        """Keyless async requests still identify as Hermes (attribution
+        headers mirror the opencode zen/go profiles)."""
+        from agent import auxiliary_client as ac
+        from hermes_cli.models import OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+
+        captured: dict = {}
+
+        def _capture_async(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        sync_client = self._fake_sync_client(OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER)
+        with patch("openai.AsyncOpenAI", side_effect=_capture_async):
+            ac._to_async_client(sync_client, "x-preview-f-free", is_vision=True)
+
+        headers = dict(captured.get("default_headers") or {})
+        assert headers.get("X-Title") == "Hermes Agent"
+        assert str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+
+    def test_keyed_providers_unchanged(self):
+        """The async path for providers with REAL API keys must be untouched —
+        no keyless Authorization blanking leaks to keyed providers."""
+        from agent import auxiliary_client as ac
+
+        captured: dict = {}
+
+        def _capture_async(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        sync_client = self._fake_sync_client("sk-real-key")
+        with patch("openai.AsyncOpenAI", side_effect=_capture_async):
+            ac._to_async_client(sync_client, "some-model")
+
+        headers = dict(captured.get("default_headers") or {})
+        # A real key should be sent as the SDK's bearer — we must NOT blank it.
+        assert captured.get("api_key") == "sk-real-key"
+        assert headers.get("Authorization") != "", (
+            "keyed providers must not have their Authorization blanked; "
+            f"got default_headers={headers!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes #94748. `vision_analyze` fails with `401 Invalid API key` on the keyless `opencode-free` provider (OpenCode Zen free tier).

The sync client chokepoint (`_create_openai_client`) already blanks the `Authorization` header for the keyless placeholder so the SDK never sends `Bearer opencode-zen-free-keyless`. But the async counterpart (`_to_async_client`) did **not** — it passed the placeholder `api_key` straight to `AsyncOpenAI`, so every async vision call sent `Bearer opencode-zen-free-keyless`, which the Zen relay rejects with 401 (it serves free models anonymously and 401s any unrecognized bearer).

This mirrors the existing sync-path handling on the async path.

## Changes

- `agent/auxiliary_client.py` (`_to_async_client`): when the sync client carries the keyless placeholder (`OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER`), override `default_headers` with `opencode_zen_free_headers()` so the `Authorization` header is blanked on the async client too. Runs **after** the base-url host matching so the keyless headers win over any provider/attribution fallback that set `default_headers`. Providers with real API keys are untouched.

## Tests

- Added `TestOpenCodeFreeAsyncVisionClientKeyless` in `tests/agent/test_auxiliary_client.py`:
  - keyless async client blanks `Authorization` (so no `Bearer opencode-zen-free-keyless` reaches the wire)
  - keyless async requests still carry Hermes attribution headers
  - providers with real API keys are unchanged (bearer not blanked)
- Focused tests: `3 passed`
- Regression proven: reverting the fix makes `test_keyless_async_client_blanks_authorization` fail (Authorization header ends up `None`, placeholder would be sent as bearer); with the fix all 3 pass.

Closes #94748
