### PR TITLE
fix(desktop): flush view sync on a timer fallback when rAF is throttled

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -261,6 +261,39 @@ describe('useSessionStateCache — per-session turn timer', () => {
   })
 })
 
+describe('useSessionStateCache — parked renderer recovery', () => {
+  afterEach(() => {
+    cleanup()
+    $messages.set([])
+    $sessionStates.set({})
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('publishes a running transcript when requestAnimationFrame never fires', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    let cache!: Cache
+    render(<ViewHarness activeSessionId="parked-thread" onReady={c => (cache = c)} />)
+
+    const messages = [userMessage('parked-user', 'keep working'), assistantText('parked-assistant', 'answer arrived')]
+
+    act(() => {
+      cache.updateSessionState('parked-thread', state => ({ ...state, busy: true, messages }), 'parked-stored')
+    })
+
+    expect($messages.get()).toEqual([])
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    expect($messages.get().map(message => message.id)).toEqual(['parked-user', 'parked-assistant'])
+  })
+})
+
 interface LayoutProbeHarnessProps {
   activeSessionId: string | null
   onLayoutSnapshot: (snapshot: { active: string | null; selected: string | null }) => void

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -36,6 +36,8 @@ interface SessionStateCacheOptions {
   setMessages: (messages: ChatMessage[]) => void
 }
 
+const VIEW_SYNC_FALLBACK_MS = 100
+
 function syncRuntimeMetadataToView(state: ClientSessionState) {
   setCurrentModel(state.model ?? '')
   setCurrentProvider(state.provider ?? '')
@@ -114,6 +116,7 @@ export function useSessionStateCache({
   const sessionStateCache = sessionStateByRuntimeIdRef.current
   const pendingViewStateRef = useRef<{ sessionId: string; state: ClientSessionState } | null>(null)
   const viewSyncRafRef = useRef<number | null>(null)
+  const viewSyncFallbackTimerRef = useRef<number | null>(null)
   // Runtime id whose transcript currently occupies `$messages` — lets the
   // flush below tell a same-session refresh from a thread switch.
   const viewSessionIdRef = useRef<string | null>(null)
@@ -181,7 +184,7 @@ export function useSessionStateCache({
   )
 
   const resetViewSync = useCallback(() => {
-    // Drop any RAF-pending transcript stage so a backgrounded turn cannot
+    // Drop any pending transcript stage so a backgrounded turn cannot
     // repaint over the chat the user just switched to (#47709 / #47743).
     pendingViewStateRef.current = null
     viewSessionIdRef.current = null
@@ -189,6 +192,11 @@ export function useSessionStateCache({
     if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
       window.cancelAnimationFrame(viewSyncRafRef.current)
       viewSyncRafRef.current = null
+    }
+
+    if (viewSyncFallbackTimerRef.current !== null && typeof window !== 'undefined') {
+      window.clearTimeout(viewSyncFallbackTimerRef.current)
+      viewSyncFallbackTimerRef.current = null
     }
   }, [])
 
@@ -276,12 +284,17 @@ export function useSessionStateCache({
           viewSyncRafRef.current = null
         }
 
+        if (viewSyncFallbackTimerRef.current !== null && typeof window !== 'undefined') {
+          window.clearTimeout(viewSyncFallbackTimerRef.current)
+          viewSyncFallbackTimerRef.current = null
+        }
+
         flushPendingViewState()
 
         return
       }
 
-      if (viewSyncRafRef.current !== null) {
+      if (viewSyncRafRef.current !== null || viewSyncFallbackTimerRef.current !== null) {
         return
       }
 
@@ -291,10 +304,28 @@ export function useSessionStateCache({
         return
       }
 
-      viewSyncRafRef.current = window.requestAnimationFrame(() => {
+      const flushFromAnimationFrame = () => {
         viewSyncRafRef.current = null
+
+        if (viewSyncFallbackTimerRef.current !== null) {
+          window.clearTimeout(viewSyncFallbackTimerRef.current)
+          viewSyncFallbackTimerRef.current = null
+        }
+
         flushPendingViewState()
-      })
+      }
+
+      viewSyncRafRef.current = window.requestAnimationFrame(flushFromAnimationFrame)
+      viewSyncFallbackTimerRef.current = window.setTimeout(() => {
+        viewSyncFallbackTimerRef.current = null
+
+        if (viewSyncRafRef.current !== null) {
+          window.cancelAnimationFrame(viewSyncRafRef.current)
+          viewSyncRafRef.current = null
+        }
+
+        flushPendingViewState()
+      }, VIEW_SYNC_FALLBACK_MS)
     },
     [flushPendingViewState]
   )
@@ -304,6 +335,11 @@ export function useSessionStateCache({
       if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {
         window.cancelAnimationFrame(viewSyncRafRef.current)
         viewSyncRafRef.current = null
+      }
+
+      if (viewSyncFallbackTimerRef.current !== null && typeof window !== 'undefined') {
+        window.clearTimeout(viewSyncFallbackTimerRef.current)
+        viewSyncFallbackTimerRef.current = null
       }
     },
     []


### PR DESCRIPTION
## What does this PR do?

Fixes the "timer keeps counting but nothing appears" bug: on a long-running
turn whose window is backgrounded/occluded/unfocused, the desktop transcript
could stop painting entirely until the user refreshed (Ctrl+R), even though
the backend kept streaming.

`useSessionStateCache.syncSessionStateToView()` batches steady-state busy
heartbeats behind `requestAnimationFrame`. Chromium pauses rAF for backgrounded,
occluded, or unfocused renderers, so a staged update could sit in
`pendingViewStateRef` indefinitely — nothing else forced a flush while the turn
was still busy. Terminal transitions (`!busy`, `needsInput`) already flushed
synchronously; the steady-state path had no such guarantee.

This PR adds a 100ms `setTimeout` watchdog that runs alongside every RAF batch.
Whichever fires first performs the single coalesced flush and clears the other,
so normal rendering still paints within one frame and a throttled renderer
catches up within 100ms instead of never. `resetViewSync` and unmount cleanup
cancel both handles so a late fallback can never repaint over a session switch
(the #47709 / #47743 guard).

## Related Issue

None found — searched open PRs/issues for rAF-throttled transcript stalls;
closest prior art is #42399 / #47919 (Electron-side throttle toggles, merged),
#72151 (synchronous flush on session switch, open), and #68724 (delta-flush
timer fallback, closed unmerged). None covers this hook's steady-state path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-state-cache.ts`
  - Added `viewSyncFallbackTimerRef` + `VIEW_SYNC_FALLBACK_MS = 100`.
  - RAF flush and timer fallback each clear the other; only one flush per stage.
  - Both handles cancelled in `resetViewSync` and on unmount.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx`
  - Regression test: stubs `requestAnimationFrame` to never invoke its callback
    and asserts the running transcript is published after advancing timers past
    the fallback window.

## How to Test

1. Start a long-running agent turn in the desktop app.
2. Background/occlude the Hermes window mid-turn.
3. Before this change: the transcript could freeze (only the elapsed-time
   counter advancing) until refocus or Ctrl+R.
4. After this change: output keeps appearing (≤100ms behind real time).
5. `npx vitest run --project ui src/app/session/hooks/use-session-state-cache.test.tsx`
   → 14 passed (13 pre-existing + 1 new; the new test fails without the fix).
6. `npm run typecheck` → passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates — N/A (no user-facing config/API change)
