### PR TITLE
fix(codex): avoid duplicate final gateway replies

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -631,11 +631,10 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 
     def _fire_agent_message_completed(item: dict) -> None:
         text = item.get("text") or ""
-        # Codex emits both commentary and the final answer as completed
-        # agentMessage items. The final answer is delivered by the gateway's
-        # normal final-response path, so emitting it here as interim
-        # commentary posts the same response twice on Discord.
-        if item.get("phase") == "final_answer":
+        # Only explicitly classified commentary belongs on the interim path.
+        # Final or unclassified messages stay on the gateway's normal final-
+        # response path; emitting them here can post the response twice.
+        if item.get("phase") != "commentary":
             return
         if not isinstance(text, str) or not text.strip():
             return

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -345,7 +345,8 @@ def _record_codex_app_server_compaction(
 # callbacks the standard runtime fires:
 #   - tool_progress_callback("tool.started"|"tool.completed", name, ...)
 #   - _fire_stream_delta(text) for streaming agentMessage chunks
-#   - _emit_interim_assistant_message({...}) for completed agentMessages
+#   - _emit_interim_assistant_message({...}) for completed commentary
+#     agentMessages
 # ---------------------------------------------------------------------------
 
 # Codex item types that map to a Hermes tool_call in the projector (and
@@ -504,9 +505,10 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
       * ``item/agentMessage/delta`` → ``_fire_stream_delta(text)`` so chat
         adapters can render the assistant's reply as it streams.
       * ``item/reasoning/delta`` → ``_fire_reasoning_delta(text)``
-      * ``item/completed`` for ``agentMessage`` →
+      * ``item/completed`` for commentary ``agentMessage`` items →
         ``_emit_interim_assistant_message({"role": "assistant",
-        "content": text})``. The gateway's ``already_streamed`` check
+        "content": text})``. Final-answer items stay on the gateway's
+        normal final-response path. The gateway's ``already_streamed`` check
         dedupes against any text the stream-delta callback already
         rendered for the same message.
 
@@ -629,6 +631,12 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 
     def _fire_agent_message_completed(item: dict) -> None:
         text = item.get("text") or ""
+        # Codex emits both commentary and the final answer as completed
+        # agentMessage items. The final answer is delivered by the gateway's
+        # normal final-response path, so emitting it here as interim
+        # commentary posts the same response twice on Discord.
+        if item.get("phase") == "final_answer":
+            return
         if not isinstance(text, str) or not text.strip():
             return
         # display.show_commentary=false — mid-turn narration stays off the

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -274,7 +274,19 @@ class TestAgentMessageInterimDispatch:
         }))
         agent._emit_interim_assistant_message.assert_not_called()
 
-
+    @pytest.mark.parametrize("phase", [None, "unknown"])
+    def test_completed_message_without_commentary_phase_is_not_interim(self, phase):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        item = {
+            "type": "agentMessage",
+            "id": "am-unclassified",
+            "text": "Test received.",
+        }
+        if phase is not None:
+            item["phase"] = phase
+        bridge(_item_completed(item))
+        agent._emit_interim_assistant_message.assert_not_called()
 
     def test_show_commentary_off_suppresses_interim(self):
         """display.show_commentary=false silences agentMessage interim
@@ -285,6 +297,7 @@ class TestAgentMessageInterimDispatch:
         bridge = make_codex_app_server_event_bridge(agent)
         bridge(_item_completed({
             "type": "agentMessage", "id": "am-5", "text": "I'll check config.",
+            "phase": "commentary",
         }))
         agent._emit_interim_assistant_message.assert_not_called()
         # Tool progress is unaffected by the commentary toggle.

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -250,17 +250,29 @@ class TestToolProgressDispatch:
 
 
 class TestAgentMessageInterimDispatch:
-    def test_completed_agent_message_emits_interim(self):
+    def test_completed_commentary_message_emits_interim(self):
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge(_item_completed({
             "type": "agentMessage",
             "id": "am-1",
             "text": "I'll check the config first.",
+            "phase": "commentary",
         }))
         agent._emit_interim_assistant_message.assert_called_once_with(
             {"role": "assistant", "content": "I'll check the config first."}
         )
+
+    def test_completed_final_answer_is_not_emitted_as_interim(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-final",
+            "text": "Test received.",
+            "phase": "final_answer",
+        }))
+        agent._emit_interim_assistant_message.assert_not_called()
 
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents Codex app-server final answers from being delivered twice by messaging gateways.

The app-server event bridge currently forwards every completed `agentMessage` through `_emit_interim_assistant_message`, including items whose phase is `final_answer`. The Codex runtime then returns that same text through the normal `final_response` path, so Discord stores both an interim post and the final reply.

This keeps completed commentary on the interim path while reserving `final_answer` items for the gateway's normal final-response delivery.

## Related Issue

No existing issue or PR found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skip interim delivery for completed Codex `agentMessage` items with `phase == "final_answer"`.
- Preserve interim delivery for `phase == "commentary"`.
- Document the phase-aware event-bridge contract.
- Add regression coverage for commentary and final-answer completion events.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_codex_app_server_event_bridge.py -q`.
2. Enable the Codex app-server runtime and a Discord gateway with commentary visible.
3. Directly mention the bot with a prompt that produces a short final answer.
4. Confirm Discord stores one final response instead of an interim copy followed by the same final reply.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] My PR contains only changes related to this bug fix.
- [ ] I've run the full test suite. The focused CI-parity file passed all 19 tests.
- [x] I've added tests for my changes.
- [x] I've tested on macOS through a live Discord gateway using the Codex app-server runtime.

### Documentation & Housekeeping

- [x] Documentation update: N/A; the internal event-bridge docstring was updated.
- [x] `cli-config.yaml.example`: N/A; no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changes.
- [x] Cross-platform impact considered; this is platform-independent event routing.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Live reproduction on Discord showed one Codex execution and one gateway final-send log entry, while Discord stored two identical bot messages: a normal interim post and a reply. The saved Codex event labeled the duplicated text `phase: "final_answer"`.

Focused verification:

```text
19 tests passed, 0 failed
✓ No Windows footguns found (2 files scanned)
```
