### PR TITLE
feat(terminal): close provider parity gaps — guard skip, prompt-probe opt-out, guest-home cwd, per-task image override

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1335,6 +1335,21 @@ def _probe_remote_backend(env_type: str) -> str | None:
     if cached is not None:
         return cached or None
 
+    # A plugin backend can opt out of the live probe (probe_at_prompt_build =
+    # False) when creating an environment is expensive or billable — a prompt
+    # build must never spin up a paid sandbox. The caller then uses the
+    # provider's static env_description fallback. Fail-soft: built-in and
+    # unknown names keep probing.
+    try:
+        from agent.terminal_env_registry import provider_flag
+
+        probe_allowed = provider_flag(env_type, "probe_at_prompt_build", True)
+    except Exception:
+        probe_allowed = True
+    if not probe_allowed:
+        _BACKEND_PROBE_CACHE[cache_key] = ""
+        return None
+
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.

--- a/agent/terminal_env_provider.py
+++ b/agent/terminal_env_provider.py
@@ -38,13 +38,18 @@ recur for plugin backends:
 * ``guest_home_root`` — the backend's guest-home directory (e.g.
   ``"/home/agent"``), or ``None``. Its subtree is accepted as a legitimate
   in-sandbox cwd by the host-path sanitizers even though it matches the
-  host-path heuristics (``/home/...`` looks like a host path).
+  host-path heuristics (``/home/...`` looks like a host path). Must be an
+  absolute path other than ``"/"`` — a bare ``"/"`` would exempt every
+  absolute path from the guard, so empty, relative, and ``"/"`` roots are
+  ignored (no exemption).
 * ``default_cwd`` — default working directory inside the backend, or
   ``None`` to use the container default (``"/root"``).
 * ``probe_at_prompt_build`` — whether the prompt builder may create a live
   environment to probe the backend's OS/$HOME/cwd at system-prompt build
   time. Set ``False`` when creating an environment is expensive or
-  billable; the prompt then falls back to ``env_description``.
+  billable; the prompt then falls back to ``env_description``. The prompt
+  builder caches the declaration per process — this is a static
+  declaration, not a runtime toggle.
 * ``skip_container_guards`` — the sandbox is isolated enough that
   dangerous-command approval prompts are skipped (a wiped filesystem is
   disposable). Defaults to ``is_container``. Backends that can mount host
@@ -226,6 +231,8 @@ class TerminalEnvironmentProvider(abc.ABC):
             timeout: Default per-command timeout in seconds.
             task_id: Task identifier for environment reuse/persistence keying.
             image: Configured container image name (may be irrelevant).
+                An empty string means no image is configured — treat ``""``
+                as unset and use the backend's own default.
             container_config: Resource config dict (``container_cpu``,
                 ``container_memory``, ``container_disk``,
                 ``container_persistent``) when :attr:`is_container` is True.

--- a/agent/terminal_env_provider.py
+++ b/agent/terminal_env_provider.py
@@ -35,6 +35,16 @@ recur for plugin backends:
   own filesystem rooted away from the host: container resource config is
   passed through, host-looking cwds are sanitized, and file tools use
   container path resolution.
+* ``guest_home_root`` — the backend's guest-home directory (e.g.
+  ``"/home/agent"``), or ``None``. Its subtree is accepted as a legitimate
+  in-sandbox cwd by the host-path sanitizers even though it matches the
+  host-path heuristics (``/home/...`` looks like a host path).
+* ``default_cwd`` — default working directory inside the backend, or
+  ``None`` to use the container default (``"/root"``).
+* ``probe_at_prompt_build`` — whether the prompt builder may create a live
+  environment to probe the backend's OS/$HOME/cwd at system-prompt build
+  time. Set ``False`` when creating an environment is expensive or
+  billable; the prompt then falls back to ``env_description``.
 * ``skip_container_guards`` — the sandbox is isolated enough that
   dangerous-command approval prompts are skipped (a wiped filesystem is
   disposable). Defaults to ``is_container``. Backends that can mount host
@@ -104,6 +114,9 @@ class TerminalEnvironmentProvider(abc.ABC):
     is_remote: bool = True
     is_container: bool = True
     session_isolated_when_nonpersistent: bool = False
+    guest_home_root: Optional[str] = None
+    default_cwd: Optional[str] = None
+    probe_at_prompt_build: bool = True
 
     @property
     def skip_container_guards(self) -> bool:

--- a/tests/tools/test_terminal_provider_parity.py
+++ b/tests/tools/test_terminal_provider_parity.py
@@ -149,6 +149,35 @@ class TestBackendGuestSubpath:
         reg.register_provider(RaiseBox())
         assert tt._is_backend_guest_subpath("raisebox", "/home/guest") is False
 
+    def test_root_slash_never_exempts(self):
+        # A bare "/" root would exempt EVERY absolute path from the
+        # host-path guard — reject it instead of honoring it.
+        class SlashBox(_GuestHomeProvider):
+            name = "slashbox"
+            guest_home_root = "/"
+
+        reg.register_provider(SlashBox())
+        assert tt._is_backend_guest_subpath("slashbox", "/Users/me/secrets") is False
+        assert tt._is_backend_guest_subpath("slashbox", "/home/guest") is False
+        assert tt._is_backend_guest_subpath("slashbox", "/") is False
+
+    def test_empty_root_never_exempts(self):
+        class EmptyBox(_GuestHomeProvider):
+            name = "emptybox"
+            guest_home_root = ""
+
+        reg.register_provider(EmptyBox())
+        assert tt._is_backend_guest_subpath("emptybox", "/home/guest") is False
+
+    def test_relative_root_never_exempts(self):
+        class RelBox(_GuestHomeProvider):
+            name = "relbox"
+            guest_home_root = "home/guest"
+
+        reg.register_provider(RelBox())
+        assert tt._is_backend_guest_subpath("relbox", "home/guest/project") is False
+        assert tt._is_backend_guest_subpath("relbox", "/home/guest") is False
+
     def test_terminal_cwd_in_guest_home_survives_sanitize(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "guestbox")
         monkeypatch.setenv("TERMINAL_CWD", "/home/guest/project")
