### PR TITLE
fix(dashboard): probe terminal backends under the target profile's secret scope

### DIFF
--- a/agent/terminal_env_provider.py
+++ b/agent/terminal_env_provider.py
@@ -155,6 +155,14 @@ class TerminalEnvironmentProvider(abc.ABC):
         ``status`` is ``"ready"`` / ``"needs_setup"`` / ``"unavailable"``;
         ``detail`` carries setup guidance for non-ready rows. Must never
         raise and must stay fast (<~2s).
+
+        ``detail`` must never include credential material — it is returned
+        verbatim to dashboard clients, and under a named-profile request it
+        is resolved against that profile's own secrets. Resolve credentials
+        synchronously on the calling thread: the profile secret scope is
+        context-local, so a probe that fans out to its own threads,
+        subprocesses, or tasks would resolve against the process
+        environment instead.
         """
         if self.is_available():
             return ("ready", "")

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -13,6 +13,7 @@ stays authoritative.
 import asyncio
 import logging
 import sys  # noqa: F401 — used by handlers
+from pathlib import Path
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 from fastapi import APIRouter, HTTPException  # noqa: F401
@@ -724,27 +725,49 @@ async def get_terminal_backends(profile: Optional[str] = None):
     status, never an error response.
     """
     def _read():
-        with _profile_scope(profile):
-            config = load_config()
-            terminal_cfg = config.get("terminal")
-            if not isinstance(terminal_cfg, dict):
-                terminal_cfg = {}
-            rows = _terminal_backend_rows()
-            active = str(terminal_cfg.get("backend") or "local").strip().lower()
-            if active not in {row["name"] for row in rows}:
-                active = "local"
+        with _profile_scope(profile) as profile_dir:
+            secret_token = None
+            if profile_dir is not None:
+                # A named profile is an isolation boundary: its probes must
+                # resolve credentials from that profile's own secrets, never
+                # from whatever the dashboard process inherited. Install the
+                # profile's secret scope so anything resolving through
+                # agent.secret_scope.get_secret (plugin provider probes,
+                # scoped credential helpers) answers for the requested
+                # profile for the duration of the config read + probe loop.
+                from agent.secret_scope import (
+                    build_profile_secret_scope,
+                    reset_secret_scope,
+                    set_secret_scope,
+                )
 
