### PR TITLE
fix(telegram): don't buffer whole files in local Bot API mode

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -12,6 +12,7 @@ import logging
 import os
 import random
 import re
+import shutil
 import socket as _socket
 import subprocess
 import sys
@@ -2263,6 +2264,16 @@ class CachedMedia:
     media_type: str           # MIME type recorded on the MessageEvent
     kind: str                 # "image" | "video" | "audio" | "document"
     display_name: str         # human-readable name for transcript notes
+    # Real on-disk path in THIS process's filesystem. Usually identical to
+    # ``path``, but ``path`` is sandbox-translated for the agent (e.g. to
+    # /root/.hermes/... under the docker terminal backend) and can therefore be
+    # unreadable from the gateway. Callers that need to re-open the cached file
+    # locally — text injection, size checks — must use this, not ``path``.
+    local_path: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.local_path:
+            self.local_path = self.path
 
     def context_note(self) -> str:
         """One-line transcript annotation pointing the agent at the file."""
@@ -2326,18 +2337,18 @@ def cache_media_bytes(
         except ValueError:
             return None
         out_mime = mime if mime.startswith("image/") else SUPPORTED_IMAGE_DOCUMENT_TYPES.get(img_ext, "image/jpeg")
-        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "image", display)
+        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "image", display, local_path=path)
 
     if is_video:
         vid_ext = ext if ext in SUPPORTED_VIDEO_TYPES else ".mp4"
         path = cache_video_from_bytes(data, ext=vid_ext)
-        return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"), "video", display)
+        return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"), "video", display, local_path=path)
 
     if is_audio:
         aud_ext = ext if ext in _AUDIO_EXTS else ".ogg"
         path = cache_audio_from_bytes(data, ext=aud_ext)
         out_mime = mime if mime.startswith("audio/") else _AUDIO_MIME_TYPES[aud_ext]
-        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display)
+        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display, local_path=path)
 
     # Any other file type is cached and surfaced to the agent as a local path
     # so it can be inspected with terminal / read_file / etc. Authorization to
