### PR TITLE
fix(desktop): reuse registry primary for owned session RPCs

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -269,7 +269,8 @@ import {
   findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
   type RegistrySessionSource,
-  spliceRegistrySessionRows
+  spliceRegistrySessionRows,
+  tagRegistrySessionResponse
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -13998,12 +13999,16 @@ async function dispatchRegistryApiRequest(
 
   const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
 
-  return fetchJsonForBackend(connection, requestPath, {
+  const response = await fetchJsonForBackend(connection, requestPath, {
     method: request?.method,
     body: request?.body,
     upload: request?.upload,
     timeoutMs: resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
   })
+
+  return (request?.method || 'GET').toUpperCase() === 'GET'
+    ? tagRegistrySessionResponse(requestPath, response, registryConnectionId)
+    : response
 }
 
 function registryConnectionKind(connectionId) {

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -9,7 +9,8 @@ import {
   fetchRemoteProfileSessions,
   findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
-  spliceRegistrySessionRows
+  spliceRegistrySessionRows,
+  tagRegistrySessionResponse
 } from './profile-session-routing'
 
 test('remote sidebar slices all follow the selected profile', () => {
@@ -299,6 +300,46 @@ test('registry sources: shared remote hosts read the cross-profile aggregate onc
       ['r-2', 'default', 'gw-cloud']
     ]
   )
+})
+
+test('registry-pinned session responses retain their owning connection', () => {
+  const sidebar = tagRegistrySessionResponse(
+    '/api/profiles/sessions/sidebar?recents_profile=default',
+    {
+      recents: { sessions: [{ id: 'remote-chat', profile: 'default' }] },
+      cron: { sessions: [{ id: 'remote-cron', profile: 'default' }] },
+      messaging: { sessions: [] }
+    },
+    'test-amnezia'
+  ) as any
+
+  assert.equal(sidebar.recents.sessions[0].connection_id, 'test-amnezia')
+  assert.equal(sidebar.cron.sessions[0].connection_id, 'test-amnezia')
+
+  const aggregate = tagRegistrySessionResponse(
+    '/api/profiles/sessions?profile=all',
+    { sessions: [{ id: 'remote-profile-chat', profile: 'research' }] },
+    'test-amnezia'
+  ) as any
+
+  assert.equal(aggregate.sessions[0].connection_id, 'test-amnezia')
+
+  const single = tagRegistrySessionResponse(
+    '/api/sessions/remote-chat?profile=default',
+    { id: 'remote-chat', profile: 'default' },
+    'test-amnezia'
+  ) as any
+
+  assert.equal(single.connection_id, 'test-amnezia')
+})
+
+test('registry response ownership tagging ignores non-session payloads and transcript messages', () => {
+  const status = { ok: true }
+  const messages = { messages: [{ id: 'message-1' }], session_id: 'remote-chat' }
+
+  assert.equal(tagRegistrySessionResponse('/api/status', status, 'test-amnezia'), status)
+  assert.equal(tagRegistrySessionResponse('/api/sessions/remote-chat/messages', messages, 'test-amnezia'), messages)
+  assert.equal((messages.messages[0] as any).connection_id, undefined)
 })
 
 test('registry sources: an older shared host without the aggregator falls back to its flat list', async () => {

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -20,6 +20,52 @@ function rowsOf(data: unknown): unknown[] {
   return Array.isArray(data.sessions) ? data.sessions : []
 }
 
+function tagRowsWithConnection(rows: unknown[], connectionId: string): void {
+  for (const row of rows) {
+    if (row && typeof row === 'object') {
+      const session = row as Record<string, unknown>
+      session.connection_id = connectionId
+    }
+  }
+}
+
+/** Preserve the registry source that served a session REST response.
+ *
+ * A registry-pinned request is dispatched directly to that remote host, so its
+ * own session rows naturally omit Desktop's synthetic `connection_id`. Without
+ * restoring that provenance, a `profile: "default"` row later resumes through
+ * the legacy local primary instead of the active registry gateway. */
+export function tagRegistrySessionResponse(path: string, data: unknown, connectionId: string): unknown {
+  if (!data || typeof data !== 'object') {
+    return data
+  }
+
+  const pathname = path.split('?', 1)[0].replace(/\/+$/, '')
+
+  if (pathname === '/api/sessions' || pathname === '/api/profiles/sessions') {
+    tagRowsWithConnection(rowsOf(data), connectionId)
+
+    return data
+  }
+
+  if (pathname === '/api/profiles/sessions/sidebar') {
+    const response = data as Record<string, unknown>
+
+    for (const key of ['recents', 'cron', 'messaging']) {
+      tagRowsWithConnection(rowsOf(response[key]), connectionId)
+    }
+
+    return data
+  }
+
+  if (/^\/api\/sessions\/[^/]+$/.test(pathname)) {
+    const session = data as Record<string, unknown>
+    session.connection_id = connectionId
+  }
+
+  return data
+}
+
 function sessionId(row: unknown): string | null {
   if (!row || typeof row !== 'object' || !('id' in row)) {
     return null

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  knownSessionProfile,
+  knownSessionOwner,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -358,7 +358,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       let owner: SessionOwnerScope =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        knownSessionProfile($sessions.get(), routingSessionId)
+        knownSessionOwner($sessions.get(), routingSessionId)
 
       if (!owner && routingSessionId) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
-import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { closeSecondaryGateways, isActivePrimary, requestGatewayForAgent } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $connection, $currentCwd, $gatewayState } from '@/store/session'
@@ -348,6 +348,17 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('publishes the cold-boot primary registry identity for owned session RPCs', async () => {
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    await expect(requestGatewayForAgent('primary-vps', 'default', 'ping')).resolves.toEqual({ pong: true })
+    expect(FakeWebSocket.instances).toHaveLength(1)
   })
 
   it('re-fetches the profile rail from the NEW backend after a connection apply (#85731)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -28,6 +28,7 @@ import {
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
   setPrimaryGateway,
+  setPrimaryGatewayConnection,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
@@ -282,6 +283,8 @@ export function useGatewayBoot({
           'Timed out reconnecting to Hermes backend'
         )
 
+        setPrimaryGatewayConnection(conn)
+
         if (cancelled) {
           return
         }
@@ -501,6 +504,7 @@ export function useGatewayBoot({
         }
 
         publish(conn)
+        setPrimaryGatewayConnection(conn)
 
         // Bounded for the same reason as attemptReconnect() (#93454): a wedged
         // ticket mint would otherwise hang the gateway switch forever.
@@ -782,6 +786,7 @@ export function useGatewayBoot({
           progress: 95
         })
         publish(conn)
+        setPrimaryGatewayConnection(conn)
 
         // Seed the workspace BEFORE the gateway opens: every session-restore
         // path is gated on gatewayState === 'open', so nothing can be active yet
@@ -896,6 +901,7 @@ export function useGatewayBoot({
 
       if (survivor?.connection) {
         publish(survivor.connection)
+        setPrimaryGatewayConnection(survivor.connection)
       }
 
       const profile = survivor?.profile ?? $activeGatewayProfile.get()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2093,6 +2093,49 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(ambientRequest).not.toHaveBeenCalled()
   })
 
+  it('keeps a registry-tagged cached session on its owning connection without an explicit route', async () => {
+    setSessions([
+      storedSession({
+        connection_id: 'test-amnezia',
+        id: 'stored-registry',
+        profile: 'default'
+      })
+    ])
+    vi.mocked(getSession).mockImplementation(async id =>
+      storedSession({ connection_id: 'test-amnezia', id, profile: 'default' })
+    )
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-registry' } as never)
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method, params) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          messages: [],
+          resumed: params?.session_id,
+          session_id: 'runtime-registry'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-registry', true)
+
+    const restScope = { connectionId: 'test-amnezia', profile: 'default' }
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-registry', restScope)
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'test-amnezia',
+      'default',
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-registry' })
+    )
+    expect(ambientRequest).not.toHaveBeenCalled()
+  })
+
   it('rejects a cross-wired runtime mapping and falls through to a full resume', async () => {
     // A recycled runtime id ('rt-recycled') is mapped to 'stored-A', but its
     // cached state actually belongs to a DIFFERENT session ('stored-B') — the

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -847,7 +847,12 @@ export function useSessionActions({
             connectionId: ownerRoute.connectionId,
             profile: ownerRoute.targetProfile || ownerRoute.profile
           }
-        : sessionProfile
+        : storedForProfile?.connection_id
+          ? {
+              connectionId: storedForProfile.connection_id,
+              profile: sessionProfile || 'default'
+            }
+          : sessionProfile
 
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -42,7 +42,7 @@ vi.mock('@/hermes', () => ({
   },
   setApiRequestConnection: vi.fn()
 }))
-vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
+vi.mock('@/store/session', () => ({ setConnection: vi.fn(), setGatewayState: vi.fn() }))
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
@@ -212,6 +212,9 @@ describe('requestGatewayForAgent', () => {
       touchBackend: vi.fn(async () => undefined)
     }
     await ensureGatewayForProfile('default')
+
+    await openGatewayForAgent('remote-primary', 'default')
+    await ensureGatewayForAgent('remote-primary', 'default')
 
     const result = await requestGatewayForAgent('remote-primary', 'default', 'session.resume', {
       session_id: 'stored-session'

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -58,7 +58,8 @@ const {
   requestGatewayForAgent,
   requestGatewayForProfile,
   retainGatewayForAgent,
-  setPrimaryGateway
+  setPrimaryGateway,
+  setPrimaryGatewayConnection
 } = await import('./gateway')
 
 function installDesktop(getConnection: ReturnType<typeof vi.fn>): void {
@@ -191,6 +192,70 @@ describe('requestGatewayForProfile', () => {
 })
 
 describe('requestGatewayForAgent', () => {
+  it('reuses the active primary socket when its registry connection owns the session', async () => {
+    const primary = makePrimary()
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }) => ({
+      connectionId,
+      port: 5151,
+      profile,
+      token: 'secondary-token'
+    }))
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(),
+      getConnectionFor,
+      getGatewayWsUrlFor: vi.fn(async () => ({ ok: true as const, wsUrl: 'wss://remote.invalid/api/ws' })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    await ensureGatewayForProfile('default')
+
+    const result = await requestGatewayForAgent('remote-primary', 'default', 'session.resume', {
+      session_id: 'stored-session'
+    })
+
+    expect(result).toEqual({
+      method: 'session.resume',
+      params: { session_id: 'stored-session' }
+    })
+    expect(primary.request).toHaveBeenCalledWith('session.resume', { session_id: 'stored-session' })
+    expect(getConnectionFor).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(0)
+    expect($gateway.get()).toBe(primary)
+  })
+
+  it('keeps another profile on the same registry source isolated from the primary', async () => {
+    const primary = makePrimary()
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }) => ({
+      connectionId,
+      port: 5151,
+      profile,
+      token: 'secondary-token'
+    }))
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(),
+      getConnectionFor,
+      getGatewayWsUrlFor: vi.fn(async () => ({ ok: true as const, wsUrl: 'wss://remote.invalid/api/ws' })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+
+    await requestGatewayForAgent('remote-primary', 'research', 'session.resume', {
+      session_id: 'research-session'
+    })
+
+    expect(getConnectionFor).toHaveBeenCalledWith({ connectionId: 'remote-primary', profile: 'research' })
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(1)
+  })
+
   it('leases separate registry sockets for duplicate profile names without changing the active gateway', async () => {
     const primary = makePrimary()
     const getConnection = vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 'legacy-token' }))
@@ -273,6 +338,7 @@ describe('requestGatewayForAgent', () => {
 
   it('evicts registry sockets when their source is edited or removed', async () => {
     const primary = makePrimary()
+
     const getConnectionFor = vi.fn(async ({ connectionId, profile }) => ({ connectionId, port: 5151, profile }))
     const onActiveConnectionInvalidated = vi.fn()
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -100,6 +100,8 @@ const ACTIVATION_LEASE_MS = 30_000
 interface GatewayRegistryState {
   config: RegistryConfig | null
   primaryGateway: HermesGateway | null
+  /** Registry source currently served by primaryGateway, when known. */
+  primaryConnectionId: null | string
   primaryProfile: string
   activeKey: string
   activationEpoch: number
@@ -114,6 +116,7 @@ function createRegistryState(): GatewayRegistryState {
   return {
     config: null,
     primaryGateway: null,
+    primaryConnectionId: null,
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
@@ -186,8 +189,17 @@ export function emitLocalGatewayEvent(event: GatewayEvent): void {
 }
 
 export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'default'): void {
+  if (g.primaryGateway !== gateway) {
+    g.primaryConnectionId = null
+  }
+
   g.primaryGateway = gateway
   g.primaryProfile = normKey(profile)
+}
+
+/** Publish the registry source owned by the window primary socket. */
+export function setPrimaryGatewayConnection(connection: Pick<HermesConnection, 'connectionId'> | null): void {
+  g.primaryConnectionId = connection?.connectionId?.trim() || null
 }
 
 export function isActivePrimary(): boolean {
@@ -665,6 +677,22 @@ export async function requestGatewayForAgent<T>(
   const scope = registryBackendScopeKey(connectionId, key)
 
   if (scope === key) {
+    return requestGatewayForProfile<T>(key, method, params, timeoutMs, signal)
+  }
+
+  // A primary remote selected from the connection registry carries its source
+  // id in the active connection descriptor. Requests for that exact
+  // (connection, profile) already have an owning socket: the window primary.
+  // Dialing a registry secondary here can resolve the same public endpoint to a
+  // different backend/profile route, so durable session.resume reports
+  // "session not found" while REST history from the primary remains visible.
+  // Require both owner identities to agree before collapsing the route; a
+  // different source or profile must retain its isolated secondary.
+  if (
+    key === g.primaryProfile &&
+    Boolean(g.primaryConnectionId) &&
+    g.primaryConnectionId === String(connectionId).trim()
+  ) {
     return requestGatewayForProfile<T>(key, method, params, timeoutMs, signal)
   }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -202,6 +202,12 @@ export function setPrimaryGatewayConnection(connection: Pick<HermesConnection, '
   g.primaryConnectionId = connection?.connectionId?.trim() || null
 }
 
+function isPrimaryRegistryRoute(connectionId: null | string, profile: string): boolean {
+  const id = String(connectionId ?? '').trim()
+
+  return normKey(profile) === g.primaryProfile && Boolean(id) && Boolean(g.primaryConnectionId) && id === g.primaryConnectionId
+}
+
 export function isActivePrimary(): boolean {
   return g.activeKey === g.primaryProfile
 }
@@ -688,11 +694,7 @@ export async function requestGatewayForAgent<T>(
   // "session not found" while REST history from the primary remains visible.
   // Require both owner identities to agree before collapsing the route; a
   // different source or profile must retain its isolated secondary.
-  if (
-    key === g.primaryProfile &&
-    Boolean(g.primaryConnectionId) &&
-    g.primaryConnectionId === String(connectionId).trim()
-  ) {
+  if (isPrimaryRegistryRoute(connectionId, key)) {
     return requestGatewayForProfile<T>(key, method, params, timeoutMs, signal)
   }
 
@@ -896,7 +898,7 @@ export async function openGatewayForProfile(profile: string): Promise<void> {
 export async function openGatewayForAgent(connectionId: null | string, profile: string): Promise<void> {
   const scope = registryBackendScopeKey(connectionId, profile)
 
-  if (scope === normKey(profile)) {
+  if (scope === normKey(profile) || isPrimaryRegistryRoute(connectionId, profile)) {
     return openGatewayForProfile(profile)
   }
 
@@ -916,7 +918,7 @@ export async function openGatewayForAgent(connectionId: null | string, profile: 
 export async function ensureGatewayForAgent(connectionId: null | string, profile: string): Promise<boolean> {
   const scope = registryBackendScopeKey(connectionId, profile)
 
-  if (scope === normKey(profile)) {
+  if (scope === normKey(profile) || isPrimaryRegistryRoute(connectionId, profile)) {
     await ensureGatewayForProfile(profile)
 
     return true

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
   rememberedSessionProfile,
@@ -57,6 +58,28 @@ import {
 const session = (over: Partial<SessionInfo>): SessionInfo => makeSessionInfo({ id: 'live', ...over })
 
 describe('session owner hints', () => {
+  it('preserves the registry owner recorded on a discovered session row', () => {
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'test-amnezia', id: 'registry-session', profile: 'default' })],
+        'registry-session'
+      )
+    ).toEqual({ connectionId: 'test-amnezia', profile: 'default' })
+  })
+
+  it('preserves the exact registry owner for session-scoped RPC routing', () => {
+    const route = {
+      connectionId: 'test-amnezia',
+      mode: 'remote' as const,
+      profile: 'default',
+      targetProfile: 'default'
+    }
+
+    setSessionOwnerHint('remote-session', route)
+
+    expect(knownSessionOwner([session({ id: 'remote-session', profile: 'default' })], 'remote-session')).toEqual(route)
+  })
+
   it('keeps identical session ids separate across connection and profile owners', () => {
     const sourceA = { connectionId: 'source-a', mode: 'remote' as const, profile: 'worker', targetProfile: 'backend-a' }
     const sourceB = { connectionId: 'source-b', mode: 'remote' as const, profile: 'worker', targetProfile: 'backend-b' }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -142,6 +142,35 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
 }
 
 /**
+ * The exact owner a session-scoped RPC should use, preserving registry
+ * connection identity when the session was discovered through a named remote
+ * connection. Falling back to only the profile is safe solely when no exact
+ * route hint exists.
+ */
+export function knownSessionOwner(
+  sessions: readonly SessionInfo[],
+  sessionId: null | string
+): SessionProfileRoute | string | undefined {
+  if (!sessionId) {
+    return undefined
+  }
+
+  const session = sessions.find(candidate => sessionMatchesStoredId(candidate, sessionId))
+  const connectionId = session?.connection_id?.trim()
+
+  if (connectionId) {
+    return {
+      connectionId,
+      profile: session?.profile?.trim() || 'default'
+    }
+  }
+
+  const hint = getSessionOwnerHint(sessionId)
+
+  return hint ?? (session?.profile?.trim() || undefined)
+}
+
+/**
  * The profile a routed session belongs to, for keying the remembered id and
  * other PRESENTATION uses (which profile's sidebar/navigation this session sits
  * under). Falls back to the active gateway profile when the owner is unknown.


### PR DESCRIPTION
## Summary

- publish the registry connection identity owned by the Desktop window's primary gateway across boot, reconnect, soft-switch, and HMR adoption
- reuse that already-open primary socket when `requestGatewayForAgent` targets the exact same `(connectionId, profile)` owner
- keep different profiles and different registry sources isolated on their existing secondary routes

## Problem

`requestGatewayForAgent` currently treats every explicit `connectionId` as requiring a registry secondary. That is wrong when the selected remote registry connection is already the window primary: the durable session's owner metadata points back to the socket that is already open.

The duplicate helper dial can resolve the public endpoint through a different backend/profile route. The result is a split symptom: REST history from the primary renders correctly, while `session.resume` on the helper returns `session not found` and the live transcript remains static.

This was reproduced against clean current `main` with a focused regression test: the owner-matched resume went to a newly-created secondary and never called the primary. The observed macOS trace independently showed the same shape: correct durable stored ID, `session.resume` returning `4007 session not found`, and a short-lived helper WebSocket; the same stored ID resumed successfully through the existing primary connection.

## Fix

The gateway registry now remembers the primary descriptor's `connectionId`. `requestGatewayForAgent` collapses to `requestGatewayForProfile` only when both owner dimensions match:

- requested `connectionId` equals the primary's published registry source
- requested profile equals the primary profile

Unknown identity, a different source, or a different profile keeps the existing isolated-secondary behavior. Changing the primary gateway clears the remembered identity before a new descriptor is published.

## Related work / duplicate check

This is complementary rather than duplicative:

- #93451 preserves/falls back session owner metadata, but its exact-owner path still funnels into `requestGatewayForAgent` and therefore still creates the duplicate helper.
- #94145 fixes the registered-switch barrier and stale runtime-ID leak; this reproduction sends the correct durable stored ID.
- #94370 preserves registered sockets during mode switches and idle handoff; it does not collapse an owner-matched request onto the primary.
- #94656 strengthens fresh-chat owner continuity; it still dispatches exact owners through `requestGatewayForAgent`.

Related symptom family: #93888. This patch addresses the durable-ID/helper-route variant, not that issue's reported cross-gateway runtime-ID leak.

## Verification

- regression proved red on clean `main`: primary request count `0`, helper created
- focused Desktop UI suites: 118 passed
- existing REST-fallback coverage included (`use-session-actions.test.tsx`)
- `npm run typecheck`
- ESLint on all changed files: 0 issues
- Prettier check on all changed files
- `git diff --check`
- full UI suite on Windows: 5,704 passed / 9 failed in five untouched files, plus four worker-start errors under parallel load
- serial rerun of those five files: 66 passed / 3 failed; two failures are Windows locale/NBSP assertions, and the remaining `gateway-settings.test.tsx` collection `STACK_TRACE_ERROR` reproduces unchanged on pristine `origin/main`

## Risk

Low and fail-closed. Primary reuse requires exact source and profile equality; all ambiguous or cross-profile routes preserve their prior secondary isolation. No backend protocol, persistence schema, credentials, or network configuration changes.

<!-- macos-registry-e2e -->
### External macOS validation (sanitized)

A source-built Apple Silicon client at final head `ed4f3c73e9bd9fcd7661237a8a38dd2ca2e29261` was validated against a generic registry-backed remote connection using profile `default`:

- the existing durable session history loaded successfully
- live activity appeared in place while the session was running, without switching or refreshing
- a message sent from the resumed session completed and returned in the same view
- after navigating to another stored session and returning, history reloaded and a second resumed-session send also completed in place
- no new `session not found` response or RPC error was observed during either send
- the source checkout and embedded application stamp matched the final PR head
- macOS-focused validation passed 3/3 files and 102/102 tests; Desktop typecheck passed
- the official installed application, remote gateway, backend, credentials, and network configuration were left unchanged

This is supplementary end-to-end evidence for the registry-owner route; it does not introduce a gateway-specific assumption into the implementation or tests.