-            backends = []
-            for row in rows:
-                status, detail = _probe_terminal_backend(row["name"], terminal_cfg)
-                backends.append({
-                    "name": row["name"],
-                    "label": row["label"],
-                    "description": row["description"],
-                    "active": row["name"] == active,
-                    "status": status,
-                    "detail": detail,
-                })
+                secret_token = set_secret_scope(
+                    build_profile_secret_scope(Path(profile_dir))
+                )
+            try:
+                config = load_config()
+                terminal_cfg = config.get("terminal")
+                if not isinstance(terminal_cfg, dict):
+                    terminal_cfg = {}
+                rows = _terminal_backend_rows()
+                active = str(terminal_cfg.get("backend") or "local").strip().lower()
+                if active not in {row["name"] for row in rows}:
+                    active = "local"
+
+                backends = []
+                for row in rows:
+                    status, detail = _probe_terminal_backend(row["name"], terminal_cfg)
+                    backends.append({
+                        "name": row["name"],
+                        "label": row["label"],
+                        "description": row["description"],
+                        "active": row["name"] == active,
+                        "status": status,
+                        "detail": detail,
+                    })
+            finally:
+                if secret_token is not None:
+                    reset_secret_scope(secret_token)
         return {"active": active, "backends": backends}
 
     return await asyncio.to_thread(_read)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2868,7 +2868,11 @@ class TestNewEndpoints:
 
     def test_terminal_probe_isolates_named_profile_secrets(self, monkeypatch):
         """A target profile's probes must resolve that profile's own secrets
-        and never borrow the dashboard process's environment values."""
+        and never borrow the dashboard process's environment values — while
+        the detail honors the probe() contract and carries no credential
+        material (it reaches dashboard clients verbatim)."""
+        import json
+
         from agent import terminal_env_registry as reg
         from agent.secret_scope import current_secret_scope, get_secret
         from agent.terminal_env_provider import TerminalEnvironmentProvider
@@ -2878,31 +2882,41 @@ class TestNewEndpoints:
             name = "fakebox"
             display_name = "FakeBox"
 
+            # Non-secret account labels keyed by the resolved token: the
+            # probe reports WHICH credential answered without ever echoing
+            # the credential itself into the detail.
+            _TOKEN_ACCOUNTS = {
+                "alpha-secret-token": "alpha-account",
+                "beta-secret-token": "beta-account",
+                "process-secret-token": "process-account",
+            }
+
             def is_available(self):
                 return bool(get_secret("FAKEBOX_API_TOKEN"))
 
             def probe(self):
                 token = get_secret("FAKEBOX_API_TOKEN") or ""
-                if token:
-                    return ("ready", f"token:{token}")
-                return ("needs_setup", "Set FAKEBOX_API_TOKEN.")
+                account = self._TOKEN_ACCOUNTS.get(token)
+                if account is None:
+                    return ("needs_setup", "Set FAKEBOX_API_TOKEN.")
+                return ("ready", f"account:{account}")
 
             def create_environment(self, *, cwd, timeout, task_id="default",
                                    image=None, container_config=None, **kwargs):
                 raise NotImplementedError
 
-        monkeypatch.setenv("FAKEBOX_API_TOKEN", "process-token-must-not-leak")
+        monkeypatch.setenv("FAKEBOX_API_TOKEN", "process-secret-token")
 
         alpha = get_profile_dir("fakebox-alpha")
         alpha.mkdir(parents=True)
         (alpha / ".env").write_text(
-            "FAKEBOX_API_TOKEN=alpha-token\n", encoding="utf-8"
+            "FAKEBOX_API_TOKEN=alpha-secret-token\n", encoding="utf-8"
         )
 
         beta = get_profile_dir("fakebox-beta")
         beta.mkdir(parents=True)
         (beta / ".env").write_text(
-            "FAKEBOX_API_TOKEN=beta-token\n", encoding="utf-8"
+            "FAKEBOX_API_TOKEN=beta-secret-token\n", encoding="utf-8"
         )
 
         provider = _ScopedProvider()
@@ -2927,12 +2941,16 @@ class TestNewEndpoints:
         )
 
         assert alpha_row["status"] == "ready"
-        assert alpha_row["detail"] == "token:alpha-token"
+        assert alpha_row["detail"] == "account:alpha-account"
         assert beta_row["status"] == "ready"
-        assert beta_row["detail"] == "token:beta-token"
-        assert process_row["detail"] == "token:process-token-must-not-leak"
+        assert beta_row["detail"] == "account:beta-account"
+        assert process_row["detail"] == "account:process-account"
         # The scope is installed per request and reset afterwards.
         assert current_secret_scope() is None
+        # No response may carry credential material anywhere (every token
+        # above shares the "secret-token" suffix, so one sweep covers all).
+        for body in (alpha_body, beta_body, process_body):
+            assert "secret-token" not in json.dumps(body)
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2866,6 +2866,74 @@ class TestNewEndpoints:
         assert ssh["status"] == "ready"
         assert "hermes@devbox.example.com" in ssh["detail"]
 
+    def test_terminal_probe_isolates_named_profile_secrets(self, monkeypatch):
+        """A target profile's probes must resolve that profile's own secrets
+        and never borrow the dashboard process's environment values."""
+        from agent import terminal_env_registry as reg
+        from agent.secret_scope import current_secret_scope, get_secret
+        from agent.terminal_env_provider import TerminalEnvironmentProvider
+        from hermes_cli.profiles import get_profile_dir
+
+        class _ScopedProvider(TerminalEnvironmentProvider):
+            name = "fakebox"
+            display_name = "FakeBox"
+
+            def is_available(self):
+                return bool(get_secret("FAKEBOX_API_TOKEN"))
+
+            def probe(self):
+                token = get_secret("FAKEBOX_API_TOKEN") or ""
+                if token:
+                    return ("ready", f"token:{token}")
+                return ("needs_setup", "Set FAKEBOX_API_TOKEN.")
+
+            def create_environment(self, *, cwd, timeout, task_id="default",
+                                   image=None, container_config=None, **kwargs):
+                raise NotImplementedError
+
+        monkeypatch.setenv("FAKEBOX_API_TOKEN", "process-token-must-not-leak")
+
+        alpha = get_profile_dir("fakebox-alpha")
+        alpha.mkdir(parents=True)
+        (alpha / ".env").write_text(
+            "FAKEBOX_API_TOKEN=alpha-token\n", encoding="utf-8"
+        )
+
+        beta = get_profile_dir("fakebox-beta")
+        beta.mkdir(parents=True)
+        (beta / ".env").write_text(
+            "FAKEBOX_API_TOKEN=beta-token\n", encoding="utf-8"
+        )
+
+        provider = _ScopedProvider()
+        reg.register_provider(provider)
+        try:
+            alpha_body = self.client.get(
+                "/api/tools/terminal/backends?profile=fakebox-alpha"
+            ).json()
+            beta_body = self.client.get(
+                "/api/tools/terminal/backends?profile=fakebox-beta"
+            ).json()
+            # No-profile request AFTER the scoped ones: the dashboard's own
+            # environment must answer, proving no profile scope lingered.
+            process_body = self.client.get("/api/tools/terminal/backends").json()
+        finally:
+            reg.restore_registration("fakebox", provider, None)
+
+        alpha_row = next(r for r in alpha_body["backends"] if r["name"] == "fakebox")
+        beta_row = next(r for r in beta_body["backends"] if r["name"] == "fakebox")
+        process_row = next(
+            r for r in process_body["backends"] if r["name"] == "fakebox"
+        )
+
+        assert alpha_row["status"] == "ready"
+        assert alpha_row["detail"] == "token:alpha-token"
+        assert beta_row["status"] == "ready"
+        assert beta_row["detail"] == "token:beta-token"
+        assert process_row["detail"] == "token:process-token-must-not-leak"
+        # The scope is installed per request and reset afterwards.
+        assert current_secret_scope() is None
+
 
 
 


