### PR TITLE
fix(venv): canonicalize .venv layout and retire the dual-venv split-brain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ packages.
 
 Create the venv **outside** the cloned source tree. A venv that lives inside
 the directory the agent operates from can be wiped by a relative-path command
-the agent runs against its own checkout (`rm -rf venv`, `uv venv venv`, etc.),
+the agent runs against its own checkout (`rm -rf .venv`, `uv venv .venv`, etc.),
 which silently destroys the running runtime mid-session. Keeping it outside the
 tree means no relative path from the workspace resolves to it.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,7 +183,7 @@ scripts/run_tests.sh
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv venv --python 3.11
+uv venv .venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
 python -m pytest tests/ -q

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,7 +184,7 @@ scripts/run_tests.sh
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv .venv --python 3.11
-source venv/bin/activate
+source .venv/bin/activate
 uv pip install -e ".[all,dev]"
 python -m pytest tests/ -q
 ```

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -459,6 +459,18 @@ _GATEWAY_SECRET_PATTERNS = (
 )
 
 
+def _resolve_project_venv(project_root) -> Optional[Path]:
+    """Canonical project venv for import-injection paths (update-boundary safe)."""
+    try:
+        from hermes_constants import project_venv_dir
+    except ImportError:
+        return None
+    try:
+        return project_venv_dir(project_root)
+    except Exception:
+        return None
+
+
 def _ensure_windows_gateway_venv_imports() -> None:
     """Make detached Windows gateway runs see the Hermes venv packages.
 
@@ -476,7 +488,10 @@ def _ensure_windows_gateway_venv_imports() -> None:
     candidates: list[Path] = []
     if os.environ.get("VIRTUAL_ENV"):
         candidates.append(Path(os.environ["VIRTUAL_ENV"]))
-    candidates.append(project_root / "venv")
+    _project_venv = _resolve_project_venv(project_root)
+    if _project_venv is not None:
+        candidates.append(_project_venv)
+    candidates.append(project_root / "venv")  # legacy-layout fallback
 
     seen: set[str] = set()
     for venv_dir in candidates:
@@ -11530,7 +11545,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # a console-less watcher forces every console-subsystem
             # descendant to allocate a visible conhost (#54220/#56747).
             watcher_python = sys.executable
-            venv_dir = Path(watcher_env.get("VIRTUAL_ENV") or project_root / "venv")
+            venv_dir = Path(
+                watcher_env.get("VIRTUAL_ENV")
+                or _resolve_project_venv(project_root)
+                or project_root / "venv"
+            )
             site_packages = venv_dir / "Lib" / "site-packages"
             if site_packages.exists():
                 watcher_env["VIRTUAL_ENV"] = str(venv_dir)

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -95,7 +95,7 @@ def _resolve_install_target(root: Path) -> tuple[list[str], dict | None]:
     if uv_bin:
         from hermes_constants import project_venv_dir
 
-        env = {**os.environ, "VIRTUAL_ENV": str(project_venv_dir(root) or root / "venv")}
+        env = {**os.environ, "VIRTUAL_ENV": str(project_venv_dir(root) or root / ".venv")}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)
             env.pop("PYTHONHOME", None)
@@ -325,6 +325,42 @@ def ensure_windows_bin_launchers(
                 file=sys.stderr,
             )
     return restored
+
+
+def reconcile_venv_layout(root) -> Path | None:
+    """Retire a stale sibling venv when both ``venv`` and ``.venv`` exist.
+
+    Two layouts are in the wild (installers historically created ``venv``;
+    ``uv venv`` defaults to ``.venv``) and nothing used to remove the loser,
+    so a checkout could run two full environments side by side -- with
+    different package sets -- and different subsystems (launcher heal vs
+    gateway import shim vs updater) could resolve to different ones. When
+    both exist and the resolved (active/canonical) venv has a usable
+    interpreter, the OTHER sibling is parked (renamed
+    ``<name>.legacy-<timestamp>``): atomic, recoverable, and it makes every
+    resolver agree immediately. stdlib-only on purpose (boot path); never
+    raises. Returns the parked path, or None when there is nothing to retire.
+    """
+    from hermes_constants import project_venv_dir, venv_python_path
+
+    root = Path(root)
+    present = [name for name in (".venv", "venv") if (root / name).is_dir()]
+    if len(present) < 2:
+        return None
+    active = project_venv_dir(root)
+    if active is None:
+        return None
+    legacy = (root / "venv") if active == root / ".venv" else root / ".venv"
+    if not venv_python_path(active, windows=_is_windows()).exists():
+        return None  # resolved venv unusable: leave the mix alone
+    parked = root / f"{legacy.name}.legacy-{time.strftime('%Y%m%d-%H%M%S')}"
+    if parked.exists():
+        return None
+    try:
+        legacy.rename(parked)
+    except OSError:
+        return None
+    return parked
 
 
 def _read_user_path_raw() -> tuple[list[str], int]:

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -327,7 +327,7 @@ def ensure_windows_bin_launchers(
     return restored
 
 
-def reconcile_venv_layout(root) -> Path | None:
+def reconcile_venv_layout(root, *, windows: bool | None = None) -> Path | None:
     """Retire a stale sibling venv when both ``venv`` and ``.venv`` exist.
 
     Two layouts are in the wild (installers historically created ``venv``;
@@ -340,10 +340,15 @@ def reconcile_venv_layout(root) -> Path | None:
     ``<name>.legacy-<timestamp>``): atomic, recoverable, and it makes every
     resolver agree immediately. stdlib-only on purpose (boot path); never
     raises. Returns the parked path, or None when there is nothing to retire.
+
+    *windows* is injectable for tests (host-independent probing), same
+    pattern as ``ensure_windows_bin_launchers``.
     """
     from hermes_constants import project_venv_dir, venv_python_path
 
     root = Path(root)
+    if windows is None:
+        windows = _is_windows()
     present = [name for name in (".venv", "venv") if (root / name).is_dir()]
     if len(present) < 2:
         return None
@@ -351,7 +356,7 @@ def reconcile_venv_layout(root) -> Path | None:
     if active is None:
         return None
     legacy = (root / "venv") if active == root / ".venv" else root / ".venv"
-    if not venv_python_path(active, windows=_is_windows()).exists():
+    if not venv_python_path(active, windows=windows).exists():
         return None  # resolved venv unusable: leave the mix alone
     parked = root / f"{legacy.name}.legacy-{time.strftime('%Y%m%d-%H%M%S')}"
     if parked.exists():

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1998,7 +1998,7 @@ def run_doctor(args):
         _section("Command Installation")
         # Determine the venv entry point location
         _venv_bin = None
-        for _venv_name in ("venv", ".venv"):
+        for _venv_name in (".venv", "venv"):
             _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
             if _candidate.exists():
                 _venv_bin = _candidate

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -707,6 +707,7 @@ if sys.platform == "win32":
         from hermes_cli import _install_repair as _install_repair_mod
 
         _install_repair_mod.ensure_windows_bin_launchers(_bootstrap_root)
+        _install_repair_mod.reconcile_venv_layout(_bootstrap_root)
     except Exception:
         pass
 
@@ -6121,7 +6122,7 @@ def _nixos_build_env() -> dict[str, str] | None:
         return None
 
     # Tier 1: fast path — hermes venv python3, no nix-shell overhead
-    for venv_name in ("venv", ".venv"):
+    for venv_name in (".venv", "venv"):
         venv_python = PROJECT_ROOT / venv_name / "bin" / "python3"
         if venv_python.exists():
             return {**os.environ, "PYTHON": str(venv_python)}
@@ -8942,7 +8943,7 @@ def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
     if uv_bin:
         from hermes_constants import project_venv_dir
 
-        venv_dir = project_venv_dir(PROJECT_ROOT) or PROJECT_ROOT / "venv"
+        venv_dir = project_venv_dir(PROJECT_ROOT) or PROJECT_ROOT / ".venv"
         env = {**os.environ, "VIRTUAL_ENV": str(venv_dir)}
         if _is_termux_env(env):
             env.pop("PYTHONPATH", None)

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -8,7 +8,7 @@ at ``$HERMES_HOME/bin`` so the installer writes directly there — no PATH
 probing, no conda guards, no multi-location resolution chains.
 
 The Python backing the install is different: it is shared by every Hermes
-profile because the checkout's ``venv`` is shared.  Runtime repair therefore
+profile because the checkout's project venv (``.venv``) is shared.  Runtime repair therefore
 uses an install-scoped store under ``<checkout>/.hermes-runtime/python``. A
 vulnerable interpreter is never reinstalled in place. We provision a new
 immutable Python generation, build and smoke-test a relocatable sibling venv,
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _RUNTIME_DIR_NAME = ".hermes-runtime"
-_VENV_NAME = "venv"
-_ALT_VENV_NAME = ".venv"
+_VENV_NAME = ".venv"
+_ALT_VENV_NAME = "venv"
 _REPAIR_LOCK_NAME = "runtime-repair.lock"
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
-from hermes_constants import venv_python_path
+from hermes_constants import project_venv_dir, venv_python_path
 
 logger = logging.getLogger(__name__)
 
@@ -476,7 +476,8 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
         interpreter = sys.executable
         try:
             venv_python = venv_python_path(
-                Path(root) / "venv", windows=_m()._is_windows()
+                project_venv_dir(root) or Path(root) / ".venv",
+                windows=_m()._is_windows(),
             )
             if venv_python.exists():
                 interpreter = str(venv_python)
@@ -1580,8 +1581,8 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                     extracted = candidate
                     break
 
-        # Copy updated files over existing installation, preserving venv/node_modules/.git
-        preserve = {"venv", "node_modules", ".git", ".env"}
+        # Copy updated files over existing installation, preserving venv layouts/node_modules/.git
+        preserve = {"venv", ".venv", "node_modules", ".git", ".env"}
         entries = [i for i in os.listdir(extracted) if i not in preserve]
 
         # Two-phase replace (#76104). Phase 1 copies every entry — directories
@@ -1733,7 +1734,9 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         from hermes_cli.managed_uv import managed_python_env
 
         uv_env = managed_python_env()
-        uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+        uv_env["VIRTUAL_ENV"] = str(
+            project_venv_dir(_m().PROJECT_ROOT) or _m().PROJECT_ROOT / ".venv"
+        )
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -3908,7 +3911,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or _m().PROJECT_ROOT / ".venv"
     venv_python = venv_python_path(venv_dir, windows=_m()._is_windows())
     if not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
@@ -3986,7 +3989,7 @@ def _detect_venv_python_processes(
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or _m().PROJECT_ROOT / ".venv"
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -4407,7 +4410,7 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
     except Exception:
         return []
 
-    venv_dir = _m().PROJECT_ROOT / "venv"
+    venv_dir = project_venv_dir(_m().PROJECT_ROOT) or _m().PROJECT_ROOT / ".venv"
     try:
         venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
     except OSError:
@@ -6403,13 +6406,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # recreated before dependencies can be installed into it.
                 venv_python_missing = not (
                     venv_python_path(
-                        _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
+                        project_venv_dir(_m().PROJECT_ROOT)
+                        or _m().PROJECT_ROOT / ".venv",
+                        windows=_m()._is_windows(),
                     )
                 ).exists()
                 if venv_python_missing and repair_uv:
                     print("→ Recreating virtual environment...")
                     subprocess.run(
-                        [repair_uv, "venv", "venv"],
+                        [repair_uv, "venv", ".venv"],
                         cwd=_m().PROJECT_ROOT,
                         check=False,
                     )
@@ -6419,7 +6424,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     from hermes_cli.managed_uv import managed_python_env
 
                     repair_env = managed_python_env()
-                    repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+                    repair_env["VIRTUAL_ENV"] = str(
+                        project_venv_dir(_m().PROJECT_ROOT)
+                        or _m().PROJECT_ROOT / ".venv"
+                    )
                     _m()._install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )
@@ -6763,7 +6771,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             from hermes_cli.managed_uv import managed_python_env
 
             uv_env = managed_python_env()
-            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+            uv_env["VIRTUAL_ENV"] = str(
+                project_venv_dir(_m().PROJECT_ROOT) or _m().PROJECT_ROOT / ".venv"
+            )
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1639,16 +1639,38 @@ def venv_bin_dir(venv_dir, *, windows: bool | None = None) -> Path:
     return Path(venv_dir) / ("Scripts" if windows else "bin")
 
 
-def project_venv_dir(project_root) -> Path | None:
-    """The project's venv directory, ``venv`` or ``.venv``, when one exists.
+#: Canonical project venv names, in resolution order: ``.venv`` (uv default /
+#: new installs) first, ``venv`` (legacy installer layout) second.
+_PROJECT_VENV_NAMES = (".venv", "venv")
 
-    ``uv venv`` defaults to ``.venv`` while our installers create ``venv``, so
-    both layouts are in the wild. Call sites that only knew about ``venv``
-    silently no-oped on a ``.venv`` install — that is how the Windows
-    shim-lock preflight skipped itself entirely (#79542). ``venv`` wins when
-    both exist, matching what the installers write.
+
+def project_venv_dir(project_root) -> Path | None:
+    """The project's venv directory, ``.venv`` or ``venv``, when one exists.
+
+    ``.venv`` is the canonical layout: ``uv venv`` defaults to it, and new
+    installs create it.  Older installs created ``venv``, so both layouts are
+    in the wild.  Call sites that only knew about ``venv`` silently no-oped on
+    a ``.venv`` install — that is how the Windows shim-lock preflight skipped
+    itself entirely (#79542).
+
+    Resolution order:
+    1. the venv the CURRENT interpreter is running from (``sys.prefix``), when
+       that venv lives inside *project_root* — this keeps every subsystem
+       attached to the environment the active process actually uses, even when
+       a stale sibling layout exists;
+    2. ``.venv`` (canonical);
+    3. ``venv`` (legacy installs).
     """
-    for name in ("venv", ".venv"):
+    try:
+        running = Path(getattr(sys, "prefix", "") or "").resolve()
+        root = Path(project_root).resolve()
+        if running.name in _PROJECT_VENV_NAMES and os.path.normcase(
+            str(running.parent)
+        ) == os.path.normcase(str(root)):
+            return Path(sys.prefix)
+    except OSError:
+        pass  # unresolvable prefix/root: fall through to name probing
+    for name in _PROJECT_VENV_NAMES:
         candidate = Path(project_root) / name
         if candidate.is_dir():
             return candidate

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2886,7 +2886,7 @@ except Exception:
     }
 
     # Baseline-import gate. Even if a tier reported success above, the
-    # actual deps may have landed somewhere other than $InstallDir\venv\
+    # actual deps may have landed somewhere other than $InstallDir\.venv\
     # (e.g. uv 0.5+ syncing into a sibling venv\ when UV_PROJECT_ENVIRONMENT
     # isn't set, leaving .venv\ empty and hermes.exe broken with
     # `ModuleNotFoundError: No module named 'dotenv'` on first run).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2791,7 +2791,7 @@ function Install-Dependencies {
         #
         # UV_PROJECT_ENVIRONMENT pins the sync target to our venv\.
         # Without it, modern uv (>=0.5) ignores VIRTUAL_ENV for `sync`
-        # and creates a sibling .venv\ inside the repo -- leaving venv\
+        # and creates a sibling venv\ inside the repo -- leaving .venv\
         # empty and producing the broken state where `hermes.exe` exists
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
@@ -2887,15 +2887,15 @@ except Exception:
 
     # Baseline-import gate. Even if a tier reported success above, the
     # actual deps may have landed somewhere other than $InstallDir\venv\
-    # (e.g. uv 0.5+ syncing into a sibling .venv\ when UV_PROJECT_ENVIRONMENT
-    # isn't set, leaving venv\ empty and hermes.exe broken with
+    # (e.g. uv 0.5+ syncing into a sibling venv\ when UV_PROJECT_ENVIRONMENT
+    # isn't set, leaving .venv\ empty and hermes.exe broken with
     # `ModuleNotFoundError: No module named 'dotenv'` on first run).
     # We probe via the venv's own python so a misdirected sync is caught
     # here, not 30 seconds later when the user runs `hermes`.
     if (-not $NoVenv) {
         $venvPython = "$InstallDir\.venv\Scripts\python.exe"
         if (-not (Test-Path $venvPython)) {
-            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
+            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
         }
         # Relax EAP=Stop while running the import probe.  Python writes
         # deprecation warnings and import-system info to stderr; under
@@ -2909,13 +2909,13 @@ except Exception:
         $importExitCode = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP
         if ($importExitCode -ne 0) {
-            $sibling = "$InstallDir\.venv"
+            $sibling = "$InstallDir\venv"
             $hint = if (Test-Path $sibling) {
-                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Close Hermes processes, preserve the existing venv, and rerun the installer so the transactional recovery path can move directories safely."
+                "Detected sibling venv\ at $sibling -- uv synced there instead of .venv\. Close Hermes processes, preserve the existing venv, and rerun the installer so the transactional recovery path can move directories safely."
             } else {
-                "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
+                "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\.venv'; uv sync --extra all --locked"
             }
-            throw "Baseline imports failed in $InstallDir\venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
+            throw "Baseline imports failed in $InstallDir\.venv (dotenv/openai/rich/prompt_toolkit). The install completed but dependencies are not in the venv. $hint"
         }
         Write-Success "Baseline imports verified in venv"
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2444,7 +2444,11 @@ function Install-Venv {
     $venvBackupName = $null
     $venvParked = $false
     try {
-    if (Test-Path -LiteralPath "venv") {
+    $existingVenvDirs = @()
+    foreach ($vn in @(".venv", "venv")) {
+        if (Test-Path -LiteralPath $vn) { $existingVenvDirs += $vn }
+    }
+    if ($existingVenvDirs.Count -gt 0) {
         $venvHadExistingVenv = $true
         Write-Info "Virtual environment already exists, recreating..."
         # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
@@ -2508,13 +2512,13 @@ function Install-Venv {
             # the window between one kill pass and venv parking. Each pass re-
             # enumerates; three consecutive clean passes (or the attempt cap)
             # ends the loop.
-            $venvPrefix = [System.IO.Path]::GetFullPath((Join-Path $InstallDir "venv")).TrimEnd('\') + '\'
+            $venvPrefixRe = '^(?:' + (($existingVenvDirs | ForEach-Object { [regex]::Escape(([System.IO.Path]::GetFullPath((Join-Path $InstallDir $_))).TrimEnd('\') + '\') }) -join '|') + ')'
             $cleanPasses = 0
             for ($sweep = 0; $sweep -lt 10 -and $cleanPasses -lt 3; $sweep++) {
                 $found = 0
                 try {
                     Get-CimInstance Win32_Process -ErrorAction Stop |
-                        Where-Object { $_.ProcessId -ne $myPid -and $_.ExecutablePath -and $_.ExecutablePath.StartsWith($venvPrefix, [System.StringComparison]::OrdinalIgnoreCase) } |
+                        Where-Object { $_.ProcessId -ne $myPid -and $_.ExecutablePath -and $_.ExecutablePath -match $venvPrefixRe } |
                         ForEach-Object {
                             $found++
                             $treePid = [string]$_.ProcessId
@@ -2536,18 +2540,24 @@ function Install-Venv {
         # then fail on one locked .pyd, leaving a gutted venv with no usable
         # interpreter and no rollback source. Abort with the previous install
         # intact so the user can close holders and retry.
-        $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
-        try {
-            Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
-            $venvParked = $true
-        } catch {
-            $renameErr = $_.Exception.Message
-            throw (
-                "Could not move the existing venv aside ($renameErr). " +
-                "A process still has the install directory open (often a non-Hermes " +
-                "python.exe that resolved into this venv via PATH). Close those " +
-                "processes and retry - the previous install was left intact."
-            )
+        $venvParkedMap = @{}
+        $venvBackupName = $null
+        foreach ($vn in @("venv", ".venv")) {
+            if ($existingVenvDirs -notcontains $vn) { continue }
+            $venvBackupName = "$vn.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+            try {
+                Rename-Item -LiteralPath $vn -NewName $venvBackupName -ErrorAction Stop
+                $venvParkedMap[$venvBackupName] = $vn
+                $venvParked = $true
+            } catch {
+                $renameErr = $_.Exception.Message
+                throw (
+                    "Could not move the existing venv aside ($renameErr). " +
+                    "A process still has the install directory open (often a non-Hermes " +
+                    "python.exe that resolved into this venv via PATH). Close those " +
+                    "processes and retry - the previous install was left intact."
+                )
+            }
         }
     }
     
@@ -2555,7 +2565,7 @@ function Install-Venv {
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv .venv --python $PythonVersion }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit
@@ -2568,7 +2578,7 @@ function Install-Venv {
     # uv can return success without leaving the interpreter expected by the
     # installer (for example after an interrupted filesystem operation). Treat
     # that as a failed transaction so the previous venv can be restored.
-    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    $venvPythonExe = Join-Path $InstallDir ".venv\Scripts\python.exe"
     if (-not (Test-Path -LiteralPath $venvPythonExe -PathType Leaf)) {
         throw "uv reported success but venv interpreter is missing at $venvPythonExe"
     }
@@ -2580,7 +2590,9 @@ function Install-Venv {
     # succeeds. Record the parked backup so the dependency stage can restore
     # it on failure and commit its cleanup only after validation (#83149).
     if ($venvParked) {
-        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value $venvBackupName -Encoding ascii
+        $pendingTarget = "venv"
+        if ($existingVenvDirs -contains ".venv") { $pendingTarget = ".venv" }
+        Set-Content -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Value @($venvBackupName, $pendingTarget) -Encoding ascii
         Write-Info "Previous venv parked at $venvBackupName until the dependency install is verified"
     }
 
@@ -2588,8 +2600,8 @@ function Install-Venv {
     # been released. Best-effort -- a still-held tree just stays for next time.
     # The backup parked THIS run is excluded: it is the rollback source until
     # Install-Dependencies commits the transaction.
-    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -ne $venvBackupName } | ForEach-Object {
+    Get-ChildItem -Directory -ErrorAction SilentlyContinue |
+        Where-Object { ($_.Name -like "venv.stale.*" -or $_.Name -like ".venv.stale.*") -and $_.Name -ne $venvBackupName } | ForEach-Object {
             Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
         }
 
@@ -2605,14 +2617,18 @@ function Install-Venv {
         $originalError = $_
         $rollbackError = $null
 
-        if ($venvParked -and $venvBackupName -and (Test-Path -LiteralPath $venvBackupName)) {
+        if ($venvParked -and $venvParkedMap.Count -gt 0) {
             try {
-                if (Test-Path -LiteralPath "venv") {
-                    $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
-                    Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
-                    Write-Warn "Failed replacement parked at $failedVenvName"
+                foreach ($vn in @(".venv", "venv")) {
+                    if (Test-Path -LiteralPath $vn) {
+                        $failedVenvName = "$vn.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                        Rename-Item -LiteralPath $vn -NewName $failedVenvName -ErrorAction Stop
+                        Write-Warn "Failed replacement parked at $failedVenvName"
+                    }
                 }
-                Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                foreach ($parkedName in $venvParkedMap.Keys) {
+                    Rename-Item -LiteralPath $parkedName -NewName $venvParkedMap[$parkedName] -ErrorAction Stop
+                }
                 Write-Warn "Restored previous virtual environment after failed recreate"
             } catch {
                 $rollbackError = $_.Exception.Message
@@ -2621,13 +2637,17 @@ function Install-Venv {
             if ($rollbackError) {
                 throw "Virtual environment recreate failed: $($originalError.Exception.Message). Rollback failed: $rollbackError. Previous venv remains at $venvBackupName."
             }
-        } elseif (-not $venvHadExistingVenv -and (Test-Path -LiteralPath "venv")) {
+        } elseif (-not $venvHadExistingVenv) {
             # Preserve a partial first install too. This branch must not touch a
             # pre-existing venv whose move-aside failed above.
             try {
-                $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
-                Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
-                Write-Warn "Partial virtual environment parked at $failedVenvName"
+                foreach ($vn in @(".venv", "venv")) {
+                    if (Test-Path -LiteralPath $vn) {
+                        $failedVenvName = "$vn.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                        Rename-Item -LiteralPath $vn -NewName $failedVenvName -ErrorAction Stop
+                        Write-Warn "Partial virtual environment parked at $failedVenvName"
+                    }
+                }
             } catch {
                 $rollbackError = $_.Exception.Message
             }
@@ -2672,6 +2692,18 @@ function Get-PendingVenvBackup {
     return $name
 }
 
+function Get-PendingVenvRestoreTarget {
+    # Original directory name of the parked venv (the restore target). Legacy
+    # single-line markers restore to "venv"; new markers carry the target on
+    # the second line so a canonical ".venv" park restores to ".venv".
+    $markerPath = Join-Path $InstallDir "venv.pending-backup"
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) { return "venv" }
+    $target = (Get-Content -LiteralPath $markerPath -ErrorAction SilentlyContinue | Select-Object -Skip 1 -First 1)
+    if ($target) { $target = $target.Trim() }
+    if (-not $target) { return "venv" }
+    return $target
+}
+
 function Complete-VenvTransaction {
     # Commit: dependency install + baseline imports passed, so the previous
     # venv is no longer needed as a rollback source. Best-effort delete; a
@@ -2692,13 +2724,14 @@ function Restore-VenvBackup {
     # venv so Hermes (and the venv-blocker probe) stay usable (#83149).
     $backupName = Get-PendingVenvBackup
     if (-not $backupName) { return }
+    $restoreTarget = Get-PendingVenvRestoreTarget
     try {
-        if (Test-Path -LiteralPath (Join-Path $InstallDir "venv")) {
-            $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
-            Rename-Item -LiteralPath (Join-Path $InstallDir "venv") -NewName $failedVenvName -ErrorAction Stop
+        if (Test-Path -LiteralPath (Join-Path $InstallDir $restoreTarget)) {
+            $failedVenvName = "$restoreTarget.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+            Rename-Item -LiteralPath (Join-Path $InstallDir $restoreTarget) -NewName $failedVenvName -ErrorAction Stop
             Write-Warn "Failed replacement parked at $failedVenvName"
         }
-        Rename-Item -LiteralPath (Join-Path $InstallDir $backupName) -NewName "venv" -ErrorAction Stop
+        Rename-Item -LiteralPath (Join-Path $InstallDir $backupName) -NewName $restoreTarget -ErrorAction Stop
         Remove-Item -LiteralPath (Join-Path $InstallDir "venv.pending-backup") -Force -ErrorAction SilentlyContinue
         Write-Warn "Restored previous virtual environment after failed dependency install"
     } catch {
@@ -2713,7 +2746,7 @@ function Install-Dependencies {
     
     if (-not $NoVenv) {
         # Tell uv to install into our venv (no activation needed)
-        $env:VIRTUAL_ENV = "$InstallDir\venv"
+        $env:VIRTUAL_ENV = "$InstallDir\.venv"
     }
 
     # Re-pin UV_PYTHON to the venv interpreter. Install-Venv already does this,
@@ -2724,7 +2757,7 @@ function Install-Dependencies {
     # tiers below recreate the venv at 3.14 and fail the maturin source build
     # (no cp314 wheels yet).
     if (-not $NoVenv) {
-        $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+        $venvPythonExe = Join-Path $InstallDir ".venv\Scripts\python.exe"
         if (Test-Path $venvPythonExe) {
             $env:UV_PYTHON = $venvPythonExe
         }
@@ -2762,7 +2795,7 @@ function Install-Dependencies {
         # empty and producing the broken state where `hermes.exe` exists
         # in the wrong directory and imports fail with ModuleNotFoundError.
         # (Mirrors the same flag in scripts/install.sh::install_deps.)
-        $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+        $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\.venv"
         Invoke-NativeWithRelaxedErrorAction { & $UvCmd sync --extra all --locked }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "Main package installed (hash-verified via uv.lock)"
@@ -2800,7 +2833,7 @@ function Install-Dependencies {
 
     # Parse [project.optional-dependencies].all from pyproject.toml.
     # tomllib is stdlib on Python 3.11+ which the bootstrap guarantees.
-    $pythonExeForParse = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    $pythonExeForParse = if (-not $NoVenv) { "$InstallDir\.venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
     $allExtras = @()
     if (Test-Path $pythonExeForParse) {
         $parsed = & $pythonExeForParse -c @"
@@ -2860,7 +2893,7 @@ except Exception:
     # We probe via the venv's own python so a misdirected sync is caught
     # here, not 30 seconds later when the user runs `hermes`.
     if (-not $NoVenv) {
-        $venvPython = "$InstallDir\venv\Scripts\python.exe"
+        $venvPython = "$InstallDir\.venv\Scripts\python.exe"
         if (-not (Test-Path $venvPython)) {
             throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
         }
@@ -2905,7 +2938,7 @@ except Exception:
         # materialise the .exe (file lock during self-update, distlib edge case).
         # Catch it here so a fresh install/update does not finish with a broken
         # `hermes` command while hermes-agent.exe / hermes-acp.exe exist
-        $scriptsDir = Join-Path $InstallDir "venv\Scripts"
+        $scriptsDir = Join-Path $InstallDir ".venv\Scripts"
         $pythonExe = Join-Path $scriptsDir "python.exe"
         if ((Test-Path $scriptsDir) -and (Test-Path $pythonExe)) {
             $scriptNames = & $pythonExe -c @"
@@ -2924,7 +2957,7 @@ print(','.join(scripts))
                 if ($missing.Count -gt 0) {
                     Write-Warn "Console entry point(s) missing: $($missing -join ', ')"
                     Write-Info "Reinstalling entry points..."
-                    $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\venv"
+                    $env:UV_PROJECT_ENVIRONMENT = "$InstallDir\.venv"
                     Invoke-NativeWithRelaxedErrorAction { & $UvCmd pip install --reinstall -e . }
                     $stillMissing = @()
                     foreach ($name in $expected) {
@@ -2946,7 +2979,7 @@ print(','.join(scripts))
     # users hit and lazy-import errors from `hermes dashboard` are confusing.
     # If tier 1 failed (the common case), [web] was still picked up by tiers
     # 2-3; only tier 4 leaves you without it.
-    $pythonExe = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    $pythonExe = if (-not $NoVenv) { "$InstallDir\.venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
     if (Test-Path $pythonExe) {
         $webOk = $false
         $webServerSyntaxOk = $false
@@ -2997,7 +3030,7 @@ function Install-HermesCommandLaunchers {
     # silently hijacks the `python` command in every terminal (#83797).
     # Requiring hermes.exe before creating the destination keeps the PATH
     # stage from reporting success with an unusable command (PR #92092).
-    $scriptsDir = Join-Path $Root "venv\Scripts"
+    $scriptsDir = Join-Path $Root ".venv\Scripts"
     $requiredSource = Join-Path $scriptsDir "hermes.exe"
     if (-not (Test-Path -LiteralPath $requiredSource -PathType Leaf)) {
         throw "Cannot set up the hermes command: required launcher not found: $requiredSource"
@@ -3012,7 +3045,8 @@ function Install-HermesCommandLaunchers {
     # --relocatable) resolves relative to its own location, and a copy
     # dies with 'uv trampoline failed to canonicalize script path' --
     # those get a .cmd delegator invoking the in-venv exe instead.
-    $pyvenvCfg = Join-Path $Root "venv\pyvenv.cfg"
+    $pyvenvCfg = Join-Path $Root ".venv\pyvenv.cfg"
+    if (-not (Test-Path -LiteralPath $pyvenvCfg)) { $pyvenvCfg = Join-Path $Root "venv\pyvenv.cfg" }
     $venvRelocatable = $false
     if (Test-Path -LiteralPath $pyvenvCfg) {
         $venvRelocatable = [bool](Select-String -Path $pyvenvCfg -Pattern '^\s*relocatable\s*=\s*true\s*$' -Quiet)
@@ -3249,7 +3283,7 @@ You are Hermes Agent, an intelligent AI assistant created by Nous Research. You 
     
     # Seed bundled skills into $HermesHome\skills (manifest-based, one-time per skill)
     Write-Info "Syncing bundled skills to $HermesHome\skills ..."
-    $pythonExe = "$InstallDir\venv\Scripts\python.exe"
+    $pythonExe = "$InstallDir\.venv\Scripts\python.exe"
     if (Test-Path $pythonExe) {
         try {
             # Force the child python.exe to emit UTF-8 on its stdout/stderr.
@@ -4250,7 +4284,7 @@ function Install-PlatformSdks {
         return
     }
 
-    $pythonExe = "$InstallDir\venv\Scripts\python.exe"
+    $pythonExe = "$InstallDir\.venv\Scripts\python.exe"
     if (-not (Test-Path $pythonExe)) {
         Write-Warn "Skipping platform-SDK verification: $pythonExe not found"
         return
@@ -4360,7 +4394,7 @@ function Invoke-SetupWizard {
 
     # Run hermes setup using the venv Python directly (no activation needed)
     if (-not $NoVenv) {
-        & ".\venv\Scripts\python.exe" -m hermes_cli.main setup
+        & ".\.venv\Scripts\python.exe" -m hermes_cli.main setup
     } else {
         python -m hermes_cli.main setup
     }
@@ -4381,7 +4415,7 @@ function Start-GatewayIfConfigured {
 
     if (-not $hasMessaging) { return }
 
-    $hermesCmd = "$InstallDir\venv\Scripts\hermes.exe"
+    $hermesCmd = "$InstallDir\.venv\Scripts\hermes.exe"
     if (-not (Test-Path $hermesCmd)) {
         $hermesCmd = "hermes"
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1537,25 +1537,25 @@ setup_venv() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Creating virtual environment with Termux Python..."
 
-        if [ -d "venv" ]; then
+        if [ -d ".venv" ] || [ -d "venv" ]; then
             log_info "Virtual environment already exists, recreating..."
-            rm -rf venv
+            rm -rf .venv venv
         fi
 
-        "$PYTHON_PATH" -m venv venv
-        log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null))"
+        "$PYTHON_PATH" -m venv .venv
+        log_success "Virtual environment ready ($(./.venv/bin/python --version 2>/dev/null))"
         return 0
     fi
 
     log_info "Creating virtual environment with Python $PYTHON_VERSION..."
 
-    if [ -d "venv" ]; then
+    if [ -d ".venv" ] || [ -d "venv" ]; then
         log_info "Virtual environment already exists, recreating..."
-        rm -rf venv
+        rm -rf .venv venv
     fi
 
     # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    $UV_CMD venv .venv --python "$PYTHON_VERSION"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1564,8 +1564,8 @@ setup_venv() {
     # version — building Rust transitives that have no wheel for that
     # version from source via maturin, which fails. Pinning UV_PYTHON to the
     # interpreter we just created forces every subsequent uv command onto it.
-    if [ -x "$INSTALL_DIR/venv/bin/python" ]; then
-        export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
+    if [ -x "$INSTALL_DIR/.venv/bin/python" ]; then
+        export UV_PYTHON="$INSTALL_DIR/.venv/bin/python"
     fi
 
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
@@ -1580,14 +1580,14 @@ install_deps() {
     # python-deps invocation. Re-deriving it here covers that path. Without it,
     # an inherited UV_PYTHON=3.14 makes the uv sync/pip tiers below recreate the
     # venv at 3.14 and fail the maturin source build (no cp314 wheels yet).
-    if [ "$DISTRO" != "termux" ] && [ -x "$INSTALL_DIR/venv/bin/python" ]; then
-        export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
+    if [ "$DISTRO" != "termux" ] && [ -x "$INSTALL_DIR/.venv/bin/python" ]; then
+        export UV_PYTHON="$INSTALL_DIR/.venv/bin/python"
     fi
 
     if [ "$DISTRO" = "termux" ]; then
         if [ "$USE_VENV" = true ]; then
-            export VIRTUAL_ENV="$INSTALL_DIR/venv"
-            PIP_PYTHON="$INSTALL_DIR/venv/bin/python"
+            export VIRTUAL_ENV="$INSTALL_DIR/.venv"
+            PIP_PYTHON="$INSTALL_DIR/.venv/bin/python"
         else
             PIP_PYTHON="$PYTHON_PATH"
         fi
@@ -1641,7 +1641,7 @@ install_deps() {
 
     if [ "$USE_VENV" = true ]; then
         # Tell uv to install into our venv (no need to activate)
-        export VIRTUAL_ENV="$INSTALL_DIR/venv"
+        export VIRTUAL_ENV="$INSTALL_DIR/.venv"
     fi
 
     # On Debian/Ubuntu (including WSL), some Python packages need build tools.
@@ -1709,7 +1709,7 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/.venv" $UV_CMD sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
@@ -1829,7 +1829,7 @@ setup_path() {
     log_info "Setting up hermes command..."
 
     if [ "$USE_VENV" = true ]; then
-        HERMES_BIN="$INSTALL_DIR/venv/bin/python"
+        HERMES_BIN="$INSTALL_DIR/.venv/bin/python"
         HERMES_ENTRYPOINT="$INSTALL_DIR/hermes"
     else
         HERMES_BIN="$(which hermes 2>/dev/null || echo "")"
@@ -2109,7 +2109,7 @@ SOUL_EOF
         log_info "  Future 'hermes update' runs will not inject bundled skills. Delete the marker to opt back in."
     else
         log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
-        if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+        if "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
             log_success "Skills synced to ~/.hermes/skills/"
         else
             # Fallback: simple directory copy if Python sync fails
@@ -2707,7 +2707,7 @@ run_setup_wizard() {
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
     if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+        "$INSTALL_DIR/.venv/bin/python" -m hermes_cli.main setup < /dev/tty
     else
         python -m hermes_cli.main setup < /dev/tty
     fi
@@ -3190,7 +3190,7 @@ install_desktop_voice_deps() {
     # for anything this best-effort step fails to fetch.
     local _prev_venv="${VIRTUAL_ENV:-}"
     if [ "$USE_VENV" = true ]; then
-        export VIRTUAL_ENV="$INSTALL_DIR/venv"
+        export VIRTUAL_ENV="$INSTALL_DIR/.venv"
     fi
     if [ -z "${UV_CMD:-}" ]; then
         install_uv || true
@@ -3397,7 +3397,7 @@ install_desktop() {
     # strip + deep ad-hoc repair so a broken venv never leaves the bundle
     # unsigned/unlaunchable.
     if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
-        local config_python="$INSTALL_DIR/venv/bin/python"
+        local config_python="$INSTALL_DIR/.venv/bin/python"
         local fixup_ok=""
         if [ -x "$config_python" ]; then
             if HERMES_HOME="$HERMES_HOME" "$config_python" - "$desktop_dir" <<'PYEOF'

--- a/tests/hermes_cli/test_ensure_windows_bin_launchers.py
+++ b/tests/hermes_cli/test_ensure_windows_bin_launchers.py
@@ -150,6 +150,41 @@ def test_noop_on_posix(managed_install):
     assert not (home / "bin").exists()
 
 
+def test_dual_layout_launchers_come_from_canonical_venv(tmp_path, monkeypatch):
+    """Both venv and .venv present → launchers resolve from .venv (canonical).
+
+    The legacy venv may be relocatable while the canonical .venv is a normal
+    venv; the healed launcher form must follow the CANONICAL one, otherwise
+    the bin dir would carry .cmd delegators into the stale environment.
+    """
+    home = tmp_path / "hermes"
+    root = home / "hermes-agent"
+    # legacy, relocatable
+    legacy = root / "venv" / "Scripts"
+    legacy.mkdir(parents=True)
+    (root / "venv" / "pyvenv.cfg").write_text(
+        "home = X\nrelocatable = true\n", encoding="utf-8"
+    )
+    for name in _WINDOWS_BIN_LAUNCHERS:
+        (legacy / f"{name}.exe").write_bytes(b"MZ legacy: " + name.encode())
+    # canonical, normal venv
+    canonical = root / ".venv" / "Scripts"
+    canonical.mkdir(parents=True)
+    (root / ".venv" / "pyvenv.cfg").write_text("home = X\n", encoding="utf-8")
+    for name in _WINDOWS_BIN_LAUNCHERS:
+        (canonical / f"{name}.exe").write_bytes(b"MZ canonical: " + name.encode())
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    restored = ensure_windows_bin_launchers(root, windows=True, user_path_entries=[])
+
+    assert {Path(p).suffix for p in restored} == {".exe"}
+    for name in _WINDOWS_BIN_LAUNCHERS:
+        assert (home / "bin" / f"{name}.exe").read_bytes() == (
+            root / ".venv" / "Scripts" / f"{name}.exe"
+        ).read_bytes()
+        assert not (home / "bin" / f"{name}.cmd").exists()
+
+
 def test_profile_session_still_heals_the_shared_bin(tmp_path, monkeypatch):
     """Under ``hermes -p <name>`` HERMES_HOME points inside profiles/<name>;
     the launcher dir is per-machine, so the heal must anchor on the default

--- a/tests/hermes_cli/test_project_venv_dir.py
+++ b/tests/hermes_cli/test_project_venv_dir.py
@@ -1,0 +1,84 @@
+"""``project_venv_dir`` must resolve ONE canonical environment.
+
+The dual-layout problem (installers historically created ``venv``, ``uv venv``
+defaults to ``.venv``) left checkouts with BOTH and made different subsystems
+resolve to different ones. The resolver now prefers the venv the current
+interpreter runs from, then ``.venv`` (canonical), then ``venv`` (legacy).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import project_venv_dir
+
+
+@pytest.fixture
+def root(tmp_path):
+    return tmp_path / "hermes-agent"
+
+
+def _venv(root, name, *, python_marker=True):
+    d = root / name
+    (d / "Scripts").mkdir(parents=True, exist_ok=True)
+    if python_marker:
+        (d / "Scripts" / "python.exe").write_bytes(b"MZ")
+    (d / "pyvenv.cfg").write_text("home = X\n", encoding="utf-8")
+    return d
+
+
+def test_single_legacy_layout_still_resolves(tmp_path, monkeypatch, root):
+    """Old installs (only ``venv``) keep working — legacy is a supported layout."""
+    _venv(root, "venv")
+
+    assert project_venv_dir(root) == root / "venv"
+
+
+def test_canonical_layout_wins_over_legacy_when_both_exist(tmp_path, monkeypatch, root):
+    """Both present → ``.venv`` (canonical); the old ``venv``-wins rule is gone."""
+    _venv(root, "venv")
+    _venv(root, ".venv")
+
+    assert project_venv_dir(root) == root / ".venv"
+
+
+def test_running_interpreter_wins_even_from_legacy_layout(tmp_path, monkeypatch, root):
+    """A process actually running from the legacy venv keeps that environment —
+    the active interpreter outranks canonical naming."""
+    _venv(root, ".venv")
+    _venv(root, "venv")
+    monkeypatch.setattr(sys, "prefix", str(root / "venv"))
+
+    assert project_venv_dir(root) == root / "venv"
+
+
+def test_running_interpreter_inside_canonical_venv(tmp_path, monkeypatch, root):
+    _venv(root, ".venv")
+    _venv(root, "venv")
+    monkeypatch.setattr(sys, "prefix", str(root / ".venv"))
+
+    assert project_venv_dir(root) == root / ".venv"
+
+
+def test_prefix_outside_project_is_ignored(tmp_path, monkeypatch, root):
+    """A base/system interpreter (or another project's venv) must not hijack
+    resolution — falls back to canonical naming."""
+    _venv(root, ".venv")
+    _venv(root, "venv")
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "elsewhere"))
+
+    assert project_venv_dir(root) == root / ".venv"
+
+
+def test_no_layout_returns_none(tmp_path, monkeypatch, root):
+    assert project_venv_dir(root) is None
+
+
+def test_prefix_probe_tolerates_unresolvable_paths(tmp_path, monkeypatch, root):
+    """resolve() can raise on odd paths; the resolver must degrade to probing."""
+    _venv(root, ".venv")
+    monkeypatch.setattr(sys, "prefix", str(root / "gone"))
+    # resolve() on a missing path returns the path non-strict; the resolver
+    # must degrade to canonical probing instead of crashing or mis-picking.
+    assert project_venv_dir(root) == root / ".venv"

--- a/tests/hermes_cli/test_reconcile_venv_layout.py
+++ b/tests/hermes_cli/test_reconcile_venv_layout.py
@@ -1,0 +1,83 @@
+"""Boot-time venv-layout reconciliation.
+
+When both ``venv`` and ``.venv`` exist, ``reconcile_venv_layout`` parks the
+sibling of the resolved (active/canonical) environment so every subsystem
+agrees on one environment. Parking is a rename — atomic and recoverable —
+and the function never raises (boot path).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli._install_repair import reconcile_venv_layout
+
+
+def _make(root, name):
+    d = root / name
+    (d / "Scripts").mkdir(parents=True, exist_ok=True)
+    (d / "Scripts" / "python.exe").write_bytes(b"MZ")
+    (d / "pyvenv.cfg").write_text("home = X\n", encoding="utf-8")
+    return d
+
+
+def test_parks_legacy_venv_when_both_exist(tmp_path):
+    root = tmp_path / "checkout"
+    _make(root, "venv")
+    _make(root, ".venv")
+
+    parked = reconcile_venv_layout(root)
+
+    assert parked is not None
+    assert parked.name.startswith("venv.legacy-")
+    assert parked.exists()
+    assert not (root / "venv").exists()
+    assert (root / ".venv" / "Scripts" / "python.exe").exists()
+
+
+def test_parks_other_sibling_when_running_from_legacy(tmp_path, monkeypatch):
+    """Reconciliation keeps the environment the running interpreter uses:
+    a process inside the legacy venv parks ``.venv`` instead."""
+    root = tmp_path / "checkout"
+    _make(root, "venv")
+    _make(root, ".venv")
+    monkeypatch.setattr(sys, "prefix", str(root / "venv"))
+
+    parked = reconcile_venv_layout(root)
+
+    assert parked is not None
+    assert parked.name.startswith(".venv.legacy-")
+    assert not (root / ".venv").exists()
+    assert (root / "venv" / "Scripts" / "python.exe").exists()
+
+
+def test_single_layout_is_a_noop(tmp_path):
+    root = tmp_path / "checkout"
+    _make(root, ".venv")
+
+    assert reconcile_venv_layout(root) is None
+    assert (root / ".venv" / "Scripts" / "python.exe").exists()
+
+
+def test_broken_resolved_venv_never_prompts_parking(tmp_path):
+    """If the resolved venv has no interpreter, do NOT park anything — the
+    sibling may be the only usable environment."""
+    root = tmp_path / "checkout"
+    (root / "venv").mkdir(parents=True)  # legacy dir without Scripts/python
+    _make(root, ".venv")
+    (root / ".venv" / "Scripts" / "python.exe").unlink()  # canonical broken
+
+    assert reconcile_venv_layout(root) is None
+    assert (root / "venv").exists()
+
+
+def test_never_raises(tmp_path):
+    root = tmp_path / "checkout"
+    root.mkdir()
+    # a *file* named venv is not a dir — resolver skips it, no crash
+    (root / "venv").write_text("not a dir", encoding="utf-8")
+    _make(root, ".venv")
+    (root / ".venv" / "Scripts" / "python.exe").unlink()
+
+    assert reconcile_venv_layout(root) is None

--- a/tests/hermes_cli/test_reconcile_venv_layout.py
+++ b/tests/hermes_cli/test_reconcile_venv_layout.py
@@ -27,7 +27,7 @@ def test_parks_legacy_venv_when_both_exist(tmp_path):
     _make(root, "venv")
     _make(root, ".venv")
 
-    parked = reconcile_venv_layout(root)
+    parked = reconcile_venv_layout(root, windows=True)
 
     assert parked is not None
     assert parked.name.startswith("venv.legacy-")
@@ -44,7 +44,7 @@ def test_parks_other_sibling_when_running_from_legacy(tmp_path, monkeypatch):
     _make(root, ".venv")
     monkeypatch.setattr(sys, "prefix", str(root / "venv"))
 
-    parked = reconcile_venv_layout(root)
+    parked = reconcile_venv_layout(root, windows=True)
 
     assert parked is not None
     assert parked.name.startswith(".venv.legacy-")
@@ -56,7 +56,7 @@ def test_single_layout_is_a_noop(tmp_path):
     root = tmp_path / "checkout"
     _make(root, ".venv")
 
-    assert reconcile_venv_layout(root) is None
+    assert reconcile_venv_layout(root, windows=True) is None
     assert (root / ".venv" / "Scripts" / "python.exe").exists()
 
 
@@ -68,7 +68,7 @@ def test_broken_resolved_venv_never_prompts_parking(tmp_path):
     _make(root, ".venv")
     (root / ".venv" / "Scripts" / "python.exe").unlink()  # canonical broken
 
-    assert reconcile_venv_layout(root) is None
+    assert reconcile_venv_layout(root, windows=True) is None
     assert (root / "venv").exists()
 
 
@@ -80,4 +80,4 @@ def test_never_raises(tmp_path):
     _make(root, ".venv")
     (root / ".venv" / "Scripts" / "python.exe").unlink()
 
-    assert reconcile_venv_layout(root) is None
+    assert reconcile_venv_layout(root, windows=True) is None

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -49,7 +49,8 @@ def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
 
 def test_uv_venv_and_dependency_installs_relax_eap() -> None:
     text = _install_ps1()
-    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
+    # Canonical venv layout is ``.venv`` (uv default); ``venv`` is legacy only.
+    _assert_relaxed_call(text, r"& \$UvCmd venv \.venv --python \$PythonVersion")
     _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
     _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
 
@@ -67,7 +68,7 @@ def test_uv_venv_failure_is_not_swallowed_after_eap_relax() -> None:
     # The uv-venv invocation, then an exit-code capture, then a throw — all
     # within a small window after the relaxed call.
     guard = re.search(
-        r"& \$UvCmd venv venv --python \$PythonVersion[\s\S]{0,400}?"
+        r"& \$UvCmd venv \.venv --python \$PythonVersion[\s\S]{0,400}?"
         r"\$LASTEXITCODE[\s\S]{0,200}?"
         r"-ne 0[\s\S]{0,200}?throw",
         text,


### PR DESCRIPTION
**Summary**
`.venv` becomes the single canonical project venv (it is uv's default and what new installs create), `venv` remains a supported legacy read-path, and every resolver — `project_venv_dir()`, the gateway MCP import shim + watcher, the updater, managed-uv repairs, launcher heal, and both installers — converges on the same resolution. At boot, when both layouts exist and the active env has a usable interpreter, the stale sibling is parked with an atomic rename (`<name>.legacy-<timestamp>`); installers now create `.venv` and park/restore both layouts transactionally on recreate. Net effect: the dual-layout split-brain (two full environments with different package sets, different subsystems resolving to different ones) can no longer be generated, and existing pairs are retired safely.

**Motivation**
Installers historically created `venv` while `uv venv` defaults to `.venv` (uv ≥ 0.5). Any `uv sync`/`uv pip` without `UV_PROJECT_ENVIRONMENT` pinned — or any dev/agent following repo guidance that says `uv venv` — silently creates a sibling `.venv`, so a checkout can carry two full environments side by side with different package sets. Resolvers disagreed: the gateway's Windows MCP import shim hardcoded `venv` and was blind to `.venv` installs, updater/repair targeted `venv`, launcher heal resolved via the "venv wins" rule, while PATH, the desktop app, and the live processes used `.venv`. Observed: 565 MB stale `venv` (318 packages, relocatable) vs 227.5 MB active `.venv` (211 packages), ≈ 853 MB duplicated including a stranded managed-Python generation; MCP tooling pip-installed into `.venv` was invisible to detached gateway runs, which inherited the stale site-packages (confirmed in vivo: gateway executable from `.venv`, import path from `venv\Lib\site-packages`).

**Changes**
* `hermes_constants.py` — `project_venv_dir()` now resolves: (1) the venv the running interpreter is in when it lives inside the project root, (2) `.venv` (canonical), (3) legacy `venv` (new `_PROJECT_VENV_NAMES`). The blanket "venv wins when both exist" rule is gone; single-layout behavior is unchanged.
* `gateway/run.py` — `_ensure_windows_gateway_venv_imports` and the watcher resolve via `project_venv_dir` (new `_resolve_project_venv()` helper; hardcoded `venv` kept only as last-resort fallback for update-boundary runs). Fixes the MCP-SDK import split-brain (the observed failure surface).
* `hermes_cli/update_cmd.py` — all 10 hardcoded `"venv"` lines are resolver-driven (9 of the 11 literals replaced; the 2 remaining are intentional legacy refs — the zip-update preserve set and the repair-uv fallback); preserve set now includes `.venv`.
* `hermes_cli/managed_uv.py` — `_VENV_NAME = ".venv"`, `_ALT_VENV_NAME = "venv"`.
* `hermes_cli/_install_repair.py` — `VIRTUAL_ENV` fallback → `.venv`; new `reconcile_venv_layout(root, *, windows=None)` (stdlib-only, never raises): when both layouts exist, `venv_python_path(active)` usable, and the sibling rename is possible, parks the sibling as `<name>.legacy-<timestamp>`; no-op when the resolved env is broken (never strands the only usable env). `windows` injectable for host-independent tests.
* `hermes_cli/main.py` — win32 boot-heal block calls `reconcile_venv_layout` right after `ensure_windows_bin_launchers`; two probe-order spots flip to `.venv`.
* `hermes_cli/doctor.py` — venv-bin probe order `.venv` first.
* `scripts/install.ps1` / `scripts/install.sh` — create `.venv` (uv's default; Termux `python -m venv .venv` too); on recreate, both legacy layouts are discovered/kill-swept/parked and restored on failure; `venv.pending-backup` marker is restore-target-aware (second line = original dir name; old single-line markers default to `venv`); all stage paths (`VIRTUAL_ENV`, `UV_PYTHON`, `UV_PROJECT_ENVIRONMENT`, entry points, skills sync, setup, gateway) point at `.venv`; diagnostics and recovery hints updated to the new canonical.
* Docs — `README.zh-CN.md` + `CONTRIBUTING.md` unified on `uv venv .venv` (create + activate lines).
* Tests — new resolver matrix (7 cases), new reconciler suite (5 cases, all injecting `windows=True` for Linux CI), dual-layout launcher-heal case, installer EAP assertions updated for `uv venv .venv`.

**Tests & verification**
* 71 passed / 4 skipped across the venv-related suites (resolver, reconciler, launcher heal, update shim/stale-venv, gateway service, doctor install, both installer static suites) — re-run against upstream main + this branch.
* All edited Python files compile; `install.ps1` parses clean with the PowerShell parser; `install.sh` reviewed read-only for stale refs.
* Live verification on a real dual-layout Windows checkout: launcher heal re-staged `bin\hermes.exe`/`hermes-acp.exe` from `.venv` on a real start; reconciliation is a no-op with a single layout.
* Independent review trail: gap analysis vs upstream at analysis time (zero file overlap), adversarial split/semantics review, numerical claims audit, code-risk review (A/B/C dimensions all APPROVE; one stale comment found post-review and fixed in `59710e9df6`); the 2026-08-25 rebase onto upstream `1bbb6e5bce` was conflict-free (upstream's 4 shared-file touches all landed in disjoint hunks).

**Risks & impact**
* Behavior change: `venv` no longer auto-wins when both exist (active interpreter's env wins, else `.venv`); `venv` stays a working legacy read-path — old single-layout installs unaffected.
* First boot after upgrade on a dual-layout machine parks the stale sibling once (rename, recoverable); a failed/unsafe rename never raises and never touches the only usable env.
* Recreated/updated installs become `.venv` with full transactional rollback (parked dirs restored on failure, restore-target-aware marker).
* Known limitation (pre-existing upstream design, unchanged): `hermes --version` uses the ultrafast startup path and exits before the boot-heal block, so reconciliation runs on real starts/subcommands, not bare `--version` probes.
* Verification gap: fresh-machine installer run (existing install was used for live validation); happy to run one on a throwaway VM if reviewers want it.

**Checklist**
- [x] Rebased onto upstream main, diff limited to 15 intended files (+440/−110)
- [x] Tests: 71 passed / 4 skipped (venv-related suites), compile + PS parser clean
- [x] Trash-free, no debug code, no unrelated changes
