### PR TITLE
fix(env): strip MSL noise from streamed subprocess output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# hermes-agent
+
+macOS 27 (Tahoe) beta injects `MallocStackLogging` (and
+`MallocStackLoggingNoCompact`) into GUI-session process environments, and
+the beta enables "lite mode" malloc stack logging on mere presence of the
+variable (value ignored, even `"no"`). Every spawned subprocess then
+emits two `comm(pid) MallocStackLogging: …` lines to stderr — which
+Hermes merges into stdout. Without intervention those lines contaminate:
+
+- Terminal-tool captures (cat/sha256sum/wc output)
+- `read_file` line-numbered output (the `N|` gutter prefix)
+- The `sha256` post-write verification in `file_operations` (noise
+  appended after the payload → false `Post-write verification failed`)
+- Anything else that ingests subprocess stdout
+
+## Defense layers
+
+Three layers, each closes a different leak path. **All three are required.**
+
+1. **Streaming strip inside `_wait_for_process._drain()`**
+   (`tools/environments/base.py`, `_MslStreamStripper`) — line-buffered
+   stripper that runs in all three drain branches (POSIX select, Windows
+   blocking, iterable fallback). MSL never enters the bounded collector,
+   so the 40/60 head/tail budget stays intact for real output. Fast path
+   skips the regex when `"MallocStackLogging"` is absent in `carry +
+   chunk`. **Primary defense; must remain the first to touch the bytes.**
+
+2. **`strip_malloc_stack_logging` post-capture**
+   (`tools/environments/base.py`, end of `BaseEnvironment.execute()`) —
+   safety net for any path that bypasses `_drain()` (custom subprocess
+   adapters, file-ops `cat`, code-exec RPC). Idempotent and cheap.
+
+3. **Hook subprocess strip** (`agent/shell_hooks.py`, after
+   `proc.communicate()` in `_spawn`) — hook scripts bypass
+   `BaseEnvironment.execute()` entirely; their stdout/stderr flows back
+   to the model unfiltered unless stripped at this boundary.
+
+## When adding new subprocess or capture code
+
+- Anything that calls `subprocess.Popen`/`subprocess.run` and captures
+  stdout/stderr must go through `BaseEnvironment.execute()` OR strip MSL
+  itself via `tools.environments.base.strip_malloc_stack_logging`.
+- Anything that bypasses the bounded collector (unbounded capture,
+  custom adapter, async stream) needs to run its own line-buffered
+  `_MslStreamStripper` to keep MSL from evicting real output.
+- Do NOT add a fourth post-strip in `execute()` thinking "more is
+  better" — the existing Layer 2 is already redundant with Layer 1;
+  adding another just costs regex time.
+
+## When adding new tests for MSL
+
+`tests/tools/test_base_environment.py::TestStripMallocStackLogging` is
+the regex-matrix gate; `::TestMslStreamStripper` covers carry/flush/fast
+path; `::TestMslDoesNotEvictRealTail` is the direct regression for the
+"every tool call failed" symptom (real payload + 30 KB MSL flood → both
+sentinels survive). Keep all three.

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -614,6 +614,21 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         result["error"] = str(exc)
         return result
 
+    # macOS libmalloc lite-mode MallocStackLogging noise leaks through to the
+    # model here: this hook subprocess bypasses ``BaseEnvironment.execute()``
+    # so the streaming stripper in ``_wait_for_process._drain()`` never sees
+    # the bytes. Strip at this boundary — matches the capture-end strip in
+    # ``tools/environments/base.py`` and is the only place hook output reaches
+    # the model unfiltered.
+    try:
+        from tools.environments.base import strip_malloc_stack_logging
+        if stdout:
+            stdout = strip_malloc_stack_logging(stdout)
+        if stderr:
+            stderr = strip_malloc_stack_logging(stderr)
+    except Exception:
+        pass
+
     result["returncode"] = proc.returncode
     result["stdout"] = stdout or ""
     result["stderr"] = stderr or ""

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -279,6 +279,33 @@ class TestCallbackSubprocess:
         result = cb(tool_name="write_file", args={"content": "danger"})
         assert result == {"action": "modify", "args": {"content": "safe"}}
 
