### PR TITLE
fix(gateway): separate routed history from transport authorization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15874,13 +15874,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Profile routes are normally stamped on ``event.source`` before this
         handler runs. Resolve the home per event so session lookup and transcript
         loading use the same profile store as the later agent run and persistence
-        path. Sources that bypass adapter routing are resolved here; genuinely
-        unrouted events retain the gateway's launch/default home.
+        path. Authorization still belongs to the primary transport profile: a
+        shared Discord/Telegram adapter can route the turn to a profile that
+        intentionally has no bot credential or platform allowlist. Preserve that
+        transport home on the live source so the auth gate does not re-check the
+        sender against the routed runtime's unrelated secret scope. Sources that
+        bypass adapter routing are resolved here; genuinely unrouted events retain
+        the gateway's launch/default home.
         """
         default_home = Path(get_hermes_home())
 
         async def _handler(event):
             source = event.source
+            # In-process only (SessionSource serialization ignores dynamic attrs).
+            # The route selects agent/session state, not which bot admitted the
+            # message. Keep those two trust domains separate.
+            source._authorization_profile_home = default_home
             if (
                 not getattr(source, "profile", None)
                 and getattr(source, "profile_route_rejected", False) is not True
@@ -15915,7 +15924,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if not has_hook("gateway_platform_event"):
                 return
-            if not self._is_user_authorized(source):
+            if not self._is_user_authorized_for_source(source):
                 return
             invoke_hook("gateway_platform_event", **event)
         except Exception:
@@ -15943,12 +15952,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _make_default_profile_platform_event_handler(self):
         """Scope primary-transport events to their routed multiplex profile."""
+        default_home = Path(get_hermes_home())
 
         async def _handler(event, source):
+            source._authorization_profile_home = default_home
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
                 return await self._handle_gateway_platform_event(event, source)
 
         return _handler
+
+    def _is_user_authorized_for_source(
+        self,
+        source: SessionSource,
+        *,
+        allow_adapter_delegation: bool = True,
+    ) -> bool:
+        """Authorize under the live transport's profile, not the routed runtime.
+
+        A primary adapter may route one chat into another profile's agent/session
+        namespace. That runtime profile need not (and normally should not) copy the
+        shared bot token or allowlist. The primary message/platform-event handlers
+        stamp the transport home as an in-process-only attribute before entering
+        the routed scope; consult it here for the narrow authorization read, then
+        restore the routed scope for the remainder of the turn.
+        """
+        def _check() -> bool:
+            # Preserve the historical one-argument seam used by plugins/tests;
+            # only pass the keyword for the explicit delegation-disabled path.
+            if allow_adapter_delegation:
+                return self._is_user_authorized(source)
+            return self._is_user_authorized(
+                source,
+                allow_adapter_delegation=False,
+            )
+
+        authorization_home = getattr(source, "_authorization_profile_home", None)
+        if authorization_home is not None:
+            with _profile_runtime_scope(Path(authorization_home)):
+                return _check()
+        return _check()
 
     def _primary_platform_event_handler(self):
         if getattr(self.config, "multiplex_profiles", False):
@@ -16863,10 +16905,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # chat-scoped allowlist (e.g. TELEGRAM_GROUP_ALLOWED_CHATS
             # authorizes every member of the listed chat regardless of
             # sender). Defer to _is_user_authorized so that path runs.
-            if not self._is_user_authorized(source):
+            if not self._is_user_authorized_for_source(source):
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
                 return None
-        elif not self._is_user_authorized(source):
+        elif not self._is_user_authorized_for_source(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15869,10 +15869,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return _handler
 
     def _make_default_profile_message_handler(self):
-        """Scope a multiplexed default-profile message from ingress onward."""
-        profile_home = Path(get_hermes_home())
+        """Scope primary-adapter messages to their routed multiplex profile.
+
+        Profile routes are normally stamped on ``event.source`` before this
+        handler runs. Resolve the home per event so session lookup and transcript
+        loading use the same profile store as the later agent run and persistence
+        path. Sources that bypass adapter routing are resolved here; genuinely
+        unrouted events retain the gateway's launch/default home.
+        """
+        default_home = Path(get_hermes_home())
 
         async def _handler(event):
+            source = event.source
+            if (
+                not getattr(source, "profile", None)
+                and getattr(source, "profile_route_rejected", False) is not True
+            ):
+                from gateway.profile_routing import ProfileRouteRejected
+
+                try:
+                    source.profile = self._profile_name_for_source(source)
+                except ProfileRouteRejected:
+                    source.profile_route_rejected = True
+
+            profile_home = (
+                self._resolve_profile_home_for_source(source)
+                if getattr(source, "profile", None)
+                else default_home
+            )
             with _profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -18,7 +18,7 @@ row sitting in the root store.
 import asyncio
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -126,6 +126,62 @@ def test_primary_handler_enters_routed_profile_scope_before_dispatch(multiplex_h
     asyncio.run(runner._primary_message_handler()(event))
 
     assert seen == [profile]
+    assert Path(get_hermes_home()) == root
+
+
+def test_primary_route_keeps_transport_authorization_scope(multiplex_homes):
+    """A shared bot authorizes with its own allowlist before using routed state.
+
+    Routed profiles commonly disable their Discord/Telegram adapters and carry
+    no platform credentials or allowlists. Scoping the complete cold-message
+    pipeline to that profile must not make the gateway reject a sender that the
+    live primary transport already admitted.
+    """
+    from agent.secret_scope import is_multiplex_active, set_multiplex_active
+    from gateway.run import GatewayRunner
+
+    root, profile = multiplex_homes
+    (root / ".env").write_text("DISCORD_ALLOWED_USERS=user-1\n", encoding="utf-8")
+    (profile / ".env").write_text("", encoding="utf-8")
+    (profile / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    seen = []
+
+    async def capture_scope_and_auth(event):
+        seen.append(
+            (
+                Path(get_hermes_home()),
+                runner._is_user_authorized_for_source(event.source),
+            )
+        )
+
+    runner._handle_message = capture_scope_and_auth
+    event = MessageEvent(
+        text="hello from the shared bot",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="routed-channel",
+            user_id="user-1",
+            chat_type="group",
+            profile="fitness",
+        ),
+    )
+
+    previous_multiplex = is_multiplex_active()
+    set_multiplex_active(True)
+    try:
+        asyncio.run(runner._primary_message_handler()(event))
+    finally:
+        set_multiplex_active(previous_multiplex)
+
+    assert seen == [(profile, True)]
     assert Path(get_hermes_home()) == root
 
 

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -15,6 +15,7 @@ that reproduces the report; it fails against the pre-fix code with the session
 row sitting in the root store.
 """
 