@@ -2352,7 +2363,114 @@ def cache_media_bytes(
         out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
     else:
         out_mime = mime if mime else "application/octet-stream"
-    return CachedMedia(to_agent_visible_cache_path(path), out_mime, "document", display or fallback_name)
+    return CachedMedia(to_agent_visible_cache_path(path), out_mime, "document", display or fallback_name, local_path=path)
+
+
+def cache_media_path(
+    source_path: str,
+    *,
+    filename: str = "",
+    mime_type: str = "",
+    default_kind: Optional[str] = None,
+) -> Optional[CachedMedia]:
+    """Cache an attachment that is ALREADY on this machine's filesystem.
+
+    Same classification and return shape as :func:`cache_media_bytes`, but the
+    payload never passes through memory: the file is copied chunk-by-chunk with
+    :func:`shutil.copyfile`. Callers therefore need only a constant-size buffer
+    regardless of file size.
+
+    This exists for local ``telegram-bot-api`` (``--local``) deployments, where
+    ``getFile`` returns an absolute server-side path instead of a download URL.
+    With a 2000MB upload ceiling, the ``bytes``-based path would need a
+    multi-GB allocation to cache a file that is already sitting on disk.
+
+    ``validate_inbound_media_size`` is still enforced, from ``stat()`` rather
+    than ``len(data)``, so the configured cap applies identically on both paths.
+    Images are the one exception: they are read into memory and routed through
+    :func:`cache_image_from_bytes` so the existing decode/validation still runs
+    (images are small and must be validated, not merely copied).
+    """
+    from tools.credential_files import to_agent_visible_cache_path
+
+    src = Path(source_path)
+    if not src.is_file():
+        return None
+
+    ext = _resolve_media_ext(filename or src.name, mime_type)
+    mime = (mime_type or "").lower()
+    display_source = filename or src.name
+    display = re.sub(r"[^\w.\- ]", "_", display_source) if display_source else (ext.lstrip(".") or "file")
+
+    is_image = (
+        mime.startswith("image/")
+        or ext in SUPPORTED_IMAGE_DOCUMENT_TYPES
+        or default_kind == "image"
+    )
+    is_video = mime.startswith("video/") or ext in SUPPORTED_VIDEO_TYPES or default_kind == "video"
+    is_audio = mime.startswith("audio/") or ext in _AUDIO_EXTS or default_kind == "audio"
+
+    validate_inbound_media_size(
+        src.stat().st_size,
+        media_type=("image" if is_image else "video" if is_video else "audio" if is_audio else "document"),
+    )
+
+    # Images keep the bytes path: they are bounded in size and
+    # cache_image_from_bytes performs real validation we must not skip.
+    if is_image:
+        try:
+            return cache_media_bytes(
+                src.read_bytes(),
+                filename=display_source,
+                mime_type=mime_type,
+                default_kind=default_kind,
+            )
+        except ValueError:
+            return None
+
+    if is_video:
+        vid_ext = ext if ext in SUPPORTED_VIDEO_TYPES else ".mp4"
+        dest = get_video_cache_dir() / f"video_{uuid.uuid4().hex[:12]}{vid_ext}"
+        shutil.copyfile(src, dest)
+        return CachedMedia(
+            to_agent_visible_cache_path(str(dest)),
+            SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"),
+            "video",
+            display,
+            local_path=str(dest),
+        )
+
+    if is_audio:
+        aud_ext = ext if ext in _AUDIO_EXTS else ".ogg"
+        dest = get_audio_cache_dir() / f"audio_{uuid.uuid4().hex[:12]}{aud_ext}"
+        shutil.copyfile(src, dest)
+        out_mime = mime if mime.startswith("audio/") else _AUDIO_MIME_TYPES[aud_ext]
+        return CachedMedia(to_agent_visible_cache_path(str(dest)), out_mime, "audio", display, local_path=str(dest))
+
+    # Everything else: document cache, mirroring cache_document_from_bytes'
+    # sanitization so the two paths produce identically-shaped names and the
+    # same path-traversal guarantees.
+    fallback_name = display_source or (f"document{ext}" if ext else "document.bin")
+    cache_dir = get_document_cache_dir()
+    safe_name = Path(fallback_name).name if fallback_name else "document"
+    safe_name = safe_name.replace("\x00", "").strip()
+    if not safe_name or safe_name in {".", ".."}:
+        safe_name = "document"
+    dest = cache_dir / f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
+    if not dest.resolve().is_relative_to(cache_dir.resolve()):
+        raise ValueError(f"Path traversal rejected: {fallback_name!r}")
+    shutil.copyfile(src, dest)
+    if ext in SUPPORTED_DOCUMENT_TYPES:
+        out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+    else:
+        out_mime = mime if mime else "application/octet-stream"
+    return CachedMedia(
+        to_agent_visible_cache_path(str(dest)),
+        out_mime,
+        "document",
+        display or fallback_name,
+        local_path=str(dest),
+    )
 
 
 class MessageType(Enum):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8,6 +8,7 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import contextlib
 import dataclasses
 import inspect
 import json
@@ -823,14 +824,35 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topic_chat_ids: Set[str] = {
             str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
         }
+        # Local telegram-bot-api mode (server started with --local). Cached here
+        # because both the outbound send path and the inbound download path
+        # branch on it, and self._bot is not built until connect().
+        self._local_mode: bool = bool(self.config.extra.get("local_mode"))
         # Document size cap. Telegram's public Bot API caps getFile at 20MB; a
         # locally-hosted telegram-bot-api server (configured via extra.base_url)
         # raises that to 2GB, so the presence of base_url is the opt-in.
-        self._max_doc_bytes: int = (
-            2 * 1024 * 1024 * 1024
-            if self.config.extra.get("base_url")
-            else 20 * 1024 * 1024
-        )
+        #
+        # The 2GB ceiling is only safe to accept because the inbound path streams
+        # to disk (see _download_media_to_temp) instead of buffering the whole
+        # file in RAM. Deployments that need a tighter bound — a small VPS, a
+        # shared host — can lower it with extra.max_file_mb without giving up
+        # local mode.
+        _max_file_mb = self.config.extra.get("max_file_mb")
+        if _max_file_mb:
+            try:
+                self._max_doc_bytes: int = int(_max_file_mb) * 1024 * 1024
+            except (TypeError, ValueError):
+                logger.warning(
+                    "[%s] Ignoring non-numeric extra.max_file_mb: %r",
+                    self.name, _max_file_mb,
+                )
+                self._max_doc_bytes = 2 * 1024 * 1024 * 1024
+        else:
+            self._max_doc_bytes = (
+                2 * 1024 * 1024 * 1024
+                if self.config.extra.get("base_url")
+                else 20 * 1024 * 1024
+            )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
@@ -1749,6 +1771,95 @@ class TelegramAdapter(BasePlatformAdapter):
             if any(marker in err_lower for marker in topic_markers):
                 return True
         return False
+
+    async def _cache_inbound_file(
+        self,
+        source: Any,
+        *,
+        filename: str = "",
+        mime_type: str = "",
+        default_kind: Optional[str] = None,
+    ) -> Any:
+        """Cache an inbound Telegram attachment, streaming when possible.
+
+        Local ``telegram-bot-api`` (``--local``) answers ``getFile`` with an
+        absolute path on the server's filesystem rather than a download URL.
+        When that path is readable here (same host, or a shared mount at an
+        identical path) the file is copied straight into the cache and never
+        enters this process's memory — essential at the 2000MB local-mode
+        ceiling, where the bytes path would need a multi-GB allocation.
+
+        Falls back to the download-and-buffer path for the cloud Bot API, and
+        also whenever the reported path is not actually reachable here (a
+        remote local-mode server, a mount mismatch), so a misconfiguration
+        degrades to the old behaviour instead of dropping the attachment.
+        """
+        from gateway.platforms.base import cache_media_bytes, cache_media_path
+
+        file_obj = await source.get_file()
+        local_path = getattr(file_obj, "file_path", "") or ""
+        _local = getattr(self, "_local_mode", False)
+        if _local and local_path and os.path.isfile(local_path):
+            cached = cache_media_path(
+                local_path,
+                filename=filename,
+                mime_type=mime_type,
+                default_kind=default_kind,
+            )
+            if cached is not None:
+                return cached
+            logger.debug(
+                "[%s] Local-mode cache miss for %s; falling back to download",
+                self.name, local_path,
+            )
+        if _local and local_path and not os.path.isfile(local_path):
+            logger.warning(
+                "[%s] local_mode is on but the Bot API path %r is not readable "
+                "here — falling back to an in-memory download. Mount the "
+                "telegram-bot-api data dir at the SAME absolute path to avoid "
+                "buffering large files in RAM.",
+                self.name, local_path,
+            )
+        data = bytes(await file_obj.download_as_bytearray())
+        return cache_media_bytes(
+            data,
+            filename=filename,
+            mime_type=mime_type,
+            default_kind=default_kind,
+        )
+
+    @contextlib.contextmanager
+    def _media_upload_source(self, path: str):
+        """Yield the value to hand PTB for ``path``, plus its rewind callback.
+
+        Two very different upload paths, selected by local mode:
+
+        * Cloud Bot API (default) — yields an open binary handle. PTB reads it
+          into an ``InputFile`` and posts it as multipart. Bounded by Telegram's
+          50MB upload cap, so the whole-file read is acceptable.
+
+        * Local telegram-bot-api ``--local`` — yields the path STRING. PTB's
+          ``parse_file_input`` only applies the ``file://`` URI optimization to
+          ``str``/``Path`` inputs; a file handle falls through to
+          ``InputFile(handle)``, whose ``load_file()`` calls ``.read()`` and
+          pulls the ENTIRE file into memory. At the 2000MB local-mode ceiling
+          that is a multi-GB allocation, which OOMs small hosts. Passing the
+          path lets the server read the bytes off disk itself — the file never
+          enters this process at all.
+
+        The second element is the rewind callback for
+        ``_send_with_dm_topic_reply_anchor_retry``. Handles must seek(0) before
+        a retry re-reads them; a path is stateless, so it is ``None``.
+        """
+        # getattr, not self._local_mode: adapters are also constructed via
+        # __new__ (tests, and some gateway rebuild paths) which never runs
+        # __init__, and an AttributeError here would sink the whole send.
+        # Absent attribute == cloud mode == the historical behaviour.
+        if getattr(self, "_local_mode", False):
+            yield os.path.abspath(path), None
+            return
+        with open(path, "rb") as handle:
+            yield handle, lambda: handle.seek(0)
 
     async def _send_with_dm_topic_reply_anchor_retry(
         self,
@@ -7753,7 +7864,7 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 _caption_variants.append((None, None))
 
-            with open(audio_path, "rb") as audio_file:
+            with self._media_upload_source(audio_path) as (audio_src, rewind):
                 ext = os.path.splitext(audio_path)[1].lower()
                 # .ogg / .opus files -> send as voice (round playable bubble)
                 if ext in {".ogg", ".opus"}:
@@ -7774,7 +7885,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 self._bot.send_voice,
                                 {
                                     "chat_id": normalize_telegram_chat_id(chat_id),
-                                    "voice": audio_file,
+                                    "voice": audio_src,
                                     "caption": _cap_text,
                                     "parse_mode": _cap_parse_mode,
                                     "reply_to_message_id": reply_to_id,
@@ -7786,7 +7897,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 metadata,
                                 reply_to_id,
                                 "voice",
-                                reset_media=lambda: audio_file.seek(0),
+                                reset_media=rewind,
                             )
                             break
                         except Exception as _cap_error:
@@ -7803,7 +7914,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                     _redact_telegram_error_text(_cap_error),
                                 )
                                 _last_parse_error = _cap_error
-                                audio_file.seek(0)
+                                if rewind is not None:
+                                    rewind()
                                 continue
                             raise
                     if msg is None:
@@ -7825,7 +7937,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._bot.send_audio,
                         {
                             "chat_id": normalize_telegram_chat_id(chat_id),
-                            "audio": audio_file,
+                            "audio": audio_src,
                             "caption": caption[:1024] if caption else None,
                             "reply_to_message_id": reply_to_id,
                             "duration": _duration_secs,
@@ -7836,7 +7948,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         metadata,
                         reply_to_id,
                         "audio",
-                        reset_media=lambda: audio_file.seek(0),
+                        reset_media=rewind,
                     )
                 else:
                     # Formats Telegram can't play natively (.wav, .flac, ...)
@@ -8020,12 +8132,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(image_path, "rb") as image_file:
+            with self._media_upload_source(image_path) as (photo_src, rewind):
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_photo,
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
-                        "photo": image_file,
+                        "photo": photo_src,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
@@ -8035,7 +8147,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     metadata,
                     reply_to_id,
                     "photo",
-                    reset_media=lambda: image_file.seek(0),
+                    reset_media=rewind,
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -8117,12 +8229,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_mode=self._reply_to_mode
             )
 