@@ -186,6 +215,35 @@ class TestBackendGuestSubpath:
         finally:
             tt.clear_session_cwd("sess-guest-cd")
         assert resolved == "/home/guest"
+
+
+class TestResolveTaskImage:
+    """_resolve_task_image is the single owner of the backend→image ladder
+    (terminal_tool, ensure_task_env, execute_code, file tools); pin the
+    helper itself so the ladder can't drift at any call site."""
+
+    def test_builtin_override_wins(self):
+        image = tt._resolve_task_image(
+            "docker", {"docker_image": "task:img"}, {"docker_image": "cfg:img"})
+        assert image == "task:img"
+
+    def test_builtin_falls_back_to_config(self):
+        image = tt._resolve_task_image("docker", {}, {"docker_image": "cfg:img"})
+        assert image == "cfg:img"
+
+    def test_plugin_override_resolved_when_registered(self):
+        reg.register_provider(_GuestHomeProvider())
+        image = tt._resolve_task_image("guestbox", {"guestbox_image": "guest:img"}, {})
+        assert image == "guest:img"
+
+    def test_plugin_without_override_is_empty(self):
+        reg.register_provider(_GuestHomeProvider())
+        assert tt._resolve_task_image("guestbox", {}, {}) == ""
+
+    def test_unknown_backend_is_empty(self):
+        # Not registered: an arbitrary *_image override key resolves nothing.
+        image = tt._resolve_task_image("nosuchbox", {"nosuchbox_image": "x:img"}, {})
+        assert image == ""
 
 
 def _plugin_backend_config(config_cwd="/home/guest"):

