### PR TITLE
feat(memory): add focused OpenViking Quick Local setup

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -96,7 +96,10 @@ _EXCLUDED_PREFIXES = ("state.db.pre-update-emergency-",)
 _IMPORT_SKIP_NAMES = {"gateway_state.json", "gateway.pid", "cron.pid", "gateway.lock", "processes.json"}
 
 # zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
-_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+_SECRET_FILE_NAMES = {".env", "auth.json", "state.db", "ov.conf"}
+# Directories containing files that seed further provider-managed state must also
+# remain private after import. The Hermes home itself retains HERMES_HOME_MODE.
+_PRIVATE_PARENT_FILE_NAMES = {"ov.conf"}
 
 # Reserved archive subtree for memory-provider state OUTSIDE HERMES_HOME (e.g. ~/.honcho, via
 # MemoryProvider.backup_paths()), stored and restored relative to the user's home; paths not
@@ -902,6 +905,15 @@ def _import_members(
                 if tighten:
                     try:
                         os.chmod(target, 0o600)
+                        # A nested provider config can seed further files beside
+                        # itself. Keep that provider-owned directory private while
+                        # preserving an explicit HERMES_HOME_MODE on the root.
+                        if (
+                            not external
+                            and target.name in _PRIVATE_PARENT_FILE_NAMES
+                            and target.parent.resolve() != root
+                        ):
+                            os.chmod(target.parent, 0o700)
                     except OSError:
                         if not external:  # external configs are tightened best-effort only
                             raise

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -99,7 +99,7 @@ _IMPORT_SKIP_NAMES = {"gateway_state.json", "gateway.pid", "cron.pid", "gateway.
 _SECRET_FILE_NAMES = {".env", "auth.json", "state.db", "ov.conf"}
 # Directories containing files that seed further provider-managed state must also
 # remain private after import. The Hermes home itself retains HERMES_HOME_MODE.
-_PRIVATE_PARENT_FILE_NAMES = {"ov.conf"}
+_PRIVATE_PARENT_PATHS = {Path("openviking/ov.conf")}
 
 # Reserved archive subtree for memory-provider state OUTSIDE HERMES_HOME (e.g. ~/.honcho, via
 # MemoryProvider.backup_paths()), stored and restored relative to the user's home; paths not
@@ -910,7 +910,7 @@ def _import_members(
                         # preserving an explicit HERMES_HOME_MODE on the root.
                         if (
                             not external
-                            and target.name in _PRIVATE_PARENT_FILE_NAMES
+                            and Path(rel) in _PRIVATE_PARENT_PATHS
                             and target.parent.resolve() != root
                         ):
                             os.chmod(target.parent, 0o700)

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -15,17 +15,17 @@ The setup offers three connection types:
 - **OpenViking Service (VolcEngine Cloud)** — connect to the managed cloud
   service with an API key.
 - **Quick Local Setup** — install a compatible OpenViking release in an
-  isolated runtime, install or reuse Ollama, download
-  `qwen3-embedding:0.6b`, and create a private local
-  configuration under the active Hermes profile. OpenViking reuses the active
-  saved Hermes LLM provider and static API-key credentials for its VLM.
+  isolated runtime with its built-in `bge-small-zh-v1.5-f16` embedding model,
+  and create a private local configuration under the active Hermes profile.
+  OpenViking runs embeddings in-process with `llama-cpp-python` and reuses the
+  active saved Hermes LLM provider and static API-key credentials for its VLM.
 - **Connect to an existing server** — link a self-managed local or remote
   OpenViking server.
 
-Quick Local streams installation and model-download output. It validates the
-generated configuration with a temporary server before activating the profile.
-Hermes starts the configured local OpenViking server when memory is first used;
-the server and Ollama remain running for reuse after a Hermes session exits.
+Quick Local reports installation and first-model-download progress. It validates
+the generated configuration with a temporary server before activating the
+profile. Hermes starts the configured local OpenViking server when memory is
+first used; the server remains running for reuse after a Hermes session exits.
 
 ## Self-managed requirements
 

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -2,12 +2,39 @@
 
 Context database by Volcengine (ByteDance) with filesystem-style knowledge hierarchy, tiered retrieval, and automatic memory extraction.
 
-## Requirements
+## Setup
 
-- OpenViking installed with the `openviking-server` command available
-- OpenViking server config initialized and validated (`openviking-server init`,
-  then `openviking-server doctor`)
-- OpenViking server running and reachable from Hermes
+Run:
+
+```bash
+hermes memory setup openviking
+```
+
+The setup offers three connection types:
+
+- **OpenViking Service (VolcEngine Cloud)** — connect to the managed cloud
+  service with an API key.
+- **Quick Local Setup** — install a compatible OpenViking release in an
+  isolated runtime, install or reuse Ollama, download
+  `qwen3-embedding:0.6b`, and create a private local
+  configuration under the active Hermes profile. OpenViking reuses the active
+  saved Hermes LLM provider and static API-key credentials for its VLM.
+- **Connect to an existing server** — link a self-managed local or remote
+  OpenViking server.
+
+Quick Local streams installation and model-download output. It validates the
+generated configuration with a temporary server before activating the profile.
+Hermes starts the configured local OpenViking server when memory is first used;
+the server and Ollama remain running for reuse after a Hermes session exits.
+
+## Self-managed requirements
+
+For an existing local server, install and prepare OpenViking separately:
+
+- Install OpenViking with the `openviking-server` command available.
+- Initialize and validate `ov.conf` with `openviking-server init` and
+  `openviking-server doctor`.
+- Make the server reachable from Hermes.
 
 OpenViking 0.2.10 or newer is recommended. For backward compatibility,
 Hermes can identify older servers that expose the legacy status-only health
@@ -15,20 +42,12 @@ response, but only when anonymous OpenAPI metadata also identifies the service
 as OpenViking. OpenViking 0.2.6 and earlier are deprecated for this integration;
 upgrade them to receive the current health contract and compatibility fixes.
 
-## Setup
-
-Prepare OpenViking first:
+Start the self-managed server with:
 
 ```bash
 openviking-server init
 openviking-server doctor
 openviking-server
-```
-
-Then configure Hermes:
-
-```bash
-hermes memory setup    # select "openviking"
 ```
 
 The setup can link to an existing `~/.openviking/ovcli.conf`, copy its current

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -26,6 +26,9 @@ Quick Local reports installation and first-model-download progress. It validates
 the generated configuration with a temporary server before activating the
 profile. Hermes starts the configured local OpenViking server when memory is
 first used; the server remains running for reuse after a Hermes session exits.
+Quick Local deliberately ignores `OPENVIKING_*` environment overrides so its
+profile-scoped managed configuration remains authoritative. Those variables
+continue to apply to self-managed connections.
 
 ## Self-managed requirements
 

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -29,6 +29,9 @@ first used; the server remains running for reuse after a Hermes session exits.
 Quick Local deliberately ignores `OPENVIKING_*` environment overrides so its
 profile-scoped managed configuration remains authoritative. Those variables
 continue to apply to self-managed connections.
+Quick Local cannot verify which configuration a manually started OpenViking
+process loaded. When setup reports that a restart is required, stop that process
+and let Hermes start the managed server through the normal Quick Local flow.
 
 ## Self-managed requirements
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1264,11 +1264,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
     """Full bidirectional memory via OpenViking context database."""
 
     def backup_paths(self) -> List[str]:
-        """The resolved ovcli config (default ~/.openviking/ovcli.conf) so endpoint/api-key
-        survive backup/import. The backup walk itself drops paths outside $HOME."""
+        """The resolved external ovcli profile; in-home profiles use the normal backup walk."""
         try:
             provider_config = _load_hermes_openviking_config()
-            return [str(_provider_ovcli_config_path(provider_config))]
+            profile = _provider_ovcli_config_path(provider_config)
+            try:
+                profile.resolve().relative_to(_hermes_home_path().resolve())
+                return []
+            except ValueError:
+                return [str(profile)]
         except Exception:
             return []
 
@@ -1464,6 +1468,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 )
             else:
                 start_state, start_message = _start_local_openviking_server(endpoint)
+            if (
+                start_state == _LOCAL_SERVER_STARTED
+                and is_quick_local
+                and config_path is not None
+                and not quick_local.clear_server_restart_required(config_path)
+            ):
+                logger.warning(
+                    "Could not clear Quick Local's restart-required marker after "
+                    "starting %s.",
+                    config_path,
+                )
             if start_state != _LOCAL_SERVER_STARTED:
                 self._runtime_start_pending = False
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -30,7 +30,7 @@ from contextlib import suppress
 from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set
 from urllib.parse import quote, unquote, urlparse
 from urllib.request import url2pathname
 
@@ -40,6 +40,8 @@ from agent.skill_commands import extract_user_instruction_from_skill_message
 from hermes_cli import __version__ as _HERMES_VERSION
 from tools.registry import tool_error
 from utils import atomic_json_write, env_var_enabled
+
+from . import quick_local
 
 try:
     import fcntl
@@ -552,6 +554,18 @@ def _resolve_ovcli_config_path(config_path: str = "") -> Path:
     return Path(chosen).expanduser() if chosen else _default_ovcli_config_path()
 
 
+def _provider_ovcli_config_path(provider_config: Mapping[str, Any]) -> Path:
+    config_path = _clean_config_value(provider_config.get("ovcli_config_path"))
+    if provider_config.get("deployment") == quick_local.DEPLOYMENT:
+        if not config_path:
+            raise _OpenVikingEndpointError(
+                "Quick Local's OpenViking profile link is missing. Rerun "
+                "`hermes memory setup openviking` to repair it."
+            )
+        return Path(config_path).expanduser()
+    return _resolve_ovcli_config_path(config_path)
+
+
 def _load_ovcli_config(path: Optional[Path] = None) -> dict:
     config_path = path or _resolve_ovcli_config_path()
     if not config_path.exists():
@@ -752,7 +766,7 @@ def _ovcli_values_for(provider_config: dict) -> dict:
     """Connection values from the linked ovcli profile, or {} when none is linked."""
     if not provider_config.get("use_ovcli_config"):
         return {}
-    ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
+    ovcli_path = _provider_ovcli_config_path(provider_config)
     return _connection_values_from_ovcli(_load_ovcli_config(ovcli_path))
 
 
@@ -762,16 +776,17 @@ def _resolve_connection_settings(provider_config: Optional[dict] = None) -> dict
     comes from config.yaml."""
     provider_config = dict(provider_config or {})
     ovcli_values = _ovcli_values_for(provider_config)
+    ignore_environment = provider_config.get("deployment") == quick_local.DEPLOYMENT
 
     def layered(key: str, default: str = "", *, env_authoritative: bool = False) -> str:
-        env = os.environ.get(f"OPENVIKING_{key.upper()}")
+        env = None if ignore_environment else os.environ.get(f"OPENVIKING_{key.upper()}")
         if env is not None:
             env = env.strip()
             if env_authoritative:
                 return env
         return env or ovcli_values.get(key) or _clean_config_value(provider_config.get(key)) or default
 
-    api_key_env = os.environ.get("OPENVIKING_API_KEY")
+    api_key_env = None if ignore_environment else os.environ.get("OPENVIKING_API_KEY")
     return {
         "endpoint": _normalize_openviking_url(layered("endpoint", _DEFAULT_ENDPOINT)),
         "api_key": api_key_env.strip() if api_key_env is not None else ovcli_values.get("api_key", ""),
@@ -955,7 +970,12 @@ def _local_listener_suffix(endpoint: str) -> str:
     return f" The listener on {host}:{port} is {_describe_local_port_listener(host, port)}."
 
 
-def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
+def _start_local_openviking_server(
+    endpoint: str,
+    *,
+    config_path: Optional[Path] = None,
+    server_command_path: Optional[Path] = None,
+) -> tuple[str, str]:
     try:
         host, port = _local_openviking_bind(endpoint)
     except ValueError as e:
@@ -968,7 +988,16 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
             f"Port {host}:{port} is occupied by {_describe_local_port_listener(host, port)}. Hermes did not start "
             "openviking-server because the listener has not passed OpenViking's /health check."
         )
-    server_cmd = shutil.which("openviking-server")
+    if server_command_path is not None:
+        server_command_path = server_command_path.expanduser()
+        if not server_command_path.is_file():
+            return (
+                _LOCAL_SERVER_FAILED,
+                f"OpenViking server executable was not found: {server_command_path}",
+            )
+        server_cmd = str(server_command_path)
+    else:
+        server_cmd = shutil.which("openviking-server")
     if not server_cmd:
         return _LOCAL_SERVER_FAILED, "openviking-server was not found on PATH. Start it manually, then retry."
     log_path = _hermes_home_path() / _OPENVIKING_SERVER_LOG_RELATIVE_PATH
@@ -983,9 +1012,46 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
         # Hermes venv, aborting `hermes update` with access-denied on .pyd files. (#78153)
         child_env = os.environ.copy()
         child_env.pop("PYTHONPATH", None)
+        command = [server_cmd]
+        if config_path is not None:
+            config_path = config_path.expanduser()
+            if not config_path.is_file():
+                return (
+                    _LOCAL_SERVER_FAILED,
+                    f"OpenViking server config was not found: {config_path}",
+                )
+            command.extend(["--config", str(config_path)])
+        command.extend(["--host", host, "--port", str(port)])
         with log_path.open("ab") as log_file:
-            subprocess.Popen([server_cmd, "--host", host, "--port", str(port)], stdout=log_file, stderr=log_file,
-                             stdin=subprocess.DEVNULL, start_new_session=True, env=child_env)
+            common_kwargs: dict[str, Any] = {
+                "stdout": log_file,
+                "stderr": log_file,
+                "stdin": subprocess.DEVNULL,
+                "env": child_env,
+            }
+            if server_command_path is None:
+                subprocess.Popen(command, **common_kwargs, start_new_session=True)
+            else:
+                from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+
+                try:
+                    subprocess.Popen(
+                        command,
+                        **common_kwargs,
+                        **windows_detach_popen_kwargs(),
+                    )
+                except OSError:
+                    if os.name != "nt":
+                        raise
+                    from hermes_cli._subprocess_compat import (
+                        windows_detach_flags_without_breakaway,
+                    )
+
+                    subprocess.Popen(
+                        command,
+                        **common_kwargs,
+                        creationflags=windows_detach_flags_without_breakaway(),
+                    )
     except Exception as e:
         return _LOCAL_SERVER_FAILED, f"Could not start openviking-server: {e}"
     return _LOCAL_SERVER_STARTED, f"Started openviking-server on {host}:{port} in the background. Logs: {log_path}"
@@ -1201,7 +1267,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         """The resolved ovcli config (default ~/.openviking/ovcli.conf) so endpoint/api-key
         survive backup/import. The backup walk itself drops paths outside $HOME."""
         try:
-            return [str(_resolve_ovcli_config_path())]
+            provider_config = _load_hermes_openviking_config()
+            return [str(_provider_ovcli_config_path(provider_config))]
         except Exception:
             return []
 
@@ -1288,17 +1355,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not provider_config.get("use_ovcli_config"):
             return {key: "(set)" if key in ("api_key", "root_api_key") else value for key, value in provider_config.items()}
 
-        ovcli_path = _resolve_ovcli_config_path(str(provider_config.get("ovcli_config_path") or ""))
-        display = {"use_ovcli_config": True, "ovcli_config_path": str(ovcli_path)}
         try:
+            ovcli_path = _provider_ovcli_config_path(provider_config)
             settings = _resolve_connection_settings(provider_config)
         except Exception as e:
-            display["error"] = _format_openviking_exception(e)
-            return display
+            return {
+                "use_ovcli_config": True,
+                "ovcli_config_path": _clean_config_value(provider_config.get("ovcli_config_path")),
+                "error": _format_openviking_exception(e),
+            }
+        display = {"use_ovcli_config": True, "ovcli_config_path": str(ovcli_path)}
         display["endpoint"] = settings.get("endpoint") or _DEFAULT_ENDPOINT
         display.update({key: settings[key] for key in ("agent", "account", "user") if settings.get(key)})
-        if env_overrides := [key for key in _OPENVIKING_ENV_KEYS if key in os.environ]:
-            display["env_overrides"] = ", ".join(env_overrides)
+        if provider_config.get("deployment") != quick_local.DEPLOYMENT:
+            if env_overrides := [key for key in _OPENVIKING_ENV_KEYS if key in os.environ]:
+                display["env_overrides"] = ", ".join(env_overrides)
         return display
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
@@ -1375,7 +1446,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if self._shutting_down or self._runtime_start_pending or (self._runtime_start_thread and self._runtime_start_thread.is_alive()):
                 return
             self._runtime_start_pending = True
-            start_state, start_message = _start_local_openviking_server(endpoint)
+            provider_config = _load_hermes_openviking_config()
+            config_path = quick_local.managed_server_config_path(provider_config)
+            server_command_path = quick_local.managed_server_command_path(provider_config)
+            is_quick_local = provider_config.get("deployment") == quick_local.DEPLOYMENT
+            if is_quick_local and (config_path is None or server_command_path is None):
+                start_state = _LOCAL_SERVER_FAILED
+                start_message = (
+                    "Quick Local's private server configuration is incomplete. "
+                    "Rerun `hermes memory setup openviking` to repair it."
+                )
+            elif is_quick_local:
+                start_state, start_message = _start_local_openviking_server(
+                    endpoint,
+                    config_path=config_path,
+                    server_command_path=server_command_path,
+                )
+            else:
+                start_state, start_message = _start_local_openviking_server(endpoint)
             if start_state != _LOCAL_SERVER_STARTED:
                 self._runtime_start_pending = False
 

--- a/plugins/memory/openviking/_setup.py
+++ b/plugins/memory/openviking/_setup.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from . import quick_local
+
 _SETUP_CANCELLED = object()
 _CANCEL_OPTION = ("Cancel setup", "no changes saved")
 
@@ -232,6 +234,7 @@ def _prompt_manual_connection_values(prompt, select, cancelled, *, service: bool
 
 def _link_ovcli_profile(*, config: dict, provider_config: dict, env_path: Path, ovcli_path: Path) -> None:
     ov = _ov()
+    quick_local.clear_managed_settings(provider_config)
     for key in ("endpoint", "api_key", "root_api_key", "account", "user", "agent", "api_key_type"):
         provider_config.pop(key, None)
     provider_config["use_ovcli_config"] = True
@@ -249,6 +252,7 @@ def _link_ovcli_profile(*, config: dict, provider_config: dict, env_path: Path, 
 
 def _save_hermes_only_config(*, config: dict, provider_config: dict, env_path: Path, values: dict) -> None:
     ov = _ov()
+    quick_local.clear_managed_settings(provider_config)
     provider_config["use_ovcli_config"] = False
     provider_config.pop("ovcli_config_path", None)
     # A newly selected connection must not inherit the previous YAML peer; a
@@ -328,12 +332,91 @@ def _mirror_manual_config_to_openviking_store(*, prompt, select, cancelled, valu
         return path
 
 
+def _run_quick_local_setup(*, config: dict, provider_config: dict, env_path: Path) -> bool:
+    ov = _ov()
+
+    def report_progress(event: quick_local.QuickLocalProgress) -> None:
+        _say(event.message)
+
+    setup = quick_local.QuickLocalSetup(
+        health_check=ov._validate_openviking_reachability,
+        progress=report_progress,
+    )
+    try:
+        preflight = setup.preflight(env_path.parent)
+    except quick_local.QuickLocalSetupError as exc:
+        _say(f"Quick Local preflight failed: {exc}")
+        return False
+
+    try:
+        result = setup.provision(hermes_home=env_path.parent, preflight=preflight)
+    except quick_local.QuickLocalSetupError as exc:
+        _say(f"Quick Local setup failed: {exc}")
+        return False
+
+    _link_ovcli_profile(
+        config=config,
+        provider_config=provider_config,
+        env_path=env_path,
+        ovcli_path=result.paths.ovcli_config,
+    )
+    provider_config.update(
+        deployment=quick_local.DEPLOYMENT,
+        server_config_path=str(result.paths.server_config),
+        server_command_path=str(result.paths.server_command),
+    )
+    if result.server_restart_required:
+        print("\n  Quick Local restart required")
+        _say(
+            "The running OpenViking server must restart to use the updated "
+            "runtime or Hermes LLM settings."
+        )
+        _say(f"Stop the Quick Local server at {result.endpoint}, then start Hermes again.")
+        _say(
+            "Hermes will restart it with the updated runtime and settings "
+            "when memory is first used."
+        )
+        _say(f"Config file: {result.paths.ovcli_config}")
+        print()
+    else:
+        action = "Reused" if result.reused else "Configured"
+        _print_openviking_ready(
+            f"{action} Quick Local at {result.endpoint}.",
+            result.paths.ovcli_config,
+        )
+    return True
+
+
 def _run_create_profile_setup(*, prompt, select, cancelled, config: dict, provider_config: dict, env_path: Path) -> bool | object:
-    source_choice = select("  OpenViking connection",
-                           [("OpenViking Service (VolcEngine Cloud)", "use the managed OpenViking endpoint"),
-                            ("Custom", "use a local, VPS, or self-hosted OpenViking server")],
-                           default=0, cancel_returns=cancelled)
+    source_choice = select(
+        "  OpenViking connection",
+        [
+            (
+                "OpenViking Service (VolcEngine Cloud)",
+                "Managed cloud service; API key required",
+            ),
+            (
+                "Quick Local Setup",
+                "Set up OpenViking with built-in local embeddings",
+            ),
+            (
+                "Connect to an existing server",
+                "Use a self-managed custom server (Remote/Local)",
+            ),
+        ],
+        default=0,
+        cancel_returns=cancelled,
+    )
     if source_choice == cancelled:
+        return _SETUP_CANCELLED
+
+    if source_choice == 1:
+        return _run_quick_local_setup(
+            config=config,
+            provider_config=provider_config,
+            env_path=env_path,
+        )
+    if source_choice not in {0, 2}:
         return _SETUP_CANCELLED
 
     values = _prompt_manual_connection_values(prompt, select, cancelled, service=(source_choice == 0))

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import platform
-import shutil
 import socket
 import subprocess
 import sys
@@ -21,28 +19,27 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 from urllib.parse import urlparse
-from urllib.request import ProxyHandler, Request, build_opener
 
-from packaging.specifiers import SpecifierSet
+from packaging.requirements import Requirement
 from packaging.version import InvalidVersion, Version
 
 from utils import atomic_json_write
 
 DEPLOYMENT = "quick_local"
-EMBEDDING_MODEL = "qwen3-embedding:0.6b"
-EMBEDDING_DIMENSION = 1024
-OPENVIKING_REQUIREMENT = "openviking>=0.4.16,<0.6"
+EMBEDDING_MODEL = "bge-small-zh-v1.5-f16"
+EMBEDDING_DIMENSION = 512
+OPENVIKING_REQUIREMENT = "openviking[local-embed]>=0.4.16,<0.6"
 
-_OPENVIKING_VERSION_SPECIFIER = SpecifierSet(
-    OPENVIKING_REQUIREMENT.removeprefix("openviking")
-)
+_OPENVIKING_REQUIREMENT = Requirement(OPENVIKING_REQUIREMENT)
+_OPENVIKING_VERSION_SPECIFIER = _OPENVIKING_REQUIREMENT.specifier
 _ROOT_DIRNAME = "openviking"
 _SERVER_CONFIG_FILENAME = "ov.conf"
 _OVCLI_CONFIG_FILENAME = "ovcli.conf"
 _WORKSPACE_DIRNAME = "data"
+_MODEL_CACHE_DIRNAME = "models"
 _DEFAULT_PORT = 1933
 _PORT_ATTEMPTS = 20
-_MODEL_DOWNLOAD_SIZE = "approximately 639 MB"
+_MODEL_DOWNLOAD_SIZE = "approximately 46 MiB"
 _HEALTH_TIMEOUT_SECONDS = 60.0
 _HEALTH_POLL_INTERVAL_SECONDS = 0.5
 _PROCESS_STOP_TIMEOUT_SECONDS = 10.0
@@ -51,9 +48,7 @@ _PROCESS_STOP_TIMEOUT_SECONDS = 10.0
 class QuickLocalStage(str, Enum):
     PREFLIGHT = "preflight"
     INSTALL_OPENVIKING = "install_openviking"
-    INSTALL_OLLAMA = "install_ollama"
-    START_OLLAMA = "start_ollama"
-    DOWNLOAD_MODEL = "download_model"
+    PREPARE_EMBEDDING = "prepare_embedding"
     VALIDATE = "validate"
     WRITE_CONFIG = "write_config"
     COMPLETE = "complete"
@@ -72,6 +67,7 @@ class QuickLocalPaths:
     server_config: Path
     ovcli_config: Path
     workspace: Path
+    model_cache: Path
 
     @property
     def runtime_python(self) -> Path:
@@ -90,7 +86,6 @@ class QuickLocalPaths:
 class QuickLocalPreflight:
     paths: QuickLocalPaths
     reusable_endpoint: Optional[str]
-    ollama_install_required: bool
 
 
 @dataclass(frozen=True)
@@ -102,10 +97,6 @@ class QuickLocalSetupResult:
 
 class QuickLocalSetupError(RuntimeError):
     """Quick Local could not finish without partially activating it."""
-
-
-class OllamaInstallRequired(QuickLocalSetupError):
-    """Quick Local needs explicit permission to install Ollama."""
 
 
 ProgressReporter = Callable[[QuickLocalProgress], None]
@@ -120,6 +111,7 @@ def managed_paths(hermes_home: Path) -> QuickLocalPaths:
         server_config=root / _SERVER_CONFIG_FILENAME,
         ovcli_config=root / _OVCLI_CONFIG_FILENAME,
         workspace=root / _WORKSPACE_DIRNAME,
+        model_cache=root / _MODEL_CACHE_DIRNAME,
     )
 
 
@@ -154,11 +146,10 @@ def build_server_config(
         "storage": {"workspace": str(paths.workspace)},
         "embedding": {
             "dense": {
-                "provider": "ollama",
+                "provider": "local",
                 "model": EMBEDDING_MODEL,
-                "api_base": "http://localhost:11434/v1",
                 "dimension": EMBEDDING_DIMENSION,
-                "input": "text",
+                "cache_dir": str(paths.model_cache),
             }
         },
         "vlm": dict(vlm),
@@ -275,22 +266,17 @@ class QuickLocalSetup:
         return QuickLocalPreflight(
             paths=paths,
             reusable_endpoint=reusable_endpoint,
-            ollama_install_required=(
-                reusable_endpoint is None and not ollama_command_available()
-            ),
         )
 
     def provision(
         self,
         *,
         hermes_home: Path,
-        allow_ollama_install: bool,
         preflight: Optional[QuickLocalPreflight] = None,
     ) -> QuickLocalSetupResult:
         try:
             return self._provision(
                 hermes_home=Path(hermes_home),
-                allow_ollama_install=allow_ollama_install,
                 preflight=preflight,
             )
         except QuickLocalSetupError:
@@ -302,7 +288,6 @@ class QuickLocalSetup:
         self,
         *,
         hermes_home: Path,
-        allow_ollama_install: bool,
         preflight: Optional[QuickLocalPreflight],
     ) -> QuickLocalSetupResult:
         preflight = preflight or self.preflight(hermes_home)
@@ -327,10 +312,6 @@ class QuickLocalSetup:
 
         vlm = resolve_hermes_vlm_config()
         self._ensure_openviking_installed(preflight.paths)
-        self._ensure_ollama(
-            paths=preflight.paths,
-            allow_install=allow_ollama_install,
-        )
 
         port = find_available_port(
             preferred_endpoint=_configured_endpoint(preflight.paths)
@@ -425,37 +406,6 @@ class QuickLocalSetup:
                 "installer output above."
             )
 
-    def _ensure_ollama(
-        self,
-        *,
-        paths: QuickLocalPaths,
-        allow_install: bool,
-    ) -> None:
-        _add_windows_ollama_to_path()
-        if not ollama_command_available():
-            if not allow_install:
-                raise OllamaInstallRequired("Ollama is required for Quick Local.")
-            self._emit(QuickLocalStage.INSTALL_OLLAMA, "Installing Ollama...")
-            if not _install_ollama() or not ollama_command_available():
-                raise QuickLocalSetupError(
-                    "Ollama installation failed or the ollama command is not yet "
-                    "available. Install it manually, restart the terminal, and retry."
-                )
-
-        if not _ollama_running():
-            self._emit(QuickLocalStage.START_OLLAMA, "Starting Ollama...")
-            started, detail = _start_ollama(paths)
-            if not started:
-                raise QuickLocalSetupError(f"Ollama could not be started: {detail}")
-
-        if not _ollama_model_available(EMBEDDING_MODEL, _ollama_models()):
-            self._emit(
-                QuickLocalStage.DOWNLOAD_MODEL,
-                f"Downloading {EMBEDDING_MODEL} ({_MODEL_DOWNLOAD_SIZE})...",
-            )
-            if not _pull_ollama_model(EMBEDDING_MODEL):
-                raise QuickLocalSetupError(f"Could not download {EMBEDDING_MODEL}.")
-
     def _validate_generated_config(
         self,
         *,
@@ -475,6 +425,12 @@ class QuickLocalSetup:
             config_path = validation_root / _SERVER_CONFIG_FILENAME
             atomic_json_write(config_path, validation_config, mode=0o600)
 
+            _prepare_private_directory(paths.model_cache)
+            self._emit(
+                QuickLocalStage.PREPARE_EMBEDDING,
+                f"Preparing {EMBEDDING_MODEL}; its {_MODEL_DOWNLOAD_SIZE} model "
+                "is downloaded once if needed...",
+            )
             self._emit(
                 QuickLocalStage.VALIDATE,
                 "Validating OpenViking with a temporary local server...",
@@ -509,7 +465,8 @@ def openviking_install_satisfies_requirement(paths: QuickLocalPaths) -> bool:
             [
                 str(paths.runtime_python),
                 "-c",
-                "import importlib.metadata; print(importlib.metadata.version('openviking'))",
+                "import importlib.metadata; import llama_cpp; "
+                "print(importlib.metadata.version('openviking'))",
             ],
             capture_output=True,
             text=True,
@@ -523,11 +480,6 @@ def openviking_install_satisfies_requirement(paths: QuickLocalPaths) -> bool:
     except (InvalidVersion, OSError, subprocess.SubprocessError):
         return False
     return version in _OPENVIKING_VERSION_SPECIFIER
-
-
-def ollama_command_available() -> bool:
-    _add_windows_ollama_to_path()
-    return shutil.which("ollama") is not None
 
 
 def find_available_port(
@@ -685,174 +637,6 @@ def _stop_process(process: subprocess.Popen) -> bool:
         return True
     except Exception:
         return False
-
-
-def _install_ollama() -> bool:
-    system = platform.system()
-    if system == "Darwin":
-        brew = shutil.which("brew")
-        if brew:
-            result = subprocess.run(
-                [brew, "install", "ollama"],
-                check=False,
-                stdin=subprocess.DEVNULL,
-            )
-            if result.returncode == 0:
-                return True
-        return _run_ollama_shell_installer()
-    if system == "Linux":
-        return _run_ollama_shell_installer()
-    if system != "Windows":
-        return False
-    powershell = next(
-        (
-            executable
-            for name in ("powershell.exe", "powershell", "pwsh.exe", "pwsh")
-            if (executable := shutil.which(name))
-        ),
-        None,
-    )
-    if not powershell:
-        return False
-    result = subprocess.run(
-        _windows_ollama_install_command(powershell),
-        check=False,
-        stdin=subprocess.DEVNULL,
-    )
-    _add_windows_ollama_to_path()
-    return result.returncode == 0
-
-
-def _windows_ollama_install_command(powershell: str) -> list[str]:
-    return [
-        powershell,
-        "-NoLogo",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
-    ]
-
-
-def _run_ollama_shell_installer() -> bool:
-    result = subprocess.run(
-        ["bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh"],
-        check=False,
-        stdin=subprocess.DEVNULL,
-    )
-    return result.returncode == 0
-
-
-def _ollama_running() -> bool:
-    try:
-        request = Request("http://127.0.0.1:11434/api/tags", method="GET")
-        with build_opener(ProxyHandler({})).open(request, timeout=3):
-            return True
-    except (OSError, TimeoutError):
-        return False
-
-
-def _ollama_models() -> list[str]:
-    try:
-        request = Request("http://127.0.0.1:11434/api/tags", method="GET")
-        with build_opener(ProxyHandler({})).open(request, timeout=5) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-        return [
-            str(model.get("name"))
-            for model in payload.get("models", [])
-            if isinstance(model, dict) and model.get("name")
-        ]
-    except (OSError, TimeoutError, json.JSONDecodeError, AttributeError):
-        return []
-
-
-def _ollama_model_available(model_name: str, available: list[str]) -> bool:
-    return any(
-        installed == model_name
-        or installed.startswith(f"{model_name}-")
-        or (":" not in model_name and installed.split(":", 1)[0] == model_name)
-        for installed in available
-    )
-
-
-def _pull_ollama_model(model_name: str) -> bool:
-    command = shutil.which("ollama")
-    if not command:
-        return False
-    try:
-        result = subprocess.run(
-            [command, "pull", model_name],
-            check=False,
-            stdin=subprocess.DEVNULL,
-        )
-        return result.returncode == 0
-    except OSError:
-        return False
-
-
-def _start_ollama(paths: QuickLocalPaths) -> tuple[bool, str]:
-    command = shutil.which("ollama")
-    if not command:
-        return False, "ollama command not found"
-    log_path = paths.root.parent / "logs" / "ollama.log"
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
-
-    try:
-        with log_path.open("ab") as log_file:
-            common_kwargs: dict[str, Any] = {
-                "stdout": log_file,
-                "stderr": log_file,
-            }
-            try:
-                process = subprocess.Popen(
-                    [command, "serve"],
-                    **common_kwargs,
-                    **windows_detach_popen_kwargs(),
-                    stdin=subprocess.DEVNULL,
-                )
-            except OSError:
-                if os.name != "nt":
-                    raise
-                from hermes_cli._subprocess_compat import (
-                    windows_detach_flags_without_breakaway,
-                )
-
-                process = subprocess.Popen(
-                    [command, "serve"],
-                    **common_kwargs,
-                    creationflags=windows_detach_flags_without_breakaway(),
-                    stdin=subprocess.DEVNULL,
-                )
-    except OSError as exc:
-        return False, str(exc)
-
-    deadline = time.monotonic() + 15.0
-    while time.monotonic() < deadline:
-        if _ollama_running():
-            return True, "started"
-        if process.poll() is not None:
-            return False, f"ollama serve exited with status {process.returncode}"
-        time.sleep(_HEALTH_POLL_INTERVAL_SECONDS)
-    _stop_process(process)
-    return False, f"timed out; review {log_path}"
-
-
-def _add_windows_ollama_to_path() -> None:
-    if platform.system() != "Windows":
-        return
-    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
-    if not local_app_data:
-        return
-    install_dir = Path(local_app_data) / "Programs" / "Ollama"
-    if not (install_dir / "ollama.exe").is_file():
-        return
-    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
-    if os.path.normcase(str(install_dir)) not in {
-        os.path.normcase(entry) for entry in entries
-    }:
-        os.environ["PATH"] = os.pathsep.join([str(install_dir), *entries])
 
 
 def _uses_noncopyable_credentials(provider: str, source: str, api_key: str) -> bool:

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -199,6 +199,14 @@ def resolve_hermes_vlm_config() -> dict[str, Any]:
     api_base = _clean_value(runtime.get("base_url"))
     api_key = _clean_value(runtime.get("api_key"))
 
+    if not api_base:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve an API base URL."
+        )
+    if not api_key:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve reusable static credentials."
+        )
     if not _has_copyable_static_credentials(provider, source, api_key):
         raise QuickLocalSetupError(
             "Hermes is using refreshed OAuth, cloud-native, or external-process "
@@ -213,15 +221,6 @@ def resolve_hermes_vlm_config() -> dict[str, Any]:
             "API-key provider, or connect to an OpenViking server configured "
             "separately."
         )
-    if not api_base:
-        raise QuickLocalSetupError(
-            "Hermes' LLM provider did not resolve an API base URL."
-        )
-    if not api_key:
-        raise QuickLocalSetupError(
-            "Hermes' LLM provider did not resolve reusable static credentials."
-        )
-
     vlm: dict[str, Any]
     if api_mode == "anthropic_messages":
         if not runtime_model.startswith("anthropic/"):
@@ -301,7 +300,7 @@ class QuickLocalSetup:
                 "Quick Local preflight belongs to a different Hermes profile."
             )
         vlm = resolve_hermes_vlm_config()
-        self._ensure_openviking_installed(preflight.paths)
+        runtime_changed = self._ensure_openviking_installed(preflight.paths)
 
         reusable_endpoint = find_reusable_endpoint(preflight.paths, self._health_check)
         if reusable_endpoint:
@@ -311,10 +310,10 @@ class QuickLocalSetup:
                     "Quick Local's saved endpoint does not contain a valid port."
                 )
             server_config = build_server_config(preflight.paths, vlm, port=port)
-            server_restart_required = not _stored_server_config_matches(
+            config_changed = not _stored_server_config_matches(
                 preflight.paths, server_config
             )
-            if server_restart_required:
+            if config_changed:
                 _prepare_private_directory(preflight.paths.root)
                 atomic_json_write(
                     preflight.paths.server_config,
@@ -335,7 +334,7 @@ class QuickLocalSetup:
                 paths=preflight.paths,
                 endpoint=reusable_endpoint,
                 reused=True,
-                server_restart_required=server_restart_required,
+                server_restart_required=runtime_changed or config_changed,
             )
 
         port = find_available_port(
@@ -374,9 +373,10 @@ class QuickLocalSetup:
             reused=False,
         )
 
-    def _ensure_openviking_installed(self, paths: QuickLocalPaths) -> None:
+    def _ensure_openviking_installed(self, paths: QuickLocalPaths) -> bool:
+        """Ensure a compatible runtime, returning whether installation was needed."""
         if openviking_install_satisfies_requirement(paths):
-            return
+            return False
         self._emit(
             QuickLocalStage.INSTALL_OPENVIKING,
             f"Installing {OPENVIKING_REQUIREMENT}...",
@@ -430,6 +430,7 @@ class QuickLocalSetup:
                 "Could not install a compatible OpenViking version. Review the "
                 "installer output above."
             )
+        return True
 
     def _validate_generated_config(
         self,

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -226,10 +226,11 @@ def resolve_hermes_vlm_config() -> dict[str, Any]:
             "Hermes' LLM provider did not resolve reusable static credentials."
         )
 
+    vlm: dict[str, Any]
     if api_mode == "anthropic_messages":
         if not runtime_model.startswith("anthropic/"):
             runtime_model = f"anthropic/{runtime_model}"
-        vlm: dict[str, Any] = {
+        vlm = {
             "provider": "litellm",
             "model": runtime_model,
             "api_key": api_key,
@@ -609,7 +610,7 @@ def _start_validation_server(
     child_env.pop("PYTHONPATH", None)
     from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
-    popen_kwargs = windows_detach_popen_kwargs()
+    popen_kwargs: dict[str, Any] = windows_detach_popen_kwargs()
     command_args = [
         command,
         "--config",
@@ -621,7 +622,7 @@ def _start_validation_server(
     ]
     try:
         with log_path.open("ab") as log_file:
-            common_kwargs = {
+            common_kwargs: dict[str, Any] = {
                 "stdout": log_file,
                 "stderr": log_file,
                 "env": child_env,
@@ -800,7 +801,7 @@ def _start_ollama(paths: QuickLocalPaths) -> tuple[bool, str]:
 
     try:
         with log_path.open("ab") as log_file:
-            common_kwargs = {
+            common_kwargs: dict[str, Any] = {
                 "stdout": log_file,
                 "stderr": log_file,
             }

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -196,14 +196,20 @@ def resolve_hermes_vlm_config() -> dict[str, Any]:
     provider = _clean_value(runtime.get("provider")).lower()
     api_mode = _clean_value(runtime.get("api_mode")).lower()
     source = _clean_value(runtime.get("source")).lower()
-    api_base = _clean_value(runtime.get("base_url"))
-    api_key = _clean_value(runtime.get("api_key"))
+    raw_api_base = runtime.get("base_url")
+    raw_api_key = runtime.get("api_key")
+    api_base = _clean_value(raw_api_base)
+    api_key = _clean_value(raw_api_key)
 
+    if raw_api_base is not None and not isinstance(raw_api_base, str):
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider API base URL must be a string."
+        )
     if not api_base:
         raise QuickLocalSetupError(
             "Hermes' LLM provider did not resolve an API base URL."
         )
-    if not api_key:
+    if raw_api_key is None or (isinstance(raw_api_key, str) and not api_key):
         raise QuickLocalSetupError(
             "Hermes' LLM provider did not resolve reusable static credentials."
         )

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -40,7 +40,11 @@ _MODEL_CACHE_DIRNAME = "models"
 _DEFAULT_PORT = 1933
 _PORT_ATTEMPTS = 20
 _MODEL_DOWNLOAD_SIZE = "approximately 46 MiB"
-_HEALTH_TIMEOUT_SECONDS = 60.0
+# OpenViking downloads the built-in model while its server lifespan starts.
+# Give a slow first download a bounded ten minutes, then leave another minute
+# for model loading and service initialization.
+_MODEL_PREPARATION_TIMEOUT_SECONDS = 600.0
+_HEALTH_TIMEOUT_SECONDS = _MODEL_PREPARATION_TIMEOUT_SECONDS + 60.0
 _HEALTH_POLL_INTERVAL_SECONDS = 0.5
 _PROCESS_STOP_TIMEOUT_SECONDS = 10.0
 
@@ -93,6 +97,7 @@ class QuickLocalSetupResult:
     paths: QuickLocalPaths
     endpoint: str
     reused: bool
+    server_restart_required: bool = False
 
 
 class QuickLocalSetupError(RuntimeError):
@@ -194,7 +199,7 @@ def resolve_hermes_vlm_config() -> dict[str, Any]:
     api_base = _clean_value(runtime.get("base_url"))
     api_key = _clean_value(runtime.get("api_key"))
 
-    if _uses_noncopyable_credentials(provider, source, api_key):
+    if not _has_copyable_static_credentials(provider, source, api_key):
         raise QuickLocalSetupError(
             "Hermes is using refreshed OAuth, cloud-native, or external-process "
             "credentials that cannot be copied safely into OpenViking. Configure "
@@ -295,11 +300,33 @@ class QuickLocalSetup:
             raise QuickLocalSetupError(
                 "Quick Local preflight belongs to a different Hermes profile."
             )
-        reusable_endpoint = find_reusable_endpoint(
-            preflight.paths,
-            self._health_check,
-        )
+        vlm = resolve_hermes_vlm_config()
+        self._ensure_openviking_installed(preflight.paths)
+
+        reusable_endpoint = find_reusable_endpoint(preflight.paths, self._health_check)
         if reusable_endpoint:
+            port = _endpoint_port(reusable_endpoint)
+            if port is None:
+                raise QuickLocalSetupError(
+                    "Quick Local's saved endpoint does not contain a valid port."
+                )
+            server_config = build_server_config(preflight.paths, vlm, port=port)
+            server_restart_required = not _stored_server_config_matches(
+                preflight.paths, server_config
+            )
+            if server_restart_required:
+                _prepare_private_directory(preflight.paths.root)
+                atomic_json_write(
+                    preflight.paths.server_config,
+                    server_config,
+                    mode=0o600,
+                )
+                _write_ovcli_profile(preflight.paths.ovcli_config, reusable_endpoint)
+                self._emit(
+                    QuickLocalStage.WRITE_CONFIG,
+                    "Updated Quick Local's saved Hermes LLM settings; the running "
+                    "server must be restarted before it can use them.",
+                )
             self._emit(
                 QuickLocalStage.COMPLETE,
                 "Existing Quick Local server is reachable; reusing it.",
@@ -308,10 +335,8 @@ class QuickLocalSetup:
                 paths=preflight.paths,
                 endpoint=reusable_endpoint,
                 reused=True,
+                server_restart_required=server_restart_required,
             )
-
-        vlm = resolve_hermes_vlm_config()
-        self._ensure_openviking_installed(preflight.paths)
 
         port = find_available_port(
             preferred_endpoint=_configured_endpoint(preflight.paths)
@@ -441,17 +466,34 @@ class QuickLocalSetup:
                 paths.root.parent,
                 paths.server_command,
             )
+            primary_error: BaseException | None = None
             try:
-                if not _wait_for_health(endpoint, self._health_check):
+                if not _wait_for_health(
+                    endpoint,
+                    self._health_check,
+                    process=process,
+                ):
+                    returncode = process.poll()
+                    if returncode is not None:
+                        raise QuickLocalSetupError(
+                            "OpenViking exited before becoming reachable "
+                            f"(status {returncode}). Review the server log at "
+                            f"{_server_log_path(paths.root.parent)} and retry."
+                        )
                     raise QuickLocalSetupError(
-                        "OpenViking did not become reachable. Review the server "
-                        f"log at {_server_log_path(paths.root.parent)} and retry."
+                        "OpenViking did not become reachable before the local model "
+                        "preparation timeout. Review the server log at "
+                        f"{_server_log_path(paths.root.parent)} and retry."
                     )
+            except BaseException as exc:
+                primary_error = exc
+                raise
             finally:
                 if not _stop_process(process):
-                    raise QuickLocalSetupError(
-                        "The temporary OpenViking validation server could not be stopped."
-                    )
+                    message = "The temporary OpenViking validation server could not be stopped."
+                    if primary_error is None:
+                        raise QuickLocalSetupError(message)
+                    primary_error.add_note(message)
 
     def _emit(self, stage: QuickLocalStage, message: str) -> None:
         self._progress(QuickLocalProgress(stage=stage, message=message))
@@ -496,13 +538,19 @@ def find_available_port(
             *(port for port in candidates if port != preferred_port),
         ]
     for port in candidates:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
-                candidate.bind(("127.0.0.1", port))
+        if _can_bind_local_port("127.0.0.1", port):
             return port
-        except OSError:
-            continue
     return None
+
+
+def _can_bind_local_port(host: str, port: int) -> bool:
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as candidate:
+            candidate.bind((host, port))
+        return True
+    except OSError:
+        return False
 
 
 def find_reusable_endpoint(
@@ -556,6 +604,11 @@ def _start_validation_server(
         )
     command = str(server_command)
     host, port = _endpoint_bind(endpoint)
+    if not _can_bind_local_port(host, port):
+        raise QuickLocalSetupError(
+            f"Local port {host}:{port} became unavailable before OpenViking "
+            "could start. Retry Quick Local setup."
+        )
     log_path = _server_log_path(hermes_home)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     child_env = os.environ.copy()
@@ -609,6 +662,7 @@ def _wait_for_health(
     endpoint: str,
     health_check: HealthCheck,
     *,
+    process: Optional[subprocess.Popen] = None,
     timeout_seconds: float = _HEALTH_TIMEOUT_SECONDS,
 ) -> bool:
     deadline = time.monotonic() + timeout_seconds
@@ -616,6 +670,8 @@ def _wait_for_health(
         healthy, _message = health_check(endpoint)
         if healthy:
             return True
+        if process is not None and process.poll() is not None:
+            return False
         time.sleep(_HEALTH_POLL_INTERVAL_SECONDS)
     return False
 
@@ -639,24 +695,60 @@ def _stop_process(process: subprocess.Popen) -> bool:
         return False
 
 
-def _uses_noncopyable_credentials(provider: str, source: str, api_key: str) -> bool:
-    return (
-        "oauth" in source
-        or "key_cmd" in source
-        or provider
-        in {
-            "bedrock",
-            "copilot-acp",
-            "minimax-oauth",
-            "nous",
-            "openai-codex",
-            "qwen-oauth",
-            "vertex",
-            "xai-oauth",
-        }
-        or api_key.startswith("sk-ant-oat")
-        or api_key == "aws-sdk"
-    )
+def _has_copyable_static_credentials(
+    provider: str,
+    source: str,
+    api_key: str,
+) -> bool:
+    """Return whether Hermes explicitly classifies this credential as static."""
+
+    if not api_key or api_key.startswith("sk-ant-oat") or api_key == "aws-sdk":
+        return False
+
+    if provider == "custom":
+        return source in {"direct-alias", "env/config"} or source.startswith((
+            "custom_provider:",
+            "pool:",
+        ))
+    if provider == "openrouter":
+        return source == "env/config" or source.startswith((
+            "credential_pool:",
+            "env:",
+            "manual:",
+            "pool:",
+        ))
+
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    provider_config = PROVIDER_REGISTRY.get(provider)
+    if (
+        provider == "copilot"
+        or provider_config is None
+        or provider_config.auth_type != "api_key"
+    ):
+        return False
+
+    if source in {"config", "default", "env", "local-offline"}:
+        return True
+    api_key_sources = {value.lower() for value in provider_config.api_key_env_vars}
+    if source in api_key_sources:
+        return True
+    if source.startswith("env:"):
+        return source.removeprefix("env:") in api_key_sources
+    if source.startswith("credential_pool:"):
+        return source.removeprefix("credential_pool:") == provider
+    return source.startswith("manual:")
+
+
+def _stored_server_config_matches(
+    paths: QuickLocalPaths,
+    expected: Mapping[str, Any],
+) -> bool:
+    try:
+        saved = json.loads(paths.server_config.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return False
+    return saved == expected
 
 
 def _prepare_private_directory(path: Path) -> None:

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -1,0 +1,928 @@
+"""Reusable, non-interactive OpenViking Quick Local provisioning.
+
+User interfaces own prompts and rendering.  This module owns the bounded
+installation, Hermes-profile-scoped configuration, and temporary validation
+needed to produce a ready-to-link OpenViking CLI profile.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+from urllib.parse import urlparse
+from urllib.request import ProxyHandler, Request, build_opener
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from utils import atomic_json_write
+
+DEPLOYMENT = "quick_local"
+EMBEDDING_MODEL = "qwen3-embedding:0.6b"
+EMBEDDING_DIMENSION = 1024
+OPENVIKING_REQUIREMENT = "openviking>=0.4.16,<0.6"
+
+_OPENVIKING_VERSION_SPECIFIER = SpecifierSet(
+    OPENVIKING_REQUIREMENT.removeprefix("openviking")
+)
+_ROOT_DIRNAME = "openviking"
+_SERVER_CONFIG_FILENAME = "ov.conf"
+_OVCLI_CONFIG_FILENAME = "ovcli.conf"
+_WORKSPACE_DIRNAME = "data"
+_DEFAULT_PORT = 1933
+_PORT_ATTEMPTS = 20
+_MODEL_DOWNLOAD_SIZE = "approximately 639 MB"
+_HEALTH_TIMEOUT_SECONDS = 60.0
+_HEALTH_POLL_INTERVAL_SECONDS = 0.5
+_PROCESS_STOP_TIMEOUT_SECONDS = 10.0
+
+
+class QuickLocalStage(str, Enum):
+    PREFLIGHT = "preflight"
+    INSTALL_OPENVIKING = "install_openviking"
+    INSTALL_OLLAMA = "install_ollama"
+    START_OLLAMA = "start_ollama"
+    DOWNLOAD_MODEL = "download_model"
+    VALIDATE = "validate"
+    WRITE_CONFIG = "write_config"
+    COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class QuickLocalProgress:
+    stage: QuickLocalStage
+    message: str
+
+
+@dataclass(frozen=True)
+class QuickLocalPaths:
+    root: Path
+    runtime: Path
+    server_config: Path
+    ovcli_config: Path
+    workspace: Path
+
+    @property
+    def runtime_python(self) -> Path:
+        scripts = "Scripts" if os.name == "nt" else "bin"
+        executable = "python.exe" if os.name == "nt" else "python"
+        return self.runtime / scripts / executable
+
+    @property
+    def server_command(self) -> Path:
+        scripts = "Scripts" if os.name == "nt" else "bin"
+        executable = "openviking-server.exe" if os.name == "nt" else "openviking-server"
+        return self.runtime / scripts / executable
+
+
+@dataclass(frozen=True)
+class QuickLocalPreflight:
+    paths: QuickLocalPaths
+    reusable_endpoint: Optional[str]
+    ollama_install_required: bool
+
+
+@dataclass(frozen=True)
+class QuickLocalSetupResult:
+    paths: QuickLocalPaths
+    endpoint: str
+    reused: bool
+
+
+class QuickLocalSetupError(RuntimeError):
+    """Quick Local could not finish without partially activating it."""
+
+
+class OllamaInstallRequired(QuickLocalSetupError):
+    """Quick Local needs explicit permission to install Ollama."""
+
+
+ProgressReporter = Callable[[QuickLocalProgress], None]
+HealthCheck = Callable[[str], tuple[bool, str]]
+
+
+def managed_paths(hermes_home: Path) -> QuickLocalPaths:
+    root = Path(hermes_home).expanduser() / _ROOT_DIRNAME
+    return QuickLocalPaths(
+        root=root,
+        runtime=root / "runtime",
+        server_config=root / _SERVER_CONFIG_FILENAME,
+        ovcli_config=root / _OVCLI_CONFIG_FILENAME,
+        workspace=root / _WORKSPACE_DIRNAME,
+    )
+
+
+def managed_server_config_path(provider_config: Mapping[str, Any]) -> Optional[Path]:
+    if provider_config.get("deployment") != DEPLOYMENT:
+        return None
+    value = _clean_value(provider_config.get("server_config_path"))
+    return Path(value).expanduser() if value else None
+
+
+def managed_server_command_path(provider_config: Mapping[str, Any]) -> Optional[Path]:
+    if provider_config.get("deployment") != DEPLOYMENT:
+        return None
+    value = _clean_value(provider_config.get("server_command_path"))
+    return Path(value).expanduser() if value else None
+
+
+def clear_managed_settings(provider_config: dict[str, Any]) -> None:
+    provider_config.pop("deployment", None)
+    provider_config.pop("server_config_path", None)
+    provider_config.pop("server_command_path", None)
+
+
+def build_server_config(
+    paths: QuickLocalPaths,
+    vlm: Mapping[str, Any],
+    *,
+    port: int = _DEFAULT_PORT,
+) -> dict[str, Any]:
+    return {
+        "server": {"host": "127.0.0.1", "port": port},
+        "storage": {"workspace": str(paths.workspace)},
+        "embedding": {
+            "dense": {
+                "provider": "ollama",
+                "model": EMBEDDING_MODEL,
+                "api_base": "http://localhost:11434/v1",
+                "dimension": EMBEDDING_DIMENSION,
+                "input": "text",
+            }
+        },
+        "vlm": dict(vlm),
+    }
+
+
+def resolve_hermes_vlm_config() -> dict[str, Any]:
+    """Translate the active persisted Hermes LLM into OpenViking VLM config."""
+
+    from hermes_cli.config import load_config
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    config = load_config()
+    model_config = config.get("model", {}) if isinstance(config, Mapping) else {}
+    if isinstance(model_config, str):
+        model_config = {"default": model_config}
+    if not isinstance(model_config, Mapping):
+        model_config = {}
+
+    default_model = model_config.get("default")
+    requested_provider = _clean_value(model_config.get("provider")) or None
+    if isinstance(default_model, Mapping):
+        from hermes_cli.config import split_model_config_default
+
+        nested_model, nested_provider = split_model_config_default(default_model)
+        default_model = nested_model
+        requested_provider = requested_provider or nested_provider or None
+    model = _clean_value(
+        default_model or model_config.get("model") or model_config.get("name")
+    )
+    if not model:
+        raise QuickLocalSetupError("Hermes has no default LLM model configured.")
+
+    runtime = resolve_runtime_provider(
+        requested=requested_provider,
+        target_model=model,
+    )
+    runtime_model = _clean_value(runtime.get("model")) or model
+    provider = _clean_value(runtime.get("provider")).lower()
+    api_mode = _clean_value(runtime.get("api_mode")).lower()
+    source = _clean_value(runtime.get("source")).lower()
+    api_base = _clean_value(runtime.get("base_url"))
+    api_key = _clean_value(runtime.get("api_key"))
+
+    if _uses_noncopyable_credentials(provider, source, api_key):
+        raise QuickLocalSetupError(
+            "Hermes is using refreshed OAuth, cloud-native, or external-process "
+            "credentials that cannot be copied safely into OpenViking. Configure "
+            "a static API-key LLM for Hermes, or connect to an OpenViking server "
+            "configured separately."
+        )
+    if api_mode not in {"chat_completions", "anthropic_messages"}:
+        raise QuickLocalSetupError(
+            f"Hermes' {api_mode or 'unknown'} LLM transport is not supported by "
+            "Quick Local. Use an OpenAI-compatible or Anthropic-compatible "
+            "API-key provider, or connect to an OpenViking server configured "
+            "separately."
+        )
+    if not api_base:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve an API base URL."
+        )
+    if not api_key:
+        raise QuickLocalSetupError(
+            "Hermes' LLM provider did not resolve reusable static credentials."
+        )
+
+    if api_mode == "anthropic_messages":
+        if not runtime_model.startswith("anthropic/"):
+            runtime_model = f"anthropic/{runtime_model}"
+        vlm: dict[str, Any] = {
+            "provider": "litellm",
+            "model": runtime_model,
+            "api_key": api_key,
+            "api_base": api_base,
+        }
+    else:
+        vlm = {
+            "provider": "openai",
+            "model": runtime_model,
+            "api_key": api_key,
+            "api_base": api_base,
+        }
+
+    extra_headers = runtime.get("extra_headers")
+    if isinstance(extra_headers, dict) and extra_headers:
+        vlm["extra_headers"] = dict(extra_headers)
+    request_overrides = runtime.get("request_overrides")
+    if isinstance(request_overrides, dict):
+        extra_body = request_overrides.get("extra_body")
+        if isinstance(extra_body, dict) and extra_body:
+            vlm["extra_request_body"] = dict(extra_body)
+    vlm.update({"temperature": 0.0, "max_retries": 2})
+    return vlm
+
+
+class QuickLocalSetup:
+    """Provision one Hermes-home-scoped Quick Local configuration."""
+
+    def __init__(
+        self,
+        *,
+        health_check: HealthCheck,
+        progress: Optional[ProgressReporter] = None,
+    ) -> None:
+        self._health_check = health_check
+        self._progress = progress or (lambda _event: None)
+
+    def preflight(self, hermes_home: Path) -> QuickLocalPreflight:
+        self._emit(QuickLocalStage.PREFLIGHT, "Checking local requirements...")
+        paths = managed_paths(hermes_home)
+        reusable_endpoint = find_reusable_endpoint(paths, self._health_check)
+        return QuickLocalPreflight(
+            paths=paths,
+            reusable_endpoint=reusable_endpoint,
+            ollama_install_required=(
+                reusable_endpoint is None and not ollama_command_available()
+            ),
+        )
+
+    def provision(
+        self,
+        *,
+        hermes_home: Path,
+        allow_ollama_install: bool,
+        preflight: Optional[QuickLocalPreflight] = None,
+    ) -> QuickLocalSetupResult:
+        try:
+            return self._provision(
+                hermes_home=Path(hermes_home),
+                allow_ollama_install=allow_ollama_install,
+                preflight=preflight,
+            )
+        except QuickLocalSetupError:
+            raise
+        except Exception as exc:
+            raise QuickLocalSetupError(f"Quick Local setup failed: {exc}") from exc
+
+    def _provision(
+        self,
+        *,
+        hermes_home: Path,
+        allow_ollama_install: bool,
+        preflight: Optional[QuickLocalPreflight],
+    ) -> QuickLocalSetupResult:
+        preflight = preflight or self.preflight(hermes_home)
+        if preflight.paths != managed_paths(hermes_home):
+            raise QuickLocalSetupError(
+                "Quick Local preflight belongs to a different Hermes profile."
+            )
+        reusable_endpoint = find_reusable_endpoint(
+            preflight.paths,
+            self._health_check,
+        )
+        if reusable_endpoint:
+            self._emit(
+                QuickLocalStage.COMPLETE,
+                "Existing Quick Local server is reachable; reusing it.",
+            )
+            return QuickLocalSetupResult(
+                paths=preflight.paths,
+                endpoint=reusable_endpoint,
+                reused=True,
+            )
+
+        vlm = resolve_hermes_vlm_config()
+        self._ensure_openviking_installed(preflight.paths)
+        self._ensure_ollama(
+            paths=preflight.paths,
+            allow_install=allow_ollama_install,
+        )
+
+        port = find_available_port(
+            preferred_endpoint=_configured_endpoint(preflight.paths)
+        )
+        if port is None:
+            last_port = _DEFAULT_PORT + _PORT_ATTEMPTS - 1
+            raise QuickLocalSetupError(
+                "No available local port was found for OpenViking "
+                f"(checked {_DEFAULT_PORT}-{last_port})."
+            )
+        endpoint = f"http://127.0.0.1:{port}"
+        server_config = build_server_config(preflight.paths, vlm, port=port)
+
+        self._validate_generated_config(
+            paths=preflight.paths,
+            endpoint=endpoint,
+            server_config=server_config,
+        )
+
+        _prepare_private_directory(preflight.paths.root)
+        preflight.paths.workspace.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(preflight.paths.server_config, server_config, mode=0o600)
+        _write_ovcli_profile(preflight.paths.ovcli_config, endpoint)
+        self._emit(
+            QuickLocalStage.WRITE_CONFIG,
+            f"Saved Quick Local configuration to {preflight.paths.server_config}.",
+        )
+        self._emit(
+            QuickLocalStage.COMPLETE,
+            f"Quick Local is configured with {EMBEDDING_MODEL}.",
+        )
+        return QuickLocalSetupResult(
+            paths=preflight.paths,
+            endpoint=endpoint,
+            reused=False,
+        )
+
+    def _ensure_openviking_installed(self, paths: QuickLocalPaths) -> None:
+        if openviking_install_satisfies_requirement(paths):
+            return
+        self._emit(
+            QuickLocalStage.INSTALL_OPENVIKING,
+            f"Installing {OPENVIKING_REQUIREMENT}...",
+        )
+        try:
+            from hermes_cli.managed_uv import ensure_uv
+
+            uv = ensure_uv()
+            if not uv:
+                raise QuickLocalSetupError("uv is required to install OpenViking.")
+            _prepare_private_directory(paths.root)
+            install_env = os.environ.copy()
+            install_env["UV_NATIVE_TLS"] = "true"
+            install_env["UV_SYSTEM_CERTS"] = "true"
+            if not paths.runtime_python.is_file():
+                venv_result = subprocess.run(
+                    [uv, "venv", str(paths.runtime), "--python", sys.executable],
+                    cwd=paths.root,
+                    env=install_env,
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                    timeout=120,
+                )
+                if venv_result.returncode != 0:
+                    raise QuickLocalSetupError(
+                        "Could not create the private OpenViking environment."
+                    )
+            result = subprocess.run(
+                [
+                    uv,
+                    "pip",
+                    "install",
+                    "--python",
+                    str(paths.runtime_python),
+                    OPENVIKING_REQUIREMENT,
+                ],
+                cwd=paths.root,
+                env=install_env,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                timeout=600,
+            )
+        except Exception as exc:
+            if isinstance(exc, QuickLocalSetupError):
+                raise
+            raise QuickLocalSetupError(f"Could not install OpenViking: {exc}") from exc
+        if result.returncode != 0 or not openviking_install_satisfies_requirement(
+            paths
+        ):
+            raise QuickLocalSetupError(
+                "Could not install a compatible OpenViking version. Review the "
+                "installer output above."
+            )
+
+    def _ensure_ollama(
+        self,
+        *,
+        paths: QuickLocalPaths,
+        allow_install: bool,
+    ) -> None:
+        _add_windows_ollama_to_path()
+        if not ollama_command_available():
+            if not allow_install:
+                raise OllamaInstallRequired("Ollama is required for Quick Local.")
+            self._emit(QuickLocalStage.INSTALL_OLLAMA, "Installing Ollama...")
+            if not _install_ollama() or not ollama_command_available():
+                raise QuickLocalSetupError(
+                    "Ollama installation failed or the ollama command is not yet "
+                    "available. Install it manually, restart the terminal, and retry."
+                )
+
+        if not _ollama_running():
+            self._emit(QuickLocalStage.START_OLLAMA, "Starting Ollama...")
+            started, detail = _start_ollama(paths)
+            if not started:
+                raise QuickLocalSetupError(f"Ollama could not be started: {detail}")
+
+        if not _ollama_model_available(EMBEDDING_MODEL, _ollama_models()):
+            self._emit(
+                QuickLocalStage.DOWNLOAD_MODEL,
+                f"Downloading {EMBEDDING_MODEL} ({_MODEL_DOWNLOAD_SIZE})...",
+            )
+            if not _pull_ollama_model(EMBEDDING_MODEL):
+                raise QuickLocalSetupError(f"Could not download {EMBEDDING_MODEL}.")
+
+    def _validate_generated_config(
+        self,
+        *,
+        paths: QuickLocalPaths,
+        endpoint: str,
+        server_config: dict[str, Any],
+    ) -> None:
+        _prepare_private_directory(paths.root)
+        with tempfile.TemporaryDirectory(
+            prefix="setup-validation-", dir=paths.root
+        ) as root:
+            validation_root = Path(root)
+            validation_config = json.loads(json.dumps(server_config))
+            validation_config["storage"]["workspace"] = str(
+                validation_root / _WORKSPACE_DIRNAME
+            )
+            config_path = validation_root / _SERVER_CONFIG_FILENAME
+            atomic_json_write(config_path, validation_config, mode=0o600)
+
+            self._emit(
+                QuickLocalStage.VALIDATE,
+                "Validating OpenViking with a temporary local server...",
+            )
+            process = _start_validation_server(
+                endpoint,
+                config_path,
+                paths.root.parent,
+                paths.server_command,
+            )
+            try:
+                if not _wait_for_health(endpoint, self._health_check):
+                    raise QuickLocalSetupError(
+                        "OpenViking did not become reachable. Review the server "
+                        f"log at {_server_log_path(paths.root.parent)} and retry."
+                    )
+            finally:
+                if not _stop_process(process):
+                    raise QuickLocalSetupError(
+                        "The temporary OpenViking validation server could not be stopped."
+                    )
+
+    def _emit(self, stage: QuickLocalStage, message: str) -> None:
+        self._progress(QuickLocalProgress(stage=stage, message=message))
+
+
+def openviking_install_satisfies_requirement(paths: QuickLocalPaths) -> bool:
+    if not paths.runtime_python.is_file() or not paths.server_command.is_file():
+        return False
+    try:
+        result = subprocess.run(
+            [
+                str(paths.runtime_python),
+                "-c",
+                "import importlib.metadata; print(importlib.metadata.version('openviking'))",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return False
+        version = Version(result.stdout.strip())
+    except (InvalidVersion, OSError, subprocess.SubprocessError):
+        return False
+    return version in _OPENVIKING_VERSION_SPECIFIER
+
+
+def ollama_command_available() -> bool:
+    _add_windows_ollama_to_path()
+    return shutil.which("ollama") is not None
+
+
+def find_available_port(
+    *,
+    preferred_endpoint: Optional[str] = None,
+    first_port: int = _DEFAULT_PORT,
+    attempts: int = _PORT_ATTEMPTS,
+) -> Optional[int]:
+    preferred_port = _endpoint_port(preferred_endpoint)
+    candidates = range(first_port, first_port + attempts)
+    if preferred_port is not None and preferred_port in candidates:
+        candidates = [
+            preferred_port,
+            *(port for port in candidates if port != preferred_port),
+        ]
+    for port in candidates:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+                candidate.bind(("127.0.0.1", port))
+            return port
+        except OSError:
+            continue
+    return None
+
+
+def find_reusable_endpoint(
+    paths: QuickLocalPaths,
+    health_check: HealthCheck,
+) -> Optional[str]:
+    endpoint = _configured_endpoint(paths)
+    if endpoint is None:
+        return None
+    healthy, _message = health_check(endpoint)
+    return endpoint if healthy else None
+
+
+def _configured_endpoint(paths: QuickLocalPaths) -> Optional[str]:
+    if not paths.server_config.is_file() or not paths.ovcli_config.is_file():
+        return None
+    try:
+        server_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
+        storage = (
+            server_config.get("storage", {}) if isinstance(server_config, dict) else {}
+        )
+        if not isinstance(storage, dict) or not _paths_equivalent(
+            storage.get("workspace"), paths.workspace
+        ):
+            return None
+        profile = json.loads(paths.ovcli_config.read_text(encoding="utf-8"))
+        return _normalize_local_endpoint(
+            profile.get("url") if isinstance(profile, dict) else ""
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def _write_ovcli_profile(path: Path, endpoint: str) -> None:
+    atomic_json_write(
+        path,
+        {"url": endpoint, "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+
+
+def _start_validation_server(
+    endpoint: str,
+    config_path: Path,
+    hermes_home: Path,
+    server_command: Path,
+) -> subprocess.Popen:
+    if not server_command.is_file():
+        raise QuickLocalSetupError(
+            "openviking-server was not found after installation."
+        )
+    command = str(server_command)
+    host, port = _endpoint_bind(endpoint)
+    log_path = _server_log_path(hermes_home)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    child_env = os.environ.copy()
+    child_env.pop("PYTHONPATH", None)
+    from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+
+    popen_kwargs = windows_detach_popen_kwargs()
+    command_args = [
+        command,
+        "--config",
+        str(config_path),
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+    try:
+        with log_path.open("ab") as log_file:
+            common_kwargs = {
+                "stdout": log_file,
+                "stderr": log_file,
+                "env": child_env,
+            }
+            try:
+                return subprocess.Popen(
+                    command_args,
+                    **common_kwargs,
+                    **popen_kwargs,
+                    stdin=subprocess.DEVNULL,
+                )
+            except OSError:
+                if os.name != "nt":
+                    raise
+                from hermes_cli._subprocess_compat import (
+                    windows_detach_flags_without_breakaway,
+                )
+
+                return subprocess.Popen(
+                    command_args,
+                    **common_kwargs,
+                    creationflags=windows_detach_flags_without_breakaway(),
+                    stdin=subprocess.DEVNULL,
+                )
+    except Exception as exc:
+        raise QuickLocalSetupError(
+            f"Could not start the OpenViking validation server: {exc}"
+        ) from exc
+
+
+def _wait_for_health(
+    endpoint: str,
+    health_check: HealthCheck,
+    *,
+    timeout_seconds: float = _HEALTH_TIMEOUT_SECONDS,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        healthy, _message = health_check(endpoint)
+        if healthy:
+            return True
+        time.sleep(_HEALTH_POLL_INTERVAL_SECONDS)
+    return False
+
+
+def _stop_process(process: subprocess.Popen) -> bool:
+    try:
+        if process.poll() is not None:
+            return True
+        process.terminate()
+        process.wait(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+        return True
+    except subprocess.TimeoutExpired:
+        pass
+    except Exception:
+        return False
+    try:
+        process.kill()
+        process.wait(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+        return True
+    except Exception:
+        return False
+
+
+def _install_ollama() -> bool:
+    system = platform.system()
+    if system == "Darwin":
+        brew = shutil.which("brew")
+        if brew:
+            result = subprocess.run(
+                [brew, "install", "ollama"],
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.returncode == 0:
+                return True
+        return _run_ollama_shell_installer()
+    if system == "Linux":
+        return _run_ollama_shell_installer()
+    if system != "Windows":
+        return False
+    powershell = next(
+        (
+            executable
+            for name in ("powershell.exe", "powershell", "pwsh.exe", "pwsh")
+            if (executable := shutil.which(name))
+        ),
+        None,
+    )
+    if not powershell:
+        return False
+    result = subprocess.run(
+        _windows_ollama_install_command(powershell),
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    _add_windows_ollama_to_path()
+    return result.returncode == 0
+
+
+def _windows_ollama_install_command(powershell: str) -> list[str]:
+    return [
+        powershell,
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
+    ]
+
+
+def _run_ollama_shell_installer() -> bool:
+    result = subprocess.run(
+        ["bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh"],
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def _ollama_running() -> bool:
+    try:
+        request = Request("http://127.0.0.1:11434/api/tags", method="GET")
+        with build_opener(ProxyHandler({})).open(request, timeout=3):
+            return True
+    except (OSError, TimeoutError):
+        return False
+
+
+def _ollama_models() -> list[str]:
+    try:
+        request = Request("http://127.0.0.1:11434/api/tags", method="GET")
+        with build_opener(ProxyHandler({})).open(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        return [
+            str(model.get("name"))
+            for model in payload.get("models", [])
+            if isinstance(model, dict) and model.get("name")
+        ]
+    except (OSError, TimeoutError, json.JSONDecodeError, AttributeError):
+        return []
+
+
+def _ollama_model_available(model_name: str, available: list[str]) -> bool:
+    return any(
+        installed == model_name
+        or installed.startswith(f"{model_name}-")
+        or (":" not in model_name and installed.split(":", 1)[0] == model_name)
+        for installed in available
+    )
+
+
+def _pull_ollama_model(model_name: str) -> bool:
+    command = shutil.which("ollama")
+    if not command:
+        return False
+    try:
+        result = subprocess.run(
+            [command, "pull", model_name],
+            check=False,
+            stdin=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except OSError:
+        return False
+
+
+def _start_ollama(paths: QuickLocalPaths) -> tuple[bool, str]:
+    command = shutil.which("ollama")
+    if not command:
+        return False, "ollama command not found"
+    log_path = paths.root.parent / "logs" / "ollama.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+
+    try:
+        with log_path.open("ab") as log_file:
+            common_kwargs = {
+                "stdout": log_file,
+                "stderr": log_file,
+            }
+            try:
+                process = subprocess.Popen(
+                    [command, "serve"],
+                    **common_kwargs,
+                    **windows_detach_popen_kwargs(),
+                    stdin=subprocess.DEVNULL,
+                )
+            except OSError:
+                if os.name != "nt":
+                    raise
+                from hermes_cli._subprocess_compat import (
+                    windows_detach_flags_without_breakaway,
+                )
+
+                process = subprocess.Popen(
+                    [command, "serve"],
+                    **common_kwargs,
+                    creationflags=windows_detach_flags_without_breakaway(),
+                    stdin=subprocess.DEVNULL,
+                )
+    except OSError as exc:
+        return False, str(exc)
+
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if _ollama_running():
+            return True, "started"
+        if process.poll() is not None:
+            return False, f"ollama serve exited with status {process.returncode}"
+        time.sleep(_HEALTH_POLL_INTERVAL_SECONDS)
+    _stop_process(process)
+    return False, f"timed out; review {log_path}"
+
+
+def _add_windows_ollama_to_path() -> None:
+    if platform.system() != "Windows":
+        return
+    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+    if not local_app_data:
+        return
+    install_dir = Path(local_app_data) / "Programs" / "Ollama"
+    if not (install_dir / "ollama.exe").is_file():
+        return
+    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    if os.path.normcase(str(install_dir)) not in {
+        os.path.normcase(entry) for entry in entries
+    }:
+        os.environ["PATH"] = os.pathsep.join([str(install_dir), *entries])
+
+
+def _uses_noncopyable_credentials(provider: str, source: str, api_key: str) -> bool:
+    return (
+        "oauth" in source
+        or "key_cmd" in source
+        or provider
+        in {
+            "bedrock",
+            "copilot-acp",
+            "minimax-oauth",
+            "nous",
+            "openai-codex",
+            "qwen-oauth",
+            "vertex",
+            "xai-oauth",
+        }
+        or api_key.startswith("sk-ant-oat")
+        or api_key == "aws-sdk"
+    )
+
+
+def _prepare_private_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+
+
+def _server_log_path(hermes_home: Path) -> Path:
+    return hermes_home / "logs" / "openviking-server.log"
+
+
+def _normalize_local_endpoint(value: Any) -> Optional[str]:
+    endpoint = _clean_value(value).rstrip("/")
+    if not endpoint:
+        return None
+    if "://" not in endpoint:
+        endpoint = f"http://{endpoint}"
+    parsed = urlparse(endpoint)
+    if parsed.scheme.lower() != "http":
+        return None
+    if (parsed.hostname or "").lower() not in {"localhost", "127.0.0.1", "::1"}:
+        return None
+    host = f"[{parsed.hostname}]" if parsed.hostname == "::1" else parsed.hostname
+    return f"http://{host}:{parsed.port or _DEFAULT_PORT}"
+
+
+def _endpoint_bind(endpoint: str) -> tuple[str, int]:
+    parsed = urlparse(endpoint)
+    return parsed.hostname or "127.0.0.1", parsed.port or _DEFAULT_PORT
+
+
+def _endpoint_port(endpoint: Optional[str]) -> Optional[int]:
+    if not endpoint:
+        return None
+    try:
+        return urlparse(endpoint).port or _DEFAULT_PORT
+    except ValueError:
+        return None
+
+
+def _paths_equivalent(left: Any, right: Path) -> bool:
+    if not isinstance(left, (str, os.PathLike)):
+        return False
+    try:
+        return Path(left).expanduser().resolve() == right.expanduser().resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _clean_value(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/plugins/memory/openviking/quick_local.py
+++ b/plugins/memory/openviking/quick_local.py
@@ -35,6 +35,7 @@ _OPENVIKING_VERSION_SPECIFIER = _OPENVIKING_REQUIREMENT.specifier
 _ROOT_DIRNAME = "openviking"
 _SERVER_CONFIG_FILENAME = "ov.conf"
 _OVCLI_CONFIG_FILENAME = "ovcli.conf"
+_RESTART_REQUIRED_FILENAME = ".restart-required"
 _WORKSPACE_DIRNAME = "data"
 _MODEL_CACHE_DIRNAME = "models"
 _DEFAULT_PORT = 1933
@@ -84,6 +85,10 @@ class QuickLocalPaths:
         scripts = "Scripts" if os.name == "nt" else "bin"
         executable = "openviking-server.exe" if os.name == "nt" else "openviking-server"
         return self.runtime / scripts / executable
+
+    @property
+    def restart_required_marker(self) -> Path:
+        return self.root / _RESTART_REQUIRED_FILENAME
 
 
 @dataclass(frozen=True)
@@ -138,6 +143,25 @@ def clear_managed_settings(provider_config: dict[str, Any]) -> None:
     provider_config.pop("deployment", None)
     provider_config.pop("server_config_path", None)
     provider_config.pop("server_command_path", None)
+
+
+def clear_server_restart_required(server_config_path: Path) -> bool:
+    """Clear the durable marker once no stale managed server remains."""
+    marker = Path(server_config_path).with_name(_RESTART_REQUIRED_FILENAME)
+    try:
+        marker.unlink(missing_ok=True)
+        return True
+    except OSError:
+        return False
+
+
+def _mark_server_restart_required(paths: QuickLocalPaths) -> None:
+    _prepare_private_directory(paths.root)
+    atomic_json_write(
+        paths.restart_required_marker,
+        {"restart_required": True},
+        mode=0o600,
+    )
 
 
 def build_server_config(
@@ -319,8 +343,9 @@ class QuickLocalSetup:
             config_changed = not _stored_server_config_matches(
                 preflight.paths, server_config
             )
+            if runtime_changed or config_changed:
+                _mark_server_restart_required(preflight.paths)
             if config_changed:
-                _prepare_private_directory(preflight.paths.root)
                 atomic_json_write(
                     preflight.paths.server_config,
                     server_config,
@@ -340,7 +365,7 @@ class QuickLocalSetup:
                 paths=preflight.paths,
                 endpoint=reusable_endpoint,
                 reused=True,
-                server_restart_required=runtime_changed or config_changed,
+                server_restart_required=preflight.paths.restart_required_marker.is_file(),
             )
 
         port = find_available_port(
@@ -361,6 +386,10 @@ class QuickLocalSetup:
             server_config=server_config,
         )
 
+        if not clear_server_restart_required(preflight.paths.server_config):
+            raise QuickLocalSetupError(
+                "Could not clear Quick Local's stale restart marker."
+            )
         _prepare_private_directory(preflight.paths.root)
         preflight.paths.workspace.mkdir(parents=True, exist_ok=True)
         atomic_json_write(preflight.paths.server_config, server_config, mode=0o600)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -579,6 +579,37 @@ class TestImport:
             mode = (hermes_home / rel).stat().st_mode & 0o777
             assert mode == 0o600, f"{rel} restored with mode {oct(mode)}, expected 0o600"
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+    def test_restores_nested_provider_conf_and_directory_privately(
+        self, tmp_path, monkeypatch
+    ):
+        """A provider config may carry credentials even under a traversable home."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(mode=0o701)
+        hermes_home.chmod(0o701)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._make_backup_zip(
+            zip_path,
+            {
+                "config.yaml": "model: openrouter\n",
+                "openviking/ov.conf": '{"vlm":{"api_key":"secret"}}',
+                "openviking/ovcli.conf": '{"url":"http://127.0.0.1:1933"}',
+            },
+        )
+
+        from hermes_cli.backup import run_import
+
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        openviking_home = hermes_home / "openviking"
+        assert stat.S_IMODE(hermes_home.stat().st_mode) == 0o701
+        assert stat.S_IMODE(openviking_home.stat().st_mode) == 0o700
+        assert stat.S_IMODE((openviking_home / "ov.conf").stat().st_mode) == 0o600
+
 
 # ---------------------------------------------------------------------------
 # Round-trip test

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -610,6 +610,39 @@ class TestImport:
         assert stat.S_IMODE(openviking_home.stat().st_mode) == 0o700
         assert stat.S_IMODE((openviking_home / "ov.conf").stat().st_mode) == 0o600
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+    def test_restoring_other_ov_conf_does_not_tighten_its_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """Credential files stay private without changing unrelated directory access."""
+        hermes_home = tmp_path / ".hermes"
+        skill_dir = hermes_home / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True, mode=0o755)
+        skill_dir.chmod(0o755)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("# My skill\n", encoding="utf-8")
+        skill_file.chmod(0o644)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "backup.zip"
+        self._make_backup_zip(
+            zip_path,
+            {
+                "config.yaml": "model: openrouter\n",
+                "skills/my-skill/ov.conf": '{"vlm":{"api_key":"secret"}}',
+            },
+        )
+
+        from hermes_cli.backup import run_import
+
+        run_import(Namespace(zipfile=str(zip_path), force=True))
+
+        assert stat.S_IMODE(skill_dir.stat().st_mode) == 0o755
+        assert stat.S_IMODE(skill_file.stat().st_mode) == 0o644
+        assert stat.S_IMODE((skill_dir / "ov.conf").stat().st_mode) == 0o600
+
 
 # ---------------------------------------------------------------------------
 # Round-trip test

--- a/tests/plugins/memory/test_openviking_optional_peer.py
+++ b/tests/plugins/memory/test_openviking_optional_peer.py
@@ -147,7 +147,7 @@ def test_new_setup_does_not_ask_for_or_save_peer(
 
     def select(title, options, **kwargs):
         choices = {
-            "  OpenViking connection": 0 if credential == "service" else 1,
+            "  OpenViking connection": 0 if credential == "service" else 2,
             "  OpenViking credential": {"dev": 2, "user": 0, "root": 1}.get(
                 credential, 0
             ),

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -16,11 +16,12 @@ def _preflight(tmp_path: Path) -> quick_local.QuickLocalPreflight:
     return quick_local.QuickLocalPreflight(
         paths=quick_local.managed_paths(tmp_path),
         reusable_endpoint=None,
-        ollama_install_required=False,
     )
 
 
-def test_build_server_config_uses_profile_scoped_storage_and_qwen_embedding(tmp_path):
+def test_build_server_config_uses_profile_scoped_storage_and_local_embedding(
+    tmp_path,
+):
     paths = quick_local.managed_paths(tmp_path)
 
     config = quick_local.build_server_config(
@@ -39,11 +40,10 @@ def test_build_server_config_uses_profile_scoped_storage_and_qwen_embedding(tmp_
         "storage": {"workspace": str(tmp_path / "openviking" / "data")},
         "embedding": {
             "dense": {
-                "provider": "ollama",
-                "model": "qwen3-embedding:0.6b",
-                "api_base": "http://localhost:11434/v1",
-                "dimension": 1024,
-                "input": "text",
+                "provider": "local",
+                "model": "bge-small-zh-v1.5-f16",
+                "dimension": 512,
+                "cache_dir": str(tmp_path / "openviking" / "models"),
             }
         },
         "vlm": {
@@ -250,7 +250,7 @@ def test_openviking_install_is_bounded_and_isolated(tmp_path, monkeypatch):
         "install",
         "--python",
         str(paths.runtime_python),
-        "openviking>=0.4.16,<0.6",
+        "openviking[local-embed]>=0.4.16,<0.6",
     ]
     assert all(kwargs["cwd"] == paths.root for _command, kwargs in calls)
     assert all(kwargs["stdin"] is subprocess.DEVNULL for _command, kwargs in calls)
@@ -277,102 +277,46 @@ def test_openviking_install_failure_is_not_activated(tmp_path, monkeypatch):
         setup._ensure_openviking_installed(quick_local.managed_paths(tmp_path))
 
 
-def test_ollama_install_requires_caller_consent(tmp_path, monkeypatch):
-    monkeypatch.setattr(quick_local, "ollama_command_available", lambda: False)
-    install = MagicMock(side_effect=AssertionError("must not install without consent"))
-    monkeypatch.setattr(quick_local, "_install_ollama", install)
-    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
-
-    with pytest.raises(quick_local.OllamaInstallRequired):
-        setup._ensure_ollama(
-            paths=quick_local.managed_paths(tmp_path),
-            allow_install=False,
+def test_existing_openviking_without_local_embedding_runtime_is_not_reused(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.runtime_python.parent.mkdir(parents=True)
+    paths.runtime_python.touch()
+    paths.server_command.touch()
+    run = MagicMock(
+        return_value=SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="ModuleNotFoundError: No module named 'llama_cpp'",
         )
-
-    install.assert_not_called()
-
-
-def test_ollama_install_start_and_model_pull(tmp_path, monkeypatch):
-    available = iter([False, True])
-    events = []
-    monkeypatch.setattr(
-        quick_local, "ollama_command_available", lambda: next(available)
-    )
-    monkeypatch.setattr(
-        quick_local,
-        "_install_ollama",
-        lambda: events.append("install") or True,
-    )
-    monkeypatch.setattr(quick_local, "_ollama_running", lambda: False)
-    monkeypatch.setattr(
-        quick_local,
-        "_start_ollama",
-        lambda _paths: events.append("start") or (True, "started"),
-    )
-    monkeypatch.setattr(quick_local, "_ollama_models", lambda: [])
-    monkeypatch.setattr(quick_local, "_ollama_model_available", lambda *_args: False)
-    monkeypatch.setattr(
-        quick_local,
-        "_pull_ollama_model",
-        lambda model: events.append(("pull", model)) or True,
-    )
-    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
-
-    setup._ensure_ollama(
-        paths=quick_local.managed_paths(tmp_path),
-        allow_install=True,
-    )
-
-    assert events == [
-        "install",
-        "start",
-        ("pull", "qwen3-embedding:0.6b"),
-    ]
-
-
-def test_windows_ollama_install_command_uses_official_powershell_installer():
-    command = quick_local._windows_ollama_install_command("powershell.exe")
-
-    assert command == [
-        "powershell.exe",
-        "-NoLogo",
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-Command",
-        "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
-    ]
-
-
-def test_homebrew_ollama_install_does_not_inherit_stdin(monkeypatch):
-    run = MagicMock(return_value=SimpleNamespace(returncode=0))
-    monkeypatch.setattr(quick_local.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(
-        quick_local.shutil, "which", lambda _name: "/opt/homebrew/bin/brew"
     )
     monkeypatch.setattr(quick_local.subprocess, "run", run)
 
-    assert quick_local._install_ollama() is True
-    run.assert_called_once_with(
-        ["/opt/homebrew/bin/brew", "install", "ollama"],
-        check=False,
-        stdin=subprocess.DEVNULL,
-    )
+    assert quick_local.openviking_install_satisfies_requirement(paths) is False
+    assert "import llama_cpp" in run.call_args.args[0][2]
 
 
-def test_ollama_model_pull_does_not_inherit_stdin(monkeypatch):
-    run = MagicMock(return_value=SimpleNamespace(returncode=0))
+def test_existing_openviking_with_local_embedding_runtime_is_reused(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.runtime_python.parent.mkdir(parents=True)
+    paths.runtime_python.touch()
+    paths.server_command.touch()
     monkeypatch.setattr(
-        quick_local.shutil, "which", lambda _name: "/usr/local/bin/ollama"
+        quick_local.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="0.4.16\n",
+            stderr="",
+        ),
     )
-    monkeypatch.setattr(quick_local.subprocess, "run", run)
 
-    assert quick_local._pull_ollama_model("qwen3-embedding:0.6b") is True
-    run.assert_called_once_with(
-        ["/usr/local/bin/ollama", "pull", "qwen3-embedding:0.6b"],
-        check=False,
-        stdin=subprocess.DEVNULL,
-    )
+    assert quick_local.openviking_install_satisfies_requirement(paths) is True
 
 
 def test_validation_server_does_not_inherit_stdin(tmp_path, monkeypatch):
@@ -414,7 +358,6 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
         },
     )
     monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
-    monkeypatch.setattr(setup, "_ensure_ollama", lambda **_kwargs: None)
     monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1937)
 
     def start(endpoint, config_path, hermes_home, server_command):
@@ -434,7 +377,6 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
 
     result = setup.provision(
         hermes_home=tmp_path,
-        allow_ollama_install=False,
         preflight=_preflight(tmp_path),
     )
 
@@ -444,16 +386,22 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
     final_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
     assert final_config["storage"]["workspace"] == str(paths.workspace)
     assert final_config["server"]["port"] == 1937
+    assert final_config["embedding"]["dense"]["cache_dir"] == str(paths.model_cache)
     assert validation_configs[0]["storage"]["workspace"] != str(paths.workspace)
+    assert validation_configs[0]["embedding"]["dense"]["cache_dir"] == str(
+        paths.model_cache
+    )
     assert json.loads(paths.ovcli_config.read_text(encoding="utf-8")) == {
         "url": "http://127.0.0.1:1937",
         "actor_peer_id": "hermes",
     }
     if os.name != "nt":
         assert stat.S_IMODE(paths.root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(paths.model_cache.stat().st_mode) == 0o700
         assert stat.S_IMODE(paths.server_config.stat().st_mode) == 0o600
         assert stat.S_IMODE(paths.ovcli_config.stat().st_mode) == 0o600
     stop.assert_called_once_with(process)
+    assert quick_local.QuickLocalStage.PREPARE_EMBEDDING in events
     assert quick_local.QuickLocalStage.VALIDATE in events
     assert events[-2:] == [
         quick_local.QuickLocalStage.WRITE_CONFIG,
@@ -477,7 +425,6 @@ def test_failed_validation_stops_child_and_leaves_profile_inactive(
         },
     )
     monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
-    monkeypatch.setattr(setup, "_ensure_ollama", lambda **_kwargs: None)
     monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1933)
     monkeypatch.setattr(
         quick_local,
@@ -493,7 +440,6 @@ def test_failed_validation_stops_child_and_leaves_profile_inactive(
     ):
         setup.provision(
             hermes_home=tmp_path,
-            allow_ollama_install=False,
             preflight=_preflight(tmp_path),
         )
 
@@ -604,7 +550,7 @@ def test_setup_menu_keeps_cloud_custom_paths_and_adds_quick_local(
                 ),
                 (
                     "Quick Local Setup",
-                    "Set up OpenViking and Ollama on this device",
+                    "Set up OpenViking with built-in local embeddings",
                 ),
                 (
                     "Connect to an existing server",
@@ -614,43 +560,6 @@ def test_setup_menu_keeps_cloud_custom_paths_and_adds_quick_local(
         )
     ]
     quick_setup.assert_called_once()
-
-
-def test_quick_local_cli_cancellation_before_ollama_install_changes_nothing(
-    tmp_path,
-    monkeypatch,
-):
-    paths = quick_local.managed_paths(tmp_path)
-
-    class FakeSetup:
-        def __init__(self, **_kwargs):
-            pass
-
-        def preflight(self, _home):
-            return quick_local.QuickLocalPreflight(
-                paths=paths,
-                reusable_endpoint=None,
-                ollama_install_required=True,
-            )
-
-        def provision(self, **_kwargs):
-            raise AssertionError("cancelled setup must not provision")
-
-    monkeypatch.setattr(quick_local, "QuickLocalSetup", FakeSetup)
-    provider_config = {}
-    config = {"memory": {}}
-
-    result = openviking_module._run_quick_local_setup(
-        select=lambda *args, **kwargs: -1,
-        cancelled=-1,
-        config=config,
-        provider_config=provider_config,
-        env_path=tmp_path / ".env",
-    )
-
-    assert result is openviking_module._SETUP_CANCELLED
-    assert provider_config == {}
-    assert config == {"memory": {}}
 
 
 def test_quick_local_cli_links_private_profile_and_runtime_config(
@@ -666,7 +575,6 @@ def test_quick_local_cli_links_private_profile_and_runtime_config(
             return quick_local.QuickLocalPreflight(
                 paths=paths,
                 reusable_endpoint=None,
-                ollama_install_required=False,
             )
 
         def provision(self, **_kwargs):
@@ -681,8 +589,6 @@ def test_quick_local_cli_links_private_profile_and_runtime_config(
     provider_config = {}
 
     result = openviking_module._run_quick_local_setup(
-        select=MagicMock(),
-        cancelled=-1,
         config=config,
         provider_config=provider_config,
         env_path=tmp_path / ".env",

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -748,6 +748,36 @@ def test_quick_local_profile_is_not_overridden_by_process_environment(
     assert settings["agent"] == "hermes"
 
 
+def test_quick_local_status_hides_only_ignored_environment_overrides(
+    tmp_path, monkeypatch
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:1998")
+
+    status = OpenVikingMemoryProvider().get_status_config({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(paths.ovcli_config),
+        "deployment": quick_local.DEPLOYMENT,
+    })
+
+    assert status["endpoint"] == "http://127.0.0.1:1938"
+    assert "env_overrides" not in status
+
+    self_managed_status = OpenVikingMemoryProvider().get_status_config({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(paths.ovcli_config),
+    })
+
+    assert self_managed_status["endpoint"] == "http://127.0.0.1:1998"
+    assert self_managed_status["env_overrides"] == "OPENVIKING_ENDPOINT"
+
+
 def test_incomplete_quick_local_profile_does_not_fall_back_to_environment(
     tmp_path, monkeypatch
 ):

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -176,7 +176,7 @@ def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
                 "api_key": lambda: "short-lived",
                 "source": "key_cmd",
             },
-            "cannot be copied safely",
+            "did not resolve reusable static credentials",
         ),
         (
             {
@@ -233,6 +233,45 @@ def test_resolve_vlm_rejects_credentials_or_transports_openviking_cannot_reuse(
         quick_local.resolve_hermes_vlm_config()
 
 
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("api_key", "did not resolve reusable static credentials"),
+        ("base_url", "did not resolve an API base URL"),
+    ],
+)
+@pytest.mark.parametrize("missing_value", [None, "", " \t "])
+def test_resolve_vlm_reports_missing_fields_before_classifying_credentials(
+    field, message, missing_value, monkeypatch
+):
+    from hermes_cli import config as config_module
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {"model": {"provider": "custom", "default": "model-1"}},
+    )
+    runtime = {
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "base_url": "https://llm.example/v1",
+        "api_key": "secret",
+        "source": "env/config",
+        field: missing_value,
+    }
+    monkeypatch.setattr(
+        runtime_provider, "resolve_runtime_provider", lambda **_kwargs: runtime
+    )
+    classify = MagicMock(wraps=quick_local._has_copyable_static_credentials)
+    monkeypatch.setattr(quick_local, "_has_copyable_static_credentials", classify)
+
+    with pytest.raises(quick_local.QuickLocalSetupError, match=message):
+        quick_local.resolve_hermes_vlm_config()
+
+    classify.assert_not_called()
+
+
 def test_openviking_install_is_bounded_and_isolated(tmp_path, monkeypatch):
     from hermes_cli import managed_uv
 
@@ -255,7 +294,7 @@ def test_openviking_install_is_bounded_and_isolated(tmp_path, monkeypatch):
     setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
     paths = quick_local.managed_paths(tmp_path)
 
-    setup._ensure_openviking_installed(paths)
+    assert setup._ensure_openviking_installed(paths) is True
 
     assert calls[0][0] == [
         "/usr/local/bin/uv",
@@ -410,7 +449,7 @@ def test_reuse_rechecks_runtime_and_refreshes_saved_vlm(tmp_path, monkeypatch):
     setup = quick_local.QuickLocalSetup(
         health_check=lambda _endpoint: (True, ""),
     )
-    ensure_runtime = MagicMock()
+    ensure_runtime = MagicMock(return_value=False)
     monkeypatch.setattr(setup, "_ensure_openviking_installed", ensure_runtime)
 
     result = setup.provision(hermes_home=tmp_path)
@@ -423,6 +462,68 @@ def test_reuse_rechecks_runtime_and_refreshes_saved_vlm(tmp_path, monkeypatch):
     )
     resolve.assert_called_once_with()
     ensure_runtime.assert_called_once_with(paths)
+
+
+@pytest.mark.parametrize("runtime_current", [False, True])
+def test_reuse_with_unchanged_config_requires_restart_only_after_runtime_upgrade(
+    tmp_path, monkeypatch, runtime_current
+):
+    from hermes_cli import managed_uv
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        json.dumps({
+            "model": {"provider": "custom:quick-local-test", "default": "model-1"},
+            "custom_providers": [
+                {
+                    "name": "quick-local-test",
+                    "base_url": "https://llm.example/v1",
+                    "api_key": "secret",
+                    "api_mode": "chat_completions",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+    paths = quick_local.managed_paths(tmp_path)
+    paths.runtime_python.parent.mkdir(parents=True)
+    paths.runtime_python.touch()
+    paths.server_command.touch()
+    vlm = quick_local.resolve_hermes_vlm_config()
+    assert vlm["model"] == "model-1"
+    assert vlm["api_key"] == "secret"
+    server_config = quick_local.build_server_config(paths, vlm, port=1938)
+    quick_local.atomic_json_write(paths.server_config, server_config, mode=0o600)
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    compatible = MagicMock(side_effect=[runtime_current, True])
+    monkeypatch.setattr(
+        quick_local, "openviking_install_satisfies_requirement", compatible
+    )
+    ensure_uv = MagicMock(return_value="/usr/local/bin/uv")
+    monkeypatch.setattr(managed_uv, "ensure_uv", ensure_uv)
+    install = MagicMock(return_value=SimpleNamespace(returncode=0))
+    monkeypatch.setattr(quick_local.subprocess, "run", install)
+    write = MagicMock(wraps=quick_local.atomic_json_write)
+    monkeypatch.setattr(quick_local, "atomic_json_write", write)
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+
+    result = setup.provision(hermes_home=tmp_path)
+
+    assert result.reused is True
+    assert result.endpoint == "http://127.0.0.1:1938"
+    assert result.server_restart_required is (not runtime_current)
+    assert json.loads(paths.server_config.read_text(encoding="utf-8")) == server_config
+    write.assert_not_called()
+    if runtime_current:
+        ensure_uv.assert_not_called()
+        install.assert_not_called()
+    else:
+        ensure_uv.assert_called_once_with()
+        install.assert_called_once()
 
 
 def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkeypatch):
@@ -443,7 +544,7 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
             "api_base": "https://llm.example/v1",
         },
     )
-    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
+    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: True)
     monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1937)
 
     def start(endpoint, config_path, hermes_home, server_command):
@@ -469,6 +570,7 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
     paths = result.paths
     assert result.endpoint == "http://127.0.0.1:1937"
     assert result.reused is False
+    assert result.server_restart_required is False
     final_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
     assert final_config["storage"]["workspace"] == str(paths.workspace)
     assert final_config["server"]["port"] == 1937
@@ -511,7 +613,7 @@ def test_failed_validation_stops_child_and_leaves_profile_inactive(
             "api_base": "https://llm.example/v1",
         },
     )
-    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
+    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: True)
     monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1933)
     monkeypatch.setattr(
         quick_local,
@@ -792,10 +894,10 @@ def test_quick_local_cli_reports_when_running_server_needs_restart(
     )
 
     output = capsys.readouterr().out
-    assert "Quick Local settings were updated" in output
-    assert "still using the previous Hermes LLM settings" in output
+    assert "Quick Local restart required" in output
+    assert "updated runtime or Hermes LLM settings" in output
     assert "Stop the Quick Local server at http://127.0.0.1:1933" in output
-    assert "Hermes will restart it with the updated settings" in output
+    assert "Hermes will restart it with the updated runtime and settings" in output
     assert "OpenViking memory is ready" not in output
 
 

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -112,7 +112,7 @@ def test_resolve_vlm_maps_anthropic_transport(monkeypatch):
             "api_mode": "anthropic_messages",
             "base_url": "https://api.anthropic.com",
             "api_key": "secret",
-            "source": "environment",
+            "source": "env",
             "model": "claude-sonnet",
         },
     )
@@ -180,11 +180,31 @@ def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
         ),
         (
             {
-                "provider": "openai",
+                "provider": "copilot",
+                "api_mode": "chat_completions",
+                "base_url": "https://api.githubcopilot.com",
+                "api_key": "short-lived-exchanged-token",
+                "source": "GH_TOKEN",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "future-oauth-provider",
+                "api_mode": "chat_completions",
+                "base_url": "https://llm.example/v1",
+                "api_key": "short-lived",
+                "source": "future-credential-store",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "openai-api",
                 "api_mode": "codex_responses",
                 "base_url": "https://api.openai.com/v1",
                 "api_key": "secret",
-                "source": "environment",
+                "source": "OPENAI_API_KEY",
             },
             "transport is not supported",
         ),
@@ -327,6 +347,7 @@ def test_validation_server_does_not_inherit_stdin(tmp_path, monkeypatch):
     process = MagicMock()
     popen = MagicMock(return_value=process)
     monkeypatch.setattr(quick_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(quick_local, "_can_bind_local_port", lambda *_args: True)
 
     result = quick_local._start_validation_server(
         "http://127.0.0.1:1933",
@@ -337,6 +358,71 @@ def test_validation_server_does_not_inherit_stdin(tmp_path, monkeypatch):
 
     assert result is process
     assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+
+def test_validation_server_rechecks_selected_port_before_start(tmp_path, monkeypatch):
+    server_command = tmp_path / "openviking-server"
+    server_command.write_text("", encoding="utf-8")
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text("{}", encoding="utf-8")
+    popen = MagicMock()
+    monkeypatch.setattr(quick_local.subprocess, "Popen", popen)
+    monkeypatch.setattr(quick_local, "_can_bind_local_port", lambda *_args: False)
+
+    with pytest.raises(quick_local.QuickLocalSetupError, match="became unavailable"):
+        quick_local._start_validation_server(
+            "http://127.0.0.1:1933",
+            config_path,
+            tmp_path,
+            server_command,
+        )
+
+    popen.assert_not_called()
+
+
+def test_reuse_rechecks_runtime_and_refreshes_saved_vlm(tmp_path, monkeypatch):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    old_vlm = {
+        "provider": "openai",
+        "model": "old-model",
+        "api_key": "old-secret",
+        "api_base": "https://old.example/v1",
+    }
+    quick_local.atomic_json_write(
+        paths.server_config,
+        quick_local.build_server_config(paths, old_vlm, port=1938),
+        mode=0o600,
+    )
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    new_vlm = {
+        "provider": "openai",
+        "model": "new-model",
+        "api_key": "new-secret",
+        "api_base": "https://new.example/v1",
+    }
+    resolve = MagicMock(return_value=new_vlm)
+    monkeypatch.setattr(quick_local, "resolve_hermes_vlm_config", resolve)
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+    )
+    ensure_runtime = MagicMock()
+    monkeypatch.setattr(setup, "_ensure_openviking_installed", ensure_runtime)
+
+    result = setup.provision(hermes_home=tmp_path)
+
+    assert result.reused is True
+    assert result.endpoint == "http://127.0.0.1:1938"
+    assert result.server_restart_required is True
+    assert json.loads(paths.server_config.read_text(encoding="utf-8")) == (
+        quick_local.build_server_config(paths, new_vlm, port=1938)
+    )
+    resolve.assert_called_once_with()
+    ensure_runtime.assert_called_once_with(paths)
 
 
 def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkeypatch):
@@ -413,6 +499,7 @@ def test_failed_validation_stops_child_and_leaves_profile_inactive(
     tmp_path, monkeypatch
 ):
     process = MagicMock()
+    process.poll.return_value = None
     setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (False, "down"))
     monkeypatch.setattr(
         quick_local,
@@ -447,6 +534,46 @@ def test_failed_validation_stops_child_and_leaves_profile_inactive(
     assert not paths.server_config.exists()
     assert not paths.ovcli_config.exists()
     stop.assert_called_once_with(process)
+
+
+def test_validation_preserves_primary_error_when_cleanup_also_fails(
+    tmp_path, monkeypatch
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    process = MagicMock()
+    process.poll.return_value = None
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (False, "down"))
+    monkeypatch.setattr(
+        quick_local,
+        "_start_validation_server",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(quick_local, "_wait_for_health", lambda *args, **kwargs: False)
+    monkeypatch.setattr(quick_local, "_stop_process", lambda _process: False)
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError,
+        match="did not become reachable",
+    ) as exc_info:
+        setup._validate_generated_config(
+            paths=paths,
+            endpoint="http://127.0.0.1:1933",
+            server_config=quick_local.build_server_config(
+                paths,
+                {
+                    "provider": "openai",
+                    "model": "model-1",
+                    "api_key": "secret",
+                    "api_base": "https://llm.example/v1",
+                },
+            ),
+        )
+
+    assert any(
+        "could not be stopped" in note
+        for note in getattr(exc_info.value, "__notes__", [])
+    )
 
 
 def test_preflight_reuses_only_healthy_profile_with_managed_workspace(tmp_path):
@@ -514,6 +641,31 @@ def test_validation_stop_force_kills_only_after_graceful_timeout():
 
     process.terminate.assert_called_once_with()
     process.kill.assert_called_once_with()
+
+
+def test_health_wait_budget_covers_openviking_model_download():
+    assert (
+        quick_local._HEALTH_TIMEOUT_SECONDS
+        > quick_local._MODEL_PREPARATION_TIMEOUT_SECONDS
+    )
+
+
+def test_health_wait_stops_as_soon_as_validation_process_exits():
+    process = MagicMock()
+    process.poll.return_value = 1
+    health = MagicMock(return_value=(False, "down"))
+
+    assert (
+        quick_local._wait_for_health(
+            "http://127.0.0.1:1933",
+            health,
+            process=process,
+            timeout_seconds=60,
+        )
+        is False
+    )
+
+    health.assert_called_once_with("http://127.0.0.1:1933")
 
 
 def test_setup_menu_keeps_cloud_custom_paths_and_adds_quick_local(
@@ -603,6 +755,48 @@ def test_quick_local_cli_links_private_profile_and_runtime_config(
         "server_config_path": str(paths.server_config),
         "server_command_path": str(paths.server_command),
     }
+
+
+def test_quick_local_cli_reports_when_running_server_needs_restart(
+    tmp_path, monkeypatch, capsys
+):
+    paths = quick_local.managed_paths(tmp_path)
+
+    class FakeSetup:
+        def __init__(self, **_kwargs):
+            pass
+
+        def preflight(self, _home):
+            return quick_local.QuickLocalPreflight(
+                paths=paths,
+                reusable_endpoint="http://127.0.0.1:1933",
+            )
+
+        def provision(self, **_kwargs):
+            return quick_local.QuickLocalSetupResult(
+                paths=paths,
+                endpoint="http://127.0.0.1:1933",
+                reused=True,
+                server_restart_required=True,
+            )
+
+    monkeypatch.setattr(quick_local, "QuickLocalSetup", FakeSetup)
+
+    assert (
+        openviking_module._run_quick_local_setup(
+            config={"memory": {}},
+            provider_config={},
+            env_path=tmp_path / ".env",
+        )
+        is True
+    )
+
+    output = capsys.readouterr().out
+    assert "Quick Local settings were updated" in output
+    assert "still using the previous Hermes LLM settings" in output
+    assert "Stop the Quick Local server at http://127.0.0.1:1933" in output
+    assert "Hermes will restart it with the updated settings" in output
+    assert "OpenViking memory is ready" not in output
 
 
 def test_linking_a_self_managed_profile_clears_quick_local_runtime_settings(tmp_path):

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -173,10 +173,10 @@ def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
                 "provider": "custom",
                 "api_mode": "chat_completions",
                 "base_url": "https://llm.example/v1",
-                "api_key": lambda: "short-lived",
+                "api_key": lambda: pytest.fail("Setup must not execute key commands"),
                 "source": "key_cmd",
             },
-            "did not resolve reusable static credentials",
+            "cannot be copied safely",
         ),
         (
             {
@@ -207,6 +207,36 @@ def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
                 "source": "OPENAI_API_KEY",
             },
             "transport is not supported",
+        ),
+        (
+            {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": "https://llm.example/v1",
+                "api_key": False,
+                "source": "env/config",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": {"url": "https://llm.example/v1"},
+                "api_key": "secret",
+                "source": "env/config",
+            },
+            "API base URL must be a string",
+        ),
+        (
+            {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": False,
+                "api_key": "secret",
+                "source": "env/config",
+            },
+            "API base URL must be a string",
         ),
     ],
 )

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -1,0 +1,872 @@
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import plugins.memory.openviking as openviking_module
+from plugins.memory.openviking import OpenVikingMemoryProvider, quick_local
+
+
+def _preflight(tmp_path: Path) -> quick_local.QuickLocalPreflight:
+    return quick_local.QuickLocalPreflight(
+        paths=quick_local.managed_paths(tmp_path),
+        reusable_endpoint=None,
+        ollama_install_required=False,
+    )
+
+
+def test_build_server_config_uses_profile_scoped_storage_and_qwen_embedding(tmp_path):
+    paths = quick_local.managed_paths(tmp_path)
+
+    config = quick_local.build_server_config(
+        paths,
+        {
+            "provider": "openai",
+            "model": "model-1",
+            "api_key": "secret",
+            "api_base": "https://llm.example/v1",
+        },
+        port=1941,
+    )
+
+    assert config == {
+        "server": {"host": "127.0.0.1", "port": 1941},
+        "storage": {"workspace": str(tmp_path / "openviking" / "data")},
+        "embedding": {
+            "dense": {
+                "provider": "ollama",
+                "model": "qwen3-embedding:0.6b",
+                "api_base": "http://localhost:11434/v1",
+                "dimension": 1024,
+                "input": "text",
+            }
+        },
+        "vlm": {
+            "provider": "openai",
+            "model": "model-1",
+            "api_key": "secret",
+            "api_base": "https://llm.example/v1",
+        },
+    }
+
+
+def test_resolve_vlm_uses_one_persisted_hermes_model_source(monkeypatch):
+    from hermes_cli import config as config_module
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {"model": {"provider": "custom:test", "default": "saved-model"}},
+    )
+    resolver = MagicMock(
+        return_value={
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://llm.example/v1",
+            "api_key": "secret",
+            "source": "custom_provider:test",
+            "extra_headers": {"X-Tenant": "tenant"},
+            "request_overrides": {"extra_body": {"thinking": {"type": "disabled"}}},
+        }
+    )
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", resolver)
+
+    vlm = quick_local.resolve_hermes_vlm_config()
+
+    resolver.assert_called_once_with(
+        requested="custom:test",
+        target_model="saved-model",
+    )
+    assert vlm == {
+        "provider": "openai",
+        "model": "saved-model",
+        "api_key": "secret",
+        "api_base": "https://llm.example/v1",
+        "extra_headers": {"X-Tenant": "tenant"},
+        "extra_request_body": {"thinking": {"type": "disabled"}},
+        "temperature": 0.0,
+        "max_retries": 2,
+    }
+
+
+def test_resolve_vlm_maps_anthropic_transport(monkeypatch):
+    from hermes_cli import config as config_module
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {"model": {"provider": "anthropic", "default": "claude-sonnet"}},
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "secret",
+            "source": "environment",
+            "model": "claude-sonnet",
+        },
+    )
+
+    vlm = quick_local.resolve_hermes_vlm_config()
+
+    assert vlm["provider"] == "litellm"
+    assert vlm["model"] == "anthropic/claude-sonnet"
+    assert vlm["api_base"] == "https://api.anthropic.com"
+
+
+def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
+    from hermes_cli import config as config_module
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "model": {"default": {"provider": "custom:corp", "model": "corp-model"}}
+        },
+    )
+    resolver = MagicMock(
+        return_value={
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://llm.example/v1",
+            "api_key": "secret",
+            "source": "custom_provider:corp",
+        }
+    )
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", resolver)
+
+    vlm = quick_local.resolve_hermes_vlm_config()
+
+    resolver.assert_called_once_with(
+        requested="custom:corp",
+        target_model="corp-model",
+    )
+    assert vlm["model"] == "corp-model"
+
+
+@pytest.mark.parametrize(
+    ("runtime", "message"),
+    [
+        (
+            {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "short-lived",
+                "source": "oauth",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": "https://llm.example/v1",
+                "api_key": lambda: "short-lived",
+                "source": "key_cmd",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "openai",
+                "api_mode": "codex_responses",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "secret",
+                "source": "environment",
+            },
+            "transport is not supported",
+        ),
+    ],
+)
+def test_resolve_vlm_rejects_credentials_or_transports_openviking_cannot_reuse(
+    runtime,
+    message,
+    monkeypatch,
+):
+    from hermes_cli import config as config_module
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {"model": {"provider": "openai", "default": "model-1"}},
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: runtime,
+    )
+
+    with pytest.raises(quick_local.QuickLocalSetupError, match=message):
+        quick_local.resolve_hermes_vlm_config()
+
+
+def test_openviking_install_is_bounded_and_isolated(tmp_path, monkeypatch):
+    from hermes_cli import managed_uv
+
+    installed = iter([False, True])
+    monkeypatch.setattr(
+        quick_local,
+        "openviking_install_satisfies_requirement",
+        lambda _paths: next(installed),
+    )
+    monkeypatch.setattr(managed_uv, "ensure_uv", lambda: "/usr/local/bin/uv")
+    calls = []
+
+    def run_isolated(command, **kwargs):
+        calls.append((command, kwargs))
+        assert kwargs["env"]["UV_NATIVE_TLS"] == "true"
+        assert kwargs["env"]["UV_SYSTEM_CERTS"] == "true"
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(quick_local.subprocess, "run", run_isolated)
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+    paths = quick_local.managed_paths(tmp_path)
+
+    setup._ensure_openviking_installed(paths)
+
+    assert calls[0][0] == [
+        "/usr/local/bin/uv",
+        "venv",
+        str(paths.runtime),
+        "--python",
+        quick_local.sys.executable,
+    ]
+    assert calls[1][0] == [
+        "/usr/local/bin/uv",
+        "pip",
+        "install",
+        "--python",
+        str(paths.runtime_python),
+        "openviking>=0.4.16,<0.6",
+    ]
+    assert all(kwargs["cwd"] == paths.root for _command, kwargs in calls)
+    assert all(kwargs["stdin"] is subprocess.DEVNULL for _command, kwargs in calls)
+
+
+def test_openviking_install_failure_is_not_activated(tmp_path, monkeypatch):
+    from hermes_cli import managed_uv
+
+    monkeypatch.setattr(
+        quick_local,
+        "openviking_install_satisfies_requirement",
+        lambda _paths: False,
+    )
+    monkeypatch.setattr(managed_uv, "ensure_uv", lambda: "/usr/local/bin/uv")
+    results = iter([SimpleNamespace(returncode=0), SimpleNamespace(returncode=1)])
+    monkeypatch.setattr(
+        quick_local.subprocess,
+        "run",
+        lambda *args, **kwargs: next(results),
+    )
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+
+    with pytest.raises(quick_local.QuickLocalSetupError, match="compatible OpenViking"):
+        setup._ensure_openviking_installed(quick_local.managed_paths(tmp_path))
+
+
+def test_ollama_install_requires_caller_consent(tmp_path, monkeypatch):
+    monkeypatch.setattr(quick_local, "ollama_command_available", lambda: False)
+    install = MagicMock(side_effect=AssertionError("must not install without consent"))
+    monkeypatch.setattr(quick_local, "_install_ollama", install)
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+
+    with pytest.raises(quick_local.OllamaInstallRequired):
+        setup._ensure_ollama(
+            paths=quick_local.managed_paths(tmp_path),
+            allow_install=False,
+        )
+
+    install.assert_not_called()
+
+
+def test_ollama_install_start_and_model_pull(tmp_path, monkeypatch):
+    available = iter([False, True])
+    events = []
+    monkeypatch.setattr(
+        quick_local, "ollama_command_available", lambda: next(available)
+    )
+    monkeypatch.setattr(
+        quick_local,
+        "_install_ollama",
+        lambda: events.append("install") or True,
+    )
+    monkeypatch.setattr(quick_local, "_ollama_running", lambda: False)
+    monkeypatch.setattr(
+        quick_local,
+        "_start_ollama",
+        lambda _paths: events.append("start") or (True, "started"),
+    )
+    monkeypatch.setattr(quick_local, "_ollama_models", lambda: [])
+    monkeypatch.setattr(quick_local, "_ollama_model_available", lambda *_args: False)
+    monkeypatch.setattr(
+        quick_local,
+        "_pull_ollama_model",
+        lambda model: events.append(("pull", model)) or True,
+    )
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+
+    setup._ensure_ollama(
+        paths=quick_local.managed_paths(tmp_path),
+        allow_install=True,
+    )
+
+    assert events == [
+        "install",
+        "start",
+        ("pull", "qwen3-embedding:0.6b"),
+    ]
+
+
+def test_windows_ollama_install_command_uses_official_powershell_installer():
+    command = quick_local._windows_ollama_install_command("powershell.exe")
+
+    assert command == [
+        "powershell.exe",
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Invoke-RestMethod https://ollama.com/install.ps1 | Invoke-Expression",
+    ]
+
+
+def test_homebrew_ollama_install_does_not_inherit_stdin(monkeypatch):
+    run = MagicMock(return_value=SimpleNamespace(returncode=0))
+    monkeypatch.setattr(quick_local.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        quick_local.shutil, "which", lambda _name: "/opt/homebrew/bin/brew"
+    )
+    monkeypatch.setattr(quick_local.subprocess, "run", run)
+
+    assert quick_local._install_ollama() is True
+    run.assert_called_once_with(
+        ["/opt/homebrew/bin/brew", "install", "ollama"],
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def test_ollama_model_pull_does_not_inherit_stdin(monkeypatch):
+    run = MagicMock(return_value=SimpleNamespace(returncode=0))
+    monkeypatch.setattr(
+        quick_local.shutil, "which", lambda _name: "/usr/local/bin/ollama"
+    )
+    monkeypatch.setattr(quick_local.subprocess, "run", run)
+
+    assert quick_local._pull_ollama_model("qwen3-embedding:0.6b") is True
+    run.assert_called_once_with(
+        ["/usr/local/bin/ollama", "pull", "qwen3-embedding:0.6b"],
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def test_validation_server_does_not_inherit_stdin(tmp_path, monkeypatch):
+    server_command = tmp_path / "openviking-server"
+    server_command.write_text("", encoding="utf-8")
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text("{}", encoding="utf-8")
+    process = MagicMock()
+    popen = MagicMock(return_value=process)
+    monkeypatch.setattr(quick_local.subprocess, "Popen", popen)
+
+    result = quick_local._start_validation_server(
+        "http://127.0.0.1:1933",
+        config_path,
+        tmp_path,
+        server_command,
+    )
+
+    assert result is process
+    assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+
+def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkeypatch):
+    events = []
+    validation_configs = []
+    process = MagicMock()
+    setup = quick_local.QuickLocalSetup(
+        health_check=lambda _endpoint: (True, ""),
+        progress=lambda event: events.append(event.stage),
+    )
+    monkeypatch.setattr(
+        quick_local,
+        "resolve_hermes_vlm_config",
+        lambda: {
+            "provider": "openai",
+            "model": "model-1",
+            "api_key": "secret",
+            "api_base": "https://llm.example/v1",
+        },
+    )
+    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
+    monkeypatch.setattr(setup, "_ensure_ollama", lambda **_kwargs: None)
+    monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1937)
+
+    def start(endpoint, config_path, hermes_home, server_command):
+        paths = quick_local.managed_paths(tmp_path)
+        assert endpoint == "http://127.0.0.1:1937"
+        assert hermes_home == tmp_path
+        assert server_command == paths.server_command
+        assert not paths.server_config.exists()
+        assert not paths.ovcli_config.exists()
+        validation_configs.append(json.loads(config_path.read_text(encoding="utf-8")))
+        return process
+
+    monkeypatch.setattr(quick_local, "_start_validation_server", start)
+    monkeypatch.setattr(quick_local, "_wait_for_health", lambda *args, **kwargs: True)
+    stop = MagicMock(return_value=True)
+    monkeypatch.setattr(quick_local, "_stop_process", stop)
+
+    result = setup.provision(
+        hermes_home=tmp_path,
+        allow_ollama_install=False,
+        preflight=_preflight(tmp_path),
+    )
+
+    paths = result.paths
+    assert result.endpoint == "http://127.0.0.1:1937"
+    assert result.reused is False
+    final_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
+    assert final_config["storage"]["workspace"] == str(paths.workspace)
+    assert final_config["server"]["port"] == 1937
+    assert validation_configs[0]["storage"]["workspace"] != str(paths.workspace)
+    assert json.loads(paths.ovcli_config.read_text(encoding="utf-8")) == {
+        "url": "http://127.0.0.1:1937",
+        "actor_peer_id": "hermes",
+    }
+    if os.name != "nt":
+        assert stat.S_IMODE(paths.root.stat().st_mode) == 0o700
+        assert stat.S_IMODE(paths.server_config.stat().st_mode) == 0o600
+        assert stat.S_IMODE(paths.ovcli_config.stat().st_mode) == 0o600
+    stop.assert_called_once_with(process)
+    assert quick_local.QuickLocalStage.VALIDATE in events
+    assert events[-2:] == [
+        quick_local.QuickLocalStage.WRITE_CONFIG,
+        quick_local.QuickLocalStage.COMPLETE,
+    ]
+
+
+def test_failed_validation_stops_child_and_leaves_profile_inactive(
+    tmp_path, monkeypatch
+):
+    process = MagicMock()
+    setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (False, "down"))
+    monkeypatch.setattr(
+        quick_local,
+        "resolve_hermes_vlm_config",
+        lambda: {
+            "provider": "openai",
+            "model": "model-1",
+            "api_key": "secret",
+            "api_base": "https://llm.example/v1",
+        },
+    )
+    monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: None)
+    monkeypatch.setattr(setup, "_ensure_ollama", lambda **_kwargs: None)
+    monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1933)
+    monkeypatch.setattr(
+        quick_local,
+        "_start_validation_server",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(quick_local, "_wait_for_health", lambda *args, **kwargs: False)
+    stop = MagicMock(return_value=True)
+    monkeypatch.setattr(quick_local, "_stop_process", stop)
+
+    with pytest.raises(
+        quick_local.QuickLocalSetupError, match="did not become reachable"
+    ):
+        setup.provision(
+            hermes_home=tmp_path,
+            allow_ollama_install=False,
+            preflight=_preflight(tmp_path),
+        )
+
+    paths = quick_local.managed_paths(tmp_path)
+    assert not paths.server_config.exists()
+    assert not paths.ovcli_config.exists()
+    stop.assert_called_once_with(process)
+
+
+def test_preflight_reuses_only_healthy_profile_with_managed_workspace(tmp_path):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    quick_local.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(paths.workspace)}},
+        mode=0o600,
+    )
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    health = MagicMock(return_value=(True, ""))
+    setup = quick_local.QuickLocalSetup(health_check=health)
+
+    preflight = setup.preflight(tmp_path)
+
+    assert preflight.reusable_endpoint == "http://127.0.0.1:1938"
+    health.assert_called_once_with("http://127.0.0.1:1938")
+
+    quick_local.atomic_json_write(
+        paths.server_config,
+        {"storage": {"workspace": str(tmp_path / "other-data")}},
+        mode=0o600,
+    )
+    health.reset_mock()
+    assert setup.preflight(tmp_path).reusable_endpoint is None
+    health.assert_not_called()
+
+
+def test_preferred_configured_port_is_reused_when_available(monkeypatch):
+    bound = []
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def bind(self, address):
+            bound.append(address)
+
+    monkeypatch.setattr(
+        quick_local.socket, "socket", lambda *args, **kwargs: FakeSocket()
+    )
+
+    port = quick_local.find_available_port(
+        preferred_endpoint="http://127.0.0.1:1940",
+    )
+
+    assert port == 1940
+    assert bound == [("127.0.0.1", 1940)]
+
+
+def test_validation_stop_force_kills_only_after_graceful_timeout():
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = [subprocess.TimeoutExpired("server", 10), 0]
+
+    assert quick_local._stop_process(process) is True
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+
+
+def test_setup_menu_keeps_cloud_custom_paths_and_adds_quick_local(
+    tmp_path, monkeypatch
+):
+    seen = []
+
+    def select(title, options, **_kwargs):
+        seen.append((title, options))
+        return 1
+
+    quick_setup = MagicMock(return_value=True)
+    monkeypatch.setattr(openviking_module, "_run_quick_local_setup", quick_setup)
+    config = {"memory": {}}
+    provider_config = {}
+
+    result = openviking_module._run_create_profile_setup(
+        prompt=MagicMock(),
+        select=select,
+        cancelled=-1,
+        config=config,
+        provider_config=provider_config,
+        env_path=tmp_path / ".env",
+    )
+
+    assert result is True
+    assert seen == [
+        (
+            "  OpenViking connection",
+            [
+                (
+                    "OpenViking Service (VolcEngine Cloud)",
+                    "Managed cloud service; API key required",
+                ),
+                (
+                    "Quick Local Setup",
+                    "Set up OpenViking and Ollama on this device",
+                ),
+                (
+                    "Connect to an existing server",
+                    "Use a self-managed custom server (Remote/Local)",
+                ),
+            ],
+        )
+    ]
+    quick_setup.assert_called_once()
+
+
+def test_quick_local_cli_cancellation_before_ollama_install_changes_nothing(
+    tmp_path,
+    monkeypatch,
+):
+    paths = quick_local.managed_paths(tmp_path)
+
+    class FakeSetup:
+        def __init__(self, **_kwargs):
+            pass
+
+        def preflight(self, _home):
+            return quick_local.QuickLocalPreflight(
+                paths=paths,
+                reusable_endpoint=None,
+                ollama_install_required=True,
+            )
+
+        def provision(self, **_kwargs):
+            raise AssertionError("cancelled setup must not provision")
+
+    monkeypatch.setattr(quick_local, "QuickLocalSetup", FakeSetup)
+    provider_config = {}
+    config = {"memory": {}}
+
+    result = openviking_module._run_quick_local_setup(
+        select=lambda *args, **kwargs: -1,
+        cancelled=-1,
+        config=config,
+        provider_config=provider_config,
+        env_path=tmp_path / ".env",
+    )
+
+    assert result is openviking_module._SETUP_CANCELLED
+    assert provider_config == {}
+    assert config == {"memory": {}}
+
+
+def test_quick_local_cli_links_private_profile_and_runtime_config(
+    tmp_path, monkeypatch
+):
+    paths = quick_local.managed_paths(tmp_path)
+
+    class FakeSetup:
+        def __init__(self, **_kwargs):
+            pass
+
+        def preflight(self, _home):
+            return quick_local.QuickLocalPreflight(
+                paths=paths,
+                reusable_endpoint=None,
+                ollama_install_required=False,
+            )
+
+        def provision(self, **_kwargs):
+            return quick_local.QuickLocalSetupResult(
+                paths=paths,
+                endpoint="http://127.0.0.1:1933",
+                reused=False,
+            )
+
+    monkeypatch.setattr(quick_local, "QuickLocalSetup", FakeSetup)
+    config = {"memory": {}}
+    provider_config = {}
+
+    result = openviking_module._run_quick_local_setup(
+        select=MagicMock(),
+        cancelled=-1,
+        config=config,
+        provider_config=provider_config,
+        env_path=tmp_path / ".env",
+    )
+
+    assert result is True
+    assert config["memory"]["provider"] == "openviking"
+    assert provider_config == {
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(paths.ovcli_config),
+        "deployment": "quick_local",
+        "server_config_path": str(paths.server_config),
+        "server_command_path": str(paths.server_command),
+    }
+
+
+def test_linking_a_self_managed_profile_clears_quick_local_runtime_settings(tmp_path):
+    provider_config = {
+        "deployment": "quick_local",
+        "server_config_path": "/old/ov.conf",
+        "server_command_path": "/old/openviking-server",
+    }
+
+    openviking_module._link_ovcli_profile(
+        config={"memory": {}},
+        provider_config=provider_config,
+        env_path=tmp_path / ".env",
+        ovcli_path=tmp_path / "ovcli.conf.remote",
+    )
+
+    assert "deployment" not in provider_config
+    assert "server_config_path" not in provider_config
+    assert "server_command_path" not in provider_config
+
+
+def test_quick_local_profile_is_not_overridden_by_process_environment(
+    tmp_path, monkeypatch
+):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    external_profile = tmp_path / "external-ovcli.conf"
+    quick_local.atomic_json_write(
+        external_profile,
+        {"url": "http://127.0.0.1:1999", "actor_peer_id": "other"},
+        mode=0o600,
+    )
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(external_profile))
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://127.0.0.1:1998")
+    monkeypatch.setenv("OPENVIKING_AGENT", "other")
+
+    settings = openviking_module._resolve_connection_settings({
+        "use_ovcli_config": True,
+        "ovcli_config_path": str(paths.ovcli_config),
+        "deployment": quick_local.DEPLOYMENT,
+    })
+
+    assert settings["endpoint"] == "http://127.0.0.1:1938"
+    assert settings["agent"] == "hermes"
+
+
+def test_incomplete_quick_local_profile_does_not_fall_back_to_environment(
+    tmp_path, monkeypatch
+):
+    external_profile = tmp_path / "external-ovcli.conf"
+    quick_local.atomic_json_write(
+        external_profile,
+        {"url": "http://127.0.0.1:1999", "actor_peer_id": "other"},
+        mode=0o600,
+    )
+    monkeypatch.setenv("OPENVIKING_CLI_CONFIG_FILE", str(external_profile))
+
+    with pytest.raises(
+        openviking_module._OpenVikingEndpointError,
+        match="profile link is missing",
+    ):
+        openviking_module._resolve_connection_settings({
+            "use_ovcli_config": True,
+            "deployment": quick_local.DEPLOYMENT,
+        })
+
+
+def test_runtime_start_passes_private_config_only_for_quick_local(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "ov.conf"
+    config_path.write_text("{}", encoding="utf-8")
+    server_command = tmp_path / "openviking-server"
+    server_command.write_text("", encoding="utf-8")
+    popen = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        openviking_module,
+        "_local_openviking_port_is_open",
+        lambda _host, _port: False,
+    )
+    monkeypatch.setattr(openviking_module.subprocess, "Popen", popen)
+
+    state, _message = openviking_module._start_local_openviking_server(
+        "http://127.0.0.1:1939",
+        config_path=config_path,
+        server_command_path=server_command,
+    )
+
+    assert state == openviking_module._LOCAL_SERVER_STARTED
+    assert popen.call_args.args[0] == [
+        str(server_command),
+        "--config",
+        str(config_path),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "1939",
+    ]
+
+
+def test_runtime_start_refuses_missing_quick_local_config(tmp_path, monkeypatch):
+    server_command = tmp_path / "openviking-server"
+    server_command.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        openviking_module,
+        "_local_openviking_port_is_open",
+        lambda _host, _port: False,
+    )
+    popen = MagicMock(side_effect=AssertionError("missing config must not spawn"))
+    monkeypatch.setattr(openviking_module.subprocess, "Popen", popen)
+
+    state, message = openviking_module._start_local_openviking_server(
+        "http://127.0.0.1:1939",
+        config_path=tmp_path / "missing-ov.conf",
+        server_command_path=server_command,
+    )
+
+    assert state == openviking_module._LOCAL_SERVER_FAILED
+    assert "server config was not found" in message
+    popen.assert_not_called()
+
+
+def test_runtime_unreachable_uses_quick_local_config_marker(tmp_path, monkeypatch):
+    config_path = tmp_path / "ov.conf"
+    start = MagicMock(
+        return_value=(openviking_module._LOCAL_SERVER_FAILED, "expected test failure")
+    )
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "deployment": "quick_local",
+            "server_config_path": str(config_path),
+            "server_command_path": "/bin/ov",
+        },
+    )
+    monkeypatch.setattr(openviking_module, "_start_local_openviking_server", start)
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1933"
+
+    provider._handle_runtime_openviking_unreachable()
+
+    start.assert_called_once_with(
+        "http://127.0.0.1:1933",
+        config_path=config_path,
+        server_command_path=Path("/bin/ov"),
+    )
+
+
+def test_runtime_does_not_fall_back_when_quick_local_markers_are_incomplete(
+    monkeypatch,
+):
+    start = MagicMock(side_effect=AssertionError("must not start a PATH server"))
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {"deployment": quick_local.DEPLOYMENT},
+    )
+    monkeypatch.setattr(openviking_module, "_start_local_openviking_server", start)
+    warnings = []
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1933"
+
+    provider._handle_runtime_openviking_unreachable(warning_callback=warnings.append)
+
+    start.assert_not_called()
+    assert len(warnings) == 1
+    assert "private server configuration is incomplete" in warnings[0]

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -20,6 +20,45 @@ def _preflight(tmp_path: Path) -> quick_local.QuickLocalPreflight:
     )
 
 
+def test_backup_paths_include_only_the_linked_external_profile(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    linked = tmp_path / "external" / "ovcli.conf.hermes"
+    linked.parent.mkdir()
+    linked.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(openviking_module, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(linked),
+        },
+    )
+
+    assert OpenVikingMemoryProvider().backup_paths() == [str(linked)]
+
+
+def test_backup_paths_skip_quick_local_profile_inside_hermes_home(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    profile = hermes_home / "openviking" / "ovcli.conf"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(openviking_module, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "use_ovcli_config": True,
+            "ovcli_config_path": str(profile),
+            "deployment": quick_local.DEPLOYMENT,
+        },
+    )
+
+    assert OpenVikingMemoryProvider().backup_paths() == []
+
+
 def test_build_server_config_uses_profile_scoped_storage_and_local_embedding(
     tmp_path,
 ):
@@ -166,6 +205,16 @@ def test_resolve_vlm_accepts_structured_persisted_default(monkeypatch):
                 "base_url": "https://chatgpt.com/backend-api/codex",
                 "api_key": "short-lived",
                 "source": "oauth",
+            },
+            "cannot be copied safely",
+        ),
+        (
+            {
+                "provider": "anthropic",
+                "api_mode": "anthropic_messages",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "sk-ant-oat01-short-lived",
+                "source": "env",
             },
             "cannot be copied safely",
         ),
@@ -495,6 +544,41 @@ def test_reuse_rechecks_runtime_and_refreshes_saved_vlm(tmp_path, monkeypatch):
     ensure_runtime.assert_called_once_with(paths)
 
 
+def test_reuse_restart_requirement_survives_separate_setup_runs(tmp_path, monkeypatch):
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    old_vlm = {
+        "provider": "openai",
+        "model": "old-model",
+        "api_key": "old-secret",
+        "api_base": "https://llm.example/v1",
+    }
+    new_vlm = {**old_vlm, "api_key": "new-secret"}
+    quick_local.atomic_json_write(
+        paths.server_config,
+        quick_local.build_server_config(paths, old_vlm, port=1938),
+        mode=0o600,
+    )
+    quick_local.atomic_json_write(
+        paths.ovcli_config,
+        {"url": "http://127.0.0.1:1938", "actor_peer_id": "hermes"},
+        mode=0o600,
+    )
+    monkeypatch.setattr(quick_local, "resolve_hermes_vlm_config", lambda: new_vlm)
+
+    def provision_again():
+        setup = quick_local.QuickLocalSetup(health_check=lambda _endpoint: (True, ""))
+        monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: False)
+        return setup.provision(hermes_home=tmp_path)
+
+    first = provision_again()
+    second = provision_again()
+
+    assert first.server_restart_required is True
+    assert second.server_restart_required is True
+    assert paths.restart_required_marker.is_file()
+
+
 @pytest.mark.parametrize("runtime_current", [False, True])
 def test_reuse_with_unchanged_config_requires_restart_only_after_runtime_upgrade(
     tmp_path, monkeypatch, runtime_current
@@ -548,11 +632,17 @@ def test_reuse_with_unchanged_config_requires_restart_only_after_runtime_upgrade
     assert result.endpoint == "http://127.0.0.1:1938"
     assert result.server_restart_required is (not runtime_current)
     assert json.loads(paths.server_config.read_text(encoding="utf-8")) == server_config
-    write.assert_not_called()
+    assert all(call.args[0] != paths.server_config for call in write.call_args_list)
     if runtime_current:
+        write.assert_not_called()
         ensure_uv.assert_not_called()
         install.assert_not_called()
     else:
+        write.assert_called_once_with(
+            paths.restart_required_marker,
+            {"restart_required": True},
+            mode=0o600,
+        )
         ensure_uv.assert_called_once_with()
         install.assert_called_once()
 
@@ -577,9 +667,15 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
     )
     monkeypatch.setattr(setup, "_ensure_openviking_installed", lambda _paths: True)
     monkeypatch.setattr(quick_local, "find_available_port", lambda **_kwargs: 1937)
+    paths = quick_local.managed_paths(tmp_path)
+    paths.root.mkdir(parents=True)
+    quick_local.atomic_json_write(
+        paths.restart_required_marker,
+        {"restart_required": True},
+        mode=0o600,
+    )
 
     def start(endpoint, config_path, hermes_home, server_command):
-        paths = quick_local.managed_paths(tmp_path)
         assert endpoint == "http://127.0.0.1:1937"
         assert hermes_home == tmp_path
         assert server_command == paths.server_command
@@ -602,6 +698,7 @@ def test_fresh_provision_validates_before_writing_active_config(tmp_path, monkey
     assert result.endpoint == "http://127.0.0.1:1937"
     assert result.reused is False
     assert result.server_restart_required is False
+    assert not paths.restart_required_marker.exists()
     final_config = json.loads(paths.server_config.read_text(encoding="utf-8"))
     assert final_config["storage"]["workspace"] == str(paths.workspace)
     assert final_config["server"]["port"] == 1937
@@ -1089,6 +1186,12 @@ def test_runtime_start_refuses_missing_quick_local_config(tmp_path, monkeypatch)
 
 def test_runtime_unreachable_uses_quick_local_config_marker(tmp_path, monkeypatch):
     config_path = tmp_path / "ov.conf"
+    restart_marker = config_path.with_name(".restart-required")
+    quick_local.atomic_json_write(
+        restart_marker,
+        {"restart_required": True},
+        mode=0o600,
+    )
     start = MagicMock(
         return_value=(openviking_module._LOCAL_SERVER_FAILED, "expected test failure")
     )
@@ -1112,6 +1215,43 @@ def test_runtime_unreachable_uses_quick_local_config_marker(tmp_path, monkeypatc
         config_path=config_path,
         server_command_path=Path("/bin/ov"),
     )
+    assert restart_marker.is_file()
+
+
+def test_runtime_managed_start_clears_durable_restart_requirement(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "ov.conf"
+    restart_marker = config_path.with_name(".restart-required")
+    quick_local.atomic_json_write(
+        restart_marker,
+        {"restart_required": True},
+        mode=0o600,
+    )
+    start = MagicMock(return_value=(openviking_module._LOCAL_SERVER_STARTED, "started"))
+    monkeypatch.setattr(
+        openviking_module,
+        "_load_hermes_openviking_config",
+        lambda: {
+            "deployment": quick_local.DEPLOYMENT,
+            "server_config_path": str(config_path),
+            "server_command_path": "/bin/ov",
+        },
+    )
+    monkeypatch.setattr(openviking_module, "_start_local_openviking_server", start)
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://127.0.0.1:1933"
+    provider._start_runtime_openviking_waiter = MagicMock()
+
+    provider._handle_runtime_openviking_unreachable()
+
+    start.assert_called_once_with(
+        "http://127.0.0.1:1933",
+        config_path=config_path,
+        server_command_path=Path("/bin/ov"),
+    )
+    assert not restart_marker.exists()
+    provider._start_runtime_openviking_waiter.assert_called_once()
 
 
 def test_runtime_does_not_fall_back_when_quick_local_markers_are_incomplete(

--- a/tests/plugins/memory/test_openviking_quick_local.py
+++ b/tests/plugins/memory/test_openviking_quick_local.py
@@ -10,6 +10,7 @@ import pytest
 
 import plugins.memory.openviking as openviking_module
 from plugins.memory.openviking import OpenVikingMemoryProvider, quick_local
+from plugins.memory.openviking import _setup as setup_flow
 
 
 def _preflight(tmp_path: Path) -> quick_local.QuickLocalPreflight:
@@ -810,11 +811,11 @@ def test_setup_menu_keeps_cloud_custom_paths_and_adds_quick_local(
         return 1
 
     quick_setup = MagicMock(return_value=True)
-    monkeypatch.setattr(openviking_module, "_run_quick_local_setup", quick_setup)
+    monkeypatch.setattr(setup_flow, "_run_quick_local_setup", quick_setup)
     config = {"memory": {}}
     provider_config = {}
 
-    result = openviking_module._run_create_profile_setup(
+    result = setup_flow._run_create_profile_setup(
         prompt=MagicMock(),
         select=select,
         cancelled=-1,
@@ -872,7 +873,7 @@ def test_quick_local_cli_links_private_profile_and_runtime_config(
     config = {"memory": {}}
     provider_config = {}
 
-    result = openviking_module._run_quick_local_setup(
+    result = setup_flow._run_quick_local_setup(
         config=config,
         provider_config=provider_config,
         env_path=tmp_path / ".env",
@@ -915,7 +916,7 @@ def test_quick_local_cli_reports_when_running_server_needs_restart(
     monkeypatch.setattr(quick_local, "QuickLocalSetup", FakeSetup)
 
     assert (
-        openviking_module._run_quick_local_setup(
+        setup_flow._run_quick_local_setup(
             config={"memory": {}},
             provider_config={},
             env_path=tmp_path / ".env",
@@ -938,7 +939,7 @@ def test_linking_a_self_managed_profile_clears_quick_local_runtime_settings(tmp_
         "server_command_path": "/old/openviking-server",
     }
 
-    openviking_module._link_ovcli_profile(
+    setup_flow._link_ovcli_profile(
         config={"memory": {}},
         provider_config=provider_config,
         env_path=tmp_path / ".env",


### PR DESCRIPTION
## What does this PR do?

Adds a focused Quick Local path to `hermes memory setup openviking`.

Quick Local provisions an upper-bounded `openviking[local-embed]` release in a profile-scoped private runtime, configures OpenViking's built-in `bge-small-zh-v1.5-f16` embedding model, derives the OpenViking VLM configuration from the active persisted Hermes provider, and validates the generated configuration before activating it. Embeddings run in-process through OpenViking's `llama-cpp-python` backend; Ollama is not installed or managed.

The CLI remains responsible only for prompts and progress rendering. Provisioning is implemented as non-interactive plugin code so another interface can reuse it without duplicating installation or configuration logic. The integration follows the current OpenViking setup boundary in `_setup.py`.

The scope is intentionally narrow: this PR does not add Desktop UI, process ownership coordination, automatic shutdown, or cancellation infrastructure. The managed OpenViking server remains running for reuse after Hermes exits.

Known limitation: reuse validates saved profile metadata and endpoint health, not a server-side instance identity; a separate OpenViking server occupying the saved port can be mistaken for Quick Local.

This is a focused replacement for #69278.

## Related Issue

Related: #69278

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a non-interactive OpenViking Quick Local provisioning engine with typed preflight, progress, result, and error contracts.
- Installed `openviking[local-embed]>=0.4.16,<0.6` in a private environment under the active Hermes home, keeping the Hermes environment unchanged.
- Configured OpenViking's built-in local BGE embedding model and profile-scoped model cache without an external embedding server.
- Generated a private OpenViking server configuration and ovcli profile from the persisted Hermes model configuration.
- Validated setup with a temporary server before activating the profile.
- Made repeated setup recheck the private OpenViking version and refresh saved VLM settings when the active Hermes model or API key changes.
- Persisted the restart-required state across separate setup invocations and cleared it only after a fresh configuration is validated or Hermes starts the managed server with the current configuration.
- Copied credentials only from provider sources Hermes classifies as static API-key authentication; OAuth, command-minted, cloud-native, and unknown credential sources fail closed. Anthropic OAuth-shaped environment tokens have an explicit regression test.
- Reported missing API keys and base URLs before classifying credential types.
- Allowed the first built-in model download to complete within a bounded startup window while failing promptly if the validation process exits.
- Rechecked the selected port immediately before launch and preserved the primary setup error when validation cleanup also fails.
- Failed closed when Quick Local's linked profile or private runtime metadata is incomplete.
- Prevented non-interactive installer and server subprocesses from consuming TUI input.
- Prevented in-home Quick Local profiles from being archived again as external provider state, avoiding duplicate archive entries and cross-profile restores to the source profile.
- Restored the secret-bearing `openviking/ov.conf` as `0600` and its containing directory as `0700`. A default `0700` Hermes home already prevents other users from traversing to a restored `0644` file; the exposed case required a deliberately traversable home mode such as `HERMES_HOME_MODE=0701`.
- Documented that Quick Local ignores `OPENVIKING_*` environment overrides while self-managed connections continue to use them.
- Preserved the existing managed-cloud and self-managed custom-server paths.
- Kept setup UI logic in the extracted `_setup.py` module and left the provisioning adapter reusable by CLI, Gateway, and Desktop callers.
- Added focused Quick Local and backup/import tests.

## How to Test

1. Run `hermes memory setup openviking` and choose **Quick Local Setup**.
2. Complete the setup, then start Hermes and send a message that uses memory.
3. Exit normally, start a new session, and verify that the stored information can be recalled.
4. Rerun setup after changing the active Hermes model or rotating its static API key. Verify that every setup run continues to report the required restart until Hermes starts the managed server with the updated configuration.
5. Back up and import a configured profile. Verify that the Quick Local ovcli profile occurs once in the archive, the source profile is not overwritten, `openviking/ov.conf` is `0600`, and `openviking/` is `0700`.

Automated validation:

- `scripts/run_tests.sh -j 4 --file-retries 0 -q tests/plugins/memory tests/hermes_cli/test_backup.py` — 532 passed, 3 skipped
- `scripts/run_tests.sh -j 4 --file-retries 0 -q tests/openviking_plugin tests/plugins/memory/test_openviking_endpoint_always_blocked.py tests/plugins/memory/test_openviking_optional_peer.py tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_quick_local.py tests/plugins/memory/test_openviking_shutdown.py` — 212 passed
- `python scripts/check-windows-footguns.py hermes_cli/backup.py plugins/memory/openviking/__init__.py plugins/memory/openviking/quick_local.py`
- `python scripts/check_compat_pointers.py`
- `ruff check hermes_cli/backup.py plugins/memory/openviking/__init__.py plugins/memory/openviking/quick_local.py tests/hermes_cli/test_backup.py tests/plugins/memory/test_openviking_quick_local.py`
- `python -m py_compile hermes_cli/backup.py plugins/memory/openviking/__init__.py plugins/memory/openviking/quick_local.py tests/hermes_cli/test_backup.py tests/plugins/memory/test_openviking_quick_local.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper and all relevant tests pass; see the validation commands above and CI for the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Real isolated validation on macOS confirmed that:

- OpenViking 0.4.17.1 and `llama-cpp-python` were installed into a fresh private runtime without changing the Hermes environment.
- OpenViking downloaded and loaded `bge-small-zh-v1.5-f16` from the profile-scoped model cache.
- The generated server and ovcli configuration files were mode `0600`.
- The linked Quick Local profile remained authoritative even with a conflicting `OPENVIKING_ENDPOINT` in the process environment.
- Hermes started the private server lazily from the generated command and config, and the server became healthy.
- The temporary validation server and disposable runtime server were stopped, and the test home was removed after validation.