-            with open(file_path, "rb") as f:
+            with self._media_upload_source(file_path) as (doc_src, rewind):
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_document,
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
-                        "document": f,
+                        "document": doc_src,
                         "filename": display_name,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
@@ -8133,7 +8245,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     metadata,
                     reply_to_id,
                     "document",
-                    reset_media=lambda: f.seek(0),
+                    reset_media=rewind,
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -8169,12 +8281,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(video_path, "rb") as f:
+            with self._media_upload_source(video_path) as (video_src, rewind):
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_video,
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
-                        "video": f,
+                        "video": video_src,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
@@ -8184,7 +8296,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     metadata,
                     reply_to_id,
                     "video",
-                    reset_media=lambda: f.seek(0),
+                    reset_media=rewind,
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -10162,13 +10274,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     ext = image_mime_to_ext.get(doc.mime_type, "")
 
                 if ext in SUPPORTED_VIDEO_TYPES:
-                    file_obj = await doc.get_file()
-                    video_bytes = await file_obj.download_as_bytearray()
-                    cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
-                    event.media_urls = [cached_path]
+                    cached_video = await self._cache_inbound_file(
+                        doc,
+                        filename=original_filename or f"video{ext}",
+                        mime_type=doc_mime or SUPPORTED_VIDEO_TYPES[ext],
+                        default_kind="video",
+                    )
+                    if cached_video is None:
+                        event.text = (
+                            f"Video '{original_filename or ext}' could not be cached."
+                        )
+                        await self.handle_message(event)
+                        return
+                    event.media_urls = [cached_video.path]
                     event.media_types = [SUPPORTED_VIDEO_TYPES[ext]]
                     event.message_type = MessageType.VIDEO
-                    logger.info("[Telegram] Cached user video document at %s", cached_path)
+                    logger.info("[Telegram] Cached user video document at %s", cached_video.path)
                     await self.handle_message(event)
                     return
 
@@ -10182,13 +10303,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # to message the agent is the gate, not the file extension.
                 # Known types keep their precise MIME; unknown types are tagged
                 # application/octet-stream so the agent reaches for terminal tools.
