### PR TITLE
fix(desktop): route sidebar sessions through the active backend (supersedes #92653)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -504,6 +504,14 @@ test('pathForRegistryBackendRequest uses the resolved registry backend scope', (
     }),
     '/api/fs/download?path=%2Fsrv%2Freport.pdf'
   )
+  assert.equal(
+    pathForRegistryBackendRequest(
+      '/api/profiles/sessions/sidebar?recents_profile=research&recents_exclude=cron%2Cdesktop',
+      'research',
+      { remoteProfile: 'remote-research' }
+    ),
+    '/api/profiles/sessions/sidebar?recents_profile=remote-research&recents_exclude=cron%2Cdesktop'
+  )
 })
 
 // --- pathWithGlobalRemoteProfile ---
@@ -604,8 +612,23 @@ test('translateSelfProfileQuery rewrites the self-profile filter into the backen
   )
 })
 
+test('translateSelfProfileQuery rewrites sidebar recents_profile aliases for managed SSH', () => {
+  assert.equal(
+    translateSelfProfileQuery(
+      '/api/profiles/sessions/sidebar?recents_profile=research&recents_limit=20&cron_limit=50&messaging_limit=100',
+      'research',
+      'remote-research'
+    ),
+    '/api/profiles/sessions/sidebar?recents_profile=remote-research&recents_limit=20&cron_limit=50&messaging_limit=100'
+  )
+})
+
 test('translateSelfProfileQuery leaves cross-profile and unfiltered paths untouched', () => {
   assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=all', 'mara', 'default'), '/api/cron/jobs?profile=all')
+  assert.equal(
+    translateSelfProfileQuery('/api/profiles/sessions/sidebar?recents_profile=all', 'mara', 'default'),
+    '/api/profiles/sessions/sidebar?recents_profile=all'
+  )
   assert.equal(
     translateSelfProfileQuery('/api/cron/jobs?profile=worker', 'mara', 'default'),
     '/api/cron/jobs?profile=worker'

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -735,14 +735,23 @@ function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = 
   return pathWithProfileScope(path, profile)
 }
 
+/** Extra profile-valued query keys, beyond `profile`, that name the same
+ *  self-scope on a given path. The sidebar batches recents/cron/messaging
+ *  behind `recents_profile` instead of `profile`, so an SSH alias rewrite
+ *  that only looks at `?profile=` leaves those reads on the remote default. */
+const SELF_PROFILE_QUERY_KEYS_BY_PATH: Record<string, string[]> = {
+  '/api/profiles/sessions/sidebar': ['recents_profile']
+}
+
 /**
  * Translate an explicit self-profile query from a Desktop routing alias to the
  * backend's own profile namespace (a managed SSH `remoteProfile` can map local
- * `mara` to remote `default`). Only a `?profile=` equal to the alias itself is
- * rewritten; cross-profile selectors (`all`, another concrete profile) and
- * unfiltered paths pass through untouched. Used by the v1 profile route above
- * and by the registry SSH branch of the `hermes:api` handler — both routes
- * reach a backend whose namespace is the remote profile, not the alias.
+ * `mara` to remote `default`). Only endpoint-declared profile-valued params
+ * equal to the alias itself are rewritten; cross-profile selectors (`all`,
+ * another concrete profile) and unfiltered paths pass through untouched. Used
+ * by the v1 profile route above and by the registry SSH branch of the
+ * `hermes:api` handler — both routes reach a backend whose namespace is the
+ * remote profile, not the alias.
  */
 function translateSelfProfileQuery(path, profile, backendProfile) {
   const scopedProfile = connectionScopeKey(profile)
@@ -766,11 +775,21 @@ function translateSelfProfileQuery(path, profile, backendProfile) {
     return path
   }
 
-  if (connectionScopeKey(parsed.searchParams.get('profile')) !== scopedProfile) {
-    return path
+  const profileQueryKeys = ['profile', ...(SELF_PROFILE_QUERY_KEYS_BY_PATH[parsed.pathname] || [])]
+  let changed = false
+
+  for (const key of profileQueryKeys) {
+    if (connectionScopeKey(parsed.searchParams.get(key)) !== scopedProfile) {
+      continue
+    }
+
+    parsed.searchParams.set(key, backend)
+    changed = true
   }
 
-  parsed.searchParams.set('profile', backend)
+  if (!changed) {
+    return path
+  }
 
   return `${parsed.pathname}${parsed.search}${parsed.hash}`
 }

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -8,7 +8,7 @@ import type {
   SessionSearchResponse
 } from '@/types/hermes'
 
-import { capabilityScoped, hermesApi, type ProfileScope } from './client'
+import { capabilityScoped, hermesApi, type ProfileScope, profileScoped } from './client'
 
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
@@ -59,6 +59,7 @@ export async function listSessions(
   order: 'created' | 'recent' = 'recent'
 ): Promise<PaginatedSessions> {
   const result = await hermesApi<PaginatedSessions>({
+    ...profileScoped(),
     path:
       `/api/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}`,
@@ -100,6 +101,7 @@ export async function listAllProfileSessions(
     : ''
 
   const result = await hermesApi<PaginatedSessions>({
+    ...profileScoped(),
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
@@ -248,6 +250,7 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 
   try {
     result = await hermesApi<SidebarSessionsResponse>({
+      ...profileScoped(),
       path: `/api/profiles/sessions/sidebar?${params.toString()}`,
       timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
     })

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -140,6 +140,57 @@ describe('Hermes REST helpers', () => {
     expect(api).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'local', path: '/api/profiles' }))
   })
 
+  it('routes the batched sidebar refresh through the active backend scope', async () => {
+    setApiRequestConnection('cubi')
+    setApiRequestProfile('default')
+    api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
+
+    await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 20,
+      recentsExclude: ['cron'],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: ['cron', 'desktop']
+    })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'cubi',
+        profile: 'default',
+        path: expect.stringContaining('/api/profiles/sessions/sidebar?recents_profile=default')
+      })
+    )
+  })
+
+  it('routes legacy profile-session slices through the active backend scope', async () => {
+    setApiRequestConnection('cubi')
+    setApiRequestProfile('default')
+
+    await listAllProfileSessions(20, 1, 'exclude', 'recent', 'default')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'cubi',
+        profile: 'default',
+        path: expect.stringContaining('/api/profiles/sessions?')
+      })
+    )
+  })
+
+  it('does not stamp ambient profile onto unscoped helpers', async () => {
+    setApiRequestProfile('iris')
+
+    await getProfiles()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/profiles'
+      })
+    )
+    expect(api.mock.calls[0][0]).not.toHaveProperty('profile')
+  })
+
   it('preserves ambient and explicit-local ownership for session and profile requests', async () => {
     setApiRequestConnection('remote-a')
 


### PR DESCRIPTION
## What does this PR do?

Supersedes #92653.

After a profile or remote switch, Desktop can show an empty Sessions list even though `state.db` still has the rows. Two seams were wrong:

1. Managed SSH aliases rewrite `?profile=` to the remote's own name, but the batched sidebar filter lives in `recents_profile`. Those reads hit the remote default namespace and come back empty.
2. `listSidebarSessions` / `listAllProfileSessions` / `listSessions` tagged the registry connection and put the profile in the query string, but Electron's `hermes:api` router keys off `request.profile`. Without that field, a pinned remote/SSH connection still served the wrong backend.

Noah's PR had both ideas. It also conflicted with main, and it spread `profileScoped()` through every `hermesApi` call. That last part is dropped: `hermesApi` stays connection-only (the existing contract), and only the session-list helpers stamp the active profile.

### What this PR does
- Rewrite `recents_profile` through the same SSH alias translation as `profile`
- Pass `profileScoped()` on sidebar and legacy session-list REST calls
- Cover both seams, plus a regression that unscoped helpers do not pick up the ambient profile

### What was dropped from #92653
- Spreading `profileScoped()` into `hermesApi` itself

## Related Issue

Fixes #87759
Related: #88528

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `cd apps/desktop && npm run test:desktop:platforms -- electron/connection-config.test.ts` — 115 passed
2. `cd apps/desktop && npm run test:ui -- src/hermes.test.ts` — 36 passed
3. On a managed SSH profile whose `remoteProfile` differs from the Desktop label: switch to that profile, confirm Sessions lists the remote chats rather than an empty default namespace
4. Switch profiles / remotes, then Reset to defaults in the Sessions filter; lists should follow the active backend, not the previous one

Credit: @n-leezy (primary).