### PR TITLE
fix(mcp): honor SDK snake-case read-only annotations

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,16 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_sdk_tool_annotations_supported(self):
+        """The MCP SDK exposes camelCase wire hints as snake_case attrs."""
+        from mcp.types import Tool
+
+        tool = Tool.model_validate({
+            "name": "list_repos",
+            "description": "List repositories",
+            "inputSchema": {"type": "object", "properties": {}},
+            "annotations": {"readOnlyHint": True},
+        })
+
+        assert mcp_tool._annotation_read_only_hint(tool) is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4592,17 +4592,24 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     """Return True only when the tool's annotations carry readOnlyHint=True.
 
     Accepts both SDK annotation objects (attribute access) and plain dicts
-    (schema-cache JSON). Anything else — missing annotations, missing key,
-    non-bool truthy values — is False: unknown metadata means the tool must
-    be treated as write-capable.
+    (schema-cache JSON). MCP SDK 2.x maps the camelCase wire field to the
+    ``read_only_hint`` Python attribute, while older test doubles and SDKs may
+    expose ``readOnlyHint`` directly. Anything else — missing annotations,
+    missing key, non-bool truthy values — is False: unknown metadata means the
+    tool must be treated as write-capable.
     """
     annotations = getattr(mcp_tool, "annotations", None)
     if annotations is None:
         return False
     if isinstance(annotations, dict):
-        hint = annotations.get("readOnlyHint")
+        hint = annotations.get(
+            "readOnlyHint", annotations.get("read_only_hint")
+        )
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        missing = object()
+        hint = getattr(annotations, "readOnlyHint", missing)
+        if hint is missing:
+            hint = getattr(annotations, "read_only_hint", None)
     return hint is True
 
 


### PR DESCRIPTION
## Summary
- recognize MCP SDK 2.x ToolAnnotations.read_only_hint alongside legacy readOnlyHint
- preserve fail-closed behavior for missing and non-boolean hints
- add a behavior test using a real mcp.types.Tool parsed from camelCase wire data

## Why
MCP SDK 2.x maps wire readOnlyHint to the Python attribute read_only_hint. Hermes only checked readOnlyHint, so read-only tools on trust: untrusted servers were incorrectly routed through dangerous-command approval.

## Test
TMPDIR=<task scratch> HERMES_PYTHON=<task venv>/bin/python scripts/run_tests.sh tests/tools/test_mcp_trust_gating.py -q

Result: 12 passed.