### PR TITLE
fix(gateway): deliver lone wrapped artifact paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5179,7 +5179,9 @@ class BasePlatformAdapter(ABC):
         partition lives in ``gateway/run.py``.
 
         Paths inside fenced code blocks (``` ... ```) and inline code
-        (`...`) are ignored so that code samples are never mutilated.
+        (`...`) are ignored so that code samples are never mutilated.  The
+        one exception is a reply whose entire non-whitespace content is a
+        single backtick-wrapped path: that is treated as an artifact handoff.
 
         Returns:
             Tuple of (list of expanded file paths, cleaned text with the
@@ -5197,24 +5199,49 @@ class BasePlatformAdapter(ABC):
             re.IGNORECASE,
         )
 
-        # Build spans covered by fenced code blocks and inline code
+        # Build spans covered by fenced code blocks and inline code. A lone
+        # backtick-wrapped path is a special case: models commonly format the
+        # final artifact path as inline code, but when that path is the entire
+        # response it is an attachment handoff rather than a code sample.
+        # Preserve the surrounding-prose exclusion below.
+        stripped = content.strip()
+        lone_inline_path_span: tuple[int, int] | None = None
+        lone_inline_cleanup: str | None = None
+        if (
+            len(stripped) > 2
+            and stripped.startswith('`')
+            and stripped.endswith('`')
+            and path_re.fullmatch(stripped[1:-1])
+        ):
+            leading_ws = len(content) - len(content.lstrip())
+            lone_inline_path_span = (
+                leading_ws + 1,
+                leading_ws + len(stripped) - 1,
+            )
+            lone_inline_cleanup = stripped
+
         code_spans: list = []
         for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
             code_spans.append((m.start(), m.end()))
         for m in re.finditer(r'`[^`\n]+`', content):
+            if lone_inline_path_span == (m.start() + 1, m.end() - 1):
+                continue
             code_spans.append((m.start(), m.end()))
 
         def _in_code(pos: int) -> bool:
             return any(s <= pos < e for s, e in code_spans)
 
-        found: list = []  # (raw_match_text, expanded_path)
+        found: list = []  # (text_to_remove, expanded_path)
         for match in path_re.finditer(content):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
             expanded = os.path.expanduser(raw)
             if os.path.isfile(expanded):
-                found.append((raw, expanded))
+                cleanup_text = raw
+                if lone_inline_path_span == (match.start(), match.end()):
+                    cleanup_text = lone_inline_cleanup or raw
+                found.append((cleanup_text, expanded))
             else:
                 # The reply mentions a deliverable-looking path that does not
                 # exist on disk, so it is silently dropped from native delivery.

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -137,6 +137,25 @@ class TestCodeBlockExclusion:
         assert paths == []
         assert "`/tmp/image.png`" in cleaned
 
+    def test_lone_backtick_wrapped_path_is_delivered(self):
+        """A response containing only an artifact path should upload it.
+
+        Models commonly wrap a final path in inline-code formatting.  That is
+        an attachment handoff, not a code sample, when it is the entire reply.
+        The wrapper must disappear with the delivered path so the user does
+        not receive an orphaned pair of backticks.
+        """
+        paths, cleaned = _extract("  `/tmp/report.html`\n")
+        assert paths == ["/tmp/report.html"]
+        assert cleaned == ""
+
+    def test_nonexistent_lone_backtick_path_remains_visible(self):
+        """Do not erase a promised artifact that is missing on disk."""
+        content = "`/tmp/missing-report.html`"
+        paths, cleaned = _extract(content, existing_files=set())
+        assert paths == []
+        assert cleaned == content
+
 
 # ---------------------------------------------------------------------------
 # Deduplication

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -344,6 +344,25 @@ class TestActiveVenvMarkerStripping:
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
 
+    def test_session_env_cannot_reintroduce_active_venv_markers(self):
+        """Terminal session overrides must not bypass the runtime guard.
+
+        ``_make_run_env`` merges the session environment after the gateway's
+        process environment.  Keep the stripping step after that merge so a
+        coding session cannot point package managers back at the live Hermes
+        environment.
+        """
+        from tools.environments.local import _make_run_env
+
+        session_env = {
+            "VIRTUAL_ENV": "/home/user/.hermes/hermes-agent/venv",
+            "CONDA_PREFIX": "/opt/conda/envs/hermes",
+        }
+        with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+            result = _make_run_env(session_env)
+        assert "VIRTUAL_ENV" not in result
+        assert "CONDA_PREFIX" not in result
+
     def test_sanitize_subprocess_env_strips_markers(self):
         from tools.environments.local import _sanitize_subprocess_env
         base = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "HOME": "/home/user"}


### PR DESCRIPTION
## Summary

- treat a reply consisting only of a backtick-wrapped local artifact path as an attachment handoff
- remove the wrapper with the delivered path so no orphaned backticks reach the user
- preserve the existing protection for inline-code paths embedded in prose and for missing files
- lock the terminal environment guard so session overrides cannot reintroduce `VIRTUAL_ENV` or `CONDA_PREFIX`

## Runtime-safety context

The package-stomp incident occurred on the pinned v0.17.0 checkout. Current `main` already contains the production isolation fix in `dbbf102b8e` (`fix(terminal): strip VIRTUAL_ENV/CONDA_PREFIX from terminal subprocess env`, #23473), so this PR does not duplicate that code. It adds coverage for the remaining merge-order invariant: a coding-session environment override cannot reintroduce those markers after the gateway environment is sanitized.

## Verification

- `scripts/run_tests.sh tests/gateway/test_extract_local_files.py tests/gateway/test_tts_media_routing.py -q` — 32 passed
- `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py -k ActiveVenvMarkerStripping -q` — 6 passed
- `ruff check gateway/platforms/base.py tests/gateway/test_extract_local_files.py tests/tools/test_local_env_blocklist.py`
- `git diff --check`
- independent review found no blockers; its documentation and missing-file test suggestions are included

## Deployment note

The live v0.17.0 installation will need an upgrade or an explicit backport of `dbbf102b8e`; merging this PR into `main` does not by itself modify that pinned runtime.