### PR TITLE
fix(terminal): resolve terminal config per profile under multiplex

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1331,10 +1331,18 @@ def _probe_remote_backend(env_type: str) -> str | None:
     operate on a different machine than the host Hermes runs on.
     """
     cwd_hint = os.getenv("TERMINAL_CWD", "")
+    profile_key = ""
     try:
         profile_key = str(get_hermes_home())
+        # The cache key's cwd hint must come from the same profile-aware view
+        # that _get_env_config() below reads — a raw os.getenv could key the
+        # cache on one cwd while a multiplexed turn's probe runs in another.
+        # Lazy import (tools/ is heavy); fail-soft to the os.getenv value.
+        from tools.terminal_tool import _runtime_terminal_env
+
+        cwd_hint = _runtime_terminal_env().get("TERMINAL_CWD", cwd_hint)
     except Exception:
-        profile_key = ""
+        logger.debug("Profile-aware probe cache key resolution failed", exc_info=True)
     cache_key = (env_type, cwd_hint, profile_key)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
@@ -1483,6 +1491,8 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
+    # Process-global read on purpose: this is the single-profile base value;
+    # the guarded block right below re-resolves it per profile under multiplex.
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
     try:
         from agent.secret_scope import current_secret_scope, is_multiplex_active

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1270,11 +1270,12 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 
 
 # Cache the backend probe result per process so we only pay the probe cost
-# on the first prompt build of a session. Keyed by (env_type, cwd_hint) so
-# a mid-process backend switch rebuilds the string. Kept in-module (not on
-# disk) because the probe captures live backend state that may change
-# across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+# on the first prompt build of a session. Keyed by (env_type, cwd_hint,
+# profile_home) so a mid-process backend switch rebuilds the string and a
+# multiplexed profile never sees another profile's probe output. Kept
+# in-module (not on disk) because the probe captures live backend state that
+# may change across Hermes restarts.
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 def _windows_marketing_version() -> str:
@@ -1330,7 +1331,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
     operate on a different machine than the host Hermes runs on.
     """
     cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
+    try:
+        profile_key = str(get_hermes_home())
+    except Exception:
+        profile_key = ""
+    cache_key = (env_type, cwd_hint, profile_key)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached or None
@@ -1479,6 +1484,15 @@ def build_environment_hints() -> str:
     hints: list[str] = []
 
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        if is_multiplex_active() and current_secret_scope() is not None:
+            from tools.terminal_tool import _get_env_config
+
+            backend = str(_get_env_config().get("env_type") or backend).strip().lower()
+    except Exception:
+        logger.debug("Could not resolve profile-scoped terminal backend", exc_info=True)
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS or _plugin_backend_is_remote(backend)
 
     if not is_remote_backend:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -811,6 +811,85 @@ class TestEnvironmentHints:
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
 
+    def test_multiplexed_profile_hint_resolves_scoped_backend(self, monkeypatch, tmp_path):
+        """Under multiplexing, the hint must describe the ACTIVE profile's
+        configured backend, not the process-global TERMINAL_ENV — two profiles
+        served by one process get two different (correct) hints."""
+        import agent.prompt_builder as _pb
+        from agent.secret_scope import is_multiplex_active, set_multiplex_active
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli import config as hermes_config
+
+        profile_ssh = tmp_path / "profile-ssh"
+        profile_local = tmp_path / "profile-local"
+        profile_ssh.mkdir()
+        profile_local.mkdir()
+        (profile_ssh / "config.yaml").write_text(
+            "terminal:\n  backend: ssh\n", encoding="utf-8"
+        )
+        (profile_local / "config.yaml").write_text(
+            "terminal:\n  backend: local\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        # Process-global selection that neither profile configured.
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        # Deterministic: never probe a live backend from a prompt build.
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        previous = is_multiplex_active()
+        set_multiplex_active(True)
+        hermes_config._LOAD_CONFIG_CACHE.clear()
+        hermes_config._RAW_CONFIG_CACHE.clear()
+        _pb._clear_backend_probe_cache()
+        try:
+            with _profile_runtime_scope(profile_ssh):
+                ssh_hint = _pb.build_environment_hints()
+            with _profile_runtime_scope(profile_local):
+                local_hint = _pb.build_environment_hints()
+        finally:
+            set_multiplex_active(previous)
+
+        assert "Terminal backend: ssh" in ssh_hint
+        assert "Host:" not in ssh_hint
+        assert "Host:" in local_hint
+        assert "Terminal backend:" not in local_hint
+
+    def test_backend_probe_cache_is_scoped_to_profile_home(self, monkeypatch, tmp_path):
+        """One profile's cached probe output must never be served as another
+        profile's environment hint."""
+        import agent.prompt_builder as _pb
+        import tools.terminal_tool as _tt
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        _pb._clear_backend_probe_cache()
+
+        outputs = iter(["user=alpha\n", "user=bravo\n"])
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {"returncode": 0, "output": next(outputs)}
+
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kwargs: _FakeEnv())
+
+        token = set_hermes_home_override(str(tmp_path / "a"))
+        try:
+            first = _pb._probe_remote_backend("docker")
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(str(tmp_path / "b"))
+        try:
+            second = _pb._probe_remote_backend("docker")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert first is not None and "alpha" in first
+        assert second is not None and "bravo" in second
+
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()
         (the daemon launch dir). Regression for #24882/#24969/#27383/#29265."""

