### PR TITLE
feat(agent): add provider-level model-request concurrency limit

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -112,6 +112,61 @@ def _ra():
     return run_agent
 
 
+# ---------------------------------------------------------------------------
+# Provider-level model-REQUEST concurrency
+# ---------------------------------------------------------------------------
+# Optional global ceiling on how many provider API requests may be in flight
+# at once. This is a REQUEST-level limit: a request slot is acquired
+# immediately before the actual blocking HTTP model request and released
+# immediately after it completes/fails — NEVER while an agent executes tools,
+# reads/writes files, runs subprocesses, or waits. It is fully independent of
+# the AGENT-level subagent concurrency governed by
+# ``delegation.max_concurrent_children``. The main agent and all subagents
+# share the request capacity.
+#
+# Config key: ``provider_max_concurrent_requests`` (int > 0, or None for
+# unlimited). None/null leaves existing behavior completely unchanged.
+#
+# The blocking model request runs on worker threads, not the asyncio loop
+# (see ``interruptible_api_call``), so the correct primitive is a
+# ``threading.BoundedSemaphore`` — matching the existing pattern in
+# ``agent/auxiliary_client.py``.
+
+_request_semaphore: "threading.BoundedSemaphore | None" = None
+_request_semaphore_limit: "int | None" = None
+_request_semaphore_limit_lock = threading.Lock()
+
+
+def _get_request_semaphore():
+    """Return the shared request-level semaphore, (re)built from config.
+
+    A ``threading.BoundedSemaphore`` with ``N`` permits means at most ``N``
+    provider model requests are in flight simultaneously. When the config
+    value is unset/None/<=0/not-an-int we return ``None`` (a no-op), preserving
+    Hermes' existing unlimited behavior exactly.
+
+    Re-reading config on each call keeps the limit live-usable across sessions
+    without a hard reload point; the value is cached for the life of the
+    process until the limit actually changes, to avoid rebinding the semaphore
+    on every request.
+    """
+    global _request_semaphore, _request_semaphore_limit
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        limit = cfg.get("provider_max_concurrent_requests")
+    except Exception:  # config load must never break a model request
+        return _request_semaphore  # keep last known value / None
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        return _request_semaphore  # unlimited — keep whatever (None normally)
+    if _request_semaphore_limit != limit or _request_semaphore is None:
+        with _request_semaphore_limit_lock:
+            if _request_semaphore_limit != limit or _request_semaphore is None:
+                _request_semaphore_limit = limit
+                _request_semaphore = threading.BoundedSemaphore(limit)
+    return _request_semaphore
+
+
 class ProviderStreamError(Exception):
     """Provider encoded an API error as streaming content instead of an SDK error."""
 
