### PR TITLE
fix(security): keep pending approval records owner-only

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -159,10 +159,17 @@ _SKILL = (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("subsystem", ("memory", "skills"))
-def test_stage_write_creates_private_pending_record(hermes_home, subsystem):
-    """Pending payloads must be owner-only even under a common 0o022 umask."""
+def _assert_stage_write_creates_private_pending_record(
+    hermes_home, subsystem, precreate_broad_directories
+):
     from tools import write_approval as wa
+
+    pending_root = Path(hermes_home) / "pending"
+    subsystem_root = pending_root / subsystem
+    if precreate_broad_directories:
+        subsystem_root.mkdir(parents=True)
+        pending_root.chmod(0o755)
+        subsystem_root.chmod(0o755)
 
     previous_umask = os.umask(0o022)
     try:
@@ -175,12 +182,58 @@ def test_stage_write_creates_private_pending_record(hermes_home, subsystem):
     finally:
         os.umask(previous_umask)
 
-    pending_root = Path(hermes_home) / "pending"
-    subsystem_root = pending_root / subsystem
     pending_path = subsystem_root / f"{record['id']}.json"
     assert stat.S_IMODE(pending_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(subsystem_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(pending_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("subsystem", ("memory", "skills"))
+@pytest.mark.parametrize("precreate_broad_directories", (False, True))
+def test_stage_write_creates_private_pending_record_macos(
+    hermes_home, subsystem, precreate_broad_directories
+):
+    """macOS pending payloads stay owner-only under a common 0o022 umask."""
+    _assert_stage_write_creates_private_pending_record(
+        hermes_home, subsystem, precreate_broad_directories
+    )
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("subsystem", ("memory", "skills"))
+@pytest.mark.parametrize("precreate_broad_directories", (False, True))
+def test_stage_write_creates_private_pending_record_linux(
+    hermes_home, subsystem, precreate_broad_directories
+):
+    """Linux pending payloads stay owner-only under a common 0o022 umask."""
+    _assert_stage_write_creates_private_pending_record(
+        hermes_home, subsystem, precreate_broad_directories
+    )
+
+
+def _assert_private_directory_rejects_leaf_symlink(tmp_path):
+    from tools import write_approval as wa
+
+    real_directory = tmp_path / "real"
+    real_directory.mkdir(mode=0o755)
+    linked_directory = tmp_path / "linked"
+    linked_directory.symlink_to(real_directory, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        wa._ensure_private_directory(linked_directory)
+
+    assert stat.S_IMODE(real_directory.stat().st_mode) == 0o755
+
+
+@pytest.mark.macos_only
+def test_private_pending_directory_rejects_leaf_symlink_macos(tmp_path):
+    _assert_private_directory_rejects_leaf_symlink(tmp_path)
+
+
+@pytest.mark.linux_only
+def test_private_pending_directory_rejects_leaf_symlink_linux(tmp_path):
+    _assert_private_directory_rejects_leaf_symlink(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -175,7 +175,11 @@ def test_stage_write_creates_private_pending_record(hermes_home, subsystem):
     finally:
         os.umask(previous_umask)
 
-    pending_path = Path(hermes_home) / "pending" / subsystem / f"{record['id']}.json"
+    pending_root = Path(hermes_home) / "pending"
+    subsystem_root = pending_root / subsystem
+    pending_path = subsystem_root / f"{record['id']}.json"
+    assert stat.S_IMODE(pending_root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(subsystem_root.stat().st_mode) == 0o700
     assert stat.S_IMODE(pending_path.stat().st_mode) == 0o600
 
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -9,8 +9,10 @@ subcommand dispatch.
 
 import json
 import os
+import stat
 import tempfile
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -155,6 +157,26 @@ _SKILL = (
 # ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subsystem", ("memory", "skills"))
+def test_stage_write_creates_private_pending_record(hermes_home, subsystem):
+    """Pending payloads must be owner-only even under a common 0o022 umask."""
+    from tools import write_approval as wa
+
+    previous_umask = os.umask(0o022)
+    try:
+        record = wa.stage_write(
+            subsystem,
+            {"action": "add", "content": "fixture"},
+            summary="fixture",
+            origin="foreground",
+        )
+    finally:
+        os.umask(previous_umask)
+
+    pending_path = Path(hermes_home) / "pending" / subsystem / f"{record['id']}.json"
+    assert stat.S_IMODE(pending_path.stat().st_mode) == 0o600
 
 
 # ---------------------------------------------------------------------------

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -45,12 +45,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+import stat
 import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +113,23 @@ def _pending_dir(subsystem: str) -> Path:
     return get_hermes_home() / "pending" / subsystem
 
 
+def _ensure_private_directory(path: Path) -> None:
+    """Create or tighten one pending directory without following a leaf symlink."""
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if os.name != "posix":
+        return
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        expected_uid = os.geteuid()  # windows-footgun: ok -- POSIX branch above
+        if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != expected_uid:
+            raise OSError("pending path is not an owner-local directory")
+        os.fchmod(descriptor, 0o700)
+    finally:
+        os.close(descriptor)
+
+
 def stage_write(subsystem: str, payload: Dict[str, Any],
                 *, summary: str, origin: str) -> Dict[str, Any]:
     """Persist a pending write and return a short record describing it.
@@ -141,11 +160,10 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     }
     try:
         d = _pending_dir(subsystem)
-        d.mkdir(parents=True, exist_ok=True)
+        _ensure_private_directory(d.parent)
+        _ensure_private_directory(d)
         path = d / f"{pid}.json"
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        atomic_json_write(path, record, indent=2, mode=0o600)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record


### PR DESCRIPTION
## What does this PR do?

Keeps pending memory and skill approval records owner-only.

`stage_write()` previously used `Path.write_text()` for a sibling temporary file. With a common `022` umask, staged content could therefore be created as `0644`. This change tightens pending directories to `0700`, rejects leaf symlinks and foreign owners on POSIX, and writes pending records atomically with mode `0600`.

Security impact: pending records may contain user-provided memory or skill content, so they should not be readable by other local users.

## Related Issue

No existing issue. I searched open and merged PRs/issues and did not find an exact duplicate for pending approval record permissions.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/write_approval.py`: descriptor-pin POSIX pending directories, enforce owner-only directory permissions, and atomically write records as `0600`.
- `tests/tools/test_write_approval.py`: cover memory and skill records in new and pre-existing broad directories, plus POSIX leaf-symlink rejection.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_write_approval.py -q` on macOS (20 passed, 5 Linux-only skipped).
2. Run `scripts/run_tests.sh tests/tools/test_write_approval.py -q -m linux_only` on Linux (5 passed in `python:3.11-slim-bookworm`).
3. Run `venv/bin/ruff check tools/write_approval.py tests/tools/test_write_approval.py`, `venv/bin/ty check tools/write_approval.py`, and `venv/bin/python scripts/check-windows-footguns.py --diff origin/main`.

The full macOS suite completed with 38,212 passed, 87 failed, and 329 skipped. All 87 failures were in 23 files outside this PR's two-file diff; the focused approval suite passed within the same run. The full-suite checkbox remains unchecked pending repository CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin host) and Linux arm64 Docker with Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); POSIX hardening is guarded and Windows behavior is preserved
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no public tool contract changed

## Screenshots / Logs

Not applicable; this is a filesystem-permission hardening change covered by automated tests.
