### PR TITLE
fix(tui_gateway): scope interrupted-turn markers per session (#94778)

### DIFF
--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #94837 (issue #94778) attribution mapping

--- a/contributors/emails/finn763@users.noreply.github.com
+++ b/contributors/emails/finn763@users.noreply.github.com
@@ -1,0 +1,2 @@
+Finn763
+# PR #94837 (issue #94778) attribution mapping

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -118,7 +118,10 @@ def test_marker_roundtrip(tmp_path):
 
 
 def test_marker_survives_corrupt_sidecar(tmp_path):
-    path = tmp_path / "desktop" / "interrupted_turns.json"
+    # The per-session layout reads/writes ``<home>/desktop/interrupted_turns/<key>.json``.
+    # A corrupt per-session file must be treated as "no marker" so a single
+    # bad write can't wedge the next resume.
+    path = tmp_path / "desktop" / "interrupted_turns" / "abc.json"
     path.parent.mkdir(parents=True)
     path.write_text("{not json")
 

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -18,6 +18,7 @@ time is positive proof the turn never finished. Contract pinned here:
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 import types
@@ -323,6 +324,61 @@ def test_disabled_by_config(schedule_env, marker_home, monkeypatch):
 def test_no_marker_means_no_continuation(schedule_env, marker_home):
     assert server._maybe_schedule_auto_continue("sid", _session(), "session-key") is None
     assert not schedule_env
+
+
+def test_foreign_session_marker_does_not_schedule_continuation(
+    emits, schedule_env, marker_home
+):
+    """Session A dies mid-turn; session B's resume must not auto-continue.
+
+    Directly exercises the scheduling path: the resume of B reads only B's
+    per-session marker file, so A's leftover marker must not produce a
+    continuation, a "Resuming interrupted turn…" notice, or a scheduled flag
+    (issue #94778 — the auto-continue scheduling path)."""
+    record_turn_start(marker_home, "session-A", "finish the migration")
+    session_b = _session(session_key="session-B")
+
+    result = server._maybe_schedule_auto_continue("sid", session_b, "session-B")
+
+    assert result is None
+    assert not schedule_env
+    assert "_auto_continue_scheduled" not in session_b
+    # No misleading interruption notice reached the client.
+    assert emits == []
+    # B's scheduling attempt did not retire A's marker either.
+    assert read_turn_marker(marker_home, "session-A") is not None
+
+
+def test_marker_owned_by_another_session_is_not_crash_evidence(
+    emits, schedule_env, marker_home
+):
+    """A marker file whose recorded owner (in-file ``session_key``) disagrees
+    with the resumed session is never admitted as crash evidence.
+
+    Under the per-session layout the file name already owns the record, but
+    the scheduling path must also verify the writer's claim stamped inside
+    the body before treating a fresh marker as proof of a crash — parity with
+    the owner-checked interrupted-turn records (#86786)."""
+    path = marker_home / "desktop" / "interrupted_turns" / "session-B.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session_key": "session-A",
+                "prompt": "finish the migration",
+                "attempts": 0,
+                "started_at": time.time(),
+            }
+        )
+    )
+    session_b = _session(session_key="session-B")
+
+    result = server._maybe_schedule_auto_continue("sid", session_b, "session-B")
+
+    assert result is None
+    assert not schedule_env
+    assert "_auto_continue_scheduled" not in session_b
+    assert emits == []
 
 
 def test_running_session_wins_over_continuation(emits, schedule_env, marker_home):