@@ -924,6 +979,34 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
 
 
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+    """Run one non-streaming LLM request under the provider request-semaphore.
+
+    Thin wrapper around ``_dispatch_nonstreaming_api_request_unlocked`` that
+    scopes the optional global provider request-concurrency limit to exactly
+    the blocking HTTP model request. A request slot is acquired immediately
+    before the call and released immediately after it returns or raises — it
+    is NEVER held while the agent executes tools, reads/writes files, runs
+    subprocesses, or waits. This is the REQUEST-level throttle, independent of
+    the AGENT-level ``delegation.max_concurrent_children`` cap. When
+    ``provider_max_concurrent_requests`` is unset (the default) the semaphore
+    is ``None`` and this is a transparent pass-through: behavior is
+    byte-identical to Hermes before this change.
+    """
+    sem = _get_request_semaphore()
+    if sem is None:
+        return _dispatch_nonstreaming_api_request_unlocked(
+            agent, api_kwargs, make_client=make_client
+        )
+    sem.acquire()
+    try:
+        return _dispatch_nonstreaming_api_request_unlocked(
+            agent, api_kwargs, make_client=make_client
+        )
+    finally:
+        sem.release()
+
+
+def _dispatch_nonstreaming_api_request_unlocked(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
     Shared by the interrupt-worker path (``interruptible_api_call``) and the

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -115,56 +115,72 @@ def _ra():
 # ---------------------------------------------------------------------------
 # Provider-level model-REQUEST concurrency
 # ---------------------------------------------------------------------------
-# Optional global ceiling on how many provider API requests may be in flight
-# at once. This is a REQUEST-level limit: a request slot is acquired
-# immediately before the actual blocking HTTP model request and released
-# immediately after it completes/fails — NEVER while an agent executes tools,
-# reads/writes files, runs subprocesses, or waits. It is fully independent of
-# the AGENT-level subagent concurrency governed by
+# Optional ceiling on how many provider API requests may be in flight at once,
+# independently per provider. This is a REQUEST-level limit: a request slot is
+# acquired immediately before the actual blocking HTTP model request and
+# released immediately after it completes/fails — NEVER while an agent executes
+# tools, reads/writes files, runs subprocesses, or waits. It is fully
+# independent of the AGENT-level subagent concurrency governed by
 # ``delegation.max_concurrent_children``. The main agent and all subagents
-# share the request capacity.
+# share the (per-provider) request capacity.
 #
-# Config key: ``provider_max_concurrent_requests`` (int > 0, or None for
-# unlimited). None/null leaves existing behavior completely unchanged.
+# Config:
+#   provider_max_concurrent_requests: int > 0 | None   # global default
+#   provider_request_concurrency: {provider: int>0|None}  # per-provider override
+# A provider with an entry in ``provider_request_concurrency`` gets its own
+# independent semaphore at that limit (this wins over the global default). Any
+# resolver value of None/absent means "unlimited" (no semaphore) for that
+# provider — existing behavior unchanged.
 #
 # The blocking model request runs on worker threads, not the asyncio loop
 # (see ``interruptible_api_call``), so the correct primitive is a
 # ``threading.BoundedSemaphore`` — matching the existing pattern in
 # ``agent/auxiliary_client.py``.
 
-_request_semaphore: "threading.BoundedSemaphore | None" = None
-_request_semaphore_limit: "int | None" = None
-_request_semaphore_limit_lock = threading.Lock()
+_request_semaphores: "dict[str, threading.BoundedSemaphore]" = {}
+_request_semaphore_limits: "dict[str, int]" = {}
+_request_semaphore_lock = threading.Lock()
 
 
-def _get_request_semaphore():
-    """Return the shared request-level semaphore, (re)built from config.
-
-    A ``threading.BoundedSemaphore`` with ``N`` permits means at most ``N``
-    provider model requests are in flight simultaneously. When the config
-    value is unset/None/<=0/not-an-int we return ``None`` (a no-op), preserving
-    Hermes' existing unlimited behavior exactly.
-
-    Re-reading config on each call keeps the limit live-usable across sessions
-    without a hard reload point; the value is cached for the life of the
-    process until the limit actually changes, to avoid rebinding the semaphore
-    on every request.
-    """
-    global _request_semaphore, _request_semaphore_limit
+def _resolve_request_limit(provider):
+    """Resolve the REQUEST-concurrency limit for a provider (or None if
+    unlimited). Not thread-safe for the cache update; callers hold the lock
+    when mutating. Resource ordering: only ever touches module state."""
     try:
         from hermes_cli.config import load_config_readonly
         cfg = load_config_readonly() or {}
-        limit = cfg.get("provider_max_concurrent_requests")
     except Exception:  # config load must never break a model request
-        return _request_semaphore  # keep last known value / None
-    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
-        return _request_semaphore  # unlimited — keep whatever (None normally)
-    if _request_semaphore_limit != limit or _request_semaphore is None:
-        with _request_semaphore_limit_lock:
-            if _request_semaphore_limit != limit or _request_semaphore is None:
-                _request_semaphore_limit = limit
-                _request_semaphore = threading.BoundedSemaphore(limit)
-    return _request_semaphore
+        return None
+    overrides = cfg.get("provider_request_concurrency") or {}
+    if isinstance(overrides, dict) and provider in overrides:
+        override = overrides[provider]
+        if isinstance(override, int) and not isinstance(override, bool) and override > 0:
+            return override
+        return None  # explicit unlimited override
+    global_limit = cfg.get("provider_max_concurrent_requests")
+    if isinstance(global_limit, int) and not isinstance(global_limit, bool) and global_limit > 0:
+        return global_limit
+    return None
+
+
+def _get_request_semaphore(provider=None):
+    """Return the request-level semaphore for ``provider`` (or None if that
+    provider has no limit configured). Semaphores are cached per provider; the
+    cache is rebuilt lazily when a provider's limit changes. ``None`` provider
+    uses the global limit only. When no limit applies, returns ``None`` (a
+    no-op), preserving Hermes' existing unlimited behavior exactly.
+    """
+    limit = _resolve_request_limit(provider or None)
+    if limit is None:
+        return None
+    with _request_semaphore_lock:
+        existing = _request_semaphores.get(provider or "")
+        if existing is not None and _request_semaphore_limits.get(provider or "") == limit:
+            return existing
+        sem = threading.BoundedSemaphore(limit)
+        _request_semaphores[provider or ""] = sem
+        _request_semaphore_limits[provider or ""] = limit
+        return sem
 
 
 class ProviderStreamError(Exception):
@@ -982,17 +998,19 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request under the provider request-semaphore.
 
     Thin wrapper around ``_dispatch_nonstreaming_api_request_unlocked`` that
-    scopes the optional global provider request-concurrency limit to exactly
-    the blocking HTTP model request. A request slot is acquired immediately
-    before the call and released immediately after it returns or raises — it
-    is NEVER held while the agent executes tools, reads/writes files, runs
-    subprocesses, or waits. This is the REQUEST-level throttle, independent of
-    the AGENT-level ``delegation.max_concurrent_children`` cap. When
-    ``provider_max_concurrent_requests`` is unset (the default) the semaphore
-    is ``None`` and this is a transparent pass-through: behavior is
-    byte-identical to Hermes before this change.
+    scopes the optional provider request-concurrency limit — global or
+    per-provider — to exactly the blocking HTTP model request. A request slot
+    is acquired immediately before the call and released immediately after it
+    returns or raises — it is NEVER held while the agent executes tools,
+    reads/writes files, runs subprocesses, or waits. This is the REQUEST-level
+    throttle, independent of the AGENT-level
+    ``delegation.max_concurrent_children`` cap. When no limit applies to the
+    active provider (the default) the semaphore is ``None`` and this is a
+    transparent pass-through: behavior is byte-identical to Hermes before this
+    change.
     """
-    sem = _get_request_semaphore()
+    provider = getattr(agent, "provider", None)
+    sem = _get_request_semaphore(provider)
     if sem is None:
         return _dispatch_nonstreaming_api_request_unlocked(
             agent, api_kwargs, make_client=make_client

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,6 +7,16 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    # Optional global ceiling on simultaneous in-flight provider model
+    # requests. This is a REQUEST-level limit (how many provider API calls
+    # may be outstanding at once) and is strictly independent of the
+    # AGENT-level subagent concurrency governed by
+    # ``delegation.max_concurrent_children``. It is provider-agnostic and
+    # optional: ``None`` (default) means "unlimited" and changes nothing.
+    # The slot is held only for the duration of the actual HTTP model
+    # request, never while the agent executes tools / reads files / runs
+    # subprocesses / waits. Children and the main agent share this capacity.
+    "provider_max_concurrent_requests": None,
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -17,6 +17,13 @@ DEFAULT_CONFIG = {
     # request, never while the agent executes tools / reads files / runs
     # subprocesses / waits. Children and the main agent share this capacity.
     "provider_max_concurrent_requests": None,
+    # Optional per-provider REQUEST-concurrency overrides. Keys are provider
+    # names (e.g. "openrouter", "nous", "anthropic"); values are int > 0 or
+    # None. A provider with an entry here uses its own independent semaphore,
+    # overriding the global ``provider_max_concurrent_requests``. This keeps
+    # REQUEST-level limits independent per provider (still separate from the
+    # AGENT-level delegation cap). Unset/empty = no per-provider override.
+    "provider_request_concurrency": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/tests/agent/test_provider_request_concurrency.py
+++ b/tests/agent/test_provider_request_concurrency.py
@@ -1,9 +1,10 @@
 """Focused tests for provider-level model-REQUEST concurrency.
 
-Verifies that ``provider_max_concurrent_requests`` (an optional REQUEST-level
-throttle, independent of the AGENT-level ``delegation.max_concurrent_children``
-cap) serializes concurrent provider model calls when configured, and is a
-transparent pass-through when unset — so existing behavior is unchanged.
+Verifies that ``provider_max_concurrent_requests`` (a global REQUEST-level
+throttle) and ``provider_request_concurrency`` (per-provider overrides) — both
+independent of the AGENT-level ``delegation.max_concurrent_children`` cap —
+serialize concurrent provider model requests when configured and are
+transparent pass-throughs when unset.
 
 Concurrency is asserted via wall-clock timing, not merely "calls happened", so
 that a subtle sequential fallback cannot masquerade as concurrency.
@@ -17,19 +18,18 @@ from unittest.mock import patch
 from agent import chat_completion_helpers as m
 
 
-def _fake_unlocked(agent, api_kwargs, *, make_client):
-    """Deterministic stand-in for the guarded blocking HTTP request."""
-    return api_kwargs
+class _Agent:
+    def __init__(self, provider=None):
+        self.provider = provider
 
 
-def _spawn_calls(wrapper, n=3):
-    """Run n parallel calls through the wrapper on worker threads."""
+def _spawn(wrapper, n=3, provider=None):
     results = [None] * n
     threads = []
     for i in range(n):
         t = threading.Thread(
             target=lambda i=i: results.__setitem__(
-                i, wrapper(None, {"i": i}, make_client=None)
+                i, wrapper(_Agent(provider), {"i": i}, make_client=None)
             ),
             daemon=True,
         )
@@ -40,9 +40,9 @@ def _spawn_calls(wrapper, n=3):
     return results
 
 
-def test_wrapper_is_pass_through_when_limit_unset():
-    """With no limit configured the wrapper must call the unlocked body and
-    return its result unchanged (behavior identical to before the change)."""
+def test_wrapper_is_pass_through_when_no_limit():
+    """With no limit configured (global or per-provider) the wrapper must call
+    the unlocked body and return its result unchanged."""
     called = []
 
     def unlocked(agent, api_kwargs, *, make_client):
@@ -51,69 +51,103 @@ def test_wrapper_is_pass_through_when_limit_unset():
 
     with patch.object(m, "_get_request_semaphore", return_value=None), \
          patch.object(m, "_dispatch_nonstreaming_api_request_unlocked", side_effect=unlocked):
-        out = m._dispatch_nonstreaming_api_request(None, {"k": 1}, make_client="mc")
+        out = m._dispatch_nonstreaming_api_request(_Agent("some_provider"), {"k": 1}, make_client="mc")
         assert out == "result"
         assert called == [{"k": 1}]
 
 
 def test_semaphore_none_when_config_unset_or_bad():
-    """Invalid / unset values must yield a no-op (None) semaphore, preserving
-    the original unlimited behavior."""
+    """Invalid / unset values must yield a no-op (None) semaphore for every
+    provider, preserving unlimited behavior."""
     for bad in (None, 0, -3, "5", True):
         with patch("hermes_cli.config.load_config_readonly",
-                   return_value={"provider_max_concurrent_requests": bad}):
-            assert m._get_request_semaphore() is None
+                   return_value={
+                       "provider_max_concurrent_requests": bad,
+                       "provider_request_concurrency": {},
+                   }):
+            assert m._get_request_semaphore(None) is None
+            assert m._get_request_semaphore("x") is None
 
 
 def test_limit_serializes_concurrent_requests():
