### PR TITLE
fix(desktop): preserve remote session ownership

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/gateway-rpc', () => ({ isMissingRestEndpoint: () => false }))
+vi.mock('@/store/transcript-tail', () => ({ recordTranscriptTail: vi.fn() }))
+vi.mock('./client', () => ({
+  capabilityScoped: vi.fn(),
+  getApiRequestConnection: vi.fn(() => 'prometheus'),
+  hermesApi: vi.fn()
+}))
+
+const client = await import('./client')
+const { listSidebarSessions } = await import('./sessions')
+
+const hermesApi = vi.mocked(client.hermesApi)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(client.getApiRequestConnection).mockReturnValue('prometheus')
+})
+
+describe('listSidebarSessions remote ownership', () => {
+  it('stamps active remote rows so a later resume stays on their gateway', async () => {
+    hermesApi.mockResolvedValue({
+      cron: { sessions: [] },
+      messaging: { sessions: [] },
+      recents: {
+        sessions: [{ id: 'remote-session', profile: 'default', source: 'desktop', title: 'Remote chat' }]
+      }
+    } as never)
+
+    const result = await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 40,
+      recentsExclude: [],
+      cronLimit: 20,
+      messagingLimit: 40,
+      messagingExclude: []
+    })
+
+    expect(result.recents.sessions[0]).toMatchObject({ connection_id: 'prometheus', id: 'remote-session' })
+  })
+})

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -8,7 +8,7 @@ import type {
   SessionSearchResponse
 } from '@/types/hermes'
 
