### PR TITLE
fix(tools): drain high-fd pipes with selectors instead of select

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,6 +4,9 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import os
+
+import pytest
 from unittest.mock import MagicMock
 
 from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
@@ -480,6 +483,10 @@ class TestWaitForProcessDrain:
     bash exits even when a grandchild still holds the pipe open).
     """
 
+    pytestmark = pytest.mark.skipif(
+        os.name != "posix", reason="POSIX-only drain path (needs /bin/bash)"
+    )
+
     def _run(self, bash_script):
         import subprocess
 
@@ -505,12 +512,10 @@ class TestWaitForProcessDrain:
 
         # Raise the soft fd limit so we can push a pipe fd past 1024.  Skip on
         # hosts whose hard limit cannot reach 2048 (the bug cannot manifest).
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         try:
-            soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
             resource.setrlimit(resource.RLIMIT_NOFILE, (max(soft, 2048), hard))
         except (ValueError, OSError):
-            import pytest
-
             pytest.skip("cannot raise RLIMIT_NOFILE past FD_SETSIZE")
 
         held = []
@@ -528,6 +533,12 @@ class TestWaitForProcessDrain:
         finally:
             for fd in held:
                 os.close(fd)
+            # Restore the original process-wide fd limit (do not leak the
+            # raised policy to later tests in the same worker).
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+            except (ValueError, OSError):
+                pass
 
     def test_drain_captures_output_at_normal_fd(self):
         """Low-fd path keeps capturing full stdout (no regression)."""

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -470,3 +470,76 @@ class TestSanitizeTaskIdForPath:
         )
         target.mkdir(parents=True)
         assert target.is_dir()
+
+
+class TestWaitForProcessDrain:
+    """Regression tests for the POSIX stdout-drain path in _wait_for_process.
+
+    Covers #94928 (select() ValueError when a pipe fd exceeds FD_SETSIZE) and
+    the #8340 backgrounded-grandchild case (drain must terminate shortly after
+    bash exits even when a grandchild still holds the pipe open).
+    """
+
+    def _run(self, bash_script):
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["/bin/bash", "-c", bash_script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        return _TestableEnv(cwd="/tmp", timeout=20)._wait_for_process(
+            proc, timeout=15
+        )
+
+    def test_drain_captures_output_when_stdout_fd_above_fd_setsize(self):
+        """#94928: a pipe fd >= 1024 must still be drained.
+
+        Before the fix the POSIX drain used select.select(), which raises
+        ValueError for fds >= FD_SETSIZE (1024); the handler mistook that for
+        EOF and silently returned empty output with a correct exit code.
+        """
+        import os
+        import resource
+
+        # Raise the soft fd limit so we can push a pipe fd past 1024.  Skip on
+        # hosts whose hard limit cannot reach 2048 (the bug cannot manifest).
+        try:
+            soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+            resource.setrlimit(resource.RLIMIT_NOFILE, (max(soft, 2048), hard))
+        except (ValueError, OSError):
+            import pytest
+
+            pytest.skip("cannot raise RLIMIT_NOFILE past FD_SETSIZE")
+
+        held = []
+        try:
+            # Hold fds open until the next allocation lands at >= 1024.
+            while True:
+                fd = os.open("/dev/null", os.O_RDONLY)
+                held.append(fd)
+                if fd >= 1024:
+                    break
+
+            result = self._run('printf "high-fd-output\\n"')
+            assert result["returncode"] == 0
+            assert "high-fd-output" in result["output"], result["output"]
+        finally:
+            for fd in held:
+                os.close(fd)
+
+    def test_drain_captures_output_at_normal_fd(self):
+        """Low-fd path keeps capturing full stdout (no regression)."""
+        result = self._run('echo line-one; echo line-two')
+        assert result["returncode"] == 0
+        assert result["output"] == "line-one\nline-two\n", result["output"]
+
+    def test_drain_terminates_with_backgrounded_grandchild(self):
+        """#8340: bash exits but a grandchild holds the pipe open — the drain
+        must stop shortly after bash exits instead of hanging."""
+        result = self._run(
+            "echo before-bg; (sleep 30 &) 2>/dev/null; disown; echo after-bg"
+        )
+        assert result["returncode"] == 0
+        assert "before-bg" in result["output"], result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1179,16 +1179,10 @@ class BaseEnvironment(ABC):
                 return
             idle_after_exit = 0
             try:
-                # select.select() only accepts fds below FD_SETSIZE (usually
-                # 1024).  Once the Electron/desktop process accumulates more
-                # than 1024 open fds, the terminal's stdout pipe lands at
-                # fd >= 1024 and select() raises "ValueError: filedescriptor
-                # out of range in select()" — which the old handler misread as
-                # "fd already closed", silently discarding ALL of the command's
-                # output while still reporting a correct exit code (#94928).
-                # selectors.DefaultSelector() (epoll/kqueue/poll on POSIX) has
-                # no fd-number limit, and a genuine readiness error is now
-                # logged instead of swallowed.
+                # select.select() only accepts fds < FD_SETSIZE (1024), so a
+                # pipe fd >= 1024 raised ValueError, misread as EOF — silently
+                # discarding all output (#94928). selectors.DefaultSelector()
+                # has no fd limit and logs a genuine readiness error instead.
                 _selector = selectors.DefaultSelector()
                 try:
                     try:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1191,34 +1191,42 @@ class BaseEnvironment(ABC):
                 # logged instead of swallowed.
                 _selector = selectors.DefaultSelector()
                 try:
-                    _selector.register(fd, selectors.EVENT_READ)
-                    while True:
-                        try:
-                            ready = _selector.select(timeout=0.1)
-                        except (ValueError, OSError) as _exc:
-                            logger.warning(
-                                "drain: readiness poll failed for fd %s (%r); "
-                                "stopping drain — output may be truncated",
-                                fd, _exc,
-                            )
-                            break
-                        if ready:
+                    try:
+                        _selector.register(fd, selectors.EVENT_READ)
+                    except (ValueError, OSError) as _exc:
+                        logger.warning(
+                            "drain: failed to register fd %s (%r); "
+                            "stopping drain",
+                            fd, _exc,
+                        )
+                    else:
+                        while True:
                             try:
-                                chunk = os.read(fd, 4096)
-                            except (ValueError, OSError):
+                                ready = _selector.select(timeout=0.1)
+                            except (ValueError, OSError) as _exc:
+                                logger.warning(
+                                    "drain: readiness poll failed for fd %s (%r); "
+                                    "stopping drain — output may be truncated",
+                                    fd, _exc,
+                                )
                                 break
-                            if not chunk:
-                                break  # true EOF — all writers closed
-                            output.append(decoder.decode(chunk))
-                            idle_after_exit = 0
-                        elif proc.poll() is not None:
-                            # bash is gone and the pipe was idle for ~100ms.
-                            # Give it two more cycles to catch any buffered
-                            # tail, then stop — otherwise we wait forever on a
-                            # grandchild pipe.
-                            idle_after_exit += 1
-                            if idle_after_exit >= 3:
-                                break
+                            if ready:
+                                try:
+                                    chunk = os.read(fd, 4096)
+                                except (ValueError, OSError):
+                                    break
+                                if not chunk:
+                                    break  # true EOF — all writers closed
+                                output.append(decoder.decode(chunk))
+                                idle_after_exit = 0
+                            elif proc.poll() is not None:
+                                # bash is gone and the pipe was idle for ~100ms.
+                                # Give it two more cycles to catch any buffered
+                                # tail, then stop — otherwise we wait forever on a
+                                # grandchild pipe.
+                                idle_after_exit += 1
+                                if idle_after_exit >= 3:
+                                    break
                 finally:
                     _selector.close()
             finally:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import re
-import select
+import selectors
 import shlex
 import subprocess
 import threading
@@ -1179,27 +1179,48 @@ class BaseEnvironment(ABC):
                 return
             idle_after_exit = 0
             try:
-                while True:
-                    try:
-                        ready, _, _ = select.select([fd], [], [], 0.1)
-                    except (ValueError, OSError):
-                        break  # fd already closed
-                    if ready:
+                # select.select() only accepts fds below FD_SETSIZE (usually
+                # 1024).  Once the Electron/desktop process accumulates more
+                # than 1024 open fds, the terminal's stdout pipe lands at
+                # fd >= 1024 and select() raises "ValueError: filedescriptor
+                # out of range in select()" — which the old handler misread as
+                # "fd already closed", silently discarding ALL of the command's
+                # output while still reporting a correct exit code (#94928).
+                # selectors.DefaultSelector() (epoll/kqueue/poll on POSIX) has
+                # no fd-number limit, and a genuine readiness error is now
+                # logged instead of swallowed.
+                _selector = selectors.DefaultSelector()
+                try:
+                    _selector.register(fd, selectors.EVENT_READ)
+                    while True:
                         try:
-                            chunk = os.read(fd, 4096)
-                        except (ValueError, OSError):
+                            ready = _selector.select(timeout=0.1)
+                        except (ValueError, OSError) as _exc:
+                            logger.warning(
+                                "drain: readiness poll failed for fd %s (%r); "
+                                "stopping drain — output may be truncated",
+                                fd, _exc,
+                            )
                             break
-                        if not chunk:
-                            break  # true EOF — all writers closed
-                        output.append(decoder.decode(chunk))
-                        idle_after_exit = 0
-                    elif proc.poll() is not None:
-                        # bash is gone and the pipe was idle for ~100ms.  Give
-                        # it two more cycles to catch any buffered tail, then
-                        # stop — otherwise we wait forever on a grandchild pipe.
-                        idle_after_exit += 1
-                        if idle_after_exit >= 3:
-                            break
+                        if ready:
+                            try:
+                                chunk = os.read(fd, 4096)
+                            except (ValueError, OSError):
+                                break
+                            if not chunk:
+                                break  # true EOF — all writers closed
+                            output.append(decoder.decode(chunk))
+                            idle_after_exit = 0
+                        elif proc.poll() is not None:
+                            # bash is gone and the pipe was idle for ~100ms.
+                            # Give it two more cycles to catch any buffered
+                            # tail, then stop — otherwise we wait forever on a
+                            # grandchild pipe.
+                            idle_after_exit += 1
+                            if idle_after_exit >= 3:
+                                break
+                finally:
+                    _selector.close()
             finally:
                 # Flush any bytes buffered mid-sequence.  With ``errors="replace"``
                 # this emits U+FFFD for any final incomplete sequence rather than


### PR DESCRIPTION
Closes #94928

## Problem
The POSIX stdout drain in `_wait_for_process` (`tools/environments/base.py`) used `select.select([fd], [], [], 0.1)` to check pipe readability. `select.select()` only accepts fds below `FD_SETSIZE` (typically 1024). Once the Electron desktop process accumulates more than 1024 open fds, the terminal's stdout pipe lands at `fd >= 1024` and `select()` raises `ValueError: filedescriptor out of range in select()` — which the old `except (ValueError, OSError): break  # fd already closed` handler mistook for EOF. The result: every `terminal`/`read_file` command silently returned `{"output": "", "exit_code": <correct>, "error": null}` — all stdout/stderr discarded while the command actually ran. `execute_code`/Python subprocesses kept working, masking the failure.

## Root cause
`tools/environments/base.py` — the POSIX drain's `select.select()` cannot handle fds >= 1024; the exception is swallowed as "fd already closed" with no log.

## Fix
Replace `select.select()` with `selectors.DefaultSelector()` (epoll/kqueue/poll on POSIX), which has no fd-number limit. Guard the `register()` call and log a genuine readiness error instead of swallowing it. The `#8340` backgrounded-grandchild idle-exit logic is preserved unchanged.

## Measured evidence (RED → GREEN)
**RED (unfixed upstream main)** — hold >1024 fds open so the subprocess stdout pipe lands at fd 1104, run `printf "hello-from-high-fd\n"; echo line2`:
```
stdout fd: 1104
RESULT OUTPUT: ''
RETURNCODE: 0
```
Empty output, exit_code 0 — exactly the reported bug.

**GREEN (with fix)** — same reproduction:
```
stdout fd: 1104
RESULT OUTPUT: 'hello-from-high-fd\nline2\n'
RETURNCODE: 0
```
Output correctly captured at fd >= 1024. Normal (low-fd) path and backgrounded-grandchild termination (#8340) still behave correctly.

## Tests
3 new targeted regression tests in `tests/tools/test_base_environment.py` (TestWaitForProcessDrain):
- `test_drain_captures_output_when_stdout_fd_above_fd_setsize` — the core #94928 repro (fails on pre-fix code, passes now).
- `test_drain_captures_output_at_normal_fd` — low-fd no-regression guard.
- `test_drain_terminates_with_backgrounded_grandchild` — #8340 termination preserved.

All 30 tests in the file pass via `scripts/run_tests.sh`. POSIX-gated; restores `RLIMIT_NOFILE` after the high-fd test.