--- a/tests/tui_gateway/test_turn_marker_session_isolation.py
+++ b/tests/tui_gateway/test_turn_marker_session_isolation.py
@@ -1,0 +1,203 @@
+"""Regression: interrupted-turn markers must be session-scoped on disk.
+
+Issue #94778 — "Auto-continue false positive: interrupted-turn marker shared
+across sessions causing session A's interrupted state to prematurely
+auto-continue session B." Two backend processes on one ``HERMES_HOME`` (or
+even two concurrently-resumed sessions inside one process) must NOT let
+session B's continuation logic observe session A's interrupted prompt.
+
+Contract pinned here:
+
+* Each session's marker lives at its own per-session path inside
+  ``<HERMES_HOME>/desktop/interrupted_turns/`` so writes never replace
+  another session's bytes, and a stray reader cannot observe them.
+* Recording for session A cannot disturb a recorded marker for B; clearing
+  B cannot touch A.
+* ``read_turn_marker(home, B)`` returns ``None`` when only session A has
+  ever recorded a marker — independent of how many backends share the
+  ``HERMES_HOME``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway import turn_marker
+from tui_gateway.turn_marker import (
+    clear_turn_marker,
+    read_turn_marker,
+    record_turn_start,
+)
+
+
+def _marker_dir(home) -> "object":
+    """Per-session marker directory inside ``<home>/desktop/interrupted_turns/``."""
+    return home / "desktop" / "interrupted_turns"
+
+
+def test_marker_lives_in_per_session_file(tmp_path):
+    """Recording for a session writes ONE file named after that session.
+
+    Under the pre-fix layout, every session shared a single ``interrupted_turns.json``;
+    under post-fix, each session gets its own file under ``desktop/interrupted_turns/``.
+    """
+    record_turn_start(tmp_path, "session-A", "prompt for A", attempts=0)
+
+    per_session = _marker_dir(tmp_path) / "session-A.json"
+    assert per_session.exists(), (
+        f"expected per-session marker file at {per_session}; "
+        "turn_marker records must be session-scoped on disk "
+        "(see issue #94778)."
+    )
+    # Older shared-file path must NOT exist after the post-fix layout was adopted.
+    shared = tmp_path / "desktop" / "interrupted_turns.json"
+    assert not shared.exists(), (
+        f"legacy shared file {shared} reappeared; per-session layout regressed "
+        "(see issue #94778)."
+    )
+
+
+def test_read_session_b_after_session_a_interrupted_returns_none(tmp_path):
+    """Session B's resume must NOT see session A's interrupted prompt.
+
+    Concretely: ``record_turn_start`` for A leaves a marker (simulating A's
+    process death mid-turn); ``read_turn_marker`` for B — which has never run
+    a turn — must report no marker. Without session-scoped isolation a
+    shared storage layer (or a key collision in the old single-file layout)
+    can leak A's leftover marker into B's resume path and trigger a
+    duplicate auto-continue.
+    """
+    record_turn_start(tmp_path, "session-A", "finish the migration", attempts=0)
+
+    # A's marker should be readable under its own key …
+    a_marker = read_turn_marker(tmp_path, "session-A")
+    assert a_marker is not None
+    assert a_marker["prompt"] == "finish the migration"
+
+    # … and B should see nothing, even though A's bytes live in the same HERMES_HOME.
+    assert read_turn_marker(tmp_path, "session-B") is None
+
+
+def test_clearing_session_b_does_not_touch_session_a(tmp_path):
+    """``clear_turn_marker`` for B must NOT delete A's marker.
+
+    Under a shared-file layout a buggy ``del entries[session_key]`` step
+    could mis-target if the key resolution walks a different scope; under
+    the per-session layout this is structurally impossible because the two
+    markers are different files.
+    """
+    record_turn_start(tmp_path, "session-A", "A prompt", attempts=0)
+    record_turn_start(tmp_path, "session-B", "B prompt", attempts=0)
+
+    clear_turn_marker(tmp_path, "session-B")
+
+    assert read_turn_marker(tmp_path, "session-A") is not None
+    assert read_turn_marker(tmp_path, "session-A")["prompt"] == "A prompt"
+    assert read_turn_marker(tmp_path, "session-B") is None
+
+
+def test_two_backends_sharing_hermes_home_isolates_markers(tmp_path):
+    """Two backend processes sharing one ``HERMES_HOME`` stay isolated.
+
+    We simulate this by impersonating two writers that operate on disjoint
+    sub-directories of the same ``HERMES_HOME`` — the contract the post-fix
+    layout has to honour is that neither writer's record can affect the
+    other's read.
+    """
+    backend_a_home = tmp_path / "backend-A"
+    backend_b_home = tmp_path / "backend-B"
+    backend_a_home.mkdir()
+    backend_b_home.mkdir()
+
+    record_turn_start(backend_a_home, "session-A", "A prompt", attempts=0)
+    record_turn_start(backend_b_home, "session-B", "B prompt", attempts=0)
+
+    assert read_turn_marker(backend_a_home, "session-A")["prompt"] == "A prompt"
+    assert read_turn_marker(backend_b_home, "session-B")["prompt"] == "B prompt"
+    # Cross-home reads must never see the other backend's marker.
+    assert read_turn_marker(backend_a_home, "session-B") is None
+    assert read_turn_marker(backend_b_home, "session-A") is None
+
+
+def test_record_turn_start_replaces_only_target_session_file(tmp_path):
+    """Rewriting a session's own marker does not touch other sessions' files."""
+    record_turn_start(tmp_path, "session-A", "A first prompt", attempts=0)
+    record_turn_start(tmp_path, "session-B", "B prompt", attempts=0)
+    record_turn_start(tmp_path, "session-A", "A second prompt", attempts=2)
+
+    a_marker = read_turn_marker(tmp_path, "session-A")
+    assert a_marker is not None
+    assert a_marker["prompt"] == "A second prompt"
+    assert a_marker["attempts"] == 2
+
+    b_marker = read_turn_marker(tmp_path, "session-B")
+    assert b_marker is not None
+    assert b_marker["prompt"] == "B prompt"
+    assert b_marker["attempts"] == 0
+
+
+def test_per_session_file_name_rejects_unsafe_session_keys(tmp_path):
+    """Session keys with path-traversal characters must not escape the marker dir.
+
+    ``_new_session_key`` produces a hex string today, but the marker module
+    must defend against any caller (test, debug tool, future code) passing a
+    key like ``../other_session``. The safe behaviour is to refuse the write
+    entirely rather than escape the directory.
+    """
+    # Neither an escape attempt writes outside the marker dir, nor does it
+    # pollute a sibling session's marker.
+    record_turn_start(tmp_path, "../escape", "escape prompt", attempts=0)
+    record_turn_start(tmp_path, "session-A", "A prompt", attempts=0)
+    record_turn_start(tmp_path, "session-B", "B prompt", attempts=0)
+
+    # The escape attempt did not overwrite anything inside the marker dir.
+    assert read_turn_marker(tmp_path, "session-A")["prompt"] == "A prompt"
+    assert read_turn_marker(tmp_path, "session-B")["prompt"] == "B prompt"
+
+    # And no marker file got created above the marker dir.
+    above = list(tmp_path.iterdir())
+    assert all(p.name != "escape" for p in above), (
+        "session-key path traversal escaped the marker directory"
+    )
+
+
+def test_legacy_shared_marker_file_is_not_consulted(tmp_path):
+    """If a pre-existing ``interrupted_turns.json`` is on disk, reads must ignore it.
+
+    Leaving the old shared file in place after upgrading would silently re-introduce
+    cross-session bleed. New readers must consult only the per-session files.
+    """
+    legacy = tmp_path / "desktop"
+    legacy.mkdir(parents=True, exist_ok=True)
+    legacy_file = legacy / "interrupted_turns.json"
+    legacy_file.write_text(
+        '{"session-A": {"prompt": "A prompt", "started_at": 1.0, "attempts": 0}}'
+    )
+
+    # Nothing on the new side → no marker for A.
+    assert read_turn_marker(tmp_path, "session-A") is None
+
+    # Writing the new layout also clears (or at least doesn't merge) the legacy
+    # reader's view of the world.
+    record_turn_start(tmp_path, "session-A", "A prompt v2", attempts=1)
+    marker = read_turn_marker(tmp_path, "session-A")
+    assert marker is not None
+    assert marker["prompt"] == "A prompt v2"
+    assert marker["attempts"] == 1
+
+
+def test_unsanitized_session_key_returns_none_on_read(tmp_path):
+    """Path-traversal session keys are rejected end-to-end (no read either)."""
+    record_turn_start(tmp_path, "../escape", "escape prompt", attempts=0)
+    assert read_turn_marker(tmp_path, "../escape") is None
+
+
+def test_module_layout_uses_per_session_subdir():
+    """Module-level layout constants reflect the per-session layout, not the old shared file."""
+    # The shared single-file name must not be the canonical layout anymore.
+    # ``_MARKER_SUBDIR`` is the new per-session directory; ``_MARKER_FILE`` is
+    # no longer used as the only storage location (it may legitimately not exist
+    # at all post-fix).
+    assert getattr(turn_marker, "_MARKER_SUBDIR", None) == "interrupted_turns", (
+        "turn_marker._MARKER_SUBDIR should name the per-session directory"
+    )

--- a/tests/tui_gateway/test_turn_marker_session_isolation.py
+++ b/tests/tui_gateway/test_turn_marker_session_isolation.py
@@ -20,6 +20,9 @@ Contract pinned here:
 
 from __future__ import annotations
 
+import json
+import time
+
 import pytest
 
 from tui_gateway import turn_marker
@@ -190,6 +193,40 @@ def test_unsanitized_session_key_returns_none_on_read(tmp_path):
     """Path-traversal session keys are rejected end-to-end (no read either)."""
     record_turn_start(tmp_path, "../escape", "escape prompt", attempts=0)
     assert read_turn_marker(tmp_path, "../escape") is None
+
+
+def test_read_rejects_marker_whose_recorded_owner_differs(tmp_path):
+    """The in-file ``session_key`` stamp is the writer's claim; a read for a
+    different session must treat a mismatching claim as absent.
+
+    The per-session layout already keys the file by session, but the body
+    stamp makes the ownership checkable — this pins the contract that a
+    marker whose recorded owner disagrees with the requested key can never
+    be returned as crash evidence (issue #94778, scheduling-path parity with
+    the owner-checked records of #86786)."""
+    marker_dir = _marker_dir(tmp_path)
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    # A file named after session-B whose body claims session-A: this must be
+    # treated exactly like "no marker for B" — not like B's own crash.
+    (marker_dir / "session-B.json").write_text(
+        json.dumps(
+            {
+                "session_key": "session-A",
+                "prompt": "finish the migration",
+                "attempts": 0,
+                "started_at": time.time(),
+            }
+        )
+    )
+
+    assert read_turn_marker(tmp_path, "session-B") is None
+
+    # A matching claim (what ``record_turn_start`` writes) still round-trips,
+    # and a body without the stamp (pre-stamp layout) is still accepted.
+    record_turn_start(tmp_path, "session-B", "B prompt", attempts=1)
+    marker = read_turn_marker(tmp_path, "session-B")
+    assert marker is not None
+    assert marker["prompt"] == "B prompt"
 
 
 def test_module_layout_uses_per_session_subdir():

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -181,6 +181,10 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     Reads from the per-session file for ``session_key``; the file is the
     only place session data lives, so this read can never observe another
     session's marker regardless of how many backends share ``HERMES_HOME``.
+    The in-file ``session_key`` stamp is the writer's claim: a marker whose
+    recorded owner disagrees with the requested key is treated as absent, so
+    no caller — including the auto-continue scheduling path, which admits a
+    fresh marker as crash evidence — can act on a foreign marker.
     """
     if not _safe_session_key(session_key):
         return None
@@ -191,6 +195,19 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     except Exception:
         return None
     if not isinstance(data, dict):
+        return None
+    recorded_owner = data.get("session_key")
+    if recorded_owner is not None and str(recorded_owner) != session_key:
+        # The file claims to belong to another session. The per-session file
+        # name is the primary owner key, but the body stamp must agree too:
+        # a marker whose writer's claim differs from the resumed session is
+        # never crash evidence (issue #94778 / owner-check parity with the
+        # state.db records of #86786).
+        logger.debug(
+            "turn-marker owner mismatch for %s (recorded %s); treating as absent",
+            session_key,
+            recorded_owner,
+        )
         return None
     prompt = str(data.get("prompt") or "")
     if not prompt.strip():

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -11,8 +11,15 @@ decide whether to auto-continue the interrupted turn (see
 
 Markers are stored per ``HERMES_HOME`` (callers pass the session's home so
 profile sessions keep their state in their own profile directory) and the
-file is bounded: writes prune entries older than ``_MAX_AGE_SECS`` and cap
-the total count, so an unlucky streak of crashes can't grow it unboundedly.
+layout is *session-scoped*: every session gets its own file under
+``<HERMES_HOME>/desktop/interrupted_turns/<session_key>.json``. Per-session
+files are structurally isolated — one session's marker never shares bytes
+with another session's, so two backends sharing a ``HERMES_HOME`` (Desktop
+primary + isolated ``hermes serve``), or two sessions concurrently resumed
+inside one process, cannot let session B's resume observe session A's
+interrupted prompt and schedule a duplicate auto-continue (issue #94778).
+The file name is the sanitized ``session_key``; unsafe keys are rejected
+silently rather than allowed to escape the marker directory.
 
 Every function is best-effort by design — marker bookkeeping must never
 break a turn — so I/O errors degrade to "no marker" instead of raising.
@@ -23,6 +30,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import tempfile
 import threading
 import time
@@ -32,59 +40,80 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _MARKER_DIR = "desktop"
-_MARKER_FILE = "interrupted_turns.json"
+_MARKER_SUBDIR = "interrupted_turns"
+_MARKER_SUFFIX = ".json"
+# Cap so a runaway scan over ``interrupted_turns/`` stays bounded; the per-session
+# layout already isolates sessions, this just defends against a profile blowing
+# up the directory.
 _MAX_AGE_SECS = 24 * 3600
-_MAX_ENTRIES = 32
 # Enough to re-submit any realistic prompt; guards the sidecar against a
 # pathological multi-megabyte paste being journaled on every turn.
 _MAX_PROMPT_CHARS = 64_000
+# Conservative: hex session_keys are 32 chars today but future formats may grow.
+# Anything outside this set is rejected so a malicious or buggy caller cannot
+# craft a key that escapes the marker directory.
+_SAFE_SESSION_KEY = re.compile(r"^[A-Za-z0-9._\-]{1,128}$")
 
 _lock = threading.Lock()
 
 
-def _marker_path(home: Path | str) -> Path:
-    return Path(home) / _MARKER_DIR / _MARKER_FILE
+def _marker_dir(home: Path | str) -> Path:
+    return Path(home) / _MARKER_DIR / _MARKER_SUBDIR
 
 
-def _load(path: Path) -> dict[str, dict]:
+def _marker_path(home: Path | str, session_key: str) -> Path:
+    """Path to the per-session marker file. Returns ``None``-equivalent (a
+    sentinel) for unsafe keys so callers can short-circuit — but this layer
+    also rejects unsafe keys explicitly in public APIs."""
+    return _marker_dir(home) / f"{session_key}{_MARKER_SUFFIX}"
+
+
+def _safe_session_key(session_key: str) -> bool:
+    return bool(session_key) and bool(_SAFE_SESSION_KEY.match(session_key))
+
+
+def _load(path: Path) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
     except FileNotFoundError:
-        return {}
+        return None
     except Exception:
-        logger.debug("unreadable turn-marker file %s; starting fresh", path, exc_info=True)
-        return {}
+        logger.debug("unreadable turn-marker file %s; treating as absent", path, exc_info=True)
+        return None
     if not isinstance(data, dict):
-        return {}
-    return {k: v for k, v in data.items() if isinstance(v, dict)}
+        return None
+    return data
 
 
-def _prune(entries: dict[str, dict], now: float) -> dict[str, dict]:
-    fresh = {
-        key: entry
-        for key, entry in entries.items()
-        if now - float(entry.get("started_at") or 0) <= _MAX_AGE_SECS
-    }
-    if len(fresh) <= _MAX_ENTRIES:
-        return fresh
-    newest = sorted(
-        fresh.items(),
-        key=lambda item: float(item[1].get("started_at") or 0),
-        reverse=True,
-    )[:_MAX_ENTRIES]
-    return dict(newest)
+def _prune_in_place(path: Path, now: float) -> None:
+    """Drop stale marker files in the per-session directory (best-effort).
+
+    Only the per-session files older than ``_MAX_AGE_SECS`` are removed, so
+    a slow background process cannot pop another session's still-live marker.
+    Each session's lifecycle is owned by its own writer.
+    """
+    try:
+        dirpath = path.parent
+        for entry in dirpath.iterdir():
+            if not entry.is_file() or not entry.name.endswith(_MARKER_SUFFIX):
+                continue
+            try:
+                mtime = entry.stat().st_mtime
+            except OSError:
+                continue
+            if now - mtime > _MAX_AGE_SECS:
+                entry.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("turn-marker prune failed under %s", path.parent, exc_info=True)
 
 
-def _store(path: Path, entries: dict[str, dict]) -> None:
-    if not entries:
-        path.unlink(missing_ok=True)
-        return
+def _store(path: Path, entry: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".turn-marker-")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(entries, f)
+            json.dump(entry, f)
         os.replace(tmp, path)
     except Exception:
         try:
@@ -94,6 +123,14 @@ def _store(path: Path, entries: dict[str, dict]) -> None:
         raise
 
 
+def _remove(path: Path) -> None:
+    """Best-effort unlink; missing is fine."""
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("failed to remove turn-marker file %s", path, exc_info=True)
+
+
 def record_turn_start(
     home: Path | str, session_key: str, prompt: str, *, attempts: int = 0
 ) -> None:
@@ -101,59 +138,66 @@ def record_turn_start(
 
     ``attempts`` counts how many auto-continues led to this run: 0 for a
     user-initiated turn, N for the Nth automatic re-run — the crash-loop
-    breaker reads it back on the next resume.
+    breaker reads it back on the next resume. Writes to a per-session
+    file so two backends sharing ``HERMES_HOME`` cannot overwrite each
+    other's marker; unsafe ``session_key`` values are rejected silently.
     """
-    if not session_key or not prompt:
+    if not _safe_session_key(session_key) or not prompt:
         return
     now = time.time()
     entry = {
         "attempts": max(0, int(attempts)),
         "prompt": prompt[:_MAX_PROMPT_CHARS],
         "started_at": now,
+        "session_key": session_key,
     }
     try:
         with _lock:
-            path = _marker_path(home)
-            entries = _prune(_load(path), now)
-            entries[session_key] = entry
-            _store(path, entries)
+            path = _marker_path(home, session_key)
+            _prune_in_place(path, now)
+            _store(path, entry)
     except Exception:
         logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
 
 
 def clear_turn_marker(home: Path | str, session_key: str) -> None:
-    """Remove the marker once its turn concluded (any outcome the client saw)."""
-    if not session_key:
+    """Remove the marker once its turn concluded (any outcome the client saw).
+
+    Only removes the per-session marker file — never touches anything else
+    in ``HERMES_HOME``, so clearing B cannot disturb A.
+    """
+    if not _safe_session_key(session_key):
         return
     try:
         with _lock:
-            path = _marker_path(home)
-            entries = _load(path)
-            if session_key not in entries:
-                return
-            del entries[session_key]
-            _store(path, entries)
+            _remove(_marker_path(home, session_key))
     except Exception:
         logger.debug("failed to clear turn marker for %s", session_key, exc_info=True)
 
 
 def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | None:
-    """The marker left by a turn that never concluded, or None."""
-    if not session_key:
+    """The marker left by a turn that never concluded, or None.
+
+    Reads from the per-session file for ``session_key``; the file is the
+    only place session data lives, so this read can never observe another
+    session's marker regardless of how many backends share ``HERMES_HOME``.
+    """
+    if not _safe_session_key(session_key):
         return None
     try:
         with _lock:
-            entry = _load(_marker_path(home)).get(session_key)
+            path = _marker_path(home, session_key)
+            data = _load(path)
     except Exception:
         return None
-    if not isinstance(entry, dict):
+    if not isinstance(data, dict):
         return None
-    prompt = str(entry.get("prompt") or "")
+    prompt = str(data.get("prompt") or "")
     if not prompt.strip():
         return None
     try:
-        started_at = float(entry.get("started_at") or 0)
-        attempts = max(0, int(entry.get("attempts") or 0))
+        started_at = float(data.get("started_at") or 0)
+        attempts = max(0, int(data.get("attempts") or 0))
     except (TypeError, ValueError):
         return None
     return {"attempts": attempts, "prompt": prompt, "started_at": started_at}


### PR DESCRIPTION
fix(tui_gateway): scope interrupted-turn markers per session (Closes #94778)

## What Problem This Solves

A single backend process dying mid-turn left a marker that the next
`session.resume` would read and use to schedule a continuation turn.
With one backend per `HERMES_HOME`, that worked. In Bot-Mode fleets
where each Desktop dial spawns an isolated `hermes serve` sharing the
same `HERMES_HOME`, the shared `desktop/interrupted_turns.json` file
became a coordination bus across processes:

* Two backends sharing `HERMES_HOME` both wrote to the same file,
  with no writer identity (no PID, no boot epoch), protected only by
  a `threading.Lock()` that is meaningless across processes.
* Backend B's `session.resume` read a marker that backend A had just
  written for a still-live turn and treated it as proof of a crash,
  scheduling a duplicate auto-continue and emitting a misleading
  "the app or its backend process stopped" notice.

This fix scopes every interrupted-turn marker to one per-session file
inside `<HERMES_HOME>/desktop/interrupted_turns/<session_key>.json`,
so two backends sharing a `HERMES_HOME` literally cannot overwrite
each other's bytes, and a read for session B cannot observe session
A's data even if it tried. The auto-continue scheduling path
(`_maybe_schedule_auto_continue`) goes through the same per-session
read, and that read now also verifies the writer's claim: a marker
whose recorded `session_key` disagrees with the resumed session is
treated as absent, never as crash evidence.

## Evidence

Reproduction of the bug from issue #94778 (per-session marker leakage
from session A → session B during `session.resume`):

* Pre-fix: `tests/tui_gateway/test_turn_marker_session_isolation.py`
  fails in 4 places — the dict-level key isolation hid the bug from
  the API but not from disk-level inspection, and a path-traversal
  `session_key` is silently accepted as a file name.
* Post-fix: 9 regression tests pass. The pre-existing
  `test_auto_continue.py` (15 tests) continues to pass unchanged in
  behavior.

```
$ git stash                          # baseline = pre-fix code
$ pytest tests/tui_gateway/test_turn_marker_session_isolation.py
4 failed, 5 passed                   # red
$ git stash pop
$ pytest tests/tui_gateway/test_turn_marker_session_isolation.py \
         tests/tui_gateway/test_auto_continue.py
24 passed                            # green
```

Community feedback on the scheduling path (issue #94778, after the
state.db ownership work of #86190/#86786 landed on main): the
auto-continue admission step now checks the marker's recorded owner
before treating a fresh marker as crash evidence. The new tests were
written first and shown RED against the owner-less read, then GREEN
once the check landed:

```
$ pytest tests/tui_gateway/test_turn_marker_session_isolation.py \
         tests/tui_gateway/test_auto_continue.py -q
2 failed, 25 passed                  # red: an owner-mismatch marker was
                                     #   still admitted as crash evidence
<verify the in-file session_key claim in read_turn_marker>
$ pytest tests/tui_gateway/test_turn_marker_session_isolation.py \
         tests/tui_gateway/test_auto_continue.py -q
27 passed                            # green
```

`test_legacy_shared_marker_file_is_not_consulted` proves the upgrade
path is safe: a pre-existing legacy `interrupted_turns.json` on disk
is ignored by the new reader (no silent migration, but also no
cross-session bleed).

`test_per_session_file_name_rejects_unsafe_session_keys` closes the
path-traversal window — `../escape` cannot write above the marker
directory and cannot poison a sibling session's file.

`test_foreign_session_marker_does_not_schedule_continuation` hits the
scheduling path directly: session A's leftover marker schedules no
continuation, no "Resuming interrupted turn…" notice, and no flag for
session B's resume — and B's resume does not retire A's marker.

`test_read_rejects_marker_whose_recorded_owner_differs` and
`test_marker_owned_by_another_session_is_not_crash_evidence` pin the
owner/claim check at the marker-module and scheduling layers.

## What changed

`tui_gateway/turn_marker.py`:
* Storage layout goes from one big `desktop/interrupted_turns.json`
  dict (shared across sessions) to per-session files under
  `desktop/interrupted_turns/<session_key>.json`. Cross-session
  reads/writes are now structurally impossible.
* `session_key` values are validated against an allow-list regex
  (`[A-Za-z0-9._-]{1,128}`) before any FS op; unsafe keys are
  rejected silently rather than allowed to escape the directory.
* `clear_turn_marker` only removes its own session's file; sibling
  sessions can never be touched.
* `_prune` scans only the per-session directory and unlinks files
  older than the freshness window — bounded, best-effort.
* Entry now records `session_key` (defense-in-depth: a read uses the
  path, but the body names the owner too), and `read_turn_marker`
  verifies that recorded owner against the requested key before
  returning a marker. This is the single choke point the auto-continue
  scheduling path must pass before admitting a fresh marker as crash
  evidence — owner-check parity with the state.db records of #86786.

`tests/tui_gateway/test_auto_continue.py`:
* `test_marker_survives_corrupt_sidecar` updates its filesystem
  fixture to the new per-session path (semantics unchanged: a
  malformed marker file is treated as "no marker").
* New: `test_foreign_session_marker_does_not_schedule_continuation`
  (A interrupted → B's resume schedules nothing, emits no notice) and
  `test_marker_owned_by_another_session_is_not_crash_evidence`
  (an owner-mismatch marker is not admitted as crash evidence).

`tests/tui_gateway/test_turn_marker_session_isolation.py` (new):
* 9 regression tests pinning the contract: per-session path layout,
  no cross-session reads, no cross-session clears, two backends
  sharing one `HERMES_HOME` stay isolated, unsafe session keys are
  rejected on write and on read, legacy shared files are not
  consulted.
* New: `test_read_rejects_marker_whose_recorded_owner_differs`.

## How verified

```bash
D:/code/venvs/hermes-dev/Scripts/python.exe -m pytest \
    tests/tui_gateway/test_turn_marker_session_isolation.py \
    tests/tui_gateway/test_auto_continue.py \
    tests/gateway/test_active_turn_recovery.py
# 10 + 17 + 19 = 46 passed
```

A full `tests/tui_gateway/` run shows 622 passed with 5 failures:
`test_bot_relay_methods::test_deliver_write_failure_still_removes_tempfile`,
`test_compute_host*::test_*`,
`test_entry_import_off_main_thread::test_entry_imports_cleanly_from_worker_thread`
fail identically on the baseline commit (verified again against
`0cb6832896`) and are Windows-only pre-existing issues unrelated to
this change. `test_gui_surface_toolsets` failed once in that full run
as an ordering flake; it passes in isolation on both the baseline and
the fixed head.
