### PR TITLE
feat(review): let the parent agent invoke auxiliary review

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7456,6 +7456,17 @@ def run_conversation(
                     failed = True
                     break
 
+                if getattr(agent, "_review_yield_requested", False):
+                    # An asynchronous review is a phase boundary. The review
+                    # result re-enters through the normal delegation rail; do
+                    # not make another model call in this work phase.
+                    agent._review_yield_requested = False
+                    _turn_exit_reason = "review_dispatched"
+                    final_response = (
+                        "Review dispatched. Yielding until the review result returns."
+                    )
+                    break
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7456,18 +7456,12 @@ def run_conversation(
                     failed = True
                     break
 
-                if getattr(agent, "_review_yield_requested", False):
-                    # An asynchronous review is a phase boundary. The review
-                    # result re-enters through the normal delegation rail; do
-                    # not make another model call in this work phase.
-                    agent._review_yield_requested = False
-                    _turn_exit_reason = "review_dispatched"
-                    final_response = (
-                        "Review dispatched. Yielding until the review result returns."
-                    )
-                    break
-
                 if agent._tool_guardrail_halt_decision is not None:
+                    # Guardrail halts are authoritative over auxiliary phase
+                    # boundaries. If both flags are set, do not let the
+                    # review-yield response mask the safety stop or leak the
+                    # yield flag into a later completion turn.
+                    agent._review_yield_requested = False
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"
                     final_response = agent._toolguard_controlled_halt_response(decision)
@@ -7488,6 +7482,17 @@ def run_conversation(
                                 agent.stream_delta_callback(None)
                             except Exception:
                                 pass
+                    break
+
+                if getattr(agent, "_review_yield_requested", False):
+                    # An asynchronous review is a phase boundary. The review
+                    # result re-enters through the normal delegation rail; do
+                    # not make another model call in this work phase.
+                    agent._review_yield_requested = False
+                    _turn_exit_reason = "review_dispatched"
+                    final_response = (
+                        "Review dispatched. Yielding until the review result returns."
+                    )
                     break
 
                 # Reset per-turn retry counters after successful tool

--- a/agent/review_engine.py
+++ b/agent/review_engine.py
@@ -148,6 +148,7 @@ def build_review_task(
     snapshot: List[Dict[str, str]],
     user_prompt: str = "",
     loaded_skills: Optional[List[str]] = None,
+    autonomous: bool = False,
 ) -> tuple:
     """Compose the reviewer subagent's (goal, context) pair."""
     goal = (
@@ -163,8 +164,13 @@ def build_review_task(
         "recommended next steps."
     )
 
+    intro = (
+        "You were spawned by the Hermes review_current_work tool."
+        if autonomous
+        else "You were spawned by the /review command."
+    )
     lines = [
-        "You were spawned by the /review command. The following is an "
+        f"{intro} The following is an "
         "excerpt of the most recent conversation between the user and "
         "their primary agent. It is your starting evidence — the work to "
         "review is referenced in it.",
@@ -238,6 +244,7 @@ def start_review(
     parent_agent,
     messages: List[Dict[str, Any]],
     user_prompt: str = "",
+    autonomous: bool = False,
 ) -> Dict[str, Any]:
     """Dispatch the reviewer subagent in the background.
 
@@ -256,7 +263,12 @@ def start_review(
         raise ValueError("Nothing to review yet — the conversation is empty.")
 
     loaded_skills = collect_parent_loaded_skills(parent_agent, messages)
-    goal, context = build_review_task(snapshot, user_prompt, loaded_skills)
+    goal, context = build_review_task(
+        snapshot,
+        user_prompt,
+        loaded_skills,
+        autonomous=autonomous,
+    )
     credentials_cfg = _load_review_credentials_cfg()
 
     from tools.delegate_tool import delegate_task

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1943,6 +1943,45 @@ def _append_cancelled_tool_results(messages: list, tool_calls, *, reason: str) -
         ))
 
 
+def _append_review_yield_cancellations(
+    agent,
+    calls,
+    messages: list,
+    effective_task_id: str,
+) -> bool:
+    """Persist skipped calls after an asynchronous review becomes a barrier."""
+    for skipped_tc in calls:
+        skipped_name = skipped_tc.function.name
+        cancelled_result = (
+            f"[Tool execution cancelled — {skipped_name} was skipped "
+            "because review_current_work yielded the parent]"
+        )
+        messages.append(make_tool_result_message(
+            skipped_name,
+            cancelled_result,
+            _pairing_tool_call_id(skipped_tc),
+            effect_disposition="none",
+        ))
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=skipped_name,
+            function_args={},
+            result=cancelled_result,
+            effective_task_id=effective_task_id,
+            tool_call_id=getattr(skipped_tc, "id", "") or "",
+            status="cancelled",
+            error_type="review_yield",
+            error_message="Tool execution skipped because review_current_work yielded the parent",
+        )
+        if not _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"review-yield cancellation {skipped_name}",
+        ):
+            return False
+    return True
+
+
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
@@ -1961,6 +2000,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         tool_call_id = _pairing_tool_call_id(tool_call)
         if getattr(agent, "_incremental_persistence_failed", False):
+            return
+        if getattr(agent, "_review_yield_requested", False):
+            _append_review_yield_cancellations(
+                agent,
+                assistant_message.tool_calls[i - 1:],
+                messages,
+                effective_task_id,
+            )
             return
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
@@ -2376,6 +2423,30 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('setup_mcp', function_args, tool_duration, result=function_result)}")
+        elif function_name == "review_current_work":
+            _review_result = None
+            try:
+                def _execute(next_args: dict) -> Any:
+                    return agent._dispatch_review_current_work(next_args, messages)
+                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                    execute=_execute,
+                    scope_block=_ts_scope_block,
+                    display_index=i,
+                ))
+                _review_result = function_result
+            finally:
+                tool_duration = time.time() - tool_start_time
+                cute_msg = _get_cute_tool_message_impl(
+                    "review_current_work", function_args, tool_duration,
+                    result=_review_result,
+                )
+                if agent._should_emit_quiet_tool_messages():
+                    agent._vprint(f"  {cute_msg}")
         elif function_name == "delegate_task":
             _action_arg = str(function_args.get("action") or "").strip().lower()
             tasks_arg = function_args.get("tasks")
@@ -2885,7 +2956,17 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
+        if getattr(agent, "_review_yield_requested", False):
+            remaining = [
+                tool_call
+                for _, segment_calls in segments[segment_index:]
+                for tool_call in segment_calls
+            ]
+            _append_review_yield_cancellations(
+                agent, remaining, messages, effective_task_id
+            )
+            return
         if getattr(agent, "_incremental_persistence_failed", False):
             return
         segment_message = SimpleNamespace(tool_calls=list(calls))
@@ -2901,6 +2982,16 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
             )
 
         if getattr(agent, "_incremental_persistence_failed", False):
+            return
+        if getattr(agent, "_review_yield_requested", False):
+            remaining = [
+                tool_call
+                for _, segment_calls in segments[segment_index + 1:]
+                for tool_call in segment_calls
+            ]
+            _append_review_yield_cancellations(
+                agent, remaining, messages, effective_task_id
+            )
             return
 
     # ── Whole-turn finalize (budget + /steer) ─────────────────────────

--- a/model_tools.py
+++ b/model_tools.py
@@ -740,7 +740,9 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {
+    "todo", "memory", "session_search", "delegate_task", "review_current_work",
+}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8400,6 +8400,30 @@ class AIAgent:
             parent_agent=self,
         )
 
+    def _dispatch_review_current_work(self, function_args: dict, messages: list) -> str:
+        """Dispatch the parent-only bridge to the existing review engine."""
+        if getattr(self, "_delegate_depth", 0) > 0:
+            return json.dumps({
+                "status": "error",
+                "error": "review_current_work is available only to the parent agent.",
+            })
+
+        from agent.review_engine import start_review
+
+        try:
+            result = start_review(
+                self,
+                messages,
+                user_prompt=str(function_args.get("focus") or ""),
+                autonomous=True,
+            )
+        except ValueError as exc:
+            return json.dumps({"status": "error", "error": str(exc)})
+
+        if result.get("status") == "dispatched":
+            self._review_yield_requested = True
+        return json.dumps(result, ensure_ascii=False)
+
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
                      tool_call_id: Optional[str] = None, messages: list = None,
                      pre_tool_block_checked: bool = False,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8417,7 +8417,7 @@ class AIAgent:
                 user_prompt=str(function_args.get("focus") or ""),
                 autonomous=True,
             )
-        except ValueError as exc:
+        except Exception as exc:
             return json.dumps({"status": "error", "error": str(exc)})
 
         if result.get("status") == "dispatched":

--- a/tests/agent/test_autonomous_review_tool.py
+++ b/tests/agent/test_autonomous_review_tool.py
@@ -143,6 +143,30 @@ def test_async_review_sets_boundary_but_sync_fallback_does_not(monkeypatch):
     assert not hasattr(sync_parent, "_review_yield_requested")
 
 
+def test_review_dispatch_converts_unexpected_start_errors_to_tool_error(monkeypatch):
+    from run_agent import AIAgent
+
+    def fail_start_review(*args, **kwargs):
+        raise RuntimeError("review backend unavailable")
+
+    monkeypatch.setattr(review_engine_module, "start_review", fail_start_review)
+
+    parent = object.__new__(AIAgent)
+    setattr(parent, "_delegate_depth", 0)
+    result = json.loads(
+        AIAgent._dispatch_review_current_work(
+            parent,
+            {},
+            [{"role": "user", "content": "review"}],
+        )
+    )
+
+    assert result == {
+        "status": "error",
+        "error": "review backend unavailable",
+    }
+
+
 def test_segmented_batch_cancels_every_segment_after_review(monkeypatch):
     from agent import tool_executor as executor
     from agent.tool_dispatch_helpers import _plan_tool_batch_segments

--- a/tests/agent/test_autonomous_review_tool.py
+++ b/tests/agent/test_autonomous_review_tool.py
@@ -1,0 +1,224 @@
+"""Focused tests for the parent-only autonomous review invocation bridge."""
+
+import json
+from types import SimpleNamespace
+from agent import review_engine as review_engine_module
+from agent.tool_executor import execute_tool_calls_segmented, execute_tool_calls_sequential
+from model_tools import get_tool_definitions
+from tools import delegate_tool
+
+
+def _call(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call-{name}",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def test_review_tool_is_parent_visible_but_child_blocked():
+    parent_names = {
+        item["function"]["name"]
+        for item in get_tool_definitions(quiet_mode=True)
+    }
+    assert "review_current_work" in parent_names
+
+    for role in ("leaf", "orchestrator"):
+        blocked = delegate_tool._blocked_toolsets_for_role(role)
+        assert "review" in blocked
+        child_names = {
+            item["function"]["name"]
+            for item in get_tool_definitions(
+                disabled_toolsets=blocked,
+                quiet_mode=True,
+            )
+        }
+        assert "review_current_work" not in child_names
+
+    from run_agent import AIAgent
+
+    child = object.__new__(AIAgent)
+    setattr(child, "_delegate_depth", 1)
+    child_result = json.loads(
+        AIAgent._dispatch_review_current_work(child, {}, [])
+    )
+    assert child_result["status"] == "error"
+    assert "parent agent" in child_result["error"]
+
+
+def test_review_dispatch_uses_auxiliary_review_model_only(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        review_engine_module,
+        "_load_review_credentials_cfg",
+        lambda: {
+            "provider": "openai-codex",
+            "model": "gpt-5.6-terra",
+            "base_url": "",
+            "api_key": "",
+            "api_mode": "",
+        },
+    )
+
+    def fake_delegate(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"status": "dispatched", "delegation_id": "review-1"})
+
+    monkeypatch.setattr(delegate_tool, "delegate_task", fake_delegate)
+    parent = SimpleNamespace(_delegate_depth=0)
+    result = review_engine_module.start_review(
+        parent,
+        [{"role": "user", "content": "review this"}],
+        autonomous=True,
+    )
+
+    assert result["status"] == "dispatched"
+    assert captured["credentials_cfg"]["provider"] == "openai-codex"
+    assert captured["credentials_cfg"]["model"] == "gpt-5.6-terra"
+    assert "reasoning_effort" not in captured["credentials_cfg"]
+    assert "toolsets" not in captured
+    assert "review_current_work tool" in captured["context"]
+
+
+def test_normal_delegate_task_does_not_receive_review_configuration(monkeypatch):
+    captured = {}
+
+    def fake_delegate(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"status": "dispatched"})
+
+    monkeypatch.setattr(delegate_tool, "delegate_task", fake_delegate)
+    from run_agent import AIAgent
+
+    parent = object.__new__(AIAgent)
+    setattr(parent, "_delegate_depth", 0)
+    AIAgent._dispatch_delegate_task(parent, {"goal": "ordinary subtask"})
+
+    assert captured["goal"] == "ordinary subtask"
+    assert captured["background"] is True
+    assert captured["parent_agent"] is parent
+    assert "credentials_cfg" not in captured
+    assert "review_source_identity" not in captured
+
+
+def test_async_review_sets_boundary_but_sync_fallback_does_not(monkeypatch):
+    from run_agent import AIAgent
+
+    def fake_start_review(*args, **kwargs):
+        return {"status": "dispatched", "delegation_id": "review-async"}
+
+    monkeypatch.setattr(review_engine_module, "start_review", fake_start_review)
+    from run_agent import AIAgent
+
+    async_parent = object.__new__(AIAgent)
+    setattr(async_parent, "_delegate_depth", 0)
+    async_result = json.loads(
+        AIAgent._dispatch_review_current_work(
+            async_parent,
+            {"focus": "security"},
+            [{"role": "user", "content": "review"}],
+        )
+    )
+    assert async_result["status"] == "dispatched"
+    assert async_parent._review_yield_requested is True
+
+    monkeypatch.setattr(
+        review_engine_module,
+        "start_review",
+        lambda *args, **kwargs: {
+            "status": "completed",
+            "results": [{"summary": "review complete"}],
+        },
+    )
+    sync_parent = object.__new__(AIAgent)
+    setattr(sync_parent, "_delegate_depth", 0)
+    sync_result = json.loads(
+        AIAgent._dispatch_review_current_work(
+            sync_parent,
+            {},
+            [{"role": "user", "content": "review"}],
+        )
+    )
+    assert sync_result["status"] == "completed"
+    assert not hasattr(sync_parent, "_review_yield_requested")
+
+
+def test_segmented_batch_cancels_every_segment_after_review(monkeypatch):
+    from agent import tool_executor as executor
+    from agent.tool_dispatch_helpers import _plan_tool_batch_segments
+
+    review = _call("review_current_work")
+    later = _call("write_file", '{"path":"later.txt","content":"x"}')
+    planned = _plan_tool_batch_segments([review, later])
+    assert len(planned) == 1
+    assert planned[0][0] == "sequential"
+    assert planned[0][1] == [review, later]
+    agent = SimpleNamespace(_review_yield_requested=False, _incremental_persistence_failed=False)
+    messages = []
+    cancelled = []
+    executed = []
+
+    def fake_sequential(*args, **kwargs):
+        executed.append("review")
+        agent._review_yield_requested = True
+
+    def fail_concurrent(*args, **kwargs):
+        executed.append("later")
+
+    monkeypatch.setattr(executor, "execute_tool_calls_sequential", fake_sequential)
+    monkeypatch.setattr(executor, "execute_tool_calls_concurrent", fail_concurrent)
+    monkeypatch.setattr(
+        executor,
+        "_append_review_yield_cancellations",
+        lambda _agent, calls, _messages, _task_id: cancelled.extend(calls) or True,
+    )
+
+    execute_tool_calls_segmented(
+        agent,
+        SimpleNamespace(tool_calls=[review, later]),
+        messages,
+        "task",
+        segments=[("sequential", [review]), ("parallel", [later])],
+    )
+
+    assert executed == ["review"]
+    assert cancelled == [later]
+
+
+def test_sequential_review_boundary_skips_later_calls(monkeypatch):
+    from agent import tool_executor as executor
+
+    review = _call("review_current_work")
+    later = _call("patch", '{"path":"later.py","old_string":"a","new_string":"b"}')
+    agent = SimpleNamespace(_review_yield_requested=True, _incremental_persistence_failed=False)
+    messages = []
+    cancelled = []
+
+    monkeypatch.setattr(executor, "_budget_for_agent", lambda _agent: None)
+    monkeypatch.setattr(executor, "_append_review_yield_cancellations", lambda _agent, calls, _messages, _task_id: cancelled.extend(calls) or True)
+
+    execute_tool_calls_sequential(
+        agent,
+        SimpleNamespace(tool_calls=[review, later]),
+        messages,
+        "task",
+    )
+
+    assert cancelled == [review, later]
+
+
+def test_default_review_briefing_remains_slash_review_compatible():
+    _, context = review_engine_module.build_review_task(
+        [{"role": "user", "text": "review"}],
+    )
+    assert "You were spawned by the /review command." in context
+    assert "review_current_work tool" not in context
+
+
+def test_autonomous_review_briefing_is_distinct_from_slash_review():
+    _, context = review_engine_module.build_review_task(
+        [{"role": "user", "text": "review"}],
+        autonomous=True,
+    )
+    assert "You were spawned by the Hermes review_current_work tool." in context
+    assert "You were spawned by the /review command." not in context

--- a/tests/agent/test_review_engine.py
+++ b/tests/agent/test_review_engine.py
@@ -255,6 +255,7 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
         except Exception:
             continue
     assert evt is not None and evt["type"] == "async_delegation"
+    assert evt["parent_session_id"] == "review-parent-sess"
     assert evt["results"][0]["summary"] == "REVIEW: looks good"
 
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,7 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.tool_guardrails import ToolGuardrailDecision
 from run_agent import AIAgent
 
 
@@ -423,3 +424,42 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_guardrail_halt_wins_over_review_yield_boundary():
+    agent = _make_agent("review_current_work", max_iterations=10)
+    response = _mock_response(
+        content="",
+        finish_reason="tool_calls",
+        tool_calls=[_mock_tool_call("review_current_work", "{}", "c-review")],
+    )
+    assert agent.client is not None
+    agent.client.chat.completions.create.return_value = response
+    decision = ToolGuardrailDecision(
+        action="halt",
+        code="test_guardrail_halt",
+        tool_name="review_current_work",
+        count=2,
+    )
+
+    def fake_execute(assistant_message, messages, *_args):
+        messages.append({
+            "role": "tool",
+            "name": "review_current_work",
+            "tool_call_id": assistant_message.tool_calls[0].id,
+            "content": json.dumps({"status": "dispatched"}),
+        })
+        agent._review_yield_requested = True
+        agent._tool_guardrail_halt_decision = decision
+
+    with (
+        patch.object(agent, "_execute_tool_calls", side_effect=fake_execute),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("review this work")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert "stopped retrying" in result["final_response"]
+    assert agent._review_yield_requested is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -50,6 +50,7 @@ from utils import base_url_hostname, is_truthy_value
 DELEGATE_BLOCKED_TOOLS = frozenset(
     [
         "delegate_task",  # no recursive delegation
+        "review_current_work",  # parent-only review bridge
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects

--- a/tools/review_tool.py
+++ b/tools/review_tool.py
@@ -8,7 +8,7 @@ REVIEW_CURRENT_WORK_SCHEMA = {
     "description": (
         "Dispatch the existing full-tool Hermes reviewer against the current "
         "work. Use at earned security, migration, architecture, provider-boundary, "
-        "or consequential pre-RED gates. If dispatched asynchronously, this is "
+        "or other consequential review points. If dispatched asynchronously, this is "
         "a hard boundary for the current tool batch and the review returns to "
         "the parent conversation when complete."
     ),

--- a/tools/review_tool.py
+++ b/tools/review_tool.py
@@ -1,0 +1,42 @@
+"""Parent-only model-facing bridge to the built-in review engine."""
+
+from tools.registry import registry, tool_error
+
+
+REVIEW_CURRENT_WORK_SCHEMA = {
+    "name": "review_current_work",
+    "description": (
+        "Dispatch the existing full-tool Hermes reviewer against the current "
+        "work. Use at earned security, migration, architecture, provider-boundary, "
+        "or consequential pre-RED gates. If dispatched asynchronously, this is "
+        "a hard boundary for the current tool batch and the review returns to "
+        "the parent conversation when complete."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "focus": {
+                "type": "string",
+                "description": "Optional narrow review focus or gate-specific question.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _parent_context_required(args, **_kwargs):
+    """Registry fallback; the agent loop owns the parent-aware dispatch."""
+    return tool_error(
+        "review_current_work requires the parent agent loop context and cannot "
+        "run as a generic tool call."
+    )
+
+
+registry.register(
+    name="review_current_work",
+    toolset="review",
+    schema=REVIEW_CURRENT_WORK_SCHEMA,
+    handler=_parent_context_required,
+    emoji="⚖",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -67,7 +67,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "review_current_work",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -279,6 +279,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "review": {
+        "description": "Dispatch a parent-only review through the built-in review rail",
+        "tools": ["review_current_work"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -397,7 +403,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search", "clarify",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "review_current_work",
         ],
         "includes": [],
         # Posture toolset: selected per-session by agent/coding_context.py,
@@ -430,7 +436,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "review_current_work",
         ],
         "includes": []
     },
@@ -459,7 +465,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "review_current_work",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

The existing `/review` command already provides an independent full-tool Hermes reviewer using `auxiliary.review`, but only a human command can invoke it. This patch lets the primary agent request that same review autonomously without changing normal `delegate_task` routing.

## Architecture

```text
parent
  → review_current_work
  → existing agent.review_engine.start_review()
  → auxiliary.review
  → normal full-tool reviewer subagent
  → existing async completion rail
```

`review_current_work` is exposed only on the parent model-facing tool surface and blocked from child subagents. In this PR alone, an asynchronous review is a hard boundary for the entire current tool batch: later calls and segments are cancelled, and the parent yields until the normal completion rail returns the result. This preserves the existing lifecycle and delivery semantics rather than introducing a second review-delivery mechanism. If the existing delegation infrastructure completes synchronously, the completed review is returned normally.

## Relationship to #76230

This PR and #76230 address complementary boundaries.

- **This PR owns autonomous review initiation:** can the parent decide that the current work needs an independent auxiliary review and start it through the existing review engine?
- **#76230 owns timely in-turn result delivery:** when an explicitly time-sensitive background dependency is ready, can that result become visible at an existing safe continuation boundary while the parent is still working?

Autonomous review is most valuable when its result can influence unfinished work. This PR provides the initiation boundary; timely same-turn delivery is a separate concern and can compose with mechanisms such as #76230.

The hard-yield behavior above is therefore the bounded behavior of this isolated invocation patch, not a requirement that autonomous review must always block future parent work. A separate delivery layer may allow the parent to continue reversible work and consume a completed review at a safe continuation boundary without changing the `review_current_work` invocation API.

This PR intentionally does **not** implement same-turn result injection, alter delegation delivery semantics, or duplicate the routing/settlement machinery owned by that work.

## Explicit non-goals

- No source-authority, stale-PASS, or review-lease system
- No `delegation.model` / `delegation.provider` changes
- No Kanban changes
- No independent reasoning-effort plumbing
- No change to ordinary subagent routing
- No same-turn review-result injection or delivery-routing changes
- `/review` remains backward compatible

## Why this is a core tool

The plugin/skill path was investigated first. It cannot reliably access and control the live parent `AIAgent`, session ownership, tool-batch cancellation, and parent-yield lifecycle across Hermes surfaces. The narrow core bridge is therefore required to connect the model-facing call to the existing agent loop and review engine without duplicating review machinery.

## Verification

- Current reviewed head: `7a38a969f5a4540f8f5febb2a9b3a7b960413530`
- Base: `1bbb6e5bce56e721ab685af4cd87df21bbff4d35`
- Original invocation implementation tests: 112 passed
- Additional model/toolset/conversation regression suite: 64 passed
- Review-feedback correction tests: 78 passed, 1 skipped
- Correction independent review: PASS
- Automated reviewer feedback: triaged and addressed
- Ruff: passed
- Compile and `git diff --check`: passed
- No live Hermes runtime activation
- No live Terra provider smoke was performed
- No full-suite green claim

## Scope

This PR contains the invocation bridge and focused tests only. No merge, runtime activation, or product changes are included.