### PR TITLE
fix(models): make determine_api_mode model-aware for Copilot's dual wire

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2034,7 +2034,11 @@ def switch_model(
     if _mandated_mode is not None:
         api_mode = _mandated_mode
     elif not api_mode:
-        api_mode = determine_api_mode(target_provider, base_url)
+        # Pass the target model: dual-wire providers (Nous, Copilot) derive
+        # the wire from the catalog id — a model-less call stamps
+        # chat_completions, which then pins every Responses-only model out
+        # of the reachable catalog (#94881).
+        api_mode = determine_api_mode(target_provider, base_url, model=new_model)
 
     # --- Normalize model name for target provider ---
     new_model = _resolve_named_custom_model_id(

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -756,9 +756,18 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     # anthropic_messages): Copilot's token/header scheme is handled by the
     # OpenAI client path — see copilot_model_api_mode().
     if provider_norm in {"copilot", "github-copilot", "github_copilot"}:
-        from hermes_cli.models import _should_use_copilot_responses_api
+        from hermes_cli.models import (
+            _should_use_copilot_responses_api,
+            normalize_copilot_model_id,
+        )
 
-        if _should_use_copilot_responses_api(str(model or "").strip()):
+        # Normalize first: the switch flow can hand a qualified form
+        # (`copilot/gpt-5.6-sol`) to this path before its own id resolution
+        # runs, and the raw prefix would make the pattern check miss and
+        # stamp chat_completions — the exact failure #94881 fixes. The
+        # no-argument normalize is local-only (no catalog fetch).
+        _normalized = normalize_copilot_model_id(model)
+        if _should_use_copilot_responses_api(_normalized):
             return "codex_responses"
         return "chat_completions"
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -725,12 +725,14 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     Resolution order:
       1. Host-mandated mode (special endpoints that only accept one protocol).
       2. Nous Portal dual-wire (model-derived; overlay alone is openai_chat).
-      3. Known provider → transport → TRANSPORT_TO_API_MODE.
-      4. Direct provider checks (bedrock).
-      5. Default: 'chat_completions'.
+      3. Copilot dual-wire (model-derived; GPT-5+ → Responses, the rest →
+         chat_completions).
+      4. Known provider → transport → TRANSPORT_TO_API_MODE.
+      5. Direct provider checks (bedrock).
+      6. Default: 'chat_completions'.
 
-    *model* is optional but required for dual-wire providers (Nous) whose
-    transport depends on the catalog id, not just the provider/host.
+    *model* is optional but required for dual-wire providers (Nous, Copilot)
+    whose transport depends on the catalog id, not just the provider/host.
     """
     mandated = host_mandated_api_mode(base_url)
     if mandated is not None:
@@ -743,6 +745,22 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     provider_norm = (provider or "").strip().lower()
     if provider_norm in {"nous", "nous-portal", "nousresearch"}:
         return nous_api_mode(model)
+
+    # Copilot is dual-wire the same way: GPT-5+ models (except gpt-5-mini)
+    # are only reachable via the Responses API, everything else via
+    # /chat/completions. Without this carve-out the transport lookup below
+    # returned chat_completions unconditionally, and the model-switch flow
+    # stamped that wrong value into config — every Responses-only model then
+    # 400'd with an error that read like an entitlement problem (#94881).
+    # Claude/Gemini Copilot slots stay on chat_completions (not
+    # anthropic_messages): Copilot's token/header scheme is handled by the
+    # OpenAI client path — see copilot_model_api_mode().
+    if provider_norm in {"copilot", "github-copilot", "github_copilot"}:
+        from hermes_cli.models import _should_use_copilot_responses_api
+
+        if _should_use_copilot_responses_api(str(model or "").strip()):
+            return "codex_responses"
+        return "chat_completions"
 
     pdef = get_provider(provider)
     if pdef is not None:

--- a/tests/hermes_cli/test_copilot_determine_api_mode.py
+++ b/tests/hermes_cli/test_copilot_determine_api_mode.py
@@ -48,6 +48,16 @@ class TestCopilotDualWire:
             == "codex_responses"
         )
 
+    @pytest.mark.parametrize(
+        "model",
+        ["copilot/gpt-5.6-sol", "github-copilot/gpt-5.5"],
+    )
+    def test_qualified_form_normalized_before_pattern_check(self, model):
+        # The switch flow can derive api_mode before its own id resolution
+        # strips the provider prefix; the raw prefix must not make the
+        # pattern check miss and stamp chat_completions.
+        assert determine_api_mode("copilot", COPILOT_HOST, model) == "codex_responses"
+
     def test_nous_carve_out_unchanged(self):
         assert (
             determine_api_mode("nous", "", "anthropic/claude-sonnet-4")

--- a/tests/hermes_cli/test_copilot_determine_api_mode.py
+++ b/tests/hermes_cli/test_copilot_determine_api_mode.py
@@ -1,0 +1,64 @@
+"""#94881: determine_api_mode() must be model-aware for Copilot.
+
+Copilot is dual-wire like Nous: GPT-5+ models (except gpt-5-mini) are only
+reachable via the Responses API, everything else via /chat/completions. The
+model-less transport lookup stamped chat_completions into config during the
+switch flow, silently pinning every Responses-only model out of the catalog
+with an error that read like an entitlement problem.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.providers import determine_api_mode
+
+COPILOT_HOST = "https://api.githubcopilot.com"
+
+
+class TestCopilotDualWire:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("gpt-5.6-sol", "codex_responses"),
+            ("gpt-5.6-luna-900k", "codex_responses"),
+            ("gpt-5.6-terra", "codex_responses"),
+            ("gpt-5.5", "codex_responses"),
+            ("gpt-5.4-mini", "codex_responses"),
+            ("gpt-5.3-codex", "codex_responses"),
+            ("gpt-5-mini", "chat_completions"),
+            ("gpt-4o", "chat_completions"),
+            ("claude-sonnet-5", "chat_completions"),
+            ("claude-opus-5", "chat_completions"),
+            ("gemini-3-pro", "chat_completions"),
+        ],
+    )
+    def test_model_derives_the_wire(self, model, expected):
+        assert determine_api_mode("copilot", COPILOT_HOST, model) == expected
+
+    def test_unknown_model_stays_on_chat_completions(self):
+        # Callers that don't yet know the model keep the safer
+        # OpenAI-compatible path — mirrors the Nous carve-out default.
+        assert determine_api_mode("copilot", COPILOT_HOST, "") == "chat_completions"
+        assert determine_api_mode("copilot", COPILOT_HOST) == "chat_completions"
+
+    @pytest.mark.parametrize("alias", ["Copilot", "github-copilot", "github_copilot"])
+    def test_provider_aliases_covered(self, alias):
+        assert (
+            determine_api_mode(alias, COPILOT_HOST, "gpt-5.6-sol")
+            == "codex_responses"
+        )
+
+    def test_nous_carve_out_unchanged(self):
+        assert (
+            determine_api_mode("nous", "", "anthropic/claude-sonnet-4")
+            == "anthropic_messages"
+        )
+        assert determine_api_mode("nous", "", "gpt/anything") == "chat_completions"
+
+    def test_non_copilot_provider_unaffected(self):
+        # An unrelated provider on an unmandated host still goes through the
+        # transport lookup, not the Copilot carve-out.
+        assert (
+            determine_api_mode("some-other-provider", "https://example.invalid", "gpt-5.6")
+            == "chat_completions"
+        )


