### PR TITLE
fix(gateway): coordinate shared backend ownership

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -290,14 +290,6 @@ def try_acquire_active_session(
     """
     max_sessions = resolve_max_concurrent_sessions(config)
     lease_id = uuid.uuid4().hex
-    if max_sessions is None:
-        return ActiveSessionLease(
-            lease_id=lease_id,
-            session_id=session_id,
-            surface=surface,
-            enabled=False,
-        ), None
-
     now = time.time()
     entry = {
         "lease_id": lease_id,
@@ -321,7 +313,7 @@ def try_acquire_active_session(
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
         active_count = len(entries)
-        if active_count >= max_sessions:
+        if max_sessions is not None and active_count >= max_sessions:
             _write_entries(state_path, entries)
             logger.info(
                 "Active session limit reached: active=%d max=%d surface=%s",
@@ -413,8 +405,8 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     """
     pid = os.getpid()
     state_path = _state_path()
-    # With the cap disabled the registry is never written, so don't take a lock
-    # (or create its file) on the idle-reaper tick for the majority of installs.
+    # Avoid creating the registry from the idle-reaper tick before any real
+    # session has acquired ownership.
     if not state_path.exists():
         return 0
     with _FileLock(_lock_path()):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19398,6 +19398,54 @@ def _report_port_in_use(host: str, port: int) -> None:
     )
 
 
+def _probe_hermes_backend(host: str, port: int) -> bool:
+    """Return whether the occupied endpoint is a live Hermes backend."""
+    if not host or port <= 0:
+        return False
+    url_host = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    try:
+        request = urllib.request.Request(
+            f"http://{url_host}:{port}/api/health",
+            headers={"Accept": "application/json"},
+            method="GET",
+        )
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(request, timeout=1.0) as response:
+            if response.status != 200:
+                return False
+            payload = json.loads(response.read(4096).decode("utf-8"))
+    except Exception:
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("ok") is True
+        and isinstance(payload.get("version"), str)
+    )
+
+
+def _wait_for_supervised_backend_holder(host: str, port: int) -> bool:
+    """Keep a launchd job alive while its prior Hermes child owns the port.
+
+    A launchd wrapper can exit while the long-lived serve child survives and
+    is re-parented to PID 1. Unconditional KeepAlive then starts a replacement
+    every throttle interval. Waiting here preserves one supervised process;
+    when the old child releases the socket, this process proceeds to bind it.
+    Manual launches and non-Hermes holders retain the exit-75 contract.
+    """
+    label = os.environ.get("XPC_SERVICE_NAME", "")
+    if not label.startswith("ai.hermes.") or not _probe_hermes_backend(host, port):
+        return False
+
+    print(
+        f"BACKEND_ALREADY_RUNNING port={port} supervisor=launchd; "
+        "waiting to take ownership",
+        flush=True,
+    )
+    while _port_bind_conflict(host, port):
+        time.sleep(5.0)
+    return True
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -19662,8 +19710,9 @@ def start_server(
     # BACKEND_PORT_IN_USE sentinel + a distinct exit code instead.
     # ``--port 0`` (ephemeral) is skipped by the probe and unaffected.
     if _port_bind_conflict(host, port):
-        _report_port_in_use(host, port)
-        raise SystemExit(PORT_IN_USE_EXIT_CODE)
+        if not _wait_for_supervised_backend_holder(host, port):
+            _report_port_in_use(host, port)
+            raise SystemExit(PORT_IN_USE_EXIT_CODE)
 
     async def _serve():
         # Split startup from main_loop so we can read the bound port

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -36,6 +36,27 @@ def test_resolve_max_concurrent_sessions_values(caplog):
     )
 
 