-    """With limit=1, N parallel worker calls must run sequentially (serialized
-    by the request semaphore). With limit=3 they overlap."""
+    """With a limit of 1, N parallel worker calls for the same provider must
+    run sequentially (serialized by the request semaphore). With limit 3 they
+    overlap."""
 
-    def run(limit, unlock):
+    def run(limit, provider="p"):
+        def sleeper(agent, api_kwargs, *, make_client):
+            time.sleep(0.25)  # simulate a blocking provider HTTP round-trip
+            return api_kwargs
+
         before = time.monotonic()
         with patch("hermes_cli.config.load_config_readonly",
-                   return_value={"provider_max_concurrent_requests": limit}), \
-             patch.object(m, "_dispatch_nonstreaming_api_request_unlocked", side_effect=unlock):
-            results = _spawn_calls(m._dispatch_nonstreaming_api_request, n=3)
+                   return_value={
+                       "provider_max_concurrent_requests": limit,
+                       "provider_request_concurrency": {},
+                   }), \
+             patch.object(m, "_dispatch_nonstreaming_api_request_unlocked", side_effect=sleeper):
+            results = _spawn(m._dispatch_nonstreaming_api_request, n=3, provider=provider)
         wall = time.monotonic() - before
         return wall, results
 
-    def sleeper(agent, api_kwargs, *, make_client):
-        time.sleep(0.25)  # simulate a blocking provider HTTP round-trip
-        return api_kwargs
-
     # limit=1 => 3 sequential sleeps of 0.25s => clearly >= 0.6s
