### PR TITLE
fix(achievements): stats and unlocks no longer regress after context compaction

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -253,6 +253,38 @@ def save_checkpoint(data: Dict[str, Any]) -> None:
     path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True), encoding="utf-8")
 
 
+_STATS_MERGE_SKIP = {"session_id", "title", "started_at", "last_active", "source"}
+
+
+def _merge_stats_monotonic(cached: Dict[str, Any], fresh: Dict[str, Any]) -> Dict[str, Any]:
+    """Element-wise max of a session's fresh stats with its cached scan.
+
+    Session transcripts are lossy: context compaction rewrites a session's
+    messages (and bumps ``last_active``), which invalidates the fingerprint
+    and forces re-analysis of the *smaller* surviving transcript. Real
+    activity only ever adds events, so a per-session metric that goes DOWN
+    between scans is an artifact of history compression, not of usage —
+    keep the max so lifetime totals never silently regress. Collection
+    fields (e.g. ``model_names``) merge by union for the same reason.
+    Session metadata (`_STATS_MERGE_SKIP`) always takes the fresh value.
+    """
+    merged = dict(fresh)
+    for key, old in cached.items():
+        if key in _STATS_MERGE_SKIP:
+            continue
+        new = merged.get(key)
+        if isinstance(old, bool) or isinstance(new, bool):
+            merged[key] = bool(old) or bool(new)
+        elif isinstance(old, (int, float)) and isinstance(new, (int, float)):
+            merged[key] = max(old, new)
+        elif isinstance(old, (set, list)) and isinstance(new, (set, list)):
+            union = set(old) | set(new)
+            merged[key] = union if isinstance(new, set) else sorted(union)
+        elif key not in merged:
+            merged[key] = old
+    return merged
+
+
 def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "last_active": meta.get("last_active"),
