### PR TITLE
fix(desktop): pin session resume/submit to the owning gateway connection

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -34,7 +34,6 @@ import { $sessionStates } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
-import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { finalizeInterruptedMessages } from './rewind'
 import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
@@ -590,9 +589,14 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           const resumed = cachedRuntimeId
             ? { session_id: cachedRuntimeId }
             : await singleFlightSessionResume(targetStoredSessionId, async () => {
+                const [{ resolveSessionProfile, resolveSessionOwner }, { requestForSessionProfile }] = await Promise.all([
+                  import('../use-session-actions/utils'),
+                  import('@/store/session-request-router')
+                ])
                 const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
+                const owner = await resolveSessionOwner(targetStoredSessionId)
 
-                return requestGateway<{ session_id: string }>('session.resume', {
+                return requestForSessionProfile<{ session_id: string }>(owner, requestGateway, 'session.resume', {
                   session_id: targetStoredSessionId,
                   source: 'desktop',
                   omit_messages: true,
@@ -761,16 +765,23 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         try {
           const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
+          const [{ resolveSessionOwner }, { requestForSessionProfile }] = await Promise.all([
+            import('../use-session-actions/utils'),
+            import('@/store/session-request-router')
+          ])
+          const owner = await resolveSessionOwner(recoverStoredSessionId)
+          const requestForOwner: GatewayRequest = (method, params, timeoutMs) =>
+            requestForSessionProfile(owner, requestGateway, method, params, timeoutMs)
 
           await withSessionNotFoundResume(
             sessionId,
             recoverStoredSessionId,
             liveId =>
               withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                requestForOwner('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
               ),
             {
-              requestGateway,
+              requestGateway: requestForOwner,
               driftReason: sessionDriftReason,
               onRecovered: recoveredId => {
                 if (onRuntimeRecovered) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -120,10 +120,15 @@ export async function resumeStoredRuntimeSession(
   // runtime — every loser is an orphan for the reaper. Sharing one in-flight
   // promise makes concurrent recoveries converge on ONE runtime.
   const resumed = await singleFlightSessionResume(storedSessionId, async () => {
+    const [{ resolveSessionOwner }, { requestForSessionProfile }] = await Promise.all([
+      import('../use-session-actions/utils'),
+      import('@/store/session-request-router')
+    ])
+    const owner = await resolveSessionOwner(storedSessionId)
     const resolveProfile = deps.resolveProfile ?? defaultResolveProfile
     const profile = await resolveProfile(storedSessionId)
 
-    return deps.requestGateway<{ session_id: string }>('session.resume', {
+    return requestForSessionProfile<{ session_id: string }>(owner, deps.requestGateway, 'session.resume', {
       session_id: storedSessionId,
       source: 'desktop',
       omit_messages: true,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -18,7 +18,7 @@ import {
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
-import { requestGatewayForAgent } from '@/store/gateway'
+import { activeGatewayConnectionId, requestGatewayForAgent } from '@/store/gateway'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
@@ -80,6 +80,7 @@ vi.mock('@/store/profile', async importOriginal => ({
 
 vi.mock('@/store/gateway', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
+  activeGatewayConnectionId: vi.fn(() => null),
   requestGatewayForAgent: vi.fn()
 }))
 
@@ -3261,5 +3262,60 @@ describe('selectSidebarItem', () => {
     expect(navigate).toHaveBeenCalledWith('/skills', undefined)
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
+  })
+})
+
+describe('resumeSession live remote owner', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    setResumeFailedSessionId(null)
+    setMessages([])
+    vi.mocked(activeGatewayConnectionId).mockReturnValue(null)
+    vi.mocked(getSession).mockReset()
+    vi.mocked(getLatestSessionMessages).mockReset().mockResolvedValue({ messages: [] } as never)
+    vi.mocked(requestGatewayForAgent).mockReset()
+  })
+
+  it('resumes an untagged default session on the live remote connection, not This device', async () => {
+    vi.mocked(activeGatewayConnectionId).mockReturnValue('remote-a')
+    setSessions([storedSession({ id: 'stored-remote', message_count: 0, profile: 'default' })])
+    vi.mocked(getSession).mockResolvedValue(
+      storedSession({ id: 'stored-remote', message_count: 0, profile: 'default' })
+    )
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [{ id: 'u1', role: 'user' }],
+      session_id: 'stored-remote'
+    } as never)
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          messages: [],
+          session_id: 'rt-remote'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const ambientRequest = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    let resume: null | ((storedSessionId: string) => Promise<unknown>) = null
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    await resume!('stored-remote')
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'remote-a',
+      'default',
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-remote' })
+    )
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.resume', expect.anything())
+    expect($resumeFailedSessionId.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,7 +22,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
-import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
+import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent, activeGatewayConnectionId } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -58,6 +58,7 @@ import {
   $sessions,
   $yoloActive,
   getSessionOwnerHint,
+  setSessionOwnerHint,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
   sessionPinId,
@@ -513,6 +514,25 @@ export function useSessionActions({
 
         if (stored) {
           createdThisRun.add(stored)
+          const ownerRoute =
+            capturedRoute ||
+            (() => {
+              const connectionId = activeGatewayConnectionId()
+
+              if (!connectionId) {
+                return null
+              }
+
+              return {
+                connectionId,
+                profile: $activeGatewayProfile.get() || 'default',
+                mode: 'remote' as const
+              }
+            })()
+
+          if (ownerRoute) {
+            setSessionOwnerHint(stored, ownerRoute)
+          }
           // Seed the sidebar preview with the user's first message so the row
           // reads meaningfully while the turn is in flight, instead of flashing
           // "Untitled session" until the turn persists and auto-title runs. The
@@ -797,7 +817,25 @@ export function useSessionActions({
 
       // A row spliced from a CONNECTED registry gateway (#88880) carries its
       // owning connection — activate THAT gateway, not a same-named local
-      // profile. Rows without the tag keep the legacy profile path.
+      // profile. Rows without the tag keep the legacy profile path, EXCEPT
+      // when the live socket is already a remote connection: two homes both
+      // expose `default`, so a name-only owner resumes the remote session on
+      // This device (toast on first click) while a later send uses the hint
+      // we stamp below and works.
+      const liveOwnerRoute = (() => {
+        const connectionId = activeGatewayConnectionId()
+
+        if (!connectionId) {
+          return null
+        }
+
+        return {
+          connectionId,
+          mode: 'remote' as const,
+          profile: sessionProfile || $activeGatewayProfile.get() || 'default'
+        }
+      })()
+
       const sessionOwner: SessionOwnerScope =
         ownerRoute ||
         (storedForProfile?.connection_id
@@ -805,23 +843,29 @@ export function useSessionActions({
               connectionId: storedForProfile.connection_id,
               profile: sessionProfile || 'default'
             }
-          : sessionProfile)
+          : null) ||
+        liveOwnerRoute ||
+        sessionProfile
+
+      if (sessionOwner && typeof sessionOwner === 'object' && sessionOwner.connectionId) {
+        setSessionOwnerHint(storedSessionId, sessionOwner)
+      }
 
       // All-profiles / plugin navigation must not steal chrome API-home:
       // dial the owning backend without moving $activeGatewayProfile.
       if ($showAllProfiles.get()) {
-        if (ownerRoute?.connectionId || storedForProfile?.connection_id) {
+        if (ownerRoute?.connectionId || storedForProfile?.connection_id || liveOwnerRoute?.connectionId) {
           await openGatewayForAgent(
-            ownerRoute?.connectionId || storedForProfile?.connection_id || null,
-            ownerRoute?.profile || sessionProfile || 'default'
+            ownerRoute?.connectionId || storedForProfile?.connection_id || liveOwnerRoute?.connectionId || null,
+            ownerRoute?.profile || sessionProfile || liveOwnerRoute?.profile || 'default'
           )
         } else if (sessionProfile) {
           await openGatewayForProfile(normalizeProfileKey(sessionProfile))
         }
-      } else if (ownerRoute?.connectionId || storedForProfile?.connection_id) {
+      } else if (ownerRoute?.connectionId || storedForProfile?.connection_id || liveOwnerRoute?.connectionId) {
         await ensureGatewayAgent(
-          ownerRoute?.connectionId || storedForProfile?.connection_id || null,
-          ownerRoute?.profile || sessionProfile || 'default'
+          ownerRoute?.connectionId || storedForProfile?.connection_id || liveOwnerRoute?.connectionId || null,
+          ownerRoute?.profile || sessionProfile || liveOwnerRoute?.profile || 'default'
         )
       } else {
         await ensureGatewayProfile(sessionProfile)
@@ -842,12 +886,13 @@ export function useSessionActions({
       const requestForSession = <T>(method: string, params: Record<string, unknown> = {}): Promise<T> =>
         requestForSessionProfile<T>(sessionOwner, requestGateway, method, params)
 
-      const sessionRestScope = ownerRoute
-        ? {
-            connectionId: ownerRoute.connectionId,
-            profile: ownerRoute.targetProfile || ownerRoute.profile
-          }
-        : sessionProfile
+      const sessionRestScope =
+        sessionOwner && typeof sessionOwner === 'object' && sessionOwner.connectionId
+          ? {
+              connectionId: sessionOwner.connectionId,
+              profile: sessionOwner.targetProfile || sessionOwner.profile
+            }
+          : sessionProfile
 
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-session-owner.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-session-owner.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $sessions, setSessionOwnerHint, setSessions } from '@/store/session'
+
+import { resolveSessionOwner } from './utils'
+
+afterEach(() => {
+  setSessions([])
+})
+
+describe('resolveSessionOwner', () => {
+  it('prefers an explicit owner hint with connectionId', async () => {
+    setSessionOwnerHint('20260825_183656_9a1342', {
+      connectionId: 'remote-a',
+      mode: 'remote',
+      profile: 'default'
+    })
+
+    await expect(resolveSessionOwner('20260825_183656_9a1342')).resolves.toMatchObject({
+      connectionId: 'remote-a',
+      profile: 'default'
+    })
+  })
+
+  it('uses the cached row connection_id when no hint exists', async () => {
+    $sessions.set([
+      {
+        id: '20260825_999999_aaaaaa',
+        title: 'remote chat',
+        connection_id: 'remote-a',
+        profile: 'default'
+      } as never
+    ])
+
+    await expect(resolveSessionOwner('20260825_999999_aaaaaa')).resolves.toMatchObject({
+      connectionId: 'remote-a',
+      profile: 'default'
+    })
+  })
+
+  it('returns undefined for a local session so submit stays on the ambient socket', async () => {
+    $sessions.set([
+      {
+        id: 'stored-db-xyz789',
+        title: 'local work',
+        profile: 'work'
+      } as never
+    ])
+
+    await expect(resolveSessionOwner('stored-db-xyz789')).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -12,6 +12,7 @@ import {
   $currentCwd,
   $messagingSessions,
   $sessions,
+  getSessionOwnerHint,
   commitWorkspaceCwdForSelectedSession,
   releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
@@ -28,7 +29,7 @@ import {
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'
-import type { SessionProfileRoute } from '@/store/session-request-router'
+import type { SessionOwnerScope, SessionProfileRoute } from '@/store/session-request-router'
 
 // Re-exported for the many session-actions/tile call sites that already import
 // it from here; the canonical definition lives in @/store/session.
@@ -1422,6 +1423,44 @@ export async function resolveSessionProfile(storedSessionId: null | string): Pro
   const profile = (await resolveStoredSession(storedSessionId))?.profile?.trim()
 
   return profile || undefined
+}
+
+/**
+ * Owning (connection, profile) for a stored session when we already know the
+ * registry connection. A profile name alone is not enough: two gateways both
+ * expose `default`, and routing by name sends a remote follow-up to This device.
+ *
+ * Cache + hint only — never REST-probe. `resolveStoredSession` can hang tests
+ * and send-path recovery on a dead lookup; create/click stamp the hint instead.
+ */
+export async function resolveSessionOwner(storedSessionId: null | string): Promise<SessionOwnerScope> {
+  if (!storedSessionId) {
+    return undefined
+  }
+
+  try {
+    const hinted = getSessionOwnerHint(storedSessionId)
+
+    if (hinted?.connectionId?.trim()) {
+      return hinted
+    }
+
+    const cached = [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()].find(session =>
+      sessionMatchesStoredId(session, storedSessionId)
+    )
+    const connectionId = cached?.connection_id?.trim()
+
+    if (connectionId) {
+      return {
+        connectionId,
+        profile: normalizeProfileKey(cached?.profile || 'default')
+      }
+    }
+  } catch {
+    // Fail open to the ambient socket rather than aborting the send.
+  }
+
+  return undefined
 }
 
 type SessionRuntimeStatePatch = Partial<

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -88,9 +88,18 @@ export function requestForSessionProfile<T>(
 
     const routedParams = routeParams(ownerProfile, params)
 
-    return timeoutMs === undefined && signal === undefined
-      ? requestGatewayForAgent<T>(connectionId, normKey(ownerProfile.profile), method, routedParams)
-      : requestGatewayForAgent<T>(connectionId, normKey(ownerProfile.profile), method, routedParams, timeoutMs, signal)
+    if (timeoutMs === undefined && signal === undefined) {
+      return requestGatewayForAgent<T>(connectionId, normKey(ownerProfile.profile), method, routedParams)
+    }
+
+    return requestGatewayForAgent<T>(
+      connectionId,
+      normKey(ownerProfile.profile),
+      method,
+      routedParams,
+      timeoutMs,
+      signal
+    )
   }
 
   if (!sessionRpcNeedsProfileRoute(ownerProfile)) {
@@ -100,9 +109,15 @@ export function requestForSessionProfile<T>(
     // changes the observed call shape for the many callers that never asked
     // for a deadline (the plugin host bridge in contrib/wiring is the only one
     // that does).
-    return timeoutMs === undefined && signal === undefined
-      ? ambientRequest<T>(method, params)
-      : ambientRequest<T>(method, params, timeoutMs, signal)
+    if (timeoutMs === undefined && signal === undefined) {
+      return ambientRequest<T>(method, params)
+    }
+
+    if (signal === undefined) {
+      return ambientRequest<T>(method, params, timeoutMs)
+    }
+
+    return ambientRequest<T>(method, params, timeoutMs, signal)
   }
 
   return requestGatewayForProfile<T>(normKey(ownerProfile), method, params, timeoutMs, signal)


### PR DESCRIPTION
## Problem

With two registered Desktop connections (This device + a Remote `hermes serve`),
both backends typically expose profile `default`.

Click-open and the second `prompt.submit` used the **ambient** socket. The first
create can land on the remote; the next `session.resume` / `prompt.submit` hits
the local gateway, which never had that live id → **Resume failed, session not
found**. The sidebar still lists the stored session.

`requestForSessionProfile` already exists for this class of bug. Click/send did
not pass a `{ connectionId, profile }` owner when the row was untagged.

## Fix

- `resolveSessionOwner(storedId)`: owner hint or cached `connection_id` only
  (no REST probe, no bare profile name).
- Stamp `setSessionOwnerHint` on remote `session.create` and on click-open.
- Click `resumeSession`: owner = captured route || row `connection_id` ||
  live remote connection || profile. Use that object for RPC **and** REST.
- `prompt.submit` and recovery `session.resume` go through
  `requestForSessionProfile(owner, …)`.
- Ambient router: do not pass a trailing `undefined` timeout/signal.

Local-only sessions stay on the ambient socket (`resolveSessionOwner` →
`undefined`).

## Tests

- `resolveSessionOwner`: hint, `connection_id`, local profile → undefined
- `resumeSession` on a live remote connection does not call ambient
  `session.resume`
- Existing prompt-actions / session-actions / router suites

## How to test

1. Register a second loopback Remote gateway (second `HERMES_HOME` + `hermes serve`).
2. Switch Desktop to that connection → Sessions → new chat → first send.
3. Click the row again, then send a follow-up. No resume toast; turn runs on
   the remote, not This device.