--- a/tests/tools/test_runtime_terminal_env.py
+++ b/tests/tools/test_runtime_terminal_env.py
@@ -71,6 +71,61 @@ class TestRuntimeTerminalEnv:
         # The overlay is private: the process env still selects local.
         assert os.environ["TERMINAL_ENV"] == "local"
 
+    def test_scoped_turn_sees_profile_dotenv_terminal_settings(
+        self, monkeypatch, _profile_home
+    ):
+        """A TERMINAL_* setting living only in the profile's ``.env`` (carried
+        by the bound secret scope, never in the process env) must reach the
+        overlay. Three-layer precedence: os.environ < profile ``.env`` <
+        config.yaml ``terminal.*``."""
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            is_multiplex_active,
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+        # Same key in the process env AND the profile .env — the .env wins.
+        monkeypatch.setenv("TERMINAL_SSH_USER", "process-user")
+        (_profile_home / ".env").write_text(
+            # ssh_host: only in .env (the substantive case).
+            "TERMINAL_SSH_HOST=dotenv.example\n"
+            "TERMINAL_SSH_USER=dotenv-user\n"
+            # timeout: .env says 99, config.yaml says 42 — config still wins.
+            "TERMINAL_TIMEOUT=99\n",
+            encoding="utf-8",
+        )
+
+        previous = is_multiplex_active()
+        set_multiplex_active(True)
+        home_token = set_hermes_home_override(str(_profile_home))
+        secret_token = set_secret_scope(build_profile_secret_scope(_profile_home))
+        try:
+            runtime_env = terminal_tool._runtime_terminal_env()
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+            set_multiplex_active(previous)
+
+        assert runtime_env["TERMINAL_SSH_HOST"] == "dotenv.example"
+        assert runtime_env["TERMINAL_SSH_USER"] == "dotenv-user"
+        assert runtime_env["TERMINAL_TIMEOUT"] == "42"
+        assert config["ssh_host"] == "dotenv.example"
+        assert config["ssh_user"] == "dotenv-user"
+        assert config["timeout"] == 42
+        # The overlay never leaks into the process environment.
+        assert "TERMINAL_SSH_HOST" not in os.environ
+        assert os.environ["TERMINAL_SSH_USER"] == "process-user"
+        assert os.environ["TERMINAL_ENV"] == "local"
+
     def test_multiplex_without_scope_keeps_process_env(self, monkeypatch, _profile_home):
         """Multiplex active but no bound secret scope (e.g. process-level
         startup work) keeps the historical process-environment path."""

