### PR TITLE
fix(desktop): clear edit-composer timers on unmount

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -83,6 +83,12 @@ interface UserEditComposerProps {
   sessionId: string | null
 }
 
+/** Cooldown before the submit latch reopens, preventing a double-Enter resend. */
+export const LATCH_COOLDOWN_MS = 200
+
+/** Grace period for focus to settle inside the composer before a blur cancels it. */
+export const BLUR_SETTLE_MS = 80
+
 export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
@@ -118,12 +124,35 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const slash = useSlashCompletions({ gateway })
   const emoji = useEmojiCompletions()
 
+  // Same reason the focus bus leaks below: this composer routinely unmounts, so
+  // a deferred callback can outlive it and touch React state (or a torn-down
+  // composer core) after teardown. In the app that is a stray update on a dead
+  // tree; under jsdom the window is already gone by the time the timer fires,
+  // so it surfaces as an uncaught `ReferenceError: window is not defined` that
+  // fails the whole suite from an unrelated test. Track every pending timer and
+  // drop them all on unmount.
+  const timersRef = useRef(new Set<number>())
+
+  const scheduleTimer = useCallback((run: () => void, delayMs: number) => {
+    const id = window.setTimeout(() => {
+      timersRef.current.delete(id)
+      run()
+    }, delayMs)
+
+    timersRef.current.add(id)
+
+    return id
+  }, [])
+
   // This is the one composer that routinely unmounts, so it is where the focus
   // bus leaks: confirming or cancelling an edit tears the composer down while
   // `'edit'` is still the active target. Release it alongside the thread-scroll
   // cleanup so keyboard routing falls back to the visible chat composer.
   useEffect(
     () => () => {
+      const timers = timersRef.current
+      timers.forEach(id => window.clearTimeout(id))
+      timers.clear()
       notifyThreadEditClose()
       releaseActiveComposer('edit')
     },
@@ -341,7 +370,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         draftRef.current = composerPlainText(editor)
         aui.composer().setText(draftRef.current)
         requestEditFocus()
-        starter ? window.setTimeout(refreshTrigger, 0) : closeTrigger()
+        starter ? scheduleTimer(refreshTrigger, 0) : closeTrigger()
       }
 
       // In place first, spanning Chromium's split text nodes (see
@@ -360,7 +389,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       finish()
     },
-    [aui, closeTrigger, recordUndoPoint, refreshTrigger, rememberInitialDraft, requestEditFocus, trigger]
+    [aui, closeTrigger, recordUndoPoint, refreshTrigger, rememberInitialDraft, requestEditFocus, scheduleTimer, trigger]
   )
 
   const insertRefStrings = useCallback(
@@ -526,11 +555,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       rememberInitialDraft()
       const nextDraft = syncDraftFromEditor(editor)
-      window.setTimeout(refreshTrigger, 0)
+      scheduleTimer(refreshTrigger, 0)
 
       return nextDraft
     },
-    [refreshTrigger, rememberInitialDraft, syncDraftFromEditor]
+    [refreshTrigger, rememberInitialDraft, scheduleTimer, syncDraftFromEditor]
   )
 
   const handleInput = (event: FormEvent<HTMLDivElement>) => {
@@ -602,9 +631,9 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       // Clear latch after cooldown to allow re-submission. This prevents rapid
       // double-Enter but doesn't require tracking when onEdit settles (which may
       // be synchronous or async, and whose promise we don't have access to).
-      window.setTimeout(() => {
+      scheduleTimer(() => {
         setSubmitting(false)
-      }, 200)
+      }, LATCH_COOLDOWN_MS)
     } catch {
       setSubmitting(false)
     }
@@ -618,7 +647,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         return
       }
 
-      window.setTimeout(() => {
+      scheduleTimer(() => {
         const root = rootRef.current
         const active = document.activeElement
 
@@ -651,9 +680,9 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         } catch {
           // Composer core already gone — the edit is closing anyway.
         }
-      }, 80)
+      }, BLUR_SETTLE_MS)
     },
-    [aui, closeTrigger, submitting, syncDraftFromEditor]
+    [aui, closeTrigger, scheduleTimer, submitting, syncDraftFromEditor]
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -810,7 +839,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
               onBeforeInput={handleBeforeInput}