--- a/tests/tools/test_terminal_provider_parity.py
+++ b/tests/tools/test_terminal_provider_parity.py
@@ -1,0 +1,513 @@
+"""Provider parity tests: plugin terminal backends get the same policy
+treatment as built-in backends at every classification site.
+
+Pluggable terminal backends participate in core policy decisions through
+declarative provider attributes (see the classification contract in
+``agent/terminal_env_provider.py``), but four sites still consulted
+hardcoded built-in names only, so a plugin backend silently lost behavior
+every in-tree backend has:
+
+  * ``_get_env_config()``'s default-cwd ladder ignored the provider's
+    ``default_cwd`` and forced ``/root``.
+  * The host-path cwd sanitizers discarded the backend's own guest home
+    (e.g. ``/home/agent``) because it matches the host-path heuristics —
+    including the agent's recorded ``cd`` state between commands.
+  * RL/benchmark per-task image overrides (``f"{backend}_image"``) neither
+    triggered rollout isolation nor reached ``create_environment``.
+  * ``_should_skip_container_guards`` never consulted the provider's
+    ``skip_container_guards`` flag, and the prompt builder's live backend
+    probe could spin up an expensive/billable sandbox at prompt-build time
+    (``probe_at_prompt_build``).
+
+All fake providers here subclass the real ABC and register through the real
+registry, so the fail-soft ``provider_flag`` chain is exercised end to end.
+"""
+
+import pytest
+
+import tools.terminal_tool as tt
+from agent import terminal_env_registry as reg
+from agent.terminal_env_provider import TerminalEnvironmentProvider
+
+
+class _FakeEnv:
+    def __init__(self, cwd="/home/guest"):
+        self.cwd = cwd
+
+    def execute(self, command, timeout=None, **kwargs):
+        return {"output": "", "exit_code": 0}
+
+    def cleanup(self):
+        pass
+
+
+class _GuestHomeProvider(TerminalEnvironmentProvider):
+    """Container-style plugin backend whose guest home hides under /home/."""
+
+    name = "guestbox"
+    display_name = "GuestBox"
+    is_remote = True
+    is_container = True
+    guest_home_root = "/home/guest"
+    default_cwd = "/home/guest"
+
+    def is_available(self):
+        return True
+
+    def create_environment(self, *, cwd, timeout, task_id="default",
+                           image=None, container_config=None, **kwargs):
+        return _FakeEnv(cwd)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reg._reset_for_tests()
+    yield
+    reg._reset_for_tests()
+
+
+def _plugin_env_config(monkeypatch, provider):
+    """Run the real _get_env_config() with *provider* as the active backend."""
+    reg.register_provider(provider)
+    monkeypatch.setenv("TERMINAL_ENV", provider.name)
+    # The config.yaml → env bridge is a no-op after first attempt; skip it so
+    # the test reads only the env vars set here.
+    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+    return tt._get_env_config()
+
+
+class TestPluginDefaultCwd:
+    def test_provider_default_cwd_honored(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        config = _plugin_env_config(monkeypatch, _GuestHomeProvider())
+        assert config["cwd"] == "/home/guest"
+
+    def test_missing_default_cwd_falls_back_to_root(self, monkeypatch):
+        class PlainBox(_GuestHomeProvider):
+            name = "plainbox"
+            guest_home_root = None
+            default_cwd = None
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        config = _plugin_env_config(monkeypatch, PlainBox())
+        assert config["cwd"] == "/root"
+
+    def test_raising_default_cwd_fails_soft_to_root(self, monkeypatch):
+        class RaiseBox(_GuestHomeProvider):
+            name = "raisebox"
+            guest_home_root = None
+
+            @property
+            def default_cwd(self):
+                raise RuntimeError("boom")
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        config = _plugin_env_config(monkeypatch, RaiseBox())
+        assert config["cwd"] == "/root"
+
+
+class TestBackendGuestSubpath:
+    """The backend's guest home (and its subtree) is a real sandbox path, so
+    it must be exempt from the host-path guard even though it shares the
+    /home/ prefix that other backends reject."""
+
+    @pytest.fixture(autouse=True)
+    def _register(self, _clean_registry):
+        reg.register_provider(_GuestHomeProvider())
+
+    def test_guest_home_root_is_subpath(self):
+        assert tt._is_backend_guest_subpath("guestbox", "/home/guest") is True
+
+    def test_guest_home_child_is_subpath(self):
+        assert tt._is_backend_guest_subpath("guestbox", "/home/guest/project") is True
+
+    def test_unrelated_home_is_not_subpath(self):
+        # A different user's home is still a host path even on guestbox.
+        assert tt._is_backend_guest_subpath("guestbox", "/home/someoneelse") is False
+
+    def test_sibling_prefix_is_not_subpath(self):
+        # /home/guestother shares the string prefix but not the subtree.
+        assert tt._is_backend_guest_subpath("guestbox", "/home/guestother") is False
+
+    def test_docker_has_no_guest_home_exemption(self):
+        # Built-in backends declare no guest home; /home/... stays a host path.
+        assert tt._is_backend_guest_subpath("docker", "/home/guest/project") is False
+
+    def test_guest_subpath_survives_full_guard(self):
+        # The combined check the call sites use: unusable-by-prefix but exempt.
+        assert tt._is_unusable_container_cwd("/home/guest/project") is True
+        assert tt._is_backend_guest_subpath("guestbox", "/home/guest/project") is True
+
+    def test_raising_guest_home_property_fails_soft(self):
+        class RaiseBox(_GuestHomeProvider):
+            name = "raisebox"
+
+            @property
+            def guest_home_root(self):
+                raise RuntimeError("boom")
+
+        reg.register_provider(RaiseBox())
+        assert tt._is_backend_guest_subpath("raisebox", "/home/guest") is False
+
+    def test_terminal_cwd_in_guest_home_survives_sanitize(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setenv("TERMINAL_CWD", "/home/guest/project")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        config = tt._get_env_config()
+        assert config["cwd"] == "/home/guest/project"
+
+    def test_terminal_cwd_outside_guest_home_still_sanitized(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setenv("TERMINAL_CWD", "/home/someoneelse/project")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        config = tt._get_env_config()
+        assert config["cwd"] == "/home/guest"
+
+    def test_recorded_guest_cd_state_survives(self):
+        # The per-command sibling site: the session's own `cd` record inside
+        # the guest home must not be discarded as a host path.
+        tt.record_session_cwd("sess-guest-cd", "/home/guest/project")
+        try:
+            resolved = tt._resolve_command_cwd(
+                workdir=None, default_cwd="/home/guest",
+                session_key="sess-guest-cd", env_type="guestbox",
+            )
+        finally:
+            tt.clear_session_cwd("sess-guest-cd")
+        assert resolved == "/home/guest/project"
+
+    def test_recorded_host_cwd_still_discarded(self):
+        tt.record_session_cwd("sess-guest-cd", "/Users/me/workspace")
+        try:
+            resolved = tt._resolve_command_cwd(
+                workdir=None, default_cwd="/home/guest",
+                session_key="sess-guest-cd", env_type="guestbox",
+            )
+        finally:
+            tt.clear_session_cwd("sess-guest-cd")
+        assert resolved == "/home/guest"
+
+
+def _plugin_backend_config(config_cwd="/home/guest"):
+    """Minimal _get_env_config()-shaped dict for the guestbox backend."""
+    return {
+        "env_type": "guestbox",
+        "cwd": config_cwd,
+        "host_cwd": None,
+        "timeout": 180,
+        "lifetime_seconds": 300,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "docker_volumes": [],
+        "docker_env": {},
+        "docker_extra_args": [],
+        "docker_mount_cwd_to_workspace": False,
+        "docker_run_as_host_user": False,
+        "docker_forward_env": [],
+        "modal_mode": "auto",
+    }
+
+
+class TestPluginImageOverride:
+    """Per-task image overrides for plugin backends (``f"{backend}_image"``)
+    must trigger rollout isolation and reach create_environment — the same
+    contract RL/benchmark envs rely on for docker/modal/... backends."""
+
+    def test_plugin_image_override_triggers_isolation(self, monkeypatch):
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        task_id = "rollout-42"
+        tt.register_task_env_overrides(task_id, {"guestbox_image": "guest:img"})
+        try:
+            assert tt._has_isolation_overrides(task_id) is True
+            assert tt._resolve_container_task_id(task_id) == task_id
+        finally:
+            tt.clear_task_env_overrides(task_id)
+
+    def test_unregistered_backend_image_key_is_not_isolation(self, monkeypatch):
+        # guestbox is NOT registered here: an arbitrary *_image key must not
+        # trigger per-task sandbox isolation.
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        task_id = "rollout-43"
+        tt.register_task_env_overrides(task_id, {"guestbox_image": "guest:img"})
+        try:
+            assert tt._has_isolation_overrides(task_id) is False
+        finally:
+            tt.clear_task_env_overrides(task_id)
+
+    def _drive_terminal_tool(self, monkeypatch, overrides, config_cwd="/home/guest"):
+        """Run terminal_tool() on the guestbox backend with *overrides*
+        registered, and return what reached _create_environment."""
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+
+        captured = {}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["image"] = image
+            captured["cwd"] = cwd
+            captured["task_id"] = kwargs.get("task_id")
+            return _FakeEnv(cwd)
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: _plugin_backend_config(config_cwd))
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda *a, **k: {"approved": True})
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        # Force a fresh environment build so _create_environment is invoked.
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+        monkeypatch.setattr(tt, "_session_cwd", {})
+
+        task_id = "rollout-image"
+        tt.register_task_env_overrides(task_id, overrides)
+        try:
+            tt.terminal_tool(command="pwd", task_id=task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt._active_environments.pop(task_id, None)
+            tt._active_environments.pop("default", None)
+        return captured
+
+    def test_plugin_image_override_reaches_terminal_create(self, monkeypatch):
+        captured = self._drive_terminal_tool(
+            monkeypatch, {"guestbox_image": "guest:img"})
+        assert captured.get("image") == "guest:img"
+        # The override isolates the rollout: its own sandbox, not "default".
+        assert captured.get("task_id") == "rollout-image"
+
+    def test_guest_home_cwd_override_survives_terminal_guard(self, monkeypatch):
+        captured = self._drive_terminal_tool(
+            monkeypatch,
+            {"guestbox_image": "guest:img", "cwd": "/home/guest/project"},
+        )
+        assert captured.get("cwd") == "/home/guest/project"
+
+    def test_host_cwd_override_still_sanitized(self, monkeypatch):
+        captured = self._drive_terminal_tool(
+            monkeypatch,
+            {"guestbox_image": "guest:img", "cwd": "/Users/me/workspace"},
+        )
+        assert captured.get("cwd") == "/home/guest"
+
+    def test_plugin_image_override_reaches_ensure_task_env(self, monkeypatch):
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+
+        captured = {}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["image"] = image
+            return _FakeEnv(cwd)
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: _plugin_backend_config())
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+        task_id = "rollout-lazy"
+        tt.register_task_env_overrides(task_id, {"guestbox_image": "guest:img"})
+        try:
+            env = tt.ensure_task_env(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt._active_environments.pop(task_id, None)
+        assert env is not None
+        assert captured.get("image") == "guest:img"
+
+    def test_plugin_image_override_reaches_code_execution_env(self, monkeypatch):
+        import tools.code_execution_tool as cet
+
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+
+        captured = {}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["image"] = image
+            return _FakeEnv(cwd)
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: _plugin_backend_config())
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+
+        task_id = "rollout-exec"
+        tt.register_task_env_overrides(task_id, {"guestbox_image": "guest:img"})
+        try:
+            env, env_type = cet._get_or_create_env(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt._active_environments.pop(task_id, None)
+        assert env_type == "guestbox"
+        assert captured.get("image") == "guest:img"
+
+    def test_plugin_image_override_reaches_file_ops_env(self, monkeypatch):
+        import tools.file_tools as ft
+
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+
+        captured = {}
+
+        def fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured["image"] = image
+            return _FakeEnv(cwd)
+
+        monkeypatch.setattr(tt, "_get_env_config", lambda: _plugin_backend_config())
+        monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+        monkeypatch.setattr(tt, "_session_cwd", {})
+        monkeypatch.setattr(ft, "_file_ops_cache", {})
+
+        task_id = "rollout-files"
+        tt.register_task_env_overrides(task_id, {"guestbox_image": "guest:img"})
+        try:
+            ft._get_file_ops(task_id)
+        finally:
+            tt.clear_task_env_overrides(task_id)
+            tt._active_environments.pop(task_id, None)
+        assert captured.get("image") == "guest:img"
+
+
+class TestPluginApprovalGuardSkip:
+    """_should_skip_container_guards consults the provider's declarative
+    skip_container_guards flag for plugin backends (fail-soft: approval
+    stays ON for unknown names and raising properties)."""
+
+    def test_provider_skip_flag_honored(self):
+        from tools.approval import _should_skip_container_guards
+
+        # ABC default: skip_container_guards mirrors is_container (True here).
+        reg.register_provider(_GuestHomeProvider())
+        assert _should_skip_container_guards("guestbox") is True
+
+    def test_host_mounting_provider_keeps_guards(self):
+        from tools.approval import _should_skip_container_guards
+
+        class HostBox(_GuestHomeProvider):
+            name = "hostbox"
+
+            @property
+            def skip_container_guards(self):
+                return False
+
+        reg.register_provider(HostBox())
+        assert _should_skip_container_guards("hostbox") is False
+
+    def test_unknown_backend_keeps_guards(self):
+        from tools.approval import _should_skip_container_guards
+
+        assert _should_skip_container_guards("nosuchbox") is False
+
+    def test_raising_property_fails_soft_to_guards_on(self):
+        from tools.approval import _should_skip_container_guards
+
+        class RaiseBox(_GuestHomeProvider):
+            name = "raisebox"
+
+            @property
+            def skip_container_guards(self):
+                raise RuntimeError("boom")
+
+        reg.register_provider(RaiseBox())
+        assert _should_skip_container_guards("raisebox") is False
+
+    def test_builtin_behavior_unchanged(self):
+        from tools.approval import _should_skip_container_guards
+
+        assert _should_skip_container_guards("modal") is True
+        assert _should_skip_container_guards("docker", has_host_access=True) is False
+        assert _should_skip_container_guards("local") is False
+
+
+class TestPromptProbeOptOut:
+    """probe_at_prompt_build=False must prevent the prompt builder from
+    creating a (potentially billable) environment; the static
+    env_description fallback describes the backend instead."""
+
+    class _NoProbeProvider(_GuestHomeProvider):
+        name = "billbox"
+        probe_at_prompt_build = False
+
+        @property
+        def env_description(self):
+            return "a BillBox cloud sandbox (Linux)"
+
+    def test_probe_disabled_skips_environment_creation(self, monkeypatch):
+        import agent.prompt_builder as _pb
+
+        reg.register_provider(self._NoProbeProvider())
+
+        def _explode(*a, **k):
+            raise AssertionError("prompt build must not create an environment")
+
+        monkeypatch.setattr(tt, "_create_environment", _explode)
+        _pb._clear_backend_probe_cache()
+        try:
+            assert _pb._probe_remote_backend("billbox") is None
+        finally:
+            _pb._clear_backend_probe_cache()
+
+    def test_probe_disabled_falls_back_to_env_description(self, monkeypatch):
+        import agent.prompt_builder as _pb
+
+        reg.register_provider(self._NoProbeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "billbox")
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+
+        def _explode(*a, **k):
+            raise AssertionError("prompt build must not create an environment")
+
+        monkeypatch.setattr(tt, "_create_environment", _explode)
+        _pb._clear_backend_probe_cache()
+        try:
+            result = _pb.build_environment_hints()
+        finally:
+            _pb._clear_backend_probe_cache()
+        assert "Terminal backend: billbox" in result
+        assert "a BillBox cloud sandbox (Linux)" in result
+
+    def test_probe_enabled_by_default_for_plugins(self, monkeypatch):
+        import agent.prompt_builder as _pb
+
+        reg.register_provider(_GuestHomeProvider())
+        monkeypatch.setenv("TERMINAL_ENV", "guestbox")
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+
+        created = {}
+
+        class _ProbeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/home/guest\n"
+                        "cwd=/home/guest\nuser=guest\n"
+                    ),
+                }
+
+        def fake_create_environment(*, env_type, **kwargs):
+            created["env_type"] = env_type
+            return _ProbeEnv()
+
+        monkeypatch.setattr(tt, "_create_environment", fake_create_environment)
+        _pb._clear_backend_probe_cache()
+        try:
+            line = _pb._probe_remote_backend("guestbox")
+        finally:
+            _pb._clear_backend_probe_cache()
+        assert created.get("env_type") == "guestbox"
+        assert line is not None
+        assert "Linux 6.8.0" in line

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3924,6 +3924,8 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     ``skip_container_guards`` flag (fail-soft: an unknown name or a raising
     property keeps the approval layer ON).
     """
+    # Built-in names are reserved by the registry (registration under one
+    # raises ValueError), so this hardcoded tuple can never shadow a plugin.
     if env_type == "docker":
         return not has_host_access
     if env_type in ("singularity", "modal", "daytona", "vercel_sandbox"):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3919,10 +3919,21 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     Docker is the exception once host paths are bind-mounted into the container:
     at that point a command like ``rm -rf /workspace`` reaches host files, so it
     must go through the normal approval flow.
+
+    Plugin-registered backends declare their own isolation via the provider's
+    ``skip_container_guards`` flag (fail-soft: an unknown name or a raising
+    property keeps the approval layer ON).
     """
     if env_type == "docker":
         return not has_host_access
