### PR TITLE
fix(skill/pdf): preserve metadata and attachments across composeable operations

### DIFF
--- a/skills/productivity/pdf/scripts/pdf_meta.py
+++ b/skills/productivity/pdf/scripts/pdf_meta.py
@@ -83,6 +83,15 @@ def main() -> int:
 
     writer = PdfWriter()
     writer.append(reader)
+    # append() copies pages/outlines but neither the Info dictionary nor
+    # embedded attachments — re-apply both so composeable operations stop
+    # losing document state (#94870). Mode branches below still override
+    # (--set-meta merges over preserved values; --clear-meta wipes them).
+    if reader.metadata:
+        writer.add_metadata(dict(reader.metadata))
+    for name, contents in (reader.attachments or {}).items():
+        data = contents[0] if isinstance(contents, list) else contents
+        writer.add_attachment(name, bytes(data))
 
     if args.set_meta:
         meta = {}

--- a/skills/productivity/pdf/scripts/pdf_meta.py
+++ b/skills/productivity/pdf/scripts/pdf_meta.py
@@ -89,9 +89,17 @@ def main() -> int:
     # (--set-meta merges over preserved values; --clear-meta wipes them).
     if reader.metadata:
         writer.add_metadata(dict(reader.metadata))
+    # append() also drops the catalog's XMP metadata stream (the packet most
+    # producer tools write) — handing the parsed object back re-attaches the
+    # stream to the new catalog (#94870).
+    if reader.xmp_metadata is not None:
+        writer.xmp_metadata = reader.xmp_metadata
     for name, contents in (reader.attachments or {}).items():
-        data = contents[0] if isinstance(contents, list) else contents
-        writer.add_attachment(name, bytes(data))
+        # attachments maps a name to a *list* of payloads — a PDF may embed
+        # several files under one name; re-attach all of them, not just the
+        # first (#94870).
+        for data in contents if isinstance(contents, list) else [contents]:
+            writer.add_attachment(name, bytes(data))
 
     if args.set_meta:
         meta = {}

--- a/skills/productivity/pdf/scripts/pdf_secure.py
+++ b/skills/productivity/pdf/scripts/pdf_secure.py
@@ -35,18 +35,34 @@ def main() -> int:
         return 2
 
     def _reapply_document_state(writer: PdfWriter, source: PdfReader) -> None:
-        # append() copies pages/outlines but neither the Info dictionary nor
-        # embedded attachments — re-apply both so encrypt/decrypt round trips
-        # stop losing document state (#94870).
+        # append() copies pages/outlines but neither the Info dictionary, the
+        # catalog's XMP metadata stream, nor embedded attachments — re-apply
+        # all three so encrypt/decrypt round trips stop losing document
+        # state (#94870).
         try:
             if source.metadata:
                 writer.add_metadata(dict(source.metadata))
         except Exception:
             pass
         try:
+            # The xmp_metadata parsing property raises on AES-encrypted
+            # sources even after decrypt(), so copy the /Metadata stream
+            # itself — byte-level, no XML round-trip — which works for
+            # encrypted and plain sources alike (#94870).
+            from pypdf.generic import NameObject
+
+            _md = source.root_object.get("/Metadata")
+            if _md is not None:
+                writer._root_object[NameObject("/Metadata")] = _md.clone(writer)
+        except Exception:
+            pass
+        try:
             for name, contents in (source.attachments or {}).items():
-                data = contents[0] if isinstance(contents, list) else contents
-                writer.add_attachment(name, bytes(data))
+                # attachments maps a name to a *list* of payloads — a PDF
+                # may embed several files under one name; re-attach all of
+                # them, not just the first (#94870).
+                for data in contents if isinstance(contents, list) else [contents]:
+                    writer.add_attachment(name, bytes(data))
         except Exception:
             pass
 