-              onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onBlur={() => scheduleTimer(closeTrigger, BLUR_SETTLE_MS)}
               onCompositionEnd={event => {
                 composingRef.current = false
                 flushEditorToDraft(event.currentTarget)

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -15,6 +15,8 @@ import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-s
 
 import { assistantMessage, stubThreadEnvironment, stubThreadViewportSize, userMessage } from '../test-utils'
 
+import { BLUR_SETTLE_MS, LATCH_COOLDOWN_MS } from './user-edit-composer'
+
 import { Thread } from '.'
 stubThreadEnvironment()
 
@@ -253,5 +255,103 @@ describe('Enter submission and latch behavior', () => {
     // The editor should allow the newline to be inserted (by not preventing default)
     // We don't simulate actual newline insertion here (requires complex DOM manipulation)
     // but we verify the guard did not block it
+  })
+})
+
+// The edit composer is the one composer that routinely unmounts (confirming or
+// cancelling tears it down), so a deferred callback can outlive the component.
+// In the app that is a stray state update on a dead tree; in jsdom the window is
+// already gone when the timer fires, surfacing as an uncaught
+// `ReferenceError: window is not defined` that fails the whole suite from an
+// unrelated test file.
+//
+// These assert on the timers this composer itself schedules — `getTimerCount()`
+// is global and legitimately non-zero from the runtime and React internals.
+describe('deferred work does not outlive the edit composer', () => {
+  // Records timers scheduled while tracking is active, keyed by their delay, so
+  // a test can assert on the composer's own timers. The global timer count is
+  // legitimately non-zero from the runtime and React internals, so filtering by
+  // this component's distinctive delays is what isolates its cleanup.
+  function trackTimers() {
+    const scheduled = new Map<number, { delayMs: number; run: () => void }>()
+    const cleared = new Set<number>()
+    const realSetTimeout = window.setTimeout.bind(window)
+    const realClearTimeout = window.clearTimeout.bind(window)
+
+    vi.spyOn(window, 'setTimeout').mockImplementation(((run: () => void, delayMs?: number) => {
+      const id = realSetTimeout(run, delayMs) as unknown as number
+      scheduled.set(id, { delayMs: delayMs ?? 0, run })
+
+      return id
+    }) as typeof window.setTimeout)
+
+    vi.spyOn(window, 'clearTimeout').mockImplementation(((id?: number) => {
+      if (id !== undefined) {
+        cleared.add(id)
+      }
+
+      realClearTimeout(id)
+    }) as typeof window.clearTimeout)
+
+    return {
+      pendingAt: (delayMs: number) =>
+        [...scheduled.entries()].filter(([id, timer]) => timer.delayMs === delayMs && !cleared.has(id)).map(([id]) => id),
+      run: (id: number) => scheduled.get(id)?.run()
+    }
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('clears the pending submit latch timer when the composer unmounts', async () => {
+    const onEdit = vi.fn(async () => {})
+    const { unmount } = render(<IncrementalHarness onEdit={onEdit} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    editor.textContent = 'edit that schedules the latch timer'
+    fireEvent.input(editor)
+
+    // Track only from here: the latch is scheduled synchronously by this
+    // keyDown. Assert before awaiting anything — a resolved onEdit closes the
+    // edit and unmounts the composer, which clears the latch on its own.
+    const timers = trackTimers()
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    const stranded = timers.pendingAt(LATCH_COOLDOWN_MS)
+    expect(stranded.length).toBeGreaterThan(0)
+
+    unmount()
+
+    // The latch timer must not survive the composer that scheduled it.
+    expect(timers.pendingAt(LATCH_COOLDOWN_MS)).toEqual([])
+  })
+
+  it('clears the deferred blur handler when the composer unmounts', async () => {
+    const onEdit = vi.fn(async () => {})
+    const { unmount } = render(<IncrementalHarness onEdit={onEdit} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+
+    const timers = trackTimers()
+    // Blur defers the trigger-close and the cancel by BLUR_SETTLE_MS.
+    fireEvent.blur(editor)
+
+    const stranded = timers.pendingAt(BLUR_SETTLE_MS)
+    expect(stranded.length).toBeGreaterThan(0)
+
+    unmount()
+
+    expect(timers.pendingAt(BLUR_SETTLE_MS)).toEqual([])
+
+    // Firing a stranded callback by hand is what a real timer flush would do:
+    // post-fix these are cleared, so nothing is left to touch the dead tree.
+    expect(() => {
+      stranded.forEach(id => timers.run(id))
+    }).not.toThrow()
   })
 })


### PR DESCRIPTION
The edit composer is the one composer that routinely unmounts — confirming or cancelling an edit tears it down — but its deferred callbacks were never cancelled with it. Five `window.setTimeout` calls (the 200 ms submit latch, the 80 ms blur settle, the trigger refreshes) could fire against a dead tree.

In the app that is a stray state update on an unmounted component. Under jsdom the window is already gone by the time the timer fires, so it surfaces as an uncaught error:

```
ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom-client.development.js:1308:7
 ❯ dispatchSetState       react-dom-client.development.js:9126:14
 ❯ Timeout._onTimeout     src/components/assistant-ui/thread/user-edit-composer.tsx:606:9
```

That fails the whole `check:test:ui` job **with every test passing** — the run reports `596 passed` / `5734 passed`, `Errors 1 error`, and still exits 1. Because it is an unhandled rejection rather than an assertion, it lands on whichever file happens to be running, so it reddens unrelated PRs with no failing test to point at. I hit it on an unrelated media PR (#94833), where a re-run on the identical commit went green.

## The fix

Track pending timers in a ref and clear them in the unmount cleanup that already exists in this component — the one releasing the focus bus, which is there for exactly the same "this composer routinely unmounts" reason. `scheduleTimer` self-removes each id when it fires, so the set does not grow.

`LATCH_COOLDOWN_MS` / `BLUR_SETTLE_MS` are extracted and exported so the tests can assert on this component's own delays. That matters: `vi.getTimerCount()` is global and legitimately non-zero from the runtime and React internals, so "no timers pending" is not an assertable condition — filtering by the component's distinctive delays is what isolates its cleanup.

## Verification

Red before green — with only the cleanup reverted (helper left in place, so this tests behavior rather than the existence of a function), the latch test strands 1 timer and the blur test strands 2:

```
× clears the pending submit latch timer when the composer unmounts
  AssertionError: expected [ …(1) ] to deeply equal []
× clears the deferred blur handler when the composer unmounts
  AssertionError: expected [ …(2) ] to deeply equal []
```

With the fix: `src/components/assistant-ui/` is 51 files / 439 tests green, no unhandled errors. `tsc -p . --noEmit` clean, eslint clean with no new warnings (both `useCallback` dep arrays updated).

One note on the latch test: it asserts synchronously after the `keyDown`, because a resolved `onEdit` closes the edit and unmounts the composer on its own — awaiting first would clear the latch and pass vacuously.