--- a/tests/tools/test_runtime_terminal_env.py
+++ b/tests/tools/test_runtime_terminal_env.py
@@ -1,0 +1,105 @@
+"""Tests for profile-scoped terminal env resolution (``_runtime_terminal_env``).
+
+A multiplex gateway serves many profiles from one process, but terminal
+settings are read from ``os.environ`` (TERMINAL_*). ``_runtime_terminal_env``
+overlays the ACTIVE profile's ``terminal.*`` config onto a private copy of the
+process env during a scoped turn, so every profile resolves its own backend
+without mutating global state; single-profile processes keep the historical
+process-environment path.
+"""
+
+import os
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+@pytest.fixture()
+def _profile_home(tmp_path):
+    """A profile home whose config selects a non-default terminal backend."""
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "terminal:\n  backend: ssh\n  timeout: 42\n",
+        encoding="utf-8",
+    )
+    from hermes_cli import config as hermes_config
+
+    hermes_config._LOAD_CONFIG_CACHE.clear()
+    hermes_config._RAW_CONFIG_CACHE.clear()
+    return profile_home
+
+
+class TestRuntimeTerminalEnv:
+    def test_scoped_turn_overlays_profile_config(self, monkeypatch, _profile_home):
+        """During a multiplexed profile turn the profile's terminal config wins
+        over the process-global env — without mutating ``os.environ``."""
+        from agent.secret_scope import (
+            is_multiplex_active,
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        # Exported value for a setting the profile does NOT configure — the
+        # overlay must preserve it.
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "exported.example")
+
+        previous = is_multiplex_active()
+        set_multiplex_active(True)
+        home_token = set_hermes_home_override(str(_profile_home))
+        secret_token = set_secret_scope({})
+        try:
+            runtime_env = terminal_tool._runtime_terminal_env()
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+            set_multiplex_active(previous)
+
+        assert runtime_env["TERMINAL_ENV"] == "ssh"
+        assert runtime_env["TERMINAL_SSH_HOST"] == "exported.example"
+        assert config["env_type"] == "ssh"
+        assert config["timeout"] == 42
+        assert config["ssh_host"] == "exported.example"
+        # The overlay is private: the process env still selects local.
+        assert os.environ["TERMINAL_ENV"] == "local"
+
+    def test_multiplex_without_scope_keeps_process_env(self, monkeypatch, _profile_home):
+        """Multiplex active but no bound secret scope (e.g. process-level
+        startup work) keeps the historical process-environment path."""
+        from agent.secret_scope import is_multiplex_active, set_multiplex_active
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        # Pin the one-shot config bridge so this test only observes the
+        # process env, not the sandboxed config backfill.
+        monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+
+        previous = is_multiplex_active()
+        set_multiplex_active(True)
+        try:
+            runtime_env = terminal_tool._runtime_terminal_env()
+        finally:
+            set_multiplex_active(previous)
+
+        assert runtime_env["TERMINAL_ENV"] == "local"
+
+    def test_single_profile_path_reads_process_environment(self, monkeypatch):
+        """Single-profile processes see exactly the process env (a private
+        copy — mutating the result must not touch ``os.environ``)."""
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "77")
+        monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+
+        runtime_env = terminal_tool._runtime_terminal_env()
+
+        assert runtime_env["TERMINAL_ENV"] == "local"
+        assert runtime_env["TERMINAL_TIMEOUT"] == "77"
+        runtime_env["TERMINAL_ENV"] = "mutated"
+        assert os.environ["TERMINAL_ENV"] == "local"

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -134,6 +134,42 @@ class TestCheckFnTransientFailureSuppression:
         t["now"] += reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
         assert reg._check_fn_cached(probe) is False
 
+    def test_cache_is_scoped_to_profile_secret_context(self, tmp_path):
+        """A success under profile A cannot make profile B's unavailable
+        backend appear ready through the shared check_fn TTL cache."""
+        import tools.registry as reg
+        from agent.secret_scope import reset_secret_scope, set_secret_scope
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        home_a = tmp_path / "a"
+        home_b = tmp_path / "b"
+        home_a.mkdir()
+        home_b.mkdir()
+
+        def profile_probe():
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() == home_a
+
+        home_token = set_hermes_home_override(home_a)
+        secret_token = set_secret_scope({"SAMPLE_AUTH_TOKEN": "token-a"})
+        try:
+            assert reg._check_fn_cached(profile_probe) is True
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
+        home_token = set_hermes_home_override(home_b)
+        secret_token = set_secret_scope({})
+        try:
+            assert reg._check_fn_cached(profile_probe) is False
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
     def test_profile_scoped_availability_does_not_cross_multiplex_profiles(
         self, tmp_path
     ):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -302,6 +302,22 @@ def _prune_check_fn_caches(now: float) -> None:
         _check_fn_last_good.pop(next(iter(_check_fn_last_good)))
 
 