-                file_obj = await doc.get_file()
-                doc_bytes = await file_obj.download_as_bytearray()
-                raw_bytes = bytes(doc_bytes)
-                from gateway.platforms.base import cache_media_bytes
-
-                cached = cache_media_bytes(
-                    raw_bytes,
+                cached = await self._cache_inbound_file(
+                    doc,
                     filename=original_filename or f"document{ext or '.bin'}",
                     mime_type=doc_mime,
                 )
@@ -10215,10 +10331,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 # UTF-8 decode, since binary formats (PDF/zip/docx) can have
                 # decodable ASCII headers. Binary files are surfaced as a cached
                 # path only (run.py emits a path-pointing context note).
+                # Read back from the cached copy rather than holding the whole
+                # payload in memory: the cache path is the one representation
+                # that exists on both the streamed (local-mode) and buffered
+                # branches, and the cap means at most 100 KB is ever read.
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
                 _is_text = ext in _TEXT_INJECT_EXTENSIONS or (doc_mime or "").startswith("text/")
-                if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                _cached_size = -1
+                if _is_text:
                     try:
+                        _cached_size = os.path.getsize(cached.local_path)
+                    except OSError:
+                        _cached_size = -1
+                if _is_text and 0 <= _cached_size <= MAX_TEXT_INJECT_BYTES:
+                    try:
+                        with open(cached.local_path, "rb") as _tf:
+                            raw_bytes = _tf.read(MAX_TEXT_INJECT_BYTES)
                         text_content = raw_bytes.decode("utf-8")
                         display_name = original_filename or f"document{ext or '.txt'}"
                         display_name = re.sub(r'[^\w.\- ]', '_', display_name)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -562,6 +562,62 @@ _POLLING_STALL_TIMEOUT = 150.0
 # dead request is still noticed quickly. Kept modest deliberately — this is
 # also how long a user waits to be told the attachment failed.
 _MEDIA_SEND_READ_TIMEOUT = 60.0
+# Local telegram-bot-api (--local) inverts the assumption above. Against the
+# cloud API this process does the uploading, so a slow send shows up as write
+# progress and 60s is only ever the post-upload transcode wait. In local mode
+# the request hands the server a path and then blocks for the WHOLE of the
+# server's own 2000MB-ceiling upload to Telegram — 1.3GB measured at ~131s on
+# a domestic link, so 60s fails every large send while the server keeps
+# uploading in the background, invisible and unreported. Sized for the ceiling
+# rather than the median: this bound only decides how long a genuinely dead
+# request goes unnoticed, and nothing else fails a large local-mode send.
+_LOCAL_MEDIA_SEND_READ_TIMEOUT = 1800.0
+
+
+def media_read_timeout(local_mode: bool) -> float:
+    """Read timeout for a media send, widened for local Bot API mode.
+
+    See ``_LOCAL_MEDIA_SEND_READ_TIMEOUT``: in local mode the call blocks for
+    the server's entire upload to Telegram, not just a transcode, so the
+    cloud-tuned budget times out every large send.
+    """
+    return _LOCAL_MEDIA_SEND_READ_TIMEOUT if local_mode else _MEDIA_SEND_READ_TIMEOUT
+
+
+@contextlib.contextmanager
+def media_upload_source(path: str, *, local_mode: bool):
+    """Yield the value to hand PTB for ``path``, plus its rewind callback.
+
+    Two very different upload paths, selected by local mode:
+
+    * Cloud Bot API (default) — yields an open binary handle. PTB reads it
+      into an ``InputFile`` and posts it as multipart. Bounded by Telegram's
+      50MB upload cap, so the whole-file read is acceptable.
+
+    * Local telegram-bot-api ``--local`` — yields the path STRING. PTB's
+      ``parse_file_input`` only applies the ``file://`` URI optimization to
+      ``str``/``Path`` inputs; a file handle falls through to
+      ``InputFile(handle)``, whose ``load_file()`` calls ``.read()`` and pulls
+      the ENTIRE file into memory. At the 2000MB local-mode ceiling that is a
+      multi-GB allocation, which OOMs small hosts. Passing the path lets the
+      server read the bytes off disk itself — the file never enters this
+      process at all.
+
+    The second element is the rewind callback for retrying callers: handles
+    must ``seek(0)`` before a retry re-reads them; a path is stateless, so it
+    is ``None``.
+
+    Module-level rather than a method so the standalone ``send_message`` path
+    — which builds its own ``Bot`` instead of reusing the adapter — gets the
+    identical behaviour instead of reimplementing it.
+    """
+    if local_mode:
+        yield os.path.abspath(path), None
+        return
+    with open(path, "rb") as handle:
+        yield handle, lambda: handle.seek(0)
+
+
 _POLLING_GENERATION_CONTEXT: ContextVar[Optional[int]] = ContextVar(
     "telegram_polling_generation", default=None
 )
@@ -1832,34 +1888,25 @@ class TelegramAdapter(BasePlatformAdapter):
     def _media_upload_source(self, path: str):
         """Yield the value to hand PTB for ``path``, plus its rewind callback.
 
-        Two very different upload paths, selected by local mode:
+        Thin instance wrapper over :func:`media_upload_source`; see there for
+        why local mode must pass a path instead of a handle.
 
-        * Cloud Bot API (default) — yields an open binary handle. PTB reads it
-          into an ``InputFile`` and posts it as multipart. Bounded by Telegram's
-          50MB upload cap, so the whole-file read is acceptable.
-
-        * Local telegram-bot-api ``--local`` — yields the path STRING. PTB's
-          ``parse_file_input`` only applies the ``file://`` URI optimization to
-          ``str``/``Path`` inputs; a file handle falls through to
-          ``InputFile(handle)``, whose ``load_file()`` calls ``.read()`` and
-          pulls the ENTIRE file into memory. At the 2000MB local-mode ceiling
-          that is a multi-GB allocation, which OOMs small hosts. Passing the
-          path lets the server read the bytes off disk itself — the file never
-          enters this process at all.
-
-        The second element is the rewind callback for
-        ``_send_with_dm_topic_reply_anchor_retry``. Handles must seek(0) before
-        a retry re-reads them; a path is stateless, so it is ``None``.
+        ``getattr``, not ``self._local_mode``: adapters are also constructed
+        via ``__new__`` (tests, and some gateway rebuild paths) which never
+        runs ``__init__``, and an ``AttributeError`` here would sink the whole
+        send. Absent attribute == cloud mode == the historical behaviour.
         """
-        # getattr, not self._local_mode: adapters are also constructed via
-        # __new__ (tests, and some gateway rebuild paths) which never runs
-        # __init__, and an AttributeError here would sink the whole send.
-        # Absent attribute == cloud mode == the historical behaviour.
-        if getattr(self, "_local_mode", False):
-            yield os.path.abspath(path), None
-            return
-        with open(path, "rb") as handle:
-            yield handle, lambda: handle.seek(0)
+        with media_upload_source(
+            path, local_mode=getattr(self, "_local_mode", False)
+        ) as pair:
+            yield pair
+
+    def _media_read_timeout(self) -> float:
+        """Read timeout for a media send, widened for local Bot API mode.
+
+        ``getattr`` for the same reason as ``_media_upload_source``.
+        """
+        return media_read_timeout(getattr(self, "_local_mode", False))
 
     async def _send_with_dm_topic_reply_anchor_retry(
         self,
@@ -7890,7 +7937,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     "parse_mode": _cap_parse_mode,
                                     "reply_to_message_id": reply_to_id,
                                     "duration": _duration_secs,
-                                    "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                                    "read_timeout": self._media_read_timeout(),
                                     **voice_thread_kwargs,
                                     **self._notification_kwargs(metadata),
                                 },
@@ -7941,7 +7988,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             "caption": caption[:1024] if caption else None,
                             "reply_to_message_id": reply_to_id,
                             "duration": _duration_secs,
-                            "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                            "read_timeout": self._media_read_timeout(),
                             **audio_thread_kwargs,
                             **self._notification_kwargs(metadata),
                         },
@@ -8140,7 +8187,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "photo": photo_src,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
-                        "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                        "read_timeout": self._media_read_timeout(),
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
@@ -8238,7 +8285,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "filename": display_name,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
-                        "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                        "read_timeout": self._media_read_timeout(),
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
@@ -8289,7 +8336,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "video": video_src,
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
-                        "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                        "read_timeout": self._media_read_timeout(),
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },

