### PR TITLE
feat(gateway): allow per-reply TTS provider override

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22345,7 +22345,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    async def _send_voice_reply(
+        self,
+        event: MessageEvent,
+        text: str,
+        *,
+        tts_provider_override: Optional[str] = None,
+    ) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
         actual_paths: List[str] = []
@@ -22363,9 +22369,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Ogg/Opus bytes for every provider. Others keep MP3.
             audio_path = build_auto_tts_output_path(event.source.platform)
 
-            result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
-            )
+            tts_kwargs: Dict[str, Any] = {
+                "text": tts_text,
+                "output_path": audio_path,
+            }
+            if tts_provider_override is not None:
+                tts_kwargs["provider"] = tts_provider_override
+            result_json = await asyncio.to_thread(text_to_speech_tool, **tts_kwargs)
             try:
                 result = json.loads(result_json)
             except (json.JSONDecodeError, TypeError):

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -316,8 +316,36 @@ class TestSendVoiceReply:
 
         mock_adapter.send_voice.assert_called_once()
         assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
+        assert "provider" not in mock_tts.call_args.kwargs
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
+
+
+    @pytest.mark.asyncio
+    async def test_forwards_tts_provider_override(self, runner):
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(
+                event,
+                "Hello world",
+                tts_provider_override="irodori",
+            )
+
+        mock_adapter.send_voice.assert_called_once()
+        assert mock_tts.call_args.kwargs["provider"] == "irodori"
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add an optional keyword-only provider override to the internal voice reply path
- forward the provider only when explicitly supplied
- preserve existing call behavior when omitted

## Verification

- `scripts/run_tests.sh tests/gateway/test_voice_command.py tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_send_voice_reply_notify.py` — 85 passed
- two independent reviews passed at commit `82f001805336e4d44120dd67342d8e1d331cac4d`

## Full-suite note

The full canonical suite could not be collected in the minimal development environment because optional ACP and Anthropic dependencies are not installed. The affected focused gateway tests pass.