### PR TITLE
fix(gateway): close open sessions the routing index can never reach

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -87,6 +87,12 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 # sweep can only ever catch genuinely abandoned rows — never a session that is
 # merely slow. See _reconcile_orphaned_open_sessions.
 _ORPHAN_SWEEP_MIN_IDLE_S = 24 * 3600.0
+# Rows ended per watcher tick. The first sweep on a leaking install faces a
+# real backlog (703 open rows observed on a single-user box); each end_session
+# is a synchronous sqlite write, so an uncapped first pass would issue all of
+# them back-to-back. The watcher ticks every 300s, so a backlog drains over a
+# few passes instead of in one burst.
+_ORPHAN_SWEEP_MAX_PER_TICK = 50
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # Telegram cold polling now proves one real getUpdates round trip before connect
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
@@ -13903,39 +13909,176 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         db = getattr(getattr(self, "_session_db", None), "_db", None)
         lister = getattr(db, "list_orphaned_open_sessions", None)
         if not callable(lister):
-            return 0
-        try:
-            rows = lister(older_than_seconds=_ORPHAN_SWEEP_MIN_IDLE_S)
-        except Exception as exc:
-            logger.debug("Orphaned-session listing failed: %s", exc)
-            return 0
-        if not rows:
+            # Reached only if the private attribute chain moved. Warn ONCE,
+            # loudly enough to be found: a silent `return 0` here turns an
+            # upstream rename into a permanent no-op that looks like "there
+            # were no orphans" forever, and the leak this method exists to
+            # fix comes straight back with nothing in the log to say so.
+            if not getattr(self, "_orphan_sweep_unavailable_warned", False):
+                self._orphan_sweep_unavailable_warned = True
+                logger.warning(
+                    "Orphaned-session sweep disabled: could not resolve "
+                    "_session_db._db.list_orphaned_open_sessions (resolved "
+                    "db=%r). Open rows unreachable from the routing index "
+                    "will accumulate until this is repaired.",
+                    type(db).__name__ if db is not None else None,
+                )
             return 0
 
-        live_keys = set(self.session_store._entries.keys())
-        closed = 0
-        for row in rows:
-            key = row.get("session_key")
-            # Still routable: the in-memory path owns it (and runs the
-            # finalize hooks this sweep deliberately does not).
-            if key and key in live_keys:
-                continue
-            if key:
-                try:
-                    if self.session_store._has_active_processes_safe(
-                        key, context="orphan-sweep"
-                    ):
-                        continue
-                except Exception:
-                    continue
+        # EVERYTHING below runs off-loop in one thread hop. Two reasons:
+        #   * end_session is blocking sqlite I/O; a slow disk must not stall
+        #     every other gateway task behind this sweep.
+        #   * the eligibility filter reads the SYNC session_store
+        #     (live_session_keys / _has_active_processes_safe). Async gateway
+        #     code may not touch the sync store on the loop — see
+        #     tests/gateway/test_async_session_store.py, which allows exactly
+        #     this shape: a nested sync helper, because it executes off-loop.
+        #     An earlier revision called _has_active_processes_safe directly in
+        #     the coroutine and tripped that test.
+        def _sweep() -> tuple:
             try:
-                db.end_session(row["id"], "orphaned_expiry")
-                closed += 1
+                rows = lister(older_than_seconds=_ORPHAN_SWEEP_MIN_IDLE_S)
             except Exception as exc:
-                logger.debug(
-                    "Could not end orphaned session %s: %s", row.get("id"), exc
-                )
+                logger.debug("Orphaned-session listing failed: %s", exc)
+                return 0, 0
+            if not rows:
+                return 0, 0
+
+            # Snapshot the routing index through the store's public, lock-held
+            # accessor. Reading `_entries` unlocked races the rebuild paths,
+            # which replace the dict wholesale — a reader can catch it
+            # half-built and mistake a live session for an orphan. Fall back to
+            # the private dict only for older stores / test doubles predating
+            # the accessor.
+            store = self.session_store
+            keys_fn = getattr(store, "live_session_keys", None)
+            if callable(keys_fn):
+                live_keys = keys_fn()
+            else:
+                live_keys = set(getattr(store, "_entries", {}) or {})
+
+            eligible = []
+            for row in rows:
+                key = row.get("session_key")
+                # Still routable: the in-memory path owns it (and runs the
+                # finalize hooks this sweep deliberately does not).
+                if key and key in live_keys:
+                    continue
+                # Would this row's OWN reset policy ever have ended it? The
+                # shipped default is mode="none" (never auto-reset), so
+                # skipping this check does not merely miss an edge case — it
+                # overrides the DEFAULT for every install that never
+                # configured session_reset.
+                if not self._orphan_sweep_policy_permits_end(row):
+                    continue
+                if key:
+                    try:
+                        if store._has_active_processes_safe(
+                            key, context="orphan-sweep"
+                        ):
+                            continue
+                    except Exception:
+                        continue
+                eligible.append(row["id"])
+                # Bound the work per tick. The first sweep on a leaking
+                # install has a real backlog (703 rows were observed on a
+                # single-user box); ending them all in one pass would run that
+                # many synchronous DB writes back-to-back. The watcher ticks
+                # every 300s, so a backlog drains steadily instead.
+                if len(eligible) >= _ORPHAN_SWEEP_MAX_PER_TICK:
+                    break
+
+            done = 0
+            for session_id in eligible:
+                try:
+                    db.end_session(session_id, "orphaned_expiry")
+                    done += 1
+                except Exception as exc:
+                    logger.debug(
+                        "Could not end orphaned session %s: %s", session_id, exc
+                    )
+            return done, len(eligible)
+
+        closed, considered = await asyncio.to_thread(_sweep)
+        if considered >= _ORPHAN_SWEEP_MAX_PER_TICK:
+            logger.info(
+                "Orphaned-session sweep hit the per-tick cap (%d); more rows "
+                "remain and will be picked up on the next pass.",
+                _ORPHAN_SWEEP_MAX_PER_TICK,
+            )
         return closed