+import asyncio
 import sqlite3
 from pathlib import Path
 from unittest.mock import patch
@@ -22,8 +23,13 @@ from unittest.mock import patch
 import pytest
 
 from gateway.config import GatewayConfig
+from gateway.platforms.base import MessageEvent, Platform, SessionSource
 from gateway.session import SessionStore
-from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 
 
 @pytest.fixture
@@ -85,6 +91,104 @@ def test_store_uses_root_db_when_no_profile_scope_is_active(multiplex_homes):
     store = _make_store(root)
 
     assert Path(store._db.db_path) == root / "state.db"
+
+
+def test_primary_handler_enters_routed_profile_scope_before_dispatch(multiplex_homes):
+    """Primary-adapter routes must scope the complete message pipeline.
+
+    Session lookup and transcript loading happen inside ``_handle_message``,
+    before the later agent-only scope.  A handler that captures the process
+    root therefore reads an empty root transcript for routed channels.
+    """
+    from gateway.run import GatewayRunner
+
+    root, profile = multiplex_homes
+    (profile / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    seen = []
+
+    async def capture_scope(event):
+        seen.append(Path(get_hermes_home()))
+
+    runner._handle_message = capture_scope
+    event = MessageEvent(
+        text="second turn",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="routed-channel",
+            user_id="user-1",
+            profile="fitness",
+        ),
+    )
+
+    asyncio.run(runner._primary_message_handler()(event))
+
+    assert seen == [profile]
+    assert Path(get_hermes_home()) == root
+
+
+def test_two_primary_routed_turns_reload_profile_transcript(multiplex_homes):
+    """A second routed turn sees the first turn in the profile database."""
+    from gateway.profile_routing import ProfileRoute
+    from gateway.run import GatewayRunner
+    from hermes_state import SessionDB
+
+    root, profile = multiplex_homes
+    (profile / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=[
+            ProfileRoute(
+                name="fitness-channel",
+                platform="discord",
+                profile="fitness",
+                chat_id="routed-channel",
+            )
+        ],
+    )
+    observed_histories = []
+    session_id = "routed-two-turn-session"
+
+    async def run_turn(event):
+        db = SessionDB()
+        try:
+            history = db.get_messages(session_id)
+            observed_histories.append(
+                [(message["role"], message["content"]) for message in history]
+            )
+            if not history:
+                db.create_session(session_id, "discord")
+                db.append_message(session_id, "user", event.text)
+                db.append_message(session_id, "assistant", "first response")
+        finally:
+            db.close()
+
+    runner._handle_message = run_turn
+    handler = runner._primary_message_handler()
+
+    def event(text):
+        return MessageEvent(
+            text=text,
+            source=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="routed-channel",
+                user_id="user-1",
+            ),
+        )
+
+    asyncio.run(handler(event("first turn")))
+    asyncio.run(handler(event("second turn")))
+
+    assert observed_histories == [
+        [],
+        [("user", "first turn"), ("assistant", "first response")],
+    ]
+    assert session_id in _session_ids(profile / "state.db")
+    assert session_id not in _session_ids(root / "state.db")
 
 
 def test_db_handle_follows_the_active_profile_scope(multiplex_homes):


### PR DESCRIPTION
## Summary

- scope primary-adapter message handling to the routed profile before session lookup so routed turns read/write that profile's transcript and `state.db`
- keep authorization scoped to the transport-owning profile, so a shared Discord/Telegram bot does not reject messages merely because the routed runtime intentionally has no platform token or allowlist
- apply the same transport-scope authorization rule to normalized platform events
- add regression coverage for two-turn routed history and the shared-bot authorization failure

## User-visible failure fixed

With `gateway.multiplex_profiles` and channel-based `profile_routes`, the shared Discord adapter admitted an allowed user and reacted to the message, but the gateway then re-checked authorization inside the routed profile's empty Discord secret scope. The request was logged as `Unauthorized user` and silently dropped, producing the observed eyes/check reactions with no response.

## Tests

```text
python3 scripts/run_tests_parallel.py \
  --files tests/gateway/test_multiplex_session_db_profile_scope.py:tests/gateway/test_multiplex_profile_authz.py:tests/gateway/test_gateway_platform_event_hook.py \
  -q --file-timeout 300

50 passed, 0 failed
```
