### PR TITLE
fix(desktop): open remote gateway media via the authenticated bridge

### DIFF
--- a/apps/desktop/src/components/chat/generated-image-result.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.tsx
@@ -7,8 +7,16 @@ import { ImageActionButton, ImageLightbox } from '@/components/chat/zoomable-ima
 import { useImageDownload } from '@/hooks/use-image-download'
 import { useI18n } from '@/i18n'
 import { generatedImageFromResult } from '@/lib/generated-images'
-import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl, mediaName } from '@/lib/media'
+import {
+  filePathFromMediaPath,
+  gatewayMediaDataUrl,
+  isRemoteGateway,
+  mediaExternalUrl,
+  mediaName,
+  openMediaFileExternally
+} from '@/lib/media'
 import { cn } from '@/lib/utils'
+import { notifyError } from '@/store/notifications'
 
 // Aspect hint from the tool args sizes the frame *before* the image loads, so
 // the placeholder and the resolved image occupy the same box — no layout shift.
@@ -100,7 +108,9 @@ export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({
         href="#"
         onClick={event => {
           event.preventDefault()
-          void window.hermesDesktop?.openExternal(mediaExternalUrl(image))
+          // The bug being fixed here was a silent no-op, so a failed fetch must
+          // not be swallowed back into silence.
+          void openMediaFileExternally(image).catch(error => notifyError(error, copy.imageDownloadFailed))
         }}
       >
         {copy.openImage}: {mediaName(image)}

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -352,4 +352,17 @@ describe('openMediaFileExternally', () => {
     await expect(openMediaFileExternally('/srv/out/a.png')).rejects.toThrow('gateway read failed')
     expect(openExternal).not.toHaveBeenCalled()
   })
+
+  // Gating the remote branch on the bridge's presence would drop a remote path
+  // into the local `file://` branch when the bridge is absent entirely, and
+  // `?.` then resolves to undefined — the exact silent no-op this fix removes.
+  // A remote open with no bridge must be a loud failure, not a quiet success.
+  it('rejects rather than silently resolving for a remote path with no bridge', async () => {
+    vi.stubGlobal('window', {})
+    $connection.set({ authMode: 'oauth', mode: 'remote', token: null } as never)
+
+    await expect(openMediaFileExternally('/srv/out/a.png')).rejects.toThrow(
+      'Desktop file download bridge is unavailable'
+    )
+  })
 })

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -10,6 +10,7 @@ import {
   isRemoteGateway,
   mediaExternalUrl,
   mediaGatewayStreamUrl,
+  openMediaFileExternally,
   resolveMediaDisplaySrc,
   resolveMediaPlaybackSrc
 } from './media'