+
+    def _orphan_sweep_policy_permits_end(self, row: dict) -> bool:
+        """True only if this row's effective reset policy would have ended it.
+
+        The sweep exists because these rows never reach the in-memory expiry
+        path, so their policy is never evaluated. Ending them without
+        consulting that policy substitutes a flat 24h rule for the user's
+        configuration — and since ``SessionResetPolicy.mode`` defaults to
+        ``"none"`` ("never auto-reset", made the default in July 2026 because
+        the old behaviour "surprised users who expected their conversations to
+        persist"), the unconditional version would auto-reset sessions on
+        installs that opted into nothing at all.
+
+        Fails CLOSED: any row whose policy cannot be resolved with confidence
+        is left open. Keeping a stale row costs disk; ending a session the
+        user asked to keep forever destroys their context.
+        """
+        config = getattr(self.session_store, "config", None)
+        resolver = getattr(config, "get_reset_policy", None)
+        if not callable(resolver):
+            return False
+
+        # `chat_type` is the session_type the live path passes (see the
+        # notify branch in _session_expiry_watcher, which resolves it as
+        # `getattr(source, 'chat_type', 'dm')`), so a bare DB row can be
+        # resolved exactly the same way the in-memory path would.
+        session_type = row.get("chat_type")
+        if not session_type and getattr(config, "reset_by_type", None):
+            # Per-type policies are configured but this row predates the
+            # column or never recorded one. Any answer would be a guess, and
+            # the guess could end a row the user pinned to "none".
+            return False
+
+        source = row.get("source")
+        platform = None
+        if source:
+            try:
+                platform = Platform(source)
+            except Exception:
+                # A source the enum cannot construct: reset_by_platform cannot
+                # be checked, so an override pinning it to "none" cannot be
+                # ruled out.
+                return False
+        try:
+            policy = resolver(platform=platform, session_type=session_type)
+        except Exception:
+            return False
+
+        mode = (getattr(policy, "mode", "none") or "none").lower()
+        if mode == "none":
+            return False
+        if mode == "daily":
+            # Only rows already idle past _ORPHAN_SWEEP_MIN_IDLE_S (24h) reach
+            # here, so at least one daily boundary has certainly passed.
+            return True
+        if mode in ("idle", "both"):
+            try:
+                idle_limit = float(getattr(policy, "idle_minutes", 1440)) * 60.0
+            except (TypeError, ValueError):
+                return False
+            last_active = row.get("last_active")
+            if last_active is None:
+                return False
+            try:
+                idle_for = time.time() - float(last_active)
+            except (TypeError, ValueError):
+                return False
+            # "both" also has a daily trigger, but the idle test is the
+            # stricter of the two at >24h idle, so it alone is sufficient.
+            return idle_for >= idle_limit
+        # Unrecognised mode from a newer config: fail closed.
+        return False
 
     async def _session_expiry_watcher(self, interval: int = 300):
         """Background task that finalizes expired sessions.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -81,6 +81,12 @@ from hermes_cli.fallback_config import get_fallback_chain
 # (see gateway/agent_cache_pressure.py).
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
+# Minimum idle time before the orphaned-session sweep will END a DB row that
+# the routing index can no longer reach. Deliberately far beyond any sane
+# reset window (the shipped default is 120 min idle / daily at 04:00), so the
+# sweep can only ever catch genuinely abandoned rows — never a session that is
+# merely slow. See _reconcile_orphaned_open_sessions.
+_ORPHAN_SWEEP_MIN_IDLE_S = 24 * 3600.0
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # Telegram cold polling now proves one real getUpdates round trip before connect
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
@@ -13868,6 +13874,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             err = getattr(result, "error", "send returned success=False")
             raise RuntimeError(f"adapter.send failed: {err}")
 
+    async def _reconcile_orphaned_open_sessions(self) -> int:
+        """End open sessions the in-memory expiry path can never see.
+
+        ``_session_expiry_watcher`` iterates ``session_store._entries``, which
+        ``_ensure_loaded_locked`` builds from the ``gateway_routing`` table —
+        keyed by ``session_key``. A row that has no key, or whose key was
+        pruned or belongs to a previous gateway process, is not in that index,
+        so its reset policy is never evaluated and it stays open indefinitely.
+        Neither ``prune`` nor ``archive`` can reach it either: their selector
+        is pinned to ``ended_at IS NOT NULL`` precisely so a live session is
+        never picked, which excludes every never-closed row by construction.
+
+        Only rows idle beyond ``_ORPHAN_SWEEP_MIN_IDLE_S`` are touched — far
+        past any reset window, so a merely-slow session is never affected.
+        Anything still present in the routing index is skipped and left to the
+        in-memory path, which additionally runs the finalize hooks. Sessions
+        with live background processes are skipped via the same guard the
+        reset policy uses.
+
+        Rows are ENDED, never deleted: they hold real transcripts.
+        ``end_session`` is idempotent and first-reason-wins, so a concurrent
+        close is harmless.
+
+        Returns:
+            Number of sessions ended.
+        """
+        db = getattr(getattr(self, "_session_db", None), "_db", None)
+        lister = getattr(db, "list_orphaned_open_sessions", None)
+        if not callable(lister):
+            return 0
+        try:
+            rows = lister(older_than_seconds=_ORPHAN_SWEEP_MIN_IDLE_S)
+        except Exception as exc:
+            logger.debug("Orphaned-session listing failed: %s", exc)
+            return 0
+        if not rows:
+            return 0
+
+        live_keys = set(self.session_store._entries.keys())
+        closed = 0
+        for row in rows:
+            key = row.get("session_key")
+            # Still routable: the in-memory path owns it (and runs the
+            # finalize hooks this sweep deliberately does not).
+            if key and key in live_keys:
+                continue
+            if key:
+                try:
+                    if self.session_store._has_active_processes_safe(
+                        key, context="orphan-sweep"
+                    ):
+                        continue
+                except Exception:
+                    continue
+            try:
+                db.end_session(row["id"], "orphaned_expiry")
+                closed += 1
+            except Exception as exc:
+                logger.debug(
+                    "Could not end orphaned session %s: %s", row.get("id"), exc
+                )
+        return closed
+
     async def _session_expiry_watcher(self, interval: int = 300):
         """Background task that finalizes expired sessions.
 
