### PR TITLE
feat(review): support review reasoning effort

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1780,6 +1780,11 @@ def _reresolve_fallback_reasoning_config(agent) -> None:
     """Per-model override > global reasoning_effort (YAML False = disabled); a config load
     failure keeps the current reasoning_config rather than killing the swap."""
     try:
+        delegated_reasoning = getattr(agent, "_delegation_reasoning_override", None)
+        if isinstance(delegated_reasoning, dict):
+            agent.reasoning_config = dict(delegated_reasoning)
+            logger.info("Fallback %s: explicit delegated reasoning_config preserved: %s", agent.model, agent.reasoning_config)
+            return
         # Re-resolve reasoning_config for the new fallback model (Closes #21256). Wrapped in try/except
         # because a config load failure must not kill the swap.
         from hermes_cli.config import load_config

--- a/agent/review_engine.py
+++ b/agent/review_engine.py
@@ -136,17 +136,18 @@ def build_review_task(snapshot: List[Dict[str, str]], user_prompt: str = "", loa
     return goal, "\n".join(lines)
 
 
-def _load_review_credentials_cfg() -> Optional[Dict[str, Any]]:
-    """``auxiliary.review`` as a delegation-credentials dict, or None when unconfigured (provider auto/empty
-    and no model/base_url) so the reviewer inherits the parent's credentials."""
+def _load_review_config() -> Dict[str, Any]:
+    """Return one snapshot of ``auxiliary.review`` or an empty mapping."""
     try:
         from hermes_cli.config import load_config_readonly
         review = (load_config_readonly().get("auxiliary") or {}).get("review") or {}
     except Exception:
-        return None
-    if not isinstance(review, dict):
-        return None
+        return {}
+    return review if isinstance(review, dict) else {}
 
+
+def _review_credentials_cfg(review: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build delegation credentials while keeping reasoning independent of routing."""
     cfg = {k: str(review.get(k) or "").strip() for k in ("provider", "model", "base_url", "api_key", "api_mode")}
     if cfg["provider"].lower() == "auto":
         cfg["provider"] = ""
@@ -165,10 +166,15 @@ def start_review(parent_agent, messages: List[Dict[str, Any]], user_prompt: str 
     if not snapshot:
         raise ValueError("Nothing to review yet — the conversation is empty.")
     goal, context = build_review_task(snapshot, user_prompt, collect_parent_loaded_skills(parent_agent, messages))
-    credentials_cfg = _load_review_credentials_cfg()
+    review_cfg = _load_review_config()
+    credentials_cfg = _review_credentials_cfg(review_cfg)
 
     from tools.delegate_tool import delegate_task
-    raw = delegate_task(goal=goal, context=context, background=True, parent_agent=parent_agent, credentials_cfg=credentials_cfg)
+    raw = delegate_task(
+        goal=goal, context=context, background=True, parent_agent=parent_agent,
+        credentials_cfg=credentials_cfg,
+        override_reasoning_effort=review_cfg.get("reasoning_effort"),
+    )
     try:
         result = json.loads(raw)
     except Exception:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -877,6 +877,12 @@ prompt_caching:
 #     model: ""
 #     # max_concurrency: 2    # Optional: cap simultaneous compression calls
 #
+#   # Full-agent work-product reviewer started by /review.
+#   review:
+#     provider: "auto"
+#     model: ""
+#     reasoning_effort: ""   # Review > delegation > parent; empty = inherit
+#
 #   # Post-turn memory/skill self-improvement review fork. Runs after a turn
 #   # when the nudge intervals fire; writes skills/memories in a daemon thread.
 #   # Usage is recorded under session_model_usage task='background_review'.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -705,7 +705,10 @@ DEFAULT_CONFIG = {
         # /review reviewer: a full subagent on the async delegation rail, credentials resolved like
         # delegation.provider pins. "auto" + "" = main agent's model. api_mode forces transport:
         # chat_completions | anthropic_messages | codex_responses.
-        "review": {"provider": "auto", "model": "", "base_url": "", "api_key": "", "api_mode": ""},
+        "review": {
+            "provider": "auto", "model": "", "base_url": "", "api_key": "", "api_mode": "",
+            "reasoning_effort": "",  # none|minimal|low|medium|high|xhigh|max|ultra; empty = inherit
+        },
         "mcp": _aux(30),
         # prefer_fast_model opts in to the provider fast tier; auto otherwise = main model.
         "title_generation": {

--- a/tests/agent/test_review_engine.py
+++ b/tests/agent/test_review_engine.py
@@ -119,16 +119,18 @@ def test_build_review_task_without_prompt_has_no_instruction_block():
 # auxiliary.review credential resolution
 # ---------------------------------------------------------------------------
 
-def test_load_review_credentials_cfg_reads_config(monkeypatch):
+def test_load_review_config_keeps_reasoning_separate_from_credentials(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.config.load_config_readonly",
         lambda: {"auxiliary": {"review": {
             "provider": "openrouter",
             "model": "anthropic/claude-opus-4.6",
+            "reasoning_effort": "medium",
         }}},
     )
-    cfg = re_mod._load_review_credentials_cfg()
-    assert cfg == {
+    review = re_mod._load_review_config()
+    assert review["reasoning_effort"] == "medium"
+    assert re_mod._review_credentials_cfg(review) == {
         "provider": "openrouter",
         "model": "anthropic/claude-opus-4.6",
         "base_url": "",
@@ -137,19 +139,36 @@ def test_load_review_credentials_cfg_reads_config(monkeypatch):
     }
 
 
-def test_load_review_credentials_cfg_auto_means_inherit(monkeypatch):
+def test_review_credentials_cfg_auto_means_inherit(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.config.load_config_readonly",
         lambda: {"auxiliary": {"review": {"provider": "auto", "model": ""}}},
     )
-    assert re_mod._load_review_credentials_cfg() is None
+    assert re_mod._review_credentials_cfg(re_mod._load_review_config()) is None
 
 
-def test_load_review_credentials_cfg_missing_section(monkeypatch):
+def test_load_review_config_missing_section(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.config.load_config_readonly", lambda: {"auxiliary": {}}
     )
-    assert re_mod._load_review_credentials_cfg() is None
+    assert re_mod._load_review_config() == {}
+    assert re_mod._review_credentials_cfg({}) is None
+
+
+def test_load_review_config_from_profile_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "auxiliary:\n  review:\n    provider: openai-codex\n"
+        "    model: gpt-review\n    reasoning_effort: medium\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    review = re_mod._load_review_config()
+
+    assert review["model"] == "gpt-review"
+    assert review["reasoning_effort"] == "medium"
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +256,10 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
     monkeypatch.setattr(dt, "_build_child_agent", fake_build)
     monkeypatch.setattr(dt, "_run_single_child", fake_run_single_child)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
-    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(
+        re_mod, "_load_review_config",
+        lambda: {"provider": "auto", "model": "", "reasoning_effort": "medium"},
+    )
 
     msgs = [
         {"role": "user", "content": "open a PR for the fix"},
@@ -251,6 +273,7 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
     assert "check the tests" in built["context"]
     assert built["goal"].startswith("Review: ")
     assert re_mod._REVIEW_GOAL in built["context"]
+    assert built["override_reasoning_effort"] == "medium"
 
     # The completion re-enters via the shared queue like any subagent.
     deadline = time.monotonic() + 5.0
@@ -373,7 +396,7 @@ def test_start_review_threads_loaded_skills_into_context(monkeypatch):
             "exit_reason": "completed",
         },
     )
-    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(re_mod, "_load_review_config", lambda: {})
 
     parent = _fake_parent()
     parent.ephemeral_system_prompt = (
@@ -467,7 +490,7 @@ def test_review_child_gets_workspace_context_via_dispatch(monkeypatch, tmp_path)
             "exit_reason": "completed",
         },
     )
-    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(re_mod, "_load_review_config", lambda: {})
 
     result = start_review(_fake_parent(), [
         {"role": "user", "content": "open a PR"},

--- a/tests/gateway/test_review_command.py
+++ b/tests/gateway/test_review_command.py
@@ -97,7 +97,7 @@ async def test_review_command_dispatches_background_subagent(monkeypatch):
             "exit_reason": "completed",
         },
     )
-    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(re_mod, "_load_review_config", lambda: {})
 
     agent = _make_agent()
     runner = _make_runner(agent)

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -135,3 +135,15 @@ class TestFallbackReasoningOverride:
 
         assert result is not None
         assert result.get("enabled") is False
+
+    def test_fallback_preserves_explicit_delegated_reasoning(self):
+        from agent.chat_completion_helpers import _reresolve_fallback_reasoning_config
+
+        agent = MagicMock()
+        agent.model = "fallback-model"
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        agent._delegation_reasoning_override = {"enabled": True, "effort": "medium"}
+
+        _reresolve_fallback_reasoning_config(agent)
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1619,6 +1619,37 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_review_override_wins_and_is_preserved_for_fallback(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"reasoning_effort": "max"}
+        child = MagicMock()
+        MockAgent.return_value = child
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0, goal="review", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent, task_count=1,
+            override_reasoning_effort="medium",
+        )
+
+        expected = {"enabled": True, "effort": "medium"}
+        self.assertEqual(MockAgent.call_args[1]["reasoning_config"], expected)
+        self.assertEqual(child._delegation_reasoning_override, expected)
+
+        fallback_child = MagicMock()
+        MockAgent.return_value = fallback_child
+        with self.assertLogs("tools.delegate_tool", level="WARNING"):
+            _build_child_agent(
+                task_index=0, goal="review", context=None, toolsets=None,
+                model=None, max_iterations=50, parent_agent=parent, task_count=1,
+                override_reasoning_effort="invalid-level",
+            )
+        delegated = {"enabled": True, "effort": "max"}
+        self.assertEqual(MockAgent.call_args[1]["reasoning_config"], delegated)
+        self.assertEqual(fallback_child._delegation_reasoning_override, delegated)
+
 # =========================================================================
 # Dispatch helper, progress events, concurrency
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -166,7 +166,8 @@ def _build_child_agent(
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
-
+    # Internal-only override used by /review, never exposed in the tool schema.
+    override_reasoning_effort: Any = None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -220,7 +221,9 @@ def _build_child_agent(
         override_acp_command=override_acp_command,
         override_acp_args=override_acp_args,
         routing_cfg=routing_cfg,
+        override_reasoning_effort=override_reasoning_effort,
     )
+    explicit_reasoning = rt.pop("_delegation_reasoning_override", None)
     if override_request_overrides is not None:
         # honored whenever set, incl. the inherit branch where
         # _resolve_delegation_credentials already merged OVER the parent's
@@ -253,6 +256,12 @@ def _build_child_agent(
             raise
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     _apply_child_cache_ttl(child)
+    # Fallback activation normally re-resolves effort for the fallback model.
+    # Preserve an explicit delegation or review level across that transport switch.
+    setattr(
+        child, "_delegation_reasoning_override",
+        dict(explicit_reasoning) if isinstance(explicit_reasoning, dict) else None,
+    )
     if child_session_db is not None:
         child._owns_session_db = True  # released by the child's close(), never by the parent
     # Ownership transfer for the dedicated handle: the child's close() must release it (nothing else holds a
@@ -361,6 +370,7 @@ def _build_children(
     task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], creds: Dict[str, Any], *,
     top_role: str, max_iterations: int, parent_agent, routing_cfg: Dict[str, Any],
     live_deleg_id: Optional[str], live_writers: list,
+    override_reasoning_effort: Any = None,
 ) -> tuple[List[tuple], Optional[str]]:
     """Build every child on the main thread (construction is not thread-safe);
     ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure."""
@@ -386,6 +396,7 @@ def _build_children(
                 toolsets=None,  # always inherit the parent's toolsets
                 model=creds["model"], max_iterations=max_iterations, task_count=len(task_list),
                 parent_agent=parent_agent, role=_normalize_role(t.get("role") or top_role), **overrides,
+                override_reasoning_effort=override_reasoning_effort,
             )
         except ValueError as exc:
             return [], str(exc)
@@ -412,6 +423,7 @@ def delegate_task(
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
     message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    override_reasoning_effort: Any = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -486,6 +498,7 @@ def delegate_task(
     children, err = _build_children(
         task_list, task_schemas, creds, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
         routing_cfg=routing_cfg, live_deleg_id=live_deleg_id, live_writers=live_writers,
+        override_reasoning_effort=override_reasoning_effort,
     )
     if err:
         return tool_error(err)

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -439,6 +439,7 @@ def _resolve_child_runtime(
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
     override_acp_command: Optional[str], override_acp_args: Optional[List[str]],
     routing_cfg: Optional[Dict[str, Any]] = None,
+    override_reasoning_effort: Any = None,
 ) -> Dict[str, Any]:
     """Child credentials, transport and routing (config override > parent inherit) as ``AIAgent`` kwargs. Rules that
     are easy to break: api_mode is re-derived (not inherited) when the child's provider differs from the parent's
@@ -491,9 +492,10 @@ def _resolve_child_runtime(
         # Forced ACP transport requires provider copilot-acp for run_agent to init the client.
         effective_provider, effective_api_mode = "copilot-acp", "chat_completions"
 
-    # Reasoning: delegation.reasoning_effort > parent. Keep the raw value — a
-    # YAML ``false`` must disable thinking, not coerce to "" and inherit.
+    # Reasoning precedence: per-call review override > delegation > parent.
+    # Keep raw values because YAML ``false`` explicitly disables thinking.
     child_reasoning = getattr(parent_agent, "reasoning_config", None)
+    explicit_reasoning = None
     try:
         delegation_effort = delegation_cfg.get("reasoning_effort")
         if delegation_effort or delegation_effort is False:
@@ -503,8 +505,21 @@ def _resolve_child_runtime(
                 logger.warning("Unknown delegation.reasoning_effort '%s', inheriting parent level", delegation_effort)
             else:
                 child_reasoning = parsed
+                explicit_reasoning = parsed
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
+
+    if override_reasoning_effort is not None and str(override_reasoning_effort).strip():
+        from hermes_constants import parse_reasoning_effort
+        parsed = parse_reasoning_effort(override_reasoning_effort)
+        if parsed is None:
+            logger.warning(
+                "Unknown auxiliary.review.reasoning_effort '%s', retaining delegation or parent level",
+                override_reasoning_effort,
+            )
+        else:
+            child_reasoning = parsed
+            explicit_reasoning = parsed
 
     kwargs: Dict[str, Any] = {
         "base_url": effective_base_url, "api_key": override_api_key or parent_api_key, "model": effective_model,
@@ -512,6 +527,7 @@ def _resolve_child_runtime(
         "capabilities": _inherit_parent_capabilities(parent_agent, override_provider, override_base_url),
         "api_mode": effective_api_mode, "acp_command": effective_acp_command, "acp_args": effective_acp_args,
         "reasoning_config": child_reasoning,
+        "_delegation_reasoning_override": explicit_reasoning,
         # Resolve routing and recovery policy from the same configuration owner. A pinned provider, endpoint, or
         # model never borrows the parent's chain; an explicitly declared child chain still remains available.
         "fallback_model": _resolve_child_fallback_chain(

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1367,11 +1367,18 @@ This is the per-task counterpart of the global `agent.reasoning_effort`: run com
 
 ```yaml
 auxiliary:
+  review:
+    reasoning_effort: "medium" # /review only; independent of delegation workers
   compression:
     reasoning_effort: "low"    # summaries don't need deep thinking
   vision:
     reasoning_effort: "none"   # disable thinking for image description
 ```
+
+For `/review`, resolution is `auxiliary.review.reasoning_effort`, then
+`delegation.reasoning_effort`, then the parent agent's reasoning level. This
+allows a reviewer to use a different effort from ordinary delegated workers.
+An empty or invalid review value falls through to the next setting.
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -298,9 +298,15 @@ auxiliary:
   review:
     provider: openrouter               # or nous, anthropic, a direct base_url, ...
     model: anthropic/claude-opus-4.6   # a strong reviewer model
+    reasoning_effort: medium           # optional review-only thinking level
 ```
 
 Credentials resolve exactly like a `delegation.provider` pin (full runtime-provider bundle: base_url, api key, api_mode). `provider: auto` with an empty `model` means "inherit the main agent's model" — the default.
+
+`auxiliary.review.reasoning_effort` accepts `none`, `minimal`, `low`, `medium`,
+`high`, `xhigh`, `max`, and `ultra`. It overrides
+`delegation.reasoning_effort` for `/review` only; otherwise the reviewer falls
+back to the delegation setting and then the parent agent's level.
 
 `/review` is deliberately separate from `/refine`: `/refine` reviews the conversation to update memory and skills, `/review` reviews the *work product* the conversation created.
 


### PR DESCRIPTION
## What does this PR do?

The `/review` command can now use a review-specific reasoning level through `auxiliary.review.reasoning_effort`.

Resolution follows this precedence:

1. `auxiliary.review.reasoning_effort`
2. `delegation.reasoning_effort`
3. Parent agent reasoning

This keeps reviewer quality and cost controls independent from ordinary delegated workers. For example, `/review` can use a dedicated model at `medium` while general delegation remains pinned to another model at `max`.

The override is internal to the review dispatch path. It does not change the public `delegate_task` schema or ordinary delegation behaviour. Explicit child reasoning is also preserved if the child activates a provider fallback.

## Related issue

Fixes #94793

## Type of change

- [x] New feature
- [x] Tests
- [x] Documentation

## Changes

- Load `auxiliary.review` once and keep routing credentials separate from reasoning configuration.
- Forward the review-only reasoning override through the internal delegation path.
- Resolve review reasoning ahead of delegation and parent defaults.
- Preserve explicit delegated reasoning when a provider fallback activates.
- Document the setting and add it to the default and example configuration.
- Add focused coverage for real profile config loading, dispatch propagation, precedence, ordinary delegation isolation, and fallback preservation.

## Verification

- `scripts/run_tests.sh tests/agent/test_review_engine.py tests/tools/test_delegate.py tests/run_agent/test_fallback_reasoning_override.py tests/gateway/test_review_command.py`
  - 118 passed
- `scripts/run_tests.sh tests/run_agent/test_fallback_api_mode_preservation.py tests/run_agent/test_fallback_reasoning_override.py tests/hermes_cli/test_config.py`
  - 135 passed, 4 skipped on Linux
- `ruff check` on all changed Python files
  - passed
- `git diff --check`
  - passed
- `npm ci && npm run build:fast` in `website/`
  - passed, with the two existing `/docs/llms*.txt` broken-link warnings

## Example

```yaml
delegation:
  model: gpt-5.6-luna
  provider: openai-codex
  reasoning_effort: max

auxiliary:
  review:
    model: gpt-5.6-astra
    provider: openai-codex
    reasoning_effort: medium
```

Ordinary delegated workers use Luna at max reasoning. `/review` uses Astra at medium reasoning.
