### PR TITLE
fix(agent): tolerate list-form delta.content in streaming (Mistral/GLM)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -357,8 +357,12 @@ def _payload_has_error_shape(payload: Any) -> bool:
     return False
 
 
-def _provider_stream_text_may_be_sse(text: str) -> bool:
+def _provider_stream_text_may_be_sse(text: Any) -> bool:
     """Return True while pending text still looks like an SSE control block."""
+    if not isinstance(text, str):
+        # Some OpenAI-compatible relays (e.g. Mistral hosting GLM-5.2) emit
+        # delta.content as a list of content blocks; treat as non-SSE text.
+        return False
     stripped = (text or "").lstrip()
     if not stripped:
         return False
@@ -390,6 +394,31 @@ def _provider_stream_text_may_be_sse(text: str) -> bool:
         return False
 
     return saw_sse_field
+
+
+def _normalize_stream_content_to_text(content: Any) -> str:
+    """Collapse an OpenAI-compatible delta ``content`` into plain text.
+
+    Standard deltas carry ``content`` as a ``str``. Some relays (e.g. Mistral
+    serving GLM-5.2) emit it as a list of multi-part blocks such as
+    ``[{"type": "text", "text": "..."}]``. Downstream code assumes a string
+    (``.lstrip()``, ``"".join()``), so normalize once at the accumulation
+    point instead of guarding every consumer. Non-text blocks are dropped;
+    non-str/non-list shapes degrade to "" (empty delta, safely ignored).
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
 
 
 def _provider_stream_error_from_text(
@@ -4199,11 +4228,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate text content — fire callback only when no tool calls
             delta_content = getattr(delta, "content", None)
+            delta_content = _normalize_stream_content_to_text(delta_content)
             if delta_content:
                 content_parts.append(delta_content)
                 if not tool_calls_acc:
-                    if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
-                        pending_text_parts.append(delta.content)
+                    if pending_text_parts or _provider_stream_text_may_be_sse(delta_content):
+                        pending_text_parts.append(delta_content)
                         pending_text = "".join(pending_text_parts)
                         if _provider_stream_text_may_be_sse(pending_text):
                             continue

--- a/tests/run_agent/test_stream_content_list_normalization.py
+++ b/tests/run_agent/test_stream_content_list_normalization.py
@@ -1,0 +1,80 @@
+"""Tests for delta.content list normalization in the streaming path.
+
+Mistral's relay serving GLM-5.2 (and other OpenAI-compatible relays) can
+emit ``delta.content`` as a list of multi-part blocks instead of a plain
+string — e.g. ``[{"type": "text", "text": "..."}]``. The streaming
+accumulator in chat_completion_helpers assumed a string and crashed with
+``AttributeError: 'list' object has no attribute 'lstrip'``, failing the
+whole API call twice (with retries) before delivery.
+
+The fix normalizes ``delta.content`` to plain text at the accumulation
+point (_normalize_stream_content_to_text) and hardens
+_provider_stream_text_may_be_sse against non-str input.
+"""
+
+from agent.chat_completion_helpers import (
+    _normalize_stream_content_to_text,
+    _provider_stream_text_may_be_sse,
+)
+
+
+class TestNormalizeStreamContentToText:
+    def test_str_passthrough(self):
+        assert _normalize_stream_content_to_text("hello") == "hello"
+        assert _normalize_stream_content_to_text("") == ""
+
+    def test_list_of_text_blocks(self):
+        content = [
+            {"type": "text", "text": "Bonjour "},
+            {"type": "text", "text": "monsieur"},
+        ]
+        assert _normalize_stream_content_to_text(content) == "Bonjour monsieur"
+
+    def test_mixed_list_with_raw_strings(self):
+        content = ["abc", {"type": "text", "text": "def"}]
+        assert _normalize_stream_content_to_text(content) == "abcdef"
+
+    def test_non_text_blocks_are_dropped(self):
+        content = [
+            {"type": "text", "text": "keep"},
+            {"type": "image_url", "image_url": {"url": "x"}},
+            {"type": "text", "text": "me"},
+        ]
+        assert _normalize_stream_content_to_text(content) == "keepme"
+
+    def test_invalid_shapes_degrade_to_empty(self):
+        assert _normalize_stream_content_to_text(None) == ""
+        assert _normalize_stream_content_to_text(42) == ""
+        assert _normalize_stream_content_to_text([{"type": "text"}]) == ""
+
+    def test_empty_list(self):
+        assert _normalize_stream_content_to_text([]) == ""
+
+    def test_accumulated_output_is_join_safe(self):
+        # Mirrors "".join(content_parts) in the streaming accumulator: the
+        # normalized parts must all be strings regardless of delta shape.
+        deltas = [
+            [{"type": "text", "text": "A"}],
+            "B",
+            [{"type": "text", "text": "C"}],
+        ]
+        accumulated = [_normalize_stream_content_to_text(d) for d in deltas]
+        assert "".join(accumulated) == "ABC"
+
+
+class TestProviderStreamTextMayBeSse:
+    def test_list_input_returns_false_without_crash(self):
+        # Regression: previously raised AttributeError on .lstrip().
+        assert (
+            _provider_stream_text_may_be_sse([{"type": "text", "text": "data: x"}])
+            is False
+        )
+
+    def test_none_input(self):
+        assert _provider_stream_text_may_be_sse(None) is False
+
+    def test_str_behavior_unchanged(self):
+        # Plain SSE-looking text is still detected as pending control block.
+        assert _provider_stream_text_may_be_sse("data: hello") is True
+        # Ordinary prose is not.
+        assert _provider_stream_text_may_be_sse("hello") is False


### PR DESCRIPTION
## Summary

Mistral's relay serving **GLM-5.2** (and other OpenAI-compatible relays) can emit `delta.content` as a **list of multi-part blocks** (`[{"type": "text", "text": "..."}]`) instead of a plain string. The streaming accumulator in `agent/chat_completion_helpers.py` appended the raw delta to `content_parts` and passed it to `_provider_stream_text_may_be_sse()`, which crashed with:

```
AttributeError: 'list' object has no attribute 'lstrip'
```

→ the entire API call failed after 2 retries (observed with `provider=custom base_url=https://api.mistral.ai/v1 model=zai-glm-5-2`).

## Fix

- New `_normalize_stream_content_to_text()`: collapses `delta.content` (str | list of `{type: text, text}` blocks) into plain text **once, at the accumulation point** — so every downstream consumer (`"".join(content_parts)`, pending SSE detection, stream delta callbacks) sees a string.
- `_provider_stream_text_may_be_sse()` hardened with an `isinstance(text, str)` guard (defense in depth; returns False for non-str).
- Signature widened to `Any` accordingly.

## Test Plan

- New `tests/run_agent/test_stream_content_list_normalization.py` — 10 tests: str passthrough, text-block lists, mixed lists, non-text blocks dropped, invalid shapes → `""`, join-safety of the accumulator, and no-crash on list/None input to the SSE detector.
- Existing streaming tests (`test_streaming_tool_call_repair.py`, `test_chat_completion_helpers_provider_sort.py`) still pass.
- Real E2E: `hermes chat --provider mistral -m zai-glm-5-2` returns a normal response.