--- a/skills/productivity/pdf/scripts/pdf_secure.py
+++ b/skills/productivity/pdf/scripts/pdf_secure.py
@@ -34,6 +34,22 @@ def main() -> int:
         print("Missing dependency: install with 'python3 -m pip install pypdf'", file=sys.stderr)
         return 2
 
+    def _reapply_document_state(writer: PdfWriter, source: PdfReader) -> None:
+        # append() copies pages/outlines but neither the Info dictionary nor
+        # embedded attachments — re-apply both so encrypt/decrypt round trips
+        # stop losing document state (#94870).
+        try:
+            if source.metadata:
+                writer.add_metadata(dict(source.metadata))
+        except Exception:
+            pass
+        try:
+            for name, contents in (source.attachments or {}).items():
+                data = contents[0] if isinstance(contents, list) else contents
+                writer.add_attachment(name, bytes(data))
+        except Exception:
+            pass
+
     reader = PdfReader(args.pdf)
     if args.encrypt:
         if not args.user_password:
@@ -44,6 +60,7 @@ def main() -> int:
             return 3
         writer = PdfWriter()
         writer.append(reader)
+        _reapply_document_state(writer, reader)
         writer.encrypt(
             user_password=args.user_password,
             owner_password=args.owner_password or args.user_password,
@@ -59,6 +76,7 @@ def main() -> int:
             return 4
         writer = PdfWriter()
         writer.append(reader)
+        _reapply_document_state(writer, reader)
         action = "decrypted"
 
     with open(args.output, "wb") as fh:

--- a/skills/productivity/pdf/tests/test_pdf_skill.py
+++ b/skills/productivity/pdf/tests/test_pdf_skill.py
@@ -412,3 +412,54 @@ def test_attachments_roundtrip(report_pdf: Path, workdir: Path):
     assert len(result["extracted"]) == 1
     extracted = Path(result["extracted"][0])
     assert "UNIQUEATTACH99" in extracted.read_text(encoding="utf-8")
+
+
+def test_attach_preserves_existing_metadata(report_pdf: Path, workdir: Path):
+    """#94870: attaching a file must not drop the document's existing
+    metadata — writer.append(reader) copies pages only, so the Info dict has
+    to be re-applied."""
+    titled = workdir / "meta_titled.pdf"
+    run("pdf_meta.py", str(report_pdf), "--set-meta",
+        "--title", "Preserve Me", "--author", "author-x", "-o", str(titled))
+    meta = json.loads(run("pdf_read.py", str(titled), "--meta").stdout)["metadata"]
+    assert meta["Title"] == "Preserve Me"
+
+    payload = workdir / "keep_meta_payload.txt"
+    payload.write_text("keep-meta payload\n", encoding="utf-8")
+    with_att = workdir / "meta_kept.pdf"
+    run("pdf_meta.py", str(titled), "--attach", str(payload), "-o", str(with_att))
+
+    meta = json.loads(run("pdf_read.py", str(with_att), "--meta").stdout)["metadata"]
+    assert meta.get("Title") == "Preserve Me", "attach dropped existing metadata"
+    assert meta.get("Author") == "author-x"
+    listing = json.loads(run("pdf_meta.py", str(with_att), "--list-attachments").stdout)
+    assert listing["attachments"] == ["keep_meta_payload.txt"]
+
+
+def test_attachments_survive_encrypt_decrypt(workdir: Path):
+    """#94870: embedded attachments must survive an encrypt→decrypt round
+    trip — both pdf_secure paths rebuild via writer.append(reader), which
+    drops embedded files."""
+    pytest.importorskip("cryptography")
+    payload = workdir / "secure_payload.txt"
+    payload.write_text("secure payload UNIQUESPEC42\n", encoding="utf-8")
+    with_att = workdir / "secure_in.pdf"
+    spec = {"title": "Secure Doc", "elements": [{"type": "paragraph", "text": "body"}]}
+    spec_path = workdir / "secure_spec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    run("pdf_create.py", str(spec_path), "-o", str(with_att))
+    run("pdf_meta.py", str(with_att), "--attach", str(payload), "-o", str(with_att))
+
+    encrypted = workdir / "secure_enc.pdf"
+    run("pdf_secure.py", str(with_att), "--encrypt",
+        "--user-password", "pw", "-o", str(encrypted))
+    decrypted = workdir / "secure_dec.pdf"
+    run("pdf_secure.py", str(encrypted), "--decrypt", "--password", "pw",
+        "-o", str(decrypted))
+
+    listing = json.loads(run("pdf_meta.py", str(decrypted), "--list-attachments").stdout)
+    assert listing["attachments"] == ["secure_payload.txt"], (
+        "attachment lost across encrypt/decrypt"
+    )
+    meta = json.loads(run("pdf_read.py", str(decrypted), "--meta").stdout)["metadata"]
+    assert meta.get("Title") == "Secure Doc"

--- a/skills/productivity/pdf/tests/test_pdf_skill.py
+++ b/skills/productivity/pdf/tests/test_pdf_skill.py
@@ -463,3 +463,83 @@ def test_attachments_survive_encrypt_decrypt(workdir: Path):
     )
     meta = json.loads(run("pdf_read.py", str(decrypted), "--meta").stdout)["metadata"]
     assert meta.get("Title") == "Secure Doc"