+# check_fn_cache_scope() runs on EVERY availability check in a scope-bound
+# process, and Path.expanduser().resolve() stats the filesystem each time.
+# Memoize the resolution per raw home string — bounded in practice because a
+# process serves a small, fixed set of profile homes.
+_RESOLVED_HOME_CACHE: Dict[str, str] = {}
+
+
+def _resolve_home_cached(raw_home: str) -> str:
+    """Resolve a Hermes home path to its canonical string, memoized."""
+    resolved = _RESOLVED_HOME_CACHE.get(raw_home)
+    if resolved is None:
+        resolved = str(Path(raw_home).expanduser().resolve())
+        _RESOLVED_HOME_CACHE[raw_home] = resolved
+    return resolved
+
+
 def check_fn_cache_scope() -> Optional[str]:
     """Return the active profile key when availability is profile-scoped.
 
@@ -341,11 +357,16 @@ def check_fn_cache_scope() -> Optional[str]:
         override = get_hermes_home_override()
         if not override:
             if multiplex_active:
+                # Deliberate cost: a multiplexed turn with no home override has
+                # no stable profile identity, so availability probes re-run
+                # every time instead of caching under a key that could alias
+                # one profile's tools onto another. Do not "optimize" this
+                # bypass back into a shared cache entry.
                 return CHECK_FN_CACHE_BYPASS
             from hermes_constants import get_hermes_home
 
-            return str(Path(get_hermes_home()).expanduser().resolve())
-        return str(Path(override).expanduser().resolve())
+            return _resolve_home_cached(str(get_hermes_home()))
+        return _resolve_home_cached(str(override))
     except Exception:
         # Fail closed: bypass both cache layers rather than aliasing requests
         # whose multiplex profile identity could not be resolved.

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -312,9 +312,10 @@ def check_fn_cache_scope() -> Optional[str]:
     from leaking into any unrelated session.
 
     Single-profile processes intentionally keep the historical process-wide
-    cache. A multiplex gateway installs a Hermes-home override for every
-    profile turn, so the canonical profile key is the stable isolation
-    boundary across repeated turns for that profile.
+    cache unless an explicit secret scope is bound. A multiplex gateway
+    installs a Hermes-home override for every profile turn, so the canonical
+    profile key is the stable isolation boundary across repeated turns for
+    that profile.
     """
     try:
         from gateway.session_context import get_session_env
@@ -330,15 +331,20 @@ def check_fn_cache_scope() -> Optional[str]:
         pass
 
     try:
-        from agent.secret_scope import is_multiplex_active
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
 
-        if not is_multiplex_active():
+        multiplex_active = is_multiplex_active()
+        if not multiplex_active and current_secret_scope() is None:
             return None
         from hermes_constants import get_hermes_home_override
 
         override = get_hermes_home_override()
         if not override:
