### PR TITLE
fix(desktop): keep open chats current after reconnect

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -859,6 +859,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     onGatewayReady: g => {
       gatewayRef.current = g
     },
+    refreshActiveTranscript,
     refreshHermesConfig,
     refreshSessions
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -203,13 +203,19 @@ function fakeDesktop() {
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  refreshActiveTranscript,
   refreshSessions
-}: { beforeConnectionSwitch?: () => void; refreshSessions?: () => Promise<void> } = {}) {
+}: {
+  beforeConnectionSwitch?: () => void
+  refreshActiveTranscript?: () => Promise<void>
+  refreshSessions?: () => Promise<void>
+} = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
+    refreshActiveTranscript: refreshActiveTranscript ?? (async () => undefined),
     refreshHermesConfig: async () => undefined,
     refreshSessions: refreshSessions ?? (async () => undefined)
   })
@@ -450,8 +456,14 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
   })
 
   it('FIX: a successful reconnect after a prolonged drop restores the open gateway', async () => {
-    render(<Harness />)
+    const refreshActiveTranscript = vi.fn(async () => undefined)
+
+    render(<Harness refreshActiveTranscript={refreshActiveTranscript} />)
     await flushAsync()
+
+    // Cold boot hydrates through the normal resume path. This backstop is only
+    // for a socket that actually disconnected.
+    expect(refreshActiveTranscript).not.toHaveBeenCalled()
 
     FakeWebSocket.mode = 'fail'
     act(() => FakeWebSocket.instances[0].drop())
@@ -469,6 +481,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+    expect(refreshActiveTranscript).toHaveBeenCalledOnce()
   })
 
   it('a getConnection() that hangs on reconnect does not permanently latch the backoff loop (#93454)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -144,6 +144,7 @@ interface GatewayBootOptions {
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
+  refreshActiveTranscript: () => Promise<unknown> | unknown
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
 }
@@ -153,6 +154,7 @@ export function useGatewayBoot({
   handleGatewayEvent,
   onConnectionReady,
   onGatewayReady,
+  refreshActiveTranscript,
   refreshHermesConfig,
   refreshSessions
 }: GatewayBootOptions) {
@@ -161,6 +163,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    refreshActiveTranscript,
     refreshHermesConfig,
     refreshSessions
   })
@@ -170,6 +173,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    refreshActiveTranscript,
     refreshHermesConfig,
     refreshSessions
   }
@@ -332,6 +336,11 @@ export function useGatewayBoot({
         // Resync state that may have moved on the backend while we were asleep.
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
+        // sessions.changed is an invalidation edge, not a replayable log. A
+        // write from cron, CLI, or another surface can land while this socket
+        // is down, so the open transcript needs the same reconnect reseed as
+        // the sidebar instead of waiting indefinitely for another write.
+        await Promise.resolve(callbacksRef.current.refreshActiveTranscript()).catch(() => undefined)
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
         // again" recovery overlay once instead of silently looping the backoff


### PR DESCRIPTION
## What does this PR do?

Desktop now refreshes the currently open transcript after its gateway WebSocket reconnects. If another Hermes surface wrote to that session while Desktop was disconnected, the conversation no longer remains stale until the user reopens it or another write happens.

### Symptom

An open non-messaging Desktop conversation can remain stale indefinitely after a WebSocket disconnect if its only `sessions.changed` invalidation was emitted during the outage. Reconnect refreshes the session list, but the visible transcript previously stayed unchanged.

### Impact

People using Desktop alongside cron, CLI, peer DM, or another client can keep reading an outdated conversation after connectivity recovers. The blast radius beyond active Desktop sessions that receive external writes during a disconnect is unknown.

### Bug Cause

**Trigger:** `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts:attemptReconnect` after `gateway.connect()` succeeds.

**Causal chain:**
1. Another Hermes surface persists messages while the Desktop WebSocket is disconnected.
2. The non-replayable `sessions.changed` event is lost, and reconnect only calls `refreshHermesConfig()` and `refreshSessions()`.
3. The sidebar reflects backend state again, but the separately cached active transcript never reconciles and remains stale.

**Why it is wrong:** The renderer treats backend data as cached truth, but the reconnect reseed omitted the active transcript cache even though its invalidation channel cannot replay missed events.

**Working sibling / contrast:** A delivered `sessions.changed` event already calls the active transcript reconciliation path, and messaging sessions retain a periodic transcript backstop. The missing path is specifically a successfully reconnected socket that lost the event.

**Ruled out:** Refreshing only the session list cannot fix this because the visible transcript lives in the session-state cache and is hydrated by `reconcileActiveTranscript`, not by list replacement.

### Fix

Pass the existing active transcript reconciler into the gateway boot hook and invoke it after the session list refresh completes on a successful reconnect. The existing reconciler preserves busy-stream and stale-response guards, performs signature-based no-op suppression, and keeps cold boot behavior unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` - reseed the active transcript after a successful reconnect.
- `apps/desktop/src/app/contrib/wiring.tsx` - provide the existing transcript reconciler to the reconnect owner.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` - prove cold boot performs no extra read and a dropped then restored socket refreshes exactly once.

## How to Test

1. Run the focused reconnect and transcript-sync tests.
2. Confirm the successful reconnect test fails when the transcript reseed call is removed and passes when restored.
3. Run Desktop renderer typechecking and ESLint on the changed files.

```bash
cd apps/desktop
npx vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx src/app/contrib/hooks/use-background-sync.test.ts
npx tsc -p . --noEmit
npx eslint src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx src/app/contrib/wiring.tsx
```

Result: 40 tests passed; TypeScript and ESLint completed with no errors.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test entry and all affected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation N/A: no user-facing behavior or configuration contract changed
- [x] `cli-config.yaml.example` N/A: no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A: no architecture or workflow changed
- [x] Cross-platform impact considered: the renderer reconnect path is platform-neutral
- [x] Tool descriptions/schemas N/A: no model tool changed

## Screenshots / Logs

No visual UI changed. The focused fake-WebSocket regression test exercises the disconnect, prolonged retry, successful reconnect, and transcript refresh sequence.