### PR TITLE
fix(desktop): preserve detached runtime workspace

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -9,6 +9,7 @@ import {
   $currentProvider,
   $selectedStoredSessionId,
   $sessions,
+  releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwdTransient,
@@ -120,28 +121,33 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       // Active-session model/provider still flows through the session state
       // cache via updateSessionState → syncRuntimeMetadataToView below.
 
-      if (typeof payload?.cwd === 'string' && sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+      if (statePatch.cwd !== undefined && sessionInfoDescribesSelectedSession(payload?.stored_session_id)) {
         // The active session's agent can relocate itself (new repo/worktree
         // via the terminal). When the SAME active session's cwd actually
         // moves, follow it — refresh the project tree + scope so the sidebar
         // tracks the live thread. A fresh selection (different session id)
         // is a switch, not a move, so it refreshes data without yanking scope.
-        const cwdMoved = payload.cwd !== $currentCwd.get()
-        const sameSession = !!sessionId && sessionId === lastCwdInfoSessionRef.current
+        if (statePatch.cwd && statePatch.cwdOwned !== false) {
+          const cwdMoved = statePatch.cwd !== $currentCwd.get()
+          const sameSession = !!sessionId && sessionId === lastCwdInfoSessionRef.current
 
-        lastCwdInfoSessionRef.current = sessionId
-        setCurrentCwdTransient(payload.cwd)
+          lastCwdInfoSessionRef.current = sessionId
+          setCurrentCwdTransient(statePatch.cwd)
 
-        // The backend just confirmed the selected conversation's real
-        // workspace, so it owns the path we wrote. Without the claim the
-        // marker keeps naming whoever held it before — including the
-        // released state a detached resume leaves behind — and the primary
-        // workspace-derived surfaces stay hidden against a folder the
-        // backend has confirmed (#71254).
-        setWorkspaceCwdOwner($selectedStoredSessionId.get())
+          // The backend just confirmed the selected conversation's real
+          // workspace, so it owns the path we wrote. Without the claim the
+          // marker keeps naming whoever held it before — including the
+          // released state a detached resume leaves behind — and the primary
+          // workspace-derived surfaces stay hidden against a folder the
+          // backend has confirmed (#71254).
+          setWorkspaceCwdOwner($selectedStoredSessionId.get())
 
-        if (cwdMoved && sameSession) {
-          void followActiveSessionCwd(payload.cwd)
+          if (cwdMoved && sameSession) {
+            void followActiveSessionCwd(statePatch.cwd)
+          }
+        } else {
+          lastCwdInfoSessionRef.current = sessionId
+          releaseWorkspaceCwdOwner()
         }
       }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-workspace-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-workspace-event.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  $currentCwd,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwd,
+  setSelectedStoredSessionId,
+  setWorkspaceCwdOwner,
+  workspaceCwdBelongsToSelectedSession
+} from '@/store/session'
+
+import { renderMessageStream } from './test-harness'
+
+const RUNTIME_ID = 'runtime-active'
+const STORED_ID = 'stored-active'
+
+describe('live session.info workspace reconciliation', () => {
+  beforeEach(() => {
+    setSelectedStoredSessionId(STORED_ID)
+    setCurrentCwd('/previous/project')
+    setWorkspaceCwdOwner(STORED_ID)
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSelectedStoredSessionId(null)
+    setCurrentCwd('')
+    releaseWorkspaceCwdOwner()
+  })
+
+  it('caches a neutral execution cwd as detached and releases the selected workspace', () => {
+    const state = createClientSessionState(STORED_ID)
+
+    const stream = renderMessageStream(RUNTIME_ID, {
+      states: new Map([[RUNTIME_ID, state]])
+    })
+
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          cwd: '/home/backend/.hermes/workspace',
+          cwd_owned: false,
+          stored_session_id: STORED_ID
+        },
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    )
+
+    expect($currentCwd.get()).toBe('/previous/project')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
+    expect(stream.state()).toMatchObject({ cwd: '', cwdOwned: false })
+  })
+
+  it('keeps legacy non-empty cwd events owned when cwd_owned is absent', () => {
+    const state = createClientSessionState(STORED_ID)
+
+    const stream = renderMessageStream(RUNTIME_ID, {
+      states: new Map([[RUNTIME_ID, state]])
+    })
+
+    act(() =>
+      stream.handleEvent({
+        payload: { cwd: '/legacy/project', stored_session_id: STORED_ID },
+        session_id: RUNTIME_ID,
+        type: 'session.info'
+      })
+    )
+
+    expect($currentCwd.get()).toBe('/legacy/project')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(true)
+    expect(stream.state()).toMatchObject({ cwd: '/legacy/project', cwdOwned: true })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -1,14 +1,7 @@
 import type { GatewayEventPayload } from '@/lib/chat-messages'
-import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { normalizePersonalityValue, runtimeWorkspaceStatePatch } from '@/lib/chat-runtime'
 
-import type { ClientSessionState } from '../../../types'
-
-type SessionRuntimeStatePatch = Partial<
-  Pick<
-    ClientSessionState,
-    'branch' | 'cwd' | 'fast' | 'model' | 'personality' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
-  >
->
+import type { SessionRuntimeStatePatch } from '../../../types'
 
 export function sessionInfoStatePatch(payload: GatewayEventPayload | undefined): SessionRuntimeStatePatch {
   const patch: SessionRuntimeStatePatch = {}
@@ -21,8 +14,8 @@ export function sessionInfoStatePatch(payload: GatewayEventPayload | undefined):
     patch.provider = payload.provider || ''
   }
 
-  if (typeof payload?.cwd === 'string') {
-    patch.cwd = payload.cwd
+  if (payload) {
+    Object.assign(patch, runtimeWorkspaceStatePatch(payload))
   }
 
   if (typeof payload?.branch === 'string') {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -33,6 +33,7 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -48,7 +49,9 @@ import {
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
   setSessions,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setWorkspaceCwdOwner,
+  workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { $sessionTiles } from '@/store/session-states'
@@ -1053,6 +1056,47 @@ describe('resumeSession failure recovery', () => {
     await resume!('stored-1', true)
 
     expect($messages.get().map(message => message.id)).toContain('user-optimistic')
+  })
+
+  it('reconciles a detached resume response without attaching its execution cwd', async () => {
+    setCurrentCwd('/previous/project')
+    setSelectedStoredSessionId('stored-detached')
+    setSessions([storedSession({ cwd: null, id: 'stored-detached' })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-detached' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: { cwd: '/home/backend/.hermes/workspace', cwd_owned: false },
+          message_count: 0,
+          messages: [],
+          resumed: 'stored-detached',
+          running: false,
+          session_id: 'runtime-detached',
+          session_key: 'stored-detached'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-detached"
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    await act(async () => {
+      await resume!('stored-detached', true)
+    })
+
+    expect($currentCwd.get()).toBe('/previous/project')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
+    expect($sessions.get().find(session => session.id === 'stored-detached')?.cwd).toBeNull()
   })
 
   it('keeps the complete transcript with the live tail after a full renderer restart', async () => {
@@ -2255,6 +2299,57 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
   })
 
+  it('keeps a detached warm cache unowned when session.activate is unsupported', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const cachedState = clientState('stored-A')
+
+    cachedState.cwd = ''
+    cachedState.cwdOwned = false
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', cachedState]])
+    }
+
+    setCurrentCwd('/previous/project')
+    setWorkspaceCwdOwner('previous-session')
+    setSessions([storedSession({ cwd: null, id: 'stored-A' })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        throw new Error('Method not found')
+      }
+
+      if (method === 'session.usage') {
+        return { input: 0, output: 0, total: 0 } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual(
+      expect.arrayContaining(['session.activate', 'session.usage'])
+    )
+    expect($currentCwd.get()).toBe('/previous/project')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
+    expect(sessionStateByRuntimeIdRef.current.get('rt-A')).toMatchObject({ cwd: '', cwdOwned: false })
+  })
+
   it('re-arms a pending clarify in place on the warm session.activate path', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])
@@ -3153,7 +3248,7 @@ describe('createBackendSessionForSend workspace target', () => {
     vi.restoreAllMocks()
   })
 
-  it('omits cwd for an explicit no-workspace draft even when global cwd changes before send', async () => {
+  it('fresh-main route omits cwd for Home even when global cwd changes before send', async () => {
     const params = await createWith(
       () => {
         $activeGatewayProfile.set('default')
@@ -3206,7 +3301,7 @@ describe('openNewSessionTile workspace target', () => {
     vi.restoreAllMocks()
   })
 
-  it('omits cwd for a Home tile even when project scope resolves to a repo', async () => {
+  it('occupied-main openNewSessionTile route omits cwd for Home even when project scope resolves to a repo', async () => {
     $projectScope.set('p_voice')
     $projectTree.set([
       {
@@ -3235,7 +3330,14 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     let handle: HarnessHandle | null = null
-    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    render(
+      <Harness
+        activeSessionId="runtime-main"
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-main"
+      />
+    )
     await waitFor(() => expect(handle).not.toBeNull())
 
     await act(async () => {
@@ -3243,6 +3345,43 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     expect(createParams).not.toHaveProperty('cwd')
+    expect($sessionTiles.get().some(tile => tile.storedSessionId === 'stored-home-tile')).toBe(true)
+  })
+
+  it('releases the previous Files workspace when a centered Home tile is detached', async () => {
+    setSelectedStoredSessionId('stored-main')
+    setCurrentCwd('/previous/project')
+    setWorkspaceCwdOwner('stored-main')
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '/home/backend/.hermes/workspace', cwd_owned: false },
+          session_id: 'runtime-home-center',
+          stored_session_id: 'stored-home-center'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId="runtime-main"
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-main"
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: null })
+    })
+
+    expect($currentCwd.get()).toBe('/previous/project')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -59,6 +59,7 @@ import {
   $yoloActive,
   getSessionOwnerHint,
   type NewChatWorkspaceTarget,
+  releaseWorkspaceCwdOwner,
   resolveComposerSessionKey,
   sessionPinId,
   setActiveSessionId,
@@ -664,9 +665,13 @@ export function useSessionActions({
         openSessionTile(stored, dir, undefined, undefined, workspaceScope)
         patchSessionTile(stored, { runtimeId: created.session_id })
 
-        if (dir === 'center' && runtimeInfo?.cwd) {
-          setCurrentCwdTransient(runtimeInfo.cwd)
-          setWorkspaceCwdOwner(stored)
+        if (dir === 'center' && runtimeInfo?.cwd !== undefined) {
+          if (runtimeInfo.cwd && runtimeInfo.cwdOwned !== false) {
+            setCurrentCwdTransient(runtimeInfo.cwd)
+            setWorkspaceCwdOwner(stored)
+          } else {
+            releaseWorkspaceCwdOwner()
+          }
         }
 
         revealTreePane(`session-tile:${stored}`)
@@ -905,13 +910,19 @@ export function useSessionActions({
           setActiveSessionId(cachedRuntimeId)
           activeSessionIdRef.current = cachedRuntimeId
           syncSessionStateToView(cachedRuntimeId, cachedViewState)
-          setCurrentCwdTransient(cachedViewState.cwd)
-          // The warm cache IS this conversation's own workspace truth, so the
-          // switch is already re-homed here. This claim cannot wait for
-          // `session.activate`: its missing-RPC compat branch returns before
-          // `applyRuntimeInfo` runs, which would leave the workspace marked
-          // un-owned for the life of the session (#71254).
-          setWorkspaceCwdOwner(storedSessionId)
+
+          if (cachedViewState.cwd && cachedViewState.cwdOwned !== false) {
+            setCurrentCwdTransient(cachedViewState.cwd)
+            // The warm cache IS this conversation's own workspace truth, so the
+            // switch is already re-homed here. This claim cannot wait for
+            // `session.activate`: its missing-RPC compat branch returns before
+            // `applyRuntimeInfo` runs, which would leave the workspace marked
+            // un-owned for the life of the session (#71254).
+            setWorkspaceCwdOwner(storedSessionId)
+          } else {
+            releaseWorkspaceCwdOwner()
+          }
+
           setCurrentBranch(cachedViewState.branch)
           setSessionStartedAt(Date.now())
 
@@ -1458,7 +1469,7 @@ export function useSessionActions({
 
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
-        patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
+        patchSessionWorkspace(storedSessionId, runtimeInfo)
 
         // Preserve the turn-elapsed timer across cold resume: the gateway
         // reports when the in-flight turn started so the desktop can restore
@@ -1754,7 +1765,7 @@ export function useSessionActions({
         )
 
         const runtimeInfo = applyRuntimeInfo(branched.info, { foreground: false })
-        patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd)
+        patchSessionWorkspace(routedSessionId, runtimeInfo)
 
         if (runtimeInfo) {
           updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -169,6 +169,15 @@ describe('applyRuntimeInfo foreground scoping', () => {
     expect($currentCwd.get()).toBe('/project-b')
     expect(workspaceCwdBelongsToSelectedSession()).toBe(true)
   })
+
+  it('keeps a neutral execution cwd available without claiming it as a workspace', () => {
+    setSelectedStoredSessionId('session-detached')
+    const patch = applyRuntimeInfo({ cwd: '/home/backend/.hermes/workspace', cwd_owned: false })
+
+    expect(patch).toMatchObject({ cwd: '', cwdOwned: false })
+    expect($currentCwd.get()).toBe('/main-repo')
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
+  })
 })
 
 describe('applyStoredSessionPreviewRuntimeInfo workspace paint', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,7 +1,7 @@
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
-import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { normalizePersonalityValue, runtimeWorkspaceStatePatch } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { parseErrorSurface } from '@/lib/error-surface'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -36,7 +36,7 @@ export { sessionMatchesStoredId }
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
 
-import type { ClientSessionState } from '../../../types'
+import type { SessionRuntimeStatePatch } from '../../../types'
 
 function withAppendedText(message: ChatMessage, suffix: string): ChatMessage {
   let appended = false
@@ -1255,7 +1255,7 @@ export function upsertOptimisticSession(
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
     // lane immediately (the overlay groups by path); fall back to the workspace
     // the session was just started in when the create response omits it.
-    cwd: created.info?.cwd ?? ($currentCwd.get().trim() || null),
+    cwd: created.info?.cwd_owned === false ? null : (created.info?.cwd ?? ($currentCwd.get().trim() || null)),
     ended_at: null,
     id,
     input_tokens: 0,
@@ -1277,11 +1277,12 @@ export function upsertOptimisticSession(
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])
 }
 
-export function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
-  if (!cwd) {
+export function patchSessionWorkspace(sessionId: string, runtimeInfo: SessionRuntimeStatePatch | null) {
+  if (!runtimeInfo || runtimeInfo.cwd === undefined) {
     return
   }
 
+  const cwd = runtimeInfo.cwdOwned === false ? null : runtimeInfo.cwd || null
   setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
 }
 
@@ -1424,13 +1425,6 @@ export async function resolveSessionProfile(storedSessionId: null | string): Pro
   return profile || undefined
 }
 
-type SessionRuntimeStatePatch = Partial<
-  Pick<
-    ClientSessionState,
-    'branch' | 'cwd' | 'fast' | 'model' | 'personality' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
-  >
->
-
 interface ApplyRuntimeInfoOptions {
   /**
    * Whether this runtime belongs to the session the MAIN pane is showing.
@@ -1459,7 +1453,9 @@ function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
   }
 
   if (state.cwd !== undefined) {
-    if (state.cwd) {
+    // Missing cwdOwned preserves compatibility with older backends, where a
+    // non-empty cwd was the only ownership signal.
+    if (state.cwd && state.cwdOwned !== false) {
       // The runtime named a real folder for the session in the main pane, so
       // that conversation owns the path.
       commitWorkspaceCwdForSelectedSession(state.cwd)
@@ -1526,14 +1522,12 @@ export function applyRuntimeInfo(
     sessionState.provider = info.provider
   }
 
-  // Empty string is authoritative, not "no opinion": a detached/bare session
-  // reports `cwd: ''`, and the truthy-only test left `$currentCwd` — and so the
-  // Files pane — pinned to the PREVIOUS project for the rest of the session
-  // (#71254). Empty is routed through ownership release below rather than
-  // persisted, so the pane hides a path it no longer owns instead of blanking.
-  if (typeof info.cwd === 'string') {
-    sessionState.cwd = info.cwd
-  }
+  // A detached session can report a non-empty execution cwd without owning it.
+  // Project that neutral path to empty workspace state so the Files pane
+  // releases the PREVIOUS project rather than claiming the backend fallback
+  // (#71254). Older backends have no explicit flag, so retain their non-empty
+  // cwd-as-owned contract.
+  Object.assign(sessionState, runtimeWorkspaceStatePatch(info))
 
   if (info.branch !== undefined) {
     sessionState.branch = info.branch || ''

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -176,6 +176,9 @@ export interface ClientSessionState {
   messages: ChatMessage[]
   branch: string
   cwd: string
+  /** Whether cwd is a user/session workspace. Absent preserves legacy
+   *  non-empty-cwd ownership for cached states created by older renderers. */
+  cwdOwned?: boolean
   model: string
   provider: string
   reasoningEffort: string
@@ -217,3 +220,19 @@ export interface ClientSessionState {
    *  tile's context count. Null until the first turn reports. */
   usage: null | UsageStats
 }
+
+export type SessionRuntimeStatePatch = Partial<
+  Pick<
+    ClientSessionState,
+    | 'branch'
+    | 'cwd'
+    | 'cwdOwned'
+    | 'fast'
+    | 'model'
+    | 'personality'
+    | 'provider'
+    | 'reasoningEffort'
+    | 'serviceTier'
+    | 'yolo'
+  >
+>

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -81,6 +81,8 @@ export type GatewayEventPayload = {
   running?: boolean
   turn_started_at?: number | null
   cwd?: string
+  /** False when cwd is only the backend's neutral execution fallback. */
+  cwd_owned?: boolean
   branch?: string
   terminal_backend?: string
   credential_warning?: string

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -48,6 +48,22 @@ export function createClientSessionState(
   }
 }
 
+/** Normalize the backend's optional cwd-ownership contract for every Desktop
+ * runtime-info consumer. Missing ownership is the legacy contract: a non-empty
+ * cwd is owned. Explicit false keeps the execution path off workspace surfaces. */
+export function runtimeWorkspaceStatePatch(info: {
+  cwd?: unknown
+  cwd_owned?: unknown
+}): Partial<Pick<ClientSessionState, 'cwd' | 'cwdOwned'>> {
+  if (typeof info.cwd !== 'string') {
+    return {}
+  }
+
+  const cwdOwned = typeof info.cwd_owned === 'boolean' ? info.cwd_owned : Boolean(info.cwd)
+
+  return { cwd: cwdOwned ? info.cwd : '', cwdOwned }
+}
+
 export function sessionTitle(session: SessionInfo): string {
   return session.title?.trim() || session.preview?.trim() || 'Untitled session'
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -693,6 +693,8 @@ export interface SessionRuntimeInfo {
   config_warning?: string
   credential_warning?: string
   cwd?: string
+  /** False when cwd is only the backend's execution fallback, not a workspace. */
+  cwd_owned?: boolean
   desktop_contract?: number
   fast?: boolean
   install_warning?: string

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -489,6 +489,721 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
         server._sessions.pop("iso-sid", None)
 
 
+def test_compute_host_turn_end_waits_for_started_parent_workspace_move(
+    monkeypatch, tmp_path
+):
+    host_lock_attempted = threading.Event()
+    allow_host_lock = threading.Event()
+
+    class ObservedHistoryLock:
+        """Expose whether completion could cross the topology boundary."""
+
+        def __init__(self):
+            self._lock = threading.Lock()
+            self.host_acquired_before_move_commit = None
+
+        def __enter__(self):
+            if threading.current_thread().name == "host-completion":
+                acquired = self._lock.acquire(blocking=False)
+                self.host_acquired_before_move_commit = acquired
+                host_lock_attempted.set()
+                if not allow_host_lock.wait(5):
+                    raise AssertionError("test did not release host completion")
+                if not acquired:
+                    self._lock.acquire()
+            else:
+                self._lock.acquire()
+            return self
+
+        def __exit__(self, *_args):
+            self._lock.release()
+
+    old_cwd = tmp_path / "neutral"
+    new_cwd = tmp_path / "explicit-project"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(old_cwd),
+        cwd_owned=False,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        source="desktop",
+        _compute_host_active=True,
+        running=True,
+        queued_prompt={"text": "queued next turn", "transport": None},
+    )
+    session["agent"] = None
+    session["session_key"] = "stored-isolated-session"
+    history_lock = ObservedHistoryLock()
+    session["history_lock"] = history_lock
+    server._sessions["iso-sid"] = session
+    emitted = []
+    queued_frames = []
+    row = {"id": session["session_key"], "cwd": str(old_cwd)}
+    db_updated = threading.Event()
+    release_move = threading.Event()
+    move_done = threading.Event()
+    completion_started = threading.Event()
+    completion_done = threading.Event()
+    move_result = {}
+    thread_errors = []
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return dict(row) if session_id == row["id"] else None
+
+        def update_session_cwd(
+            self,
+            session_id,
+            cwd,
+            branch=None,
+            root=None,
+            replace_git_meta=True,
+        ):
+            assert session_id == row["id"]
+            row["cwd"] = cwd
+            db_updated.set()
+            if not release_move.wait(5):
+                raise AssertionError("test did not release paused workspace move")
+
+    class FakeSupervisor:
+        def submit_turn(self, frame, *, on_complete=None):
+            queued_frames.append(dict(frame))
+            return frame["request_id"]
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def fake_profile_db(_params):
+        yield FakeDB()
+
+    monkeypatch.setattr(server, "_profile_db", fake_profile_db)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "main")
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", lambda _cwd: str(new_cwd))
+    monkeypatch.setattr(server, "_persist_session_cwd_and_schedule_git_meta", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: FakeSupervisor())
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, current=None: {
+            "cwd": (current or session)["cwd"],
+            "cwd_owned": bool((current or session).get("cwd_owned")),
+            "explicit_cwd": bool((current or session).get("explicit_cwd")),
+            "cwd_from_settle": bool((current or session).get("cwd_from_settle")),
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "_load_dashboard_process_isolation_config",
+        lambda _cfg=None: {
+            "turn_isolation": True,
+            "compute_host_heartbeat_secs": 15,
+            "compute_host_respawn_max": 3,
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    turn_start = server._compute_host_turn_frame(
+        "turn-1", "iso-sid", session, "running turn"
+    )
+
+    def run_move():
+        try:
+            move_result.update(
+                server._methods["session.workspace.move"](
+                    "move-1",
+                    {"session_key": session["session_key"], "cwd": str(new_cwd)},
+                )
+            )
+        except BaseException as exc:
+            thread_errors.append(exc)
+        finally:
+            move_done.set()
+
+    def complete_host_turn():
+        completion_started.set()
+        try:
+            server._on_compute_host_turn_done(
+                "turn-1",
+                "iso-sid",
+                session,
+                {
+                    "type": "turn.end",
+                    "workspace_topology_base_generation": turn_start[
+                        "workspace_topology_generation"
+                    ],
+                    "workspace_topology_generation": turn_start[
+                        "workspace_topology_generation"
+                    ],
+                    "session_info": {
+                        "cwd": str(old_cwd),
+                        "cwd_owned": False,
+                        "explicit_cwd": False,
+                        "cwd_from_settle": False,
+                    },
+                },
+            )
+        except BaseException as exc:
+            thread_errors.append(exc)
+        finally:
+            completion_done.set()
+
+    move_thread = threading.Thread(target=run_move, name="workspace-move")
+    completion_thread = threading.Thread(
+        target=complete_host_turn, name="host-completion"
+    )
+    try:
+        move_thread.start()
+        assert db_updated.wait(5), "workspace move never reached the DB/live gap"
+
+        completion_thread.start()
+        assert completion_started.wait(5), "host completion thread did not start"
+        assert host_lock_attempted.wait(5), "host completion did not reach history_lock"
+
+        # The row already names the new workspace, but live topology has not
+        # published yet. Completion must remain ordered behind that publication:
+        # it may neither emit the host's stale neutral snapshot nor drain the
+        # queued turn into a frame built from generation 0.
+        assert history_lock.host_acquired_before_move_commit is False
+        allow_host_lock.set()
+        assert not completion_done.is_set()
+        assert not emitted
+        assert not queued_frames
+
+        release_move.set()
+        assert move_done.wait(5), "workspace move did not finish"
+        assert completion_done.wait(5), "host completion did not finish"
+        move_thread.join(timeout=1)
+        completion_thread.join(timeout=1)
+
+        assert not thread_errors
+        assert "error" not in move_result, move_result
+
+        assert session["cwd"] == str(new_cwd)
+        assert session["cwd_owned"] is True
+        assert session["explicit_cwd"] is True
+        assert session["cwd_from_settle"] is False
+        assert session["_workspace_topology_generation"] == 1
+        assert row["cwd"] == str(new_cwd)
+        assert queued_frames[-1]["cwd"] == str(new_cwd)
+        assert queued_frames[-1]["cwd_owned"] is True
+        assert queued_frames[-1]["explicit_cwd"] is True
+        assert queued_frames[-1]["cwd_from_settle"] is False
+        session_info_events = [
+            payload for event, _sid, payload in emitted if event == "session.info"
+        ]
+        assert session_info_events
+        assert all(payload["cwd"] == str(new_cwd) for payload in session_info_events)
+        assert all(payload["cwd_owned"] is True for payload in session_info_events)
+    finally:
+        allow_host_lock.set()
+        release_move.set()
+        move_thread.join(timeout=5)
+        completion_thread.join(timeout=5)
+        server._sessions.pop("iso-sid", None)
+
+
+def test_compute_host_turn_end_applies_host_settle_without_parent_mutation(
+    monkeypatch, tmp_path
+):
+    old_cwd = tmp_path / "neutral"
+    settled_cwd = tmp_path / "settled-project"
+    old_cwd.mkdir()
+    settled_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(old_cwd),
+        cwd_owned=False,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        source="desktop",
+        _compute_host_active=True,
+        running=True,
+        queued_prompt={"text": "queued next turn", "transport": None},
+    )
+    session["agent"] = None
+    queued_frames = []
+
+    class FakeSupervisor:
+        def submit_turn(self, frame, *, on_complete=None):
+            queued_frames.append(dict(frame))
+            return frame["request_id"]
+
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: FakeSupervisor())
+    monkeypatch.setattr(
+        server,
+        "_load_dashboard_process_isolation_config",
+        lambda _cfg=None: {
+            "turn_isolation": True,
+            "compute_host_heartbeat_secs": 15,
+            "compute_host_respawn_max": 3,
+        },
+    )
+
+    turn_start = server._compute_host_turn_frame(
+        "turn-1", "iso-sid", session, "running turn"
+    )
+
+    server._on_compute_host_turn_done(
+        "turn-1",
+        "iso-sid",
+        session,
+        {
+            "type": "turn.end",
+            "workspace_topology_base_generation": turn_start[
+                "workspace_topology_generation"
+            ],
+            "workspace_topology_generation": (
+                turn_start["workspace_topology_generation"] + 1
+            ),
+            "session_info": {
+                "cwd": str(settled_cwd),
+                "cwd_owned": True,
+                "explicit_cwd": True,
+                "cwd_from_settle": True,
+            },
+        },
+    )
+
+    assert session["cwd"] == str(settled_cwd)
+    assert session["cwd_owned"] is True
+    assert session["explicit_cwd"] is True
+    assert session["cwd_from_settle"] is True
+
+    next_frame = queued_frames[-1]
+    assert next_frame["cwd"] == str(settled_cwd)
+    assert next_frame["cwd_owned"] is True
+    assert next_frame["explicit_cwd"] is True
+    assert next_frame["cwd_from_settle"] is True
+
+
+def test_generationless_control_ack_cannot_rewind_generation_aware_workspace(
+    monkeypatch, tmp_path
+):
+    old_cwd = tmp_path / "old-host-workspace"
+    new_cwd = tmp_path / "new-parent-workspace"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(new_cwd),
+        cwd_owned=True,
+        explicit_cwd=True,
+        cwd_from_settle=False,
+        source="desktop",
+        _compute_host_active=True,
+        _workspace_topology_generation=1,
+    )
+    session["agent"] = None
+    emitted = []
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "new-branch")
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    # An acknowledgement from a legacy/old child arrives after generation 1
+    # was published by session.workspace.move. It carries topology but no
+    # causal envelope, so only its non-topology metadata remains usable.
+    server._apply_compute_host_metadata_mirror(
+        session,
+        {
+            "type": "control.ack",
+            "session_info": {
+                "cwd": str(old_cwd),
+                "cwd_owned": False,
+                "explicit_cwd": False,
+                "cwd_from_settle": True,
+                "branch": "old-branch",
+                "project": {"id": "old-project"},
+                "model": "host-model",
+            },
+        },
+    )
+    server._emit("session.info", "sid", server._session_info(None, session))
+    next_frame = server._compute_host_turn_frame(
+        "next-turn", "sid", session, "continue"
+    )
+
+    assert session["cwd"] == str(new_cwd)
+    assert session["cwd_owned"] is True
+    assert session["explicit_cwd"] is True
+    assert session["cwd_from_settle"] is False
+    assert session["_metadata_mirror"]["model"] == "host-model"
+    assert "cwd" not in session["_metadata_mirror"]
+    assert "branch" not in session["_metadata_mirror"]
+    assert emitted[-1][2]["cwd"] == str(new_cwd)
+    assert emitted[-1][2]["cwd_owned"] is True
+    assert emitted[-1][2]["branch"] == "new-branch"
+    assert next_frame["cwd"] == str(new_cwd)
+    assert next_frame["cwd_owned"] is True
+    assert next_frame["workspace_topology_generation"] == 1
+
+
+def test_generationless_control_ack_remains_compatible_with_legacy_session(
+    monkeypatch, tmp_path
+):
+    legacy_cwd = tmp_path / "legacy-host-workspace"
+    legacy_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(tmp_path),
+        cwd_owned=False,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        source="desktop",
+    )
+    session["agent"] = None
+    session.pop("_workspace_topology_generation", None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+
+    server._apply_compute_host_metadata_mirror(
+        session,
+        {
+            "type": "control.ack",
+            "session_info": {
+                "cwd": str(legacy_cwd),
+                "cwd_owned": True,
+                "explicit_cwd": True,
+                "cwd_from_settle": True,
+            },
+        },
+    )
+
+    assert session["cwd"] == str(legacy_cwd)
+    assert session["cwd_owned"] is True
+    assert session["explicit_cwd"] is True
+    assert session["cwd_from_settle"] is True
+
+
+def test_compute_host_control_request_snapshots_parent_topology_generation(monkeypatch):
+    captured = {}
+
+    class FakeSupervisor:
+        def control(self, sid, **kwargs):
+            captured.update({"sid": sid, **kwargs})
+            return {"type": "control.ack"}
+
+    session = _session(_workspace_topology_generation=7)
+    server._sessions["control-generation"] = session
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda: FakeSupervisor())
+    try:
+        server._send_compute_host_control(
+            "control-generation",
+            route_name="slash.prompt",
+            command="/prompt concise",
+        )
+    finally:
+        server._sessions.pop("control-generation", None)
+
+    assert captured["payload"]["workspace_topology_generation"] == 7
+
+
+def test_stale_compute_host_control_metadata_emits_no_parent_session_info(
+    monkeypatch, tmp_path
+):
+    child_cwd = tmp_path / "child-old"
+    parent_cwd = tmp_path / "parent-new"
+    child_cwd.mkdir()
+    parent_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(parent_cwd),
+        cwd_owned=True,
+        explicit_cwd=True,
+        cwd_from_settle=False,
+        _compute_host_active=True,
+        _workspace_topology_generation=1,
+    )
+    session["agent"] = None
+    server._sessions["stale-control"] = session
+    emitted = []
+    ack = {
+        "type": "control.ack",
+        "workspace_topology_base_generation": 1,
+        "workspace_topology_generation": 0,
+        "session_info": {
+            "cwd": str(child_cwd),
+            "cwd_owned": False,
+            "explicit_cwd": False,
+            "cwd_from_settle": False,
+        },
+    }
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    try:
+        server._apply_compute_host_control_metadata("stale-control", session, ack)
+    finally:
+        server._sessions.pop("stale-control", None)
+
+    assert session["cwd"] == str(parent_cwd)
+    assert session["cwd_owned"] is True
+    assert session["_workspace_topology_generation"] == 1
+    assert "cwd" not in ack["session_info"]
+    assert emitted == []
+
+
+def test_accepted_compute_host_control_topology_emits_one_parent_session_info(
+    monkeypatch, tmp_path
+):
+    old_cwd = tmp_path / "old"
+    child_cwd = tmp_path / "child-current"
+    old_cwd.mkdir()
+    child_cwd.mkdir()
+    session = _session(
+        agent=None,
+        cwd=str(old_cwd),
+        cwd_owned=False,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        _compute_host_active=True,
+        _workspace_topology_generation=1,
+    )
+    session["agent"] = None
+    server._sessions["accepted-control"] = session
+    emitted = []
+    ack = {
+        "type": "control.ack",
+        "workspace_topology_base_generation": 1,
+        "workspace_topology_generation": 2,
+        "session_info": {
+            "cwd": str(child_cwd),
+            "cwd_owned": True,
+            "explicit_cwd": True,
+            "cwd_from_settle": True,
+        },
+    }
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        server,
+        "_persist_session_cwd_and_schedule_git_meta",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, current: {
+            "cwd": current["cwd"],
+            "cwd_owned": current["cwd_owned"],
+            "explicit_cwd": current["explicit_cwd"],
+            "cwd_from_settle": current["cwd_from_settle"],
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    try:
+        server._apply_compute_host_control_metadata("accepted-control", session, ack)
+    finally:
+        server._sessions.pop("accepted-control", None)
+
+    assert session["cwd"] == str(child_cwd)
+    assert session["cwd_owned"] is True
+    assert session["_workspace_topology_generation"] == 2
+    assert emitted == [
+        (
+            "session.info",
+            "accepted-control",
+            {
+                "cwd": str(child_cwd),
+                "cwd_owned": True,
+                "explicit_cwd": True,
+                "cwd_from_settle": True,
+            },
+        )
+    ]
+
+
+def test_stale_host_settle_completion_repairs_shared_db_before_resume(
+    monkeypatch, tmp_path
+):
+    """A rejected child settle cannot remain authoritative after restart."""
+    import contextlib
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from hermes_state import SessionDB
+
+    home = tmp_path / ".hermes"
+    old_cwd = tmp_path / "old-workspace"
+    parent_cwd = tmp_path / "parent-workspace"
+    stale_settled_cwd = tmp_path / "stale-settled-workspace"
+    for path in (home, old_cwd, parent_cwd, stale_settled_cwd):
+        path.mkdir()
+    db_path = home / "state.db"
+    parent_db = SessionDB(db_path=db_path)
+    child_db = SessionDB(db_path=db_path)
+    session_key = "stale-settle-row"
+    parent_db.create_session(session_key, source="desktop", cwd=str(old_cwd))
+    token = set_hermes_home_override(home)
+    resumed_sid = ""
+
+    @contextlib.contextmanager
+    def parent_profile_db(_params):
+        yield parent_db
+
+    session = _session(
+        agent=None,
+        session_key=session_key,
+        profile_home=str(home),
+        cwd=str(old_cwd),
+        cwd_owned=True,
+        explicit_cwd=True,
+        cwd_from_settle=False,
+        source="desktop",
+        running=True,
+        _compute_host_active=True,
+        _workspace_topology_generation=0,
+    )
+    session["agent"] = None
+    server._sessions["stale-settle-live"] = session
+    monkeypatch.setattr(server, "_profile_db", parent_profile_db)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "main")
+    monkeypatch.setattr(
+        server, "_git_common_repo_root_for_cwd", lambda _cwd: str(parent_cwd)
+    )
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+
+    try:
+        moved = server._methods["session.workspace.move"](
+            "move-1", {"session_key": session_key, "cwd": str(parent_cwd)}
+        )
+        assert "error" not in moved, moved
+        assert session["_workspace_topology_generation"] == 1
+        assert parent_db.get_session(session_key)["cwd"] == str(parent_cwd)
+
+        # This is the real two-handle race: the child commits its stale settle
+        # after the parent's generation-1 move has already committed.
+        child_db.update_session_cwd(session_key, str(stale_settled_cwd))
+        assert parent_db.get_session(session_key)["cwd"] == str(stale_settled_cwd)
+
+        server._on_compute_host_turn_done(
+            "turn-1",
+            "stale-settle-live",
+            session,
+            {
+                "type": "turn.end",
+                "workspace_topology_base_generation": 0,
+                "workspace_topology_generation": 1,
+                "session_info": {
+                    "cwd": str(stale_settled_cwd),
+                    "cwd_owned": True,
+                    "explicit_cwd": True,
+                    "cwd_from_settle": True,
+                },
+                "session_info_emitted": False,
+            },
+        )
+
+        assert session["cwd"] == str(parent_cwd)
+        assert session["cwd_from_settle"] is False
+        assert parent_db.get_session(session_key)["cwd"] == str(parent_cwd)
+
+        # Drop all live authority and reconstruct through the real resume path.
+        server._sessions.pop("stale-settle-live", None)
+        _prepare_workspace_resume_runtime(monkeypatch, home, parent_db, home)
+        resumed = _resume_workspace_session(session_key, "cold")
+        resumed_sid = resumed["result"]["session_id"]
+        assert server._sessions[resumed_sid]["cwd"] == str(parent_cwd)
+        assert resumed["result"]["info"]["cwd_owned"] is True
+    finally:
+        server._sessions.pop("stale-settle-live", None)
+        if resumed_sid:
+            _close_workspace_test_session(resumed_sid, session_key)
+        child_db.close()
+        parent_db.close()
+        reset_hermes_home_override(token)
+
+
+def test_accepted_host_settle_persists_and_resumes(monkeypatch, tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from hermes_state import SessionDB
+
+    home = tmp_path / ".hermes"
+    old_cwd = tmp_path / "old-workspace"
+    settled_cwd = tmp_path / "settled-workspace"
+    for path in (home, old_cwd, settled_cwd):
+        path.mkdir()
+    db = SessionDB(db_path=home / "state.db")
+    session_key = "accepted-settle-row"
+    db.create_session(session_key, source="desktop", cwd=str(old_cwd))
+    token = set_hermes_home_override(home)
+    resumed_sid = ""
+    session = _session(
+        agent=None,
+        session_key=session_key,
+        profile_home=str(home),
+        cwd=str(old_cwd),
+        cwd_owned=True,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        source="desktop",
+        running=True,
+        _compute_host_active=True,
+        _workspace_topology_generation=0,
+    )
+    session["agent"] = None
+    server._sessions["accepted-settle-live"] = session
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+
+    try:
+        server._on_compute_host_turn_done(
+            "turn-1",
+            "accepted-settle-live",
+            session,
+            {
+                "type": "turn.end",
+                "workspace_topology_base_generation": 0,
+                "workspace_topology_generation": 1,
+                "session_info": {
+                    "cwd": str(settled_cwd),
+                    "cwd_owned": True,
+                    "explicit_cwd": True,
+                    "cwd_from_settle": True,
+                },
+                "session_info_emitted": False,
+            },
+        )
+
+        assert session["cwd"] == str(settled_cwd)
+        assert session["cwd_from_settle"] is True
+        assert db.get_session(session_key)["cwd"] == str(settled_cwd)
+
+        server._sessions.pop("accepted-settle-live", None)
+        _prepare_workspace_resume_runtime(monkeypatch, home, db, home)
+        resumed = _resume_workspace_session(session_key, "cold")
+        resumed_sid = resumed["result"]["session_id"]
+        assert server._sessions[resumed_sid]["cwd"] == str(settled_cwd)
+        assert resumed["result"]["info"]["cwd_owned"] is True
+    finally:
+        server._sessions.pop("accepted-settle-live", None)
+        if resumed_sid:
+            _close_workspace_test_session(resumed_sid, session_key)
+        db.close()
+        reset_hermes_home_override(token)
+
+
 def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
     class _ExplodingWorker:
         def __init__(self, *args, **kwargs):
@@ -5409,7 +6124,9 @@ def test_superseded_by_resume_is_recoverable_end_reason():
     assert "superseded_by_resume" not in server._RECLAIM_END_REASONS
 
 
-def test_lazy_unpersisted_resume_rebinds_transport_and_cancels_reap(monkeypatch):
+def test_lazy_unpersisted_resume_rebinds_transport_and_cancels_reap(
+    monkeypatch, tmp_path
+):
     """The lazy/unpersisted resume branch (no state.db row yet — every fresh
     Bot Chat) must ALSO rebind the transport and cancel the pending reap when
     it hands back a sentinel-parked live record. Found by live WS E2E after
@@ -5448,13 +6165,21 @@ def test_lazy_unpersisted_resume_rebinds_transport_and_cancels_reap(monkeypatch)
         ),
     )
 
+    neutral_cwd = tmp_path / "neutral-workspace"
+    neutral_cwd.mkdir()
     session = _session(
         session_key="stored-lazy",
         transport=server._detached_ws_transport,
         running=False,
         history=[],
         profile_home=None,
+        cwd=str(neutral_cwd),
+        cwd_owned=False,
+        explicit_cwd=False,
+        source="desktop",
     )
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda *_args, **_kwargs: None)
     server._sessions["lazy-sid"] = session
 
     try:
@@ -5471,6 +6196,15 @@ def test_lazy_unpersisted_resume_rebinds_transport_and_cancels_reap(monkeypatch)
         )
 
         assert resp is not None and resp["result"]["session_id"] == "lazy-sid"
+        assert resp["result"]["info"] == {
+            "branch": "",
+            "cwd": str(neutral_cwd),
+            "cwd_owned": False,
+            "lazy": True,
+            "model": server._resolve_model(),
+            "profile_name": "",
+            "project": None,
+        }
         assert session["transport"] is live_transport
         assert "lazy-sid" not in server._pending_ws_reaps
         assert len(cancelled) == 1
@@ -14306,6 +15040,391 @@ def test_session_create_reports_requested_profile_name(monkeypatch, tmp_path):
         _clear()
 
 
+@pytest.mark.parametrize("profile", ["default", "coder"])
+@pytest.mark.parametrize("workspace_exists", [False, True])
+def test_desktop_detached_session_create_uses_profile_default_workspace(
+    monkeypatch, tmp_path, profile, workspace_exists
+):
+    from hermes_cli import projects_db as pdb
+
+    default_home = tmp_path / ".hermes"
+    named_home = default_home / "profiles" / "coder"
+    profile_home = default_home if profile == "default" else named_home
+    profile_home.mkdir(parents=True)
+    workspace = profile_home / "workspace"
+    if workspace_exists:
+        workspace.mkdir()
+    fallback_cwd = workspace if workspace_exists else profile_home
+    with pdb.connect_closing(profile_home / "projects.db") as conn:
+        pdb.create_project(
+            conn,
+            name="Neutral Cwd Project",
+            folders=[str(profile_home)],
+            primary_path=str(profile_home),
+        )
+
+    stale_config_cwd = tmp_path / "configured-project"
+    stale_env_cwd = tmp_path / "process-project"
+    for path in (stale_config_cwd, stale_env_cwd):
+        path.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(stale_env_cwd))
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(stale_config_cwd)}}
+    )
+    monkeypatch.setattr(server, "get_hermes_home", lambda: default_home)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda name: named_home if name == "coder" else None
+    )
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    sid = None
+    session_key = ""
+    token = set_hermes_home_override(default_home)
+    try:
+        response = server._methods["session.create"](
+            "detached",
+            {"cols": 80, "profile": profile, "source": "desktop"},
+        )
+        sid = response["result"]["session_id"]
+        session_key = response["result"]["stored_session_id"]
+        session = server._sessions[sid]
+        assert response["result"]["info"]["cwd"] == str(fallback_cwd)
+        assert response["result"]["info"]["cwd_owned"] is False
+        assert session["cwd"] == str(fallback_cwd)
+        assert session["explicit_cwd"] is False
+        assert server._persisted_session_cwd(session) is None
+        assert response["result"]["info"]["project"] is None
+    finally:
+        if sid is not None:
+            _close_workspace_test_session(sid, session_key)
+        reset_hermes_home_override(token)
+
+
+def _close_workspace_test_session(sid: str, session_key: str) -> None:
+    """Use the runtime cleanup seams and release terminal cwd registration."""
+    if sid in server._sessions:
+        server._methods["session.close"]("workspace-test-close", {"session_id": sid})
+    from tools.terminal_tool import clear_task_env_overrides
+
+    clear_task_env_overrides(session_key)
+
+
+class _WorkspaceResumeAgent:
+    model = "test-model"
+    provider = "test-provider"
+    reasoning_config = None
+    service_tier = ""
+    tools = []
+
+    def close(self):
+        return None
+
+
+def _prepare_workspace_resume_runtime(monkeypatch, home, db, configured_cwd):
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured_cwd)}}
+    )
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: _WorkspaceResumeAgent())
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *a, **k: threading.Event()
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    # Deferred history owns its hydration thread, but these tests stop at the
+    # reconstructed live record rather than building an external model client.
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+
+def _resume_workspace_session(session_key: str, mode: str) -> dict:
+    params = {"session_id": session_key, "source": "desktop"}
+    if mode == "deferred":
+        params["defer_history"] = True
+    elif mode == "eager":
+        params["eager_build"] = True
+    response = server._methods["session.resume"]("workspace-resume", params)
+    assert "error" not in response, response
+    return response
+
+
+@pytest.mark.parametrize("mode", ["cold", "deferred", "eager"])
+@pytest.mark.parametrize("owned", [False, True], ids=["detached", "explicit"])
+def test_desktop_create_restart_resume_preserves_workspace_ownership(
+    monkeypatch, tmp_path, mode, owned
+):
+    from hermes_cli import projects_db as pdb
+    from hermes_state import SessionDB
+
+    home = tmp_path / ".hermes"
+    neutral = home / "workspace"
+    workspace = tmp_path / "picked-workspace"
+    neutral.mkdir(parents=True)
+    workspace.mkdir()
+    token = set_hermes_home_override(home)
+    db = SessionDB(db_path=home / "state.db")
+    created_sid = resumed_sid = session_key = ""
+    try:
+        with pdb.connect_closing(home / "projects.db") as conn:
+            project_id = pdb.create_project(
+                conn,
+                name="Picked Project",
+                folders=[str(workspace)],
+                primary_path=str(workspace),
+            )
+        project = {
+            "id": project_id,
+            "name": "Picked Project",
+            "primary_path": str(workspace),
+            "slug": "picked-project",
+        }
+        _prepare_workspace_resume_runtime(monkeypatch, home, db, home)
+
+        create_params = {"source": "desktop"}
+        if owned:
+            create_params["cwd"] = str(workspace)
+        created = server._methods["session.create"](
+            "workspace-create", create_params
+        )["result"]
+        created_sid = created["session_id"]
+        session_key = created["stored_session_id"]
+        server._ensure_session_db_row(server._sessions[created_sid])
+        assert db.get_session(session_key)["cwd"] == (str(workspace) if owned else None)
+        if not owned and mode == "cold":
+            db._conn.execute("UPDATE sessions SET source='' WHERE id=?", (session_key,))
+            db._conn.commit()
+            monkeypatch.setattr(server, "_resolve_session_platform", lambda: "tui")
+        _close_workspace_test_session(created_sid, session_key)
+        created_sid = ""
+
+        resumed = _resume_workspace_session(session_key, mode)
+        resumed_sid = resumed["result"]["session_id"]
+        record = server._sessions[resumed_sid]
+        if mode == "deferred":
+            assert record["resume_history_ready"].wait(2)
+
+        expected_cwd = workspace if owned else neutral
+        expected_project = project if owned else None
+        assert record["cwd"] == str(expected_cwd)
+        assert record["explicit_cwd"] is owned
+        assert resumed["result"]["info"]["cwd_owned"] is owned
+        assert resumed["result"]["info"]["project"] == expected_project
+        assert server._session_info(_WorkspaceResumeAgent(), record)["project"] == expected_project
+        assert db.get_session(session_key)["cwd"] == (str(workspace) if owned else None)
+
+        # A second resume exercises the warm live-reuse response, not a builder.
+        warm = _resume_workspace_session(session_key, "cold")["result"]
+        assert warm["session_id"] == resumed_sid
+        assert warm["info"]["cwd_owned"] is owned
+    finally:
+        if created_sid:
+            _close_workspace_test_session(created_sid, session_key)
+        if resumed_sid:
+            _close_workspace_test_session(resumed_sid, session_key)
+        db.close()
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.parametrize(
+    ("stored_source", "request_source", "stored_cwd", "owned", "explicit", "cwd_kind"),
+    [
+        ("", "desktop", None, False, False, "neutral"),
+        ("tui", "desktop", None, True, False, "default"),
+        ("desktop", "tui", "picked", True, True, "picked"),
+    ],
+)
+def test_reconstruct_cwd_uses_stored_topology_then_explicit_request_source(
+    monkeypatch, tmp_path, stored_source, request_source, stored_cwd, owned, explicit, cwd_kind
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    neutral = home / "workspace"
+    neutral.mkdir()
+    monkeypatch.setattr(server, "_resolve_session_platform", lambda: "tui")
+
+    picked = tmp_path / "picked"
+    picked.mkdir()
+    cwd, actual_owned, actual_explicit = server._reconstruct_session_cwd(
+        {"cwd": str(picked) if stored_cwd else None, "source": stored_source},
+        home,
+        request_source=request_source,
+    )
+
+    expected_cwd = {
+        "default": Path(server._default_session_cwd()),
+        "neutral": neutral,
+        "picked": picked,
+    }[cwd_kind]
+    assert (cwd, actual_owned, actual_explicit) == (str(expected_cwd), owned, explicit)
+
+
+def test_named_profile_session_info_resolves_project_from_its_own_db(
+    monkeypatch, tmp_path
+):
+    from hermes_cli import projects_db as pdb
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "coder"
+    workspace = tmp_path / "coder-project"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    workspace.mkdir()
+    with pdb.connect_closing(profile_home / "projects.db") as conn:
+        project_id = pdb.create_project(
+            conn,
+            name="Coder Project",
+            folders=[str(workspace)],
+            primary_path=str(workspace),
+        )
+
+    token = set_hermes_home_override(launch_home)
+    try:
+        session = {
+            "cwd": str(workspace),
+            "cwd_owned": True,
+            "explicit_cwd": True,
+            "history_lock": threading.Lock(),
+            "profile_home": str(profile_home),
+            "session_key": "named-project",
+            "source": "desktop",
+        }
+        monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "")
+        info = server._session_info(_WorkspaceResumeAgent(), session)
+        assert info["project"] == {
+            "id": project_id,
+            "name": "Coder Project",
+            "primary_path": str(workspace),
+            "slug": "coder-project",
+        }
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_workspace_ownership_survives_turn_isolation_frame_and_fallback_record(
+    tmp_path,
+):
+    detached = {
+        "cols": 80,
+        "cwd": str(tmp_path),
+        "cwd_owned": False,
+        "explicit_cwd": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": "detached-frame",
+        "source": "desktop",
+    }
+
+    frame = server._compute_host_turn_frame("rid", "sid", detached, "hello")
+    record = server._deferred_session_record(
+        "detached-frame",
+        cols=80,
+        cwd=str(tmp_path),
+        history=[],
+        lease=None,
+        source="desktop",
+        explicit_cwd=False,
+        cwd_owned=False,
+    )
+
+    assert frame["cwd_owned"] is False
+    assert frame["explicit_cwd"] is False
+    assert record["cwd_owned"] is False
+    assert record["explicit_cwd"] is False
+
+
+@pytest.mark.parametrize("projection", ["lazy", "fallback", "built", "status"])
+def test_every_info_projection_heals_dead_neutral_cwd(
+    monkeypatch, tmp_path, projection
+):
+    live = tmp_path / "live"
+    live.mkdir()
+    session = {
+        "agent": None,
+        "cwd": str(live / "dead"),
+        "cwd_owned": False,
+        "explicit_cwd": False,
+        "history_lock": threading.Lock(),
+        "session_key": "dead-neutral",
+        "source": "desktop",
+    }
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(server, "_git_repo_root_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(
+        server,
+        "_project_info_for_cwd",
+        lambda cwd, *_args, **_kwargs: (
+            {
+                "id": "wrong-neutral-project",
+                "name": "Wrong Neutral Project",
+                "primary_path": str(live),
+                "slug": "wrong-neutral-project",
+            }
+            if cwd
+            else None
+        ),
+    )
+    if projection == "status":
+        server._sessions["dead-neutral-status"] = session
+        try:
+            response = server._methods["session.status"](
+                "rid", {"session_id": "dead-neutral-status"}
+            )
+            assert "result" in response
+            assert "Project:" not in response["result"]["output"]
+            assert session["cwd"] == str(live)
+        finally:
+            server._sessions.pop("dead-neutral-status", None)
+        return
+    else:
+        info = {
+            "lazy": lambda: server._lazy_resume_info(session),
+            "fallback": lambda: server._fallback_session_info(session),
+            "built": lambda: server._session_info(_WorkspaceResumeAgent(), session),
+        }[projection]()
+    assert (info["cwd"], info["cwd_owned"], info["project"]) == (
+        str(live),
+        False,
+        None,
+    )
+
+
+@pytest.mark.parametrize("mode", ["deferred", "eager"])
+def test_legacy_tui_null_cwd_persistence_is_resume_mode_independent(
+    monkeypatch, tmp_path, mode
+):
+    from hermes_state import SessionDB
+
+    home = tmp_path / ".hermes"
+    workspace = home / "workspace"
+    workspace.mkdir(parents=True)
+    token = set_hermes_home_override(home)
+    db = SessionDB(db_path=home / "state.db")
+    resumed_sid = ""
+    try:
+        db.create_session("legacy-tui-null", source="tui", cwd=None)
+        _prepare_workspace_resume_runtime(monkeypatch, home, db, workspace)
+        resumed = _resume_workspace_session("legacy-tui-null", mode)
+        resumed_sid = resumed["result"]["session_id"]
+        if mode == "deferred":
+            assert server._sessions[resumed_sid]["resume_history_ready"].wait(2)
+        assert db.get_session("legacy-tui-null")["cwd"] == str(workspace)
+        assert resumed["result"]["info"]["cwd_owned"] is True
+    finally:
+        if resumed_sid:
+            _close_workspace_test_session(resumed_sid, "legacy-tui-null")
+        db.close()
+        reset_hermes_home_override(token)
+
+
 def test_session_delete_honors_params_profile_sessions_dir(monkeypatch, tmp_path):
     """Issue #62503: delete must target the profile state.db + sessions dir."""
     profile_home = tmp_path / "profiles" / "mlperf"
@@ -14594,7 +15713,13 @@ def test_teardown_ends_session_in_profile_db(monkeypatch, tmp_path):
     assert str(seen.get("db_path")).endswith("state.db")
 
 
-def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("parent_owned", "parent_explicit"),
+    [(False, False), (True, True)],
+)
+def test_session_branch_writes_to_parent_profile_db(
+    monkeypatch, tmp_path, parent_owned, parent_explicit
+):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
@@ -14630,6 +15755,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             seen["created"] = new_key
             seen["parent"] = kwargs.get("parent_session_id")
             seen["profile_name"] = kwargs.get("profile_name")
+            seen["created_cwd"] = kwargs.get("cwd")
 
         def append_message(self, **kwargs):
             seen["msgs"].append(kwargs)
@@ -14664,11 +15790,13 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         "running": False,
         "cols": 80,
         "profile_home": str(profile_home),
-        "source": "tui",
+        "source": "desktop",
         "agent": FakeAgent(),
         "created_at": 1.0,
         "last_active": 1.0,
         "cwd": str(tmp_path),
+        "cwd_owned": parent_owned,
+        "explicit_cwd": parent_explicit,
     }
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
@@ -14705,7 +15833,12 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         assert seen.get("launch") is None
         assert seen.get("launch_create") is None
         child_sid = resp["result"]["session_id"]
-        assert server._sessions[child_sid]["profile_home"] == str(profile_home)
+        child = server._sessions[child_sid]
+        assert child["profile_home"] == str(profile_home)
+        assert seen["created_cwd"] == (str(tmp_path) if parent_owned else None)
+        assert child["cwd_owned"] is parent_owned
+        assert child["explicit_cwd"] is parent_explicit
+        assert resp["result"]["info"]["cwd_owned"] is parent_owned
         # The branched AGENT must be bound to the parent profile's state.db —
         # not just the row. Otherwise its own flushes (and a later compression
         # rotation) land on the launch db, splitting the lineage again.
@@ -19509,7 +20642,7 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         server._sessions.pop("sid_trim", None)
 
 
-def test_fallback_session_info_reports_session_cwd_not_launch_dir(monkeypatch):
+def test_fallback_session_info_reports_session_cwd_not_launch_dir(monkeypatch, tmp_path):
     """A lazily-resumed session must report ITS workspace, not the gateway's.
 
     ``_fallback_session_info`` used ``_default_session_cwd()`` — the directory the
@@ -19521,9 +20654,11 @@ def test_fallback_session_info_reports_session_cwd_not_launch_dir(monkeypatch):
     monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    info = server._fallback_session_info({"cwd": "/projects/session-own-repo"})
+    session_cwd = tmp_path / "session-own-repo"
+    session_cwd.mkdir()
+    info = server._fallback_session_info({"cwd": str(session_cwd)})
 
-    assert info["cwd"] == "/projects/session-own-repo"
+    assert info["cwd"] == str(session_cwd)
     assert info["branch"] == "bb/feature"
 
 
@@ -20975,7 +22110,13 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
         lambda cwd: str(new_cwd),
     )
 
-    live = {"session_key": target, "running": True, "cwd": str(tmp_path / "old-project")}
+    live = {
+        "session_key": target,
+        "running": True,
+        "cwd": str(tmp_path / "old-project"),
+        "cwd_owned": False,
+        "source": "desktop",
+    }
     server._sessions["live-sid"] = live
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
 
@@ -20988,3 +22129,67 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+    assert live.get("cwd_owned") is True
+
+
+def test_workspace_move_db_failure_does_not_publish_live_topology(
+    monkeypatch, tmp_path
+):
+    target = "stored-running-session"
+    old_cwd = tmp_path / "old-project"
+    new_cwd = tmp_path / "dest-project"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def update_session_cwd(self, *_args, **_kwargs):
+            raise OSError("disk write failed")
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def fake_db(_params):
+        yield FakeDB()
+
+    live = _session(
+        agent=None,
+        session_key=target,
+        running=True,
+        cwd=str(old_cwd),
+        cwd_owned=False,
+        explicit_cwd=False,
+        cwd_from_settle=False,
+        source="desktop",
+        _workspace_topology_generation=4,
+    )
+    live["agent"] = None
+    server._sessions["live-sid"] = live
+    emitted = []
+    monkeypatch.setattr(server, "_profile_db", fake_db)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "main")
+    monkeypatch.setattr(
+        server, "_git_common_repo_root_for_cwd", lambda _cwd: str(new_cwd)
+    )
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    try:
+        result = server._methods["session.workspace.move"](
+            "move-1", {"session_key": target, "cwd": str(new_cwd)}
+        )
+
+        assert result["error"]["code"] == 5007
+        assert live["cwd"] == str(old_cwd)
+        assert live["cwd_owned"] is False
+        assert live["explicit_cwd"] is False
+        assert live["cwd_from_settle"] is False
+        assert live["_workspace_topology_generation"] == 4
+        assert not emitted
+    finally:
+        server._sessions.pop("live-sid", None)

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -48,6 +48,557 @@ def test_compute_host_workers_inherit_tui_pool_env_or_8(monkeypatch):
     assert _default_workers() == 8
 
 
+@pytest.mark.parametrize("fallback", [False, True])
+def test_compute_host_reconstructs_workspace_ownership(monkeypatch, tmp_path, fallback):
+    host = ComputeHost(stdout=io.StringIO(), max_workers=1, heartbeat_secs=0)
+    sid = f"ownership-{'fallback' if fallback else 'native'}"
+    agent = object()
+    monkeypatch.setattr(server, "_make_agent", lambda *args, **kwargs: agent)
+    monkeypatch.setattr(server, "_transfer_db_to_agent", lambda *_args: False)
+
+    def init_session(init_sid, key, init_agent, history, **kwargs):
+        if fallback:
+            raise RuntimeError("boom")
+        server._sessions[init_sid] = {
+            "agent": init_agent,
+            "cwd": kwargs["cwd"],
+            "cwd_owned": kwargs["cwd_owned"],
+            "explicit_cwd": kwargs["explicit_cwd"],
+            "history": history,
+            "history_lock": threading.Lock(),
+            "session_key": key,
+        }
+
+    monkeypatch.setattr(server, "_init_session", init_session)
+
+    frame = {
+        "cols": 80,
+        "cwd": str(tmp_path),
+        "cwd_owned": False,
+        "explicit_cwd": False,
+        "history": [],
+        "session_key": "detached-host",
+        "sid": sid,
+        "source": "desktop",
+    }
+    try:
+        session = host._ensure_server_session(server, frame)
+        assert session["cwd_owned"] is False
+        assert session["explicit_cwd"] is False
+        assert session["_defer_compute_host_session_info"] is True
+    finally:
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_compute_host_fallback_preserves_absent_legacy_cwd_ownership(monkeypatch, tmp_path):
+    host = ComputeHost(stdout=io.StringIO(), max_workers=1, heartbeat_secs=0)
+    sid = "legacy-fallback-ownership"
+    monkeypatch.setattr(server, "_make_agent", lambda *args, **kwargs: object())
+    monkeypatch.setattr(server, "_transfer_db_to_agent", lambda *_args: False)
+    monkeypatch.setattr(
+        server,
+        "_init_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    frame = {
+        "cols": 80,
+        "cwd": str(tmp_path),
+        "explicit_cwd": False,
+        "history": [],
+        "session_key": "legacy-tui-host",
+        "sid": sid,
+        "source": "tui",
+    }
+    try:
+        session = host._ensure_server_session(server, frame)
+        assert "cwd_owned" not in session
+        assert server._session_owns_cwd(session) is True
+    finally:
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_compute_host_reused_session_refreshes_actual_terminal_cwd(
+    monkeypatch, tmp_path
+):
+    """A newer parent topology must reach the host's real terminal resolver."""
+    from tools import terminal_tool
+
+    old_cwd = tmp_path / "old-workspace"
+    new_cwd = tmp_path / "new-workspace"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    sid = "reused-host-cwd"
+    session_key = "stored-reused-host-cwd"
+    session = {
+        "agent": object(),
+        "cwd": str(old_cwd),
+        "cwd_owned": True,
+        "explicit_cwd": True,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": session_key,
+        "_workspace_topology_generation": 0,
+    }
+    host = ComputeHost(stdout=io.StringIO(), max_workers=1, heartbeat_secs=0)
+
+    # Keep this production-path terminal invocation hermetic while still using
+    # the real LocalEnvironment and foreground cwd-resolution chain.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(old_cwd))
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+    server._sessions[sid] = session
+    server._register_session_cwd(session)
+    assert terminal_tool.get_session_cwd(session_key) == str(old_cwd)
+
+    try:
+        before_update = json.loads(
+            terminal_tool.terminal_tool(command="pwd", task_id=session_key)
+        )
+        assert before_update["exit_code"] == 0, before_update
+        assert os.path.realpath(
+            before_update["output"].strip()
+        ) == os.path.realpath(str(old_cwd))
+
+        updated = host._ensure_server_session(
+            server,
+            {
+                "sid": sid,
+                "session_key": session_key,
+                "cwd": str(new_cwd),
+                "cwd_owned": True,
+                "explicit_cwd": True,
+                "cwd_from_settle": False,
+                "workspace_topology_generation": 1,
+            },
+        )
+        assert updated["cwd"] == str(new_cwd)
+        assert updated["_workspace_topology_generation"] == 1
+
+        result = json.loads(
+            terminal_tool.terminal_tool(command="pwd", task_id=session_key)
+        )
+        assert result["exit_code"] == 0, result
+        assert os.path.realpath(result["output"].strip()) == os.path.realpath(
+            str(new_cwd)
+        )
+
+        transient = json.loads(
+            terminal_tool.terminal_tool(
+                command="pwd", task_id=session_key, workdir=str(old_cwd)
+            )
+        )
+        assert transient["exit_code"] == 0, transient
+        assert os.path.realpath(transient["output"].strip()) == os.path.realpath(
+            str(old_cwd)
+        )
+        after_transient = json.loads(
+            terminal_tool.terminal_tool(command="pwd", task_id=session_key)
+        )
+        assert after_transient["exit_code"] == 0, after_transient
+        assert os.path.realpath(
+            after_transient["output"].strip()
+        ) == os.path.realpath(str(new_cwd))
+    finally:
+        terminal_tool.cleanup_all_environments()
+        terminal_tool.clear_task_env_overrides(session_key)
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_compute_host_reused_session_rejects_stale_topology_and_skips_noop_reset(
+    monkeypatch, tmp_path
+):
+    from tools import terminal_tool
+
+    current_cwd = tmp_path / "current-workspace"
+    stale_cwd = tmp_path / "stale-workspace"
+    shell_cwd = tmp_path / "shell-subdirectory"
+    current_cwd.mkdir()
+    stale_cwd.mkdir()
+    shell_cwd.mkdir()
+    sid = "host-topology-ordering"
+    session = {
+        "agent": object(),
+        "cwd": str(current_cwd),
+        "cwd_owned": True,
+        "explicit_cwd": True,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": "stored-host-topology-ordering",
+        "_workspace_topology_generation": 2,
+    }
+    host = ComputeHost(stdout=io.StringIO(), max_workers=1, heartbeat_secs=0)
+    resets = []
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(
+        server,
+        "_finish_explicit_session_cwd_change",
+        lambda current, resolved, *, persist: resets.append(
+            (current["cwd"], resolved, persist)
+        ),
+    )
+    server._sessions[sid] = session
+    server._register_session_cwd(session)
+    terminal_tool.record_session_cwd(session["session_key"], str(shell_cwd))
+
+    try:
+        for stale_generation in (1, 2):
+            host._ensure_server_session(
+                server,
+                {
+                    "sid": sid,
+                    "session_key": session["session_key"],
+                    "cwd": str(stale_cwd),
+                    "cwd_owned": False,
+                    "explicit_cwd": False,
+                    "cwd_from_settle": True,
+                    "workspace_topology_generation": stale_generation,
+                },
+            )
+            assert session["cwd"] == str(current_cwd)
+            assert session["cwd_owned"] is True
+            assert session["explicit_cwd"] is True
+            assert session["cwd_from_settle"] is False
+            assert session["_workspace_topology_generation"] == 2
+            assert terminal_tool.get_session_cwd(session["session_key"]) == str(
+                shell_cwd
+            )
+
+        # A causally newer explicit move re-anchors an active shell even when
+        # its topology tuple is idempotent, but does not tear down/reseed the
+        # host environment because its workspace/backend topology is unchanged.
+        host._ensure_server_session(
+            server,
+            {
+                "sid": sid,
+                "session_key": session["session_key"],
+                "cwd": str(current_cwd),
+                "cwd_owned": True,
+                "explicit_cwd": True,
+                "cwd_from_settle": False,
+                "workspace_topology_generation": 3,
+            },
+        )
+        assert session["_workspace_topology_generation"] == 3
+        assert terminal_tool.get_session_cwd(session["session_key"]) == str(
+            current_cwd
+        )
+        assert resets == []
+    finally:
+        terminal_tool.clear_task_env_overrides(session["session_key"])
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+@pytest.mark.parametrize(
+    ("source", "frame_extra", "expected_owned"),
+    [
+        ("tui", {}, True),
+        (
+            "desktop",
+            {
+                "cwd_owned": False,
+                "workspace_topology_generation": 1,
+            },
+            False,
+        ),
+    ],
+    ids=["legacy-absent-cwd-owned", "detached-neutral"],
+)
+def test_compute_host_reused_session_preserves_workspace_ownership_registration(
+    monkeypatch, tmp_path, source, frame_extra, expected_owned
+):
+    from tools import terminal_tool
+
+    old_cwd = tmp_path / f"{source}-old"
+    new_cwd = tmp_path / f"{source}-new"
+    old_cwd.mkdir()
+    new_cwd.mkdir()
+    sid = f"host-{source}-ownership"
+    session_key = f"stored-host-{source}-ownership"
+    session = {
+        "agent": object(),
+        "cwd": str(old_cwd),
+        "explicit_cwd": False,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "session_key": session_key,
+        "source": source,
+    }
+    if source == "desktop":
+        session["cwd_owned"] = False
+        session["_workspace_topology_generation"] = 0
+
+    host = ComputeHost(stdout=io.StringIO(), max_workers=1, heartbeat_secs=0)
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    server._sessions[sid] = session
+    server._register_session_cwd(session)
+
+    try:
+        host._ensure_server_session(
+            server,
+            {
+                "sid": sid,
+                "session_key": session_key,
+                "cwd": str(new_cwd),
+                "explicit_cwd": False,
+                **frame_extra,
+            },
+        )
+        assert ("cwd_owned" in session) is (source == "desktop")
+        assert server._session_owns_cwd(session) is expected_owned
+        assert terminal_tool.get_session_cwd(session_key) == str(new_cwd)
+        assert terminal_tool.resolve_task_overrides(session_key) == {
+            "cwd": str(new_cwd),
+            "cwd_source": "session",
+        }
+    finally:
+        terminal_tool.clear_task_env_overrides(session_key)
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_compute_host_turn_end_returns_host_workspace_topology(monkeypatch, tmp_path):
+    out = io.StringIO()
+    host = ComputeHost(stdout=out, max_workers=1, heartbeat_secs=0)
+    settled_cwd = tmp_path / "settled-project"
+    settled_cwd.mkdir()
+    session = {
+        "agent": object(),
+        "cwd": str(tmp_path),
+        "cwd_owned": False,
+        "explicit_cwd": False,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "session_key": "host-topology",
+    }
+    monkeypatch.setattr(host, "_ensure_server_session", lambda _server, _frame: session)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+
+    def run_prompt(*_args, **_kwargs):
+        with session["history_lock"]:
+            session.update(
+                {
+                    "cwd": str(settled_cwd),
+                    "cwd_owned": True,
+                    "explicit_cwd": True,
+                    "cwd_from_settle": True,
+                    "running": False,
+                }
+            )
+            server._bump_workspace_topology_generation_locked(session)
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, _session: {
+            "cwd": _session["cwd"],
+            "cwd_owned": _session["cwd_owned"],
+        },
+    )
+
+    try:
+        host._run_real_turn(
+            {
+                "request_id": "turn-topology",
+                "sid": "host-topology",
+                "text": "settle",
+                "workspace_topology_generation": 0,
+            }
+        )
+        turn_end = next(
+            frame
+            for frame in _json_lines(out)
+            if frame.get("type") == "turn.end"
+        )
+        assert turn_end["session_info"] == {
+            "cwd": str(settled_cwd),
+            "cwd_owned": True,
+            "explicit_cwd": True,
+            "cwd_from_settle": True,
+        }
+        assert turn_end["workspace_topology_base_generation"] == 0
+        assert turn_end["workspace_topology_generation"] == 1
+        assert turn_end["session_info_emitted"] is False
+    finally:
+        host.close()
+
+
+@pytest.mark.parametrize("route_name", ["slash.prompt", "session.compress"])
+def test_compute_host_control_session_info_carries_topology_generations(
+    monkeypatch, route_name
+):
+    out = io.StringIO()
+    host = ComputeHost(stdout=out, max_workers=1, heartbeat_secs=0)
+    sid = f"control-topology-{route_name}"
+    session = {
+        "agent": object(),
+        "cwd": "/host/workspace",
+        "cwd_owned": True,
+        "explicit_cwd": True,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 4,
+        "session_key": "stored-control-topology",
+        "_workspace_topology_generation": 3,
+    }
+    server._sessions[sid] = session
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, _session: {
+            "cwd": _session["cwd"],
+            "cwd_owned": _session["cwd_owned"],
+        },
+    )
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", lambda *_args: "ok")
+    if route_name == "session.compress":
+        monkeypatch.setitem(
+            server._methods,
+            "session.compress",
+            lambda _rid, _params: {"result": {"status": "compressed"}},
+        )
+
+    try:
+        host._handle_control(
+            {
+                "type": "control",
+                "sid": sid,
+                "request_id": "control-1",
+                "route_name": route_name,
+                "command": "/prompt concise",
+                "workspace_topology_generation": 2,
+            }
+        )
+        ack = next(
+            frame
+            for frame in _json_lines(out)
+            if frame.get("type") == "control.ack"
+        )
+        assert ack["workspace_topology_base_generation"] == 2
+        assert ack["workspace_topology_generation"] == 3
+        assert ack["session_info"] == {
+            "cwd": "/host/workspace",
+            "cwd_owned": True,
+            "explicit_cwd": True,
+            "cwd_from_settle": False,
+        }
+    finally:
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_compute_host_control_defers_direct_session_info_until_parent_ack(
+    monkeypatch,
+):
+    out = io.StringIO()
+    host = ComputeHost(stdout=out, max_workers=1, heartbeat_secs=0)
+    sid = "stale-control-session-info"
+    session = {
+        "agent": object(),
+        "cwd": "/child/old",
+        "cwd_owned": False,
+        "explicit_cwd": False,
+        "cwd_from_settle": False,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 1,
+        "session_key": "stored-stale-control",
+        "transport": host._transport,
+        "_workspace_topology_generation": 0,
+        "_defer_compute_host_session_info": True,
+    }
+    server._sessions[sid] = session
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, current: {
+            "cwd": current["cwd"],
+            "cwd_owned": current["cwd_owned"],
+        },
+    )
+
+    def emit_before_ack(*_args):
+        server._emit(
+            "session.info",
+            sid,
+            {"cwd": "/child/old", "cwd_owned": False},
+        )
+        return "ok"
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", emit_before_ack)
+
+    try:
+        host._handle_control(
+            {
+                "type": "control",
+                "sid": sid,
+                "request_id": "control-stale",
+                "route_name": "slash.prompt",
+                "command": "/prompt concise",
+                "workspace_topology_generation": 1,
+            }
+        )
+        frames = _json_lines(out)
+        assert not [frame for frame in frames if frame.get("type") == "rpc"]
+        ack = next(frame for frame in frames if frame.get("type") == "control.ack")
+        assert ack["workspace_topology_base_generation"] == 1
+        assert ack["workspace_topology_generation"] == 0
+    finally:
+        server._sessions.pop(sid, None)
+        host.close()
+
+
+def test_supervisor_still_forwards_ordinary_child_rpc(tmp_path):
+    forwarded = []
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "compute-host.json",
+        rpc_sink=forwarded.append,
+        autostart=False,
+    )
+    message = {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "message.delta",
+            "session_id": "sid",
+            "payload": {"text": "still forwarded"},
+        },
+    }
+
+    supervisor._handle_host_frame({"type": "rpc", "message": message})
+
+    assert forwarded == [message]
+
+
 def test_mutator_route_table_matches_prd_inventory():
     assert MUTATOR_ROUTE_TABLE == {
         "prompt.submit": "turn-path",

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -499,7 +499,16 @@ class ComputeHost:
                 message_count = len(session.get("history") or [])
                 interrupted = bool(session.get("_turn_cancel_requested"))
                 session_key = str(session.get("session_key") or "")
+                workspace_topology_generation = server._workspace_topology_generation(
+                    session
+                )
             session_info = server._session_info(session.get("agent"), session)
+            session_info.update(
+                {
+                    "explicit_cwd": bool(session.get("explicit_cwd")),
+                    "cwd_from_settle": bool(session.get("cwd_from_settle")),
+                }
+            )
             self._bump_progress()
             self.emit(
                 {
@@ -512,7 +521,14 @@ class ComputeHost:
                     "interrupted": interrupted,
                     "ended_ns": now_ns(),
                     "session_info": session_info,
-                    "session_info_emitted": True,
+                    "workspace_topology_base_generation": frame.get(
+                        "workspace_topology_generation"
+                    ),
+                    "workspace_topology_generation": workspace_topology_generation,
+                    # The child defers its final session.info so the serving
+                    # process can resolve parent-vs-host workspace ordering
+                    # before publishing one authoritative Desktop event.
+                    "session_info_emitted": False,
                 }
             )
         except Exception as exc:
@@ -536,12 +552,80 @@ class ComputeHost:
             session["transport"] = self._transport
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)
-            if frame.get("cwd"):
-                session["cwd"] = str(frame.get("cwd"))
+            topology_keys = (
+                "cwd",
+                "cwd_owned",
+                "explicit_cwd",
+                "cwd_from_settle",
+            )
+            topology_changed = False
+            generation_advanced = False
+            history_lock = session.get("history_lock")
+            lock_context = (
+                history_lock
+                if history_lock is not None
+                else contextlib.nullcontext()
+            )
+            with lock_context:
+                before = tuple(
+                    (field in session, session.get(field)) for field in topology_keys
+                )
+                incoming_generation = frame.get("workspace_topology_generation")
+                generation_aware = (
+                    isinstance(incoming_generation, int)
+                    and not isinstance(incoming_generation, bool)
+                    and incoming_generation >= 0
+                )
+                current_generation = server._workspace_topology_generation(session)
+                current_generation_aware = (
+                    isinstance(session.get("_workspace_topology_generation"), int)
+                    and not isinstance(
+                        session.get("_workspace_topology_generation"), bool
+                    )
+                    and session.get("_workspace_topology_generation") >= 0
+                )
+                generation_advanced = generation_aware and (
+                    not current_generation_aware
+                    or incoming_generation > current_generation
+                )
+                accept_topology = not generation_aware or generation_advanced
+                if accept_topology:
+                    if frame.get("cwd"):
+                        session["cwd"] = str(frame.get("cwd"))
+                    if "cwd_owned" in frame:
+                        session["cwd_owned"] = bool(frame.get("cwd_owned"))
+                    if "explicit_cwd" in frame:
+                        session["explicit_cwd"] = bool(frame.get("explicit_cwd"))
+                    if "cwd_from_settle" in frame:
+                        session["cwd_from_settle"] = bool(
+                            frame.get("cwd_from_settle")
+                        )
+                    if generation_aware:
+                        session["_workspace_topology_generation"] = (
+                            incoming_generation
+                        )
+                    after = tuple(
+                        (field in session, session.get(field))
+                        for field in topology_keys
+                    )
+                    topology_changed = after != before
+            session["_defer_compute_host_session_info"] = True
             if frame.get("profile_home"):
                 session["profile_home"] = str(frame.get("profile_home"))
             if isinstance(frame.get("attached_images"), list):
                 session["attached_images"] = list(frame.get("attached_images") or [])
+            if topology_changed:
+                # This is the child-process half of a native workspace move.
+                # Reuse its non-persisting side effects so terminal registration
+                # and any cached backend reseed happen here, where tool calls run.
+                server._finish_explicit_session_cwd_change(
+                    session, str(session.get("cwd") or ""), persist=False
+                )
+            elif generation_advanced:
+                # Even an idempotent explicit move must re-anchor a shell that
+                # wandered beneath the same session workspace. No backend
+                # cleanup is needed when the topology tuple itself is unchanged.
+                server._register_session_cwd(session)
             return session
 
         history = frame.get("history") if isinstance(frame.get("history"), list) else []
@@ -604,6 +688,12 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    explicit_cwd=bool(frame.get("explicit_cwd")),
+                    cwd_owned=(
+                        bool(frame.get("cwd_owned"))
+                        if "cwd_owned" in frame
+                        else None
+                    ),
                 )
             finally:
                 reset_transport(token)
@@ -611,7 +701,7 @@ class ComputeHost:
             # If _init_session's side machinery (slash worker, approval notify) is
             # unavailable, keep a minimal host-owned session rather than failing
             # the turn after the expensive agent build succeeded.
-            server._sessions[sid] = {
+            fallback = {
                 "agent": agent,
                 "session_key": key,
                 "history": list(history),
@@ -624,6 +714,12 @@ class ComputeHost:
                 "attached_images": [],
                 "image_counter": 0,
                 "cwd": str(frame.get("cwd") or os.getcwd()),
+                "explicit_cwd": bool(frame.get("explicit_cwd")),
+                "cwd_from_settle": bool(frame.get("cwd_from_settle")),
+                "_workspace_topology_generation": int(
+                    frame.get("workspace_topology_generation") or 0
+                ),
+                "_defer_compute_host_session_info": True,
                 "cols": int(frame.get("cols") or 80),
                 "slash_worker": None,
                 "show_reasoning": server._load_show_reasoning(),
@@ -631,16 +727,25 @@ class ComputeHost:
                 "edit_snapshots": {},
                 "tool_started_at": {},
                 "model_override": frame.get("model_override"),
-                "source": server._sanitize_client_source(frame.get("source")),
+                "source": server._resolve_session_source(frame.get("source")),
                 "transport": self._transport,
             }
+            if "cwd_owned" in frame:
+                fallback["cwd_owned"] = bool(frame.get("cwd_owned"))
+            server._sessions[sid] = fallback
         session = server._sessions[sid]
         session["transport"] = self._transport
+        session["_workspace_topology_generation"] = int(
+            frame.get("workspace_topology_generation") or 0
+        )
+        session["_defer_compute_host_session_info"] = True
         session["profile_home"] = profile_home or session.get("profile_home")
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])
         if frame.get("model_override") is not None:
             session["model_override"] = frame.get("model_override")
+        if "cwd_from_settle" in frame:
+            session["cwd_from_settle"] = bool(frame.get("cwd_from_settle"))
         return session
 
     def _handle_reload_mcp(self, frame: dict[str, Any]) -> None:
@@ -653,6 +758,36 @@ class ComputeHost:
             self.emit({"type": "reload_mcp.ack", "sid": sid, "request_id": request_id, "response": resp})
         except Exception as exc:
             self.emit({"type": "control.error", "sid": sid, "request_id": request_id, "message": str(exc)})
+
+    @staticmethod
+    def _control_session_snapshot(server: Any, session: dict, frame: dict) -> dict:
+        """Return the same causal topology envelope used by ``turn.end``."""
+        with session["history_lock"]:
+            session_key = str(session.get("session_key") or "")
+            history_version = int(session.get("history_version", 0))
+            message_count = len(session.get("history") or [])
+            workspace_topology_generation = server._workspace_topology_generation(
+                session
+            )
+            explicit_cwd = bool(session.get("explicit_cwd"))
+            cwd_from_settle = bool(session.get("cwd_from_settle"))
+        session_info = server._session_info(session.get("agent"), session)
+        session_info.update(
+            {
+                "explicit_cwd": explicit_cwd,
+                "cwd_from_settle": cwd_from_settle,
+            }
+        )
+        return {
+            "session_key": session_key,
+            "history_version": history_version,
+            "message_count": message_count,
+            "session_info": session_info,
+            "workspace_topology_base_generation": frame.get(
+                "workspace_topology_generation"
+            ),
+            "workspace_topology_generation": workspace_topology_generation,
+        }
 
     def _handle_control(self, frame: dict[str, Any]) -> None:
         sid = str(frame.get("sid") or "")
@@ -721,10 +856,6 @@ class ComputeHost:
                         }
                     )
                     return
-                with session["history_lock"]:
-                    session_key = str(session.get("session_key") or "")
-                    history_version = int(session.get("history_version", 0))
-                    message_count = len(session.get("history") or [])
                 self.emit(
                     {
                         "type": "control.ack",
@@ -732,10 +863,7 @@ class ComputeHost:
                         "request_id": request_id,
                         "route_name": route_name,
                         "result": response.get("result") or {},
-                        "session_key": session_key,
-                        "history_version": history_version,
-                        "message_count": message_count,
-                        "session_info": server._session_info(session.get("agent"), session),
+                        **self._control_session_snapshot(server, session, frame),
                     }
                 )
                 return
@@ -745,9 +873,6 @@ class ComputeHost:
                 output = server._mirror_slash_side_effects(sid, session, command)
             with session["history_lock"]:
                 messages = server._history_to_messages(list(session.get("history") or []))
-                history_version = int(session.get("history_version", 0))
-                message_count = len(session.get("history") or [])
-                session_key = str(session.get("session_key") or "")
             self.emit(
                 {
                     "type": "control.ack",
@@ -755,11 +880,8 @@ class ComputeHost:
                     "request_id": request_id,
                     "route_name": route_name,
                     "output": output,
-                    "session_key": session_key,
-                    "history_version": history_version,
-                    "message_count": message_count,
                     "messages": messages,
-                    "session_info": server._session_info(session.get("agent"), session),
+                    **self._control_session_snapshot(server, session, frame),
                 }
             )
         except Exception as exc:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -32,7 +32,9 @@ def _(rid, params: dict) -> dict:
     except Exception:
         explicit_cwd = False
     resolved_cwd = _completion_cwd(params)
-    source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+    source = _resolve_session_source(
+        str(params.get("source") or "").strip() or None
+    )
     _enable_gateway_prompts()
 
     # ``profile`` (app-global remote mode): a new chat started under a non-launch
@@ -86,6 +88,7 @@ def _(rid, params: dict) -> dict:
             "created_at": now,
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
+            "cwd_owned": explicit_cwd or source not in _LAUNCH_CWD_NOT_A_WORKSPACE,
             "history": history,
             "history_lock": threading.Lock(),
             "history_version": 0,
@@ -149,9 +152,7 @@ def _(rid, params: dict) -> dict:
                 ),
                 "tools": {},
                 "skills": {},
-                "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
-                "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
+                **_session_workspace_info(_sessions[sid]),
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
                 "profile_name": _response_profile_name(profile),
@@ -382,6 +383,7 @@ def _(rid, params: dict) -> dict:
     # local profile's state.db. None/own profile → the launch profile (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     defer_history = is_truthy_value(params.get("defer_history", False))
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
@@ -477,6 +479,7 @@ def _(rid, params: dict) -> dict:
                             "message_count": len(history),
                             "messages": [] if omit_messages else _history_to_messages(history),
                             "info": {
+                                **_session_workspace_info(live),
                                 "model": _resolve_model(),
                                 "lazy": True,
                                 "profile_name": profile or "",
@@ -591,9 +594,24 @@ def _(rid, params: dict) -> dict:
                 target, exc,
             )
 
-        profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-            profile_home
+        resume_cwd, resume_cwd_owned, resume_explicit_cwd = _reconstruct_session_cwd(
+            found, profile_home, request_source=source
         )
+        # Heal legacy terminal rows once at the shared resume boundary so
+        # deferred and eager builders see the same durable cwd. Detached
+        # Desktop rows remain NULL by ownership contract.
+        if resume_cwd_owned and not str(found.get("cwd") or "").strip():
+            try:
+                db.update_session_cwd(
+                    target,
+                    resume_cwd,
+                    _git_branch_for_cwd(resume_cwd),
+                    _git_common_repo_root_for_cwd(resume_cwd),
+                    replace_git_meta=True,
+                )
+                found["cwd"] = resume_cwd
+            except Exception:
+                logger.debug("failed to heal legacy resumed session cwd", exc_info=True)
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
             payload = _live_session_payload(
@@ -652,7 +670,6 @@ def _(rid, params: dict) -> dict:
         # (resume_session_id keeps the upgrade on the stored conversation).
         if is_truthy_value(params.get("lazy", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
             lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
             try:
                 db.reopen_session(target)
@@ -669,17 +686,18 @@ def _(rid, params: dict) -> dict:
                 if lease is not None:
                     lease.release()
                 return _err(rid, 5000, f"resume failed: {e}")
-            cwd = profile_resume_cwd or _default_session_cwd()
             record = _deferred_session_record(
                 target,
                 cols=cols,
-                cwd=cwd,
+                cwd=resume_cwd,
                 history=history,
                 lease=lease,
                 source=source,
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
+                explicit_cwd=resume_explicit_cwd,
+                cwd_owned=resume_cwd_owned,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -708,7 +726,7 @@ def _(rid, params: dict) -> dict:
                     "message_count": len(display_history) if omit_messages else len(messages),
                     "messages": messages,
                     "messages_omitted": omit_messages,
-                    "info": _lazy_resume_info(cwd, profile=profile),
+                    "info": _lazy_resume_info(record, profile=profile),
                     "inflight": None,
                     "running": child_running,
                     "session_key": target,
@@ -731,16 +749,14 @@ def _(rid, params: dict) -> dict:
         # governs the response shape of the non-deferred paths.
         if defer_history and not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
             lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
             _enable_gateway_prompts()
             overrides = _stored_session_runtime_overrides(found) or {}
             model_override = overrides.get("model_override") or {}
-            cwd = profile_resume_cwd or _default_session_cwd()
             record = _deferred_session_record(
                 target,
                 cols=cols,
-                cwd=cwd,
+                cwd=resume_cwd,
                 history=[],
                 lease=lease,
                 source=source,
@@ -748,6 +764,8 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                explicit_cwd=resume_explicit_cwd,
+                cwd_owned=resume_cwd_owned,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -770,7 +788,7 @@ def _(rid, params: dict) -> dict:
                     "messages": [],
                     "hydrating": True,
                     "info": _lazy_resume_info(
-                        cwd,
+                        record,
                         model=model_override.get("model") or "",
                         provider=overrides.get("provider_override") or "",
                         profile=profile,
@@ -798,7 +816,6 @@ def _(rid, params: dict) -> dict:
         # session's persisted runtime identity, and is a real (upgradable) session.
         if not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
             lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
             # Interactive resume routes approvals/clarify through gateway prompts;
             # the deferred build wires the remaining per-session callbacks.
@@ -831,11 +848,10 @@ def _(rid, params: dict) -> dict:
             # the build drops the provider ("No LLM provider configured").
             overrides = _stored_session_runtime_overrides(found) or {}
             model_override = overrides.get("model_override") or {}
-            cwd = profile_resume_cwd or _default_session_cwd()
             record = _deferred_session_record(
                 target,
                 cols=cols,
-                cwd=cwd,
+                cwd=resume_cwd,
                 history=history,
                 lease=lease,
                 source=source,
@@ -844,6 +860,8 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                explicit_cwd=resume_explicit_cwd,
+                cwd_owned=resume_cwd_owned,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -860,7 +878,7 @@ def _(rid, params: dict) -> dict:
                 "messages": messages,
                 "messages_omitted": omit_messages,
                 "info": _lazy_resume_info(
-                    cwd,
+                    record,
                     model=model_override.get("model") or "",
                     provider=overrides.get("provider_override") or "",
                     profile=profile,
@@ -880,7 +898,6 @@ def _(rid, params: dict) -> dict:
         # _session_resume_lock across it would stall session.close on the main
         # dispatch thread (it's not a _LONG_HANDLER), blocking fast-path RPCs.
         sid = uuid.uuid4().hex[:8]
-        source = _resolve_session_source(str(params.get("source") or "").strip() or None)
         lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
         _enable_gateway_prompts()
         home_token = (
@@ -975,9 +992,12 @@ def _(rid, params: dict) -> dict:
                         agent,
                         history,
                         cols=cols,
-                        cwd=profile_resume_cwd,
+                        cwd=resume_cwd,
                         session_db=db,
                         source=source,
+                        profile_home=str(profile_home) if profile_home is not None else None,
+                        explicit_cwd=resume_explicit_cwd,
+                        cwd_owned=resume_cwd_owned,
                     )
                     # Ownership TRANSFER — the registered session's agent now
                     # holds this handle for its whole life, and _init_session
@@ -1093,12 +1113,11 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-    }
+    info = (
+        _session_info(agent, session)
+        if agent is not None
+        else {**_session_workspace_info(session), "lazy": True}
+    )
     _emit("session.info", params.get("session_id", ""), info)
     return _ok(rid, info)
 
@@ -1153,7 +1172,34 @@ def _(rid, params: dict) -> dict:
         row_exists = bool(db.get_session(target))
         if not row_exists and live is None:
             return _err(rid, 4007, "session not found")
-        if row_exists:
+        if live is not None:
+            history_lock = live.get("history_lock")
+            lock_context = (
+                history_lock
+                if history_lock is not None
+                else contextlib.nullcontext()
+            )
+            try:
+                # This bounded SQLite write and the matching live publication
+                # are one topology commit at the same boundary used by host
+                # completion and queued-turn framing. A completion carrying an
+                # older generation therefore waits until it can observe either
+                # the fully committed move or, on DB failure, the untouched old
+                # topology. Connection setup, row lookup, and Git probes stay
+                # outside the lock; update_session_cwd has no session callbacks.
+                with lock_context:
+                    if row_exists:
+                        db.update_session_cwd(
+                            target,
+                            resolved,
+                            branch,
+                            root,
+                            replace_git_meta=True,
+                        )
+                    _publish_explicit_session_cwd_locked(live, resolved)
+            except Exception as e:
+                return _err(rid, 5007, f"move failed: {e}")
+        elif row_exists:
             try:
                 db.update_session_cwd(
                     target, resolved, branch, root, replace_git_meta=True
@@ -1162,17 +1208,16 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 5007, f"move failed: {e}")
 
     if live is not None:
-        try:
-            _set_session_cwd(live, resolved)
-        except ValueError as e:
-            return _err(rid, 4017, str(e))
+        # The DB-backed path already committed the authoritative row inside the
+        # history-lock boundary. A draft has no row to update yet and will
+        # inherit this published cwd when its first row is created.
+        _finish_explicit_session_cwd_change(live, resolved, persist=False)
         agent = live.get("agent")
-        info = _session_info(agent, live) if agent is not None else {
-            "cwd": resolved,
-            "branch": branch,
-            "project": _project_info_for_cwd(resolved),
-            "lazy": True,
-        }
+        info = (
+            _session_info(agent, live)
+            if agent is not None
+            else {**_session_workspace_info(live), "lazy": True}
+        )
         _emit("session.info", live_sid, info)
 
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
@@ -2749,7 +2794,9 @@ def _(rid, params: dict) -> dict:
     usage = _session_usage_snapshot(session)
     provider = getattr(agent, "provider", None) or mirror.get("provider") or "unknown"
     model = getattr(agent, "model", None) or mirror.get("model") or "(unknown)"
-    project = _project_info_for_cwd(_display_session_cwd(session))
+    # Status intentionally heals a deleted local cwd while reporting it. The
+    # shared projection persists owned paths and leaves neutral DB rows NULL.
+    project = _session_workspace_info(session)["project"]
     lines = [
         "Hermes TUI Status",
         "",
@@ -2874,7 +2921,7 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
             return _err(rid, 4009, str(ack.get("message") or "compute-host compress failed"))
-        _apply_compute_host_metadata_mirror(session, ack)
+        _apply_compute_host_control_metadata(sid, session, ack)
         host_result = ack.get("result")
         if isinstance(host_result, dict):
             # The host owns the isolated session's agent/history, so preserve
@@ -3186,7 +3233,7 @@ def _(rid, params: dict) -> dict:
                 # thing that surfaces TUI branches. See issue #20856.
                 model_config={"_branched_from": old_key},
                 parent_session_id=old_key,
-                cwd=_session_cwd(session),
+                cwd=_persisted_session_cwd(session),
                 # The branch stays on its parent's profile. Explicit stamp (not
                 # just the parent-backfill) so it holds even when the parent row
                 # predates the profile_name column.
@@ -3286,6 +3333,8 @@ def _(rid, params: dict) -> dict:
                 session_db=branch_db,
                 source=source,
                 profile_home=parent_home,
+                explicit_cwd=bool(session.get("explicit_cwd")),
+                cwd_owned=_session_owns_cwd(session),
             )
             # Ownership TRANSFER — the branched session's agent holds this
             # handle for its whole life and closes it on teardown. Drop is

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1987,6 +1987,13 @@ def _default_session_cwd() -> str:
     return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
+def _detached_profile_cwd(profile_home: Path | None) -> str:
+    """Neutral execution cwd for a session with no workspace ownership."""
+    home = Path(profile_home) if profile_home is not None else get_hermes_home()
+    workspace = home / "workspace"
+    return str(workspace if workspace.is_dir() else home)
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -2008,6 +2015,16 @@ def write_json(obj: dict) -> bool:
     if obj.get("method") == "event":
         params = obj.get("params")
         sid = ((params or {}).get("session_id")) if isinstance(params, dict) else ""
+        # Isolated child metadata must cross the process boundary in its turn
+        # or control frame so the serving parent can validate topology first.
+        if (
+            isinstance(params, dict)
+            and params.get("type") == "session.info"
+            and (_sessions.get(sid) or {}).get(
+                "_defer_compute_host_session_info"
+            )
+        ):
+            return True
         if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
             from tui_gateway.event_replay import _stamp_event
 
@@ -2135,6 +2152,11 @@ def _compute_host_turn_frame(
             if image_paths is not None
             else list(session.get("attached_images", []))
         )
+        cwd = _session_cwd(session)
+        cwd_owned = _session_owns_cwd(session)
+        explicit_cwd = bool(session.get("explicit_cwd"))
+        cwd_from_settle = bool(session.get("cwd_from_settle"))
+        workspace_topology_generation = _workspace_topology_generation(session)
     return {
         "type": "turn.start",
         "sid": sid,
@@ -2145,7 +2167,14 @@ def _compute_host_turn_frame(
         "history": history,
         "history_version": history_version,
         "cols": int(session.get("cols", 80) or 80),
-        "cwd": _session_cwd(session),
+        "cwd": cwd,
+        "cwd_owned": cwd_owned,
+        "explicit_cwd": explicit_cwd,
+        "cwd_from_settle": cwd_from_settle,
+        # Causal version of the parent topology this turn starts from. The host
+        # returns it as its snapshot base so completion can distinguish a
+        # genuine host-side settle from a parent move that happened meanwhile.
+        "workspace_topology_generation": workspace_topology_generation,
         "profile_home": session.get("profile_home") or "",
         "model_override": session.get("model_override"),
         "reasoning_config_override": session.get("create_reasoning_override"),
@@ -2161,15 +2190,21 @@ def _metadata_mirror(session: dict | None) -> dict:
     return mirror if isinstance(mirror, dict) else {}
 
 
-def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> None:
+def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> bool:
     """Mirror host-owned session metadata in the serving process.
 
     The compute host is the only writer of live agent/history state while turn
     isolation is active. The serving process keeps read metadata from the last
     host frame so UI reads do not construct a second in-process agent.
+    Returns whether the frame passed the parent's workspace-generation gate.
     """
     if not isinstance(frame, dict):
-        return
+        return False
+    info = frame.get("session_info")
+    workspace_changed = False
+    workspace_accepted = False
+    persist_host_workspace = False
+    repair_parent_workspace = False
     with session.get("history_lock", threading.Lock()):
         if frame.get("session_key"):
             session["session_key"] = str(frame.get("session_key"))
@@ -2186,16 +2221,102 @@ def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> No
                 session["_metadata_message_count"] = int(frame.get("message_count") or 0)
             except Exception:
                 pass
-    info = frame.get("session_info")
-    if isinstance(info, dict):
-        mirror = dict(_metadata_mirror(session))
-        mirror.update(info)
-        session["_metadata_mirror"] = mirror
-        session["_metadata_mirror_updated_at"] = time.time()
+        if isinstance(info, dict):
+            base_generation = frame.get("workspace_topology_base_generation")
+            host_generation = frame.get("workspace_topology_generation")
+            current_generation = _workspace_topology_generation(session)
+            generation_aware = (
+                isinstance(base_generation, int)
+                and not isinstance(base_generation, bool)
+                and base_generation >= 0
+            )
+            host_generation_aware = (
+                isinstance(host_generation, int)
+                and not isinstance(host_generation, bool)
+                and host_generation >= 0
+            )
+            current_generation_aware = (
+                isinstance(session.get("_workspace_topology_generation"), int)
+                and not isinstance(
+                    session.get("_workspace_topology_generation"), bool
+                )
+                and session.get("_workspace_topology_generation") >= 0
+            )
+            accept_workspace = (
+                host_generation_aware
+                and host_generation >= base_generation
+                and current_generation <= base_generation
+                if generation_aware
+                else not current_generation_aware
+            )
+            workspace_accepted = accept_workspace
+            if accept_workspace:
+                if isinstance(info.get("cwd"), str):
+                    session["cwd"] = info["cwd"]
+                    workspace_changed = True
+                for key in ("cwd_owned", "explicit_cwd", "cwd_from_settle"):
+                    if key in info:
+                        session[key] = bool(info.get(key))
+                        workspace_changed = True
+                if host_generation_aware:
+                    session["_workspace_topology_generation"] = max(
+                        current_generation, host_generation
+                    )
+                    persist_host_workspace = (
+                        generation_aware
+                        and host_generation > base_generation
+                        and _session_owns_cwd(session)
+                    )
+            elif frame.get("type") in {"turn.end", "turn.error"}:
+                # A stale child from the pre-authoritative persistence contract
+                # may already have written its settled cwd through another
+                # SQLite handle. Repair that row before the queued turn drains.
+                repair_parent_workspace = _session_owns_cwd(session)
+            mirror = dict(_metadata_mirror(session))
+            if accept_workspace:
+                mirror.update(info)
+            else:
+                # Callers may return the acknowledgement itself to Desktop.
+                # Remove rejected topology there as well as from the mirror so
+                # no response consumer can repaint the stale host workspace.
+                for key in {
+                    "cwd",
+                    "cwd_owned",
+                    "explicit_cwd",
+                    "cwd_from_settle",
+                    "branch",
+                    "project",
+                }:
+                    info.pop(key, None)
+                mirror.update(info)
+            session["_metadata_mirror"] = mirror
+            session["_metadata_mirror_updated_at"] = time.time()
+            authoritative_cwd = _persisted_session_cwd(session)
+            if (
+                persist_host_workspace or repair_parent_workspace
+            ) and authoritative_cwd:
+                # Workspace moves use this same lock around their SQLite write.
+                # Keeping acceptance/repair inside it makes the DB ordering
+                # match the in-memory generation ordering in both directions.
+                _persist_session_cwd_and_schedule_git_meta(
+                    session, authoritative_cwd
+                )
+    if workspace_changed:
+        _register_session_cwd(session)
+    return workspace_accepted
+
+
+def _apply_compute_host_control_metadata(sid: str, session: dict, frame: dict) -> None:
+    if _apply_compute_host_metadata_mirror(session, frame):
+        _emit("session.info", sid, _session_info(session.get("agent"), session))
 
 
 def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -> None:
     is_error = frame.get("type") == "turn.error"
+    # Host metadata is authoritative for the completed turn. Merge it before
+    # publishing running=False so no concurrently accepted next turn can frame
+    # stale cwd ownership back into the host.
+    _apply_compute_host_metadata_mirror(session, frame)
     with session["history_lock"]:
         if frame.get("session_key"):
             session["session_key"] = str(frame.get("session_key"))
@@ -2213,7 +2334,6 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
         _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
-    _apply_compute_host_metadata_mirror(session, frame)
     try:
         info = _session_info(session.get("agent"), session)
     except TypeError:
@@ -2275,6 +2395,16 @@ def _send_compute_host_control(
     frame = dict(payload or {})
     frame.setdefault("type", "control")
     frame.setdefault("command", command)
+    session = _sessions.get(sid)
+    if session is not None and "workspace_topology_generation" not in frame:
+        history_lock = session.get("history_lock")
+        lock_context = (
+            history_lock if history_lock is not None else contextlib.nullcontext()
+        )
+        with lock_context:
+            frame["workspace_topology_generation"] = _workspace_topology_generation(
+                session
+            )
     return _get_compute_host_supervisor().control(
         sid,
         route_name=route_name,
@@ -2957,6 +3087,16 @@ def _normalize_completion_path(path_part: str) -> str:
 
 def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
+    # Desktop omits cwd when creating a session detached from a named Project.
+    # Detached is an ownership state, not permission to inherit whichever
+    # project path last reached terminal config / the gateway process. Resolve
+    # the session's neutral cwd on the authoritative backend profile instead.
+    source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+    if source in _LAUNCH_CWD_NOT_A_WORKSPACE and not str(
+        params.get("cwd") or ""
+    ).strip():
+        return _detached_profile_cwd(_profile_home(params.get("profile")))
+
     raw = (
         params.get("cwd")
         or _sessions.get(params.get("session_id") or "", {}).get("cwd")
@@ -3069,20 +3209,82 @@ def _session_cwd(session: dict | None) -> str:
 _LAUNCH_CWD_NOT_A_WORKSPACE = {"desktop"}
 
 
+def _workspace_topology_generation(session: dict | None) -> int:
+    """Return this session's monotonic workspace mutation version."""
+    if session is None:
+        return 0
+    value = session.get("_workspace_topology_generation", 0)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return 0
+    return value
+
+
+def _bump_workspace_topology_generation_locked(session: dict) -> int:
+    """Claim the next workspace topology version while history_lock is held."""
+    generation = _workspace_topology_generation(session) + 1
+    session["_workspace_topology_generation"] = generation
+    return generation
+
+
+def _session_owns_cwd(session: dict | None) -> bool:
+    """Whether a session's runtime cwd is also durable workspace ownership.
+
+    Fresh sessions derive this from the native source + explicit-cwd contract.
+    Resumed sessions carry ``cwd_owned`` reconstructed from the stored row so
+    the current client surface cannot reinterpret legacy or detached topology.
+    """
+    if session is None:
+        return False
+    if "cwd_owned" in session:
+        return bool(session.get("cwd_owned"))
+    return bool(session.get("explicit_cwd")) or (
+        _session_source(session) not in _LAUNCH_CWD_NOT_A_WORKSPACE
+    )
+
+
 def _persisted_session_cwd(session: dict) -> str | None:
     """The cwd to stamp on the session's DB row, or None to leave it unset.
 
     See :func:`_ensure_session_db_row` for why the launch directory counts as a
     workspace for terminal sessions but not for the desktop.
     """
-    if session.get("explicit_cwd"):
-        return _session_cwd(session)
-    if _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE:
+    if not _session_owns_cwd(session):
         return None
     # Only the session's OWN directory. `_session_cwd` falls back to the
     # gateway-wide completion cwd, which belongs to no session in particular —
     # stamping that would invent a workspace for a session that never had one.
     return str(session.get("cwd") or "") or None
+
+
+def _reconstruct_session_cwd(
+    row: dict,
+    profile_home: Path | None,
+    *,
+    request_source: str | None = None,
+) -> tuple[str, bool, bool]:
+    """Rebuild runtime cwd, ownership, and explicitness from one stored row."""
+    stored_cwd = str(row.get("cwd") or "").strip()
+    stored_source = _resolve_session_source(
+        str(row.get("source") or "").strip()
+        or str(request_source or "").strip()
+        or None
+    )
+    stored_state = {
+        "cwd": stored_cwd,
+        "explicit_cwd": bool(stored_cwd),
+        "source": stored_source,
+    }
+    owned = _session_owns_cwd(stored_state)
+    if stored_cwd:
+        cwd = stored_cwd
+    elif owned:
+        cwd = _profile_configured_cwd(profile_home) or _default_session_cwd()
+    else:
+        cwd = _detached_profile_cwd(profile_home)
+    # Only Desktop rows distinguish an explicit pick from their neutral launch
+    # cwd. Terminal rows own their launch cwd but remain settle-followable.
+    explicit = bool(stored_cwd) and stored_source in _LAUNCH_CWD_NOT_A_WORKSPACE
+    return cwd, owned, explicit
 
 
 def _heal_dead_cwd(cwd: str) -> str:
@@ -3164,12 +3366,40 @@ def _display_session_cwd(session: dict | None) -> str:
     healed = _heal_dead_cwd(cwd)
     if healed and healed != cwd and session is not None:
         session["cwd"] = healed
-        _persist_session_cwd_and_schedule_git_meta(session, healed)
+        _register_session_cwd(session)
+        if _session_owns_cwd(session):
+            _persist_session_cwd_and_schedule_git_meta(session, healed)
 
     return healed
 
 
-def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
+def _session_workspace_info(session: dict | None) -> dict:
+    """Project runtime cwd separately from durable workspace ownership.
+
+    The projection performs the existing local dead-cwd healing. Owned paths
+    are persisted by :func:`_display_session_cwd`; neutral execution paths are
+    updated in memory only, so a detached session stays detached.
+    """
+    cwd = _display_session_cwd(session)
+    owned = _session_owns_cwd(session)
+    profile_home = str((session or {}).get("profile_home") or "").strip()
+    project_cwd = _persisted_session_cwd(session) if session is not None else cwd
+    project = (
+        _project_info_for_cwd(project_cwd, Path(profile_home))
+        if profile_home
+        else _project_info_for_cwd(project_cwd)
+    )
+    return {
+        "cwd": cwd,
+        "cwd_owned": owned,
+        "branch": _git_branch_for_cwd(cwd) if owned else "",
+        "project": project,
+    }
+
+
+def _reconcile_session_cwd_from_terminal(
+    session: dict | None, *, persist: bool = True
+) -> bool:
     """Re-anchor a session that SETTLED in another git checkout. Returns moved.
 
     An agent told to work in a fresh worktree does exactly that — `git worktree
@@ -3238,16 +3468,26 @@ def _reconcile_session_cwd_from_terminal(session: dict | None) -> bool:
     if not landed_common or landed_common != current_common:
         return False
 
-    session["cwd"] = resolved
-    # The session works here now, so this is its workspace — a desktop chat
-    # whose cwd was an unpersisted launch artifact earns a real row. The
-    # settle marker keeps this adoption overridable by the NEXT settle while
-    # still yielding to a user's explicit choice (see the guard above).
-    session["explicit_cwd"] = True
-    session["cwd_from_settle"] = True
+    history_lock = session.get("history_lock")
+    lock_context = history_lock if history_lock is not None else contextlib.nullcontext()
+    with lock_context:
+        # Re-check after the git probes: an explicit parent/user move may have
+        # landed while those subprocesses ran and must retain authority.
+        if session.get("explicit_cwd") and not session.get("cwd_from_settle"):
+            return False
+        session["cwd"] = resolved
+        # The session works here now, so this is its workspace — a desktop chat
+        # whose cwd was an unpersisted launch artifact earns a real row. The
+        # settle marker keeps this adoption overridable by the NEXT settle while
+        # still yielding to a user's explicit choice (see the guard above).
+        session["explicit_cwd"] = True
+        session["cwd_owned"] = True
+        session["cwd_from_settle"] = True
+        _bump_workspace_topology_generation_locked(session)
     _register_session_cwd(session)
 
-    _persist_session_cwd_and_schedule_git_meta(session, resolved)
+    if persist:
+        _persist_session_cwd_and_schedule_git_meta(session, resolved)
     return True
 
 
@@ -3760,24 +4000,42 @@ def _set_session_cwd(session: dict, cwd: str) -> str:
     resolved = os.path.abspath(os.path.expanduser(cwd))
     if not os.path.isdir(resolved):
         raise ValueError(f"working directory does not exist: {cwd}")
+    history_lock = session.get("history_lock")
+    lock_context = history_lock if history_lock is not None else contextlib.nullcontext()
+    with lock_context:
+        _publish_explicit_session_cwd_locked(session, resolved)
+    _finish_explicit_session_cwd_change(session, resolved, persist=True)
+    return resolved
+
+
+def _publish_explicit_session_cwd_locked(session: dict, resolved: str) -> int:
+    """Publish an explicit workspace while the session history lock is held."""
     session["cwd"] = resolved
     # An explicit user choice — persist it as the workspace (and let a later
     # lazy row creation persist it too, not the launch-dir fallback).
     session["explicit_cwd"] = True
+    session["cwd_owned"] = True
     # A user's choice supersedes any earlier settle-adopted cwd: from here on
     # the terminal wandering must not move the workspace again.
     session["cwd_from_settle"] = False
+    return _bump_workspace_topology_generation_locked(session)
+
+
+def _finish_explicit_session_cwd_change(
+    session: dict, resolved: str, *, persist: bool
+) -> None:
+    """Run non-authoritative side effects after live topology publication."""
     _register_session_cwd(session)
-    # The synchronous DB write claims ordering authority; Git subprocesses stay
-    # off the hot path and may publish only for that exact generation.
-    _persist_session_cwd_and_schedule_git_meta(session, resolved)
+    if persist:
+        # The synchronous DB write claims ordering authority; Git subprocesses
+        # stay off the hot path and may publish only for that exact generation.
+        _persist_session_cwd_and_schedule_git_meta(session, resolved)
     try:
         from tools.terminal_tool import cleanup_vm
 
         cleanup_vm(session["session_key"])
     except Exception:
         pass
-    return resolved
 
 
 # ── Config I/O ────────────────────────────────────────────────────────
@@ -6225,7 +6483,9 @@ def _session_usage_snapshot(session: dict | None) -> dict:
     return dict(mirror_usage) if isinstance(mirror_usage, dict) else {}
 
 
-def _project_info_for_cwd(cwd: str) -> dict | None:
+def _project_info_for_cwd(
+    cwd: str, profile_home: Path | None = None
+) -> dict | None:
     """Return the first-class Project owning ``cwd`` for UI status surfaces.
 
     Backed by the per-profile projects.db (the same store the desktop's project
@@ -6239,7 +6499,8 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
     try:
         from hermes_cli import projects_db as pdb
 
-        with pdb.connect_closing() as conn:
+        db_path = Path(profile_home) / "projects.db" if profile_home else None
+        with pdb.connect_closing(db_path) as conn:
             project = pdb.project_for_path(conn, cwd)
         if project is None:
             return None
@@ -6261,7 +6522,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
                 session = candidate
                 break
     mirror = _metadata_mirror(session)
-    cwd = _display_session_cwd(session)
+    workspace = _session_workspace_info(session)
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
@@ -6326,9 +6587,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "approval_mode": approval_mode,
         "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
         "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        **workspace,
         "terminal_backend": _effective_terminal_backend(),
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
@@ -7045,10 +7304,15 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
     if not os.path.isdir(resolved):
         return
 
-    session["cwd"] = resolved
-    session["explicit_cwd"] = True
-    # An explicit project switch supersedes any earlier settle-adopted cwd.
-    session["cwd_from_settle"] = False
+    history_lock = session.get("history_lock")
+    lock_context = history_lock if history_lock is not None else contextlib.nullcontext()
+    with lock_context:
+        session["cwd"] = resolved
+        session["explicit_cwd"] = True
+        session["cwd_owned"] = True
+        # An explicit project switch supersedes any earlier settle-adopted cwd.
+        session["cwd_from_settle"] = False
+        _bump_workspace_topology_generation_locked(session)
     _register_session_cwd(session)
 
     _persist_session_cwd_and_schedule_git_meta(session, resolved)
@@ -7058,12 +7322,7 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         info = (
             _session_info(agent, session)
             if agent is not None
-            else {
-                "cwd": resolved,
-                "branch": _git_branch_for_cwd(resolved),
-                "project": _project_info_for_cwd(resolved),
-                "lazy": True,
-            }
+            else {**_session_workspace_info(session), "lazy": True}
         )
         _emit("session.info", sid, info)
     except Exception:
@@ -7803,6 +8062,8 @@ def _init_session(
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
+    explicit_cwd: bool = False,
+    cwd_owned: bool | None = None,
 ):
     now = time.time()
     with _sessions_lock:
@@ -7819,6 +8080,7 @@ def _init_session(
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
+            "explicit_cwd": explicit_cwd,
             "cols": cols,
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
@@ -7838,6 +8100,8 @@ def _init_session(
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
         }
+        if cwd_owned is not None:
+            _sessions[sid]["cwd_owned"] = cwd_owned
     _init_owns_db = False
     if session_db is not None:
         db = session_db
@@ -7858,9 +8122,9 @@ def _init_session(
                 with _sessions_lock:
                     if sid in _sessions:
                         _sessions[sid]["cwd"] = row["cwd"]
-            else:
+            elif _persisted_session_cwd(_sessions[sid]):
                 try:
-                    _cwd = _sessions[sid]["cwd"]
+                    _cwd = _persisted_session_cwd(_sessions[sid])
                     if hasattr(db, "update_session_cwd"):
                         _persist_session_cwd_and_schedule_git_meta(
                             _sessions[sid], _cwd, db=db
@@ -9163,7 +9427,7 @@ def _queued_prompt_snapshot(session: dict) -> dict | None:
 
 
 def _lazy_resume_info(
-    cwd: str,
+    session: dict,
     *,
     model: str = "",
     provider: str = "",
@@ -9172,9 +9436,7 @@ def _lazy_resume_info(
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
     info = {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        **_session_workspace_info(session),
         "model": model or _resolve_model(),
         "tools": {},
         "skills": {},
@@ -9201,11 +9463,13 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    explicit_cwd: bool = False,
+    cwd_owned: bool | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
     now = time.time()
-    return {
+    record = {
         "agent": None,
         "agent_error": None,
         "agent_ready": threading.Event(),
@@ -9217,7 +9481,7 @@ def _deferred_session_record(
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
         "edit_snapshots": {},
-        "explicit_cwd": False,
+        "explicit_cwd": explicit_cwd,
         "history": history,
         "history_lock": threading.Lock(),
         "history_version": 0,
@@ -9239,6 +9503,9 @@ def _deferred_session_record(
         "tool_started_at": {},
         "transport": current_transport() or _stdio_transport,
     }
+    if cwd_owned is not None:
+        record["cwd_owned"] = cwd_owned
+    return record
 
 
 def _claim_or_reuse_live(
@@ -9497,7 +9764,7 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
-        return _session_info(agent)
+        return _session_info(agent, session)
     # The SESSION's own workspace, not the gateway's launch directory. Reporting
     # `_default_session_cwd()` here told a lazily-resumed session's client that
     # its workspace was wherever the gateway process happened to start, so the
@@ -9505,11 +9772,8 @@ def _fallback_session_info(session: dict) -> dict:
     # rebound correctly (#71254). `branch` is always emitted ("" outside a git
     # repo) so a client can clear a stale label instead of retaining it — the
     # same contract `_lazy_session_info` above already follows.
-    cwd = _session_cwd(session)
     return {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
+        **_session_workspace_info(session),
         "lazy": True,
         "model": _resolve_model(),
         "skills": {},
@@ -12232,7 +12496,20 @@ def _run_prompt_submit(
             # frame paths retire the marker as they emit).
             _retire_turn_marker(session, marker_key)
             session.pop("_auto_continue_scheduled", None)
-            _emit_settled_session_info(sid, session, agent)
+            # Isolated turns return this snapshot in turn.end. Publishing it
+            # directly from the child would bypass the serving process' causal
+            # workspace-generation check and could repaint a newer explicit
+            # parent move with the turn-start cwd.
+            if session.get("_defer_compute_host_session_info"):
+                try:
+                    _reconcile_session_cwd_from_terminal(session, persist=False)
+                except Exception:
+                    logger.debug(
+                        "failed to reconcile isolated settled session cwd",
+                        exc_info=True,
+                    )
+            else:
+                _emit_settled_session_info(sid, session, agent)
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
         # every auto follow-up below — drain it first and skip them this cycle;
@@ -14883,7 +15160,7 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             return f"compute-host {route_name} failed: {exc}"
         if ack.get("type") in {"control.error", "error"}:
             return str(ack.get("message") or f"compute-host {route_name} failed")
-        _apply_compute_host_metadata_mirror(session, ack)
+        _apply_compute_host_control_metadata(sid, session, ack)
         return str(ack.get("output") or "")
     if name in _MUTATES_WHILE_RUNNING and session.get("running"):
         return f"session busy — /interrupt the current turn before running /{name}"


### PR DESCRIPTION
## What does this PR do?

A Desktop session with no selected Project or workspace needs two facts that were previously conflated:

1. a neutral runtime directory where the backend can execute; and
2. whether Desktop should treat that directory as user-owned workspace state for Files, Projects, and sidebar placement.

Without that distinction, detached sessions can either execute from the backend launch profile's stale directory or publish a profile fallback directory back to Desktop as if the user selected it. The former loads the wrong working context; the latter silently attaches a detached conversation to a Project/Files workspace.

This PR gives detached sessions the selected profile's `workspace/` directory when it exists, otherwise that profile's home, while carrying `cwd_owned: false` through the existing session lifecycle. Desktop uses the runtime directory for execution but does not adopt it as Project, Files, sidebar, or durable session ownership.

The contract covers fresh sessions, resume, warm cache reuse, branch, restart reconstruction, compute-host isolation, queued turns, and later explicit workspace moves. Parent workspace generations remain authoritative: isolated child `session.info` metadata is deferred until the parent accepts the matching control generation, preventing stale child cwd state from escaping before validation.

This extends the cross-profile fallback identified in #87584 / #87659 from fresh pooled-profile creation to the complete detached-session lifecycle. #87659 is explicitly credited as the prior focused fallback.

## Related Issue

Closes #87584. Supersedes #87659 with the complete lifecycle and ownership contract.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: resolve neutral profile runtime cwd, thread explicit ownership through session create/resume/cache/restart/branch responses, and defer isolated child metadata until parent generation validation.
- `tui_gateway/methods_session.py`: preserve detached ownership across session methods and promote later explicit workspace moves to owned state.
- `tui_gateway/compute_host.py`: carry topology generations and ownership across parent/child control frames without allowing stale child state to win.
- Desktop session runtime/types/hooks: accept `cwd_owned`, use unowned cwd for execution only, and avoid publishing it into Files/Projects/sidebar ownership.
- Backend regressions cover database failure, restart, warm/unpersisted reuse, branch, queued turns, compute-host generation races, host settle, child terminal cwd, and explicit-workdir precedence.
- Desktop regressions cover create, resume, warm-cache fallback, session-info events, centered Home tiles, and legacy compatibility when the field is absent.

## How to Test

1. Run `scripts/run_tests.sh` from the repository root.
2. From `apps/desktop`, run `corepack npm@11.17.0 run check`.
3. In Desktop, select a non-default profile and create a top-level session without choosing a Project/workspace. Confirm terminal commands execute from that profile's workspace/home while Files and Project ownership remain detached.
4. Resume, branch, restart, and reuse the session; it must remain detached. Then select an explicit workspace and confirm ownership is promoted.
5. Move the parent workspace while an isolated compute-host turn is active; stale child metadata must not overwrite the accepted parent generation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full sweep was stopped after unrelated optional-provider failures; on the rebased branch, the 20 compute-host tests passed before the remaining focused run was cancelled
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux backend and macOS packaged arm64 Desktop; focused backend/Desktop regressions passed before current-`main` reconciliation and the integrated candidate passed live backend plus packaged-app acceptance

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this preserves the existing detached-session UX and documents the internal contract in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — runtime paths remain backend-native opaque strings and renderer ownership logic is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changes

## Screenshots / Logs

No screenshots: this fixes runtime/session ownership semantics rather than a visual component.

## AI assistance disclosure

Prepared with AI-assisted implementation and review. The final branch was reconciled onto current `main` and audited for unrelated or environment-identifying data. Heavy full-suite/Desktop checks were cancelled before completion; the focused and live acceptance evidence above is reported without claiming a combined post-rebase pass.