@@ -14002,6 +14071,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.info(
                             "Session expiry done: %d finalized", _done,
                         )
+
+                # Close DB rows that no in-memory entry can ever reach.
+                # The loop above walks session_store._entries — the routing
+                # index, keyed by session_key — so a row with a NULL key, or
+                # one whose key was evicted or belongs to a previous gateway
+                # process, is never evaluated and stays open forever. See
+                # _reconcile_orphaned_open_sessions.
+                try:
+                    _orphans_closed = await self._reconcile_orphaned_open_sessions()
+                    if _orphans_closed:
+                        logger.info(
+                            "Session expiry: closed %d orphaned open session(s) "
+                            "unreachable from the routing index",
+                            _orphans_closed,
+                        )
+                except Exception as _e:
+                    logger.debug("Orphaned-session reconcile failed: %s", _e)
 
                 # Sweep agents that have been idle beyond the TTL regardless
                 # of session reset policy.  This catches sessions with very

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Set
 
 logger = logging.getLogger(__name__)
 
@@ -3649,7 +3649,24 @@ class SessionStore:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             return getattr(entry, "session_id", None) if entry else None
-    
+
+    def live_session_keys(self) -> Set[str]:
+        """Return a snapshot of every routable session key.
+
+        Public, lock-held companion to ``peek_session_id`` for callers that
+        need the whole key set rather than one lookup — e.g. the orphaned-row
+        sweep, which must know which DB rows are still owned by the in-memory
+        expiry path. Reaching into ``_entries`` directly races
+        ``_ensure_loaded_locked`` and the reset path, both of which REPLACE
+        entries wholesale, so an unlocked reader can observe a partially
+        rebuilt index and conclude a live session is orphaned.
+
+        The returned set is a copy; mutating it does not affect the store.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            return set(self._entries.keys())
+
     def _get_transcript_drain_lock(self):
         """Return the lock that serializes pending-queue drain boundaries."""
         drain_lock = getattr(self, "_transcript_drain_lock", None)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6070,6 +6070,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         them ``api_server`` with a NULL key, and Matrix rows idle for 69 days
         under a 120-minute idle policy.
 
+        ``source`` and ``chat_type`` are returned so the caller can resolve the
+        row's effective reset policy (``get_reset_policy(platform,
+        session_type)``) rather than applying a flat age rule — the shipped
+        default is ``mode="none"``, so an age-only sweep would auto-reset
+        sessions on installs that configured nothing.
+
         Deliberately narrower than the in-memory path: it only reports rows
         idle far beyond any sane reset window (see ``_ORPHAN_SWEEP_MIN_IDLE_S``
         in ``gateway/run.py``), and skips ``pinned``/``archived`` rows, which
@@ -6082,7 +6088,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._lock:
             rows = self._conn.execute(
                 """
-                SELECT s.id, s.session_key, s.source,
+                SELECT s.id, s.session_key, s.source, s.chat_type,
                        COALESCE(s.last_activity_at, s.started_at) AS last_active
                   FROM sessions s
                  WHERE s.ended_at IS NULL

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6048,6 +6048,54 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchall()
         return [dict(r) for r in rows]
 