@@ -651,6 +683,10 @@ def scan_sessions(
             else:
                 messages = db.get_messages(sid)
                 stats = analyze_messages(sid, meta.get("title") or meta.get("preview") or "Untitled", messages)
+                if isinstance(cached_stats, dict):
+                    # Same session, changed fingerprint: the transcript may have
+                    # been compacted. Merge monotonically so counts never drop.
+                    stats = _merge_stats_monotonic(cached_stats, stats)
                 rescanned += 1
 
             stats["session_id"] = sid
@@ -834,7 +870,16 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
         if not is_partial and result["unlocked"] and unlock_id not in unlocks:
             unlocks[unlock_id] = {"unlocked_at": now, "first_tier": result.get("tier"), "evidence": evidence_for(definition, scan.get("sessions", []))}
         item = {**definition, **result}
-        if result["unlocked"]:
+        recorded = unlocks.get(unlock_id)
+        if recorded and not result["unlocked"]:
+            # Unlock floor: state.json is the durable record of what was
+            # earned; the live aggregate can lose its backing when compaction
+            # shrinks session history. Once earned, never displayed as
+            # un-earned — floor at the recorded first tier.
+            item["unlocked"] = True
+            item["state"] = "unlocked"
+            item["tier"] = item.get("tier") or recorded.get("first_tier")
+        if item["unlocked"]:
             item["unlocked_at"] = unlocks.get(unlock_id, {}).get("unlocked_at")
             item["evidence"] = unlocks.get(unlock_id, {}).get("evidence") or evidence_for(definition, scan.get("sessions", []))
         evaluated.append(display_achievement(item))

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -273,15 +273,24 @@ def _merge_stats_monotonic(cached: Dict[str, Any], fresh: Dict[str, Any]) -> Dic
         if key in _STATS_MERGE_SKIP:
             continue
         new = merged.get(key)
-        if isinstance(old, bool) or isinstance(new, bool):
-            merged[key] = bool(old) or bool(new)
-        elif isinstance(old, (int, float)) and isinstance(new, (int, float)):
+        old_is_bool, new_is_bool = isinstance(old, bool), isinstance(new, bool)
+        if new is None:
+            # A fresh analysis that omits or blanks a metric is a partial answer,
+            # not a zero -- a newer analyzer that no longer emits a field must not
+            # erase what an older scan measured.
+            merged[key] = old
+        elif old_is_bool and new_is_bool:
+            merged[key] = old or new
+        elif isinstance(old, (int, float)) and isinstance(new, (int, float)) and not (old_is_bool or new_is_bool):
             merged[key] = max(old, new)
+        elif isinstance(old, (int, float)) and isinstance(new, (int, float)):
+            # Type drift (bool <-> count) between analyzer versions: keep the
+            # count. Coercing a count through bool() would turn 400 into True,
+            # which sums downstream as 1 -- a worse regression than compaction.
+            merged[key] = new if not new_is_bool else old
         elif isinstance(old, (set, list)) and isinstance(new, (set, list)):
             union = set(old) | set(new)
             merged[key] = union if isinstance(new, set) else sorted(union)
-        elif key not in merged:
-            merged[key] = old
     return merged
 
 
@@ -851,6 +860,14 @@ def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> 
     return None
 
 
+def _tier_rank(definition: Dict[str, Any], tier_name: Optional[str]) -> int:
+    """Position of ``tier_name`` in the definition's ascending tier ladder; -1 if none."""
+    if not tier_name:
+        return -1
+    ladder = [t.get("name") for t in sorted(definition.get("tiers", []), key=lambda t: t.get("threshold", 0))]
+    return ladder.index(tier_name) if tier_name in ladder else -1
+
+
 def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dict[str, Any]:
     """Evaluate every achievement definition against a scan result.
 
@@ -868,17 +885,28 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
         result = evaluate_definition(definition, aggregate)
         unlock_id = definition["id"]
         if not is_partial and result["unlocked"] and unlock_id not in unlocks:
-            unlocks[unlock_id] = {"unlocked_at": now, "first_tier": result.get("tier"), "evidence": evidence_for(definition, scan.get("sessions", []))}
+            unlocks[unlock_id] = {"unlocked_at": now, "first_tier": result.get("tier"), "highest_tier": result.get("tier"), "evidence": evidence_for(definition, scan.get("sessions", []))}
         item = {**definition, **result}
         recorded = unlocks.get(unlock_id)
-        if recorded and not result["unlocked"]:
+        if recorded and not is_partial and result["unlocked"]:
+            # Track the best tier ever reached so the floor below can restore
+            # it, not just the first one earned.
+            if _tier_rank(definition, result.get("tier")) > _tier_rank(definition, recorded.get("highest_tier")):
+                recorded["highest_tier"] = result.get("tier")
+        if recorded:
             # Unlock floor: state.json is the durable record of what was
             # earned; the live aggregate can lose its backing when compaction
             # shrinks session history. Once earned, never displayed as
-            # un-earned — floor at the recorded first tier.
-            item["unlocked"] = True
-            item["state"] = "unlocked"
-            item["tier"] = item.get("tier") or recorded.get("first_tier")
+            # un-earned -- and never at a lower tier than was reached. The
+            # floor survives compaction only: /reset-state drops state.json,
+            # the scan checkpoint and the snapshot together, so a deliberate
+            # reset clears it along with the evidence.
+            floor_tier = recorded.get("highest_tier") or recorded.get("first_tier")
+            if not result["unlocked"]:
+                item["unlocked"] = True
+                item["state"] = "unlocked"
+            if _tier_rank(definition, floor_tier) > _tier_rank(definition, item.get("tier")):
+                item["tier"] = floor_tier
         if item["unlocked"]:
             item["unlocked_at"] = unlocks.get(unlock_id, {}).get("unlocked_at")
             item["evidence"] = unlocks.get(unlock_id, {}).get("evidence") or evidence_for(definition, scan.get("sessions", []))
@@ -1117,6 +1145,10 @@ async def rescan():
 
 @router.post("/reset-state")
 async def reset_state():
+    """Full reset: drops ``state.json`` (recorded unlocks, i.e. the unlock
+    floor), the scan checkpoint (cached per-session stats, i.e. the monotonic
+    merge's memory) and the snapshot, together. After this nothing earned is
+    remembered -- the floor protects against compaction, not against a reset."""
     global _SNAPSHOT_CACHE, _SNAPSHOT_CACHE_AT
     save_state({"unlocks": {}})
     _SNAPSHOT_CACHE = None

--- a/tests/plugins/test_achievements_monotonic.py
+++ b/tests/plugins/test_achievements_monotonic.py
@@ -1,0 +1,128 @@
+"""Regression tests: achievement stats must never regress after compaction.
+
+Context compaction rewrites a session's messages (fewer survive) and bumps
+``last_active``, which invalidates the scan checkpoint's fingerprint and forces
+re-analysis of the smaller transcript. Before the monotonic guard, the fresh
+(smaller) stats replaced the cached ones, lifetime aggregates dropped, and
+earned badges visibly rolled back — including, fittingly, ``rollback_wizard``.
+
+Two guards under test:
+
+* ``_merge_stats_monotonic`` — per-session metrics take the element-wise max
+  with the cached scan, so counts only ever go up.
+* the unlock floor in ``_compute_from_scan`` — a badge recorded in
+  ``state.json`` stays displayed as unlocked (at >= its recorded first tier)
+  even if the live aggregate loses its backing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+PLUGIN_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "hermes-achievements"
+    / "dashboard"
+    / "plugin_api.py"
+)
+
+
+def load_plugin():
+    spec = importlib.util.spec_from_file_location("achievements_monotonic_test_module", PLUGIN_MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_merge_keeps_higher_cached_counts_after_compaction_shrink():
+    pa = load_plugin()
+    cached = {"tool_calls": 400, "git_events": 12, "model_names": ["qwen"], "title": "before"}
+    fresh = {"tool_calls": 37, "git_events": 0, "model_names": ["claude"], "title": "after"}
+    merged = pa._merge_stats_monotonic(cached, fresh)
+    assert merged["tool_calls"] == 400
+    assert merged["git_events"] == 12
+    assert sorted(merged["model_names"]) == ["claude", "qwen"]
+    # session metadata is not a metric — the fresh value wins
+    assert merged["title"] == "after"
+
+
+def test_merge_lets_genuine_growth_through():
+    pa = load_plugin()
+    merged = pa._merge_stats_monotonic({"tool_calls": 10}, {"tool_calls": 22, "new_metric": 5})
+    assert merged["tool_calls"] == 22
+    assert merged["new_metric"] == 5
+
+
+def test_rescan_after_compaction_does_not_shrink_aggregate(monkeypatch, tmp_path):
+    """End-to-end through scan_sessions with a fake SessionDB: analyze once,
+    compact (shrink messages + bump last_active), rescan — totals must hold."""
+    pa = load_plugin()
+    monkeypatch.setattr(pa, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "plugins" / "hermes-achievements").mkdir(parents=True)
+
+    def make_msgs(n: int):
+        return [
+            {"role": "assistant", "content": "ran a tool", "tool_calls": [{"function": {"name": "terminal"}}]}
+            for _ in range(n)
+        ]
+
+    class FakeDB:
+        def __init__(self, messages, last_active):
+            self._messages = messages
+            self._last_active = last_active
+
+        def list_sessions_rich(self, **_kw):
+            return [{"id": "s1", "title": "t", "started_at": 1.0, "last_active": self._last_active, "model": "m"}]
+
+        def get_messages(self, _sid):
+            return self._messages
+
+        def close(self):
+            pass
+
+    class FakeState:
+        SessionDB = None  # replaced per-scan below
+
+    # first scan: 40 tool calls
+    fake_module = type(sys)("hermes_state")
+    fake_module.SessionDB = lambda: FakeDB(make_msgs(40), last_active=100.0)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_module)
+    first = pa.scan_sessions()
+    first_calls = first["sessions"][0]["tool_call_count"]
+    assert first_calls >= 40
+
+    # compaction: only 3 messages survive, last_active bumps -> fingerprint change
+    fake_module.SessionDB = lambda: FakeDB(make_msgs(3), last_active=200.0)
+    second = pa.scan_sessions()
+    second_calls = second["sessions"][0]["tool_call_count"]
+    assert second_calls == first_calls, (
+        f"per-session tool_calls regressed after compaction: {first_calls} -> {second_calls}"
+    )
+
+
+def test_unlock_floor_survives_lost_aggregate(monkeypatch, tmp_path):
+    pa = load_plugin()
+    monkeypatch.setattr(pa, "get_hermes_home", lambda: tmp_path)
+    state_dir = tmp_path / "plugins" / "hermes-achievements"
+    state_dir.mkdir(parents=True)
+    # pick a real tiered achievement from the catalog
+    definition = next(d for d in pa.ACHIEVEMENTS if d.get("threshold_metric") and d.get("tiers"))
+    metric = definition["threshold_metric"]
+    first_tier = definition["tiers"][0]["name"]
+    pa.save_state({"unlocks": {definition["id"]: {"unlocked_at": 1, "first_tier": first_tier, "evidence": None}}})
+
+    computed = pa._compute_from_scan({"aggregate": {metric: 0}, "sessions": []})
+    flat: Dict[str, Any] = {}
+    for section in computed.values():
+        if isinstance(section, list):
+            for item in section:
+                if isinstance(item, dict) and item.get("id") == definition["id"]:
+                    flat = item
+    assert flat, "achievement missing from computed payload"
+    assert flat["unlocked"] is True, "recorded unlock rolled back when aggregate lost its backing"
+    assert flat.get("tier") == first_tier

--- a/tests/plugins/test_achievements_monotonic.py
+++ b/tests/plugins/test_achievements_monotonic.py
@@ -126,3 +126,68 @@ def test_unlock_floor_survives_lost_aggregate(monkeypatch, tmp_path):
     assert flat, "achievement missing from computed payload"
     assert flat["unlocked"] is True, "recorded unlock rolled back when aggregate lost its backing"
     assert flat.get("tier") == first_tier
+
+
+def test_merge_bool_branch_only_when_both_sides_are_bool():
+    """Type drift between analyzer versions must not collapse a count to True."""
+    pa = load_plugin()
+    assert pa._merge_stats_monotonic({"tool_calls": 400}, {"tool_calls": True})["tool_calls"] == 400
+    assert pa._merge_stats_monotonic({"used_git": True}, {"used_git": 400})["used_git"] == 400
+    assert pa._merge_stats_monotonic({"used_git": True}, {"used_git": False})["used_git"] is True
+    assert pa._merge_stats_monotonic({"used_git": False}, {"used_git": False})["used_git"] is False
+
+
+def test_merge_none_from_fresh_scan_keeps_cached_value():
+    """A partial fresh analysis (metric omitted or None) cannot erase known data."""
+    pa = load_plugin()
+    merged = pa._merge_stats_monotonic({"git_events": 12, "model_names": ["qwen"]}, {"git_events": None})
+    assert merged["git_events"] == 12
+    assert merged["model_names"] == ["qwen"]
+
+
+def _find(computed: Dict[str, Any], achievement_id: str) -> Dict[str, Any]:
+    for section in computed.values():
+        if isinstance(section, list):
+            for item in section:
+                if isinstance(item, dict) and item.get("id") == achievement_id:
+                    return item
+    return {}
+
+
+def test_unlock_floor_restores_highest_tier_not_first(monkeypatch, tmp_path):
+    """A badge that climbed to Gold must not re-display at Copper after compaction."""
+    pa = load_plugin()
+    monkeypatch.setattr(pa, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "plugins" / "hermes-achievements").mkdir(parents=True)
+    definition = next(d for d in pa.ACHIEVEMENTS if d.get("threshold_metric") and len(d.get("tiers", [])) >= 3)
+    metric = definition["threshold_metric"]
+    ladder = sorted(definition["tiers"], key=lambda t: t["threshold"])
+    pa.save_state({"unlocks": {definition["id"]: {"unlocked_at": 1, "first_tier": ladder[0]["name"], "highest_tier": ladder[2]["name"], "evidence": None}}})
+
+    # aggregate lost entirely -> floor at the highest tier reached, not the first
+    lost = _find(pa._compute_from_scan({"aggregate": {metric: 0}, "sessions": []}), definition["id"])
+    assert lost["unlocked"] is True
+    assert lost["tier"] == ladder[2]["name"]
+
+    # aggregate partially lost (live says tier 2) -> still the recorded highest
+    partial = _find(pa._compute_from_scan({"aggregate": {metric: ladder[1]["threshold"]}, "sessions": []}), definition["id"])
+    assert partial["tier"] == ladder[2]["name"]
+
+
+def test_highest_tier_is_recorded_as_progress_climbs(monkeypatch, tmp_path):
+    pa = load_plugin()
+    monkeypatch.setattr(pa, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / "plugins" / "hermes-achievements").mkdir(parents=True)
+    definition = next(d for d in pa.ACHIEVEMENTS if d.get("threshold_metric") and len(d.get("tiers", [])) >= 3)
+    metric = definition["threshold_metric"]
+    ladder = sorted(definition["tiers"], key=lambda t: t["threshold"])
+
+    pa._compute_from_scan({"aggregate": {metric: ladder[0]["threshold"]}, "sessions": []})
+    assert pa.load_state()["unlocks"][definition["id"]]["highest_tier"] == ladder[0]["name"]
+    pa._compute_from_scan({"aggregate": {metric: ladder[2]["threshold"]}, "sessions": []})
+    rec = pa.load_state()["unlocks"][definition["id"]]
+    assert rec["first_tier"] == ladder[0]["name"]
+    assert rec["highest_tier"] == ladder[2]["name"]
+    # a later, smaller scan never lowers the record
+    pa._compute_from_scan({"aggregate": {metric: ladder[1]["threshold"]}, "sessions": []})
+    assert pa.load_state()["unlocks"][definition["id"]]["highest_tier"] == ladder[2]["name"]


### PR DESCRIPTION
Lifetime achievement counters and unlocked badges roll back when a session's context is compacted.

## How this relates to #28661

This is the same symptom reported in #28661 — lifetime counters regressing — but it comes from a different trigger, so I wanted to check carefully whether the existing work there already covered it before adding another PR to the pile.

| | trigger | session row | covered by #28713 / #50882 / #63736 |
|---|---|---|---|
| #28661 | `sessions.auto_prune` deletes rows | gone | yes |
| this PR | context compaction rewrites a transcript | still present, smaller | no |

#63736 takes the approach I'd have reached for, and its ledger is populated from:

```python
pruned_sids = set(previous_sessions) - set(checkpoint_sessions)
```

A compacted session never leaves `checkpoint_sessions` — it didn't disappear, it got smaller — so it falls outside that set by design. That's correct for the problem #63736 is solving; it just leaves this case open.

The two changes compose cleanly: #63736 handles *session gone*, this handles *session shrank*. **This PR doesn't address pruning and isn't a substitute for that work** — if #63736 lands first I'm happy to rebase on top of it.

## The bug

1. Per-session stats come from scanning session messages; the checkpoint cache keys reuse on a fingerprint that includes `last_active`.
2. Compaction rewrites the session's messages (fewer survive) and bumps `last_active`, so the fingerprint mismatches and the smaller transcript is re-analyzed.
3. The fresh, smaller stats replace the cached ones with no monotonic guard, so lifetime aggregates drop.
4. `state.json` durably records first-unlocks, but display state is computed purely from the live aggregate — so a badge reads locked while the record says earned.

The missing invariant is the one #28661 already names: usage counters only ever go up. A per-session metric that decreases between scans is an artifact of history compression, never of usage.

## The fix — two independent guards

**`_merge_stats_monotonic(cached, fresh)`** — on rescan of a known session id: element-wise max of numeric metrics, union of collection fields, fresh values for session metadata. Called from the rescan branch of `scan_sessions`.

**Unlock floor in `_compute_from_scan`** — an achievement recorded in `state.json` displays unlocked at no less than its recorded `first_tier`, even if the live aggregate has lost its backing.

Deliberately not done: no inferring destructive operations, no second mapping from session keys to aggregate keys, and no change to how unknown or absent sessions are treated.

## Tests and verification

`tests/plugins/test_achievements_monotonic.py`, 4 new tests:

- merge keeps higher cached counts on shrink, and lets genuine growth through
- end-to-end `scan_sessions` against a fake SessionDB: analyze, compact (shrink messages, bump `last_active`), rescan, and confirm per-session `tool_call_count` is unchanged
- unlock floor survives a zeroed aggregate

On this branch:

```
pytest tests/plugins/test_achievements_monotonic.py  →  4 passed
ruff check plugins/hermes-achievements/dashboard/plugin_api.py \
           tests/plugins/test_achievements_monotonic.py  →  All checks passed
```

Full `tests/plugins/` shows 15 failures, all in `tests/plugins/video_gen/test_fal_plugin.py`. Those fail identically on a clean `origin/main` checkout, so they look pre-existing and unrelated — happy to be told otherwise.

Thanks for the work on the achievements plugin, and for #28661's write-up in particular — the "achievements are lifetime state and should be monotonic" framing there is what made this case easy to recognize.

*co-authored with Kai*