--- a/tests/gateway/test_telegram_local_mode_streaming.py
+++ b/tests/gateway/test_telegram_local_mode_streaming.py
@@ -1,0 +1,224 @@
+"""Local Bot API (``--local``) media handling must never buffer whole files.
+
+A self-hosted ``telegram-bot-api`` raises the upload cap from 50MB to 2000MB
+and answers ``getFile`` with an absolute server-side path instead of a
+download URL. Both directions therefore need to avoid materialising the
+payload in memory, or a 2GB transfer OOMs a small host:
+
+  * outbound — hand PTB the path STRING. ``parse_file_input`` only applies the
+    ``file://`` optimization to ``str``/``Path``; a file HANDLE falls through
+    to ``InputFile(handle)``, whose ``load_file()`` calls ``.read()``.
+  * inbound — copy from the server-reported path with ``shutil.copyfile``
+    instead of ``download_as_bytearray()``.
+
+Cloud-mode behaviour (the default) must be completely unchanged.
+"""
+
+import os
+
+import pytest
+
+from gateway.platforms.base import (
+    CachedMedia,
+    cache_media_bytes,
+    cache_media_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _adapter(local_mode: bool, base_url: str = "", **extra):
+    """Build a bare TelegramAdapter without running __init__/connect.
+
+    ``name`` is a read-only property on the adapter, so it is left alone;
+    only the attributes the code under test reads are set.
+    """
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter.__new__(TelegramAdapter)
+    a._local_mode = local_mode
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Outbound: _media_upload_source
+# ---------------------------------------------------------------------------
+
+def test_local_mode_yields_path_string_not_handle(tmp_path):
+    """Local mode must yield a str path so PTB uses the file:// URI."""
+    f = tmp_path / "movie.mp4"
+    f.write_bytes(b"\x00" * 1024)
+
+    with _adapter(local_mode=True)._media_upload_source(str(f)) as (src, rewind):
+        assert isinstance(src, str), "local mode must pass a path, not a handle"
+        assert src == os.path.abspath(str(f))
+        assert not hasattr(src, "read"), "a readable handle would be buffered by PTB"
+        # A path is stateless, so there is nothing to rewind on retry.
+        assert rewind is None
+
+
+def test_cloud_mode_yields_open_handle(tmp_path):
+    """Cloud mode keeps the historical handle-based upload."""
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"abc123")
+
+    with _adapter(local_mode=False)._media_upload_source(str(f)) as (src, rewind):
+        assert hasattr(src, "read"), "cloud mode should still pass a file object"
+        assert src.read() == b"abc123"
+        assert callable(rewind)
+        rewind()
+        assert src.read() == b"abc123", "rewind must reset the handle for retries"
+
+
+def test_cloud_mode_closes_handle_on_exit(tmp_path):
+    """The context manager must not leak file descriptors."""
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"x")
+
+    with _adapter(local_mode=False)._media_upload_source(str(f)) as (src, _):
+        assert not src.closed
+    assert src.closed
+
+
+def test_local_mode_does_not_open_the_file(tmp_path, monkeypatch):
+    """The whole point: local mode must not read the file at all."""
+    f = tmp_path / "huge.mp4"
+    f.write_bytes(b"y" * 4096)
+
+    real_open = open
+    opened = []
+
+    def _tracking_open(path, *args, **kwargs):
+        opened.append(str(path))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _tracking_open)
+    with _adapter(local_mode=True)._media_upload_source(str(f)) as (src, _):
+        assert isinstance(src, str)
+    assert str(f) not in opened, "local mode must never open the payload"
+
+
+def test_missing_local_mode_attr_falls_back_to_cloud(tmp_path):
+    """An adapter built via __new__ (no __init__) must not explode.
+
+    Several call sites construct the adapter without running __init__, so
+    ``_local_mode`` can be absent. Reading it unguarded raised AttributeError
+    and sank the entire send into the text-only fallback.
+    """
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    bare = TelegramAdapter.__new__(TelegramAdapter)
+    assert not hasattr(bare, "_local_mode")
+
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"q")
+    with bare._media_upload_source(str(f)) as (src, rewind):
+        assert hasattr(src, "read"), "must default to cloud-mode handle"
+        assert callable(rewind)
+
+
+def test_local_mode_relative_path_is_absolutised(tmp_path, monkeypatch):
+    """PTB's file:// URI needs an absolute path; relative input must resolve."""
+    f = tmp_path / "rel.mp4"
+    f.write_bytes(b"z")
+    monkeypatch.chdir(tmp_path)
+
+    with _adapter(local_mode=True)._media_upload_source("rel.mp4") as (src, _):
+        assert os.path.isabs(src)
+        assert src == str(f)
+
+
+# ---------------------------------------------------------------------------
+# Inbound: cache_media_path
+# ---------------------------------------------------------------------------
+
+def test_cache_media_path_streams_video_without_reading_bytes(tmp_path, monkeypatch):
+    """A video must be copied, never slurped via read_bytes()."""
+    src = tmp_path / "in.mp4"
+    src.write_bytes(b"v" * 2048)
+
+    copied = {}
+
+    def _fake_copyfile(a, b):
+        copied["args"] = (str(a), str(b))
+        with open(a, "rb") as fh_in, open(b, "wb") as fh_out:
+            fh_out.write(fh_in.read())
+
+    monkeypatch.setattr("gateway.platforms.base.shutil.copyfile", _fake_copyfile)
+
+    cached = cache_media_path(str(src), filename="in.mp4", mime_type="video/mp4")
+
+    assert cached is not None
+    assert cached.kind == "video"
+    assert copied["args"][0] == str(src), "must copy, not buffer"
+    assert os.path.isfile(cached.local_path)
+    assert open(cached.local_path, "rb").read() == b"v" * 2048
+
+
+def test_cache_media_path_matches_bytes_path_classification(tmp_path):
+    """Streamed and buffered paths must classify a file identically."""
+    for name, mime, expect in [
+        ("a.mp4", "video/mp4", "video"),
+        ("a.ogg", "audio/ogg", "audio"),
+        ("a.pdf", "application/pdf", "document"),
+        ("a.bin", "", "document"),
+    ]:
+        src = tmp_path / f"src_{name}"
+        src.write_bytes(b"data")
+
+        streamed = cache_media_path(str(src), filename=name, mime_type=mime)
+        buffered = cache_media_bytes(b"data", filename=name, mime_type=mime)
+
+        assert streamed is not None and buffered is not None
+        assert streamed.kind == buffered.kind == expect, name
+        assert streamed.media_type == buffered.media_type, name
+
+
+def test_cache_media_path_missing_file_returns_none(tmp_path):
+    """A dangling server path must degrade gracefully, not raise."""
+    assert cache_media_path(str(tmp_path / "nope.mp4"), filename="nope.mp4") is None
+
+
+def test_cache_media_path_enforces_size_cap(tmp_path, monkeypatch):
+    """The inbound cap applies to the streamed path too, via stat()."""
+    src = tmp_path / "big.mp4"
+    src.write_bytes(b"x" * 4096)
+
+    monkeypatch.setattr(
+        "gateway.platforms.base.get_inbound_media_max_bytes", lambda: 1024
+    )
+    with pytest.raises(ValueError, match="too large"):
+        cache_media_path(str(src), filename="big.mp4", mime_type="video/mp4")
+
+
+def test_cache_media_path_rejects_path_traversal(tmp_path):
+    """A malicious filename must not escape the document cache."""
+    src = tmp_path / "ok.bin"
+    src.write_bytes(b"d")
+
+    cached = cache_media_path(str(src), filename="../../etc/passwd")
+    assert cached is not None
+    # Sanitised to a basename inside the cache dir, never an escape.
+    assert "etc" not in os.path.dirname(cached.local_path).split(os.sep)[-1]
+    assert os.path.basename(cached.local_path).endswith("passwd")
+
+
+def test_cached_media_local_path_defaults_to_path():
+    """Back-compat: constructing without local_path mirrors path."""
+    cm = CachedMedia("/x/y.mp4", "video/mp4", "video", "y.mp4")
+    assert cm.local_path == "/x/y.mp4"
+
+
+def test_cached_media_local_path_survives_sandbox_translation():
+    """local_path must stay host-real even when path is container-visible."""
+    cm = CachedMedia(
+        "/root/.hermes/cache/videos/v.mp4",
+        "video/mp4",
+        "video",
+        "v.mp4",
+        local_path="/home/and/.hermes/cache/videos/v.mp4",
+    )
+    assert cm.path != cm.local_path
+    assert cm.local_path.startswith("/home/and")