-    return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
+    if env_type in ("singularity", "modal", "daytona", "vercel_sandbox"):
+        return True
+    try:
+        from agent.terminal_env_registry import provider_flag
+
+        return bool(provider_flag(env_type, "skip_container_guards", False))
+    except Exception:
+        return False
 
 
 def check_dangerous_command(command: str, env_type: str,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -793,7 +793,7 @@ def _get_or_create_env(task_id: str):
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
         _resolve_container_task_id, _resolve_task_host_cwd,
-        _get_plugin_env_provider,
+        _resolve_task_image,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -819,19 +819,7 @@ def _get_or_create_env(task_id: str):
         config = _get_env_config()
         env_type = config["env_type"]
         overrides = _task_env_overrides.get(effective_task_id, {})
-
-        if env_type == "docker":
-            image = overrides.get("docker_image") or config["docker_image"]
-        elif env_type == "singularity":
-            image = overrides.get("singularity_image") or config["singularity_image"]
-        elif env_type == "modal":
-            image = overrides.get("modal_image") or config["modal_image"]
-        elif env_type == "daytona":
-            image = overrides.get("daytona_image") or config["daytona_image"]
-        elif _get_plugin_env_provider(env_type) is not None:
-            image = overrides.get(f"{env_type}_image") or ""
-        else:
-            image = ""
+        image = _resolve_task_image(env_type, overrides, config)
 
         cwd = overrides.get("cwd") or config["cwd"]
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -793,6 +793,7 @@ def _get_or_create_env(task_id: str):
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
         _resolve_container_task_id, _resolve_task_host_cwd,
+        _get_plugin_env_provider,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -827,6 +828,8 @@ def _get_or_create_env(task_id: str):
             image = overrides.get("modal_image") or config["modal_image"]
         elif env_type == "daytona":
             image = overrides.get("daytona_image") or config["daytona_image"]
+        elif _get_plugin_env_provider(env_type) is not None:
+            image = overrides.get(f"{env_type}_image") or ""
         else:
             image = ""
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1430,7 +1430,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_task_host_cwd,
         _is_unusable_container_cwd,
         _CONTAINER_BACKENDS,
-        _get_plugin_env_provider,
+        _resolve_task_image,
     )
     import time
 
