### PR TITLE
fix(gateway): deduplicate media across cache path aliases

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1835,10 +1835,70 @@ from gateway.media_repair import (  # noqa: E402
 )
 
 
+def _media_path_aliases(
+    path: str, profile_name: Optional[str] = None
+) -> set[str]:
+    """Return literal and profile-scoped identities for a cached media path.
+
+    The gateway and Docker worker can name the same cache entry with different
+    absolute roots. Keep the profile in the canonical identity: a basename or
+    an unqualified ``cache/images/...`` alias would make two profiles suppress
+    each other's files.
+    """
+    normalized = os.path.normpath(str(path).strip())
+    aliases = {normalized}
+    slash_path = normalized.replace("\\", "/")
+    lower_path = slash_path.lower()
+    cache_relative = None
+    for marker in (
+        "cache/images/",
+        "cache/audio/",
+        "cache/videos/",
+        "cache/documents/",
+        "cache/screenshots/",
+    ):
+        marker_index = lower_path.find(f"/{marker}")
+        if marker_index >= 0:
+            cache_relative = slash_path[marker_index + 1 :]
+            break
+        if lower_path.startswith(marker):
+            cache_relative = slash_path
+            break
+    if cache_relative is None:
+        return aliases
+
+    path_profile = None
+    profiles_marker = "/profiles/"
+    profiles_index = lower_path.find(profiles_marker)
+    if profiles_index >= 0:
+        after_profiles = slash_path[profiles_index + len(profiles_marker) :]
+        cache_index = after_profiles.lower().find("/cache/")
+        if cache_index > 0:
+            path_profile = after_profiles[:cache_index]
+    scoped_profile = path_profile or str(profile_name or "").strip()
+    if scoped_profile:
+        aliases.add(f"profile:{scoped_profile}/{cache_relative}")
+    return aliases
+
+
+def _media_path_seen(
+    path: str,
+    history_media_paths: set[str],
+    profile_name: Optional[str] = None,
+) -> bool:
+    """Whether ``path`` identifies an artifact already present in history."""
+    candidate = _media_path_aliases(path, profile_name)
+    return any(
+        candidate.intersection(_media_path_aliases(old, profile_name))
+        for old in history_media_paths
+    )
+
+
 def _collect_auto_append_media_tags(
     messages: List[Dict[str, Any]],
     history_offset: int = 0,
     history_media_paths: Optional[set] = None,
+    profile_name: Optional[str] = None,
 ) -> tuple[List[str], bool]:
     """Collect real media tags from current-turn producer-tool results only.
 
@@ -1891,7 +1951,9 @@ def _collect_auto_append_media_tags(
                     path = payload.get(field)
                     if (isinstance(path, str)
                             and _TOOL_MEDIA_RE.fullmatch(f"MEDIA:{path}")
-                            and path not in history_media_paths):
+                            and not _media_path_seen(
+                                path, history_media_paths, profile_name
+                            )):
                         media_tags.append(f"MEDIA:{path}")
                         break
             continue
@@ -1899,7 +1961,9 @@ def _collect_auto_append_media_tags(
             continue
         for match in _TOOL_MEDIA_RE.finditer(content):
             path = match.group(1).strip().rstrip('",}')
-            if path and path not in history_media_paths:
+            if path and not _media_path_seen(
+                path, history_media_paths, profile_name
+            ):
                 media_tags.append(f"MEDIA:{path}")
         if "[[audio_as_voice]]" in content:
             has_voice_directive = True
@@ -6094,6 +6158,12 @@ class TurnRunner:
         # Collect MEDIA paths already in history so we can exclude them
         # from the current turn's extraction. This is compression-safe:
         # even if the message list shrinks, we know which paths are old.
+        _profile_name = (
+            getattr(ctx.source, "profile", None)
+            or self._runner._profile_name_for_source(ctx.source)
+            or self._runner._active_profile_name()
+            or "default"
+        )
         _history_media_paths: set = _collect_history_media_paths(agent_history)
         
         # Register per-session gateway approval callback so dangerous
@@ -6662,6 +6732,7 @@ class TurnRunner:
                 result.get("messages", []),
                 history_offset=len(agent_history),
                 history_media_paths=_history_media_paths,
+                profile_name=_profile_name,
             )
 
             if media_tags:

--- a/tests/gateway/test_media_aliases.py
+++ b/tests/gateway/test_media_aliases.py
@@ -1,0 +1,57 @@
+"""Regression tests for profile-scoped worker/host media aliases."""
+
+
+def _turn(path):
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "call", "function": {"name": "image_generate"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call",
+            "content": '{"success": true, "image": "' + path + '"}',
+        },
+    ]
+
+
+def test_worker_alias_is_not_reemitted_for_same_profile():
+    from gateway.run import (
+        _collect_auto_append_media_tags,
+        _collect_history_media_paths,
+    )
+
+    history_paths = _collect_history_media_paths(
+        _turn(
+            "/host-hermes/profiles/profile-a/cache/images/old.png"
+        ),
+    )
+    tags, _ = _collect_auto_append_media_tags(
+        _turn("/worker-home/.hermes/cache/images/old.png"),
+        history_offset=9999,
+        history_media_paths=history_paths,
+        profile_name="profile-a",
+    )
+    assert tags == []
+
+
+def test_same_basename_in_another_profile_is_not_suppressed():
+    from gateway.run import (
+        _collect_auto_append_media_tags,
+        _collect_history_media_paths,
+    )
+
+    history_paths = _collect_history_media_paths(
+        _turn(
+            "/host-hermes/profiles/profile-b/cache/images/shared.png"
+        ),
+    )
+    tags, _ = _collect_auto_append_media_tags(
+        _turn("/worker-home/.hermes/cache/images/shared.png"),
+        history_offset=9999,
+        history_media_paths=history_paths,
+        profile_name="profile-a",
+    )
+    assert tags == ["MEDIA:/worker-home/.hermes/cache/images/shared.png"]


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway media de-duplication gap when a Docker worker and the host
represent the same cached artifact with different absolute paths.

After context compression, an old attachment could be mistaken for a new one
and appended to a later text-only response. The gateway now compares a
profile-scoped cache identity in addition to the literal path.

## Related upstream context

Related reports include [#46627](https://github.com/NousResearch/hermes-agent/issues/46627)
(the compression-era duplicate path, fixed by
[#49989](https://github.com/NousResearch/hermes-agent/pull/49989)),
[#34375](https://github.com/NousResearch/hermes-agent/issues/34375)
(serialized `MEDIA:` extraction), and
[#73771](https://github.com/NousResearch/hermes-agent/issues/73771)
(explicit resend behavior). This PR covers a distinct host/worker cache-path
identity case and preserves the existing current-turn and explicit-resend
handling.

## Type of Change

- [x] Bug fix (non-breaking change that fixes incorrect media delivery)

## Changes Made

- Add profile-scoped aliases for supported Hermes cache paths in gateway
  history de-duplication.
- Preserve literal-path matching and current-turn isolation.
- Keep equal basenames in independent profiles deliverable.
- Add regression coverage for host/worker aliases and profile isolation.

The canonical identity includes the active profile. A basename-only or
unqualified `cache/images/<name>` alias would incorrectly suppress equal names
across independent profiles, so that approach is intentionally excluded.

## How to Test

The regression sequence is: deliver one generated attachment, then send
text-only turns after the worker/host path roots differ; the old attachment must
not be re-attached. An equal basename in another profile must remain deliverable.

Automated validation uses Hermes's canonical runner:

- 2 new alias tests + 40 existing focused media tests: **42 total passed**;
- compression/session synchronization regression: **2 passed**;
- Ruff and the repository Windows-footgun check: passed.

## Platforms and Scope

- Reproduction environment: Linux aarch64 Docker worker.
- Automated test environment: macOS arm64, Python 3.11, disposable checkout
  based on current upstream `main`.
- No new dependencies, provider changes, cache-mount changes, Telegram API
  changes, or platform-adapter path translation are included.

The patch applies cleanly to upstream `main` and is limited to gateway
de-duplication plus regression tests.