@@ -266,5 +267,89 @@ describe('downloadGatewayMediaFile', () => {
     await expect(downloadGatewayMediaFile('/Users/me/project/report.md')).rejects.toThrow(
       'Desktop file download bridge'
     )
+  })
+})
+
+describe('openMediaFileExternally', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    $connection.set(null)
+  })
+
+  // A token-bearing remote can mint an authenticated ?token= download URL, so
+  // the shell open still resolves on the gateway.
+  it('opens a token remote gateway path via the authenticated download URL', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, saveGatewayFile } })
+    $connection.set({ baseUrl: 'https://gw', mode: 'remote', token: 'secret' } as never)
+
+    await openMediaFileExternally('/srv/out/a.png')
+
+    expect(saveGatewayFile).toHaveBeenCalledTimes(1)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  // The regression: an OAuth/gated remote exposes no renderer token, so
+  // mediaExternalUrl() degrades to file:///srv/... — a path on the GATEWAY.
+  // Handing that to the shell silently does nothing on the user's machine.
+  it('never hands a gateway-local file:// path to the shell on an OAuth remote', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, saveGatewayFile } })
+    $connection.set({ authMode: 'oauth', mode: 'remote', profile: 'default', token: null } as never)
+
+    await openMediaFileExternally('/srv/merittas/report.png')
+
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      path: '/srv/merittas/report.png',
+      profile: 'default',
+      suggestedName: 'report.png'
+    })
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('opens local-mode paths with the shell as before', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, saveGatewayFile } })
+    $connection.set({ mode: 'local' } as never)
+
+    await openMediaFileExternally('/Users/me/a.png')
+
+    expect(openExternal).toHaveBeenCalledWith('file:///Users/me/a.png')
+    expect(saveGatewayFile).not.toHaveBeenCalled()
+  })
+
+  it('passes http(s) URLs straight to the shell in any mode', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const saveGatewayFile = vi.fn(async () => ({ saved: true }))
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, saveGatewayFile } })
+    $connection.set({ authMode: 'oauth', mode: 'remote', token: null } as never)
+
+    await openMediaFileExternally('https://example.com/a.png')
+
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/a.png')
+    expect(saveGatewayFile).not.toHaveBeenCalled()
+  })
+
+  // A failed remote fetch must reject so the caller can surface it. Swallowing
+  // it here would restore the silent no-op this fix exists to remove.
+  it('rejects instead of failing silently when the remote fetch fails', async () => {
+    const openExternal = vi.fn(async () => undefined)
+
+    const saveGatewayFile = vi.fn(async () => {
+      throw new Error('gateway read failed')
+    })
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, saveGatewayFile } })
+    $connection.set({ authMode: 'oauth', mode: 'remote', token: null } as never)
+
+    await expect(openMediaFileExternally('/srv/out/a.png')).rejects.toThrow('gateway read failed')
+    expect(openExternal).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -221,6 +221,37 @@ export async function downloadGatewayMediaFile(
   })
 }
 