+    def list_orphaned_open_sessions(
+        self, *, older_than_seconds: float
+    ) -> List[Dict[str, Any]]:
+        """Open sessions that no in-memory entry can ever finalize.
+
+        ``_session_expiry_watcher`` walks ``session_store._entries`` — the
+        gateway routing index, keyed by ``session_key``. Two shapes of row can
+        never appear there, so the reset policy is never evaluated for them and
+        they stay open forever:
+
+        * ``session_key IS NULL`` — e.g. every ``api_server`` row. The
+          stateless ``/v1/chat/completions`` path derives a per-request session
+          id and never registers a routing key, so nothing can look it up.
+        * keys evicted from the index (``_prune_stale_sessions_locked``) or
+          belonging to a previous gateway process. A key that is never
+          revisited — a per-message thread root, a one-shot request — is not
+          reloaded, so the entry that would have carried the policy is gone.
+
+        Observed in the wild: 703 open rows on a single-user install, 551 of
+        them ``api_server`` with a NULL key, and Matrix rows idle for 69 days
+        under a 120-minute idle policy.
+
+        Deliberately narrower than the in-memory path: it only reports rows
+        idle far beyond any sane reset window (see ``_ORPHAN_SWEEP_MIN_IDLE_S``
+        in ``gateway/run.py``), and skips ``pinned``/``archived`` rows, which
+        are explicit user intent to keep. Unlike
+        ``list_never_active_keyed_sessions`` it does NOT require the row to be
+        empty — these rows have real transcripts; the caller ENDS them, it
+        never deletes them.
+        """
+        cutoff = time.time() - float(older_than_seconds)
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT s.id, s.session_key, s.source,
+                       COALESCE(s.last_activity_at, s.started_at) AS last_active
+                  FROM sessions s
+                 WHERE s.ended_at IS NULL
+                   AND COALESCE(s.pinned, 0) = 0
+                   AND COALESCE(s.archived, 0) = 0
+                   AND COALESCE(s.last_activity_at, s.started_at) IS NOT NULL
+                   AND COALESCE(s.last_activity_at, s.started_at) < ?
+                 ORDER BY last_active
+                """,
+                (cutoff,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
     def _delete_routing_entries_for_sessions(self, session_ids: Set[str]) -> int:
         """Drop ``gateway_routing`` rows pointing at any of *session_ids*.
 