--- a/tests/gateway/test_telegram_local_mode_streaming.py
+++ b/tests/gateway/test_telegram_local_mode_streaming.py
@@ -222,3 +222,237 @@ def test_cached_media_local_path_survives_sandbox_translation():
     )
     assert cm.path != cm.local_path
     assert cm.local_path.startswith("/home/and")
+
+
+# ---------------------------------------------------------------------------
+# Media send read timeout
+#
+# In local mode the sendVideo call blocks for the SERVER's whole upload to
+# Telegram, not just a post-upload transcode. A measured 1.29GB send took
+# ~131s, so the cloud-tuned 60s budget failed every large send while the
+# server kept uploading unobserved in the background.
+# ---------------------------------------------------------------------------
+
+def test_local_mode_media_read_timeout_covers_full_upload():
+    """Local mode must allow far more than the cloud transcode budget."""
+    from plugins.platforms.telegram.adapter import (
+        _MEDIA_SEND_READ_TIMEOUT,
+        media_read_timeout,
+    )
+
+    local = media_read_timeout(True)
+    assert local > _MEDIA_SEND_READ_TIMEOUT
+    # A 1.29GB send measured ~131s; the ceiling is 2000MB, so the budget has
+    # to leave room for a slow link at full size.
+    assert local >= 900
+
+
+def test_cloud_mode_media_read_timeout_unchanged():
+    """Cloud mode keeps the short budget so dead sends are noticed fast."""
+    from plugins.platforms.telegram.adapter import (
+        _MEDIA_SEND_READ_TIMEOUT,
+        media_read_timeout,
+    )
+
+    assert media_read_timeout(False) == _MEDIA_SEND_READ_TIMEOUT
+
+
+def test_adapter_media_read_timeout_follows_local_mode():
+    """The adapter wrapper must track its own _local_mode flag."""
+    from plugins.platforms.telegram.adapter import media_read_timeout
+
+    assert _adapter(local_mode=True)._media_read_timeout() == media_read_timeout(True)
+    assert _adapter(local_mode=False)._media_read_timeout() == media_read_timeout(False)
+
+
+def test_media_read_timeout_missing_attr_falls_back_to_cloud():
+    """An adapter built via __new__ without _local_mode must not raise."""
+    from plugins.platforms.telegram.adapter import (
+        TelegramAdapter,
+        media_read_timeout,
+    )
+
+    a = TelegramAdapter.__new__(TelegramAdapter)
+    assert not hasattr(a, "_local_mode")
+    assert a._media_read_timeout() == media_read_timeout(False)
+
+
+# ---------------------------------------------------------------------------
+# Standalone send path (`hermes send`, cron, scripts)
+#
+# _send_telegram builds its OWN Bot rather than reusing the gateway adapter.
+# It therefore has to apply base_url / local_mode itself: without them a
+# deployment pointed at a self-hosted server silently sent via
+# api.telegram.org — a different server, still capped at 50MB, and after a
+# logOut not even the one holding the bot. It also opened the file, which
+# buffered a multi-GB payload into RAM.
+# ---------------------------------------------------------------------------
+
+def test_shared_upload_source_local_mode_yields_path(tmp_path):
+    """The shared helper backs both the adapter and the standalone path."""
+    from plugins.platforms.telegram.adapter import media_upload_source
+
+    f = tmp_path / "big.mp4"
+    f.write_bytes(b"\x00" * 512)
+
+    with media_upload_source(str(f), local_mode=True) as (src, rewind):
+        assert isinstance(src, str)
+        assert src == os.path.abspath(str(f))
+        assert rewind is None
+
+
+def test_shared_upload_source_cloud_mode_yields_handle(tmp_path):
+    """Cloud mode still yields a rewindable handle for retries."""
+    from plugins.platforms.telegram.adapter import media_upload_source
+
+    f = tmp_path / "small.mp4"
+    f.write_bytes(b"xyz")
+
+    with media_upload_source(str(f), local_mode=False) as (src, rewind):
+        assert src.read() == b"xyz"
+        assert callable(rewind)
+        rewind()
+        assert src.read() == b"xyz", "rewind must make a retry re-readable"
+
+
+def test_shared_upload_source_local_mode_does_not_open_file(tmp_path, monkeypatch):
+    """True zero-copy: local mode must never open the file in-process."""
+    from plugins.platforms.telegram.adapter import media_upload_source
+
+    f = tmp_path / "huge.mp4"
+    f.write_bytes(b"\x00" * 256)
+
+    def _boom(*a, **kw):
+        raise AssertionError("local mode must not open the media file")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    with media_upload_source(str(f), local_mode=True) as (src, _):
+        assert isinstance(src, str)
+
+
+@pytest.mark.parametrize(
+    "extra, expect_base_url, expect_local",
+    [
+        ({}, False, False),
+        ({"base_url": "http://127.0.0.1:8081/bot", "local_mode": True}, True, True),
+        ({"base_url": "http://127.0.0.1:8081/bot"}, True, False),
+    ],
+)
+def test_standalone_send_honours_base_url_and_local_mode(
+    extra, expect_base_url, expect_local, tmp_path, monkeypatch
+):
+    """`hermes send` must reach the configured server, not api.telegram.org."""
+    import asyncio
+
+    import tools.send_message_tool as smt
+
+    captured = {}
+
+    class _FakeMsg:
+        message_id = 7
+
+    class _FakeBot:
+        def __init__(self, token, **kwargs):
+            captured["kwargs"] = kwargs
+
+        async def send_message(self, **kw):
+            return _FakeMsg()
+
+    import telegram
+
+    monkeypatch.setattr(telegram, "Bot", _FakeBot)
+
+    asyncio.run(
+        smt._send_telegram(
+            "123:ABC", "60469177", "hello", media_files=[], extra=extra
+        )
+    )
+
+    kwargs = captured["kwargs"]
+    assert ("base_url" in kwargs) is expect_base_url
+    assert bool(kwargs.get("local_mode")) is expect_local
+    if expect_base_url:
+        assert kwargs["base_url"] == extra["base_url"]
+        # base_file_url must default to the same origin, not the cloud one.
+        assert kwargs["base_file_url"] == extra["base_url"]
+
+
+def test_standalone_send_local_mode_passes_path_not_handle(tmp_path, monkeypatch):
+    """The standalone media path must stream in local mode, not buffer."""
+    import asyncio
+
+    import tools.send_message_tool as smt
+
+    video = tmp_path / "movie.mp4"
+    video.write_bytes(b"\x00" * 2048)
+    captured = {}
+
+    class _FakeMsg:
+        message_id = 9
+
+    class _FakeBot:
+        def __init__(self, token, **kwargs):
+            pass
+
+        async def send_video(self, **kw):
+            captured["video"] = kw["video"]
+            captured["read_timeout"] = kw.get("read_timeout")
+            return _FakeMsg()
+
+    import telegram
+
+    monkeypatch.setattr(telegram, "Bot", _FakeBot)
+
+    asyncio.run(
+        smt._send_telegram(
+            "123:ABC",
+            "60469177",
+            "",
+            media_files=[(str(video), False)],
+            extra={"base_url": "http://127.0.0.1:8081/bot", "local_mode": True},
+        )
+    )
+
+    from plugins.platforms.telegram.adapter import media_read_timeout
+
+    assert isinstance(captured["video"], str), "local mode must hand PTB a path"
+    assert captured["video"] == os.path.abspath(str(video))
+    assert captured["read_timeout"] == media_read_timeout(True)
+
+
+def test_standalone_send_cloud_mode_still_passes_handle(tmp_path, monkeypatch):
+    """No regression: without local_mode the handle upload is unchanged."""
+    import asyncio
+
+    import tools.send_message_tool as smt
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"data")
+    captured = {}
+
+    class _FakeMsg:
+        message_id = 11
+
+    class _FakeBot:
+        def __init__(self, token, **kwargs):
+            pass
+
+        async def send_video(self, **kw):
+            captured["video"] = kw["video"]
+            captured["read_timeout"] = kw.get("read_timeout")
+            return _FakeMsg()
+
+    import telegram
+
+    monkeypatch.setattr(telegram, "Bot", _FakeBot)
+
+    asyncio.run(
+        smt._send_telegram(
+            "123:ABC", "60469177", "", media_files=[(str(video), False)], extra={}
+        )
+    )
+
+    from plugins.platforms.telegram.adapter import media_read_timeout
+
+    assert hasattr(captured["video"], "read"), "cloud mode must keep the handle"
+    assert captured["read_timeout"] == media_read_timeout(False)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -1016,6 +1017,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            extra=getattr(pconfig, "extra", None),
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1343,13 +1345,21 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, extra=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
     so that bold, links, and headers render correctly.  If the message
     already contains HTML tags, it is sent with ``parse_mode='HTML'``
     instead, bypassing MarkdownV2 conversion.
