### PR TITLE
fix(tools): treat around_message_id=0 as no anchor in session_search

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -413,6 +413,37 @@ class TestShapePrecedence:
         result = json.loads(session_search(session_id="s_oldest", db=db))
         assert result["mode"] == "read"
 
+    def test_zero_anchor_reads_instead_of_scrolling(self, db):
+        _seed_modpack_sessions(db)
+        # Message ids are AUTOINCREMENT rowids starting at 1, so 0 can never
+        # address a row. Clients that emit the full argument schema send
+        # around_message_id=0 to mean "unset" — the same way they send
+        # session_id="" — and must still land on the read shape.
+        result = json.loads(session_search(
+            session_id="s_oldest", around_message_id=0, db=db,
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "read"
+
+    def test_full_schema_zero_defaults_still_read(self, db):
+        _seed_modpack_sessions(db)
+        # The complete argument object a tool-calling model typically emits.
+        result = json.loads(session_search(
+            session_id="s_oldest", around_message_id=0, query="", profile="",
+            role_filter="", limit=3, sort="newest", window=5, db=db,
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "read"
+
+    def test_missing_anchor_error_says_how_to_recover(self, db):
+        _seed_modpack_sessions(db)
+        # A genuinely wrong anchor still errors, but actionably.
+        result = json.loads(session_search(
+            session_id="s_oldest", around_message_id=10**9, db=db,
+        ))
+        assert result["success"] is False
+        assert "omit around_message_id" in result["error"].lower()
+
 
 # =========================================================================
 # Read shape — dump a whole session by id (serves @session links)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -651,7 +651,9 @@ def _scroll(
 
     if not messages:
         return tool_error(
-            f"around_message_id {around_message_id} not in session_id {session_id}",
+            f"around_message_id {around_message_id} not in session_id {session_id}. "
+            "Omit around_message_id to read the whole session, or pass an id "
+            "returned by a previous discovery/scroll result.",
             success=False,
         )
 
@@ -990,7 +992,11 @@ def _session_search_impl(
             current_session_id = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
-    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+    # A falsy anchor is *no* anchor: message ids are AUTOINCREMENT rowids and
+    # start at 1, so 0 can never address a row. Clients that emit the full
+    # argument schema send around_message_id=0 to mean "unset" — the same way
+    # they send session_id="" — and must still reach the read shape below.
+    if (isinstance(session_id, str) and session_id.strip()) and around_message_id:
         return _scroll(
             db=db,
             session_id=session_id,


### PR DESCRIPTION
## What does this PR do?

`session_search` infers its shape from which arguments are set (#27590: "all modes inferred from which arguments are set… there is no mode parameter"). The scroll branch was gated on `around_message_id is not None`, while `session_id` on the same line was already normalised with `.strip()`. So `""` counted as *unset* but `0` counted as an *explicit anchor*.

`messages.id` is `INTEGER PRIMARY KEY AUTOINCREMENT`, so ids start at 1 and **0 can never address a row**. Clients that emit the complete argument schema — normal tool-calling behaviour — send `around_message_id=0` to mean "unset", exactly as they send `session_id=""`. Those clients could never reach the read shape: every attempt to read a specific session failed, and the agent looped on the identical call until `same_tool_failure_halt` fired (5/5 runs in the issue).

Two independent changes:

1. Gate scroll on a *usable* anchor, matching the `.strip()` treatment `session_id` already gets.
2. Make the anchor-miss error actionable — it previously said the id was wrong but never that the parameter could be omitted, which is why agents retried unchanged.

(1) removes the footgun; (2) makes any other bad anchor self-correcting. Either can be taken alone.

## Related Issue

Fixes #94792

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

Three regression tests added to `TestShapePrecedence`, next to the existing `test_scroll_args_beat_query` and `test_session_id_without_anchor_reads`:

- `test_zero_anchor_reads_instead_of_scrolling` — `around_message_id=0` lands on the read shape
- `test_full_schema_zero_defaults_still_read` — the complete argument object a model typically emits
- `test_missing_anchor_error_says_how_to_recover` — a genuinely wrong anchor still errors, but actionably

`tests/tools/test_session_search.py` run against the project venv:

```
source unpatched, tests applied  ->  3 failed, 53 passed
source patched,   tests applied  ->  56 passed
```

The three failures are exactly the new cases, so they fail for the right reason. No existing test changes behaviour — nothing that previously worked can have passed `0` as a valid anchor.