--- a/tests/gateway/test_orphan_sweep_policy.py
+++ b/tests/gateway/test_orphan_sweep_policy.py
@@ -1,0 +1,351 @@
+"""The orphaned-session sweep must obey the user's reset policy.
+
+The sweep exists because these rows never reach ``_session_expiry_watcher``,
+so their reset policy is never evaluated. The first version drew the wrong
+conclusion from that: if nothing else will close them, close them on age
+alone. That substitutes a flat 24h rule for the user's configuration.
+
+It matters more than an edge case, because ``SessionResetPolicy.mode``
+defaults to ``"none"`` — never auto-reset. That became the default in July
+2026 precisely because the old behaviour "surprised users who expected their
+conversations to persist". An age-only sweep therefore auto-resets sessions on
+every install that configured nothing at all, which is the exact complaint the
+default was changed to fix.
+
+These tests pin the rule: end a row only when its OWN effective policy would
+have ended it, and fail CLOSED whenever the policy cannot be resolved. Keeping
+a stale row costs disk. Ending a session the user asked to keep forever
+destroys their context.
+
+Also covered here: the two other ways this sweep can misbehave quietly —
+resolving its DB handle through private attributes (a rename becomes a silent
+permanent no-op) and ending an unbounded backlog in one pass.
+"""
+
+import asyncio
+import time
+import types
+
+import pytest
+
+
+DAY = 86400.0
+
+
+# ── doubles ──────────────────────────────────────────────────────────────────
+
+class _Policy:
+    def __init__(self, mode="none", idle_minutes=1440):
+        self.mode = mode
+        self.idle_minutes = idle_minutes
+
+
+class _Config:
+    """Stands in for GatewayConfig's resolution order.
+
+    Mirrors get_reset_policy: platform override > type override > default.
+    """
+
+    def __init__(self, default=None, by_platform=None, by_type=None):
+        self.default_reset_policy = default or _Policy()
+        self.reset_by_platform = by_platform or {}
+        self.reset_by_type = by_type or {}
+
+    def get_reset_policy(self, platform=None, session_type=None):
+        if platform is not None and platform in self.reset_by_platform:
+            return self.reset_by_platform[platform]
+        if session_type and session_type in self.reset_by_type:
+            return self.reset_by_type[session_type]
+        return self.default_reset_policy
+
+
+class _Store:
+    def __init__(self, config, live_keys=(), active=()):
+        self.config = config
+        self._entries = {k: object() for k in live_keys}
+        self._active = set(active)
+        self.live_keys_calls = 0
+
+    def live_session_keys(self):
+        self.live_keys_calls += 1
+        return set(self._entries)
+
+    def _has_active_processes_safe(self, key, *, context):
+        return key in self._active
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+        self.ended = []
+        self.list_calls = 0
+
+    def list_orphaned_open_sessions(self, *, older_than_seconds):
+        self.list_calls += 1
+        cutoff = time.time() - older_than_seconds
+        return [r for r in self._rows if r["last_active"] < cutoff]
+
+    def end_session(self, session_id, reason):
+        self.ended.append((session_id, reason))
+
+
+def _runner(rows, config, *, live_keys=(), active=()):
+    """Build a minimal object carrying the real methods under test."""
+    from gateway.run import GatewayRunner
+
+    r = types.SimpleNamespace()
+    db = _DB(rows)
+    r._session_db = types.SimpleNamespace(_db=db)
+    r.session_store = _Store(config, live_keys, active)
+    r._reconcile_orphaned_open_sessions = types.MethodType(
+        GatewayRunner._reconcile_orphaned_open_sessions, r)
+    r._orphan_sweep_policy_permits_end = types.MethodType(
+        GatewayRunner._orphan_sweep_policy_permits_end, r)
+    return r, db
+
+
+def _row(sid, *, idle_days=30, source="api_server", key=None, chat_type=None):
+    return {
+        "id": sid,
+        "session_key": key,
+        "source": source,
+        "chat_type": chat_type,
+        "last_active": time.time() - idle_days * DAY,
+    }
+
+
+def _sweep(runner):
+    return asyncio.run(runner._reconcile_orphaned_open_sessions())
+
+
+# ── 1. the reset policy must be consulted ────────────────────────────────────
+
+def test_mode_none_is_never_swept():
+    """The SHIPPED DEFAULT. This is the regression that matters most."""
+    runner, db = _runner([_row("keep-me")], _Config(_Policy("none")))
+    assert _sweep(runner) == 0
+    assert db.ended == [], (
+        "ended a session whose policy is 'never auto-reset' — this is the "
+        "default, so it would fire on installs that configured nothing"
+    )
+
+
+def test_idle_mode_sweeps_only_past_its_own_window():
+    """A 120-minute idle policy: 30 days idle is well past it."""
+    cfg = _Config(_Policy("idle", idle_minutes=120))
+    runner, db = _runner([_row("stale", idle_days=30)], cfg)
+    assert _sweep(runner) == 1
+    assert db.ended == [("stale", "orphaned_expiry")]
+
+
+def test_idle_mode_respects_a_window_longer_than_the_floor():
+    """idle_minutes can exceed the 24h sweep floor; the policy still wins.
+
+    A 90-day idle policy must not be cut short at 24h just because the sweep's
+    own floor has passed.
+    """
+    cfg = _Config(_Policy("idle", idle_minutes=90 * 24 * 60))
+    runner, db = _runner([_row("young", idle_days=30)], cfg)
+    assert _sweep(runner) == 0
+    assert db.ended == []
+
+
+def test_daily_mode_sweeps_since_a_boundary_has_certainly_passed():
+    """Only rows already >24h idle reach the check, so a 04:00 boundary passed."""
+    runner, db = _runner([_row("d", idle_days=30)], _Config(_Policy("daily")))
+    assert _sweep(runner) == 1
+
+
+def test_both_mode_uses_the_idle_leg():
+    cfg = _Config(_Policy("both", idle_minutes=120))
+    runner, _ = _runner([_row("b", idle_days=30)], cfg)
+    assert _sweep(runner) == 1
+
+
+def test_platform_override_beats_the_default():
+    """A 'none' pin on one platform must survive a permissive global default."""
+    from gateway.config import Platform
+
+    cfg = _Config(
+        default=_Policy("idle", idle_minutes=60),
+        by_platform={Platform("matrix"): _Policy("none")},
+    )
+    rows = [_row("matrix-keep", source="matrix"), _row("api-go")]
+    runner, db = _runner(rows, cfg)
+    assert _sweep(runner) == 1
+    assert [s for s, _ in db.ended] == ["api-go"]
+
+
+def test_type_override_is_resolved_from_chat_type():
+    """reset_by_type is reachable because the row carries chat_type."""
+    cfg = _Config(
+        default=_Policy("idle", idle_minutes=60),
+        by_type={"dm": _Policy("none")},
+    )
+    rows = [_row("dm-keep", chat_type="dm"), _row("grp-go", chat_type="group")]
+    runner, db = _runner(rows, cfg)
+    assert _sweep(runner) == 1
+    assert [s for s, _ in db.ended] == ["grp-go"]
+
+
+def test_unresolvable_type_fails_closed():
+    """Per-type policies configured but the row has no chat_type -> keep it."""
+    cfg = _Config(default=_Policy("idle", idle_minutes=60),
+                  by_type={"dm": _Policy("none")})
+    runner, db = _runner([_row("unknown-type", chat_type=None)], cfg)
+    assert _sweep(runner) == 0
+
+
+def test_unrecognised_mode_fails_closed():
+    """A mode from a newer config must not be treated as permission."""
+    runner, _ = _runner([_row("x")], _Config(_Policy("quantum")))
+    assert _sweep(runner) == 0
+
+
+def test_missing_config_fails_closed():
+    """No resolvable config at all -> end nothing."""
+    runner, db = _runner([_row("x")], _Config(_Policy("idle", idle_minutes=1)))
+    runner.session_store.config = None
+    assert _sweep(runner) == 0
+
+
+# ── 2. no silent no-op, no unlocked index read ───────────────────────────────
+
+def test_missing_db_handle_warns_instead_of_returning_zero(caplog):
+    """A rename of the private chain must be visible, not silent.
+
+    `getattr(getattr(self,'_session_db',None),'_db',None)` returning None
+    yields "0 orphans" forever, indistinguishable from a healthy install.
+    """
+    from gateway.run import GatewayRunner
+
+    r = types.SimpleNamespace()
+    r._session_db = types.SimpleNamespace()  # no ._db -> chain broken
+    r.session_store = _Store(_Config(_Policy("idle", idle_minutes=1)))
+    r._reconcile_orphaned_open_sessions = types.MethodType(
+        GatewayRunner._reconcile_orphaned_open_sessions, r)
+
+    with caplog.at_level("WARNING"):
+        assert asyncio.run(r._reconcile_orphaned_open_sessions()) == 0
+    assert any("Orphaned-session sweep disabled" in m for m in caplog.messages), (
+        f"broken attribute chain produced no warning: {caplog.messages}"
+    )
+
+
+def test_the_unavailable_warning_is_not_repeated_every_tick(caplog):
+    """It runs every 300s forever; one warning, not a log flood."""
+    from gateway.run import GatewayRunner
+
+    r = types.SimpleNamespace()
+    r._session_db = types.SimpleNamespace()
+    r.session_store = _Store(_Config())
+    r._reconcile_orphaned_open_sessions = types.MethodType(
+        GatewayRunner._reconcile_orphaned_open_sessions, r)
+    with caplog.at_level("WARNING"):
+        for _ in range(5):
+            asyncio.run(r._reconcile_orphaned_open_sessions())
+    hits = [m for m in caplog.messages if "sweep disabled" in m]
+    assert len(hits) == 1, f"warned {len(hits)} times across 5 ticks"
+
+
+def test_live_index_is_read_through_the_locked_accessor():
+    """Not `session_store._entries` directly — that races the rebuild paths."""
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    runner, db = _runner([_row("orphan")], cfg, live_keys=("some:other:key",))
+    _sweep(runner)
+    assert runner.session_store.live_keys_calls == 1, (
+        "live_session_keys() was not used; the sweep read _entries unlocked"
+    )
+
+
+def test_row_still_in_the_routing_index_is_left_to_the_in_memory_path():
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    runner, db = _runner([_row("live", key="k1")], cfg, live_keys=("k1",))
+    assert _sweep(runner) == 0
+    assert db.ended == []
+
+
+def test_row_with_live_background_process_is_skipped():
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    runner, db = _runner([_row("busy", key="k2")], cfg, active=("k2",))
+    assert _sweep(runner) == 0
+
+
+# ── 3. the first-run burst is bounded ────────────────────────────────────────
+
+def test_backlog_is_capped_per_tick():
+    """703 open rows were observed on one install; do not end them in one pass."""
+    from gateway.run import _ORPHAN_SWEEP_MAX_PER_TICK
+
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    rows = [_row(f"s{i}") for i in range(_ORPHAN_SWEEP_MAX_PER_TICK * 4)]
+    runner, db = _runner(rows, cfg)
+    closed = _sweep(runner)
+    assert closed == _ORPHAN_SWEEP_MAX_PER_TICK
+    assert len(db.ended) == _ORPHAN_SWEEP_MAX_PER_TICK
+
+
+def test_backlog_drains_across_successive_ticks():
+    """Capping must not strand rows — later passes pick up the remainder."""
+    from gateway.run import _ORPHAN_SWEEP_MAX_PER_TICK as CAP
+
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    rows = [_row(f"s{i}") for i in range(CAP + 7)]
+    runner, db = _runner(rows, cfg)
+
+    # end_session must actually remove rows from the selector, as it does in
+    # the real DB (ended_at IS NOT NULL), or this test proves nothing.
+    real_end = db.end_session
+
+    def _end(sid, reason):
+        real_end(sid, reason)
+        db._rows = [r for r in db._rows if r["id"] != sid]
+
+    db.end_session = _end
+
+    assert _sweep(runner) == CAP
+    assert _sweep(runner) == 7
+    assert _sweep(runner) == 0
+    assert len(db.ended) == CAP + 7
+
+
+def test_cap_is_small_enough_to_bound_one_tick():
+    from gateway.run import _ORPHAN_SWEEP_MAX_PER_TICK
+
+    assert 1 <= _ORPHAN_SWEEP_MAX_PER_TICK <= 200
+
+
+def test_ending_runs_off_the_event_loop():
+    """end_session is blocking sqlite I/O; it must not run inline on the loop.
+
+    Asserted by recording the thread the DB writes happen on and comparing it
+    to the loop's thread.
+    """
+    import threading
+
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    runner, db = _runner([_row("a"), _row("b")], cfg)
+    seen = []
+    real_end = db.end_session
+    db.end_session = lambda s, r: (seen.append(threading.get_ident()), real_end(s, r))
+
+    async def _go():
+        loop_thread = threading.get_ident()
+        await runner._reconcile_orphaned_open_sessions()
+        return loop_thread
+
+    loop_thread = asyncio.run(_go())
+    assert seen, "no end_session calls recorded"
+    assert all(t != loop_thread for t in seen), (
+        "end_session ran on the event-loop thread; a slow disk would stall "
+        "every other gateway task behind this sweep"
+    )
+
+
+# ── the reason string is load-bearing ────────────────────────────────────────
+
+def test_rows_are_ended_not_deleted_with_a_distinguishable_reason():
+    cfg = _Config(_Policy("idle", idle_minutes=1))
+    runner, db = _runner([_row("x")], cfg)
+    _sweep(runner)
+    assert db.ended == [("x", "orphaned_expiry")]

