### PR TITLE
fix(security): judge NAT64/DNS64 addresses by embedded IPv4 in SSRF guard

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -269,6 +269,59 @@ class TestIsBlockedIp:
         assert _is_blocked_ip(ip) is False, f"{ip_str} should be allowed"
 
 
+class TestNat64Dns64Addresses:
+    """DNS64 answers under 64:ff9b::/96 (RFC 6052) wrap a public IPv4
+    destination for IPv6-only clients — CPython marks the well-known prefix
+    ``is_reserved``, which used to false-positive every A-only hostname on
+    IPv6-only networks (carrier mobile data) with "Blocked: URL targets a
+    private or internal network address". The address must be judged by its
+    embedded IPv4 bits instead; DNS64 for genuinely internal hosts stays
+    blocked.
+    """
+
+    def test_public_embedded_ipv4_allowed(self):
+        # Real-world shape: DNS64 synthesis of 216.150.16.193
+        ip = ipaddress.ip_address("64:ff9b::d896:10c1")
+        assert _is_blocked_ip(ip) is False
+
+    @pytest.mark.parametrize("embedded, expected", [
+        ("216.150.16.193", False),   # public web host (hermes docs domain)
+        ("93.184.216.34", False),    # example.com's classic A record
+        ("10.0.0.1", True),          # RFC1918 behind NAT64 stays blocked
+        ("192.168.1.10", True),
+        ("172.16.0.9", True),
+        ("169.254.169.254", True),   # cloud metadata via NAT64 synthesis
+        ("127.0.0.1", True),
+        ("100.64.0.1", True),        # CGNAT range embedded
+    ])
+    def test_judged_by_embedded_ipv4(self, embedded, expected):
+        import struct
+        n = struct.unpack("!I", socket.inet_aton(embedded))[0]
+        ip = ipaddress.ip_address(f"64:ff9b::{n >> 16:x}:{n & 0xFFFF:x}")
+        assert _is_blocked_ip(ip) is expected, f"NAT64({embedded}) -> {expected}"
+
+    def test_is_safe_url_allows_dns64_resolved_public_host(self):
+        """End-to-end: hostname resolving only to NAT64 addresses passes."""
+        with _resolves_to("64:ff9b::d896:1065", "64:ff9b::d896:141"):
+            assert (
+                is_safe_url("https://hermes-agent.nousresearch.com/docs/llms.txt")
+                is True
+            )
+
+    def test_connect_path_allows_dns64_resolved_public_host(self):
+        """The connect-time transport check shares the same verdict."""
+        from tools.url_safety import _resolved_http_connect_ips
+        with _resolves_to("64:ff9b::d896:1065"):
+            assert _resolved_http_connect_ips(
+                "a-only.example.com", 443, "https"
+            ) == ["64:ff9b::d896:1065"]
+
+    def test_metadata_floor_unaffected_by_nat64(self):
+        """Cloud metadata stays blocked even when reached via NAT64 form."""
+        with _resolves_to("64:ff9b::a9fe:a9fe"):
+            assert is_safe_url("http://example.com/latest/meta-data/") is False
+
+
 class TestGlobalAllowPrivateUrls:
     """Tests for the security.allow_private_urls config toggle."""
 

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -209,6 +209,17 @@ _MAX_SSRF_CONNECT_IPS = 8
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
+# NAT64 well-known prefix (RFC 6052). IPv6-only networks (carrier mobile
+# data, some enterprise/hotel WLANs) run DNS64, which answers AAAA queries
+# for hosts that only publish A records with synthesized addresses under
+# 64:ff9b::/96 — i.e. how most of the IPv4 internet appears on those
+# networks. CPython classifies the prefix as is_reserved, so treating
+# is_reserved as "internal" here blocks ordinary public websites on any
+# IPv6-only client while the same URLs load fine everywhere else. These
+# addresses are judged by their embedded IPv4 address instead (which may
+# itself be private — a DNS64 answer for an RFC1918 host stays blocked).
+_NAT64_WELLKNOWN_NETWORK = ipaddress.ip_network("64:ff9b::/96")
+
 # ---------------------------------------------------------------------------
 # Global toggle: allow private/internal IP resolution
 # ---------------------------------------------------------------------------
@@ -296,6 +307,19 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
                 embedded_ip.is_link_local or embedded_ip.is_reserved or
                 embedded_ip.is_multicast or embedded_ip.is_unspecified or
                 embedded_ip in _CGNAT_NETWORK)
