### PR TITLE
fix(gigachat): cap tool-schema width so required args survive

### DIFF
--- a/agent/gigachat_schema.py
+++ b/agent/gigachat_schema.py
@@ -1,0 +1,97 @@
+"""GigaChat tool-schema sanitization.
+
+GigaChat's function-call decoder degrades on *wide* parameter schemas. Past
+roughly a dozen properties it stops emitting a well-formed arguments object:
+it silently drops keys the prose marked required and writes a JSON formatting
+fragment (``",\n    "``) into an unrelated field in place of a real value. The
+call still arrives as parseable JSON, so nothing upstream notices — the tool
+just rejects it, the model reads the rejection as a tool malfunction, and
+retries the identical call.
+
+Measured against GigaChat-2-Max through the local shim, asking it to create a
+cron job:
+
+    cronjob as shipped (17 properties, 10.0 KB)  -> 3/3 malformed
+                                                    ('prompt' dropped,
+                                                     '"script": ",\\n    "')
+    same schema trimmed to 8 properties (4.4 KB) -> 3/3 correct
+
+Width is what matters, not byte size: a 6-property schema whose descriptions
+were shortened to 2.3 KB *also* failed, because this model leans on the verbose
+per-property prose to fill required fields. So trim the property count and
+leave the descriptions alone.
+
+Properties are kept in declaration order — which in this codebase runs
+most-important-first — and anything named in ``required`` is always kept, even
+if that pushes the result past the cap. Advanced options beyond the cap become
+unreachable in GigaChat sessions; that is the deliberate trade for tool calls
+that are well-formed at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# 10 properties still round-tripped cleanly in testing and 17 did not; 8 keeps
+# a margin below the observed edge without cutting into the common fields of
+# any shipped tool.
+MAX_GIGACHAT_PROPERTIES = 8
+
+
+def is_gigachat_model(model: str | None) -> bool:
+    """Return whether *model* is served by GigaChat."""
+    return bool(model) and str(model).strip().lower().startswith("gigachat")
+
+
+def sanitize_gigachat_tool_parameters(params: Any) -> Any:
+    """Narrow a JSON-Schema ``parameters`` object to a GigaChat-safe width.
+
+    Returns *params* unchanged (identity) when nothing needs trimming, so
+    callers can cheaply detect a no-op.
+    """
+    if not isinstance(params, dict):
+        return params
+
+    properties = params.get("properties")
+    if not isinstance(properties, dict) or len(properties) <= MAX_GIGACHAT_PROPERTIES:
+        return params
+
+    required = params.get("required")
+    required_names = [n for n in required if isinstance(n, str)] if isinstance(required, list) else []
+
+    kept: Dict[str, Any] = {name: properties[name] for name in required_names if name in properties}
+    for name, spec in properties.items():
+        if len(kept) >= MAX_GIGACHAT_PROPERTIES:
+            break
+        kept.setdefault(name, spec)
+
+    # Preserve the original declaration order rather than required-first, so
+    # the model reads the schema in the order its descriptions were written.
+    ordered = {name: properties[name] for name in properties if name in kept}
+    return {**params, "properties": ordered}
+
+
+def sanitize_gigachat_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Apply ``sanitize_gigachat_tool_parameters`` to every tool's parameters."""
+    if not tools:
+        return tools
+
+    sanitized: List[Dict[str, Any]] = []
+    any_change = False
+    for tool in tools:
+        if not isinstance(tool, dict):
+            sanitized.append(tool)
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            sanitized.append(tool)
+            continue
+        params = fn.get("parameters")
+        repaired = sanitize_gigachat_tool_parameters(params)
+        if repaired is not params:
+            any_change = True
+            sanitized.append({**tool, "function": {**fn, "parameters": repaired}})
+        else:
+            sanitized.append(tool)
+
+    return sanitized if any_change else tools

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -23,6 +23,7 @@ from agent.reasoning_effort import (
     requested_effort,
 )
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
+from agent.gigachat_schema import is_gigachat_model, sanitize_gigachat_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
@@ -544,6 +545,9 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            # GigaChat's decoder drops required keys on wide schemas.
+            if is_gigachat_model(model):
+                tools = sanitize_gigachat_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
@@ -756,10 +760,12 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
+        # Tools — apply provider-specific schema sanitization regardless of path
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            if is_gigachat_model(model) or getattr(profile, "name", "") == "gigachat":
+                tools = sanitize_gigachat_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/tests/agent/test_gigachat_schema.py
+++ b/tests/agent/test_gigachat_schema.py
@@ -1,0 +1,91 @@
+"""GigaChat tool-schema width sanitization tests."""
+
+from agent.gigachat_schema import (
+    MAX_GIGACHAT_PROPERTIES,
+    is_gigachat_model,
+    sanitize_gigachat_tool_parameters,
+    sanitize_gigachat_tools,
+)
+
+
+def _params(count, required=None):
+    return {
+        "type": "object",
+        "properties": {f"p{i}": {"type": "string", "description": f"d{i}"} for i in range(count)},
+        **({"required": required} if required else {}),
+    }
+
+
+def test_is_gigachat_model_matches_gigachat_families_only():
+    assert is_gigachat_model("GigaChat-2-Max")
+    assert is_gigachat_model("gigachat")
+    assert not is_gigachat_model("claude-opus-5")
+    assert not is_gigachat_model("kimi-k2")
+    assert not is_gigachat_model(None)
+
+
+def test_narrow_schema_is_returned_unchanged_by_identity():
+    params = _params(MAX_GIGACHAT_PROPERTIES)
+    assert sanitize_gigachat_tool_parameters(params) is params
+
+
+def test_wide_schema_is_trimmed_to_the_cap():
+    out = sanitize_gigachat_tool_parameters(_params(20))
+    assert len(out["properties"]) == MAX_GIGACHAT_PROPERTIES
+
+
+def test_required_properties_survive_trimming():
+    # p19 sits past the cap in declaration order but is required.
+    out = sanitize_gigachat_tool_parameters(_params(20, required=["p19"]))
+    assert "p19" in out["properties"]
+    assert len(out["properties"]) == MAX_GIGACHAT_PROPERTIES
+
+
+def test_required_set_wider_than_the_cap_is_kept_whole():
+    required = [f"p{i}" for i in range(12)]
+    out = sanitize_gigachat_tool_parameters(_params(20, required=required))
+    assert all(name in out["properties"] for name in required)
+
+
+def test_trimming_preserves_declaration_order():
+    out = sanitize_gigachat_tool_parameters(_params(20, required=["p19"]))
+    names = list(out["properties"])
+    assert names == sorted(names, key=lambda n: int(n[1:]))
+
+
+def test_original_schema_is_not_mutated():
+    params = _params(20)
+    before = list(params["properties"])
+    sanitize_gigachat_tool_parameters(params)
+    assert list(params["properties"]) == before
+
+
+def test_sanitize_tools_returns_identity_when_nothing_is_wide():
+    tools = [{"type": "function", "function": {"name": "t", "parameters": _params(3)}}]
+    assert sanitize_gigachat_tools(tools) is tools
+
+
+def test_sanitize_tools_trims_only_the_wide_tool():
+    tools = [
+        {"type": "function", "function": {"name": "narrow", "parameters": _params(3)}},
+        {"type": "function", "function": {"name": "wide", "parameters": _params(20)}},
+    ]
+    out = sanitize_gigachat_tools(tools)
+    assert len(out[0]["function"]["parameters"]["properties"]) == 3
+    assert len(out[1]["function"]["parameters"]["properties"]) == MAX_GIGACHAT_PROPERTIES
+
+
+def test_malformed_tools_pass_through_untouched():
+    tools = [{"no_function": True}, "not-a-dict", {"type": "function", "function": {"name": "x"}}]
+    assert sanitize_gigachat_tools(tools) == tools
+    assert sanitize_gigachat_tools([]) == []
+
+
+def test_shipped_cronjob_schema_keeps_its_core_fields():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    out = sanitize_gigachat_tools([{"type": "function", "function": CRONJOB_SCHEMA}])
+    kept = out[0]["function"]["parameters"]["properties"]
+    assert len(kept) == MAX_GIGACHAT_PROPERTIES
+    for field in ("action", "schedule", "prompt", "job_id"):
+        assert field in kept, f"{field} must survive for cronjob to be usable"