-    m._request_semaphore = None
-    m._request_semaphore_limit = None
-    wall1, results1 = run(1, sleeper)
-    assert results1 == [{"i": 0}, {"i": 1}, {"i": 2}], results1
+    m._request_semaphores.clear()
+    wall1, r1 = run(1)
+    assert r1 == [{"i": 0}, {"i": 1}, {"i": 2}], r1
     assert wall1 >= 0.6, f"expected serialization, got {wall1:.2f}s"
 
     # limit=3 => 3 overlapping sleeps => clearly < 0.6s
-    m._request_semaphore = None
-    m._request_semaphore_limit = None
-    wall3, results3 = run(3, sleeper)
-    assert results3 == [{"i": 0}, {"i": 1}, {"i": 2}], results3
+    m._request_semaphores.clear()
+    wall3, r3 = run(3)
+    assert r3 == [{"i": 0}, {"i": 1}, {"i": 2}], r3
     assert wall3 < 0.6, f"expected overlap, got {wall3:.2f}s"
 
 
-def test_limit_is_independent_of_agent_concurrency_config():
-    """The request-level throttle must not read or depend on
-    delegation.max_concurrent_children; the two levels stay independent."""
-    with patch("hermes_cli.config.load_config_readonly",
-               return_value={
-                   "provider_max_concurrent_requests": 2,
-                   "delegation": {"max_concurrent_children": 5},
-               }):
-        sem = m._get_request_semaphore()
-        assert sem is not None
-        assert sem._value == 2
+def test_provider_override_wins_over_global():
+    """A per-provider entry overrides the global limit for that provider, while
+    other providers keep the global limit."""
+    cfg = {
+        "provider_max_concurrent_requests": 4,
+        "provider_request_concurrency": {"alpha": 1, "beta": None},
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        # Provider 'alpha' -> per-provider limit 1 (own semaphore).
+        sa = m._get_request_semaphore("alpha")
+        assert sa is not None and sa._value == 1
+        # Provider 'beta' -> explicit None override -> unlimited.
+        assert m._get_request_semaphore("beta") is None
+        # Unknown provider / no override -> global limit 4.
+        sg = m._get_request_semaphore("gamma")
+        assert sg is not None and sg._value == 4
+        # providers get independent semaphores.
+        assert sa is not sg
 
-    m._request_semaphore = None
-    m._request_semaphore_limit = None
+
+def test_resolver_returns_none_on_config_load_error():
+    """If config can't be loaded the resolver must not raise; it returns None."""
+    before = m._request_semaphores.copy()
     with patch("hermes_cli.config.load_config_readonly",
-               return_value={
-                   "provider_max_concurrent_requests": None,
-                   "delegation": {"max_concurrent_children": 5},
-               }):
-        assert m._get_request_semaphore() is None
+               side_effect=RuntimeError("boom")):
+        assert m._resolve_request_limit("p") is None
+        assert m._get_request_semaphore("p") is None
+
+
+def test_limit_independent_of_agent_concurrency_config():
+    """The request-level throttle must not read or depend on
+    delegation.max_concurrent_children; the two levels stay separate."""
+    cfg = {
+        "provider_max_concurrent_requests": 2,
+        "provider_request_concurrency": {},
+        "delegation": {"max_concurrent_children": 5},
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert m._get_request_semaphore("p")._value == 2
+
+    m._request_semaphores.clear()
+    cfg_none = {
+        "provider_max_concurrent_requests": None,
+        "provider_request_concurrency": {},
+        "delegation": {"max_concurrent_children": 5},
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg_none):
+        assert m._get_request_semaphore("p") is None

--- a/tests/agent/test_provider_request_concurrency.py
+++ b/tests/agent/test_provider_request_concurrency.py
@@ -1,0 +1,119 @@
+"""Focused tests for provider-level model-REQUEST concurrency.
+
+Verifies that ``provider_max_concurrent_requests`` (an optional REQUEST-level
+throttle, independent of the AGENT-level ``delegation.max_concurrent_children``
+cap) serializes concurrent provider model calls when configured, and is a
+transparent pass-through when unset — so existing behavior is unchanged.
+
+Concurrency is asserted via wall-clock timing, not merely "calls happened", so
+that a subtle sequential fallback cannot masquerade as concurrency.
+"""
+
+import threading
+import time
+
+from unittest.mock import patch
+
+from agent import chat_completion_helpers as m
+
+
+def _fake_unlocked(agent, api_kwargs, *, make_client):
+    """Deterministic stand-in for the guarded blocking HTTP request."""
+    return api_kwargs
+
+
+def _spawn_calls(wrapper, n=3):
+    """Run n parallel calls through the wrapper on worker threads."""
+    results = [None] * n
+    threads = []
+    for i in range(n):
+        t = threading.Thread(
+            target=lambda i=i: results.__setitem__(
+                i, wrapper(None, {"i": i}, make_client=None)
+            ),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join(timeout=15)
+    return results
+
+
+def test_wrapper_is_pass_through_when_limit_unset():
+    """With no limit configured the wrapper must call the unlocked body and
+    return its result unchanged (behavior identical to before the change)."""
+    called = []
+
+    def unlocked(agent, api_kwargs, *, make_client):
+        called.append(api_kwargs)
+        return "result"
+
+    with patch.object(m, "_get_request_semaphore", return_value=None), \
+         patch.object(m, "_dispatch_nonstreaming_api_request_unlocked", side_effect=unlocked):
+        out = m._dispatch_nonstreaming_api_request(None, {"k": 1}, make_client="mc")
+        assert out == "result"
+        assert called == [{"k": 1}]
+
+
+def test_semaphore_none_when_config_unset_or_bad():
+    """Invalid / unset values must yield a no-op (None) semaphore, preserving
+    the original unlimited behavior."""
+    for bad in (None, 0, -3, "5", True):
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"provider_max_concurrent_requests": bad}):
+            assert m._get_request_semaphore() is None
+
+
+def test_limit_serializes_concurrent_requests():
+    """With limit=1, N parallel worker calls must run sequentially (serialized
+    by the request semaphore). With limit=3 they overlap."""
+
+    def run(limit, unlock):
+        before = time.monotonic()
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"provider_max_concurrent_requests": limit}), \
+             patch.object(m, "_dispatch_nonstreaming_api_request_unlocked", side_effect=unlock):
+            results = _spawn_calls(m._dispatch_nonstreaming_api_request, n=3)
+        wall = time.monotonic() - before
+        return wall, results
+
+    def sleeper(agent, api_kwargs, *, make_client):
+        time.sleep(0.25)  # simulate a blocking provider HTTP round-trip
+        return api_kwargs
+
+    # limit=1 => 3 sequential sleeps of 0.25s => clearly >= 0.6s
+    m._request_semaphore = None
+    m._request_semaphore_limit = None
+    wall1, results1 = run(1, sleeper)
+    assert results1 == [{"i": 0}, {"i": 1}, {"i": 2}], results1
+    assert wall1 >= 0.6, f"expected serialization, got {wall1:.2f}s"
+
+    # limit=3 => 3 overlapping sleeps => clearly < 0.6s
+    m._request_semaphore = None
+    m._request_semaphore_limit = None
+    wall3, results3 = run(3, sleeper)
+    assert results3 == [{"i": 0}, {"i": 1}, {"i": 2}], results3
+    assert wall3 < 0.6, f"expected overlap, got {wall3:.2f}s"
+
+
+def test_limit_is_independent_of_agent_concurrency_config():
+    """The request-level throttle must not read or depend on
+    delegation.max_concurrent_children; the two levels stay independent."""
+    with patch("hermes_cli.config.load_config_readonly",
+               return_value={
+                   "provider_max_concurrent_requests": 2,
+                   "delegation": {"max_concurrent_children": 5},
+               }):
+        sem = m._get_request_semaphore()
+        assert sem is not None
+        assert sem._value == 2
+
+    m._request_semaphore = None
+    m._request_semaphore_limit = None
+    with patch("hermes_cli.config.load_config_readonly",
+               return_value={
+                   "provider_max_concurrent_requests": None,
+                   "delegation": {"max_concurrent_children": 5},
+               }):
+        assert m._get_request_semaphore() is None


