### PR TITLE
fix(desktop): preserve ordinary session connection ownership

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
 import { getSessionOwnerHint } from '@/store/session'
-import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
@@ -74,7 +74,9 @@ export function useSessionTileDelegate({
       }
     }
 
-    const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
+    const ownerForStoredSession = async (
+      storedSessionId: string
+    ): Promise<SessionProfileRoute | string | undefined> => {
       const owner =
         getSessionOwnerHint(storedSessionId) ??
         sessionTileOwnerRoute(storedSessionId) ??

--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
+import { findStoredIdForRuntimeId, resolveKnownSessionRpcOwner, resolveRoutingSessionId } from './wiring-routing'
+
+describe('resolveKnownSessionRpcOwner', () => {
+  it('keeps the production dispatcher pinned to a connection-qualified row owner', () => {
+    expect(
+      resolveKnownSessionRpcOwner(
+        [{ connection_id: 'remote-source', id: 'ordinary-session', profile: 'default' } as never],
+        'ordinary-session'
+      )
+    ).toEqual({ connectionId: 'remote-source', profile: 'default' })
+  })
+})
 
 describe('findStoredIdForRuntimeId', () => {
   it('reverse-resolves a runtime id to its stored id', () => {

--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { findStoredIdForRuntimeId, resolveKnownSessionRpcOwner, resolveRoutingSessionId } from './wiring-routing'
+import {
+  findStoredIdForRuntimeId,
+  resolveKnownSessionRpcOwner,
+  resolveRoutingSessionId,
+  sessionOwnerNeedsProbe
+} from './wiring-routing'
 
 describe('resolveKnownSessionRpcOwner', () => {
   it('keeps the production dispatcher pinned to a connection-qualified row owner', () => {
@@ -10,6 +15,26 @@ describe('resolveKnownSessionRpcOwner', () => {
         'ordinary-session'
       )
     ).toEqual({ connectionId: 'remote-source', profile: 'default' })
+  })
+})
+
+describe('sessionOwnerNeedsProbe', () => {
+  it('probes an unresolved owner', () => {
+    expect(sessionOwnerNeedsProbe(undefined)).toBe(true)
+    expect(sessionOwnerNeedsProbe(null)).toBe(true)
+    expect(sessionOwnerNeedsProbe('')).toBe(true)
+  })
+
+  it('probes an ambiguous owner instead of skipping it as truthy', () => {
+    // The regression this guards: `{ambiguous: true}` is an object, so a plain
+    // `!owner` check treats it as resolved, skips the probe, and leaves every
+    // RPC for that session rejecting with no way to re-resolve it.
+    expect(sessionOwnerNeedsProbe({ ambiguous: true })).toBe(true)
+  })
+
+  it('never spends a probe on an owner that is already pinned', () => {
+    expect(sessionOwnerNeedsProbe({ connectionId: 'remote-source', profile: 'default' })).toBe(false)
+    expect(sessionOwnerNeedsProbe('worker')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -6,7 +6,7 @@
  */
 
 import { knownSessionOwner } from '@/store/session'
-import type { SessionOwnerScope, SessionProfileRoute } from '@/store/session-request-router'
+import { isAmbiguousOwner, type SessionOwnerScope, type SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionInfo } from '@/types/hermes'
 
 export function resolveKnownSessionRpcOwner(
@@ -15,6 +15,21 @@ export function resolveKnownSessionRpcOwner(
   tileOwner?: SessionProfileRoute
 ): SessionOwnerScope {
   return tileOwner ?? knownSessionOwner(sessions, routingSessionId)
+}
+
+/**
+ * True when a real session's owner is worth spending a cross-profile probe on.
+ *
+ * An UNKNOWN owner has never been resolved. An AMBIGUOUS one was resolved to
+ * contradictory local evidence — which is exactly what the backends can settle
+ * and the renderer cannot — so it probes too. The distinction matters because an
+ * ambiguous verdict is a truthy object: a bare `!owner` check skips the probe
+ * for it, and since nothing re-resolves that contradiction on its own, every
+ * session-scoped RPC for that session then rejects until the app restarts.
+ * A probe miss changes nothing here; the caller still fails closed.
+ */
+export function sessionOwnerNeedsProbe(owner: SessionOwnerScope): boolean {
+  return !owner || isAmbiguousOwner(owner)
 }
 
 /**

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -5,6 +5,18 @@
  * React/Electron controller module.
  */
 
+import { knownSessionOwner } from '@/store/session'
+import type { SessionOwnerScope, SessionProfileRoute } from '@/store/session-request-router'
+import type { SessionInfo } from '@/types/hermes'
+
+export function resolveKnownSessionRpcOwner(
+  sessions: readonly SessionInfo[],
+  routingSessionId: null | string,
+  tileOwner?: SessionProfileRoute
+): SessionOwnerScope {
+  return tileOwner ?? knownSessionOwner(sessions, routingSessionId)
+}
+
 /**
  * Resolve a runtime session id back to its stored id by reverse-scanning the
  * stored->runtime binding map — the same ladder use-session-tile-delegate's

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,6 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  knownSessionProfile,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -153,7 +152,7 @@ import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
-import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
+import { findStoredIdForRuntimeId, resolveKnownSessionRpcOwner, resolveRoutingSessionId } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -356,9 +355,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           undefined
       })
 
-      let owner: SessionOwnerScope =
-        (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        knownSessionProfile($sessions.get(), routingSessionId)
+      let owner: SessionOwnerScope = resolveKnownSessionRpcOwner(
+        $sessions.get(),
+        routingSessionId,
+        routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined
+      )
 
       if (!owner && routingSessionId) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -152,7 +152,12 @@ import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
-import { findStoredIdForRuntimeId, resolveKnownSessionRpcOwner, resolveRoutingSessionId } from './wiring-routing'
+import {
+  findStoredIdForRuntimeId,
+  resolveKnownSessionRpcOwner,
+  resolveRoutingSessionId,
+  sessionOwnerNeedsProbe
+} from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -361,12 +366,20 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined
       )
 
-      if (!owner && routingSessionId) {
+      if (routingSessionId && sessionOwnerNeedsProbe(owner)) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the
         // gateway socket, so no recursion) rather than defaulting to active. A
         // hit stamps ownership + caches a hint; a miss leaves owner undefined
         // and the request falls to ambient, exactly as an unroutable session did
         // before — but only after we tried, never as a silent active fallback.
+        //
+        // An AMBIGUOUS owner probes too: contradictory local evidence is exactly
+        // the case the backends can settle and we cannot, and this dispatcher is
+        // the one caller that holds the probe. Without this the object is truthy,
+        // the probe is skipped, and every RPC for that session rejects for the
+        // life of the process — the local contradiction never re-resolves on its
+        // own. A miss keeps `owner` ambiguous and still fails closed below; it
+        // never degrades to ambient.
         const probed = await resolveSessionProfile(routingSessionId)
 
         if (probed) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -18,8 +18,14 @@ import {
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
-import { requestGatewayForAgent } from '@/store/gateway'
-import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
+import { activeGatewayConnectionId, requestGatewayForAgent } from '@/store/gateway'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $newChatRoute,
+  ensureGatewayAgent,
+  ensureGatewayProfile
+} from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
@@ -33,7 +39,9 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
+  knownSessionOwner,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -80,6 +88,7 @@ vi.mock('@/store/profile', async importOriginal => ({
 
 vi.mock('@/store/gateway', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
+  activeGatewayConnectionId: vi.fn(() => null),
   requestGatewayForAgent: vi.fn()
 }))
 
@@ -536,6 +545,7 @@ describe('createBackendSessionForSend profile routing', () => {
     cleanup()
     $newChatProfile.set(null)
     $newChatRoute.set(null)
+    vi.mocked(activeGatewayConnectionId).mockReturnValue(null)
     $activeGatewayProfile.set('default')
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
@@ -545,6 +555,8 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentProvider.set('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    setSessions([])
+    vi.clearAllMocks()
     vi.restoreAllMocks()
   })
 
@@ -626,6 +638,55 @@ describe('createBackendSessionForSend profile routing', () => {
       expect.objectContaining({ profile: 'backend-default', source: 'desktop' })
     )
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
+  })
+
+  it('captures an ordinary secondary owner before create and stamps the optimistic row', async () => {
+    const ready = deferred<void>()
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    vi.mocked(activeGatewayConnectionId).mockReturnValue('remote-source')
+    vi.mocked(ensureGatewayAgent).mockReturnValueOnce(ready.promise)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({
+      session_id: RUNTIME_SESSION_ID,
+      stored_session_id: 'stored-remote'
+    } as never)
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set('writer')
+    $newChatRoute.set(null)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    let createPromise!: Promise<null | string>
+    act(() => {
+      createPromise = handle!.createBackendSessionForSend('remote preview')
+    })
+    await waitFor(() => expect(ensureGatewayAgent).toHaveBeenCalledWith('remote-source', 'writer'))
+
+    vi.mocked(activeGatewayConnectionId).mockReturnValue('other-source')
+    $activeGatewayProfile.set('other-profile')
+    ready.resolve()
+
+    await act(async () => {
+      await createPromise
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'remote-source',
+      'writer',
+      'session.create',
+      expect.objectContaining({ profile: 'writer', source: 'desktop' })
+    )
+    expect($sessions.get().find(session => session.id === 'stored-remote')).toMatchObject({
+      connection_id: 'remote-source',
+      profile: 'writer'
+    })
+    expect(knownSessionOwner($sessions.get(), 'stored-remote')).toEqual({
+      connectionId: 'remote-source',
+      profile: 'writer'
+    })
+    expect(ambientRequest).not.toHaveBeenCalled()
   })
 
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,7 +22,12 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
-import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
+import {
+  activeGatewayConnectionId,
+  openGatewayForAgent,
+  openGatewayForProfile,
+  requestGatewayForAgent
+} from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -77,6 +82,7 @@ import {
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
+  setSessionOwnerHint,
   setSessions,
   setSessionStartedAt,
   setTurnStartedAt,
@@ -167,6 +173,23 @@ interface SessionActionsOptions {
 // bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
+
+function currentSessionOwnerRoute(capturedRoute?: SessionProfileRoute | null): SessionProfileRoute | undefined {
+  if (capturedRoute) {
+    return { ...capturedRoute }
+  }
+
+  const connectionId = activeGatewayConnectionId()
+
+  if (!connectionId) {
+    return undefined
+  }
+
+  return {
+    connectionId,
+    profile: normalizeProfileKey($activeGatewayProfile.get())
+  }
+}
 
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
@@ -506,6 +529,16 @@ export function useSessionActions({
           return null
         }
 
+        const ownerRoute = currentSessionOwnerRoute(capturedRoute)
+
+        if (ownerRoute) {
+          setSessionOwnerHint(created.session_id, ownerRoute)
+
+          if (stored) {
+            setSessionOwnerHint(stored, ownerRoute)
+          }
+        }
+
         resetViewSync()
         activeSessionIdRef.current = created.session_id
         selectedStoredSessionIdRef.current = stored
@@ -644,6 +677,13 @@ export function useSessionActions({
 
         createdThisRun.add(stored)
 
+        const ownerRoute = currentSessionOwnerRoute(capturedRoute)
+
+        if (ownerRoute) {
+          setSessionOwnerHint(created.session_id, ownerRoute)
+          setSessionOwnerHint(stored, ownerRoute)
+        }
+
         // Seed the per-runtime cache so the tile renders immediately without a
         // redundant resume. Only add the row to the SIDEBAR when `listed` — an
         // unlisted (draft) tab stays out of the session list until its first
@@ -661,7 +701,13 @@ export function useSessionActions({
         const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false })
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
-        openSessionTile(stored, dir, undefined, undefined, workspaceScope)
+        openSessionTile(
+          stored,
+          dir,
+          undefined,
+          undefined,
+          ownerRoute ? { ...workspaceScope, ownerRoute } : workspaceScope
+        )
         patchSessionTile(stored, { runtimeId: created.session_id })
 
         if (dir === 'center' && runtimeInfo?.cwd) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,12 +22,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
-import {
-  activeGatewayConnectionId,
-  openGatewayForAgent,
-  openGatewayForProfile,
-  requestGatewayForAgent
-} from '@/store/gateway'
+import { activeGatewayConnectionId, openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -174,7 +169,7 @@ interface SessionActionsOptions {
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
 
-function currentSessionOwnerRoute(capturedRoute?: SessionProfileRoute | null): SessionProfileRoute | undefined {
+function captureNewSessionOwner(capturedRoute?: SessionProfileRoute | null): SessionProfileRoute | undefined {
   if (capturedRoute) {
     return { ...capturedRoute }
   }
@@ -187,7 +182,7 @@ function currentSessionOwnerRoute(capturedRoute?: SessionProfileRoute | null): S
 
   return {
     connectionId,
-    profile: normalizeProfileKey($activeGatewayProfile.get())
+    profile: $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
   }
 }
 
@@ -236,7 +231,7 @@ function reconcileAuthoritativeMessages(
 // never the profile default (that lives in Settings → Model).
 async function desktopSessionCreateParams(
   cwd: string,
-  capturedRoute = $newChatRoute.get()
+  ownerRoute = captureNewSessionOwner($newChatRoute.get())
 ): Promise<Record<string, unknown>> {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
@@ -249,10 +244,10 @@ async function desktopSessionCreateParams(
     provider: $currentProvider.get().trim()
   }
 
-  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  const profile = ownerRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
 
-  if (capturedRoute) {
-    await ensureGatewayAgent(capturedRoute.connectionId, profile)
+  if (ownerRoute) {
+    await ensureGatewayAgent(ownerRoute.connectionId, profile)
   } else {
     await ensureGatewayProfile(profile)
   }
@@ -261,7 +256,7 @@ async function desktopSessionCreateParams(
     cols: 96,
     source: 'desktop',
     ...(cwd && { cwd }),
-    ...(profile ? { profile: capturedRoute?.targetProfile || profile } : {}),
+    ...(profile ? { profile: ownerRoute?.targetProfile || profile } : {}),
     ...(selection.model
       ? { model: selection.model, ...(selection.provider ? { provider: selection.provider } : {}) }
       : {}),
@@ -493,16 +488,14 @@ export function useSessionActions({
               : $currentCwd.get().trim() || resolveNewSessionCwd()
 
         const capturedRoute = $newChatRoute.get()
-        const params = await desktopSessionCreateParams(cwd, capturedRoute)
+        const ownerRoute = captureNewSessionOwner(capturedRoute)
 
-        const created = capturedRoute
-          ? await requestGatewayForAgent<SessionCreateResponse>(
-              capturedRoute.connectionId,
-              capturedRoute.profile,
-              'session.create',
-              params
-            )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+        const requestForNewSession = <T>(method: string, params: Record<string, unknown> = {}): Promise<T> =>
+          requestForSessionProfile<T>(ownerRoute, requestGateway, method, params)
+
+        const params = await desktopSessionCreateParams(cwd, ownerRoute)
+
+        const created = await requestForNewSession<SessionCreateResponse>('session.create', params)
 
         const stored = created.stored_session_id ?? null
 
@@ -524,12 +517,10 @@ export function useSessionActions({
 
         if (drift) {
           console.warn('[submit-drift-abort]', drift, { phase: 'mid-create' })
-          await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
+          await requestForNewSession('session.close', { session_id: created.session_id }).catch(() => undefined)
 
           return null
         }
-
-        const ownerRoute = currentSessionOwnerRoute(capturedRoute)
 
         if (ownerRoute) {
           setSessionOwnerHint(created.session_id, ownerRoute)
@@ -550,7 +541,7 @@ export function useSessionActions({
           // reads meaningfully while the turn is in flight, instead of flashing
           // "Untitled session" until the turn persists and auto-title runs. The
           // server later returns its own preview/title and supersedes this.
-          upsertOptimisticSession(created, stored, null, preview?.trim() || null)
+          upsertOptimisticSession(created, stored, null, preview?.trim() || null, null, undefined, ownerRoute)
           navigate(sessionRoute(stored), { replace: true })
           // Other windows (e.g. the main window when this is the pop-out) can't
           // see this session until they re-pull the shared list.
@@ -572,7 +563,7 @@ export function useSessionActions({
         // User may have armed YOLO on the new-chat draft before the runtime
         // session existed — apply it to the freshly created session.
         if (yoloArmed) {
-          await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
+          await setSessionYolo(requestForNewSession, created.session_id, true).catch(() => undefined)
         }
 
         return created.session_id
@@ -641,43 +632,33 @@ export function useSessionActions({
         // to fall through into the last project folder while main chat was
         // occupied (openTab path for "New session in Home").
         const capturedRoute = options?.route === undefined ? $newChatRoute.get() : options.route
+        const ownerRoute = captureNewSessionOwner(capturedRoute)
+
+        const requestForNewSession = <T>(method: string, params: Record<string, unknown> = {}): Promise<T> =>
+          requestForSessionProfile<T>(ownerRoute, requestGateway, method, params)
+
         const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
 
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
         const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
+          ...(await desktopSessionCreateParams(cwd, ownerRoute)),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
 
-        const created = capturedRoute
-          ? await requestGatewayForAgent<SessionCreateResponse>(
-              capturedRoute.connectionId,
-              capturedRoute.profile,
-              'session.create',
-              params
-            )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+        const created = await requestForNewSession<SessionCreateResponse>('session.create', params)
 
         const stored = created.stored_session_id
 
         if (!stored) {
-          const closeCreated = capturedRoute
-            ? requestGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile, 'session.close', {
-                session_id: created.session_id
-              })
-            : requestGateway('session.close', { session_id: created.session_id })
-
-          await closeCreated.catch(() => undefined)
+          await requestForNewSession('session.close', { session_id: created.session_id }).catch(() => undefined)
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
 
           return
         }
 
         createdThisRun.add(stored)
-
-        const ownerRoute = currentSessionOwnerRoute(capturedRoute)
 
         if (ownerRoute) {
           setSessionOwnerHint(created.session_id, ownerRoute)
@@ -689,7 +670,7 @@ export function useSessionActions({
         // unlisted (draft) tab stays out of the session list until its first
         // turn persists and a refresh surfaces it.
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null)
+          upsertOptimisticSession(created, stored, null, null, null, undefined, ownerRoute)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,9 +8,12 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $sessions,
+  getSessionOwnerHint,
   setCurrentBranch,
   setCurrentCwd,
   setSelectedStoredSessionId,
+  setSessions,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
@@ -33,8 +36,39 @@ import {
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertOptimisticSession
 } from './utils'
+
+describe('upsertOptimisticSession ownership', () => {
+  afterEach(() => setSessions([]))
+
+  it('stamps the captured profile and connection while recording its owner hint', () => {
+    const owner = {
+      connectionId: 'remote-source',
+      mode: 'remote' as const,
+      profile: 'writer',
+      targetProfile: 'backend-writer'
+    }
+
+    upsertOptimisticSession(
+      { session_id: 'runtime-owner', stored_session_id: 'stored-owner' },
+      'stored-owner',
+      null,
+      null,
+      null,
+      undefined,
+      owner
+    )
+
+    expect($sessions.get()[0]).toMatchObject({
+      connection_id: 'remote-source',
+      id: 'stored-owner',
+      profile: 'writer'
+    })
+    expect(getSessionOwnerHint('stored-owner')).toEqual(owner)
+  })
+})
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
   ({ id, role, parts: [{ type: 'text', text }], ...extra }) as ChatMessage

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -24,6 +24,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSessionOwnerHint,
   setSessions,
   setWorkspaceCwdOwner,
   setYoloActive
@@ -1243,19 +1244,25 @@ export function upsertOptimisticSession(
   title: string | null = null,
   preview: string | null = null,
   parentSessionId: string | null = null,
-  lastActive?: number
+  lastActive?: number,
+  ownerRoute?: SessionProfileRoute | null
 ) {
   const now = lastActive ?? Date.now() / 1000
   // Stamp the profile the session was just created on (= the live gateway's
   // profile) so the scoped sidebar shows the new row immediately instead of
   // filtering it out as "default" until the aggregator re-fetches.
-  const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  const profileKey = normalizeProfileKey(ownerRoute?.profile ?? $activeGatewayProfile.get())
+
+  if (ownerRoute) {
+    setSessionOwnerHint(id, ownerRoute)
+  }
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
     // lane immediately (the overlay groups by path); fall back to the workspace
     // the session was just started in when the create response omits it.
     cwd: created.info?.cwd ?? ($currentCwd.get().trim() || null),
+    ...(ownerRoute ? { connection_id: ownerRoute.connectionId } : {}),
     ended_at: null,
     id,
     input_tokens: 0,

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -77,10 +77,9 @@ import {
   $messages,
   $selectedStoredSessionId,
   $sessions,
-  getSessionOwnerHints,
+  knownSessionOwner,
   rememberedSessionProfile,
   requestSessionResume,
-  sessionMatchesStoredId,
   setResumeExhaustedSessionId,
   setSessionOwnerHint
 } from '@/store/session'
@@ -154,31 +153,18 @@ const $focusedSessionOwner = computed(
       return fallback
     }
 
-    const hints = getSessionOwnerHints(focused)
+    // ONE owner ladder for the whole app: this used to reconcile hints and rows
+    // on its own rules (a lone hint won outright, rows were never consulted),
+    // which meant the plugin bridge and the session-RPC router could name
+    // different backends for the same session. knownSessionOwner is that ladder;
+    // anything it cannot pin to a connection fails closed here, exactly as it
+    // does there. A bare profile name carries no connection identity, so it is
+    // no more routable for a per-bot readout than an ambiguous verdict is.
+    const owner = knownSessionOwner(sessions, focused)
 
-    if (hints.length === 1) {
-      return {
-        connectionId: hints[0].connectionId,
-        profile: normalizeProfileKey(hints[0].profile)
-      }
-    }
-
-    if (hints.length > 1) {
-      return null
-    }
-
-    const owners = new Map<string, PluginFocusedSessionOwner>()
-
-    for (const row of sessions.filter(session => sessionMatchesStoredId(session, focused))) {
-      const connectionId = String(row.connection_id || '').trim()
-      const profile = normalizeProfileKey(row.profile)
-
-      if (connectionId) {
-        owners.set(`${connectionId}::${profile}`, { connectionId, profile })
-      }
-    }
-
-    return owners.size === 1 ? [...owners.values()][0] : null
+    return owner && typeof owner === 'object' && 'connectionId' in owner
+      ? { connectionId: owner.connectionId, profile: normalizeProfileKey(owner.profile) }
+      : null
   }
 )
 

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -152,6 +152,19 @@ describe('sessionRpcNeedsProfileRoute', () => {
 })
 
 describe('requestForSessionProfile', () => {
+  it('rejects an ambiguous owner before ambient, agent, or profile routing', async () => {
+    const ambient = vi.fn(async () => ({ ambient: true }))
+
+    await expect(
+      requestForSessionProfile({ ambiguous: true }, ambient as never, 'session.resume', {
+        session_id: 'contradictory-owner'
+      })
+    ).rejects.toThrow('Session owner is ambiguous; refusing to route session-scoped RPC')
+
+    expect(ambient).not.toHaveBeenCalled()
+    expect(secondaryGateways).toHaveLength(0)
+  })
+
   it('keeps concurrent same-name requests pinned while foreground activation changes', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -53,7 +53,8 @@ const {
   setPrimaryGateway
 } = await import('./gateway')
 
-const { requestForSessionProfile, sessionRpcNeedsProfileRoute } = await import('./session-request-router')
+const { isAmbiguousOwner, requestForSessionProfile, sessionRpcNeedsProfileRoute } =
+  await import('./session-request-router')
 
 function installDesktop(): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -148,6 +149,22 @@ describe('sessionRpcNeedsProfileRoute', () => {
   it('pins a route owner with a connectionId', () => {
     expect(sessionRpcNeedsProfileRoute({ connectionId: 'local', profile: 'developer' })).toBe(true)
     expect(sessionRpcNeedsProfileRoute({ connectionId: '', profile: 'developer' })).toBe(false)
+  })
+})
+
+describe('isAmbiguousOwner', () => {
+  it('separates an unresolvable verdict from a real route', () => {
+    expect(isAmbiguousOwner({ ambiguous: true })).toBe(true)
+    expect(isAmbiguousOwner({ connectionId: 'local', profile: 'developer' })).toBe(false)
+    expect(isAmbiguousOwner('developer')).toBe(false)
+    expect(isAmbiguousOwner(undefined)).toBe(false)
+    expect(isAmbiguousOwner(null)).toBe(false)
+  })
+
+  it('reports an ambiguous owner as needing a route, never as ambient-safe', () => {
+    // `false` here would read as "no owner, ambient is fine" — the exact
+    // wrong-backend dispatch this module exists to prevent.
+    expect(sessionRpcNeedsProfileRoute({ ambiguous: true })).toBe(true)
   })
 })
 

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -7,7 +7,11 @@ export interface SessionProfileRoute {
   targetProfile?: string
 }
 
-export type SessionOwnerScope = undefined | null | string | SessionProfileRoute
+export interface AmbiguousSessionOwner {
+  ambiguous: true
+}
+
+export type SessionOwnerScope = undefined | null | string | AmbiguousSessionOwner | SessionProfileRoute
 
 // ── Session-scoped RPC routing (the #89206 class) ───────────────────────────
 // A session-scoped RPC (session.resume / session.activate / session.usage /
@@ -31,6 +35,9 @@ const normKey = (profile: null | string | undefined): string => (profile ?? '').
 
 const isRoute = (owner: SessionOwnerScope): owner is SessionProfileRoute =>
   Boolean(owner && typeof owner === 'object' && 'connectionId' in owner)
+
+const isAmbiguousOwner = (owner: SessionOwnerScope): owner is AmbiguousSessionOwner =>
+  Boolean(owner && typeof owner === 'object' && 'ambiguous' in owner)
 
 function routeParams(route: SessionProfileRoute, params: Record<string, unknown>): Record<string, unknown> {
   if (!route.targetProfile || !Object.prototype.hasOwnProperty.call(params, 'profile')) {
@@ -79,6 +86,10 @@ export function requestForSessionProfile<T>(
   timeoutMs?: number,
   signal?: AbortSignal
 ): Promise<T> {
+  if (isAmbiguousOwner(ownerProfile)) {
+    return Promise.reject(new Error('Session owner is ambiguous; refusing to route session-scoped RPC'))
+  }
+
   if (isRoute(ownerProfile)) {
     const connectionId = ownerProfile.connectionId.trim()
 

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -36,7 +36,15 @@ const normKey = (profile: null | string | undefined): string => (profile ?? '').
 const isRoute = (owner: SessionOwnerScope): owner is SessionProfileRoute =>
   Boolean(owner && typeof owner === 'object' && 'connectionId' in owner)
 
-const isAmbiguousOwner = (owner: SessionOwnerScope): owner is AmbiguousSessionOwner =>
+/**
+ * True when the evidence names no single backend. Exported because the decision
+ * of what to do about it belongs to the caller, not here: a caller holding a
+ * cross-profile probe (contrib/wiring) resolves the owner against the backends
+ * and routes; one without a probe has nothing left to try and surfaces the
+ * rejection below. Neither may fall through to ambient — that is the exact
+ * wrong-backend dispatch the whole module exists to prevent.
+ */
+export const isAmbiguousOwner = (owner: SessionOwnerScope): owner is AmbiguousSessionOwner =>
   Boolean(owner && typeof owner === 'object' && 'ambiguous' in owner)
 
 function routeParams(route: SessionProfileRoute, params: Record<string, unknown>): Record<string, unknown> {
@@ -57,6 +65,14 @@ function routeParams(route: SessionProfileRoute, params: Record<string, unknown>
  * fresh draft with no session, or global chrome) routes ambient.
  */
 export function sessionRpcNeedsProfileRoute(ownerProfile: SessionOwnerScope | undefined): boolean {
+  if (isAmbiguousOwner(ownerProfile)) {
+    // Unroutable, but emphatically NOT ambient: an ambiguous owner is one we
+    // could not pin, never a session that has no owner. requestForSessionProfile
+    // rejects it before any dispatch; answering false here would invite a
+    // future caller to send it down the ambient path instead.
+    return true
+  }
+
   if (isRoute(ownerProfile)) {
     // A descriptor is an immutable ownership claim. Even an explicitly local
     // route must not collapse to the ambient request: another connection can

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
@@ -27,6 +28,11 @@ import {
   setSessionTileDelegate,
   setSessionTileWorkspaceScope
 } from '@/store/session-states'
+
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  requestGatewayForAgent: vi.fn()
+}))
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
@@ -245,6 +251,15 @@ describe('SessionTile workspace scope', () => {
     })
   })
 
+  it('keeps an ordinary remote tile owner when an existing tile is re-opened or re-scoped', () => {
+    const ownerRoute = { connectionId: 'remote-source', mode: 'remote' as const, profile: 'writer' }
+
+    openSessionTile('remote-chat', 'right', undefined, undefined, { ownerRoute, workspaceMode: 'sessions' })
+    openSessionTile('remote-chat', 'left', 'workspace')
+
+    expect($sessionTiles.get()[0]).toMatchObject({ ownerRoute, storedSessionId: 'remote-chat' })
+  })
+
   it('preserves workspace scope while dropping a stale runtime binding', () => {
     $sessionTiles.set([
       {
@@ -459,6 +474,7 @@ describe('blankDraftTile', () => {
 describe('reopenLastClosedTile focuses the restored tab', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    vi.mocked(requestGatewayForAgent).mockReset()
     vi.resetModules()
   })
 
@@ -539,6 +555,30 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
     expect(states.$sessionTiles.get().some(t => t.storedSessionId === 'closed')).toBe(true)
     expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))?.active).toBe(tilePane('closed'))
     expect(tree.$activeTreeGroup.get()).toBe('grp-main')
+  })
+
+  it('restores an ordinary remote owner route and uses it after close/reopen', async () => {
+    const { states } = await setup()
+    const ownerRoute = { connectionId: 'remote-source', profile: 'writer' }
+    const ambientRequest = vi.fn()
+
+    states.openSessionTile('ordinary-remote', 'center', 'workspace', undefined, {
+      ownerRoute,
+      workspaceMode: 'sessions'
+    })
+    states.closeSessionTile('ordinary-remote')
+    states.reopenLastClosedTile()
+
+    expect(states.sessionTileOwnerRoute('ordinary-remote')).toEqual(ownerRoute)
+
+    await states.requestForOwnedSession('ordinary-remote', ambientRequest, 'session.resume', {
+      session_id: 'ordinary-remote'
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-source', 'writer', 'session.resume', {
+      session_id: 'ordinary-remote'
+    })
+    expect(ambientRequest).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,7 +42,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
-  knownSessionProfile,
+  knownSessionOwner,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
@@ -752,7 +752,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner($sessions.get(), storedSessionId)
 }
 
 /**
@@ -809,7 +809,7 @@ export function storedSessionIdForRuntimeId(sessionId: string): null | string {
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
-  const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : undefined
+  const ownerRoute = scope.ownerRoute
   const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
 
   if (

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -809,7 +809,7 @@ export function storedSessionIdForRuntimeId(sessionId: string): null | string {
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
-  const ownerRoute = scope.ownerRoute
+  const ownerRoute = scope.ownerRoute ?? tile?.ownerRoute
   const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
 
   if (
@@ -817,6 +817,7 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
     ((tile.workspaceMode ?? 'sessions') === scope.workspaceMode &&
       tile.workspaceOwnerKey === workspaceOwnerKey &&
       tile.ownerRoute?.connectionId === ownerRoute?.connectionId &&
+      tile.ownerRoute?.mode === ownerRoute?.mode &&
       tile.ownerRoute?.profile === ownerRoute?.profile &&
       tile.ownerRoute?.targetProfile === ownerRoute?.targetProfile &&
       tile.workspaceTabTitle === workspaceTabTitle)
@@ -1064,7 +1065,7 @@ export function openSessionTile(
         anchor: dock,
         before,
         dir,
-        ownerRoute: workspaceScope.workspaceMode === 'bots' ? workspaceScope.ownerRoute : undefined,
+        ownerRoute: workspaceScope.ownerRoute,
         storedSessionId,
         workspaceMode: workspaceScope.workspaceMode,
         workspaceOwnerKey,
@@ -1276,6 +1277,7 @@ export function reopenLastClosedTile(): void {
 
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
       openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, {
+        ownerRoute: tile.ownerRoute,
         workspaceMode: tile.workspaceMode ?? 'sessions',
         workspaceOwnerKey: tile.workspaceOwnerKey
       })

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
   rememberedSessionProfile,
@@ -956,6 +957,22 @@ describe('knownSessionProfile', () => {
     const sessions = [session({ id: 'stored-1', profile: 'ai-engineer' })]
 
     expect(knownSessionProfile(sessions, 'stored-1')).toBe('ai-engineer')
+  })
+
+  it('preserves a connection-scoped row as a route instead of reducing it to a profile', () => {
+    const sessions = [session({ id: 'local-session', connection_id: 'local', profile: 'default' })]
+
+    expect(knownSessionOwner(sessions, 'local-session')).toEqual({
+      connectionId: 'local',
+      profile: 'default'
+    })
+  })
+
+  it('prefers the unique owner hint when a normal session row lacks connection identity', () => {
+    const owner = { connectionId: 'local', mode: 'local' as const, profile: 'default' }
+    setSessionOwnerHint('local-session', owner)
+
+    expect(knownSessionOwner([session({ id: 'local-session', profile: 'default' })], 'local-session')).toEqual(owner)
   })
 
   it('returns the owner hint for a hidden session absent from the list', () => {

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -989,3 +989,60 @@ describe('knownSessionProfile', () => {
     expect(knownSessionProfile([], null)).toBeUndefined()
   })
 })
+
+describe('knownSessionOwner reconciliation', () => {
+  it('reconciles a complete hint with same-profile profile-only evidence', () => {
+    const hint = {
+      connectionId: 'remote-source',
+      mode: 'remote' as const,
+      profile: 'default',
+      targetProfile: 'backend-default'
+    }
+
+    setSessionOwnerHint('partial-confirmation', hint)
+
+    expect(knownSessionOwner([session({ id: 'partial-confirmation', profile: 'default' })], 'partial-confirmation')).toEqual(
+      hint
+    )
+  })
+
+  it('reconciles a qualified row with a same-profile profile-only row', () => {
+    expect(
+      knownSessionOwner(
+        [
+          session({ connection_id: 'source-a', id: 'compatible-rows', profile: 'worker' }),
+          session({ connection_id: undefined, id: 'compatible-rows', profile: 'worker' })
+        ],
+        'compatible-rows'
+      )
+    ).toEqual({ connectionId: 'source-a', profile: 'worker' })
+  })
+
+  it('fails closed for contradictory connection-qualified owners', () => {
+    setSessionOwnerHint('contradictory-connections', { connectionId: 'source-a', profile: 'worker' })
+
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'source-b', id: 'contradictory-connections', profile: 'worker' })],
+        'contradictory-connections'
+      )
+    ).toEqual({ ambiguous: true })
+  })
+
+  it('fails closed when profile-only evidence contradicts the qualified owner', () => {
+    setSessionOwnerHint('contradictory-profiles', { connectionId: 'source-a', profile: 'worker' })
+
+    expect(
+      knownSessionOwner([session({ id: 'contradictory-profiles', profile: 'reviewer' })], 'contradictory-profiles')
+    ).toEqual({ ambiguous: true })
+  })
+
+  it('ignores profileless rows instead of inventing default ownership', () => {
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'source-profileless', id: 'profileless-row', profile: undefined })],
+        'profileless-row'
+      )
+    ).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1001,9 +1001,9 @@ describe('knownSessionOwner reconciliation', () => {
 
     setSessionOwnerHint('partial-confirmation', hint)
 
-    expect(knownSessionOwner([session({ id: 'partial-confirmation', profile: 'default' })], 'partial-confirmation')).toEqual(
-      hint
-    )
+    expect(
+      knownSessionOwner([session({ id: 'partial-confirmation', profile: 'default' })], 'partial-confirmation')
+    ).toEqual(hint)
   })
 
   it('reconciles a qualified row with a same-profile profile-only row', () => {
@@ -1027,6 +1027,59 @@ describe('knownSessionOwner reconciliation', () => {
         'contradictory-connections'
       )
     ).toEqual({ ambiguous: true })
+  })
+
+  it('fails closed when two qualified rows disagree', () => {
+    // Contradiction with no hint involved at all. A paginated list cannot prove
+    // either row wrong, so refuse rather than dispatch at a backend that may
+    // never have held the session; contrib/wiring probes this case instead.
+    expect(
+      knownSessionOwner(
+        [
+          session({ connection_id: 'source-a', id: 'contradictory-rows', profile: 'worker' }),
+          session({ connection_id: 'source-b', id: 'contradictory-rows', profile: 'worker' })
+        ],
+        'contradictory-rows'
+      )
+    ).toEqual({ ambiguous: true })
+  })
+
+  it('keeps a hint targetProfile that the corroborating row cannot express', () => {
+    setSessionOwnerHint('enriched-row', {
+      connectionId: 'source-a',
+      mode: 'remote',
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    })
+
+    expect(
+      knownSessionOwner([session({ connection_id: 'source-a', id: 'enriched-row', profile: 'worker' })], 'enriched-row')
+    ).toEqual({
+      connectionId: 'source-a',
+      mode: 'remote',
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    })
+  })
+
+  it("keeps a local row's mode when the corroborating hint omits it", () => {
+    // Hint-first precedence used to drop this: the row that knows the backend
+    // is local was skipped wholesale once a hint claimed the same key.
+    setSessionOwnerHint('local-row', { connectionId: 'local', profile: 'worker' })
+
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'local', id: 'local-row', profile: 'worker', source: 'local' })],
+        'local-row'
+      )
+    ).toEqual({ connectionId: 'local', mode: 'local', profile: 'worker' })
+  })
+
+  it('fails closed for contradictory hints when no row corroborates either', () => {
+    setSessionOwnerHint('contradictory-hints', { connectionId: 'source-a', profile: 'worker' })
+    setSessionOwnerHint('contradictory-hints', { connectionId: 'source-b', profile: 'worker' })
+
+    expect(knownSessionOwner([], 'contradictory-hints')).toEqual({ ambiguous: true })
   })
 
   it('fails closed when profile-only evidence contradicts the qualified owner', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -141,10 +141,46 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
   return (hint?.targetProfile ?? hint?.profile)?.trim() || undefined
 }
 
+const ownerScopeKey = (connectionId: string, profile: string): string => JSON.stringify([connectionId, profile])
+
+/**
+ * Fold what a corroborating claim knows into the winning one, filling only the
+ * fields the winner lacks. A hint outranks the row it agrees with because it
+ * carries `targetProfile`, which no row can express — but the row still knows
+ * one thing the hint may not: whether that backend is local. Precedence must not
+ * silently drop it. The two agree on connection and profile by construction, or
+ * they would not share a key, so neither side can invent an owner here.
+ */
+function mergeOwnerEvidence(winner: SessionProfileRoute, other: SessionProfileRoute): SessionProfileRoute {
+  const mode = winner.mode ?? other.mode
+  const targetProfile = winner.targetProfile ?? other.targetProfile
+
+  return {
+    connectionId: winner.connectionId,
+    ...(mode ? { mode } : {}),
+    profile: winner.profile,
+    ...(targetProfile ? { targetProfile } : {})
+  }
+}
+
 /**
  * Resolve the strongest owner identity available for a session. A connection-
  * scoped row or open-time hint must stay a route object; reducing it to a bare
  * profile name sends same-named sessions to the primary connection.
+ *
+ * Hints and rows are peers, not a hierarchy. Neither can overrule the other:
+ * a hint has no invalidation path (setSessionOwnerHint only ever adds), and the
+ * session list is a paginated WINDOW, so a row's absence is never evidence that
+ * a backend does not own the session. With no side able to prove the other
+ * wrong, contradiction returns `{ ambiguous: true }` rather than a guess —
+ * picking one dispatches the RPC at a machine that may never have held the
+ * session, which is the whole failure class this module exists to prevent.
+ *
+ * Ambiguity is a verdict, not a dead end: the caller that holds a cross-profile
+ * probe (contrib/wiring) asks the backends, which is the only authority that can
+ * actually settle it. See sessionOwnerNeedsProbe — an ambiguous verdict is a
+ * truthy object, so a caller checking only `!owner` skips that escape hatch and
+ * leaves the session unroutable for the life of the process.
  */
 export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: null | string): SessionOwnerScope {
   if (!sessionId) {
@@ -156,7 +192,7 @@ export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: n
   const profileOnlyOwners = new Set<string>()
 
   for (const hint of hints) {
-    qualifiedOwners.set(JSON.stringify([hint.connectionId, hint.profile]), hint)
+    qualifiedOwners.set(ownerScopeKey(hint.connectionId, hint.profile), hint)
   }
 
   for (const row of sessions.filter(session => sessionMatchesStoredId(session, sessionId))) {
@@ -170,19 +206,22 @@ export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: n
       continue
     }
 
-    if (connectionId) {
-      const key = JSON.stringify([connectionId, profile])
-
-      if (!qualifiedOwners.has(key)) {
-        qualifiedOwners.set(key, {
-          connectionId,
-          ...(row.source === 'local' ? { mode: 'local' as const } : {}),
-          profile
-        })
-      }
-    } else {
+    if (!connectionId) {
       profileOnlyOwners.add(profile)
+
+      continue
     }
+
+    const key = ownerScopeKey(connectionId, profile)
+    const claimed = qualifiedOwners.get(key)
+
+    const rowOwner: SessionProfileRoute = {
+      connectionId,
+      ...(row.source === 'local' ? { mode: 'local' as const } : {}),
+      profile
+    }
+
+    qualifiedOwners.set(key, claimed ? mergeOwnerEvidence(claimed, rowOwner) : rowOwner)
   }
 
   if (qualifiedOwners.size > 0) {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -10,7 +10,7 @@ import { persistBoolean, persistString, storedBoolean, storedString } from '@/li
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
-import type { SessionProfileRoute } from './session-request-router'
+import type { SessionOwnerScope, SessionProfileRoute } from './session-request-router'
 import { clearUnreadOnOpen } from './session-unread-remote'
 
 type Updater<T> = T | ((current: T) => T)
@@ -146,33 +146,64 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
  * scoped row or open-time hint must stay a route object; reducing it to a bare
  * profile name sends same-named sessions to the primary connection.
  */
-export function knownSessionOwner(
-  sessions: readonly SessionInfo[],
-  sessionId: null | string
-): SessionProfileRoute | string | undefined {
+export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: null | string): SessionOwnerScope {
   if (!sessionId) {
     return undefined
   }
 
-  const row = sessions.find(session => sessionMatchesStoredId(session, sessionId))
-  const rowProfile = row?.profile?.trim()
-  const rowConnection = row?.connection_id?.trim()
+  const hints = getSessionOwnerHints(sessionId)
+  const qualifiedOwners = new Map<string, SessionProfileRoute>()
+  const profileOnlyOwners = new Set<string>()
 
-  if (rowConnection) {
-    return {
-      connectionId: rowConnection,
-      ...(row?.source === 'local' ? { mode: 'local' as const } : {}),
-      profile: rowProfile || 'default'
+  for (const hint of hints) {
+    qualifiedOwners.set(JSON.stringify([hint.connectionId, hint.profile]), hint)
+  }
+
+  for (const row of sessions.filter(session => sessionMatchesStoredId(session, sessionId))) {
+    const connectionId = row.connection_id?.trim()
+    const profile = row.profile?.trim()
+
+    // A connection without a profile is incomplete evidence. In particular,
+    // do not invent "default": that could turn an unrelated projection into
+    // a routable owner claim on the wrong backend.
+    if (!profile) {
+      continue
+    }
+
+    if (connectionId) {
+      const key = JSON.stringify([connectionId, profile])
+
+      if (!qualifiedOwners.has(key)) {
+        qualifiedOwners.set(key, {
+          connectionId,
+          ...(row.source === 'local' ? { mode: 'local' as const } : {}),
+          profile
+        })
+      }
+    } else {
+      profileOnlyOwners.add(profile)
     }
   }
 
-  const hint = getSessionOwnerHint(sessionId)
+  if (qualifiedOwners.size > 0) {
+    if (qualifiedOwners.size !== 1) {
+      return { ambiguous: true }
+    }
 
-  if (hint) {
-    return hint
+    const owner = qualifiedOwners.values().next().value
+
+    if (!owner || [...profileOnlyOwners].some(profile => profile !== owner.profile)) {
+      return { ambiguous: true }
+    }
+
+    return owner
   }
 
-  return rowProfile || undefined
+  if (profileOnlyOwners.size === 0) {
+    return undefined
+  }
+
+  return profileOnlyOwners.size === 1 ? [...profileOnlyOwners][0] : { ambiguous: true }
 }
 
 /**

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -142,6 +142,40 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
 }
 
 /**
+ * Resolve the strongest owner identity available for a session. A connection-
+ * scoped row or open-time hint must stay a route object; reducing it to a bare
+ * profile name sends same-named sessions to the primary connection.
+ */
+export function knownSessionOwner(
+  sessions: readonly SessionInfo[],
+  sessionId: null | string
+): SessionProfileRoute | string | undefined {
+  if (!sessionId) {
+    return undefined
+  }
+
+  const row = sessions.find(session => sessionMatchesStoredId(session, sessionId))
+  const rowProfile = row?.profile?.trim()
+  const rowConnection = row?.connection_id?.trim()
+
+  if (rowConnection) {
+    return {
+      connectionId: rowConnection,
+      ...(row?.source === 'local' ? { mode: 'local' as const } : {}),
+      profile: rowProfile || 'default'
+    }
+  }
+
+  const hint = getSessionOwnerHint(sessionId)
+
+  if (hint) {
+    return hint
+  }
+
+  return rowProfile || undefined
+}
+
+/**
  * The profile a routed session belongs to, for keying the remembered id and
  * other PRESENTATION uses (which profile's sidebar/navigation this session sits
  * under). Falls back to the active gateway profile when the owner is unknown.


### PR DESCRIPTION
## Summary

Fixes #94811.

Ordinary Desktop sessions created on a non-primary connection could lose the connection identity after creation. Once the transient create binding disappeared, later session-scoped RPCs were reduced to a bare profile name and dispatched through the primary socket. With two connections exposing the same profile (for example, local and remote both using `default`), the second prompt then failed with `4001 session not found`.

## What changed

- Preserve the strongest known session owner as a connection-bearing `{ connectionId, profile }` route when it comes from:
  - a connection-scoped session row; or
  - the unique owner hint captured at session creation.
- Record the owner route for both the runtime id and stored id when ordinary sessions are created or opened in a tile.
- Preserve owner routes on ordinary session tiles, not only Bot Mode tiles.
- Route owned session RPCs through the connection-scoped gateway instead of the profile-name/primary fallback.
- Add regression coverage for connection-scoped rows and ordinary-session owner hints.

## Verification

Passed:

- Prettier check on all changed files
- ESLint on all changed files
- `git diff --check`

Blocked by the local checkout's dependency state:

- Vitest could not start because `@rolldown/plugin-babel` is missing.
- Full dependency installation is currently blocked by npm's registry/date resolution for `blobatar@2.0.0`.
- TypeScript reached the project but reported the same incomplete dependency tree (missing Desktop packages), with no diagnostic pointing to the changed files.

## Scope

The change is limited to Desktop session ownership and routing. No configuration, backend protocol, or user-facing setting is added.