### PR DESCRIPTION
## Problem

GigaChat's function-call decoder degrades on **wide** parameter schemas. Past roughly a dozen properties it stops emitting a well-formed arguments object: it drops keys the schema marks required and writes a JSON formatting fragment (`",\n    "`) into an unrelated field in place of a value.

The call still arrives as parseable JSON, so nothing upstream notices. The tool rejects it, the model reads the rejection as a tool malfunction, and retries the identical call — until it hits `max_iterations`.

Observed in production on a Telegram session: 150 iterations of the same malformed `cronjob` call, each a live API round trip, before the turn capped out.

```
# what the model emitted, asking to create a cron job
{"action":"create","deliver":"local","schedule":"*/30 * * * *","script":",\n    "}
                                                  ↑ prompt is gone, junk in `script`
```

## Root cause

Schema **width**, not byte size. Measured against GigaChat-2-Max through an OpenAI-compatible shim, asking it to create a cron job with the shipped 17-property `cronjob` schema:

| schema | result |
|---|---|
| `cronjob` as shipped — 17 properties, 10.0 KB | **3/3 malformed** (`prompt` dropped) |
| trimmed to 8 properties, 4.4 KB | **3/3 correct** |
| 6 properties, descriptions shortened to 2.3 KB | **malformed** |

