### PR TITLE
fix(tools): treat around_message_id=0 as unset in session_search mode inference

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -388,6 +388,47 @@ class TestScrollPattern:
         assert last_id in [m["id"] for m in v1["messages"]]
         assert last_id in [m["id"] for m in v2["messages"]]
 
+    def test_scroll_zero_anchor_falls_through_to_read(self, db):
+        """#94792: around_message_id=0 is the schema zero-value, not an
+        anchor — message ids come from an AUTOINCREMENT primary key and
+        start at 1. Models that fill the complete argument object send 0
+        for every read; treating it as set hijacked the scroll branch and
+        failed 100% of the time, so 0 must count as unset."""
+        db.create_session("s_zero", source="cli")
+        for i in range(3):
+            db.append_message("s_zero", role="user", content=f"zero msg {i}")
+
+        result = json.loads(session_search(
+            session_id="s_zero", around_message_id=0, window=2, db=db
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "read"
+        # The full zero-filled schema shape still reads, matching how
+        # query="" / profile="" are already tolerated as empty.
+        full = dict(
+            around_message_id=0, detail="adaptive", limit=3, profile="",
+            query="", role_filter="user,assistant", session_id="s_zero",
+            sort="newest", window=5,
+        )
+        full_result = json.loads(session_search(db=db, **full))
+        assert full_result["success"] is True
+        assert full_result["mode"] == "read"
+
+    def test_scroll_positive_anchor_still_scrolls(self, db):
+        """The zero-tolerance must not eat real anchors: a positive id
+        keeps selecting the scroll shape."""
+        db.create_session("s_pos", source="cli")
+        ids = []
+        for i in range(5):
+            ids.append(db.append_message("s_pos", role="user", content=f"pos {i}"))
+
+        result = json.loads(session_search(
+            session_id="s_pos", around_message_id=ids[2], window=2, db=db
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "scroll"
+        assert ids[2] in [m["id"] for m in result["messages"]]
+
 
 # =========================================================================
 # Shape precedence

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -429,6 +429,23 @@ class TestScrollPattern:
         assert result["mode"] == "scroll"
         assert ids[2] in [m["id"] for m in result["messages"]]
 
+    def test_scroll_string_anchor_still_scrolls(self, db):
+        """Review on #94801: _scroll coerces string anchors (\"4408\"
+        scrolls on main), so the zero-anchor gate must coerce before
+        comparing — a naive `> 0` on the raw value raised TypeError and
+        broke every string-anchor scroll."""
+        db.create_session("s_str", source="cli")
+        ids = []
+        for i in range(3):
+            ids.append(db.append_message("s_str", role="user", content=f"str {i}"))
+
+        result = json.loads(session_search(
+            session_id="s_str", around_message_id=str(ids[1]), window=2, db=db
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "scroll"
+        assert ids[1] in [m["id"] for m in result["messages"]]
+
 
 # =========================================================================
 # Shape precedence

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -990,7 +990,18 @@ def _session_search_impl(
             current_session_id = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
-    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+    # The anchor gate checks for a POSITIVE integer: message ids come from
+    # an AUTOINCREMENT primary key and start at 1, so 0 can never be a
+    # valid anchor — yet models that fill the complete schema with zero
+    # values send around_message_id=0 for every read, hijacking the scroll
+    # branch and failing 100% of the time ("0 not in session_id") until
+    # same_tool_failure_halt fires. Treat 0 like every other empty field
+    # (query="", profile="") is already treated: as unset (#94792).
+    if (
+        (isinstance(session_id, str) and session_id.strip())
+        and around_message_id is not None
+        and around_message_id > 0
+    ):
         return _scroll(
             db=db,
             session_id=session_id,

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -990,17 +990,23 @@ def _session_search_impl(
             current_session_id = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
-    # The anchor gate checks for a POSITIVE integer: message ids come from
-    # an AUTOINCREMENT primary key and start at 1, so 0 can never be a
-    # valid anchor — yet models that fill the complete schema with zero
-    # values send around_message_id=0 for every read, hijacking the scroll
-    # branch and failing 100% of the time ("0 not in session_id") until
+    # The anchor gate checks for a POSITIVE id: message ids come from an
+    # AUTOINCREMENT primary key and start at 1, so 0 can never be a valid
+    # anchor — yet models that fill the complete schema with zero values
+    # send around_message_id=0 for every read, hijacking the scroll branch
+    # and failing 100% of the time ("0 not in session_id") until
     # same_tool_failure_halt fires. Treat 0 like every other empty field
     # (query="", profile="") is already treated: as unset (#94792).
+    # Coerce before comparing (same semantics as _scroll itself): string
+    # anchors like "4408" scroll successfully today and must keep doing so.
+    try:
+        _anchor_ok = int(around_message_id) > 0
+    except (TypeError, ValueError):
+        _anchor_ok = False
     if (
         (isinstance(session_id, str) and session_id.strip())
         and around_message_id is not None
-        and around_message_id > 0
+        and _anchor_ok
     ):
         return _scroll(
             db=db,


### PR DESCRIPTION
## What does this PR do?

`session_search` infers its mode from which arguments are set. The scroll gate used `around_message_id is not None`, so `0` counted as **set** — but message ids come from an `AUTOINCREMENT` primary key and start at `1`, so 0 can never be a valid anchor. Models that emit the complete argument object fill every optional field with its zero value (`query=""`, `profile=""`, `role_filter=""` … `around_message_id=0`); every other empty field is tolerated, but the zero anchor hijacked the scroll branch and failed **100% of the time** with `around_message_id 0 not in session_id` — an error that never says to omit the parameter, so the agent retried the identical shape until `same_tool_failure_halt` fired. A client filling the full schema could use discovery/browse (`session_id=""` is handled) but could never reach read mode (#94792).

The fix gates the scroll shape on a **positive** anchor:

```python
if (
    (isinstance(session_id, str) and session_id.strip())
    and around_message_id is not None
    and around_message_id > 0
):
```

`around_message_id=0` now falls through to the read shape like every other zero-valued field, and a real (positive) anchor keeps selecting scroll. Same-line symmetry restored: `session_id` normalizes empties away, and so does the anchor.

## Related Issue

Fixes #94792

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py` — the scroll-shape gate additionally requires `around_message_id > 0`, with a comment stating the AUTOINCREMENT-starts-at-1 invariant and the zero-filled-schema failure mode.
- `tests/tools/test_session_search.py` — two regressions: a zero anchor (bare and inside the verbatim full zero-filled schema from the issue) lands in read mode; a positive anchor still selects scroll with the anchor in the window.

## How to Test

1. `pytest tests/tools/test_session_search.py -q` — should pass (55 passed).
2. Observed result: with this PR's source reverted, the zero-anchor test fails — the call returns `success: False, error: around_message_id 0 not in session_id ...` in scroll mode; with the change it returns `success: True, mode: read`, and positive anchors still scroll.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue (before, verbatim tool payloads from the session store):

```
1) around_message_id=0, session_id=<sid>     → success: False  error: around_message_id 0 not in session_id <sid>
2) same payload minus around_message_id      → success: True   mode: read
3) around_message_id=0, session_id=""        → success: True   mode: browse   # "" handled, 0 not
```

Five consecutive runs of the same prompt: every one hit the anchor failure and ended in a `same_tool_failure_halt` guardrail stop.
