### PR TITLE
fix(desktop): isolate loopback auth from public dashboard URL

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19447,7 +19447,17 @@ def start_server(
     # request middleware never reloads config. Any non-loopback public hostname
     # engages the auth gate even when the backend itself remains on loopback;
     # otherwise the SPA's local session token would become remotely reachable.
-    app.state.trusted_public_hosts = _dashboard_public_hosts()
+    #
+    # Exception: Electron-spawned loopback backends are separate ephemeral
+    # processes with a process-local session token. The machine-wide public URL
+    # describes a separately started dashboard and must not switch these local
+    # backends to cookie/OAuth mode. Keep non-loopback Desktop binds fail-closed.
+    _desktop_loopback = (
+        os.getenv("HERMES_DESKTOP") == "1" and host in _LOOPBACK_HOST_VALUES
+    )
+    app.state.trusted_public_hosts = (
+        frozenset() if _desktop_loopback else _dashboard_public_hosts()
+    )
     # Stash the auth-gate flag on app.state so middleware / SPA-token injection /
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -289,6 +289,62 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
         clear_providers()
 
 
+def test_desktop_loopback_ignores_public_dashboard_url(monkeypatch):
+    """A Desktop-spawned loopback backend keeps its process-local token mode.
+
+    ``dashboard.public_url`` describes the separately started public dashboard;
+    it must not turn an ephemeral Desktop backend into an OAuth-cookie server.
+    """
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    web_server.start_server(
+        host="127.0.0.1", port=0,
+        open_browser=False, allow_public=False,
+    )
+
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset()
+
+
+def test_desktop_marker_does_not_bypass_non_loopback_auth(monkeypatch):
+    """The Desktop marker never weakens a bind reachable off-host."""
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    clear_providers()
+    _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    with pytest.raises(SystemExit, match=r"no auth providers"):
+        web_server.start_server(
+            host="0.0.0.0", port=0,
+            open_browser=False, allow_public=False,
+        )
+
+    assert web_server.app.state.auth_required is True
+
+
 def test_start_server_loopback_public_url_without_provider_fails_closed(monkeypatch):
     """Trusting an external Host must never expose the loopback token mode."""
     from hermes_cli.dashboard_auth import clear_providers


### PR DESCRIPTION
## Summary
- keep Electron-spawned loopback backends in process-local session-token mode even when `dashboard.public_url` declares a separate public dashboard
- clear public Host/Origin trust for that ephemeral local backend
- preserve fail-closed OAuth gating for all non-loopback binds and ordinary loopback reverse-proxy dashboards

## Root cause
`start_server()` applied machine-wide `dashboard.public_url` to every serve process. A Desktop-spawned `127.0.0.1:<ephemeral>` backend therefore entered cookie/OAuth mode, stopped honoring the Desktop session token, and rejected `/api/ws`. Electron then terminated the otherwise HTTP-ready backend.

## Security boundary
The exemption is conjunctive: `HERMES_DESKTOP=1` **and** a loopback bind. `HERMES_DESKTOP=1` on `0.0.0.0` or another non-loopback host remains auth-gated and fails closed without a provider. The local process also does not trust the configured public hostname.

## Verification
- RED before patch: Desktop-loopback regression raised `SystemExit` because the public URL engaged OAuth
- GREEN after patch: `179 passed, 3 skipped` across `tests/hermes_cli/test_dashboard_auth_*.py` and `tests/test_web_server.py`
- independent review: no security concerns or logic errors