The third row is the important one: a *smaller* schema still failed once its prose was cut. This model leans on the verbose per-property descriptions to fill required fields, so the fix trims the property **count** and leaves the descriptions alone.

Ruled out along the way — none of these were the cause:
- `max_tokens` truncation (clean at both 512 and 4096)
- streaming vs non-streaming (identical failure both ways)
- the tool schema itself (`schedule` is declared and marked REQUIRED three separate times)
- `additionalProperties` / `$schema` / `$ref` incompatibilities (none present)

## Fix

`sanitize_gigachat_tools`, mirroring the existing `sanitize_moonshot_tools` hook and applied on both transport paths. Properties are kept in declaration order — which in this codebase runs most-important-first — and anything named in `required` always survives, even if that pushes past the cap.

10 properties still round-tripped cleanly and 17 did not; the cap is **8** for margin.

Six shipped tools exceed it; all keep their core fields:

| tool | properties | kept |
|---|---|---|
| `kanban_create` | 19 → 8 | title, assignee, body, parents, tenant, priority, workspace_kind, workspace_path |
| `cronjob` | 17 → 8 | action, job_id, prompt, schedule, name, repeat, deliver, skills |
| `skill_manage` | 10 → 8 | core intact |
| `drive_preview` | 10 → 8 | core intact |
| `session_search` | 9 → 8 | core intact |
| `delegate_task` | 9 → 8 | core intact |

**Trade-off:** options past the cap become unreachable in GigaChat sessions — deliberate, in exchange for tool calls that are well-formed at all. Other providers are unaffected; the hook is gated on GigaChat.

A longer-term alternative worth considering is splitting `cronjob` and `kanban_create` into narrower verbs, which would help weaker models generally rather than only this provider.

## Tests

11 new tests in `tests/agent/test_gigachat_schema.py`: identity on narrow schemas, a required set wider than the cap, declaration-order preservation, no mutation of the caller's schema, malformed-input passthrough, and that the shipped `cronjob` schema keeps its core fields.
