### PR TITLE
fix(environments): route heredoc stdin to compound commands

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -333,7 +333,7 @@ class TestEmbedStdinHeredoc:
     def test_heredoc_format(self):
         result = BaseEnvironment._embed_stdin_heredoc("cat", "hello world")
 
-        assert result.startswith("cat << '")
+        assert result.startswith("{\ncat\n} << '")
         assert "hello world" in result
         assert "HERMES_STDIN_" in result
 
@@ -345,6 +345,31 @@ class TestEmbedStdinHeredoc:
         d1 = r1.split("'")[1]
         d2 = r2.split("'")[1]
         assert d1 != d2  # UUID-based, should be unique
+
+    def test_compound_command_receives_stdin_as_a_group(self):
+        import shutil
+        import subprocess
+
+        import pytest
+
+        bash = shutil.which("bash")
+        if bash is None:
+            pytest.skip("bash required")
+
+        command = BaseEnvironment._embed_stdin_heredoc(
+            'IFS= read -r first; IFS= read -r second; '
+            'printf \'<%s|%s>\' "$first" "$second"',
+            "alpha\nbeta",
+        )
+
+        result = subprocess.run(
+            [bash, "-c", command],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout == "<alpha|beta>"
 
 
 class TestInitSessionFailure:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1020,9 +1020,9 @@ class BaseEnvironment(ABC):
 
     @staticmethod
     def _embed_stdin_heredoc(command: str, stdin_data: str) -> str:
-        """Append stdin_data as a shell heredoc to the command string."""
+        """Redirect stdin_data to the complete command with a shell heredoc."""
         delimiter = f"HERMES_STDIN_{uuid.uuid4().hex[:12]}"
-        return f"{command} << '{delimiter}'\n{stdin_data}\n{delimiter}"
+        return f"{{\n{command}\n}} << '{delimiter}'\n{stdin_data}\n{delimiter}"
 
     # ------------------------------------------------------------------
     # Process lifecycle


### PR DESCRIPTION
## Summary

- redirect SDK-backend heredoc stdin to the complete shell command via a brace group
- preserve same-shell behavior while allowing an earlier command in a compound command to consume stdin
- add an executable regression using two `read` commands before a final `printf`

## Reproduction

On current `main`, `_embed_stdin_heredoc` appends the redirection directly to the command string. For `read first; read second; printf ...`, Bash attaches the heredoc only to the final `printf`; both reads see EOF and the command prints `<|>` instead of `<alpha|beta>`.

This surfaced in a real remote-environment integration where `git credential approve; git clone ...` received the heredoc on `git clone`, leaving the credential command blocked on stdin.

## Validation

- `scripts/run_tests.sh tests/tools/test_base_environment.py -q` (28 passed)
- `ruff check tools/environments/base.py tests/tools/test_base_environment.py`