+
+
+XMP_PACKET = (
+    b'<?xpacket begin="\xef\xbb\xbf" id="W5M0MpCehiHzreSzNTczkc9d"?>\n'
+    b'<x:xmpmeta xmlns:x="adobe:ns:meta/">'
+    b'<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">'
+    b'<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">'
+    b'<dc:title><rdf:Alt><rdf:li xml:lang="x-default">XMPTitle</rdf:li>'
+    b'</rdf:Alt></dc:title></rdf:Description>'
+    b'</rdf:RDF></x:xmpmeta>\n<?xpacket end="w"?>'
+)
+
+
+def _write_pdf_with_xmp_and_dup_attachments(path):
+    """Build a source PDF carrying an XMP packet plus two payloads sharing
+    one attachment name — both shapes that writer.append() drops."""
+    import io
+
+    pypdf = pytest.importorskip("pypdf")
+    from pypdf.generic import NameObject, StreamObject
+    w = pypdf.PdfWriter()
+    w.add_blank_page(200, 200)
+    w.add_metadata({"/Title": "InfoTitle"})
+    stream = StreamObject()
+    stream.set_data(XMP_PACKET)
+    stream.update({
+        NameObject("/Type"): NameObject("/Metadata"),
+        NameObject("/Subtype"): NameObject("/XML"),
+    })
+    w._root_object[NameObject("/Metadata")] = stream
+    w.add_attachment("dup.bin", b"one")
+    w.add_attachment("dup.bin", b"two")
+    buf = io.BytesIO()
+    w.write(buf)
+    Path(path).write_bytes(buf.getvalue())
+
+
+def test_set_meta_preserves_xmp_and_all_same_name_attachments(workdir: Path):
+    """#94870 review: the preserve block must also carry the catalog's XMP
+    metadata stream and *every* payload under a shared attachment name —
+    writer.append() drops both."""
+    pypdf = pytest.importorskip("pypdf")
+    src = workdir / "xmp_src.pdf"
+    _write_pdf_with_xmp_and_dup_attachments(src)
+
+    out = workdir / "xmp_kept.pdf"
+    run("pdf_meta.py", str(src), "--set-meta", "--title", "New", "-o", str(out))
+
+    r = pypdf.PdfReader(str(out))
+    assert r.xmp_metadata is not None, "XMP packet dropped by --set-meta"
+    assert "XMPTitle" in (r.xmp_metadata.dc_title or {}).values()
+    payloads = r.attachments.get("dup.bin")
+    assert sorted(bytes(p) for p in payloads) == [b"one", b"two"], (
+        "same-name attachment payloads truncated"
+    )
+    assert (r.metadata or {}).get("/Title") == "New"
+
+
+def test_xmp_and_same_name_attachments_survive_encrypt_decrypt(workdir: Path):
+    """#94870 review: pdf_secure rebuilds via append() too — the XMP packet
+    and every payload under a shared name must survive the round trip."""
+    pypdf = pytest.importorskip("pypdf")
+    pytest.importorskip("cryptography")
+    src = workdir / "xmp_secure_src.pdf"
+    _write_pdf_with_xmp_and_dup_attachments(src)
+
+    encrypted = workdir / "xmp_enc.pdf"
+    run("pdf_secure.py", str(src), "--encrypt", "--user-password", "pw",
+        "-o", str(encrypted))
+    decrypted = workdir / "xmp_dec.pdf"
+    run("pdf_secure.py", str(encrypted), "--decrypt", "--password", "pw",
+        "-o", str(decrypted))
+
+    r = pypdf.PdfReader(str(decrypted))
+    assert r.xmp_metadata is not None, "XMP packet dropped by encrypt/decrypt"
+    assert "XMPTitle" in (r.xmp_metadata.dc_title or {}).values()
+    payloads = r.attachments.get("dup.bin")
+    assert sorted(bytes(p) for p in payloads) == [b"one", b"two"], (
+        "same-name attachment payloads truncated across encrypt/decrypt"
+    )