-            return CHECK_FN_CACHE_BYPASS
+            if multiplex_active:
+                return CHECK_FN_CACHE_BYPASS
+            from hermes_constants import get_hermes_home
+
+            return str(Path(get_hermes_home()).expanduser().resolve())
         return str(Path(override).expanduser().resolve())
     except Exception:
         # Fail closed: bypass both cache layers rather than aliasing requests

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -117,6 +117,8 @@ def _safe_parse_import_env(
 
 
 # Hard cap on foreground timeout; override via TERMINAL_MAX_FOREGROUND_TIMEOUT env var.
+# Deliberately process-global (import-time constant, not a config-bridged
+# per-profile setting) — same for TERMINAL_DISK_WARNING_GB below.
 FOREGROUND_MAX_TIMEOUT = _safe_parse_import_env(
     "TERMINAL_MAX_FOREGROUND_TIMEOUT",
     600,
@@ -839,7 +841,9 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = (
+        _runtime_terminal_env().get("TERMINAL_ENV", "local").strip().lower() or "local"
+    )
     if terminal_env != "local":
         return False
 
@@ -1194,9 +1198,10 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
     # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
     # doesn't get an instant-reap that races their own setup.
     # ``container_config`` only carries container_* keys, so read
-    # lifetime_seconds from the env var the rest of the module uses.
+    # lifetime_seconds from the profile-aware env view the rest of the
+    # module uses.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(_runtime_terminal_env().get("TERMINAL_LIFETIME_SECONDS", "300"))
     except (TypeError, ValueError):
         lifetime = 300
     lifetime = max(60, lifetime)
@@ -1384,13 +1389,13 @@ def _session_isolation_enabled() -> bool:
       under non-persistent mode would let two independent ephemeral runs
       attach one live VM and delete it out from under each other).
     """
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    runtime_env = _runtime_terminal_env()
+    env_type = runtime_env.get("TERMINAL_ENV", "local")
     if env_type != "docker" and not _plugin_env_flag(
         env_type, "session_isolated_when_nonpersistent"
     ):
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return runtime_env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 def _docker_session_isolation_enabled() -> bool:
@@ -1400,7 +1405,7 @@ def _docker_session_isolation_enabled() -> bool:
     selection, session-scoped container teardown) key off it; those must
     not fire for other backends.
     """
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if _runtime_terminal_env().get("TERMINAL_ENV", "local") != "docker":
         return False
     return _session_isolation_enabled()
 
@@ -1419,10 +1424,10 @@ def _docker_persistent_profile_scoped() -> bool:
     profile scoping for exactly this backend/mode; SSH and other backends
     keep the session-scoped cache key that fixed the original leak.
     """
-    _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    runtime_env = _runtime_terminal_env()
+    if runtime_env.get("TERMINAL_ENV", "local") != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"}
+    return runtime_env.get("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"}
 
 
 def _current_session_profile() -> str:
@@ -1516,7 +1521,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
             # Explicit opt-in: trusted profiles configuring the same
             # terminal.docker_shared_container_key share ONE container/cache
             # slot (and sandbox dir) regardless of profile name (#84671).
-            shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+            shared = _runtime_terminal_env().get("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
             if shared:
                 return f"shared:{shared}"
             profile = _current_session_profile() or "default"
@@ -1529,7 +1534,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # sessions land in "shared:<key>" — splitting the very container the
     # setting exists to unify.
     if _docker_persistent_profile_scoped():
-        shared = os.getenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+        shared = _runtime_terminal_env().get("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
         if shared:
             return f"shared:{shared}"
     return "default"
@@ -1635,6 +1640,9 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except FileNotFoundError:
+        # Deliberately process-global: an emergency fallback for the HOST
+        # process's deleted cwd (a process-level condition, not a per-profile
+        # setting) that must stay import-light and re-entrant.
         return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 
@@ -1771,13 +1779,27 @@ def _runtime_terminal_env() -> Dict[str, str]:
     try:
         from agent.secret_scope import current_secret_scope, is_multiplex_active
 
-        if is_multiplex_active() and current_secret_scope() is not None:
+        scope = current_secret_scope()
+        if is_multiplex_active() and scope is not None:
             from hermes_cli.config import (
                 apply_terminal_config_to_env,
                 load_config_readonly,
             )
 
+            # Three layers, lowest precedence first:
+            #   1. os.environ — process-wide exports for settings the profile
+            #      carries nowhere itself;
+            #   2. the profile's own ``.env`` TERMINAL_* entries — they travel
+            #      in the bound secret scope (never in os.environ, which would
+            #      leak them across profiles), so seed them here or a setting
+            #      that lives only in the profile's ``.env`` is invisible;
+            #   3. the profile's config.yaml ``terminal.*`` section — config
+            #      wins over any (possibly stale) env value, matching the
+            #      ``_ensure_terminal_env_bridged()`` semantics.
             target = dict(os.environ)
+            for name, value in scope.items():
+                if name.startswith("TERMINAL_"):
+                    target[name] = value
             return apply_terminal_config_to_env(
                 env=target,
                 config=load_config_readonly(),
@@ -3885,7 +3907,9 @@ def terminal_tool(
         #   warn (default) — return a structured degraded result the model
         #                    can act on (reason + retry hint, no traceback).
         #   fail           — preserve the historical error+traceback result.
-        degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        degraded_mode = (
+            _runtime_terminal_env().get("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        )
         if degraded_mode == "fail":
             import traceback
             tb_str = traceback.format_exc()
@@ -4103,6 +4127,8 @@ if __name__ == "__main__":
     print("  result = terminal_tool(command='python server.py', background=True)")
 
     print("\nEnvironment Variables:")
+    # Deliberately process-global reads: this standalone diagnostic prints the
+    # invoking process's own environment and never runs inside a scoped turn.
     default_img = "nikolaik/python-nodejs:python3.11-nodejs20"
     print(
         "  TERMINAL_ENV: "

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1601,13 +1601,20 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
-def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
+def _parse_env_var(
+    name: str,
+    default: str,
+    converter: Any = int,
+    type_label: str = "integer",
+    *,
+    env: Optional[Dict[str, str]] = None,
+):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = (os.environ if env is None else env).get(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1753,14 +1760,44 @@ def _ensure_terminal_env_bridged() -> None:
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
 
 
+def _runtime_terminal_env() -> Dict[str, str]:
+    """Return terminal env values for the active runtime/profile context.
+
+    Single-profile processes keep the historical process environment. A
+    multiplexed turn instead overlays the active profile's config into a
+    private mapping, avoiding cross-profile mutation of ``os.environ`` while
+    preserving exported values for settings that profile did not configure.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        if is_multiplex_active() and current_secret_scope() is not None:
+            from hermes_cli.config import (
+                apply_terminal_config_to_env,
+                load_config_readonly,
+            )
+
+            target = dict(os.environ)
+            return apply_terminal_config_to_env(
+                env=target,
+                config=load_config_readonly(),
+                override=None,
+            )
+    except Exception:
+        logger.debug("profile terminal config resolution failed", exc_info=True)
+    _ensure_terminal_env_bridged()
+    return dict(os.environ)
+
+
 def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    runtime_env = _runtime_terminal_env()
+    getenv = runtime_env.get
+    env_type = getenv("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = _is_container_backend(env_type)
     docker_backend = env_type == "docker"
 
@@ -1769,20 +1806,20 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number", env=runtime_env)
+        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120", env=runtime_env)
+        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200", env=runtime_env)
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON", env=runtime_env)
+        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON", env=runtime_env)
+        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON", env=runtime_env)
+        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON", env=runtime_env)
+        docker_shm_size = getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1806,13 +1843,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = getenv("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = getenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1830,41 +1867,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(getenv("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": getenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": getenv("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180", env=runtime_env),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300", env=runtime_env),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": getenv("TERMINAL_SSH_HOST", ""),
+        "ssh_user": getenv("TERMINAL_SSH_USER", ""),
+        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22", env=runtime_env),
+        "ssh_key": getenv("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": getenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            getenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1873,17 +1910,17 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": getenv(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
-        "docker_shared_container_key": os.getenv(
+        "docker_shared_container_key": getenv(
             "TERMINAL_DOCKER_SHARED_CONTAINER_KEY", ""
         ).strip(),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }


### PR DESCRIPTION
## Summary

In a multiplex gateway every profile shares one process, but `_get_env_config` reads process-global `os.environ` — so every profile gets the SAME terminal backend, images, timeouts, and container resources regardless of its own `config.yaml`. Downstream, the system prompt describes the wrong backend, one profile's backend-probe output is served as another profile's environment hint, and the tool-availability TTL cache aliases across profiles.

## Changes

- **`tools/terminal_tool.py`** — `_runtime_terminal_env()`: during a profile-scoped turn (`is_multiplex_active()` and a bound secret scope), overlay the active profile's terminal config onto a **private copy** of the environment via the existing `apply_terminal_config_to_env(env=..., config=load_config_readonly())` — `os.environ` is never mutated, and exported values the profile did not configure are preserved. Single-profile processes keep the historical `_ensure_terminal_env_bridged()` + `os.environ` path byte-for-byte. `_get_env_config` reads every `TERMINAL_*` value through this mapping, and `_parse_env_var` gains a keyword-only `env` parameter so numeric/JSON parsing reads the same snapshot.
- **`agent/prompt_builder.py`** — `build_environment_hints` resolves the backend from `_get_env_config()["env_type"]` under multiplex (fail-soft to the env var), and `_BACKEND_PROBE_CACHE` is additionally keyed by the resolved profile home so one profile's probe output is never another profile's hint.
- **`tools/registry.py`** — `check_fn_cache_scope`: an explicitly bound secret scope **without** multiplex (e.g. dashboard probe threads) now also scopes the availability cache, keyed by the resolved hermes home; multiplex-without-override still bypasses; failures still fail closed to bypass.

## Validation

| Check | Result |
|---|---|
| New `tests/tools/test_runtime_terminal_env.py` (scoped overlay wins; `os.environ` untouched; unconfigured exports preserved; multiplex-without-scope and single-profile paths unchanged) + new profile-scoped availability-cache test + multiplexed-hint test (two profiles configuring ssh vs local, driven through the real `gateway.run._profile_runtime_scope` chain) + probe-cache profile-key test | all pass |
| Touched + related suites: terminal_tool_requirements, parse_env_var, terminal_tool, prompt_builder, registry, terminal_env_bridge, terminal_config_env_sync, browser_extension_router | 179 pass / 0 fail / 1 pre-existing skip |
| `_get_env_config` consumer sweep: container_cwd_sanitize, docker_network_config, file_tools_container_config ×2, gateway_cwd_contract, interrupted_command_cwd, modal_sandbox_fixes, ssh_environment, terminal_task_cwd, docker_session_isolation, terminal_degraded_mode | 124 pass / 0 fail (5 environmental skips) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)