### PR TITLE
fix(agent): honor auxiliary.background_review.reasoning_effort on routed review forks

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,7 @@ import threading
 from typing import Any, Dict, List, Optional
 
 from agent.thread_scoped_output import thread_scoped_silence
+from hermes_constants import parse_reasoning_effort
 
 logger = logging.getLogger(__name__)
 
@@ -1262,10 +1263,12 @@ def _run_review_in_thread(
                 # over provider defaults (#94825), same wire contract as
                 # every other auxiliary task (_get_task_extra_body folds the
                 # same key into extra_body.reasoning there).
-                _routed_effort = task_cfg.get("reasoning_effort") if task_cfg else None
+                _routed_effort = (
+                    task_cfg.get("reasoning_effort")
+                    if isinstance(task_cfg, dict)
+                    else None
+                )
                 if _routed_effort is not None and _routed_effort != "":
-                    from hermes_constants import parse_reasoning_effort
-
                     _parsed = parse_reasoning_effort(_routed_effort)
                     if _parsed is not None:
                         _fork_kwargs["reasoning_config"] = _parsed

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1210,9 +1210,29 @@ def _run_review_in_thread(
             # unclamped; codex_responses passes ``max``/``ultra`` through
             # unmapped except on gpt-5.6/xAI). Let the routed fork use
             # provider defaults — matching the ``not _routed`` gate on
-            # _cached_system_prompt below.
+            # _cached_system_prompt below — UNLESS the user pinned the
+            # effort for this task: auxiliary.background_review.
+            # reasoning_effort is declared config (#64597) and an explicit
+            # value must win over provider defaults (#94825), same wire
+            # contract as every other auxiliary task (_get_task_extra_body
+            # folds the same key into extra_body.reasoning there).
             if not _routed:
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
+            else:
+                _routed_effort = task_cfg.get("reasoning_effort") if task_cfg else None
+                if _routed_effort is not None and _routed_effort != "":
+                    from hermes_constants import parse_reasoning_effort
+
+                    _parsed = parse_reasoning_effort(_routed_effort)
+                    if _parsed is not None:
+                        _fork_kwargs["reasoning_config"] = _parsed
+                    else:
+                        logger.warning(
+                            "auxiliary.background_review.reasoning_effort %r "
+                            "is not a valid level (none, minimal, low, medium, "
+                            "high, xhigh, max, ultra) — ignoring",
+                            _routed_effort,
+                        )
                 # Gateway session context is appended to the parent's cached
                 # system prompt at API-call time through this field.  Preserve
                 # it on same-model forks so the complete effective system

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1218,21 +1218,6 @@ def _run_review_in_thread(
             # folds the same key into extra_body.reasoning there).
             if not _routed:
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
-            else:
-                _routed_effort = task_cfg.get("reasoning_effort") if task_cfg else None
-                if _routed_effort is not None and _routed_effort != "":
-                    from hermes_constants import parse_reasoning_effort
-
-                    _parsed = parse_reasoning_effort(_routed_effort)
-                    if _parsed is not None:
-                        _fork_kwargs["reasoning_config"] = _parsed
-                    else:
-                        logger.warning(
-                            "auxiliary.background_review.reasoning_effort %r "
-                            "is not a valid level (none, minimal, low, medium, "
-                            "high, xhigh, max, ultra) — ignoring",
-                            _routed_effort,
-                        )
                 # Gateway session context is appended to the parent's cached
                 # system prompt at API-call time through this field.  Preserve
                 # it on same-model forks so the complete effective system
@@ -1270,6 +1255,27 @@ def _run_review_in_thread(
                     _pref_val = getattr(agent, _pref_attr, None)
                     if _pref_val:
                         _fork_kwargs[_pref_attr] = _pref_val
+            else:
+                # The user may still pin the effort FOR THIS TASK on the
+                # routed model: auxiliary.background_review.reasoning_effort
+                # is declared config (#64597) and an explicit value must win
+                # over provider defaults (#94825), same wire contract as
+                # every other auxiliary task (_get_task_extra_body folds the
+                # same key into extra_body.reasoning there).
+                _routed_effort = task_cfg.get("reasoning_effort") if task_cfg else None
+                if _routed_effort is not None and _routed_effort != "":
+                    from hermes_constants import parse_reasoning_effort
+
+                    _parsed = parse_reasoning_effort(_routed_effort)
+                    if _parsed is not None:
+                        _fork_kwargs["reasoning_config"] = _parsed
+                    else:
+                        logger.warning(
+                            "auxiliary.background_review.reasoning_effort %r "
+                            "is not a valid level (none, minimal, low, medium, "
+                            "high, xhigh, max, ultra) — ignoring",
+                            _routed_effort,
+                        )
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=_REVIEW_MAX_ITERATIONS,

--- a/tests/agent/test_background_review_routed_effort.py
+++ b/tests/agent/test_background_review_routed_effort.py
@@ -1,0 +1,155 @@
+"""Routed background reviews must honor auxiliary.background_review.reasoning_effort (#94825).
+
+The review fork is a full AIAgent, not an auxiliary_client call, and the
+routed branch deliberately skips the parent's reasoning_config (its effort
+vocabulary may not be valid for the routed model). But an explicitly
+configured ``auxiliary.background_review.reasoning_effort`` — declared config
+since #64597 — must win over provider defaults, mirroring how every other
+auxiliary task folds the same key into ``extra_body.reasoning``.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import agent.background_review as br
+
+
+class _StubAgent:
+    """Minimal parent satisfying the fork path's attribute reads."""
+
+    model = "gpt-5.6-terra"
+    provider = "openai-codex"
+    platform = "cli"
+    session_id = "sess-review-effort"
+    enabled_toolsets = None
+    disabled_toolsets = None
+    reasoning_config = {"enabled": True, "effort": "high"}
+    ephemeral_system_prompt = None
+    prefill_messages = None
+
+    def __init__(self):
+        for attr in (
+            "providers_allowed", "providers_ignored", "providers_order",
+            "provider_sort", "provider_require_parameters",
+            "provider_data_collection",
+        ):
+            setattr(self, attr, None)
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    _memory_store = None
+    _memory_enabled = False
+    _session_db = None
+
+    def _emit_auxiliary_failure(self, *a, **k):
+        pass
+
+
+def _run_with_captured_fork(monkeypatch, routed_runtime, task_cfg):
+    captured = {}
+
+    class _FakeFork:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.session_id = "fork"
+            self._session_db = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+
+    monkeypatch.setattr("run_agent.AIAgent", _FakeFork)
+    monkeypatch.setattr(
+        br, "_resolve_review_runtime", lambda agent, cfg: routed_runtime
+    )
+
+    # Silence the review run itself: capture run_conversation so the thread
+    # returns before touching any provider.
+    monkeypatch.setattr(
+        br, "_REVIEW_MAX_ITERATIONS", 1, raising=False
+    )
+    ran = {}
+
+    def _fake_run(self, *a, **k):
+        ran["called"] = True
+        return None
+
+    _FakeFork.run_conversation = _fake_run
+    monkeypatch.setattr(
+        br, "_snapshot_review_usage", lambda ra: {}, raising=False
+    )
+    monkeypatch.setattr(
+        br, "_record_review_usage_to_parent",
+        lambda *a, **k: None, raising=False,
+    )
+    monkeypatch.setattr(
+        br, "_classify_review_result", lambda actions: "ok", raising=False
+    )
+    monkeypatch.setattr(
+        br, "_log_review_completion", lambda *a, **k: None, raising=False
+    )
+
+    agent = _StubAgent()
+    br._run_review_in_thread(
+        agent,
+        [{"role": "user", "content": "review me"}],
+        "review prompt",
+        task_cfg=task_cfg,
+    )
+    return captured, ran
+
+
+ROUTED_RUNTIME = {
+    "routed": True,
+    "model": "gpt-5.6-luna-900k",
+    "provider": "openai-codex",
+    "api_mode": None,
+    "base_url": None,
+    "api_key": None,
+    "credential_pool": None,
+    "request_overrides": {},
+}
+
+
+def test_routed_review_applies_configured_effort(monkeypatch):
+    captured, _ = _run_with_captured_fork(
+        monkeypatch,
+        ROUTED_RUNTIME,
+        {"reasoning_effort": "xhigh"},
+    )
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+
+def test_routed_review_without_effort_uses_provider_default(monkeypatch):
+    captured, _ = _run_with_captured_fork(
+        monkeypatch,
+        ROUTED_RUNTIME,
+        {"reasoning_effort": ""},
+    )
+    assert "reasoning_config" not in captured, (
+        "no explicit effort: the routed fork keeps provider defaults"
+    )
+
+
+def test_routed_review_invalid_effort_ignored_with_warning(monkeypatch, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        captured, _ = _run_with_captured_fork(
+            monkeypatch,
+            ROUTED_RUNTIME,
+            {"reasoning_effort": "ludicrous"},
+        )
+    assert "reasoning_config" not in captured
+    assert "not a valid level" in caplog.text
+
+
+def test_same_model_review_still_inherits_parent_config(monkeypatch):
+    captured, _ = _run_with_captured_fork(
+        monkeypatch,
+        dict(ROUTED_RUNTIME, routed=False),
+        {"reasoning_effort": "xhigh"},
+    )
+    # Same-model path is unchanged: parent parity wins for cache reuse.
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "high"}

--- a/tests/agent/test_background_review_routed_effort.py
+++ b/tests/agent/test_background_review_routed_effort.py
@@ -40,6 +40,14 @@ class _StubAgent:
     def _safe_print(self, *a, **k):
         pass
 
+    # No-op seams so future fork-path changes (activity tracking, progress
+    # reporting) fail assertions on behavior instead of AttributeError.
+    def _touch_activity(self, *a, **k):
+        pass
+
+    def tool_progress_callback(self, *a, **k):
+        pass
+
     _memory_store = None
     _memory_enabled = False
     _session_db = None
@@ -142,7 +150,9 @@ def test_routed_review_invalid_effort_ignored_with_warning(monkeypatch, caplog):
             {"reasoning_effort": "ludicrous"},
         )
     assert "reasoning_config" not in captured
-    assert "not a valid level" in caplog.text
+    # Assert on the invalid value, not the warning's exact wording, so a
+    # message edit can't break this test for a cosmetic reason.
+    assert "ludicrous" in caplog.text
 
 
 def test_same_model_review_still_inherits_parent_config(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`auxiliary.background_review.reasoning_effort` is declared config (#64597), and every other auxiliary task folds the same key into `extra_body.reasoning` via `_get_task_extra_body`. But the background memory/skill review is a full `AIAgent` fork, not an `auxiliary_client` call — and its routed branch never read the key. A review routed via `auxiliary.background_review.{provider, model}` silently fell back to the routed provider's default reasoning level instead of the explicitly configured effort, with no user-visible error (#94825).

The fix applies the explicit effort on the **routed branch only**:

- `reasoning_effort` set → parsed with the shared `parse_reasoning_effort` (same valid levels and `none`-aliases as every other surface) and passed as the fork's `reasoning_config`.
- empty / absent → provider defaults, exactly as before.
- invalid value → warning naming the valid levels, ignored (fail-open to defaults, same as `_get_task_extra_body`).
- **same-model (non-routed) path is byte-for-byte unchanged** — it still inherits the parent's `reasoning_config` for cache-prefix parity, which is the deliberate design documented on that branch.

This respects the routed branch's own rationale (the *parent's* effort vocabulary may not be valid for the routed model) while honoring the one value the user explicitly pinned *for this task on that routed model*.

## Related Issue

Fixes #94825

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/background_review.py` — the `_routed` branch of the fork-kwargs builder now consumes `task_cfg["reasoning_effort"]` through `parse_reasoning_effort`, warning on invalid values; the `not _routed` branch is untouched.
- `tests/agent/test_background_review_routed_effort.py` — new suite capturing the fork's `AIAgent` kwargs via a stub: configured effort reaches the fork as `reasoning_config`; empty keeps provider defaults; invalid warns and falls through; same-model still inherits the parent's config.

## How to Test

1. `pytest tests/agent/test_background_review_routed_effort.py -q` — should pass (4 passed). Adjacent suites (`test_background_review_list_shapes.py`, `test_background_review_session_isolation.py`, `test_compression_concurrent_fork.py`) pass 54/54.
2. Observed result: with this PR's source reverted, the configured-effort and invalid-effort tests fail — the routed fork is constructed with no `reasoning_config` regardless of the setting; with the change, `xhigh` reaches the fork and the other three behaviors pin the unchanged/edge paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue: with `auxiliary.background_review.{provider: openai-codex, model: gpt-5.6-luna-900k, reasoning_effort: xhigh}`, the routed review fork resolved the provider and model but never received the effort — observable only in source (`agent/background_review.py` has no consumption of the key). After this fix the fork's `reasoning_config` is `{"enabled": true, "effort": "xhigh"}`.