+/**
+ * Open a delivered media path the way the current connection allows.
+ *
+ * On a remote gateway the file lives on the GATEWAY's disk, not this machine,
+ * so `file://` is meaningless here: Electron's shell silently refuses it and
+ * the click appears to do nothing. `mediaExternalUrl()` only avoids that when
+ * the connection exposes a renderer-visible `token` it can put in a
+ * `?token=` download URL — an OAuth/gated remote deliberately exposes none, so
+ * it degrades to exactly that dead `file://` path.
+ *
+ * Route every remote open through the authenticated save bridge instead (the
+ * same one the Files rail uses), which fetches the bytes over the connection
+ * and lands them on the user's machine. Local mode and http(s) URLs keep the
+ * previous shell behaviour.
+ */
+export async function openMediaFileExternally(path: string): Promise<void> {
+  if (/^https?:/i.test(path)) {
+    await window.hermesDesktop?.openExternal(path)
+
+    return
+  }
+
+  if (window.hermesDesktop && isRemoteGateway()) {
+    await downloadGatewayMediaFile(path)
+
+    return
+  }
+
+  await window.hermesDesktop?.openExternal(mediaExternalUrl(path))
+}
+
 export function mediaDisplayLabel(path: string): string {
   const escaped = mediaName(path).replace(/[[\]\\]/g, '\\$&')
   const kind = mediaKind(path)

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -243,12 +243,19 @@ export async function openMediaFileExternally(path: string): Promise<void> {
     return
   }
 
-  if (window.hermesDesktop && isRemoteGateway()) {
+  // Gate on the connection alone, NOT on the bridge being present. Requiring
+  // `window.hermesDesktop` here would send a remote path down the local branch
+  // whenever the bridge is missing — reinstating the dead `file://` open this
+  // function exists to remove. `downloadGatewayMediaFile()` raises an explicit
+  // "bridge is unavailable" error instead, which the caller surfaces.
+  if (isRemoteGateway()) {
     await downloadGatewayMediaFile(path)
 
     return
   }
 
+  // Local mode only: the file really is on this machine, so `mediaExternalUrl()`
+  // resolves to a `file://` the shell can open.
   await window.hermesDesktop?.openExternal(mediaExternalUrl(path))
 }
 


### PR DESCRIPTION
## The bug

On an OAuth/cookie-gated remote gateway, the generated-image failure fallback ("Open image: …") is a **silent no-op** — nothing opens, no error is shown.

The delivered file lives on the *gateway's* disk, not the user's machine, so a `file://` URL is meaningless locally; Electron's shell just refuses it.

`mediaExternalUrl()` only avoids that when the connection exposes a renderer-visible `token` it can put in a `?token=` download URL:

```ts
if (isRemoteGateway()) {
  const conn = $connection.get()
  if (conn?.baseUrl && conn.token) { /* authenticated download URL */ }
}
return /^file:/i.test(path) ? path : `file://${path}`   // ← gated remote lands here
```

A gated remote deliberately exposes no renderer token, so it falls through to exactly that dead gateway-local `file:///…` path — which `generated-image-result.tsx` handed straight to `openExternal()`.

## The fix

Add `openMediaFileExternally()` in `lib/media.ts`, which routes any remote-gateway open through the existing authenticated `saveGatewayFile` bridge and keeps the previous shell behaviour for local mode and http(s) URLs. Point the generated-image fallback at it.

This is not a new mechanism — it's the **same chokepoint the sibling call sites already use**, extracted so the last one that didn't stops being a special case:

| Call site | Before |
|---|---|
| `store/file-actions.ts` (Files rail download) | already `downloadGatewayMediaFile` |
| `app/artifacts/index.tsx` (`openArtifact`) | already guards `isRemoteGateway()` → `downloadGatewayMediaFile` |
| `assistant-ui/markdown-text.tsx` (`useOpenMediaFile`) | already guards `isRemoteGateway()` → `downloadGatewayMediaFile` |
| `chat/generated-image-result.tsx` | ❌ raw `openExternal(mediaExternalUrl(...))` — **the bug** |

A failed fetch is surfaced via `notifyError` rather than swallowed, so the fix cannot degrade back into the silent no-op it exists to remove (this mirrors `useOpenMediaFile`'s `openFailed` note and `downloadRemoteFile`'s `notifyError`).

## Scope note

`mediaExternalUrl()` itself is left alone. It is still correct for its other consumers (`artifact-utils.artifactHref`, `mediaGatewayStreamUrl`'s local fallback, `resolveMediaDisplaySrc`'s no-bridge path), which are URL-producing and synchronous. Changing it would have required making it async and touching all of them; the narrower fix is a new async opener at the one layer that actually performs the open.

## Verification

Red before / green after, on the substance rather than a missing export — with the pre-fix body (`openExternal(mediaExternalUrl(path))`) restored under the new name, the two remote tests fail because the authenticated bridge is never reached:

```
FAIL  openMediaFileExternally > opens a token remote gateway path via the authenticated download URL
  AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
FAIL  openMediaFileExternally > never hands a gateway-local file:// path to the shell on an OAuth remote
  AssertionError: expected "vi.fn()" to be called with arguments: [ { …(3) } ]
  Number of calls: 0
```

After the fix:

```
npx vitest run --project ui src/lib/media.remote.test.ts
  Test Files  1 passed (1)
       Tests  27 passed (27)
```

Neighboring suites, lint, and typecheck:

```
npx vitest run --project ui src/lib/ src/components/chat/   →  110 files, 1122 tests passed
npx eslint src/lib/media.ts src/lib/media.remote.test.ts src/components/chat/generated-image-result.tsx  →  clean
npx tsc -p . --noEmit                                        →  clean
```

Five cases covered: token remote, OAuth remote (the regression), local mode, http(s) passthrough, and fetch-failure rejection.

Server side was verified against a live gated gateway (`auth_required: true`, `auth_providers: ["basic"]`): with a session cookie both `/api/files/download` and `/api/fs/read-data-url` return the file — the server was already correct, the renderer simply was not using it.

## Not verified

No packaged-Electron manual run of the OAuth "Open image" click; the OAuth-remote leg is covered at the unit level against the bridge contract, not end-to-end through a built app.