-import { capabilityScoped, hermesApi, type ProfileScope } from './client'
+import { capabilityScoped, getApiRequestConnection, hermesApi, type ProfileScope } from './client'
 
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
@@ -30,6 +30,23 @@ function sessionScopeQuery(scope?: ProfileScope): string {
   const profile = sessionScoped(scope).profile
 
   return profile ? `?profile=${encodeURIComponent(profile)}` : ''
+}
+
+/**
+ * The active registered gateway owns every row it returns, but its HTTP APIs
+ * correctly know nothing about this Desktop-local registry id. Preserve an
+ * explicit owner from a multi-source response; otherwise stamp the active
+ * non-local source so a later resume cannot fall back to a same-named local
+ * profile.
+ */
+function stampActiveConnectionOwner(sessions: SessionInfo[]): SessionInfo[] {
+  const connectionId = getApiRequestConnection()?.trim()
+
+  if (!connectionId || connectionId === 'local') {
+    return sessions
+  }
+
+  return sessions.map(session => (session.connection_id ? session : { ...session, connection_id: connectionId }))
 }
 
 /**
@@ -67,7 +84,7 @@ export async function listSessions(
 
   return {
     ...result,
-    sessions: pageWindow(result.sessions, limit),
+    sessions: pageWindow(stampActiveConnectionOwner(result.sessions), limit),
     offset: 0
   }
 }
@@ -108,7 +125,7 @@ export async function listAllProfileSessions(
 
   return {
     ...result,
-    sessions: pageWindow(result.sessions, limit),
+    sessions: pageWindow(stampActiveConnectionOwner(result.sessions), limit),
     offset: 0
   }
 }
@@ -265,9 +282,9 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 
   return {
-    recents: { ...result.recents, sessions: result.recents?.sessions ?? [] },
-    cron: { ...result.cron, sessions: result.cron?.sessions ?? [] },
-    messaging: { ...result.messaging, sessions: result.messaging?.sessions ?? [] },
+    recents: { ...result.recents, sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []) },
+    cron: { ...result.cron, sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []) },
+    messaging: { ...result.messaging, sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []) },
     errors: result.errors
   }
 }

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  knownSessionProfile,
+  knownSessionOwner,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -358,7 +358,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       let owner: SessionOwnerScope =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        knownSessionProfile($sessions.get(), routingSessionId)
+        knownSessionOwner($sessions.get(), routingSessionId)
 
       if (!owner && routingSessionId) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,9 +8,12 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $sessions,
+  setConnection,
   setCurrentBranch,
   setCurrentCwd,
   setSelectedStoredSessionId,
+  setSessions,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionInfo, SessionResumeResponse } from '@/types/hermes'
@@ -33,8 +36,28 @@ import {
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
-  toBranchMessages
+  toBranchMessages,
+  upsertOptimisticSession
 } from './utils'
+
+describe('upsertOptimisticSession remote ownership', () => {
+  const initialSessions = $sessions.get()
+
+  afterEach(() => {
+    setConnection(null)
+    setSessions(initialSessions)
+  })
+
+  it('stamps a newly created row with the active remote gateway for its next turn', () => {
+    setConnection({ connectionId: 'prometheus', mode: 'remote', profile: 'default' } as never)
+    $activeGatewayProfile.set('default')
+    setSessions([])
+
+    upsertOptimisticSession({ session_id: 'runtime-new', stored_session_id: 'stored-new' } as never, 'stored-new')
+
+    expect($sessions.get()[0]).toMatchObject({ connection_id: 'prometheus', id: 'stored-new', profile: 'default' })
+  })
+})
 
 const msg = (id: string, role: ChatMessage['role'], text: string, extra: Partial<ChatMessage> = {}): ChatMessage =>
   ({ id, role, parts: [{ type: 'text', text }], ...extra }) as ChatMessage

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -8,6 +8,7 @@ import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import {
+  $connection,
   $cronSessions,
   $currentCwd,
   $messagingSessions,
@@ -1250,12 +1251,15 @@ export function upsertOptimisticSession(
   // profile) so the scoped sidebar shows the new row immediately instead of
   // filtering it out as "default" until the aggregator re-fetches.
   const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  const activeConnection = $connection.get()
+  const connectionId = activeConnection?.mode === 'remote' ? activeConnection.connectionId?.trim() : ''
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
     // lane immediately (the overlay groups by path); fall back to the workspace
     // the session was just started in when the create response omits it.
     cwd: created.info?.cwd ?? ($currentCwd.get().trim() || null),
+    ...(connectionId ? { connection_id: connectionId } : {}),
     ended_at: null,
     id,
     input_tokens: 0,

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -728,6 +728,25 @@ describe('project tree profile isolation', () => {
     $projectTree.set([])
   })
 
+  it('retries a dropped projects.tree request once on the active gateway', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('request timed out after 30s: projects.tree'))
+      .mockResolvedValueOnce({
+        active_id: null,
+        projects: [{ id: 'remote-tree', label: 'Remote tree', path: null, repos: [], sessionCount: 0 }],
+        scoped_session_ids: []
+      })
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    await refreshProjectTree()
+
+    expect(request).toHaveBeenCalledTimes(2)
+    expect($projectTree.get().map(project => project.id)).toEqual(['remote-tree'])
+  })
+
   it('does not publish a late response from the previous gateway', async () => {
     let resolveA: ((value: unknown) => void) | undefined
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -372,6 +372,12 @@ async function gatewayRequestOn<T>(
   return gateway.request<T>(method, params)
 }
 
+function isRetryableProjectTreeReadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return message.includes('request timed out') || message.includes('gateway connection closed')
+}
+
 interface ActiveProjectsContext {
   gateway: HermesGateway
   profile: string
@@ -479,11 +485,29 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
   }
 
   try {
-    const res = await gatewayRequestOn<ProjectTreePayload>(
-      gateway,
-      'projects.tree',
-      projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
-    )
+    let res: ProjectTreePayload
+
+    try {
+      res = await gatewayRequestOn<ProjectTreePayload>(
+        gateway,
+        'projects.tree',
+        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+      )
+    } catch (error) {
+      // A remote source switch can leave the first read RPC on a newly-opened
+      // socket without a response even though the gateway remains healthy.
+      // Retry once only while this exact gateway/profile is still foreground;
+      // missing-method and other authoritative failures stay visible as-is.
+      if (!isRetryableProjectTreeReadError(error) || !stillOnProjectsContext(context)) {
+        throw error
+      }
+
+      res = await gatewayRequestOn<ProjectTreePayload>(
+        gateway,
+        'projects.tree',
+        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+      )
+    }
 
     if (generation !== projectTreeRefreshGeneration || !stillOnProjectsContext(context)) {
       return

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -603,7 +603,13 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
     expect(knownOwnerForSession('stored-1')).toEqual({ connectionId: 'conn-a', profile: 'work' })
   })
 
-  it('falls back to the session row profile when no tile route exists', () => {
+  it('preserves a listed remote row connection when no tile route exists', () => {
+    setSessions([{ connection_id: 'prometheus', id: 'stored-2', profile: 'default' } as never])
+
+    expect(knownOwnerForSession('stored-2')).toEqual({ connectionId: 'prometheus', profile: 'default' })
+  })
+
+  it('falls back to the session row profile when no connection is recorded', () => {
     setSessions([{ id: 'stored-2', profile: 'loki' } as never])
 
     expect(knownOwnerForSession('stored-2')).toBe('loki')

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,7 +42,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
-  knownSessionProfile,
+  knownSessionOwner,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
@@ -752,7 +752,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner($sessions.get(), storedSessionId)
 }
 
 /**

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -10,7 +10,7 @@ import { persistBoolean, persistString, storedBoolean, storedString } from '@/li
 import { syncCronModelImpactConnection } from '@/store/cron-model-impact-scope'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
-import type { SessionProfileRoute } from './session-request-router'
+import type { SessionOwnerScope, SessionProfileRoute } from './session-request-router'
 import { clearUnreadOnOpen } from './session-unread-remote'
 
 type Updater<T> = T | ((current: T) => T)
@@ -125,20 +125,34 @@ export function sessionBelongsToProfile(
  * (Bot Mode's canonical "Bot Chat") never appear in the row list, so the hint is
  * often the only sync source.
  */