+def test_disabled_limit_still_records_live_session_ownership(tmp_path, monkeypatch):
+    """Ownership is needed by the startup sweep even when no cap is configured."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="live-on-another-backend",
+        surface="desktop",
+        config={},
+    )
+
+    assert lease is not None and message is None
+    assert lease.enabled is True
+    assert [
+        entry["session_id"]
+        for entry in active_sessions.active_session_registry_snapshot()
+    ] == ["live-on-another-backend"]
+
+    lease.release()
+    assert active_sessions.active_session_registry_snapshot() == []
+
+
 
 
 

--- a/tests/hermes_cli/test_serve_supervisor_port_handoff.py
+++ b/tests/hermes_cli/test_serve_supervisor_port_handoff.py
@@ -1,0 +1,29 @@
+"""Supervisor-owned fixed-port Hermes backend handoff contracts."""
+
+from unittest.mock import patch
+
+
+def test_launchd_waits_for_existing_hermes_backend(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.dashboard")
+    conflicts = iter((True, False))
+    monkeypatch.setattr(web_server, "_port_bind_conflict", lambda *_: next(conflicts))
+    monkeypatch.setattr(web_server, "_probe_hermes_backend", lambda *_: True)
+
+    with patch("time.sleep") as sleep:
+        assert web_server._wait_for_supervised_backend_holder("127.0.0.1", 9119)
+
+    assert sleep.call_count == 1
+
+
+def test_manual_or_foreign_port_holder_is_not_adopted(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    monkeypatch.setattr(web_server, "_probe_hermes_backend", lambda *_: True)
+    assert not web_server._wait_for_supervised_backend_holder("127.0.0.1", 9119)
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.dashboard")
+    monkeypatch.setattr(web_server, "_probe_hermes_backend", lambda *_: False)
+    assert not web_server._wait_for_supervised_backend_holder("127.0.0.1", 9119)

--- a/tests/tui_gateway/test_startup_orphan_sweep.py
+++ b/tests/tui_gateway/test_startup_orphan_sweep.py
@@ -141,6 +141,30 @@ class TestSweepOrphanedSessionRows:
         for row_id in ("resumed-tui", "gateway-row", "recent-tui"):
             assert db.get_session(row_id)["ended_at"] is None
 
+    def test_spares_session_leased_by_another_live_backend(self, monkeypatch, tmp_path):
+        from hermes_cli.active_sessions import try_acquire_active_session
+
+        home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db = SessionDB(home / "state.db")
+        stale = time.time() - 8 * 3600
+        _seed_session(db, "other-backend", source="desktop", last_active=stale)
+        _seed_session(db, "dead-backend", source="desktop", last_active=stale)
+        lease, message = try_acquire_active_session(
+            session_id="other-backend", surface="desktop", config={}
+        )
+        assert lease is not None and message is None
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_SESSION_TTL_S", float(IDLE_S))
+        monkeypatch.setattr(server, "_sessions", {})
+
+        try:
+            assert server._sweep_orphaned_session_rows() == ["dead-backend"]
+            assert db.get_session("other-backend")["ended_at"] is None
+            assert db.get_session("dead-backend")["end_reason"] == "startup_orphan_reap"
+        finally:
+            lease.release()
+
     def test_leaves_already_ended_rows_untouched(self, monkeypatch, tmp_path):
         db = SessionDB(tmp_path / "state.db")
         stale = time.time() - 8 * 3600

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1683,10 +1683,24 @@ def _sweep_orphaned_session_rows() -> list[str]:
     ttl = _SESSION_TTL_S
     if ttl <= 0:
         return []
+    excluded = set(_live_session_ids())
+    try:
+        from hermes_cli.active_sessions import active_session_registry_snapshot
+
+        excluded.update(
+            str(entry.get("session_id"))
+            for entry in active_session_registry_snapshot()
+            if entry.get("session_id")
+        )
+    except Exception:
+        # Ownership lookup is best-effort. Existing in-process exclusions and
+        # dual-clock staleness still provide the pre-registry safety floor.
+        logger.warning("active session ownership lookup failed", exc_info=True)
+
     swept = db.sweep_orphaned_sessions(
         max_idle_seconds=ttl,
         sources=_ORPHAN_SWEEP_SOURCES,
-        exclude_ids=tuple(_live_session_ids()),
+        exclude_ids=tuple(sorted(excluded)),
     )
     if swept:
         logger.info(


### PR DESCRIPTION
## Summary

- record live UI session ownership across backend processes even when the concurrent-session cap is disabled
- exclude every live backend lease from the startup orphan sweep while preserving stale-row cleanup
- keep a launchd-supervised fixed-port backend alive when its prior Hermes child still owns the socket, then take over after the holder exits

## Root cause

The startup sweep only excluded session IDs held by the current process. In a shared `state.db` deployment, an idle session owned by another live backend was indistinguishable from a row left behind by a dead process. Separately, a launchd replacement treated its own surviving Hermes endpoint like a foreign port conflict and exited with `EX_TEMPFAIL`, so unconditional `KeepAlive` repeatedly respawned it.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_active_sessions.py -q` (6 passed)
- `scripts/run_tests.sh tests/tui_gateway/test_startup_orphan_sweep.py -q` (12 passed)
- `scripts/run_tests.sh tests/hermes_state/test_sweep_orphaned_sessions.py -q` (12 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_serve_supervisor_port_handoff.py -q` (2 passed)
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` (611 passed)

## Related Issue

Closes #94895