### PR DESCRIPTION
## Summary

`GET /api/tools/terminal/backends?profile=X` probes every backend's readiness, but the probes run against the dashboard **process's** environment — so a named profile's rows answer with the wrong credentials (the process env, or machine-global logins), not the profile's own. A profile that has no credential for a backend shows "ready" because the dashboard host happens to be logged in; the profile then fails at runtime.

Named profiles are isolation boundaries: a probe for profile X must resolve X's secrets.

## Changes

When `_profile_scope(profile)` yields a named profile's directory, `get_terminal_backends` builds that profile's secret mapping (`agent.secret_scope.build_profile_secret_scope`) and installs it with `set_secret_scope` for the duration of the config read + probe loop (`finally: reset_secret_scope`). The no-profile path is unchanged (body only re-indented).

Under the scope, plugin `TerminalEnvironmentProvider.probe()` implementations (which resolve via `agent.secret_scope.get_secret`) and the built-in modal/daytona probes (via the scope-aware `get_env_value`, #67027) all answer with the target profile's credentials. `asyncio.to_thread` copies the caller's context per call, so the scope cannot leak across requests even without the reset — the reset keeps the worker-thread context clean regardless.

One boundary worth stating: with multiplexing off, `get_secret`'s documented overlay semantics still let a key *absent* from the profile's `.env` fall through to the process environment — that's `secret_scope`'s deliberate single-profile contract, unchanged here. What this PR fixes is the profile's own values being ignored entirely.

## Validation

| Check | Result |
|---|---|
| New `test_terminal_probe_isolates_named_profile_secrets` — fake provider whose `probe()` reads a secret through `get_secret`; two profiles with different `.env` values + a process-env value; asserts each profile's row reflects its own token, a later no-profile request sees the process env, and no scope lingers | pass |
| `tests/hermes_cli/test_web_server.py` (full file) | 169 pass / 0 fail |
| Adjacent: web_routers_tools_install_on_enable, secret_scope, terminal_env_registry | 53 pass / 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)