### PR TITLE
fix(update): avoid passkey prompts for official SSH remotes

### DIFF
--- a/apps/desktop/electron/update-remote.ts
+++ b/apps/desktop/electron/update-remote.ts
@@ -5,8 +5,9 @@
  * If the user's GitHub SSH key is FIDO2/passkey-backed, a background `git fetch
  * origin` triggers an unexplained hardware-touch prompt. For passive checks
  * against the official repo we substitute the public HTTPS `ls-remote` path,
- * which needs no auth and cannot prompt. Active update/apply flows are left
- * unchanged.
+ * which needs no auth and cannot prompt. The active apply flow is handed to
+ * the CLI updater, which applies the same command-local HTTPS override when
+ * fetching the official SSH remote.
  *
  * Extracted from main.ts so the security-critical remote detection is unit
  * testable without booting Electron (main.ts requires('electron') at load).

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -35,6 +35,7 @@ import time as _time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlsplit
 
 from hermes_cli.config import get_hermes_home
 from hermes_constants import venv_python_path
@@ -2285,6 +2286,7 @@ OFFICIAL_REPO_URLS = {
 }
 
 OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
+OFFICIAL_REPO_CANONICAL = "github.com/nousresearch/hermes-agent"
 
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
@@ -2303,9 +2305,56 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
         pass
     return None
 
+
+def _canonical_remote_url(url: Optional[str]) -> str:
+    """Normalize common GitHub remote forms to ``host/owner/repo``."""
+    value = str(url or "").strip().lower()
+
+    if value.startswith("git@github.com:"):
+        value = f"github.com/{value[len('git@github.com:'):]}"
+    elif value.startswith("ssh://git@github.com/"):
+        value = f"github.com/{value[len('ssh://git@github.com/'):]}"
+    else:
+        try:
+            parsed = urlsplit(value)
+            if parsed.hostname and parsed.path:
+                value = f"{parsed.hostname}{parsed.path}"
+        except ValueError:
+            pass
+
+    value = value.rstrip("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    return value
+
+
+def _is_official_ssh_remote(url: Optional[str]) -> bool:
+    """Whether *url* is the official Hermes repo over an SSH transport."""
+    value = str(url or "").strip().lower()
+    if not (value.startswith("git@") or value.startswith("ssh://")):
+        return False
+    return _canonical_remote_url(value) == OFFICIAL_REPO_CANONICAL
+
+
+def _git_cmd_for_remote_fetch(
+    git_cmd: list[str], remote: str, remote_url: Optional[str]
+) -> list[str]:
+    """Use anonymous HTTPS for official SSH fetches without mutating Git config.
+
+    Public Hermes source does not need SSH authentication. The command-local
+    URL override prevents a FIDO2/passkey prompt during update while preserving
+    the user's configured remote and all fork/custom SSH remotes.
+    """
+    if not _is_official_ssh_remote(remote_url):
+        return git_cmd
+    return [*git_cmd, "-c", f"remote.{remote}.url={OFFICIAL_REPO_URL}"]
+
+
 def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
+        return False
+    if _canonical_remote_url(origin_url) == OFFICIAL_REPO_CANONICAL:
         return False
     # Normalize URL for comparison (strip trailing .git if present)
     normalized = origin_url.rstrip("/")
@@ -3325,20 +3374,24 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         # before spending a network fetch on it. Non-fork installs have no
         # 'upstream' remote, and the old flow burned a failed network attempt
         # (~0.3-1 s) on every --check before falling back to origin.
-        has_upstream_remote = (
-            subprocess.run(
-                git_cmd + ["remote", "get-url", "upstream"],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-            ).returncode
-            == 0
+        upstream_probe = subprocess.run(
+            git_cmd + ["remote", "get-url", "upstream"],
+            cwd=_m().PROJECT_ROOT,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
         )
+        has_upstream_remote = upstream_probe.returncode == 0
+        upstream_url = upstream_probe.stdout.strip() if has_upstream_remote else None
         fetch_result = None
         if has_upstream_remote:
             print("→ Fetching from upstream...")
+            fetch_git_cmd = _git_cmd_for_remote_fetch(
+                git_cmd, "upstream", upstream_url
+            )
+            if fetch_git_cmd != git_cmd:
+                print("  (using anonymous HTTPS for the official SSH remote)")
             fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["upstream", branch],
+                fetch_git_cmd + ["fetch"] + depth_args + ["upstream", branch],
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
@@ -3349,8 +3402,14 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         else:
             # No upstream remote, or the upstream fetch failed — use origin.
             print("→ Fetching from origin...")
+            origin_url = _m()._get_origin_url(git_cmd, _m().PROJECT_ROOT)
+            fetch_git_cmd = _git_cmd_for_remote_fetch(
+                git_cmd, "origin", origin_url
+            )
+            if fetch_git_cmd != git_cmd:
+                print("  (using anonymous HTTPS for the official SSH remote)")
             fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["origin", branch],
+                fetch_git_cmd + ["fetch"] + depth_args + ["origin", branch],
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
@@ -3360,8 +3419,12 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     else:
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
+        origin_url = _m()._get_origin_url(git_cmd, _m().PROJECT_ROOT)
+        fetch_git_cmd = _git_cmd_for_remote_fetch(git_cmd, "origin", origin_url)
+        if fetch_git_cmd != git_cmd:
+            print("  (using anonymous HTTPS for the official SSH remote)")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch"] + depth_args + ["origin", branch],
+            fetch_git_cmd + ["fetch"] + depth_args + ["origin", branch],
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
@@ -6087,8 +6150,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  (removed stale git lock(s): %s)" % ", ".join(cleared))
 
         print("→ Fetching updates...")
+        fetch_git_cmd = _git_cmd_for_remote_fetch(git_cmd, "origin", origin_url)
+        if fetch_git_cmd != git_cmd:
+            print("  (using anonymous HTTPS for the official SSH remote)")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            fetch_git_cmd + ["fetch", "origin", branch],
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",

--- a/tests/hermes_cli/test_update_ssh_remote.py
+++ b/tests/hermes_cli/test_update_ssh_remote.py
@@ -1,0 +1,100 @@
+import subprocess
+from types import SimpleNamespace
+
+from hermes_cli import update_cmd
+
+
+def test_official_ssh_remote_forms_are_detected():
+    assert update_cmd._is_official_ssh_remote(
+        "git@github.com:NousResearch/hermes-agent.git"
+    )
+    assert update_cmd._is_official_ssh_remote(
+        "ssh://git@github.com/NousResearch/hermes-agent.git"
+    )
+
+
+def test_only_official_ssh_fetches_use_anonymous_https_override():
+    git_cmd = ["git"]
+
+    assert update_cmd._git_cmd_for_remote_fetch(
+        git_cmd,
+        "origin",
+        "git@github.com:NousResearch/hermes-agent.git",
+    ) == [
+        "git",
+        "-c",
+        "remote.origin.url=https://github.com/NousResearch/hermes-agent.git",
+    ]
+    assert update_cmd._git_cmd_for_remote_fetch(
+        git_cmd, "origin", "https://github.com/NousResearch/hermes-agent.git"
+    ) == git_cmd
+    assert update_cmd._git_cmd_for_remote_fetch(
+        git_cmd, "origin", "git@github.com:example/hermes-agent.git"
+    ) == git_cmd
+    assert update_cmd._git_cmd_for_remote_fetch(
+        git_cmd, "origin", "ssh://git@example.com/hermes-agent.git"
+    ) == git_cmd
+
+
+def test_official_ssh_remote_is_not_misclassified_as_fork():
+    assert not update_cmd._is_fork(
+        "ssh://git@github.com/NousResearch/hermes-agent.git"
+    )
+
+
+def test_active_update_fetch_uses_remote_fetch_helper():
+    source = update_cmd._cmd_update_impl.__code__.co_consts
+    assert any(
+        isinstance(const, str) and "_git_cmd_for_remote_fetch" in const
+        for const in source
+    ) or "_git_cmd_for_remote_fetch" in update_cmd._cmd_update_impl.__code__.co_names
+
+
+def test_update_check_fetches_official_ssh_origin_via_https(monkeypatch, tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / ".git").mkdir(parents=True)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-3:] == ["rev-parse", "--is-shallow-repository"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="false\n", stderr="")
+        if cmd[-3:] == ["remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+        if "fetch" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[-3:] == ["rev-parse", "--verify", "--quiet"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="remote-sha\n", stderr="")
+        if "rev-list" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        update_cmd,
+        "_m",
+        lambda: SimpleNamespace(
+            PROJECT_ROOT=repo,
+            _get_origin_url=lambda *_args: (
+                "git@github.com:NousResearch/hermes-agent.git"
+            ),
+        ),
+    )
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda _root: "git"
+    )
+    monkeypatch.setattr("hermes_cli.config.is_nix_install_method", lambda _method: False)
+
+    update_cmd._cmd_update_check()
+
+    fetches = [cmd for cmd in calls if "fetch" in cmd]
+    assert fetches == [
+        [
+            "git",
+            "-c",
+            "remote.origin.url=https://github.com/NousResearch/hermes-agent.git",
+            "fetch",
+            "origin",
+            "main",
+        ]
+    ]


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes updates from prompting for a FIDO2/passkey approval when the official Hermes repository is configured as an SSH remote.

## Why

The updater previously ran `git fetch` through the configured SSH URL. For the official repository, that can invoke the user's SSH-backed GitHub authentication and require the Hermes Secrets Passkey even though the update only needs public repository data.

## How

- Use a command-local anonymous HTTPS URL override only for official Hermes SSH remotes.
- Preserve configured remotes and behavior for forks, custom SSH remotes, and HTTPS remotes.
- Recognize both scp-style and `ssh://` official remotes as the official repository.
- Add regression coverage for helper behavior and the actual update-check fetch command.
- Update the desktop updater comment to document that the CLI owns this behavior.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_update_ssh_remote.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_update_fetch_failure_classifier.py -q` — 16 passed.
- `python3 scripts/check-windows-footguns.py hermes_cli/update_cmd.py tests/hermes_cli/test_update_ssh_remote.py` — passed.
- `git diff --check` — passed.
- Python compilation — passed.

## Platforms tested

- macOS on Apple Silicon.

## Limitations

- The full suite was attempted but could not complete because this checkout lacks the `anthropic` dependency; the first failures were unrelated Anthropic-client tests.
- A live FIDO2 prompt was not reproduced because the local checkout currently uses an HTTPS origin; the fix is covered by focused command-level regression tests.
- No credentials, remote configuration, or user state were modified.

## Related work

I reviewed related open PRs #54573 and #85405 and did not find an existing change covering this official-SSH updater path.