@@ -1494,19 +1494,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             config = _get_env_config()
             env_type = config["env_type"]
             overrides = resolve_task_overrides(raw_task_id)
-
-            if env_type == "docker":
-                image = overrides.get("docker_image") or config["docker_image"]
-            elif env_type == "singularity":
-                image = overrides.get("singularity_image") or config["singularity_image"]
-            elif env_type == "modal":
-                image = overrides.get("modal_image") or config["modal_image"]
-            elif env_type == "daytona":
-                image = overrides.get("daytona_image") or config["daytona_image"]
-            elif _get_plugin_env_provider(env_type) is not None:
-                image = overrides.get(f"{env_type}_image") or ""
-            else:
-                image = ""
+            image = _resolve_task_image(env_type, overrides, config)
 
             try:
                 from tools.terminal_tool import get_session_cwd

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1430,6 +1430,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_task_host_cwd,
         _is_unusable_container_cwd,
         _CONTAINER_BACKENDS,
+        _get_plugin_env_provider,
     )
     import time
 
@@ -1502,6 +1503,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 image = overrides.get("modal_image") or config["modal_image"]
             elif env_type == "daytona":
                 image = overrides.get("daytona_image") or config["daytona_image"]
+            elif _get_plugin_env_provider(env_type) is not None:
+                image = overrides.get(f"{env_type}_image") or ""
             else:
                 image = ""
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1691,6 +1691,27 @@ def _get_plugin_env_provider(env_type: str):
         return None
 
 