--- a/tests/hermes_state/test_orphaned_open_sessions.py
+++ b/tests/hermes_state/test_orphaned_open_sessions.py
@@ -29,6 +29,17 @@ def db(tmp_path):
     return SessionDB(db_path=tmp_path / "state.db")
 
 
+def _sessions_columns(db) -> frozenset:
+    """Real column set, read from the schema.
+
+    A hand-maintained list drifts: the first version of it omitted
+    `end_reason` and broke a test that had been passing.
+    """
+    return frozenset(
+        r[1] for r in db._conn.execute("PRAGMA table_info(sessions)").fetchall()
+    )
+
+
 def _insert(db, session_id, *, idle_days, **overrides):
     """Insert an open row that has done real work (the leaking shape)."""
     row = {
@@ -43,10 +54,19 @@ def _insert(db, session_id, *, idle_days, **overrides):
         "pinned": 0,
     }
     row.update(overrides)
-    cols = ", ".join(row)
+    # Column names come from an explicit allow-list rather than straight from
+    # the dict keys. Values were always bound as parameters, but interpolating
+    # caller-supplied **overrides keys into the statement text meant a typo'd
+    # kwarg produced a confusing SQL syntax error instead of a clear one — and
+    # it is a bad shape to copy into a helper that later takes real input.
+    unknown = set(row) - _sessions_columns(db)
+    if unknown:
+        raise ValueError(f"not a sessions column: {sorted(unknown)}")
+    cols = ", ".join(sorted(row))
     placeholders = ", ".join("?" for _ in row)
     db._conn.execute(
-        f"INSERT INTO sessions ({cols}) VALUES ({placeholders})", list(row.values())
+        f"INSERT INTO sessions ({cols}) VALUES ({placeholders})",
+        [row[c] for c in sorted(row)],
     )
     db._conn.commit()
     return session_id