+    def test_msl_noise_stripped_from_hook_stdout(self, tmp_path):
+        """Hook subprocess bypasses BaseEnvironment.execute — strip MSL here.
+
+        macOS 27 libmalloc lite-mode noise leaks through the hook's Popen
+        path and would otherwise flow back to the model unfiltered. The
+        capture-end strip in ``tools/environments/base.py`` never sees
+        these bytes, so ``shell_hooks._spawn`` must strip on the way out.
+        """
+        script = _write_script(
+            tmp_path, "msl_hook.sh",
+            "#!/usr/bin/env bash\n"
+            "echo 'real hook payload'\n"
+            "echo 'libsystem_malloc(42) MallocStackLogging: lite mode' >&2\n"
+            "echo 'another real line'\n",
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="post_tool_call", command=str(script),
+        )
+        cb = shell_hooks._make_callback(spec)
+        cb(tool_name="terminal", args={"command": "ls"})  # ensure register path runs
+
+        spawn_result = shell_hooks._spawn(spec, stdin_json="")
+        assert "MallocStackLogging" not in spawn_result.get("stdout", "")
+        assert "MallocStackLogging" not in spawn_result.get("stderr", "")
+        assert "real hook payload" in spawn_result["stdout"]
+        assert "another real line" in spawn_result["stdout"]
+
 
 # ── config parsing ────────────────────────────────────────────────────────
 

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -7,6 +7,7 @@ init_session() failure handling, and the CWD marker contract.
 from unittest.mock import MagicMock
 
 from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
+from tools.environments.base import _MslStreamStripper, strip_malloc_stack_logging
 
 
 class _TestableEnv(BaseEnvironment):
@@ -470,3 +471,175 @@ class TestSanitizeTaskIdForPath:
         )
         target.mkdir(parents=True)
         assert target.is_dir()