+def _resolve_task_image(env_type: str, overrides: Dict[str, Any], config: Dict[str, Any]) -> str:
+    """Resolve the container image for an environment about to be created.
+
+    The single owner of the backend→image ladder — shared by
+    ``terminal_tool()``, :func:`ensure_task_env`, execute_code's
+    ``_get_or_create_env``, and the file tools' ``_get_file_ops`` so the
+    four creation paths can't drift. Built-in container backends resolve
+    their per-task override then the configured image; plugin-registered
+    backends resolve their ``f"{env_type}_image"`` override so RL/benchmark
+    per-task images reach ``provider.create_environment``; everything else
+    resolves to ``""`` (no image configured — the backend's own default
+    applies).
+    """
+    if env_type in ("docker", "singularity", "modal", "daytona"):
+        key = f"{env_type}_image"
+        return overrides.get(key) or config[key]
+    if _get_plugin_env_provider(env_type) is not None:
+        return overrides.get(f"{env_type}_image") or ""
+    return ""
+
+
 def _is_backend_guest_subpath(env_type: str, cwd: str) -> bool:
     """True when *cwd* is the backend's guest-home root or a path beneath it.
 
@@ -1698,11 +1719,18 @@ def _is_backend_guest_subpath(env_type: str, cwd: str) -> bool:
     declares it via the provider's ``guest_home_root`` attribute (e.g.
     ``/home/agent``); its subtree is a legitimate in-sandbox cwd that the
     host-path sanitizers must not discard.
+
+    The root must be an absolute path other than ``/`` — a bare ``/`` would
+    exempt every absolute path from the host-path guard, and an empty or
+    relative root is meaningless; all such roots yield False.
     """
     root = _plugin_env_flag(env_type, "guest_home_root", None)
-    if not isinstance(root, str) or not root or not cwd:
+    if not isinstance(root, str) or not cwd:
         return False
-    return cwd == root or cwd.startswith(root.rstrip("/") + "/")
+    root = root.rstrip("/")
+    if not root or not root.startswith("/"):
+        return False
+    return cwd == root or cwd.startswith(root + "/")
 
 
 def _is_unusable_container_cwd(cwd: str) -> bool:
@@ -2331,18 +2359,7 @@ def ensure_task_env(task_id: Optional[str] = None):
         return existing
 
     overrides = resolve_task_overrides(task_id)
-    if env_type == "docker":
-        image = overrides.get("docker_image") or config["docker_image"]
-    elif env_type == "singularity":
-        image = overrides.get("singularity_image") or config["singularity_image"]
-    elif env_type == "modal":
-        image = overrides.get("modal_image") or config["modal_image"]
-    elif env_type == "daytona":
-        image = overrides.get("daytona_image") or config["daytona_image"]
-    elif _get_plugin_env_provider(env_type) is not None:
-        image = overrides.get(f"{env_type}_image") or ""
-    else:
-        image = ""
+    image = _resolve_task_image(env_type, overrides, config)
 
     _start_cleanup_thread()
 
@@ -2928,21 +2945,9 @@ def terminal_tool(
         # isolation-keyed RL/benchmark overrides keep resolving as before.
         overrides = resolve_task_overrides(task_id)
         
-        # Select image based on env type, with per-task override support.
-        # Plugin backends resolve their override under f"{backend}_image" so
-        # RL/benchmark per-task images reach provider.create_environment too.
-        if env_type == "docker":
-            image = overrides.get("docker_image") or config["docker_image"]
-        elif env_type == "singularity":
-            image = overrides.get("singularity_image") or config["singularity_image"]
-        elif env_type == "modal":
-            image = overrides.get("modal_image") or config["modal_image"]
-        elif env_type == "daytona":
-            image = overrides.get("daytona_image") or config["daytona_image"]
-        elif _get_plugin_env_provider(env_type) is not None:
-            image = overrides.get(f"{env_type}_image") or ""
-        else:
-            image = ""
+        # Select image based on env type, with per-task override support
+        # (single owner: _resolve_task_image).
+        image = _resolve_task_image(env_type, overrides, config)
 
         cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
         # Session-scoped mount resolution (single owner: _resolve_task_host_cwd).

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1450,10 +1450,23 @@ def _has_isolation_overrides(task_id: Optional[str]) -> bool:
     The single owner of the "is this an RL/benchmark-style isolated rollout"
     predicate — shared by container-key resolution and container creation so
     the two can't drift.
+
+    Plugin-registered backends have no fixed entry in
+    ``_ISOLATION_OVERRIDE_KEYS``; their per-task image override key is
+    ``f"{backend}_image"``, honored when the backend is actually registered
+    so an arbitrary ``*_image`` key can't trigger isolation.
     """
     if not task_id or task_id not in _task_env_overrides:
         return False
-    return bool(set(_task_env_overrides[task_id].keys()) & _ISOLATION_OVERRIDE_KEYS)
+    overrides = _task_env_overrides[task_id]
+    if set(overrides.keys()) & _ISOLATION_OVERRIDE_KEYS:
+        return True
+    _ensure_terminal_env_bridged()
+    env_type = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    return (
+        f"{env_type}_image" in overrides
+        and _get_plugin_env_provider(env_type) is not None
+    )
 
 
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
@@ -1678,6 +1691,20 @@ def _get_plugin_env_provider(env_type: str):
         return None
 
 
+def _is_backend_guest_subpath(env_type: str, cwd: str) -> bool:
+    """True when *cwd* is the backend's guest-home root or a path beneath it.
+
+    A plugin backend whose guest home lives under a host-looking prefix
+    declares it via the provider's ``guest_home_root`` attribute (e.g.
+    ``/home/agent``); its subtree is a legitimate in-sandbox cwd that the
+    host-path sanitizers must not discard.
+    """
+    root = _plugin_env_flag(env_type, "guest_home_root", None)
+    if not isinstance(root, str) or not root or not cwd:
+        return False
+    return cwd == root or cwd.startswith(root.rstrip("/") + "/")
+
+
 def _is_unusable_container_cwd(cwd: str) -> bool:
     """Return True if *cwd* is a host/relative path that won't work as the
     working directory inside a container sandbox.