--- a/tests/hermes_state/test_orphaned_open_sessions.py
+++ b/tests/hermes_state/test_orphaned_open_sessions.py
@@ -1,0 +1,124 @@
+"""Open rows the routing index can never reach.
+
+``_session_expiry_watcher`` walks ``session_store._entries`` — the
+``gateway_routing`` index, keyed by ``session_key``. A row with a NULL key, or
+one whose key was pruned or belongs to a previous gateway process, is not in
+that index, so its reset policy is never evaluated and it stays open forever.
+``prune``/``archive`` cannot reach it either: their selector is pinned to
+``ended_at IS NOT NULL``.
+
+Observed on a single-user install: 703 open rows, 551 of them ``api_server``
+with a NULL key, and Matrix rows idle 69 days under a 120-minute idle policy.
+
+These tests pin the selector and — more importantly — the rows it must refuse
+to touch. Unlike ``list_never_active_keyed_sessions`` this one deliberately
+DOES claim rows that carry a transcript, so the "refuses" cases matter more.
+"""
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+DAY = 86400.0
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _insert(db, session_id, *, idle_days, **overrides):
+    """Insert an open row that has done real work (the leaking shape)."""
+    row = {
+        "id": session_id,
+        "source": "api_server",
+        "user_id": "user-1",
+        "session_key": None,
+        "started_at": time.time() - idle_days * DAY,
+        "last_activity_at": time.time() - idle_days * DAY,
+        "message_count": 2,
+        "archived": 0,
+        "pinned": 0,
+    }
+    row.update(overrides)
+    cols = ", ".join(row)
+    placeholders = ", ".join("?" for _ in row)
+    db._conn.execute(
+        f"INSERT INTO sessions ({cols}) VALUES ({placeholders})", list(row.values())
+    )
+    db._conn.commit()
+    return session_id
+
+
+class TestSelector:
+    def test_claims_stale_unkeyed_open_row(self, db):
+        """The api_server shape: NULL key, real transcript, never closed."""
+        _insert(db, "api-orphan", idle_days=5)
+        found = db.list_orphaned_open_sessions(older_than_seconds=DAY)
+        assert [r["id"] for r in found] == ["api-orphan"]
+
+    def test_claims_stale_keyed_row_too(self, db):
+        """A key alone is no protection — it may be evicted or from a dead
+        process. The caller decides by checking the live index."""
+        _insert(db, "matrix-orphan", idle_days=69, source="matrix",
+                session_key="agent:main:matrix:group:!room:$evt")
+        found = db.list_orphaned_open_sessions(older_than_seconds=DAY)
+        assert [r["id"] for r in found] == ["matrix-orphan"]
+
+    def test_refuses_row_inside_the_idle_floor(self, db):
+        """A merely-slow session must never be closed underneath its turn."""
+        _insert(db, "recent", idle_days=0.1)
+        assert db.list_orphaned_open_sessions(older_than_seconds=DAY) == []
+
+    def test_refuses_already_ended_row(self, db):
+        _insert(db, "ended", idle_days=30, ended_at=time.time() - 20 * DAY,
+                end_reason="cli_close")
+        assert db.list_orphaned_open_sessions(older_than_seconds=DAY) == []
+
+    @pytest.mark.parametrize("field", ["pinned", "archived"])
+    def test_refuses_explicit_user_intent(self, db, field):
+        """pinned/archived are explicit "keep this" — never auto-close."""
+        _insert(db, f"kept-{field}", idle_days=30, **{field: 1})
+        assert db.list_orphaned_open_sessions(older_than_seconds=DAY) == []
+
+    def test_falls_back_to_started_at_when_never_active(self, db):
+        """last_activity_at is NULL on rows that never recorded activity;
+        age must still be judged, not skipped."""
+        _insert(db, "no-activity", idle_days=10, last_activity_at=None)
+        found = db.list_orphaned_open_sessions(older_than_seconds=DAY)
+        assert [r["id"] for r in found] == ["no-activity"]
+
+    def test_orders_oldest_first(self, db):
+        _insert(db, "newer", idle_days=3)
+        _insert(db, "older", idle_days=40)
+        found = db.list_orphaned_open_sessions(older_than_seconds=DAY)
+        assert [r["id"] for r in found] == ["older", "newer"]
+
+
+class TestEnding:
+    def test_end_session_closes_the_orphan_without_deleting_it(self, db):
+        """The remediation is ENDING, never deletion: these rows hold real
+        transcripts."""
+        _insert(db, "api-orphan", idle_days=5)
+        db.end_session("api-orphan", "orphaned_expiry")
+
+        assert db.list_orphaned_open_sessions(older_than_seconds=DAY) == []
+        row = db._conn.execute(
+            "SELECT ended_at, end_reason, message_count FROM sessions WHERE id = ?",
+            ("api-orphan",),
+        ).fetchone()
+        assert row["ended_at"] is not None
+        assert row["end_reason"] == "orphaned_expiry"
+        assert row["message_count"] == 2  # transcript untouched
+
+    def test_end_session_is_idempotent_first_reason_wins(self, db):
+        """A concurrent close from the in-memory path must not be clobbered."""
+        _insert(db, "raced", idle_days=5)
+        db.end_session("raced", "session_reset")
+        db.end_session("raced", "orphaned_expiry")
+        row = db._conn.execute(
+            "SELECT end_reason FROM sessions WHERE id = ?", ("raced",)
+        ).fetchone()
+        assert row["end_reason"] == "session_reset"


