### PR TITLE
fix(profiles): ignore cron-only directory shells in profile discovery

### DIFF
--- a/contributors/emails/nicolas@users.noreply.github.com
+++ b/contributors/emails/nicolas@users.noreply.github.com
@@ -1,0 +1,2 @@
+Nicolas-Formenton
+# PR author mapping

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -979,6 +979,24 @@ def set_profile_display_name(profile_name: str, display_name: str) -> str:
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+_PROFILE_IDENTITY_MARKERS = (
+    "config.yaml",
+    ".env",
+    "SOUL.md",
+    "profile.yaml",
+    "auth.json",
+    "state.db",
+)
+
+
+def _is_profile_directory(path: Path) -> bool:
+    """Return whether *path* contains durable profile identity.
+
+    Runtime subsystems such as cron may recreate an otherwise deleted profile's
+    directory.  A runtime-only shell must not become a listed or served profile.
+    """
+    return path.is_dir() and any((path / marker).is_file() for marker in _PROFILE_IDENTITY_MARKERS)
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
@@ -1015,7 +1033,7 @@ def list_profiles() -> List[ProfileInfo]:
         # wrapper dir each time — O(N*M), the dominant cost in this function).
         alias_map = build_alias_map()
         for entry in sorted(profiles_root.iterdir()):
-            if not entry.is_dir():
+            if not _is_profile_directory(entry):
                 continue
             name = entry.name
             if name == "default":
@@ -1100,7 +1118,7 @@ def profiles_to_serve(
     profiles_root = _get_profiles_root()
     if profiles_root.is_dir():
         for entry in sorted(profiles_root.iterdir()):
-            if not entry.is_dir():
+            if not _is_profile_directory(entry):
                 continue
             name = entry.name
             if name == "default":

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -27,7 +27,12 @@ def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     default_home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(default_home))
     for name in ("worker", "guest"):
-        (default_home / "profiles" / name).mkdir(parents=True)
+        # A durable identity marker is what profile discovery requires; a
+        # bare mkdir would now read as a runtime-only shell (see
+        # hermes_cli.profiles._is_profile_directory).
+        profile_dir = default_home / "profiles" / name
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text("", encoding="utf-8")
 
     import gateway.run as gateway_run
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -489,6 +489,14 @@ class TestListProfiles:
         assert "alpha" in names
         assert "beta" in names
 
+    def test_ignores_cron_only_profile_shells(self, profile_env):
+        tmp_path = profile_env
+        (tmp_path / ".hermes" / "profiles" / "ghost" / "cron").mkdir(parents=True)
+
+        names = [p.name for p in list_profiles()]
+
+        assert "ghost" not in names
+
 
 # ===================================================================
 # TestActiveProfile
@@ -1064,6 +1072,15 @@ class TestProfilesToServe:
         assert set(serve) == {"default", "coder", "writer"}
         assert serve["default"] == _get_default_hermes_home()
         assert serve["coder"] == get_profile_dir("coder")
+
+    def test_on_ignores_cron_only_profile_shells(self, profile_env):
+        tmp_path = profile_env
+        create_profile("worker", no_alias=True)
+        (tmp_path / ".hermes" / "profiles" / "ghost" / "cron").mkdir(parents=True)
+
+        serve = dict(profiles_to_serve(multiplex=True))
+
+        assert set(serve) == {"default", "worker"}
 
     def test_empty_allowlist_serves_only_default(self, profile_env):
         create_profile("worker", no_alias=True)


### PR DESCRIPTION
## What does this PR do?

Stops runtime-only directory shells under `profiles/` from being discovered as
real profiles. A deleted profile can be resurrected as an empty directory by
runtime subsystems — most visibly the cron ticker, which recreates
`<profile>/cron/` to write `ticker_heartbeat` — and that shell then reappeared
in `hermes profile list` and was served again by multiplexed gateways.

`list_profiles()` and `profiles_to_serve()` treated *any* directory under
`profiles/` as a valid profile. This PR requires at least one durable identity
marker before treating a directory as a profile:

- `config.yaml`
- `.env`
- `SOUL.md`
- `profile.yaml`
- `auth.json`
- `state.db`

Every one of these exists from profile creation onward, so real profiles are
unaffected; a cron-only shell fails the check and stays invisible. The check is
a bounded stat scan (≤6 stats per candidate), keeping `profiles_to_serve`'s
documented cheap-scan contract intact.

Related upstream work in the same problem family: #94604 (ticker recreating
archived homes), #90141 (tombstones so logging cannot resurrect profiles),
#59554 (stale `HERMES_HOME` at startup), issue #69934 ("Ghost profiles. Profiles
re-appear after deleting"). Those address other resurrection paths; none
changes what counts as a discoverable profile, which is the gap this closes.

## Related Issue

Fixes the discovery half of the ghost-profile cluster (#69934); no dedicated
issue found for the cron-shell variant.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`
  - Added `_PROFILE_IDENTITY_MARKERS` + `_is_profile_directory()`.
  - `list_profiles()` and `profiles_to_serve()` use it instead of bare `is_dir()`.
- `tests/hermes_cli/test_profiles.py`
  - `test_ignores_cron_only_profile_shells` (list path).
  - `test_on_ignores_cron_only_profile_shells` (serve path).

## How to Test

1. Delete a profile, then let the desktop's cron ticker tick once over its home:
   `profiles/<name>/cron/ticker_heartbeat` reappears.
2. `hermes profile list` before: the deleted name shows up again.
3. After: it stays gone; real profiles are unchanged.
4. `pytest tests/hermes_cli/test_profiles.py -q` → both new tests pass
   (2 pre-existing Windows-environment failures on this machine are identical
   with and without the patch; full file: 52 passed / 6 failed patched vs
   50 passed / 6 failed clean).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal discovery predicate)
- [x] Cross-platform impact considered — pure pathlib checks, no platform-specific calls