+
+    ``extra`` is the platform's ``extra`` config block. It carries
+    ``base_url`` / ``base_file_url`` / ``local_mode``, which MUST be honoured
+    here: this standalone path builds its own ``Bot`` rather than reusing the
+    gateway adapter, so without them a deployment pointed at a self-hosted
+    ``telegram-bot-api`` silently sends via api.telegram.org instead — a
+    different server, still bound by the 50MB cloud cap, and (once the bot has
+    been ``logOut``-ed to bind locally) not even the one holding this bot.
     """
     try:
         from telegram import Bot
@@ -1383,6 +1393,40 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
+        # Self-hosted telegram-bot-api (--local). The gateway adapter reads
+        # these off the same extra block; this path builds its own Bot, so it
+        # has to apply them itself or every standalone send silently goes to
+        # the cloud API instead of the configured server.
+        _extra = extra if isinstance(extra, dict) else {}
+        _base_url = (_extra.get("base_url") or "").strip()
+        _local_mode = bool(_extra.get("local_mode"))
+        try:
+            from plugins.platforms.telegram.adapter import (
+                media_read_timeout as _media_read_timeout,
+                media_upload_source as _media_upload_source,
+            )
+        except Exception:
+            # python-telegram-bot is optional here; without the adapter module
+            # fall back to cloud behaviour rather than failing the send.
+            _local_mode = False
+
+            @contextlib.contextmanager
+            def _media_upload_source(path, *, local_mode=False):
+                with open(path, "rb") as handle:
+                    yield handle, lambda: handle.seek(0)
+
+            def _media_read_timeout(local_mode=False):
+                return 60.0
+
+        _bot_kwargs = {}
+        if _base_url:
+            _bot_kwargs["base_url"] = _base_url
+            _bot_kwargs["base_file_url"] = (
+                _extra.get("base_file_url") or _base_url
+            )
+        if _local_mode:
+            _bot_kwargs["local_mode"] = True
+
         if _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
@@ -1391,12 +1435,13 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     token=token,
                     request=HTTPXRequest(proxy=_tg_proxy),
                     get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                    **_bot_kwargs,
                 )
             except Exception as _proxy_err:
                 logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
+                bot = Bot(token=token, **_bot_kwargs)
         else:
-            bot = Bot(token=token)
+            bot = Bot(token=token, **_bot_kwargs)
         from plugins.platforms.telegram.telegram_ids import (
             normalize_telegram_chat_id,
         )
@@ -1535,8 +1580,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
             ext = os.path.splitext(media_path)[1].lower()
             try:
-                with open(media_path, "rb") as f:
+                # Local mode hands PTB a path so the bytes never enter this
+                # process; cloud mode keeps the historical open handle. Shared
+                # with the gateway adapter so both paths behave identically.
+                with _media_upload_source(media_path, local_mode=_local_mode) as (f, _rewind):
                     media_kwargs = dict(thread_kwargs)
+                    # Same reason as the adapter's send sites: in local mode
+                    # this call blocks for the server's whole upload to
+                    # Telegram, which the cloud-tuned default never covers.
+                    media_kwargs["read_timeout"] = _media_read_timeout(_local_mode)
                     # Attach the MEDIA:<path> caption to the bubble itself for
                     # captionable kinds (photo/video/document). _tg_caption is
                     # only set for a single captionable file, so this never
@@ -1581,8 +1633,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 "Thread %s not found for media send, retrying without message_thread_id",
                                 media_kwargs["message_thread_id"],
                             )
-                            # Re-seek the file since the first attempt consumed it
-                            f.seek(0)
+                            # Re-seek the file since the first attempt consumed
+                            # it. No-op in local mode, where ``f`` is a path
+                            # string and nothing was consumed.
+                            if _rewind is not None:
+                                _rewind()
                             media_kwargs.pop("message_thread_id", None)
                             if ext in _IMAGE_EXTS and not force_document:
                                 last_msg = await bot.send_photo(
@@ -1615,7 +1670,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 "Caption parse failed for media send, retrying plain: %s",
                                 _sanitize_error_text(media_err),
                             )
-                            f.seek(0)
+                            if _rewind is not None:
+                                _rewind()
                             media_kwargs.pop("parse_mode", None)
                             if not _has_html and media_kwargs.get("caption"):
                                 try:


### PR DESCRIPTION
## Problem

A self-hosted [`telegram-bot-api`](https://github.com/tdlib/telegram-bot-api) server run with `--local` raises the bot upload cap from 50MB to 2000MB. Hermes can already be pointed at one via `platforms.telegram.extra.base_url`, but three things make large transfers fail or OOM the host.

All three were found end-to-end on a 3.7GiB host: a 1.29GB send **failed at 50s** while spiking the gateway to **2.6GiB**.

### 1. Media is read fully into RAM

PTB's `parse_file_input` only applies its `file://` URI optimization to `str`/`Path` inputs. A file **handle** falls through to `InputFile(handle)`, whose `load_file()` calls `.read()` — so every send pulled the entire file into memory. At the 2000MB ceiling that is a multi-GB allocation.

Inbound had the mirror problem: local mode answers `getFile` with an absolute server-side path, but the file was still fetched with `download_as_bytearray()`.

### 2. The standalone send path ignored `base_url` entirely

`tools/send_message_tool.py::_send_telegram` (used by `hermes send`, cron, and scripts) builds its **own** `Bot(token)` rather than reusing the gateway adapter, and never read `extra`. So a deployment configured for a self-hosted server silently sent via `api.telegram.org` — a different server, still 50MB-capped, and after the required `logOut` not even the one serving the bot. It also `open()`ed the file, which is where the 2.6GiB spike came from.

### 3. The media read timeout assumed the wrong thing

`_MEDIA_SEND_READ_TIMEOUT = 60s` is sized for Telegram's post-upload transcode, which is correct for the cloud API where *this* process does the uploading. In local mode the request hands over a path and then blocks for the **server's entire upload to Telegram** — measured ~131s for 1.29GB. Every large send failed at 60s while the server kept uploading in the background, invisible and unreported.

## Changes

- **Outbound**: `media_upload_source()` yields the path *string* in local mode (zero-copy) and the historical open handle otherwise.
- **Inbound**: `cache_media_path()` copies from the server-reported path with `shutil.copyfile` instead of buffering. `CachedMedia` gains `local_path` so callers that must re-open the file locally don't use the sandbox-translated `path`.
- **Standalone path**: applies `base_url` / `base_file_url` / `local_mode`, and streams by path.
- **Timeout**: `_LOCAL_MEDIA_SEND_READ_TIMEOUT = 1800s` in local mode only.
- Both helpers are **module-level** so the adapter and the standalone path cannot drift apart again; the adapter methods are thin wrappers.

Cloud-mode behaviour is unchanged throughout — every branch is gated on `local_mode`, which is opt-in.

## Notes for review

- `getattr(self, "_local_mode", False)` rather than direct attribute access: adapters are also built via `__new__` (tests, some gateway rebuild paths) and never run `__init__`. Absent attribute == cloud mode == historical behaviour. There's a regression test for this.
- The two media retry paths previously called `f.seek(0)`, which raises on a path string. They now use the rewind callback (`None` in local mode).
- `cache_media_path` still enforces `validate_inbound_media_size`, from `stat()` instead of `len(data)`, so the configured cap applies identically on both paths. Images deliberately keep the bytes path so `cache_image_from_bytes` validation still runs.
- If the server-reported path isn't readable from the gateway (remote server, mount mismatch), it logs a warning and falls back to the download — a misconfiguration degrades instead of dropping the attachment.

## Testing

25 new tests in `tests/gateway/test_telegram_local_mode_streaming.py`, covering both modes: local yields a path and **never opens the file**, cloud still yields a rewindable handle, size caps, path traversal, sandbox translation, and the missing-attribute fallback.

Regression run of the telegram + media suites against this branch and against clean `main`:

| | passed | failed |
|---|---|---|
| `main` | 954 | 20 |
| this branch | **979** | 20 |

The 20 failures are identical in both and pre-existing (`telegram_format` tables, `telegram_rich_messages`, `weixin`) — unrelated to this change.

Verified end-to-end on a 3.7GiB host against a real `--local` server:

| | before | after |
|---|---|---|
| 1.29GB send | failed at 50s | completes |
| peak RSS | 2.75GiB | 60.7MiB |
| host RAM floor | 146MiB | 2.1GiB |

Also confirmed with 700MB of unique bytes (Telegram deduplicates identical content, so a repeat send of the same file proves nothing): 84s, RAM floor 2.09GiB.