-export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId: null | string): string | undefined {
+export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: null | string): SessionOwnerScope {
   if (!sessionId) {
     return undefined
   }
 
-  const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
+  const row = sessions.find(session => sessionMatchesStoredId(session, sessionId))
+  const connectionId = row?.connection_id?.trim()
+  const profile = row?.profile?.trim()
 
-  if (owner) {
+  if (connectionId) {
+    return { connectionId, profile: profile || 'default' }
+  }
+
+  if (profile) {
+    return profile
+  }
+
+  return getSessionOwnerHint(sessionId)
+}
+
+export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId: null | string): string | undefined {
+  const owner = knownSessionOwner(sessions, sessionId)
+
+  if (typeof owner === 'string') {
     return owner
   }
 
-  const hint = getSessionOwnerHint(sessionId)
-
-  return (hint?.targetProfile ?? hint?.profile)?.trim() || undefined
+  return owner ? (owner.targetProfile ?? owner.profile)?.trim() || undefined : undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes Desktop routing and hydration for sessions owned by a registered remote gateway.

- Retries one retryable `projects.tree` transport failure so the sidebar does not remain indefinitely loading after a remote gateway switch.
- Stamps remote session-list and newly created optimistic rows with their registry `connection_id`.
- Preserves the complete session owner route (`connectionId` + profile) through prompt and session-state RPC routing, preventing a new remote chat's second turn from being sent to a same-named local profile.

## Reproduction fixed

With a remote gateway named `prometheus` and a local `default` profile:

1. Select the remote gateway.
2. Create a new chat and send a first message successfully.
3. Send a second message in the same chat.

Before this change, the second `prompt.submit` could route to local `default` and fail with `session not found` while the UI continued to show the remote gateway as ready.

## Validation

- Added regression coverage for remote sidebar-row ownership, optimistic new-session ownership, a retryable `projects.tree` loss, and full remote owner resolution.
- Focused Desktop routing/session tests: 238 passed.
- Desktop typecheck and `git diff --check` passed.
- Manual Windows validation against the remote Prometheus gateway: remote session sidebar rendered, existing sessions opened, and two consecutive turns in a new remote chat succeeded.