### PR DESCRIPTION
## What does this PR do?

Copilot is dual-wire exactly like Nous: GPT-5+ models (except `gpt-5-mini`) are only reachable via the Responses API, everything else (Claude, Gemini, older GPT) via `/chat/completions`. `determine_api_mode()` had a Nous carve-out for exactly this property but fell through to the flat transport lookup for Copilot, returning `chat_completions` unconditionally — and the model-switch flow stamped that value into config, after which the explicit pin outranked per-model resolution at runtime. Six of Copilot's 23 catalog models became **silently unreachable** with an error that read like an entitlement problem ("model X is not accessible via the /chat/completions endpoint"), sending users to check their seat instead of their config (#94881). The reporter verified across the full catalog: 15/23 reachable before, 21/23 after unsetting the pinned `api_mode`.

Two stacked defects, both fixed:

1. **Copilot gets the same carve-out as Nous** in `determine_api_mode()`, delegating to the existing `_should_use_copilot_responses_api()` pattern check (the same logic opencode uses — GPT-5+ except `gpt-5-mini` → Responses; Claude/Gemini stay on `chat_completions`, matching `copilot_model_api_mode()`'s OpenAI-client-path rule, not `anthropic_messages`).
2. **The model-switch stamping site passes the target model** (`determine_api_mode(target_provider, base_url, model=new_model)`), so the value written into config reflects the wire of the model actually being switched to rather than a model-less default.

What this does NOT do (deliberately): the reporter's stronger suggestion 2 — stop persisting `api_mode` for model-dependent providers entirely — is a behavior-policy change to the config surface that belongs to the maintainers. This PR fixes the resolver + stamping correctness within the existing persistence contract; a later `/model` switch between wires still re-resolves because the switch flow re-runs this call.

## Related Issue

Fixes #94881

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/providers.py` — `determine_api_mode()` gains the Copilot dual-wire carve-out (after the Nous one, before the transport lookup), using the pattern check from `hermes_cli/models.py` via lazy import (avoids an import cycle at module load); docstring resolution order updated.
- `hermes_cli/model_switch.py` — the config-stamping fallback call now passes `model=new_model`.
- `tests/hermes_cli/test_copilot_determine_api_mode.py` — the issue's full model matrix (six Responses-only ids → `codex_responses`, `gpt-5-mini`/`gpt-4o`/Claude/Gemini → `chat_completions`), the unknown-model default, provider aliases, the unchanged Nous carve-out, and an unrelated-provider passthrough.

## How to Test

1. `pytest tests/hermes_cli/test_copilot_determine_api_mode.py tests/hermes_cli/test_determine_api_mode_hostname.py tests/hermes_cli/test_runtime_transport_precedence.py tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py -q` — should pass (34 passed).
2. Observed result: with this PR's source reverted (plain main), the new matrix fails 9/17 — every Copilot model resolves to `chat_completions` regardless of id; with the change, the wire follows the model id.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

From the issue (before): with `model.api_mode: chat_completions` stamped by the switch flow, `gpt-5.6-sol` → `HTTP 400: model "gpt-5.6-sol" is not accessible via the /chat/completions endpoint` (and five more); after `hermes config unset model.api_mode`, the same invocations succeed. With this fix the switch flow stamps the per-model-correct wire at selection time, so the unset workaround is no longer needed.