@@ -1791,8 +1818,9 @@ def _get_env_config() -> Dict[str, Any]:
         docker_shm_size = "1g"
 
     # Default cwd: local uses the host's current directory, ssh uses the
-    # remote home, Vercel uses its documented workspace root, and everything
-    # else starts in the backend's default root-like cwd.
+    # remote home, Vercel uses its documented workspace root, plugin backends
+    # may declare their own via the provider's ``default_cwd`` attribute, and
+    # everything else starts in the backend's default root-like cwd.
     if env_type == "local":
         default_cwd = _safe_getcwd()
     elif env_type == "ssh":
@@ -1800,7 +1828,12 @@ def _get_env_config() -> Dict[str, Any]:
     elif env_type == "vercel_sandbox":
         default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
     else:
-        default_cwd = "/root"
+        plugin_default_cwd = _plugin_env_flag(env_type, "default_cwd", None)
+        default_cwd = (
+            plugin_default_cwd
+            if isinstance(plugin_default_cwd, str) and plugin_default_cwd
+            else "/root"
+        )
 
     # Read TERMINAL_CWD but sanity-check it for container backends.
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
@@ -1821,8 +1854,14 @@ def _get_env_config() -> Dict[str, Any]:
             host_cwd = candidate
             cwd = "/workspace"
     elif _is_container_backend(env_type) and cwd:
-        # Host paths and relative paths that won't work inside containers
-        if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
+        # Host paths and relative paths that won't work inside containers. A
+        # path inside the backend's own guest-home subtree is valid even though
+        # it may share a host-looking prefix (see _is_backend_guest_subpath).
+        if (
+            _is_unusable_container_cwd(cwd)
+            and cwd != default_cwd
+            and not _is_backend_guest_subpath(env_type, cwd)
+        ):
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                         "(host/relative path won't work in sandbox). Using %r instead.",
                         cwd, env_type, default_cwd)
@@ -2300,6 +2339,8 @@ def ensure_task_env(task_id: Optional[str] = None):
         image = overrides.get("modal_image") or config["modal_image"]
     elif env_type == "daytona":
         image = overrides.get("daytona_image") or config["daytona_image"]
+    elif _get_plugin_env_provider(env_type) is not None:
+        image = overrides.get(f"{env_type}_image") or ""
     else:
         image = ""
 
