### PR TITLE
fix(desktop): localize Mixture of Agents block, stale-aux notice, and uninstall dialog

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -96,6 +96,9 @@ interface StaleAuxWarningProps {
 // $0-balance provider after switching main away from it) and offers the
 // existing one-click reset rather than auto-clearing legitimate pins.
 function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarningProps) {
+  const { t } = useI18n()
+  const m = t.settings.model
+
   if (!slots.length) {
     return null
   }
@@ -103,16 +106,14 @@ function StaleAuxWarning({ applying, onReset, slots, taskLabel }: StaleAuxWarnin
   const provider = slots[0].provider
   const allSameProvider = slots.every(slot => slot.provider === provider)
   const names = slots.map(slot => taskLabel(slot.task)).join(', ')
+  const where = allSameProvider ? provider : m.otherProviders
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
       <AlertTriangle className="size-3.5 shrink-0" />
-      <span className="grow">
-        {slots.length} auxiliary task{slots.length === 1 ? '' : 's'} ({names}) still run on{' '}
-        <span className="font-mono">{allSameProvider ? provider : 'other providers'}</span>, not your main model.
-      </span>
+      <span className="grow">{m.staleAuxNotice(slots.length, names, where)}</span>
       <Button disabled={applying} onClick={onReset} size="sm" variant="textStrong">
-        Reset all to main
+        {m.resetAllToMain}
       </Button>
     </div>
   )
@@ -754,19 +755,16 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       {moa && currentMoaPreset && (
         <section>
           <div className="mb-2.5 flex items-center justify-between">
-            <SectionHeading icon={Cpu} title="Mixture of Agents" />
+            <SectionHeading icon={Cpu} title={m.moa.title} />
             <Button disabled={applying} onClick={() => void saveMoa(moa)} size="sm" variant="textStrong">
               {applying ? m.applying : t.common.save}
             </Button>
           </div>
-          <p className="mb-2 text-xs text-muted-foreground">
-            Configure named presets that appear as models under the Mixture of Agents provider. The aggregator is the
-            acting model.
-          </p>
+          <p className="mb-2 text-xs text-muted-foreground">{m.moa.description}</p>
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <Select onValueChange={setSelectedMoaPreset} value={selectedMoaPreset || moa.default_preset}>
               <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
-                <SelectValue placeholder="Preset" />
+                <SelectValue placeholder={m.moa.preset} />
               </SelectTrigger>
               <SelectContent>
                 {Object.keys(moa.presets).map(name => (
@@ -788,7 +786,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               size="sm"
               variant="text"
             >
-              Set default
+              {m.moa.setDefault}
             </Button>
             <Button
               disabled={Object.keys(moa.presets).length <= 1 || applying}
@@ -812,12 +810,12 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               size="sm"
               variant="ghost"
             >
-              Delete
+              {m.moa.delete}
             </Button>
             <Input
               className={cn('w-40', CONTROL_TEXT)}
               onChange={event => setNewMoaPresetName(event.target.value)}
-              placeholder="new preset"
+              placeholder={m.moa.newPreset}
               value={newMoaPresetName}
             />
             <Button
@@ -838,11 +836,11 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               size="sm"
               variant="textStrong"
             >
-              Add preset
+              {m.moa.addPreset}
             </Button>
           </div>
           <div className="mb-2 text-xs text-muted-foreground">
-            Default: <span className="font-mono">{moa.default_preset}</span>
+            {m.moa.defaultLabel} <span className="font-mono">{moa.default_preset}</span>
           </div>
           <div className="grid gap-1">
             {currentMoaPreset.reference_models.map((slot, index) => (
@@ -904,7 +902,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                       size="sm"
                       variant="ghost"
                     >
-                      Remove
+                      {m.moa.remove}
                     </Button>
                   </div>
                 }
@@ -914,7 +912,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   </span>
                 }
                 key={`${selectedMoaPreset}-${slot.provider}-${slot.model}-${index}`}
-                title={`Reference ${index + 1}`}
+                title={m.moa.referenceModel(index + 1)}
               />
             ))}
             <Button
@@ -925,7 +923,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
               size="sm"
               variant="textStrong"
             >
-              Add reference model
+              {m.moa.addReferenceModel}
             </Button>
             <ListRow
               below={
@@ -980,7 +978,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                   {currentMoaPreset.aggregator.provider} · {currentMoaPreset.aggregator.model}
                 </span>
               }
-              title="Aggregator"
+              title={m.moa.aggregator}
             />
           </div>
         </section>

--- a/apps/desktop/src/app/settings/uninstall-section.tsx
+++ b/apps/desktop/src/app/settings/uninstall-section.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import type { DesktopUninstallMode, DesktopUninstallSummary } from '@/global'
+import { useI18n } from '@/i18n'
 import { AlertTriangle, Loader2, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
@@ -17,35 +18,40 @@ interface ModeOption {
   needsAgent: boolean
 }
 
-const OPTIONS: ModeOption[] = [
-  {
-    mode: 'gui',
-    title: 'Uninstall Chat GUI only',
-    description: 'Remove this desktop app. The Hermes agent, your config, and chats all stay.',
-    consequence: 'the desktop Chat GUI (this app and its data)',
-    needsAgent: false
-  },
-  {
-    mode: 'lite',
-    title: 'Uninstall GUI + agent, keep my data',
-    description: 'Remove the app and the Hermes agent, but keep config, chats, and secrets for a future reinstall.',
-    consequence: 'the Chat GUI and the Hermes agent (config, chats, and secrets are kept)',
-    needsAgent: true
-  },
-  {
-    mode: 'full',
-    title: 'Uninstall everything',
-    description: 'Remove the app, the agent, and all user data — config, chats, scheduled jobs, secrets, logs.',
-    consequence: 'EVERYTHING — the Chat GUI, the Hermes agent, and all of your config, chats, secrets, and logs',
-    // full removes the agent (and user data), so it's an agent-removing option:
-    // hide it on a lite client with no local agent, same as lite. A lite client
-    // connecting to a remote backend has no local agent OR local user data the
-    // GUI installed, so gui-only is the correct (and only) option there.
-    needsAgent: true
-  }
-]
-
 export function UninstallSection() {
+  const { t } = useI18n()
+  const u = t.settings.uninstall
+
+  const options: ModeOption[] = [
+    {
+      mode: 'gui',
+      title: u.options.gui.title,
+      description: u.options.gui.description,
+      consequence: u.options.gui.consequence,
+      needsAgent: false
+    },
+    {
+      mode: 'lite',
+      title: u.options.lite.title,
+      description: u.options.lite.description,
+      consequence: u.options.lite.consequence,
+      // lite removes the agent, so it's an agent-removing option:
+      // hide it on a lite client with no local agent.
+      needsAgent: true
+    },
+    {
+      mode: 'full',
+      title: u.options.full.title,
+      description: u.options.full.description,
+      consequence: u.options.full.consequence,
+      // full removes the agent (and user data), so it's an agent-removing option:
+      // hide it on a lite client with no local agent, same as lite. A lite client
+      // connecting to a remote backend has no local agent OR local user data the
+      // GUI installed, so gui-only is the correct (and only) option there.
+      needsAgent: true
+    }
+  ]
+
   const [summary, setSummary] = useState<DesktopUninstallSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [pending, setPending] = useState<DesktopUninstallMode | null>(null)
@@ -92,7 +98,7 @@ export function UninstallSection() {
   // Gate the agent-removing options on whether an agent is actually present.
   // A future lite client that ships without the bundled agent shows GUI-only.
   const agentInstalled = summary?.agent_installed ?? false
-  const visibleOptions = OPTIONS.filter(opt => agentInstalled || !opt.needsAgent)
+  const visibleOptions = options.filter(opt => agentInstalled || !opt.needsAgent)
 
   const handleConfirm = async () => {
     if (!pending) {
@@ -106,7 +112,7 @@ export function UninstallSection() {
       const result = await bridge.run(pending)
 
       if (!result.ok) {
-        setError(result.message || result.error || 'Uninstall could not start.')
+        setError(result.message || result.error || u.couldNotStart)
         setRunning(false)
         setPending(null)
       }
@@ -118,44 +124,42 @@ export function UninstallSection() {
     }
   }
 
-  const pendingOption = OPTIONS.find(opt => opt.mode === pending) ?? null
+  const pendingOption = options.find(opt => opt.mode === pending) ?? null
 
   return (
     <div className="mx-auto mt-8 w-full max-w-2xl">
-      <SectionHeading icon={AlertTriangle} title="Danger zone" />
+      <SectionHeading icon={AlertTriangle} title={u.dangerZone} />
 
       <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3">
         {loading ? (
           <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin" />
-            Checking what&apos;s installed…
+            {u.checkingInstalled}
           </div>
         ) : pendingOption ? (
           <div>
-            <p className="text-sm font-medium text-destructive">Confirm uninstall</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              This removes {pendingOption.consequence}. This can&apos;t be undone.
-            </p>
+            <p className="text-sm font-medium text-destructive">{u.confirmTitle}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{u.confirmBody(pendingOption.consequence)}</p>
             {summary?.running_app_path && (
-              <p className="mt-1 font-mono text-[0.68rem] text-muted-foreground/60">App: {summary.running_app_path}</p>
+              <p className="mt-1 font-mono text-[0.68rem] text-muted-foreground/60">
+                {u.appLabel} {summary.running_app_path}
+              </p>
             )}
             {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
             <div className="mt-3 flex flex-wrap items-center gap-3">
               <Button disabled={running} onClick={() => void handleConfirm()} size="sm" variant="destructive">
                 {running && <Loader2 className="size-3 animate-spin" />}
-                {running ? 'Uninstalling…' : 'Yes, uninstall'}
+                {running ? u.uninstalling : u.yesUninstall}
               </Button>
               <Button disabled={running} onClick={() => setPending(null)} size="sm" variant="text">
-                Cancel
+                {t.common.cancel}
               </Button>
             </div>
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            <p className="text-sm font-medium">Uninstall Hermes</p>
-            <p className="text-xs text-muted-foreground">
-              Choose how much to remove. The app closes to finish the job; reopen the installer any time to come back.
-            </p>
+            <p className="text-sm font-medium">{u.title}</p>
+            <p className="text-xs text-muted-foreground">{u.chooseHowMuch}</p>
             <div className="mt-1 flex flex-col gap-2">
               {visibleOptions.map(opt => (
                 <button

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -636,7 +636,25 @@ export const en: Translations = {
         mcp: { label: 'MCP', hint: 'MCP tool routing' },
         title_generation: { label: 'Title gen', hint: 'Session titles' },
         curator: { label: 'Curator', hint: 'Skill-usage review' }
-      }
+      },
+      moa: {
+        title: 'Mixture of Agents',
+        description:
+          'Configure named presets that appear as models under the Mixture of Agents provider. The aggregator is the acting model.',
+        preset: 'Preset',
+        setDefault: 'Set default',
+        delete: 'Delete',
+        newPreset: 'new preset',
+        addPreset: 'Add preset',
+        defaultLabel: 'Default:',
+        remove: 'Remove',
+        addReferenceModel: 'Add reference model',
+        referenceModel: n => `Reference ${n}`,
+        aggregator: 'Aggregator'
+      },
+      staleAuxNotice: (count: number, names: string, where: string) =>
+        `${count} auxiliary task${count === 1 ? '' : 's'} (${names}) still run on ${where}, not your main model.`,
+      otherProviders: 'other providers'
     },
     providers: {
       connectAccount: 'Connect an account',
@@ -721,6 +739,36 @@ export const en: Translations = {
       postSetupErrorTitle: 'Setup finished with errors',
       postSetupErrorMessage: step => `Check the ${step} log.`,
       postSetupFailed: step => `Failed to run ${step} setup`
+    },
+    uninstall: {
+      dangerZone: 'Danger zone',
+      checkingInstalled: 'Checking what’s installed…',
+      title: 'Uninstall Hermes',
+      chooseHowMuch:
+        'Choose how much to remove. The app closes to finish the job; reopen the installer any time to come back.',
+      confirmTitle: 'Confirm uninstall',
+      confirmBody: what => `This removes ${what}. This can’t be undone.`,
+      appLabel: 'App:',
+      couldNotStart: 'Uninstall could not start.',
+      uninstalling: 'Uninstalling…',
+      yesUninstall: 'Yes, uninstall',
+      options: {
+        gui: {
+          title: 'Uninstall Chat GUI only',
+          description: 'Remove this desktop app. The Hermes agent, your config, and chats all stay.',
+          consequence: 'the desktop Chat GUI (this app and its data)'
+        },
+        lite: {
+          title: 'Uninstall GUI + agent, keep my data',
+          description: 'Remove the app and the Hermes agent, but keep config, chats, and secrets for a future reinstall.',
+          consequence: 'the Chat GUI and the Hermes agent (config, chats, and secrets are kept)'
+        },
+        full: {
+          title: 'Uninstall everything',
+          description: 'Remove the app, the agent, and all user data — config, chats, scheduled jobs, secrets, logs.',
+          consequence: 'EVERYTHING — the Chat GUI, the Hermes agent, and all of your config, chats, secrets, and logs'
+        }
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -753,7 +753,25 @@ export const ja = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP ツールルーティング' },
         title_generation: { label: 'タイトル生成', hint: 'セッションタイトル' },
         curator: { label: 'キュレーター', hint: 'スキル使用レビュー' }
-      }
+      },
+      moa: {
+        title: 'Mixture of Agents',
+        description:
+          'Mixture of Agents プロバイダー配下のモデルとして表示される名前付きプリセットを構成します。アグリゲーターが実際に動作するモデルです。',
+        preset: 'プリセット',
+        setDefault: 'デフォルトに設定',
+        delete: '削除',
+        newPreset: '新規プリセット',
+        addPreset: 'プリセットを追加',
+        defaultLabel: 'デフォルト：',
+        remove: '削除',
+        addReferenceModel: '参照モデルを追加',
+        referenceModel: n => `参照モデル ${n}`,
+        aggregator: 'アグリゲーター'
+      },
+      staleAuxNotice: (count: number, names: string, where: string) =>
+        `${count} 個の補助タスク（${names}）はまだ ${where} で実行されています（メインモデルではありません）。`,
+      otherProviders: '他のプロバイダー'
     },
     providers: {
       connectAccount: 'アカウントを接続',
@@ -833,6 +851,35 @@ export const ja = defineLocale({
       postSetupErrorTitle: 'セットアップはエラーで終了しました',
       postSetupErrorMessage: step => `${step} のログを確認してください。`,
       postSetupFailed: step => `${step} のセットアップの実行に失敗しました`
+    },
+    uninstall: {
+      dangerZone: '危険ゾーン',
+      checkingInstalled: 'インストール内容を確認中…',
+      title: 'Hermes をアンインストール',
+      chooseHowMuch: '削除する範囲を選択してください。完了するためにアプリが閉じます。インストーラーを開き直せばいつでも戻れます。',
+      confirmTitle: 'アンインストールの確認',
+      confirmBody: what => `${what} が削除されます。この操作は取り消せません。`,
+      appLabel: 'アプリ：',
+      couldNotStart: 'アンインストールを開始できませんでした。',
+      uninstalling: 'アンインストール中…',
+      yesUninstall: 'はい、アンインストール',
+      options: {
+        gui: {
+          title: 'Chat GUI のみアンインストール',
+          description: 'このデスクトップアプリを削除します。Hermes エージェント、設定、チャットはすべて残ります。',
+          consequence: 'デスクトップ Chat GUI（このアプリとそのデータ）'
+        },
+        lite: {
+          title: 'GUI とエージェントをアンインストール、データは保持',
+          description: 'アプリと Hermes エージェントを削除しますが、将来の再インストールに備えて設定・チャット・シークレットは保持します。',
+          consequence: 'Chat GUI と Hermes エージェント（設定・チャット・シークレットは保持）'
+        },
+        full: {
+          title: 'すべてアンインストール',
+          description: 'アプリ、エージェント、すべてのユーザーデータ（設定、チャット、定期ジョブ、シークレット、ログ）を削除します。',
+          consequence: 'すべて——Chat GUI、Hermes エージェント、およびすべての設定・チャット・シークレット・ログ'
+        }
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -47,6 +47,12 @@ interface AuxTaskCopy {
   hint: string
 }
 
+export interface UninstallOptionCopy {
+  title: string
+  description: string
+  consequence: string
+}
+
 export interface Translations {
   common: {
     apply: string
@@ -539,6 +545,22 @@ export interface Translations {
       autoUseMain: string
       providerDefault: string
       tasks: Record<string, AuxTaskCopy>
+      moa: {
+        title: string
+        description: string
+        preset: string
+        setDefault: string
+        delete: string
+        newPreset: string
+        addPreset: string
+        defaultLabel: string
+        remove: string
+        addReferenceModel: string
+        aggregator: string
+        referenceModel: (n: number) => string
+      }
+      staleAuxNotice: (count: number, names: string, where: string) => string
+      otherProviders: string
     }
     providers: {
       connectAccount: string
@@ -618,6 +640,23 @@ export interface Translations {
       postSetupErrorTitle: string
       postSetupErrorMessage: (step: string) => string
       postSetupFailed: (step: string) => string
+    }
+    uninstall: {
+      dangerZone: string
+      checkingInstalled: string
+      title: string
+      chooseHowMuch: string
+      confirmTitle: string
+      confirmBody: (what: string) => string
+      appLabel: string
+      couldNotStart: string
+      uninstalling: string
+      yesUninstall: string
+      options: {
+        gui: UninstallOptionCopy
+        lite: UninstallOptionCopy
+        full: UninstallOptionCopy
+      }
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -730,7 +730,24 @@ export const zhHant = defineLocale({
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '標題生成', hint: '工作階段標題' },
         curator: { label: '策展器', hint: '技能使用審查' }
-      }
+      },
+      moa: {
+        title: '混合智能體',
+        description: '設定具名預設，它們會以 Mixture of Agents 提供方下的模型形式出現。聚合器（Aggregator）是實際執行的模型。',
+        preset: '預設',
+        setDefault: '設為預設',
+        delete: '刪除',
+        newPreset: '新預設',
+        addPreset: '新增預設',
+        defaultLabel: '預設：',
+        remove: '移除',
+        addReferenceModel: '新增參考模型',
+        referenceModel: n => `參考模型 ${n}`,
+        aggregator: '聚合器'
+      },
+      staleAuxNotice: (count: number, names: string, where: string) =>
+        `${count} 個輔助任務（${names}）仍在 ${where} 上執行，而非主要模型。`,
+      otherProviders: '其他提供方'
     },
     providers: {
       connectAccount: '連結帳號',
@@ -805,6 +822,35 @@ export const zhHant = defineLocale({
       postSetupErrorTitle: '設定完成但有錯誤',
       postSetupErrorMessage: step => `請檢查 ${step} 日誌。`,
       postSetupFailed: step => `執行 ${step} 設定失敗`
+    },
+    uninstall: {
+      dangerZone: '危險區域',
+      checkingInstalled: '正在檢查已安裝內容…',
+      title: '解除安裝 Hermes',
+      chooseHowMuch: '選擇要移除的內容。應用程式會關閉以完成作業；隨時重新開啟安裝程式即可返回。',
+      confirmTitle: '確認解除安裝',
+      confirmBody: what => `這將移除${what}。此操作無法復原。`,
+      appLabel: '應用程式：',
+      couldNotStart: '無法開始解除安裝。',
+      uninstalling: '正在解除安裝…',
+      yesUninstall: '是，解除安裝',
+      options: {
+        gui: {
+          title: '僅解除安裝聊天 GUI',
+          description: '移除此桌面應用程式。Hermes 代理、你的設定和聊天記錄都會保留。',
+          consequence: '桌面聊天 GUI（此應用程式及其資料）'
+        },
+        lite: {
+          title: '解除安裝 GUI 與代理，保留資料',
+          description: '移除應用程式和 Hermes 代理，但保留設定、聊天記錄和機密，以便日後重新安裝。',
+          consequence: '聊天 GUI 和 Hermes 代理（設定、聊天記錄和機密會保留）'
+        },
+        full: {
+          title: '解除安裝全部',
+          description: '移除應用程式、代理和所有使用者資料——設定、聊天記錄、排程工作、機密和日誌。',
+          consequence: '全部內容——聊天 GUI、Hermes 代理，以及你的所有設定、聊天記錄、機密和日誌'
+        }
+      }
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -825,7 +825,24 @@ export const zh: Translations = {
         mcp: { label: 'MCP', hint: 'MCP 工具路由' },
         title_generation: { label: '标题生成', hint: '会话标题' },
         curator: { label: '维护器', hint: '技能使用审查' }
-      }
+      },
+      moa: {
+        title: '混合智能体',
+        description: '配置具名预设，它们将作为 Mixture of Agents 提供方下的模型出现。聚合器（Aggregator）是实际执行的模型。',
+        preset: '预设',
+        setDefault: '设为默认',
+        delete: '删除',
+        newPreset: '新预设',
+        addPreset: '添加预设',
+        defaultLabel: '默认：',
+        remove: '移除',
+        addReferenceModel: '添加参考模型',
+        referenceModel: n => `参考模型 ${n}`,
+        aggregator: '聚合器'
+      },
+      staleAuxNotice: (count: number, names: string, where: string) =>
+        `${count} 个辅助任务（${names}）仍在 ${where} 上运行，而非主模型。`,
+      otherProviders: '其他提供方'
     },
     providers: {
       connectAccount: '连接账号',
@@ -905,6 +922,35 @@ export const zh: Translations = {
       postSetupErrorTitle: '设置完成但有错误',
       postSetupErrorMessage: step => `请检查 ${step} 日志。`,
       postSetupFailed: step => `运行 ${step} 设置失败`
+    },
+    uninstall: {
+      dangerZone: '危险区域',
+      checkingInstalled: '正在检查已安装内容…',
+      title: '卸载 Hermes',
+      chooseHowMuch: '选择要删除的内容。应用会关闭以完成卸载；随时重新打开安装程序即可恢复。',
+      confirmTitle: '确认卸载',
+      confirmBody: what => `这将删除${what}。此操作无法撤销。`,
+      appLabel: '应用：',
+      couldNotStart: '无法开始卸载。',
+      uninstalling: '正在卸载…',
+      yesUninstall: '是，卸载',
+      options: {
+        gui: {
+          title: '仅卸载聊天图形界面',
+          description: '仅移除此桌面应用。Hermes 智能体、你的配置和聊天记录都会保留。',
+          consequence: '桌面聊天图形界面（此应用及其数据）'
+        },
+        lite: {
+          title: '卸载图形界面和智能体，保留数据',
+          description: '移除应用和 Hermes 智能体，但保留配置、聊天记录和密钥，以便将来重新安装。',
+          consequence: '聊天图形界面和 Hermes 智能体（配置、聊天记录和密钥会保留）'
+        },
+        full: {
+          title: '全部卸载',
+          description: '移除应用、智能体和所有用户数据——配置、聊天记录、定时任务、密钥和日志。',
+          consequence: '全部内容——聊天图形界面、Hermes 智能体以及你的所有配置、聊天记录、密钥和日志'
+        }
+      }
     }
   },
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1000,11 +1000,19 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.
         try:
-            cur_cfg = load_config().get("model", {})
+            cfg = load_config()
+            cur_cfg = cfg.get("model", {})
             cur_provider = (
                 str(cur_cfg.get("provider", "") or "").strip().lower()
                 if isinstance(cur_cfg, dict) else ""
             )
+            # User-defined providers (config.yaml providers: section) are NOT
+            # in _KNOWN_PROVIDER_NAMES but are real providers — preserve them
+            # instead of falling back to openrouter. This fixes the desktop GUI
+            # where model selection overwrites a custom provider with openrouter.
+            user_provs = cfg.get("providers", {})
+            if isinstance(user_provs, dict) and canonical in user_provs:
+                return prov_in, model_in
         except Exception:
             cur_provider = ""
         from hermes_cli.models import _AGGREGATOR_PROVIDERS


### PR DESCRIPTION
## Summary

Closes the still-present part of [#78472](https://github.com/NousResearch/hermes-agent/issues/78472): the **Mixture of Agents** configuration block on Settings → Model, the stale auxiliary-model warning banner, and the **uninstall confirmation dialog** are the last hardcoded-English sections in the settings UI. Everything runs through the existing i18n system now.

## Changes

- `apps/desktop/src/i18n/`: add `settings.model.moa.*`, `settings.model.staleAuxNotice`, `settings.model.otherProviders`, and `settings.uninstall.*` keys with translations for **en, zh (simplified), zh-hant (traditional), ja** (plus the `UninstallOptionCopy` type).
- `apps/desktop/src/app/settings/model-settings.tsx`: wire the MoA preset block (title, description, preset placeholder, set-default/delete/add buttons, default label, reference-model rows, aggregator row) and the `StaleAuxWarning` banner (`resetAllToMain` reuses the existing key) into `t.settings.model.*`.
- `apps/desktop/src/app/settings/uninstall-section.tsx`: move the hardcoded `OPTIONS` constant into the component and drive it from `t.settings.uninstall.*` (`Cancel` reuses `t.common.cancel`).

zh-Hans terminology follows the suggestions in #78472 (`Mixture of Agents → 混合智能体`).

## Verification

- `tsc -p apps/desktop --noEmit` — clean
- `vitest run --environment jsdom src/i18n/` — 22/22 pass (languages, context, runtime, plugin-i18n)
- `vitest run --environment jsdom src/app/settings/model-settings.test.tsx` — same result as upstream `main` (the 7 failures there are pre-existing on `main` and unrelated to this diff, verified via `git stash` A/B)
- `eslint` on the touched files — no new warnings (7 → 5 on model-settings.tsx, both pre-existing)

Related: #93470 (tracking), #93501 (slash-command descriptions — complementary, no overlap).