### PR DESCRIPTION
## What does this PR do?

The bundled `pdf` skill's compound workflows silently lost document state (#94870):

1. `pdf_meta.py --attach` **dropped pre-existing document metadata** (Title/Author gone after attaching a file).
2. `pdf_secure.py --encrypt` → `--decrypt` **dropped embedded attachments** (an attached file listed before encrypting was absent after decrypting).

Both scripts rebuild the document via `writer.append(reader)` — and pypdf's `append()` copies pages and outlines only: neither the Info dictionary nor embedded file attachments travel with it. Verified directly against pypdf: after `append`, metadata reduces to `/Producer` and `reader.attachments` comes back empty. This is the same single root cause behind both losses.

The fix re-applies both surfaces after every `append`:

- **`pdf_meta.py`** — preserved metadata composes with the existing mode branches: the re-apply runs *before* the branch, so `--set-meta` still merges over (and overrides) preserved values, and `--clear-meta` still wipes them; `--attach` now keeps what was already there.
- **`pdf_secure.py`** — a `_reapply_document_state` helper runs on both the encrypt and the decrypt path, guarded per surface (metadata / attachments) so one unreadable surface never blocks the other.

## Related Issue

Fixes #94870

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/productivity/pdf/scripts/pdf_meta.py` — after `writer.append(reader)`, re-apply the reader's Info dict and embedded attachments before the mode branches.
- `skills/productivity/pdf/scripts/pdf_secure.py` — `_reapply_document_state(writer, source)` called after the append on both the `--encrypt` and `--decrypt` paths.
- `skills/productivity/pdf/tests/test_pdf_skill.py` — two regressions mirroring the issue's reproduction: `--attach` over a titled document keeps Title/Author and the new attachment; an attachment + Title survive a full `--encrypt`/`--decrypt` round trip (with `importorskip("cryptography")` for the AES-256 dependency).

## How to Test

1. `pytest skills/productivity/pdf/tests/test_pdf_skill.py -q` — should pass (23 passed; 21 pre-existing + 2 new).
2. Observed result: with this PR's scripts reverted (plain main) and the new tests kept, both regressions fail — `--attach` returns metadata without the Title/Author, and the decrypted document lists zero attachments; with the change, both document surfaces survive the operation chains.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction from the issue (before): after `pdf_meta.py --attach` over a document with Title/Author set, `pdf_read.py --meta` showed neither; after `pdf_secure.py --encrypt` + `--decrypt`, `pdf_meta.py --list-attachments` showed `attachment_count: 0`. After this fix both operations preserve the prior state.