@@ -2802,6 +2843,7 @@ def _resolve_command_cwd(
         recorded
         and _is_container_backend(env_type)
         and _is_unusable_container_cwd(recorded)
+        and not _is_backend_guest_subpath(env_type, recorded)
     ):
         logger.info(
             "Ignoring recorded session cwd %r for %s backend "
@@ -2886,7 +2928,9 @@ def terminal_tool(
         # isolation-keyed RL/benchmark overrides keep resolving as before.
         overrides = resolve_task_overrides(task_id)
         
-        # Select image based on env type, with per-task override support
+        # Select image based on env type, with per-task override support.
+        # Plugin backends resolve their override under f"{backend}_image" so
+        # RL/benchmark per-task images reach provider.create_environment too.
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
         elif env_type == "singularity":
@@ -2895,6 +2939,8 @@ def terminal_tool(
             image = overrides.get("modal_image") or config["modal_image"]
         elif env_type == "daytona":
             image = overrides.get("daytona_image") or config["daytona_image"]
+        elif _get_plugin_env_provider(env_type) is not None:
+            image = overrides.get(f"{env_type}_image") or ""
         else:
             image = ""
 
@@ -2914,9 +2960,13 @@ def terminal_tool(
         # When the host path IS this session's mounted workspace, remap it to
         # /workspace (where the mount lands) instead of discarding it.
         # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
+        # cwd to /workspace, /root, or a backend's own guest-home subtree)
+        # pass through untouched.
+        if (
+            _is_container_backend(env_type)
+            and _is_unusable_container_cwd(cwd)
+            and not _is_backend_guest_subpath(env_type, cwd)
+        ):
             remapped = "/workspace" if host_cwd else config["cwd"]
             if cwd != remapped:
                 logger.info(

--- a/website/docs/developer-guide/terminal-environment-plugin.md
+++ b/website/docs/developer-guide/terminal-environment-plugin.md
@@ -110,7 +110,8 @@ hermes config set terminal.backend acmebox
   never shadow in-tree backends.
 - **`create_environment` must accept `**kwargs`** and ignore unknown keys —
   the forward-compat contract that lets the factory signature evolve without
-  breaking older plugins.
+  breaking older plugins. An empty `image` string means no image is
+  configured — treat `""` as unset and use your backend's own default.
 - **`is_available()` / `probe()` must be cheap.** No network calls — they run
   during requirement checks and UI paints.
 - **Fail-soft everywhere.** A provider attribute that raises is treated as
@@ -146,7 +147,8 @@ default cwd instead of failing the environment start.
 - Declare `guest_home_root` when the guest home lives under a host-looking
   prefix (e.g. `/home/agent`). Its subtree is then accepted as a valid
   in-sandbox cwd — including the agent's recorded `cd` state between
-  commands — instead of being discarded as a host path.
+  commands — instead of being discarded as a host path. The root must be an
+  absolute path other than `/`; empty, relative, and `/` roots are ignored.
 - Set `probe_at_prompt_build = False` when creating an environment is
   expensive or billable: the system-prompt builder then skips the live
   OS/$HOME/cwd probe and describes the backend with your `env_description`.

--- a/website/docs/developer-guide/terminal-environment-plugin.md
+++ b/website/docs/developer-guide/terminal-environment-plugin.md
@@ -21,8 +21,11 @@ A registered backend automatically participates in every core surface:
 | Dashboard terminal-backend picker (probe status) | `probe()` |
 | `hermes status` / `hermes doctor` | `doctor_checks()` |
 | System-prompt environment hints | `is_remote`, `env_description` |
+| System-prompt live backend probe opt-out | `probe_at_prompt_build` |
 | Dangerous-command approval skipping | `skip_container_guards` |
 | Container path/cwd handling | `is_container` |
+| Default working directory inside the backend | `default_cwd` |
+| Guest-home exemption from host-path cwd sanitizing | `guest_home_root` |
 | Synced cache-file path translation | `cache_path_base` |
 | Secret stripping from spawned subprocesses | `strip_env_keys` |
 | Per-session sandbox isolation (`container_persistent: false`) | `session_isolated_when_nonpersistent` |
@@ -129,6 +132,24 @@ interface as `tools.environments.base.BaseEnvironment`:
 
 Subclassing `BaseEnvironment` is recommended (you inherit the shared file-sync
 and background-process plumbing) but not required.
+
+## Cwd semantics
+
+The core sanitizes working directories before they reach your backend: a
+host-looking path (`/Users/...`, `/home/...`, `C:\...`) or a relative path
+cannot exist inside a container sandbox, so it is replaced with the backend's
+default cwd instead of failing the environment start.
+
+- Declare `default_cwd` when your sandbox does not start in `/root` (e.g. a
+  guest-user home). It seeds new environments and is the sanitizers' fallback
+  target.
+- Declare `guest_home_root` when the guest home lives under a host-looking
+  prefix (e.g. `/home/agent`). Its subtree is then accepted as a valid
+  in-sandbox cwd — including the agent's recorded `cd` state between
+  commands — instead of being discarded as a host path.
+- Set `probe_at_prompt_build = False` when creating an environment is
+  expensive or billable: the system-prompt builder then skips the live
+  OS/$HOME/cwd probe and describes the backend with your `env_description`.
 
 ## Session isolation semantics
 


### PR DESCRIPTION
## Summary

#94400 made terminal backends pluggable, but four policy sites still consult hardcoded built-in name lists, so a plugin backend silently loses behavior every in-tree backend has. This closes them, each through the existing fail-soft `provider_flag()` chain — a misbehaving plugin degrades to built-in-equivalent behavior (approval stays ON, cwd falls back to `/root`, probe stays enabled).

Found while moving our Tenki backend (#64190) out of core onto the plugin registry, but every gap applies to any third-party backend (the Sprites move hits the same four).

## Changes

- **`agent/terminal_env_provider.py`**: three new declarative attributes, documented in the classification-contract section — `guest_home_root` (the backend's guest-home directory, whose subtree is a legitimate in-sandbox cwd despite matching the host-path heuristics), `default_cwd`, and `probe_at_prompt_build` (set `False` when creating an environment is expensive/billable).
- **`tools/approval.py`**: `_should_skip_container_guards` falls through to `provider_flag(env_type, "skip_container_guards", False)` for non-built-in names. The ABC has documented this flag since #94400, but nothing consulted it — a plugin sandbox kept triggering dangerous-command approval prompts the in-tree backends skip.
- **`agent/prompt_builder.py`**: `_probe_remote_backend` honors `probe_at_prompt_build=False` by skipping the live probe (the caller's existing `env_description` static fallback takes over). Without this, building a system prompt creates a live — potentially billable — sandbox for any remote plugin backend.
- **`tools/terminal_tool.py`**: the default-cwd ladder consults the provider's `default_cwd`; a provider-declared guest home survives the host-path cwd sanitizers (`_get_env_config`, the override re-guard, and `_resolve_command_cwd`'s recorded-`cd` discard — `/home/<user>` guest images currently have their own cwd thrown away as a "host path" on every command); `_has_isolation_overrides` and all four image-selection ladders (terminal, `ensure_task_env`, execute_code, file tools) honor `f"{backend}_image"` per-task overrides for registered plugin backends, so RL/benchmark harnesses get the same isolated-rollout semantics they get with `docker_image`/`modal_image`.
- **Docs**: `terminal-environment-plugin.md` surface table + a cwd-semantics note.

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_terminal_provider_parity.py` (new, fake providers; covers all four sites incl. fail-soft on raising properties) | 30/30 pass |
| Pre-existing suites: terminal_env_registry, container_cwd_sanitize, hardline_blocklist, prompt_builder, terminal_tool, approval, file_tools_cwd_resolution, file_ops_cwd_tracking, terminal_task_cwd, session_cwd_store, terminal_env_bridge, execute_code_approval_cluster | 424 pass / 0 fail (1 `test_approval.py` failure reproduces byte-identically on base `1bbb6e5bce` — pre-existing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)