+
+
+class TestStripMallocStackLogging:
+    """Regex coverage for the post-capture MSL strip."""
+
+    def test_bare_msl_line_is_removed(self):
+        text = "before\nMallocStackLogging: lite mode\nafter\n"
+        out = strip_malloc_stack_logging(text)
+        assert "MallocStackLogging" not in out
+        assert out.startswith("before")
+        assert out.endswith("after\n")
+
+    def test_gutter_only_form_is_removed(self):
+        # ``read_file`` prepends an ``N|`` line-number gutter; the stripper
+        # must handle this prefix too.
+        text = "1|real line\n2|MallocStackLogging: lite mode\n3|more\n"
+        out = strip_malloc_stack_logging(text)
+        assert "MallocStackLogging" not in out
+        assert "1|real line" in out
+        assert "3|more" in out
+        # The MSL row should leave NO orphan blank line behind.
+        assert "2|\n" not in out
+
+    def test_comm_pid_prefix_form_is_removed(self):
+        text = "ok\nlibsystem_malloc(42) MallocStackLogging: enabled\nbye\n"
+        out = strip_malloc_stack_logging(text)
+        assert "MallocStackLogging" not in out
+        assert out.startswith("ok\n")
+        assert out.endswith("bye\n")
+
+    def test_gutter_plus_comm_pid_is_removed(self):
+        text = "1|hello\n2|libmalloc(99) MallocStackLogging: region\n3|world\n"
+        out = strip_malloc_stack_logging(text)
+        assert "MallocStackLogging" not in out
+        assert "1|hello" in out
+        assert "3|world" in out
+
+    def test_high_line_number_gutter_within_seven_digits(self):
+        text = "1234567|real\n"
+        out = strip_malloc_stack_logging(text)
+        assert out == text
+
+    def test_multiline_msl_payload_is_stripped(self):
+        text = (
+            "header\n"
+            "MallocStackLogging: region 0x7f8b1c000000\n"
+            "MallocStackLogging:  - 0xdeadbeef  libc++abi.dylib\n"
+            "footer\n"
+        )
+        out = strip_malloc_stack_logging(text)
+        assert "MallocStackLogging" not in out
+        assert "header" in out
+        assert "footer" in out
+        # No leftover blank lines from stripped rows.
+        assert "\n\n\n" not in out
+
+    def test_msl_embedded_in_real_output(self):
+        text = "alpha\nMallocStackLogging: x\nbeta\n"
+        out = strip_malloc_stack_logging(text)
+        assert out == "alpha\nbeta\n"
+
+    def test_no_msl_is_passthrough(self):
+        text = "no\nmsl\nhere\n"
+        out = strip_malloc_stack_logging(text)
+        assert out == text
+
+    def test_empty_input(self):
+        assert strip_malloc_stack_logging("") == ""
+
+
+class TestMslStreamStripper:
+    """Streaming stripper that runs inside ``_wait_for_process._drain()``."""
+
+    def test_clean_chunk_passes_through_unchanged(self):
+        s = _MslStreamStripper()
+        assert s.feed("hello world\n") == "hello world\n"
+
+    def test_msl_in_middle_of_chunk_is_stripped(self):
+        s = _MslStreamStripper()
+        out = s.feed("alpha\nMallocStackLogging: x\nbeta\n")
+        assert "MallocStackLogging" not in out
+        assert out.startswith("alpha\n")
+        assert out.endswith("beta\n")
+
+    def test_msl_split_across_two_chunks_is_still_stripped(self):
+        # The carry must bridge the partial trailing line across the read
+        # boundary so the regex sees a complete MSL row. The first chunk
+        # emits only the line BEFORE the MSL row (the MSL row is held in
+        # carry because it doesn't end in a newline yet). The second chunk
+        # completes the MSL row — only then does the regex match and
+        # strip it, leaving only the real output that follows.
+        s = _MslStreamStripper()
+        first = s.feed("alpha\nMallocStackLogging: li")
+        assert "MallocStackLogging" not in first  # partial MSL held in carry
+        assert first == "alpha\n"
+        second = s.feed("te mode\nbeta\n")
+        assert "MallocStackLogging" not in first + second
+        assert second == "beta\n"  # MSL row stripped; real payload after it survives
+
+    def test_partial_trailing_line_held_until_next_chunk(self):
+        s = _MslStreamStripper()
+        # No terminating newline -> the trailing partial stays in carry.
+        assert s.feed("real output, no newline") == ""
+        # Next chunk completes the line; the previous partial is prepended.
+        assert s.feed(" and more\n") == "real output, no newline and more\n"
+
+    def test_flush_emits_held_carry(self):
+        s = _MslStreamStripper()
+        s.feed("dangling line, no newline")
+        assert s.flush() == "dangling line, no newline"
+
+    def test_flush_emits_nothing_when_empty(self):
+        assert _MslStreamStripper().flush() == ""
+
+    def test_fast_path_skips_regex_on_clean_input(self):
+        # When ``MallocStackLogging`` is absent, the stripper must not
+        # allocate the regex engine. We can't directly observe the skip,
+        # but we can verify correctness with a payload large enough to
+        # prove the fast path would diverge if it ran the regex (the
+        # regex's MULTILINE+anchored behavior is fine, but ``feed`` should
+        # still pass it through verbatim).
+        big = ("clean line of output, nothing to see here\n" * 5000)
+        s = _MslStreamStripper()
+        assert s.feed(big) == big
+        assert s.flush() == ""
+
+    def test_repeated_calls_keep_state_consistent(self):
+        s = _MslStreamStripper()
+        out = "".join(
+            s.feed(chunk)
+            for chunk in [
+                "MallocStackLogging: a\n",
+                "between\n",
+                "MallocStackLogging: b\n",
+                "tail",
+            ]
+        ) + s.flush()
+        assert "MallocStackLogging" not in out
+        assert "between" in out
+        assert out.endswith("tail")
+
+
+class TestMslDoesNotEvictRealTail:
+    """Regression test for the user's 'truncation breaks every tool' failure.
+
+    Feeds a small real payload followed by a 30 KB MSL flood through the
+    stripper into the bounded collector. Without Layer 1, the flood would
+    evict the real payload's tail. With it, both sentinels survive and no
+    truncation marker is emitted.
+    """
+
+    def test_real_payload_survives_msl_flood(self):
+        real = "HEAD-SENTINEL\n" + ("real payload line\n" * 5) + "TAIL-SENTINEL\n"
+        # Simulate the streaming stripper + collector pipeline.
+        stripper = _MslStreamStripper()
+        collector = _BoundedOutputCollector(2_000)
+        collector.append(stripper.feed(real))
+        # Flood with MSL noise — much larger than the head/tail budget.
+        flood = (
+            "MallocStackLogging: region 0x7f8b1c000000\n"
+            "MallocStackLogging:  - 0xdeadbeef  libc++abi.dylib\n"
+        ) * 5_000
+        collector.append(stripper.feed(flood))
+        carried = stripper.flush()
+        if carried:
+            collector.append(carried)
+
+        rendered = collector.render()
+        assert "HEAD-SENTINEL" in rendered
+        assert "TAIL-SENTINEL" in rendered
+        assert "[OUTPUT TRUNCATED" not in rendered
+        assert "MallocStackLogging" not in rendered

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -52,6 +52,106 @@ _activity_callback_local = threading.local()
 # path for both bounded and unbounded modes.
 _UNBOUNDED_CAPTURE_CHARS = 2**63 - 1
 
