### PR TITLE
fix(desktop): scope boot-failure reauth logout to the gateway origin

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -133,6 +133,64 @@ describe('BootFailureOverlay', () => {
       expect(screen.getByText(/ares-3009\.agents\.nousresearch\.com/i)).toBeTruthy()
     } finally {
       restore()
+    }
+  })
+
+  it('scopes the pre-signin oauth logout to THIS gateway URL (no partition-wide wipe)', async () => {
+    // Boot failure on an OAuth remote gateway whose session lapsed → the
+    // recovery card offers "Sign out & sign in". The pre-login clear MUST be
+    // scoped to the gateway's own origin. Before #94856 the argument-less
+    // oauthLogoutConnectionConfig() cleared EVERY hostname's cookies in the
+    // shared `persist:hermes-remote-oauth` partition — silently signing out
+    // every other registered gateway, not just the one being re-authenticated.
+    const logout = vi.fn().mockResolvedValue({ ok: true, connected: false })
+    const login = vi.fn().mockResolvedValue({ ok: true, baseUrl: 'https://box:8443', connected: false })
+
+    const reauthConfig = {
+      cloudOrg: '',
+      envOverride: false,
+      mode: 'remote',
+      remoteAuthMode: 'oauth',
+      remoteOauthConnected: false,
+      remoteTokenPreview: null,
+      remoteTokenSet: false,
+      remoteUrl: 'https://box:8443'
+    }
+
+    const original = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getConnectionConfig: async () => reauthConfig,
+        getRecentLogs: async () => ({ lines: [] }),
+        oauthLoginConnectionConfig: login,
+        oauthLogoutConnectionConfig: logout,
+        probeConnectionConfig: async () => ({
+          authMode: 'oauth',
+          baseUrl: 'https://box:8443',
+          error: null,
+          providers: [],
+          reachable: true,
+          version: null
+        })
+      }
+    })
+
+    try {
+      render(<BootFailureOverlay />)
+
+      // Reauth surfaces the "Sign out & sign in" recovery action.
+      const signIn = await screen.findByRole('button', { name: /sign out & sign in/i })
+      fireEvent.click(signIn)
+
+      // The logout must be scoped to the gateway origin, never argument-less.
+      await waitFor(() => expect(logout).toHaveBeenCalledWith('https://box:8443'))
+      expect(logout).not.toHaveBeenCalledWith(undefined)
+      expect(logout).not.toHaveBeenCalledWith()
+      // The login window must open for the SAME gateway.
+      expect(login).toHaveBeenCalledWith('https://box:8443')
+    } finally {
+      Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
     }
   })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -177,7 +177,11 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
+      // Scope the pre-login clear to THIS gateway's origin only. Passing no
+      // argument clears every cookie of every hostname in the shared
+      // `persist:hermes-remote-oauth` partition — i.e. a global sign-out that
+      // silently deletes the other registered gateways' sessions (#94856).
+      await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
 
       if (result?.connected) {


### PR DESCRIPTION
## Summary

The boot-failure reauth card's **Sign In** silently signs out *every* other registered remote gateway. Its `signInRemote()` in `apps/desktop/src/components/boot-failure-overlay.tsx` called `oauthLogoutConnectionConfig()` with **no argument**, which reaches `clearOauthSession(undefined)` in `electron/main.ts`. An empty cookie filter (`sess.cookies.get({})`) enumerates and removes every cookie of every hostname in the shared `persist:hermes-remote-oauth` partition — so a boot-card reauth was a global sign-out, not a per-gateway re-login. Switching back to another gateway then fails with `401 {"reason":"no_cookie"}` / "Your remote gateway session has expired."

The Settings → Gateway sign-in path (`gateway-settings.tsx`) already scopes the logout to the gateway URL (`oauthLogoutConnectionConfig(trimmedUrl || undefined)`); the boot-failure card was the sole unscoped call site. This fix mirrors that established pattern.

## Changes

- `apps/desktop/src/components/boot-failure-overlay.tsx`: scope the pre-login clear to the gateway being re-authenticated — `await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)` — instead of wiping the whole partition.
- `apps/desktop/src/components/boot-failure-overlay.test.tsx`: regression test rendering the real `BootFailureOverlay` against a stubbed `window.hermesDesktop`, clicking the "Sign out & sign in" recovery action, and asserting the logout is called **with** the gateway URL and never argument-less/`undefined`, plus the login window opens for the same gateway.

## Tests

- Regression test proven: with the fix reverted to the argument-less call, the new test **fails** (`logout` never called with the gateway URL); with the fix in place it **passes**.
- Focused suite: `npx vitest run --environment jsdom src/components/boot-failure-overlay.test.tsx src/components/boot-failure-reauth.test.ts` — **29 passed (2 files)**, no regression in the sibling reauth flow.
- `npm run typecheck` — clean.
