### PR TITLE
fix(dashboard): drop root to the profile owner for profile-scoped chats

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -37,7 +37,7 @@ import struct
 import sys
 import termios
 import time
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 try:
     import ptyprocess  # type: ignore
@@ -118,8 +118,13 @@ class PtyBridge:
         env: Optional[dict] = None,
         cols: int = 80,
         rows: int = 24,
+        preexec_fn: Optional[Callable[[], None]] = None,
     ) -> "PtyBridge":
         """Spawn ``argv`` behind a new PTY and return a bridge.
+
+        ``preexec_fn`` runs in the forked child before the target program
+        starts (same contract as :class:`subprocess.Popen`) — the dashboard
+        chat uses it to drop root to the selected profile's owner (#94847).
 
         Raises :class:`PtyUnavailableError` if the platform can't host a
         PTY.  Raises :class:`FileNotFoundError` or :class:`OSError` for
@@ -157,6 +162,7 @@ class PtyBridge:
             list(argv),
             cwd=cwd,
             env=spawn_env,
+            preexec_fn=preexec_fn,
             dimensions=(rows, cols),
         )
         return cls(proc)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16746,11 +16746,19 @@ def _profile_chat_demotion(profile: Optional[str]):
 
     def _drop_to_profile_owner() -> None:
         # Order matters: drop supplementary groups, then gid, then uid —
-        # each step retains the privilege needed for the next one.
-        try:
+        # each step retains the privilege needed for the next one. A failed
+        # supplementary-group drop must kill the child before exec: letting
+        # it continue would leave root's supplementary groups (docker, disk,
+        # …) attached to the demoted process, keeping group-reachable
+        # privileged files open — so the OSError propagates, ptyprocess
+        # _exit(1)s the child before exec, and the ws handler reports the
+        # refused spawn (#94847). With a passwd entry, initgroups keeps the
+        # owner's own legitimate group memberships instead of collapsing to
+        # the single primary gid.
+        if username is not None:
+            os.initgroups(username, target_gid)
+        else:
             os.setgroups([target_gid])
-        except OSError:
-            pass  # best-effort: primary gid drop below is the hard floor
         os.setgid(target_gid)
         os.setuid(target_uid)
 
@@ -16760,6 +16768,16 @@ def _profile_chat_demotion(profile: Optional[str]):
     if username:
         env_overrides["USER"] = username
         env_overrides["LOGNAME"] = username
+    # Root's own session handles must not survive the drop: the demoted
+    # child runs as another OS user and must not reach root's ssh-agent or
+    # runtime-bus sockets. None marks "strip this variable" for the caller.
+    for _session_var in (
+        "SSH_AUTH_SOCK",
+        "SSH_AGENT_PID",
+        "XDG_RUNTIME_DIR",
+        "DBUS_SESSION_BUS_ADDRESS",
+    ):
+        env_overrides[_session_var] = None
     return _drop_to_profile_owner, env_overrides, None
 
 
@@ -17581,7 +17599,13 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
     if demote_env:
-        env.update(demote_env)
+        # None-valued entries strip the variable (root's session handles);
+        # everything else overrides it.
+        for _k, _v in demote_env.items():
+            if _v is None:
+                env.pop(_k, None)
+            else:
+                env[_k] = _v
 
     def _spawn():
         return PtyBridge.spawn(argv, cwd=cwd, env=env, preexec_fn=demote_preexec)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16697,6 +16697,72 @@ def _build_gateway_ws_url() -> Optional[str]:
     return f"ws://{netloc}/api/ws?{qs}"
 
 
+def _profile_chat_demotion(profile: Optional[str]):
+    """Fail-closed uid demotion for profile-scoped dashboard chats (#94847).
+
+    When the dashboard runs as root and the selected profile dir is owned by
+    another OS user, the chat child must run as that owner: spawning it as
+    root lets an ordinary UI action write root-owned state into the profile
+    (projects.db, notices) that the profile's own gateway then cannot read.
+    Returns ``(preexec_fn, env_overrides, error_message)``:
+
+    - root server + non-root-owned profile dir → a ``preexec_fn`` that does
+      setgid/setgroups/setuid to the dir owner, plus HOME/USER/LOGNAME
+      overrides so the child's dotfile writes land in the owner's home.
+    - root server + root-owned profile dir, non-root server, or the
+      server's own profile → ``(None, None, None)`` (no change).
+    - the drop cannot be computed (stat fails) → an error message; the
+      caller must refuse the chat rather than silently spawn root against
+      a non-root profile.
+    """
+    if not hasattr(os, "geteuid") or os.geteuid() != 0:
+        return None, None, None
+    requested = (profile or "").strip()
+    if not requested or requested.lower() == "current":
+        return None, None, None
+    try:
+        profile_dir = _resolve_profile_dir(requested)
+        stat_result = os.stat(profile_dir)
+    except Exception as exc:
+        return None, None, (
+            f"Chat unavailable: cannot inspect profile dir for ownership ({exc})"
+        )
+    if stat_result.st_uid == 0:
+        return None, None, None
+    gid = stat_result.st_gid
+    home = username = None
+    try:
+        import pwd
+
+        pw = pwd.getpwuid(stat_result.st_uid)
+        gid = pw.pw_gid
+        home = pw.pw_dir
+        username = pw.pw_name
+    except (KeyError, ImportError, OSError):
+        pass  # owner not in passwd: still drop by raw uid/gid from the dir
+
+    target_uid = stat_result.st_uid
+    target_gid = gid
+
+    def _drop_to_profile_owner() -> None:
+        # Order matters: drop supplementary groups, then gid, then uid —
+        # each step retains the privilege needed for the next one.
+        try:
+            os.setgroups([target_gid])
+        except OSError:
+            pass  # best-effort: primary gid drop below is the hard floor
+        os.setgid(target_gid)
+        os.setuid(target_uid)
+
+    env_overrides: dict = {}
+    if home:
+        env_overrides["HOME"] = home
+    if username:
+        env_overrides["USER"] = username
+        env_overrides["LOGNAME"] = username
+    return _drop_to_profile_owner, env_overrides, None
+
+
 async def _resolve_chat_argv_async(
     resume: Optional[str] = None,
     sidecar_url: Optional[str] = None,
@@ -17505,8 +17571,20 @@ async def pty_ws(ws: WebSocket) -> None:
         # Key explicit resumes on their canonical target, never the active-session fallback.
         attach_token = f"{attach_token}\0{profile or ''}\0{registry_resume or ''}"
 
+    # Root-run dashboard + non-root-owned profile dir: the child must run as
+    # the profile's owner, and a drop that cannot be computed must REFUSE the
+    # chat — spawning root against a non-root profile corrupts its state
+    # (#94847).
+    demote_preexec, demote_env, demote_err = _profile_chat_demotion(profile)
+    if demote_err:
+        await ws.send_text(f"\r\n\x1b[31m{demote_err}\x1b[0m\r\n")
+        await ws.close(code=1011)
+        return
+    if demote_env:
+        env.update(demote_env)
+
     def _spawn():
-        return PtyBridge.spawn(argv, cwd=cwd, env=env)
+        return PtyBridge.spawn(argv, cwd=cwd, env=env, preexec_fn=demote_preexec)
 
     if attach_token is None:
         # Legacy path: 1:1 socket<->PTY, killed on disconnect (unchanged).

--- a/tests/hermes_cli/test_web_server_profile_chat_demotion.py
+++ b/tests/hermes_cli/test_web_server_profile_chat_demotion.py
@@ -71,18 +71,51 @@ class TestProfileChatDemotion:
             "HOME": "/home/hermes-echo",
             "USER": "hermes-echo",
             "LOGNAME": "hermes-echo",
+            # Root's session handles are marked for stripping (None), not
+            # inherited — the demoted child must not reach root's
+            # ssh-agent or runtime bus.
+            "SSH_AUTH_SOCK": None,
+            "SSH_AGENT_PID": None,
+            "XDG_RUNTIME_DIR": None,
+            "DBUS_SESSION_BUS_ADDRESS": None,
         }
-        # The preexec performs the ordered drop: groups → gid → uid.
+        # The preexec performs the ordered drop: initgroups → gid → uid.
         import hermes_cli.web_server as fresh_ws
 
         calls = []
+        monkeypatch.setattr(os, "initgroups", lambda u, g: calls.append(("initgroups", u, g)), raising=False)
         monkeypatch.setattr(os, "setgroups", lambda g: calls.append(("groups", g)))
         monkeypatch.setattr(os, "setgid", lambda g: calls.append(("gid", g)))
         monkeypatch.setattr(os, "setuid", lambda u: calls.append(("uid", u)))
         # Re-resolve so the closure binds the patched os functions.
         preexec, _, _ = fresh_ws._profile_chat_demotion("echo")
         preexec()
-        assert calls == [("groups", [300]), ("gid", 300), ("uid", 985)]
+        assert calls == [("initgroups", "hermes-echo", 300), ("gid", 300), ("uid", 985)]
+
+    def test_failed_supplementary_group_drop_kills_child(
+        self, profile_dir, monkeypatch
+    ):
+        # A swallowed setgroups failure would leave root's supplementary
+        # groups attached to the demoted child — the OSError must propagate
+        # so ptyprocess terminates the forked child before the target
+        # program starts (#94847 fail-closed).
+        _as_root(monkeypatch)
+        monkeypatch.setattr(os, "stat", lambda p: _Stat(985, 300))
+        import pwd
+
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+
+        def _boom(groups):
+            raise PermissionError("setgroups denied")
+
+        import hermes_cli.web_server as fresh_ws
+
+        monkeypatch.setattr(os, "setgroups", _boom)
+        monkeypatch.setattr(os, "setgid", lambda g: None)
+        monkeypatch.setattr(os, "setuid", lambda u: None)
+        preexec, _, _ = fresh_ws._profile_chat_demotion("echo")
+        with pytest.raises(OSError):
+            preexec()
 
     def test_owner_missing_from_passwd_still_drops_by_dir_ids(
         self, profile_dir, monkeypatch
@@ -95,7 +128,14 @@ class TestProfileChatDemotion:
         preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
         assert err is None
         assert preexec is not None
-        assert overrides == {}  # no HOME/USER data — ids alone still drop
+        # no HOME/USER data — ids alone still drop, and root's session
+        # handles are still stripped.
+        assert overrides == {
+            "SSH_AUTH_SOCK": None,
+            "SSH_AGENT_PID": None,
+            "XDG_RUNTIME_DIR": None,
+            "DBUS_SESSION_BUS_ADDRESS": None,
+        }
 
     def test_stat_failure_fails_closed_with_error(self, profile_dir, monkeypatch):
         _as_root(monkeypatch)

--- a/tests/hermes_cli/test_web_server_profile_chat_demotion.py
+++ b/tests/hermes_cli/test_web_server_profile_chat_demotion.py
@@ -1,0 +1,131 @@
+"""Root-run dashboard chats must drop to the profile dir's owner (#94847).
+
+A machine-level dashboard running as root, opening Chat for a profile that
+belongs to a different OS user, spawned the chat child as root with
+HERMES_HOME=<that profile dir> — ordinary UI writes then created root-owned
+state (projects.db, notices) that the profile's own gateway could no longer
+read. The child must run as the profile dir's owner; a drop that cannot be
+computed must refuse the chat instead of silently spawning root.
+"""
+from __future__ import annotations
+
+import os
+import types
+
+import pytest
+
+import hermes_cli.web_server as ws_mod
+
+
+class _Stat:
+    def __init__(self, uid, gid):
+        self.st_uid = uid
+        self.st_gid = gid
+
+
+@pytest.fixture
+def profile_dir(tmp_path, monkeypatch):
+    d = tmp_path / "echo-profile"
+    d.mkdir()
+    monkeypatch.setattr(ws_mod, "_resolve_profile_dir", lambda name: d)
+    return d
+
+
+def _as_root(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+
+
+class TestProfileChatDemotion:
+    def test_non_root_server_never_demotes(self, profile_dir, monkeypatch):
+        monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+        preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
+        assert preexec is None and overrides is None and err is None
+
+    def test_no_profile_or_current_profile_no_demotion(self, profile_dir, monkeypatch):
+        _as_root(monkeypatch)
+        for name in ("", None, "current", "CURRENT"):
+            preexec, overrides, err = ws_mod._profile_chat_demotion(name)
+            assert preexec is None and err is None, name
+
+    def test_root_owned_profile_dir_no_demotion(self, profile_dir, monkeypatch):
+        _as_root(monkeypatch)
+        monkeypatch.setattr(os, "stat", lambda p: _Stat(0, 0))
+        preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
+        assert preexec is None and overrides is None and err is None
+
+    def test_non_root_owned_dir_demotes_to_owner(self, profile_dir, monkeypatch):
+        _as_root(monkeypatch)
+        monkeypatch.setattr(os, "stat", lambda p: _Stat(985, 300))
+        monkeypatch.setattr(
+            ws_mod.pwd if hasattr(ws_mod, "pwd") else __import__("pwd"),
+            "getpwuid",
+            lambda uid: types.SimpleNamespace(
+                pw_gid=300, pw_dir="/home/hermes-echo", pw_name="hermes-echo"
+            ),
+            raising=False,
+        )
+        preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
+        assert err is None
+        assert preexec is not None
+        assert overrides == {
+            "HOME": "/home/hermes-echo",
+            "USER": "hermes-echo",
+            "LOGNAME": "hermes-echo",
+        }
+        # The preexec performs the ordered drop: groups → gid → uid.
+        import hermes_cli.web_server as fresh_ws
+
+        calls = []
+        monkeypatch.setattr(os, "setgroups", lambda g: calls.append(("groups", g)))
+        monkeypatch.setattr(os, "setgid", lambda g: calls.append(("gid", g)))
+        monkeypatch.setattr(os, "setuid", lambda u: calls.append(("uid", u)))
+        # Re-resolve so the closure binds the patched os functions.
+        preexec, _, _ = fresh_ws._profile_chat_demotion("echo")
+        preexec()
+        assert calls == [("groups", [300]), ("gid", 300), ("uid", 985)]
+
+    def test_owner_missing_from_passwd_still_drops_by_dir_ids(
+        self, profile_dir, monkeypatch
+    ):
+        _as_root(monkeypatch)
+        monkeypatch.setattr(os, "stat", lambda p: _Stat(985, 300))
+        import pwd
+
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: (_ for _ in ()).throw(KeyError(uid)))
+        preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
+        assert err is None
+        assert preexec is not None
+        assert overrides == {}  # no HOME/USER data — ids alone still drop
+
+    def test_stat_failure_fails_closed_with_error(self, profile_dir, monkeypatch):
+        _as_root(monkeypatch)
+
+        def _boom(p):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(os, "stat", _boom)
+        preexec, overrides, err = ws_mod._profile_chat_demotion("echo")
+        assert preexec is None and overrides is None
+        assert err is not None and "cannot inspect profile dir" in err
+
+    def test_pty_spawn_forwards_preexec_fn(self, monkeypatch):
+        from hermes_cli import pty_bridge
+
+        assert pty_bridge.ptyprocess is not None, "ptyprocess must be installed"
+        captured = {}
+
+        class _FakeProc:
+            pid = 4242
+            fd = 99
+
+        def fake_spawn(argv, cwd=None, env=None, preexec_fn=None, dimensions=None, **kw):
+            captured["preexec"] = preexec_fn
+            return _FakeProc()
+
+        monkeypatch.setattr(
+            pty_bridge.ptyprocess.PtyProcess, "spawn", staticmethod(fake_spawn)
+        )
+        marker = lambda: None
+        bridge = pty_bridge.PtyBridge.spawn(["sh"], preexec_fn=marker)
+        assert captured["preexec"] is marker
+        assert bridge.pid == 4242

--- a/tests/test_pty_keepalive_ws.py
+++ b/tests/test_pty_keepalive_ws.py
@@ -31,7 +31,9 @@ def pty_keepalive_harness(monkeypatch):
     spawned = Spawned()
     spawned.bridges = []
 
-    def fake_spawn(argv, cwd=None, env=None):
+    def fake_spawn(argv, cwd=None, env=None, preexec_fn=None):
+        # preexec_fn: the chat handler now passes a (possibly-None) uid-drop
+        # hook through to PtyBridge.spawn (#94847); the harness ignores it.
         b = FakeBridge()
         spawned.append(argv)
         spawned.bridges.append(b)


### PR DESCRIPTION
## What does this PR do?

A machine-level dashboard running as root, opening **Chat** for a profile that belongs to a different OS user, spawned the chat child as **root** with `HERMES_HOME=<that profile dir>`. Ordinary UI writes then created root-owned state inside the profile (`projects.db`, notices at mode 0600), and the profile's own gateway — running as its dedicated user — could no longer read that state (`hermes doctor`: `journal mode could not be read (permission denied)`). On hosts isolating bounded assistants under separate OS users (the systemd hardening pattern), one UI click silently corrupts the profile; the reporter's site treats any root-owned file in a profile as an incident after this cost them 12.5 h of dead cron (#94847).

The fix fails closed around the ownership mismatch:

- **Root server + non-root-owned profile dir** → the chat child spawns through a `preexec_fn` that drops supplementary groups, then gid, then uid (in that order — each step retains the privilege the next one needs) to the dir's owner, and the child env's `HOME`/`USER`/`LOGNAME` are pointed at the owner so dotfile writes land in the owner's home. An owner missing from passwd still drops by the raw dir uid/gid — only the cosmetic env overrides are skipped.
- **A drop that cannot be computed** (stat failure) → the chat is **refused** with a clear message; the dashboard never silently spawns root against a non-root profile.
- **Root-owned profile dirs, non-root servers, and the server's own profile** (`""` / `current`) → byte-for-byte unchanged.

`PtyBridge.spawn` gains an optional `preexec_fn` passed through to `ptyprocess.PtyProcess.spawn` (same contract as `subprocess.Popen`); `None` keeps the previous behavior for every other caller.

## Related Issue

Fixes #94847

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — new `_profile_chat_demotion(profile)` returning `(preexec_fn, env_overrides, error)` with the fail-closed triage above; the chat websocket handler applies it after argv resolution, refuses on error, and passes the drop into `PtyBridge.spawn`.
- `hermes_cli/pty_bridge.py` — `spawn()` accepts and forwards `preexec_fn` (no behavior change when omitted).
- `tests/hermes_cli/test_web_server_profile_chat_demotion.py` — 7 regressions: non-root never demotes; empty/`current` profile no demotion; root-owned dir no demotion; non-root-owned dir demotes with ordered groups→gid→uid (captured via patched setters) plus HOME/USER/LOGNAME overrides; passwd-missing owner still drops by dir ids; stat failure returns the refusal error; `PtyBridge.spawn` forwards the callable to the PTY library.

## How to Test

1. `pytest tests/hermes_cli/test_web_server_profile_chat_demotion.py tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server_pty_import.py tests/hermes_cli/test_web_server_pty_idle_backoff.py -q` — should pass (7 + 18).
2. Observed result: with this PR's source reverted, the new suite fails (`_profile_chat_demotion` does not exist on main and no drop/refusal exists on any path); with the change, the drop closure pins the exact setter order and the refusal path is exercised.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue (before): after opening Chat for profile `echo` (owned by `hermes-echo`, uid 985) from the root-run dashboard —

```
$ find /root/.hermes/profiles/echo -maxdepth 1 -not -user hermes-echo
projects.db
.codex_gpt55_autoraise_notice        # both now root:root 0600
$ hermes doctor (for the echo profile)
journal mode could not be read (permission denied: …/projects.db)
```

After this fix, the same action spawns the chat child as `hermes-echo` — profile state stays owned by the profile's user.
