### PR TITLE
feat(kanban): review-gate guard + ADR-19 object-fidelity + gate-stalled recovery

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1409,6 +1409,48 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        # Review-gate guard. When kanban.gate_required_assignees is non-empty,
+        # a ready card owned by one of those assignees is not started until a
+        # card assigned to kanban.gate_assignee depends on it — closing the
+        # create-then-link window in which an orchestrator's worker card runs
+        # before its reviewer exists. Empty (the default) = feature off, so
+        # installs that don't model review gates are unaffected.
+        raw_gate_roles = kanban_cfg.get("gate_required_assignees", None) or []
+        gate_required_assignees = None
+        if isinstance(raw_gate_roles, (list, tuple, set, frozenset)):
+            cleaned = frozenset(
+                str(r).strip() for r in raw_gate_roles if str(r).strip()
+            )
+            gate_required_assignees = cleaned or None
+        elif raw_gate_roles:
+            logger.warning(
+                "kanban dispatcher: kanban.gate_required_assignees=%r is not a "
+                "list; ignoring (review-gate guard stays off)",
+                raw_gate_roles,
+            )
+        gate_assignee = (
+            str(kanban_cfg.get("gate_assignee") or "critic").strip() or "critic"
+        )
+        try:
+            gate_grace_seconds = int(
+                kanban_cfg.get("gate_grace_seconds", _kb.DEFAULT_GATE_GRACE_SECONDS)
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.gate_grace_seconds=%r; using %d",
+                kanban_cfg.get("gate_grace_seconds"),
+                _kb.DEFAULT_GATE_GRACE_SECONDS,
+            )
+            gate_grace_seconds = _kb.DEFAULT_GATE_GRACE_SECONDS
+        if gate_grace_seconds < 0:
+            gate_grace_seconds = _kb.DEFAULT_GATE_GRACE_SECONDS
+        if gate_required_assignees:
+            logger.info(
+                "kanban dispatcher: review-gate guard on for %d assignee(s); "
+                "gate=%s grace=%ds",
+                len(gate_required_assignees), gate_assignee, gate_grace_seconds,
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -1503,6 +1545,9 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,
+                    gate_required_assignees=gate_required_assignees,
+                    gate_assignee=gate_assignee,
+                    gate_grace_seconds=gate_grace_seconds,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8069,6 +8069,12 @@ class DispatchResult:
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    auto_blocked_fidelity: list[str] = field(default_factory=list)
+    """Task ids auto-blocked by the object-fidelity guard (ADR-19): a quoted
+    entity in the card looks like a near-miss transcription of one named in
+    the root card. Separate bucket from ``auto_blocked`` so telemetry can
+    tell "spawn kept failing" apart from "entity drift suspected" — the
+    remediation and urgency are different (the latter always needs Gab)."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -9585,6 +9591,142 @@ def has_review_gate(
     return row is not None
 
 
+# Object-fidelity guard (ADR-19, 2026-08-04). See DECISIONS.md D-63 for the
+# full design discussion; the short version: the 2026-08-03 半鞅→半鞍 incident
+# showed that ADR-6's fact-check gates verify "is this information true", not
+# "is this the same object the root card named" — a decomposition-time
+# transcription error can survive every downstream gate because the swapped-in
+# entity is itself real. This is a narrow, mechanical heuristic (edit-distance
+# near-miss on quoted proper nouns), not a semantic "did we answer the
+# question" judge — it catches the specific transcription-typo shape of the
+# actual incident and deliberately does not flag wholly new entities a child
+# card introduces, to avoid blocking legitimate research.
+_QUOTE_PAIRS: tuple[tuple[str, str], ...] = (
+    ("「", "」"),  # 「」
+    ("“", "”"),  # “ ”
+    ('"', '"'),
+)
+
+
+def _extract_quoted_entities(text: str) -> set[str]:
+    """Pull proper-noun-shaped substrings wrapped in quote marks out of *text*.
+
+    Terms shorter than 2 characters are dropped (too noisy to be an entity
+    name — usually stray punctuation or a quoted single word like "是").
+    """
+    if not text:
+        return set()
+    out: set[str] = set()
+    for open_q, close_q in _QUOTE_PAIRS:
+        start = 0
+        while True:
+            i = text.find(open_q, start)
+            if i == -1:
+                break
+            j = text.find(close_q, i + len(open_q))
+            if j == -1:
+                break
+            term = text[i + len(open_q):j].strip()
+            if len(term) >= 2:
+                out.add(term)
+            start = j + len(close_q)
+    return out
+
+
+def _edit_distance_le(a: str, b: str, limit: int) -> bool:
+    """True iff the Levenshtein distance between *a* and *b* is <= *limit*.
+
+    Entity names here are always short (a handful of characters), so a plain
+    O(len(a)*len(b)) DP table is cheap — no need for the banded/early-exit
+    variants a general-purpose diff library would use for long strings.
+    """
+    if abs(len(a) - len(b)) > limit:
+        return False
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i] + [0] * len(b)
+        for j, cb in enumerate(b, 1):
+            cur[j] = min(
+                prev[j] + 1,
+                cur[j - 1] + 1,
+                prev[j - 1] + (0 if ca == cb else 1),
+            )
+        prev = cur
+    return prev[len(b)] <= limit
+
+
+def _object_fidelity_mismatches(
+    root_entities: set[str], child_text: str,
+) -> list[tuple[str, str]]:
+    """Find root-card entities that look like they were transcribed wrong.
+
+    For each entity named in the root card: verbatim presence in
+    *child_text* is fine. Otherwise, if *child_text* quotes a *different*
+    entity that is a near-miss (edit distance exactly 1, length difference
+    <= 1 — the exact shape of the 半鞅→半鞍 transcription) — flag the pair.
+    A root entity with neither a verbatim match nor a near-miss candidate is
+    NOT flagged: that is "the child card doesn't mention this yet", not
+    drift, and flagging it would block ordinary partial-progress cards.
+    """
+    if not root_entities:
+        return []
+    child_entities = _extract_quoted_entities(child_text)
+    mismatches: list[tuple[str, str]] = []
+    for root_term in root_entities:
+        if root_term in child_text:
+            continue
+        for child_term in child_entities:
+            if child_term == root_term:
+                continue
+            if _edit_distance_le(root_term, child_term, 1):
+                mismatches.append((root_term, child_term))
+                break
+    return mismatches
+
+
+def _root_ancestor_texts(
+    conn: sqlite3.Connection, task_id: str, *, max_nodes: int = 50,
+) -> list[str]:
+    """Walk ``task_links`` upward from *task_id* to every ancestor that has no
+    parents of its own, and return each such root's ``title``+``body`` text.
+
+    BFS with a visited set and a node cap: a real decomposition graph is never
+    remotely this deep, but the cap keeps a malformed/cyclic link graph (which
+    should never exist, but this reads the DB, not a promise about it) from
+    hanging a dispatcher tick. Returns ``[]`` (fail-open, not fail-closed) on
+    any DB error — an unreadable link graph should not itself halt dispatch;
+    the caller simply won't have a root to compare against this tick.
+    """
+    try:
+        seen: set[str] = set()
+        frontier = [task_id]
+        roots: list[str] = []
+        while frontier and len(seen) < max_nodes:
+            current = frontier.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            parent_rows = conn.execute(
+                "SELECT parent_id FROM task_links WHERE child_id = ?", (current,),
+            ).fetchall()
+            parent_ids = [r["parent_id"] for r in parent_rows]
+            if not parent_ids:
+                if current != task_id:
+                    roots.append(current)
+                continue
+            frontier.extend(pid for pid in parent_ids if pid not in seen)
+        texts = []
+        for rid in roots:
+            row = conn.execute(
+                "SELECT title, body FROM tasks WHERE id = ?", (rid,),
+            ).fetchone()
+            if row is not None:
+                texts.append(f"{row['title'] or ''}\n{row['body'] or ''}")
+        return texts
+    except sqlite3.Error:
+        return []
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
@@ -10242,6 +10384,62 @@ def _dispatch_once_locked(
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
             continue
+        # Object-fidelity guard (ADR-19): refuse to dispatch a producer card
+        # whose quoted entities look like a near-miss transcription of the
+        # root card's. See the helper docstrings above and DECISIONS.md D-63
+        # for the full incident/design writeup. A heuristic this blunt must
+        # not be able to talk itself back into running — only a human
+        # (needs_input, same escape hatch as ADR-10) clears the block.
+        #
+        # Deliberately checked BEFORE the review-gate guard below: this is an
+        # independent concern (does the card's content match the root it
+        # descends from), not something that should wait on gate-card
+        # linkage timing. A card that is wrong doesn't become less wrong by
+        # sitting in ``skipped_ungated`` for a tick.
+        if gate_required_assignees and row_assignee in gate_required_assignees:
+            root_texts = _root_ancestor_texts(conn, row["id"])
+            if root_texts:
+                root_entities: set = set()
+                for t in root_texts:
+                    root_entities |= _extract_quoted_entities(t)
+                # ready_rows above only selects id/assignee/created_at (the
+                # hot-path dispatch query) — fetch this card's own text with
+                # a targeted lookup rather than widening that shared query.
+                own_row = conn.execute(
+                    "SELECT title, body FROM tasks WHERE id = ?", (row["id"],),
+                ).fetchone()
+                child_text = (
+                    f"{own_row['title'] or ''}\n{own_row['body'] or ''}"
+                    if own_row is not None else ""
+                )
+                mismatches = _object_fidelity_mismatches(root_entities, child_text)
+                if mismatches:
+                    detail = "; ".join(
+                        f"根卡「{r}」→ 本卡「{c}」" for r, c in mismatches
+                    )
+                    reason = (
+                        f"object-fidelity guard (ADR-19): possible entity "
+                        f"transcription drift — {detail}. Needs Gab to confirm "
+                        f"this is not a mis-transcription before dispatch."
+                    )
+                    if not dry_run:
+                        try:
+                            block_task(
+                                conn, row["id"], reason=reason, kind="needs_input",
+                            )
+                        except Exception:
+                            _log.debug(
+                                "kanban dispatch: failed to auto-block "
+                                "fidelity-mismatched task %s",
+                                row["id"], exc_info=True,
+                            )
+                            continue
+                    _log.warning(
+                        "kanban dispatch: task %s (%s) blocked — %s",
+                        row["id"], row_assignee, reason,
+                    )
+                    result.auto_blocked_fidelity.append(row["id"])
+                    continue
         # Review-gate guard: refuse to start a card whose output is supposed to
         # be reviewed until the reviewing card actually exists.
         #

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8104,6 +8104,18 @@ class DispatchResult:
     spawned. ``None`` when memory was fine/unknown and the guard imposed
     no restriction. Reclaim/promotion bookkeeping still ran either way;
     deferred tasks stay queued for the next tick."""
+    recovered_from_triage: list[str] = field(default_factory=list)
+    """Task ids auto-promoted ``triage`` -> ``todo`` this tick because they
+    were routed to triage specifically by the no-review-gate loop breaker
+    (see ``skipped_ungated``/``auto_blocked`` above) and a review-gate card
+    now exists. 2026-08-10: found via a real 2-day stuck chain (8 cards on
+    the ``compliance`` board) — ``triage`` is a deliberate human-in-the-loop
+    parking state (see ``block_task``'s ``BLOCK_RECURRENCE_LIMIT`` branch),
+    but nothing ever told a human a card had landed there, so cards whose
+    blocking cause had since resolved sat forever with no automatic path
+    back to ``todo``. This does NOT touch triage cards routed there for any
+    other reason (ADR-19 object-fidelity, a worker's own ``needs_input``) —
+    those still require an actual human decision."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -9591,6 +9603,75 @@ def has_review_gate(
     return row is not None
 
 
+# Auto-recovery for triage cards the no-gate loop breaker parked (2026-08-10).
+# See DispatchResult.recovered_from_triage for the full incident/rationale.
+# Matched on the two stable phrases from the reason string `block_task` writes
+# for THIS specific cause (see its `f"no {gate_assignee} review gate after "`
+# f-string a few hundred lines below) rather than a full-string compare, so a
+# future tweak to the grace-seconds wording doesn't silently stop matching.
+_TRIAGE_GATE_REASON_MARKERS = ("review gate after", "refusing to run ungated")
+
+
+def _recover_gate_stalled_triage(
+    conn: sqlite3.Connection, *, gate_assignee: str = "critic",
+) -> list[str]:
+    """Auto-promote ``triage`` -> ``todo`` for cards the no-gate loop breaker
+    parked there, once a review-gate card has since appeared.
+
+    Narrowly scoped to that ONE cause: only a card whose most recent
+    ``block_loop_detected`` event names "no review gate" is touched. A card
+    in ``triage`` for any other reason (ADR-19 object-fidelity mismatch, a
+    worker's own ``needs_input``) is left exactly where it is — those still
+    need an actual human decision, and this function must not blur that
+    line by loosening the reason match.
+    """
+    recovered: list[str] = []
+    try:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE status = 'triage' AND block_kind = 'needs_input'"
+        ).fetchall()
+    except sqlite3.Error:
+        return recovered
+    for row in rows:
+        task_id = row["id"]
+        try:
+            evt = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? "
+                "AND kind = 'block_loop_detected' ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+        except sqlite3.Error:
+            continue
+        if evt is None:
+            continue
+        try:
+            payload = json.loads(evt["payload"] or "{}")
+        except (ValueError, TypeError):
+            continue
+        reason = str(payload.get("reason") or "")
+        if not all(marker in reason for marker in _TRIAGE_GATE_REASON_MARKERS):
+            continue
+        if not has_review_gate(conn, task_id, gate_assignee):
+            continue
+        try:
+            with write_txn(conn):
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'todo', block_kind = NULL, "
+                    "block_recurrences = 0 WHERE id = ? AND status = 'triage'",
+                    (task_id,),
+                )
+                if cur.rowcount != 1:
+                    continue
+                _append_event(
+                    conn, task_id, "auto_recovered",
+                    {"reason": "review gate now linked", "from_status": "triage"},
+                )
+        except sqlite3.Error:
+            continue
+        recovered.append(task_id)
+    return recovered
+
+
 # Object-fidelity guard (ADR-19, 2026-08-04). See DECISIONS.md D-63 for the
 # full design discussion; the short version: the 2026-08-03 半鞅→半鞍 incident
 # showed that ADR-6's fact-check gates verify "is this information true", not
@@ -10172,6 +10253,15 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    result.recovered_from_triage = _recover_gate_stalled_triage(
+        conn, gate_assignee=gate_assignee,
+    )
+    if result.recovered_from_triage:
+        # Fold straight into this tick rather than waiting for the next one:
+        # a recovered card with no parents is immediately ready to run, and
+        # recompute_ready() only just ran above (it never looks at
+        # ``triage``, so it could not have picked these up itself).
+        result.promoted += recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8041,6 +8041,22 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_ungated: list[str] = field(default_factory=list)
+    """Ready task ids deferred this tick because their assignee is listed in
+    ``kanban.gate_required_assignees`` but no review-gate card depends on them
+    yet.
+
+    Closes a create-then-link race: an orchestrator that creates the worker
+    card and only afterwards links its gate leaves a window in which the
+    dispatcher can claim and run the card ungated, so the output is produced
+    (and delivered) before anything reviews it. Prompt instructions alone do
+    not close it — the orchestrator's own report of what it did is not
+    evidence that it did it in that order.
+
+    NOT operator-actionable on its own: the gate is normally linked within the
+    same turn, so the card simply starts one tick later. Only if the gate is
+    still missing after ``kanban.gate_grace_seconds`` is the card auto-blocked
+    (it then appears in ``auto_blocked`` instead, which IS actionable)."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -9537,6 +9553,38 @@ def check_respawn_guard(
     return None
 
 
+# Default grace before an ungated card is auto-blocked rather than deferred.
+# Sized to comfortably span several dispatcher ticks (default interval 60s):
+# the orchestrator normally links the gate in the same turn it creates the
+# card, so the common case is one deferred tick, not five minutes of waiting.
+DEFAULT_GATE_GRACE_SECONDS = 300
+
+
+def has_review_gate(
+    conn: sqlite3.Connection, task_id: str, gate_assignee: str = "critic",
+) -> bool:
+    """True when some card assigned to ``gate_assignee`` depends on ``task_id``.
+
+    The review gate is modelled as a CHILD card blocked-by the work card, so a
+    gated worker card is one that appears as ``parent_id`` in ``task_links``
+    with a gate-assignee child. Returns False on any error — callers treat an
+    unreadable link graph as "cannot prove a gate exists", which is the
+    fail-closed reading.
+    """
+    if not task_id or not gate_assignee:
+        return False
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM task_links l JOIN tasks t ON t.id = l.child_id "
+            "WHERE l.parent_id = ? AND t.assignee = ? "
+            "AND t.status != 'archived' LIMIT 1",
+            (task_id, gate_assignee),
+        ).fetchone()
+    except sqlite3.Error:
+        return False
+    return row is not None
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
@@ -9819,6 +9867,9 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    gate_required_assignees: Optional[frozenset] = None,
+    gate_assignee: str = "critic",
+    gate_grace_seconds: int = DEFAULT_GATE_GRACE_SECONDS,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -9854,6 +9905,9 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            gate_required_assignees=gate_required_assignees,
+            gate_assignee=gate_assignee,
+            gate_grace_seconds=gate_grace_seconds,
         )
         _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
         return result