### PR DESCRIPTION
## Summary

Adds an optional **request-level** provider concurrency limit, kept strictly from Hermes' existing **agent-level** subagent concurrency. Supports a global default **and independent per-provider** limits.

- **Global:** `provider_max_concurrent_requests` (int > 0, or `None` = unlimited; default off).
- **Per-provider:** `provider_request_concurrency` map (`{provider: int > 0 | None}`) — each provider with an entry gets its own independent semaphore, overriding the global default. Provider names are data, never hard-coded → provider-independent.
- Built on a `threading.BoundedSemaphore` (matching Hermes' worker-thread request context; see `agent/auxiliary_client.py` precedent). Cached per provider, rebuilt lazily on limit change.
- The slot is acquired only immediately before the blocking HTTP model call and released in `finally` — **never held** while an agent executes tools, reads/writes files, runs subprocesses, or waits.
- **Off by default**: unset/empty config leaves behavior byte-identical to before. The existing agent-level `delegation.max_concurrent_children` cap is untouched.

This is a **REQUEST-level** throttle (Concept B), independent of the **AGENT-level** `delegation.max_concurrent_children` (Concept A). The main agent and subagents share the per-provider request capacity; no single request slot is reserved for the main agent.

## Scope
- `agent/chat_completion_helpers.py`: request-semaphore resolver + per-provider cache + thin wrapper around `_dispatch_nonstreaming_api_request` (the choke point all provider routes already share).
- `hermes_cli/config_defaults.py`: `provider_max_concurrent_requests` (None) + `provider_request_concurrency` ({}).
- `tests/agent/test_provider_request_concurrency.py`: 6 tests incl. **timing-based** concurrency proof (limit=1 serializes ≥0.6s; limit=3 overlaps <0.6s), per-provider-overrides-global, explicit-None-unlimited, unknown-provider-uses-global, config-load-failure no-op, and independence from the agent-level config.

## Verification
- [x] Affected suites (`test_config.py`, `test_delegate.py`, `test_chat_completion_helpers_provider_sort.py`) — **149 passed, 0 failures**.
- [x] New test file — **6 passed**.
- [x] Credential audit on modified/added files — no credentials added.
- [ ] Live validation not run (branch sandboxed; not executed against a running runtime with live keys).

## Risk
- Additive only; default-off means no behavior change for existing users until they opt in (global via `provider_max_concurrent_requests`, per-provider via `provider_request_concurrency`).