+
+    # DNS64 answers (RFC 6052 ``64:ff9b::/96``): these wrap a public IPv4
+    # destination for IPv6-only clients, not an internal network — CPython
+    # marks the well-known prefix reserved, which would otherwise false-
+    # positive every A-only hostname on IPv6-only networks. Judge the
+    # address by its embedded IPv4 bits instead.
+    if (
+        isinstance(ip, ipaddress.IPv6Address)
+        and ip.version == 6
+        and ip in _NAT64_WELLKNOWN_NETWORK
+    ):
+        embedded_ip = ipaddress.ip_address(ip.packed[-4:])
+        return _is_blocked_ip(embedded_ip)
 
     # Standard IPv4/IPv6 address checking
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:


### PR DESCRIPTION
On an IPv6-only carrier connection, every Hermes web tool (`web_extract`, SSRF-guarded fetches, vision downloads) failed on IPv4-only websites with "Blocked: URL targets a private or internal network address", while the same URLs loaded fine via `curl` and on dual-stack networks. The culprit was the SSRF guard misclassifying DNS64/NAT64-synthesized addresses under `64:ff9b::/96` as internal infrastructure.

## Bug Description

On hosts whose only network path is IPv6 + NAT64 (carrier mobile data being the most common case), DNS64 resolvers synthesize AAAA records for **A-only hostnames** under the RFC 6052 well-known prefix `64:ff9b::/96`. CPython's `ipaddress` module classifies that prefix as *reserved* space, and `_is_blocked_ip()` blocks anything `is_reserved` — so most of the IPv4 internet appears "internal" to Hermes running on those devices.

Reproduced on Android 15 / Termux (IPv6-only carrier), Python 3.13.13:

```
Blocked request to private/internal address: hermes-agent.nousresearch.com -> 64:ff9b::d896:181
```

The domain publishes A records only (verified via DoH); its synthesized NAT64 form was rejected by `is_safe_url()` while `curl https://hermes-agent.nousresearch.com/docs/llms.txt` succeeded from the same shell.

Dual-stack domains (e.g. `example.com`, which has real AAAA records) were unaffected, which made the failure look like a per-domain block rather than a network-condition bug.

## Root Cause

`tools/url_safety.py::_is_blocked_ip()` treats `ip.is_reserved` as "private/internal". Since CPython b9e7bdb0d4 (3.14; also in 3.13.x maintenance), `64:ff9b::/96` is classified reserved. Any client whose resolver answers with DNS64 synthesis therefore fails the guard for every A-only destination — in both the pre-flight check (`is_safe_url`) and the connect-time transport check (`_resolved_http_connect_ips`).

## Fix

Judge `64:ff9b::/96` addresses by their **embedded IPv4 bits**, mirroring the function's existing `::ffff:` mapped-address handling:

- NAT64 wrapping of a public IPv4 → allowed (the false positive, fixed)
- NAT64 wrapping of RFC1918 / loopback / link-local / CGNAT / metadata IPs → still blocked
- Cloud-metadata floor (`_ALWAYS_BLOCKED_IPS`, `_BLOCKED_HOSTNAMES`) and all other checks unchanged
- Both call paths share `_is_blocked_ip()`, so pre-flight and connect-time verdicts stay consistent

## How to Verify

1. On any machine: `python -c "import ipaddress; ipaddress.ip_address('64:ff9b::d896:10c1').is_reserved"` → `True` on current CPython (the classification this PR compensates for).
2. With the patch, from an IPv6-only/NAT64 client (or by mocking `socket.getaddrinfo` to return `64:ff9b::…`):
   - `is_safe_url("https://<a-only-domain>")` → `True` (was `False`)
   - `is_safe_url("http://metadata.google.internal/...")` → still `False`
   - `_resolved_http_connect_ips(host, 443, "https")` accepts NAT64-resolved public hosts
3. `pytest tests/tools/test_url_safety.py` — 73 passed (61 pre-existing + 12 new).

Live verification on the affected device after patching: the previously failing docs URL passes the real-DNS guard, and cloud metadata remains blocked.

## Test Plan

- [x] Added regression tests (`TestNat64Dns64Addresses`): embedded-IPv4 matrix (public/RFC1918/metadata/loopback/CGNAT), pre-flight `is_safe_url` path, connect-time transport path, metadata-floor preservation
- [x] All pre-existing SSRF tests still pass (73/73 total)
- [x] Manual end-to-end verification with real DNS on an IPv6-only carrier network

## Risk Assessment

**Low** — the only verdicts that change are addresses inside `64:ff9b::/96`; each is re-judged through the same rules applied to its embedded IPv4 address, which can only *relax* blocking for genuinely public destinations and keeps everything else (including NAT64-wrapped private/metadata space) blocked. No config surface, no API changes.