### PR DESCRIPTION
## The bug

`_session_expiry_watcher` iterates `session_store._entries`. `_ensure_loaded_locked` builds that from the `gateway_routing` table — **keyed by `session_key`**. Two shapes of row can therefore never appear in it, so their reset policy is never evaluated and they stay open forever:

1. **`session_key IS NULL`** — every `api_server` row. The stateless `/v1/chat/completions` path derives a per-request id via `_derive_chat_session_id()` and never registers a routing key.
2. **Keys that left the index** — evicted by `_prune_stale_sessions_locked`, or belonging to a previous gateway process. A key never revisited (a per-message Matrix thread root, a one-shot request) is not reloaded.

Nothing else reaches them either:

- `prune`/`archive` are pinned to `ended_at IS NOT NULL`, specifically so a live session is never picked — which by construction excludes every never-closed row. `list_never_active_keyed_sessions`'s own docstring says as much.
- That helper only claims rows that are *completely empty*. These rows have transcripts.

## Evidence

One single-user install, `state.db` at 255 MB:

| source | sessions | open | distinct keys | NULL keys |
|---|---|---|---|---|
| api_server | 574 | **551** | 0 | **574** |
| matrix | 74 | **72** | 73 | 1 |
| cli | 57 | 43 | 0 | 57 |
| telegram | 111 | 12 | **3** | 108 |
| cron | 171 | 6 | 0 | 171 |

**703 open sessions.** The configured policy was `mode: both, idle_minutes: 120, at_hour: 4` the entire time — correct, and never evaluated. The open Matrix rows were idle between **4.7 and 69 days**, i.e. 56×–833× past a 120-minute deadline.

Telegram is healthy only *by accident*: it funnels 111 sessions through **3 stable keys**, so each new message recovers the previous session and trips the idle check (73 clean `session_reset` closes). It isn't doing anything special — it just happens to reuse keys. `cron`/`cli` survive by calling `end_session()` explicitly on their own exit.

`api_server`'s 23 "ended" rows all closed via `compression`/`orphaned_compression` — incidental rotation. **No `api_server` session has ever been closed deliberately**; there is no `end_session()` caller on that path.

## The change

`SessionDB.list_orphaned_open_sessions()` plus `_reconcile_orphaned_open_sessions()`, called at the end of the watcher loop beside the existing idle-agent sweep.

Deliberately conservative:

- only rows idle beyond `_ORPHAN_SWEEP_MIN_IDLE_S` (24 h — far past any reset window), so a merely-slow session is never touched
- rows still in the routing index are **skipped** and left to the in-memory path, which also runs the finalize hooks this sweep intentionally does not
- skips live background processes via the same `_has_active_processes_safe` guard the reset policy uses
- skips `pinned`/`archived` — explicit user intent to keep
- rows are **ENDED, never deleted**; they hold real transcripts
- `end_session` is idempotent and first-reason-wins, so racing the in-memory path is harmless
- no-ops if the DB handle or method is absent

## Tests

10 new tests in `tests/hermes_state/test_orphaned_open_sessions.py`, following `test_never_active_keyed_prune.py`. They pin the selector and — more importantly, since this one *does* claim rows with transcripts — every row it must refuse: inside the idle floor, already ended, pinned, archived.

The `pinned`/`archived` guard is mutation-verified: removing it from the query fails 2 tests.

`tests/hermes_state/` has 4 pre-existing failures on this commit (`test_aux_usage_accounting` ×2, `test_live_db_guard_ancestry`, `test_session_lifecycle_status`); I confirmed they fail identically on a pristine checkout of both modified files, so they are unrelated.

## Notes for review

- The 24 h floor is a constant rather than derived from the reset policy on purpose: these rows often have no key, so there is no platform to resolve a policy against. It is a backstop, not a replacement for the policy path.
- Happy to split the `hermes_state.py` helper and the `gateway/run.py` caller into separate commits if you prefer.