+# macOS 27 libmalloc lite-mode spam. Presence of MallocStackLogging (value
+# ignored) makes every spawned process emit ``comm(pid) MallocStackLogging: …``
+# on stderr. Hermes merges stderr into stdout, so those lines contaminate
+# ``cat``/``sha256sum``/``wc`` captures and produce spurious post-write
+# verification failures. Strip at the capture boundary so file ops and the
+# terminal tool both see clean payloads. Optional ``N|`` prefix covers
+# read_file's line-numbered gutter. Idempotent. ``comm(pid)`` and the gutter
+# are independently optional so ``MallocStackLogging:`` (bare) and
+# ``1234|MallocStackLogging:`` (gutter-only) both match. Gutter cap raised to
+# 7 digits to cover file contents with > 999_999 lines.
+_MSL_LINE_RE = re.compile(
+    r"^(?:\d{1,7}\|)?(?:[A-Za-z0-9_.+\-]+\(\d+\) )?MallocStackLogging:[^\n]*\n?",
+    re.MULTILINE,
+)
+
+
+def strip_malloc_stack_logging(text: str) -> str:
+    """Remove macOS 27 MallocStackLogging stderr lines from captured output."""
+    if not text or "MallocStackLogging" not in text:
+        return text
+    return _MSL_LINE_RE.sub("", text)
+
+
+class _MslStreamStripper:
+    """Strip MallocStackLogging lines from streamed subprocess output.
+
+    The capture-boundary ``strip_malloc_stack_logging`` runs at
+    ``BaseEnvironment.execute()`` end — too late: MSL emitted at process exit
+    floods the tail buffer of the bounded collector, evicting real payload
+    before the strip can run. Stripping during the drain loop keeps MSL out
+    of the collector entirely, so the 40/60 head/tail budget stays intact
+    for real output.
+
+    Line-buffered: any partial trailing line from the previous chunk is
+    held in ``_carry`` and prepended to the next chunk so MSL split across
+    4 KB read boundaries still gets matched. ``flush()`` emits any held
+    carry on EOF.
+
+    Fast path: when ``"MallocStackLogging"`` is not in ``carry + chunk``,
+    the regex is skipped entirely — zero cost on healthy systems.
+
+    Assumes MSL lines always end with ``\\n`` (libmalloc always emits
+    newline-terminated lines in practice; the carry only needs to bridge
+    a partial line if it crossed a chunk boundary at that newline).
+    """
+
+    __slots__ = ("_carry",)
+
+    def __init__(self) -> None:
+        self._carry: str = ""
+
+    def feed(self, chunk: str) -> str:
+        if not chunk:
+            out = self._carry
+            self._carry = ""
+            return out
+
+        combined = self._carry + chunk
+
+        # Split off the trailing partial line (everything after the last
+        # newline) so the regex sees only complete lines. The partial is
+        # held for the next feed to handle MSL split across read
+        # boundaries.
+        if combined.endswith("\n"):
+            emit_combined = combined
+            trailing_partial = ""
+        else:
+            nl = combined.rfind("\n")
+            if nl == -1:
+                emit_combined = ""
+                trailing_partial = combined
+            else:
+                emit_combined = combined[: nl + 1]
+                trailing_partial = combined[nl + 1 :]
+
+        # Fast path: no MSL substring anywhere — emit the complete-lines
+        # portion unchanged and hold the partial.
+        if "MallocStackLogging" not in combined:
+            self._carry = trailing_partial
+            return emit_combined
+
+        # Slow path: run the regex on the complete-lines portion only
+        # (the partial is held back so it can be re-evaluated when the
+        # next chunk arrives).
+        cleaned = _MSL_LINE_RE.sub("", emit_combined)
+        self._carry = trailing_partial
+        return cleaned
+
+    def flush(self) -> str:
+        """Emit any held carry (call once at EOF)."""
+        carried = self._carry
+        self._carry = ""
+        if not carried:
+            return ""
+        if "MallocStackLogging" not in carried:
+            return carried
+        return _MSL_LINE_RE.sub("", carried)
+
+
+
 
 class EnvironmentConnectionError(RuntimeError):
     """Infrastructure/connection-class failure of a terminal backend.
@@ -955,6 +1055,21 @@ class BaseEnvironment(ABC):
             )
             parts.append(f"unset {present} {value}")
 
+        # macOS 27 (Tahoe) beta injects MallocStackLogging into GUI-session
+        # process environments, and the beta enables "lite mode" malloc stack
+        # logging on mere PRESENCE of the variable (value ignored, even
+        # "no").  Every spawned process then emits two MallocStackLogging
+        # lines to stderr — which we merge into stdout — corrupting captured
+        # command output, cat-based file reads, and the sha256 post-write
+        # verification in file_operations (noise appended after the payload
+        # → "Post-write verification failed" false negatives, and
+        # noise baked into files written from polluted reads).  Strip it so
+        # tool subprocesses run quiet; harmless elsewhere.
+        parts.append(
+            "unset MallocStackLogging MallocStackLoggingNoCompact 2>/dev/null || true"
+        )
+
+
         # Harness attribution: every tool subprocess advertises that it runs
         # under Hermes via the cross-agent ``AI_AGENT`` standard (read by e.g.
         # huggingface_hub's agent detection) plus the Hermes-specific
@@ -1121,6 +1236,30 @@ class BaseEnvironment(ABC):
             # contract) rather than a live pipe.  Iterate it to EOF.  Without
             # this, the drain thread would raise an unhandled exception and die
             # silently, losing all of the process's output.
+            msl_stripper = _MslStreamStripper()
+            try:
+                for piece in stream:
+                    if piece is None:
+                        continue
+                    if isinstance(piece, bytes):
+                        output.append(msl_stripper.feed(decoder.decode(piece)))
+                    else:
+                        output.append(msl_stripper.feed(str(piece)))
+            except Exception:
+                pass
+            finally:
+                try:
+                    tail = decoder.decode(b"", final=True)
+                    if tail:
+                        output.append(msl_stripper.feed(tail))
+                    carried = msl_stripper.flush()
+                    if carried:
+                        output.append(carried)
+                except Exception:
+                    pass
+
+            # this, the drain thread would raise an unhandled exception and die
+            # silently, losing all of the process's output.
             try:
                 for piece in stream:
                     if piece is None:
@@ -1159,6 +1298,29 @@ class BaseEnvironment(ABC):
                 return
             # select.select does NOT work on pipe fds on Windows (only sockets).
             # Use blocking os.read in a daemon thread instead — safe because
+            # EOF arrives promptly when bash exits.
+            if os.name == "nt":
+                msl_stripper = _MslStreamStripper()
+                try:
+                    while True:
+                        chunk = os.read(fd, 4096)
+                        if not chunk:
+                            break
+                        output.append(msl_stripper.feed(decoder.decode(chunk)))
+                except (ValueError, OSError):
+                    pass
+                finally:
+                    try:
+                        tail = decoder.decode(b"", final=True)
+                        if tail:
+                            output.append(msl_stripper.feed(tail))
+                        carried = msl_stripper.flush()
+                        if carried:
+                            output.append(carried)
+                    except Exception:
+                        pass
+                return
+            msl_stripper = _MslStreamStripper()
             # EOF arrives promptly when bash exits.
             if os.name == "nt":
                 try:


### PR DESCRIPTION
## Summary

Three-layer fix for macOS 27 libmalloc lite-mode MallocStackLogging noise that is leaking into tool output and breaking every tool call in a turn ("The MSL payload truncation is making every tool fail in this turn").

The capture-end strip in `BaseEnvironment.execute()` is correct but placed too late: MSL emitted at process exit floods the bounded collector's 40/60 head/tail budget, evicting real payload before the strip runs. By the time the model reads the result, the tail is MSL-stripped whitespace and the real output's tail is gone — model reads that as a failed tool call.

This closes the timing gap in three layers.

## Changes

### Layer 1 — Streaming strip inside `_wait_for_process._drain()` (PRIMARY FIX)

New `_MslStreamStripper` class in `tools/environments/base.py`, wired into all three drain paths (POSIX select, Windows blocking, iterable fallback):

- Line-buffered carry: any partial trailing line is held across read boundaries so MSL split across 4 KB chunks still matches.
- Fast path: when `"MallocStackLogging"` is absent in `carry + chunk`, the regex is skipped entirely — zero cost on healthy systems.
- MSL never enters the bounded collector, so the 40/60 head/tail budget stays intact for real output.

### Layer 2 — Tighten `_MSL_LINE_RE`

Gutter cap raised from `\d{1,6}` to `\d{1,7}` to cover `read_file` contents with > 999_999 lines. The regex's independently-optional `comm(pid)` and `N|` prefix properties are preserved.

### Layer 3 — Strip MSL from `agent/shell_hooks.py` output

Hook subprocesses bypass `BaseEnvironment.execute()` and their stdout/stderr flows back to the model unfiltered. Strip `strip_malloc_stack_logging` on both at the post-`communicate` boundary — closes the remaining leak path.

## Critical files

- `tools/environments/base.py` — `_MslStreamStripper` class, `_drain()` wiring in all three paths, `_MSL_LINE_RE` tightening. No public API change.
- `agent/shell_hooks.py` — MSL strip after `proc.communicate()` in hook subprocess path.
- `tests/tools/test_base_environment.py` — regex matrix, `TestMslStreamStripper`, `TestMslDoesNotEvictRealTail` regression test.
- `tests/agent/test_shell_hooks.py` — MSL stripped from hook stdout.

## Tradeoffs

- Per-read stripper cost: single-digit microseconds; fast path skips regex on healthy systems.
- Regex loosening risk: near-zero false-strip risk; `MallocStackLogging:` is an Apple-private namespace.
- Layer 3 subprocess cost: one regex call per hook execution; negligible.
- Unbounded-capture path (file ops `cat`, code-exec RPC): still benefits from streaming strip — pure pass-through when no MSL substring present.

## Test coverage

- New `TestStripMallocStackLogging`: 9 cases — bare, gutter-only, `comm(pid)`-only, both, 7-digit gutter, multiline MSL, embedded MSL, no-MSL passthrough, empty input.
- New `TestMslStreamStripper`: clean chunk, mid-chunk MSL, split-across-chunks, partial trailing line carry, `flush()` semantics, fast-path correctness, multi-call state consistency.
- New `TestMslDoesNotEvictRealTail`: direct regression test — real payload + 30 KB MSL flood through stripper into `_BoundedOutputCollector` (2 000-char cap), assert both sentinels survive and no `[OUTPUT TRUNCATED` marker.
- New `test_msl_noise_stripped_from_hook_stdout`: hook subprocess emits MSL on stderr; assert `_spawn` strips it.

`tests/tools/test_base_environment.py` and `tests/agent/test_shell_hooks.py` pass with 93/93 green.