### PR TITLE
fix(agent): block fuzzy remap of check_fn-gated tool names to siblings (#94506)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3500,7 +3500,10 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
        Claude-style models sometimes tack on (TodoTool_tool ->
        TodoTool -> Todo -> todo). Applied twice so double-tacked
        suffixes like ``TodoTool_tool`` reduce all the way.
-    5. Fuzzy match (difflib, cutoff=0.7).
+    5. Fuzzy match (difflib, cutoff=0.7) — but only when the input
+       name is NOT a real tool in the full registry. A tool that the
+       registry knows but ``check_fn`` gated for this turn must not be
+       remapped to a sibling (cross-operation remap, #94506).
 
     See #14784 for the original reports (TodoTool_tool, Patch_tool,
     BrowserClick_tool were all returning "Unknown tool" before).
@@ -3572,7 +3575,23 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         if c and c in agent.valid_tool_names:
             return c
 
-    # Fuzzy match as last resort.
+    # Fuzzy match as last resort — but only when the input name is NOT a
+    # real tool in the full registry.  A tool that the registry knows but
+    # check_fn gated for this turn was *intentionally* withheld; remapping
+    # it to a sibling (e.g. kanban_list → kanban_link) silently changes
+    # the operation — a cross-operation remap that can turn a read into a
+    # write or stall a board with no error (#94506).  Returning None lets
+    # the caller fall through to the normal "unknown tool" path so the
+    # model learns the name is unavailable here and can pick another
+    # approach.
+    try:
+        from tools.registry import registry as _tool_registry
+        _all_names = _tool_registry.get_all_tool_names()
+    except Exception:  # noqa: BLE001 — registry import best-effort
+        _all_names = []
+    if lowered in _all_names:
+        return None
+
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
     if matches:
         return matches[0]

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 VALID = {
     "todo",
     "patch",
@@ -51,11 +50,6 @@ class TestExistingBehaviorStillWorks:
         assert repair("browser_click") == "browser_click"
 
 
-
-
-
-
-
 class TestClassLikeEmissions:
     """Regression coverage for #14784 — CamelCase + _tool suffix variants."""
 
@@ -63,21 +57,11 @@ class TestClassLikeEmissions:
         assert repair("BrowserClick") == "browser_click"
 
 
-
-
-
-
-
-
-
 class TestEdgeCases:
     """Edge inputs that must not crash or produce surprising results."""
 
     def test_empty_string(self, repair):
         assert repair("") is None
-
-
-
 
 
 class TestVolcEngineXmlPollution:
@@ -100,12 +84,9 @@ class TestVolcEngineXmlPollution:
         assert repair(polluted) == "terminal"
 
 
-
-
     def test_tool_name_with_trailing_quote_only(self, repair):
         # Minimal leak — just a stray trailing quote, no full attribute.
         assert repair('terminal"') == "terminal"
-
 
 
     def test_clean_tool_name_unaffected_by_sanitizer(self, repair):
@@ -118,10 +99,80 @@ class TestVolcEngineXmlPollution:
         # legitimate ``"write file" -> write_file`` repair path breaks.
         assert repair("write file") == "write_file"
 
-
     def test_leading_quote_falls_through_to_fuzzy_match(self, repair):
         # Sanitizer only trims when the XML char is at idx > 0 — a
         # name that *starts* with a quote is left untouched so the
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+class TestCrossOperationRemapGuard:
+    """Regression for #94506: a tool name that the full registry knows
+    but check_fn gated for this turn must NOT be fuzzy-matched onto a
+    sibling tool.  Returning None lets the caller fall through to the
+    normal 'unknown tool' error path."""
+
+    def test_gated_tool_not_fuzzy_remappped_to_sibling(self, monkeypatch):
+        """kanban_list is in the registry but gated — must not remap to
+        kanban_link."""
+        from run_agent import AIAgent
+
+        # valid_tool_names excludes kanban_list (check_fn gated) but
+        # includes the nearby kanban_link.
+        stub = SimpleNamespace(valid_tool_names=VALID | {"kanban_link"})
+
+        # Mock the registry to return kanban_list as a known tool.
+        class _FakeRegistry:
+            def get_all_tool_names(self):
+                return sorted(VALID | {"kanban_list", "kanban_link",
+                                       "kanban_complete", "kanban_block"})
+
+        import tools.registry as _reg_mod
+        monkeypatch.setattr(_reg_mod, "registry", _FakeRegistry())
+
+        repair_fn = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+        # kanban_list is in the registry but not valid_tool_names —
+        # must NOT be remapped to kanban_link.
+        assert repair_fn("kanban_list") is None
+
+    def test_unknown_tool_still_fuzzy_matched(self, monkeypatch):
+        """A tool that is NEITHER in valid_tool_names NOR in the registry
+        should still be fuzzy-matched as before (e.g. a typo)."""
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names=VALID)
+
+        class _FakeRegistry:
+            def get_all_tool_names(self):
+                return sorted(VALID)
+
+        import tools.registry as _reg_mod
+        monkeypatch.setattr(_reg_mod, "registry", _FakeRegistry())
+
+        repair_fn = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+        # "brower_click" is a typo — fuzzy match should still find
+        # "browser_click".
+        assert repair_fn("brower_click") == "browser_click"
+
+    def test_registry_import_failure_falls_through_to_fuzzy(self, monkeypatch):
+        """If the registry import fails, the guard must not crash —
+        fall through to the normal fuzzy match."""
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names=VALID)
+
+        # Make the import fail.
+        import builtins
+        real_import = builtins.__import__
+
+        def _fail_tools_import(name, *args, **kwargs):
+            if name == "tools.registry":
+                raise ImportError("mocked failure")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fail_tools_import)
+
+        repair_fn = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+        # Should still fuzzy-match despite the import failure.
+        assert repair_fn("brower_click") == "browser_click"


### PR DESCRIPTION
## Problem

`repair_tool_call()`'s step-5 fuzzy fallback (`difflib.get_close_matches` cutoff=0.7) remaps a tool name that the registry knows but `check_fn` withheld for this turn onto a different, available tool. A read intent can become a write.

**Example:** kanban workers call `kanban_list`, which `_check_kanban_orchestrator_mode` deliberately hides. The name is absent from `agent.valid_tool_names`, steps 1–4 don't match, and step 5 resolves it to the nearest sibling — `kanban_link`. If `kanban_link`'s arguments happen to validate, the board silently draws a parent→child dependency edge and stalls with no error anywhere.

## Fix

Before the fuzzy match fallback, check if the input name is a real tool in the full tool registry. If so, it was intentionally gated by `check_fn` — return `None` so the caller falls through to the normal "unknown tool" error path. The model learns the name is unavailable and can pick another approach.

Guard is best-effort: if the registry import fails, fall through to normal fuzzy matching (no crash).

## Tests

3 new cases in `TestCrossOperationRemapGuard`:
- **gated tool not fuzzy remapped to sibling** — `kanban_list` (registry-known, check_fn-gated) must not become `kanban_link`
- **unknown tool still fuzzy matched** — typos like `brower_click` still resolve to `browser_click`
- **registry import failure fallback** — import error doesn't crash, falls through to fuzzy

All 11 tests pass. No regressions in existing repair behavior.

Fixes #94506