@@ -9874,6 +9928,9 @@ def dispatch_once(
                 default_assignee=default_assignee,
                 max_in_progress_per_profile=max_in_progress_per_profile,
                 reconcile_orphans=reconcile_orphans,
+                gate_required_assignees=gate_required_assignees,
+                gate_assignee=gate_assignee,
+                gate_grace_seconds=gate_grace_seconds,
             )
             # Still under the dispatch lock: run the periodic PASSIVE WAL
             # checkpoint (see _maybe_checkpoint_wal; the -wal file size is
@@ -9901,6 +9958,9 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    gate_required_assignees: Optional[frozenset] = None,
+    gate_assignee: str = "critic",
+    gate_grace_seconds: int = DEFAULT_GATE_GRACE_SECONDS,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -10033,8 +10093,9 @@ def _dispatch_once_locked(
             )
             spawn_budget = 1
 
+    # created_at is selected for the review-gate guard's grace-period check.
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, created_at FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -10181,6 +10242,68 @@ def _dispatch_once_locked(
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
             continue
+        # Review-gate guard: refuse to start a card whose output is supposed to
+        # be reviewed until the reviewing card actually exists.
+        #
+        # The failure this closes is a create-then-link race. An orchestrator
+        # that creates the worker card first and links its gate a moment later
+        # leaves a window where the dispatcher claims and runs the card with
+        # nothing gating it; by the time the gate appears the work is done and
+        # already delivered. Ordering instructions in a prompt cannot close
+        # this — the orchestrator's own account of what it did is not evidence
+        # of the order it did it in. Only the dispatcher can refuse to start.
+        #
+        # Deferring (not blocking) is the common path: the gate is normally
+        # linked in the same turn, so the card starts one tick later and
+        # nothing is lost. Blocking is reserved for cards still ungated after
+        # the grace period, where the gate is genuinely never coming and a
+        # human needs to see it — silently running it ungated, or silently
+        # parking it forever, are both worse.
+        if gate_required_assignees and row_assignee in gate_required_assignees:
+            if not has_review_gate(conn, row["id"], gate_assignee):
+                age = 0
+                try:
+                    age = int(time.time()) - int(row["created_at"] or 0)
+                except (TypeError, ValueError):
+                    age = 0
+                if age < max(0, int(gate_grace_seconds)):
+                    result.skipped_ungated.append(row["id"])
+                    continue
+                reason = (
+                    f"no {gate_assignee} review gate after "
+                    f"{gate_grace_seconds}s — refusing to run ungated. "
+                    f"Create a {gate_assignee} card blocked-by this one, then "
+                    f"unblock."
+                )
+                if not dry_run:
+                    try:
+                        # kind=needs_input, NOT dependency. `dependency` means
+                        # "a parent card will finish and free me", and routes
+                        # to `todo` so recompute_ready can promote it — which
+                        # here would loop forever: the card has no unfinished
+                        # parent, so it is promoted straight back to `ready`,
+                        # re-blocked next tick, every tick. The gate card does
+                        # not exist and nothing will create it on its own, so
+                        # this genuinely needs someone to act: `needs_input`
+                        # lands it in the human bucket and participates in the
+                        # unblock-loop breaker.
+                        block_task(
+                            conn, row["id"], reason=reason, kind="needs_input",
+                        )
+                    except Exception:
+                        _log.debug(
+                            "kanban dispatch: failed to auto-block ungated task %s",
+                            row["id"], exc_info=True,
+                        )
+                        result.skipped_ungated.append(row["id"])
+                        continue
+                _log.warning(
+                    "kanban dispatch: task %s (%s) has no %s gate after %ds; "
+                    "blocked instead of running ungated",
+                    row["id"], row_assignee, gate_assignee, age,
+                )
+                result.auto_blocked.append(row["id"])
+                continue
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
         # its in-flight cap. Prevents one profile's local model / API

--- a/tests/hermes_cli/test_kanban_object_fidelity_guard.py
+++ b/tests/hermes_cli/test_kanban_object_fidelity_guard.py
@@ -1,0 +1,204 @@
+"""Regression tests for ADR-19 — the object-fidelity dispatch guard.
+
+2026-08-03 incident: Conductor decomposed a root card naming「半鞅」into a
+child card naming「半鞍」(a one-character near-miss), and every downstream
+fact-check gate PASSed because the swapped-in entity was itself real. ADR-6
+verifies "is this information true", never "is this the same object the root
+card named". This guard closes that gap at dispatch time: a producer card
+whose quoted entities look like a near-miss transcription of a root-card
+entity is blocked (kind=needs_input) instead of dispatched. See
+DECISIONS.md D-63 for the full design discussion.
+
+Tests use assignee="default" for dispatchable cards: ``profile_exists``
+always returns True for "default" without needing an on-disk profiles/
+directory, keeping these tests independent of any real profile fixture.
+``gate_required_assignees`` is passed explicitly per test — it does not need
+to match a real roles.yaml population, just the guard's own scoping.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    """Spin up a fresh HERMES_HOME with a clean kanban DB."""
+    test_home = tempfile.mkdtemp(prefix="kanban_object_fidelity_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db, test_home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+ROOT_BODY = "「半鞅」这家管理人的股票类产品最近表现怎么样？"
+
+
+def _make_root_and_child(kb, conn, child_body, *, child_assignee="default"):
+    root_id = kb.create_task(conn, title="root", body=ROOT_BODY, assignee="conductor")
+    conn.execute("UPDATE tasks SET status='done' WHERE id=?", (root_id,))
+    child_id = kb.create_task(
+        conn, title="child", body=child_body, assignee=child_assignee, parents=[root_id],
+    )
+    return root_id, child_id
+
+
+def _add_review_gate(kb, conn, child_id):
+    """Satisfy has_review_gate() so ADR-6's separate review-gate check (which
+    the object-fidelity guard runs alongside, not instead of) doesn't defer
+    the card for an unrelated reason in tests that expect a clean dispatch."""
+    kb.create_task(conn, title="gate", assignee="critic", parents=[child_id])
+
+
+def test_exact_match_dispatches_normally(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "去查一下「半鞅」这家私募的产品线",
+        )
+        _add_review_gate(kb, conn, child_id)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.auto_blocked_fidelity == []
+    assert any(s[0] == child_id for s in res.spawned)
+
+
+def test_near_miss_transcription_blocks_with_needs_input(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "去查一下「半鞍」这家私募的产品线",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.auto_blocked_fidelity == [child_id]
+    assert not res.spawned
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (child_id,),
+        ).fetchone()
+    assert row["status"] == "blocked"
+
+
+def test_wholly_new_entity_not_blocked(isolated_kanban_home):
+    """A child card that never mentions the root's entity at all — e.g. it's
+    the first of several parallel research cards on a different angle —
+    must not be blocked just because it doesn't repeat the root's quotes."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "查一下「联想集团」最近的财报",
+        )
+        _add_review_gate(kb, conn, child_id)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.auto_blocked_fidelity == []
+    assert any(s[0] == child_id for s in res.spawned)
+
+
+def test_guard_only_applies_to_gated_assignees(isolated_kanban_home):
+    """A near-miss on a card whose assignee isn't in gate_required_assignees
+    must not be blocked — the guard is scoped to the same producer
+    population ADR-6's review gate already covers, not every card."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "综合一下「半鞍」的分析结果",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            # "default" (the child's assignee) deliberately NOT included.
+            gate_required_assignees=frozenset({"researcher"}),
+        )
+    assert res.auto_blocked_fidelity == []
+    assert any(s[0] == child_id for s in res.spawned)
+
+
+def test_unblock_alone_does_not_bypass_the_guard(isolated_kanban_home):
+    """A bare unblock must NOT be a free pass: the guard is content-based, so
+    if nobody actually fixed the card's text, the very next tick blocks it
+    again. This is deliberate (mirrors block_task's block_recurrences design,
+    which never resets on unblock) — a heuristic this blunt should not be
+    escapable by reflexively clicking 'unblock' without addressing the
+    underlying mismatch. Real remediation is to fix the card's wording (or,
+    after enough repeats, block_task's own recurrence limit escalates the
+    task to 'triage' instead of looping in 'blocked' forever)."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "去查一下「半鞍」这家私募的产品线",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.auto_blocked_fidelity == [child_id]
+
+    with kb.connect_closing() as conn:
+        assert kb.unblock_task(conn, child_id)
+
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res2.auto_blocked_fidelity == [child_id]
+    assert not res2.spawned
+
+
+def test_fixing_the_wording_then_unblocking_lets_it_dispatch(isolated_kanban_home):
+    """The real remediation path: a human edits the card so the mismatch is
+    actually gone (here: the near-miss quote is corrected to match the root),
+    then unblocks it. The next tick dispatches normally."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _root_id, child_id = _make_root_and_child(
+            kb, conn, "去查一下「半鞍」这家私募的产品线",
+        )
+        _add_review_gate(kb, conn, child_id)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.auto_blocked_fidelity == [child_id]
+
+    with kb.connect_closing() as conn:
+        conn.execute(
+            "UPDATE tasks SET body = ? WHERE id = ?",
+            ("去查一下「半鞅」这家私募的产品线", child_id),
+        )
+        assert kb.unblock_task(conn, child_id)
+
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res2.auto_blocked_fidelity == []
+    assert any(s[0] == child_id for s in res2.spawned)

--- a/tests/hermes_cli/test_kanban_review_gate_guard.py
+++ b/tests/hermes_cli/test_kanban_review_gate_guard.py
@@ -1,0 +1,228 @@
+"""Regression tests for the review-gate guard (kanban.gate_required_assignees).
+
+Closes a create-then-link race. An orchestrator that creates the worker card
+first and links its review gate a moment later leaves a window in which the
+dispatcher claims and runs the card with nothing gating it — by the time the
+gate appears the work is done and already delivered. Prompt-level ordering
+rules cannot close this: the orchestrator's own account of what it did is not
+evidence of the order it did it in. Only the dispatcher can refuse to start.
+
+A ready card owned by an assignee listed in ``kanban.gate_required_assignees``
+is deferred (``skipped_ungated``) while no card assigned to
+``kanban.gate_assignee`` (default "critic") depends on it, then auto-blocked
+(``needs_input``) after ``kanban.gate_grace_seconds`` if the gate never
+arrives. Empty ``gate_required_assignees`` (the default) means the guard is
+off.
+
+Tests use assignee="default" for dispatchable cards: ``profile_exists``
+always returns True for "default" without needing an on-disk profiles/
+directory. ``gate_required_assignees`` is passed explicitly per test — it
+does not need to match a real roles.yaml population, just the guard's own
+scoping.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    """Spin up a fresh HERMES_HOME with a clean kanban DB."""
+    test_home = tempfile.mkdtemp(prefix="kanban_review_gate_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db, test_home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _add_review_gate(kb, conn, work_id, gate_assignee="critic"):
+    """Create a gate card (assigned to ``gate_assignee``) blocked-by ``work_id``,
+    satisfying ``has_review_gate()``. Returns the gate card id."""
+    return kb.create_task(
+        conn, title="review gate", assignee=gate_assignee, parents=[work_id],
+    )
+
+
+# --- has_review_gate() — DB primitive ---
+
+def test_has_review_gate_true_when_gate_child_depends(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        _add_review_gate(kb, conn, work_id)
+    with kb.connect_closing() as conn:
+        assert kb.has_review_gate(conn, work_id) is True
+
+
+def test_has_review_gate_false_when_no_gate(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+    with kb.connect_closing() as conn:
+        assert kb.has_review_gate(conn, work_id) is False
+
+
+def test_has_review_gate_false_when_gate_archived(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        gate_id = _add_review_gate(kb, conn, work_id)
+        conn.execute("UPDATE tasks SET status='archived' WHERE id=?", (gate_id,))
+    with kb.connect_closing() as conn:
+        assert kb.has_review_gate(conn, work_id) is False
+
+
+def test_has_review_gate_false_when_gate_assignee_differs(isolated_kanban_home):
+    """A gate card assigned to anyone other than gate_assignee does not count."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        _add_review_gate(kb, conn, work_id, gate_assignee="reviewer")
+    with kb.connect_closing() as conn:
+        assert kb.has_review_gate(conn, work_id, gate_assignee="critic") is False
+
+
+def test_has_review_gate_false_for_empty_args(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        _add_review_gate(kb, conn, work_id)
+    with kb.connect_closing() as conn:
+        assert kb.has_review_gate(conn, "") is False
+        assert kb.has_review_gate(conn, work_id, "") is False
+
+
+# --- dispatch-level deferral / blocking ---
+
+def test_ungated_card_deferred_not_run(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        # gate not linked yet — the create-then-link window
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.skipped_ungated == [work_id]
+    assert not res.spawned
+
+
+def test_card_runs_once_gate_linked(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        _add_review_gate(kb, conn, work_id)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+        )
+    assert res.skipped_ungated == []
+    assert any(s[0] == work_id for s in res.spawned)
+
+
+def test_non_listed_assignee_unaffected(isolated_kanban_home):
+    """A card whose assignee is not in gate_required_assignees runs even without
+    a gate — the guard is scoped to the gated population, not every card."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        # no gate
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"researcher"}),
+        )
+    assert res.skipped_ungated == []
+    assert any(s[0] == work_id for s in res.spawned)
+
+
+def test_guard_off_by_default(isolated_kanban_home):
+    """None gate_required_assignees (the default) = feature off; card runs."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=None,
+        )
+    assert res.skipped_ungated == []
+    assert any(s[0] == work_id for s in res.spawned)
+
+
+def test_past_grace_card_auto_blocked(isolated_kanban_home):
+    """A card still ungated after gate_grace_seconds is auto-blocked (needs_input)
+    instead of running ungated or parking forever."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        conn.execute(
+            "UPDATE tasks SET created_at=? WHERE id=?",
+            (int(time.time()) - 1000, work_id),
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+            gate_grace_seconds=300,
+        )
+    assert res.auto_blocked == [work_id]
+    assert res.skipped_ungated == []
+    assert not res.spawned
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (work_id,)).fetchone()
+    assert row["status"] == "blocked"
+
+
+def test_blocked_card_stays_blocked(isolated_kanban_home):
+    """Once auto-blocked, the card must not re-enter ready and re-block on the
+    next tick (the gate is still not coming)."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        work_id = kb.create_task(conn, title="work", assignee="default")
+        conn.execute(
+            "UPDATE tasks SET created_at=? WHERE id=?",
+            (int(time.time()) - 1000, work_id),
+        )
+    with kb.connect_closing() as conn:
+        res1 = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+            gate_grace_seconds=300,
+        )
+    assert res1.auto_blocked == [work_id]
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=frozenset({"default"}),
+            gate_grace_seconds=300,
+        )
+    assert res2.auto_blocked == []
+    assert res2.skipped_ungated == []
+    assert not res2.spawned
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (work_id,)).fetchone()
+    assert row["status"] == "blocked"

--- a/tests/hermes_cli/test_kanban_triage_recovery.py
+++ b/tests/hermes_cli/test_kanban_triage_recovery.py
@@ -1,0 +1,141 @@
+"""Regression tests for the triage auto-recovery patch (2026-08-10).
+
+Incident: a card assigned to a gate-required role got no review-gate card
+within `gate_grace_seconds`, was auto-blocked (kind=needs_input), a human
+unblocked it before the gate existed, and it was immediately re-blocked for
+the same reason — tripping BLOCK_RECURRENCE_LIMIT and landing in `triage`.
+`triage` is a deliberate human-in-the-loop parking state
+(`block_task`'s BLOCK_RECURRENCE_LIMIT branch) with no automatic path back
+out. On the real `compliance` board this stranded 8 cards for 2 days: the
+review-gate card was created 43 minutes later, but nothing ever promoted the
+triage'd root card back to `todo` once it existed.
+
+`_recover_gate_stalled_triage()` closes that gap: each dispatch tick, any
+`triage` card whose most recent `block_loop_detected` reason names "no
+review gate" is promoted back to `todo` (then folded into `ready` the same
+tick via a follow-up `recompute_ready()`) once `has_review_gate()` is true.
+Narrowly scoped to that one cause — a card in `triage` for any other reason
+(ADR-19 object-fidelity, a worker's own needs_input) must be left alone.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    test_home = tempfile.mkdtemp(prefix="kanban_triage_recovery_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db, test_home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+GATE_ASSIGNEES = frozenset({"default"})
+
+
+def _drive_into_triage(kb, conn, task_id):
+    """Replay the real incident's sequence: block for no-gate, get manually
+    unblocked while the gate still doesn't exist, re-block for the same
+    cause -> BLOCK_RECURRENCE_LIMIT trips -> triage."""
+    res1 = kb.dispatch_once(
+        conn, spawn_fn=_fake_spawn, dry_run=False,
+        gate_required_assignees=GATE_ASSIGNEES, gate_grace_seconds=0,
+    )
+    assert task_id in res1.auto_blocked
+    row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+    assert row["status"] == "blocked"
+
+    assert kb.unblock_task(conn, task_id)
+
+    res2 = kb.dispatch_once(
+        conn, spawn_fn=_fake_spawn, dry_run=False,
+        gate_required_assignees=GATE_ASSIGNEES, gate_grace_seconds=0,
+    )
+    row = conn.execute(
+        "SELECT status, block_kind FROM tasks WHERE id=?", (task_id,)
+    ).fetchone()
+    assert row["status"] == "triage", res2
+    assert row["block_kind"] == "needs_input"
+
+
+def test_triage_card_recovers_once_gate_appears(isolated_kanban_home):
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        task_id = kb.create_task(conn, title="ocr chain root", assignee="default")
+    with kb.connect_closing() as conn:
+        _drive_into_triage(kb, conn, task_id)
+
+    # Gate still missing: an ordinary tick must NOT touch the triage'd card.
+    with kb.connect_closing() as conn:
+        res_still_stuck = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=GATE_ASSIGNEES, gate_grace_seconds=0,
+        )
+    assert res_still_stuck.recovered_from_triage == []
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+        assert row["status"] == "triage"
+
+    # Gate created (mirrors a human/Conductor creating the missing critic
+    # card and linking it) -> the next tick must recover and dispatch it.
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="gate", assignee="critic", parents=[task_id])
+    with kb.connect_closing() as conn:
+        res_recovered = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=GATE_ASSIGNEES, gate_grace_seconds=0,
+        )
+    assert res_recovered.recovered_from_triage == [task_id]
+    assert any(s[0] == task_id for s in res_recovered.spawned), res_recovered
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id=?", (task_id,)
+        ).fetchone()
+        assert row["status"] == "running"
+        assert row["block_kind"] is None
+        assert row["block_recurrences"] == 0
+
+
+def test_triage_card_for_an_unrelated_reason_is_left_alone(isolated_kanban_home):
+    """A card in triage for any OTHER cause must never be silently promoted,
+    even once something that looks like a review gate exists — recovery
+    must be scoped to the exact "no review gate" reason, not to "any
+    triage card with a gate-assignee child somewhere in the graph"."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        task_id = kb.create_task(conn, title="paywalled source", assignee="default")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,))
+        assert kb.block_task(
+            conn, task_id, reason="hit a paywall, need credentials", kind="needs_input",
+        )
+        assert kb.unblock_task(conn, task_id)
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,))
+        assert kb.block_task(
+            conn, task_id, reason="hit a paywall, need credentials", kind="needs_input",
+        )
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+        assert row["status"] == "triage"
+        # Even with an unrelated gate-assignee card now pointing at it...
+        kb.create_task(conn, title="gate", assignee="critic", parents=[task_id])
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            gate_required_assignees=GATE_ASSIGNEES, gate_grace_seconds=0,
+        )
+    assert res.recovered_from_triage == []
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (task_id,)).fetchone()
+        assert row["status"] == "triage"


### PR DESCRIPTION
## What does this PR do?

Closes a create-then-link race in the kanban dispatcher: an orchestrator that
creates the worker card first and links its review gate a moment later leaves
a window where the dispatcher runs the card ungated and the output is
delivered before anything reviews it. Prompt-level ordering rules cannot close
this — the orchestrator's own account of what it did is not evidence of the
order it did it in, so only the dispatcher (which sees the DB) can enforce it.

Four dispatcher-side guards, each closing a distinct failure class:

1. **Review-gate DB support** — `has_review_gate()` (fail-closed link-graph
   lookup), `DispatchResult.skipped_ungated`, `DEFAULT_GATE_GRACE_SECONDS`,
   and `gate_required_assignees` / `gate_assignee` / `gate_grace_seconds`
   plumbing through `dispatch_once`.
2. **Refuse to start an ungated card** — a ready card owned by a
   `kanban.gate_required_assignees` member is deferred (`skipped_ungated`)
   while no `kanban.gate_assignee` card (default `critic`) depends on it, then
   auto-blocked (`needs_input`, deliberately NOT `dependency` — which would
   loop) after `kanban.gate_grace_seconds` (default 300). Off by default.
3. **ADR-19 object-fidelity guard** — blocks a producer card whose quoted
   entities look like a near-miss transcription of the root card's (real
   incident: 「半鞅」→「半鞍」, which passed every downstream fact-check gate
   because the swapped-in entity was itself real).
4. **Gate-stalled triage recovery** — auto-promotes `triage` → `todo` cards the
   no-gate loop breaker parked, once a review-gate card has since appeared.
   Narrowly scoped to that ONE cause.

## Related Issue

N/A (no issue exists). Independent of #88035 (connect-guard) — the two change
disjoint regions of `kanban_db.py` and merge cleanly in either order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — review-gate DB support: `has_review_gate()`,
  `DispatchResult.skipped_ungated`, `DEFAULT_GATE_GRACE_SECONDS`, dispatch
  deferral/auto-block logic, `gate_required_assignees`/`gate_assignee`/
  `gate_grace_seconds` params; ADR-19 object-fidelity dispatch guard;
  gate-stalled triage auto-recovery
- `gateway/kanban_watchers.py` — read `kanban.gate_required_assignees` /
  `gate_assignee` / `gate_grace_seconds` from config and pass into
  `dispatch_once` (refuse to start an ungated card)
- `tests/hermes_cli/test_kanban_review_gate_guard.py` — new, 11 cases
- `tests/hermes_cli/test_kanban_object_fidelity_guard.py` — ADR-19 tests
- `tests/hermes_cli/test_kanban_triage_recovery.py` — gate-stalled tests

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_review_gate_guard.py -q`
   — 11/11 pass (run against this checkout)
2. `scripts/run_tests.sh tests/hermes_cli/test_kanban_object_fidelity_guard.py tests/hermes_cli/test_kanban_triage_recovery.py -q`
3. Manual: set `kanban.gate_required_assignees: ["<profile>"]` in config, create
   a worker card for that profile with no gate → it defers (`skipped_ungated`);
   link a `critic` child → it runs next tick; leave it ungated past the grace
   → it auto-blocks with `needs_input`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — focused test files pass locally; full suite runs in CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (docstrings updated inline)
- [ ] I've updated `cli-config.yaml.example` — N/A (config keys are read from existing `kanban.*` namespace, no new top-level keys)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

N/A