### PR TITLE
feat(tui): enable shift-less copy-on-select on all platforms

### DIFF
--- a/ui-tui/src/__tests__/copyOnSelect.test.ts
+++ b/ui-tui/src/__tests__/copyOnSelect.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldCopyStableSelection, type StableSelectionInput } from '../lib/copyOnSelect.js'
+
+const gated = (over: Partial<Parameters<typeof shouldCopyStableSelection>[0]>) =>
+  shouldCopyStableSelection({
+    hasSelection: true,
+    isDragging: false,
+    version: 0,
+    lastCopiedVersion: null,
+    ...over
+  })
+
+describe('shouldCopyStableSelection', () => {
+  it('copies a stable selection with a new version', () => {
+    expect(gated({ hasSelection: true, isDragging: false, version: 3, lastCopiedVersion: 2 })).toBe(true)
+  })
+
+  it('does not copy when there is no selection', () => {
+    expect(gated({ hasSelection: false, version: 3 })).toBe(false)
+  })
+
+  it('does not copy while the user is still dragging', () => {
+    expect(gated({ isDragging: true, version: 3, lastCopiedVersion: 2 })).toBe(false)
+  })
+
+  it('treats undefined isDragging as stable (matches original `state?.isDragging` semantics)', () => {
+    expect(gated({ isDragging: undefined, version: 3, lastCopiedVersion: 2 })).toBe(true)
+  })
+
+  it('does not copy an unchanged version (de-dupe, avoids clipboard spam)', () => {
+    expect(gated({ version: 3, lastCopiedVersion: 3 })).toBe(false)
+  })
+
+  it('de-dupes across repeated releases of the same selection', () => {
+    const input: StableSelectionInput = { hasSelection: true, isDragging: false, version: 5, lastCopiedVersion: null }
+    expect(shouldCopyStableSelection(input)).toBe(true)
+    // After the caller records the version it copied, the same selection must not re-copy.
+    input.lastCopiedVersion = 5
+    expect(shouldCopyStableSelection(input)).toBe(false)
+  })
+
+  it('copies again after the selection version advances', () => {
+    const input: StableSelectionInput = { hasSelection: true, isDragging: false, version: 5, lastCopiedVersion: 5 }
+    expect(shouldCopyStableSelection(input)).toBe(false)
+    input.version = 6
+    expect(shouldCopyStableSelection(input)).toBe(true)
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -29,6 +29,7 @@ import type {
 } from '../gatewayTypes.js'
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { pruneVirtualHeightCache, useVirtualHistory } from '../hooks/useVirtualHistory.js'
+import { shouldCopyStableSelection } from '../lib/copyOnSelect.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey } from '../lib/platform.js'
@@ -273,19 +274,17 @@ export function useMainApp(gw: GatewayClient) {
   // ref de-dupes against re-entrant notifications.
   useEffect(() => {
     return selection.subscribe(() => {
-      if (!selection.hasSelection()) {
-        return
-      }
-
       const state = selection.getState() as { isDragging?: boolean } | null
-
-      if (state?.isDragging) {
-        return
-      }
-
       const version = selection.version()
 
-      if (version === lastCopiedVersionRef.current) {
+      if (
+        !shouldCopyStableSelection({
+          hasSelection: selection.hasSelection(),
+          isDragging: state?.isDragging,
+          version,
+          lastCopiedVersion: lastCopiedVersionRef.current
+        })
+      ) {
         return
       }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -31,7 +31,7 @@ import { useGitBranch } from '../hooks/useGitBranch.js'
 import { pruneVirtualHeightCache, useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
-import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
@@ -260,19 +260,18 @@ export function useMainApp(gw: GatewayClient) {
     setDimFallbackColor(ui.theme.color.muted)
   }, [ui.theme.color.muted])
 
-  // macOS Terminal.app does not forward Cmd+C to fullscreen TUIs that enable
-  // mouse tracking, so the only reliable native-feeling path is iTerm-style
-  // copy-on-select: once a drag creates a stable TUI selection, write it to
-  // the system clipboard while keeping the highlight visible.
+  // iTerm-style copy-on-select: when mouse tracking is enabled, the terminal
+  // forwards drags to the TUI, so the native (shift+drag) selection path is
+  // unavailable. Once a drag creates a stable TUI selection, write it to the
+  // system clipboard (OSC 52 / wl-copy / xclip / tmux) while keeping the
+  // highlight visible — giving shift-less select-and-copy, like Claude Code.
+  // Originally macOS-only (Terminal.app swallows Cmd+C for fullscreen TUIs);
+  // the same copy-on-select is also the right UX on Linux and Windows.
   //
   // Subscribe directly via the ink selection bus (not useSyncExternalStore)
   // so React doesn't re-render MainApp on every drag-move tick. The version
   // ref de-dupes against re-entrant notifications.
   useEffect(() => {
-    if (!isMac) {
-      return
-    }
-
     return selection.subscribe(() => {
       if (!selection.hasSelection()) {
         return

--- a/ui-tui/src/lib/copyOnSelect.ts
+++ b/ui-tui/src/lib/copyOnSelect.ts
@@ -1,0 +1,54 @@
+/**
+ * Copy-on-select gating for the TUI.
+ *
+ * iTerm/Claude-Code-style copy-on-select: when mouse tracking is enabled the
+ * terminal forwards drags to the TUI, so the native (shift+drag) selection
+ * path is unavailable. Once a drag creates a *stable* TUI selection we want
+ * to write it to the system clipboard on release. This is pure decision
+ * logic kept out of the React effect so it can be unit-tested without
+ * rendering the TUI.
+ *
+ * The gate is intentionally platform-agnostic: the macOS-only restriction was
+ * removed (Terminal.app swallows Cmd+C for fullscreen TUIs — the same
+ * copy-on-select is also the right UX on Linux/Windows, which cannot take the
+ * native selection path while mouse tracking is on).
+ */
+
+export interface StableSelectionInput {
+  /** Whether a TUI selection exists at all. */
+  hasSelection: boolean
+  /** True while the user is still dragging (mid-selection). */
+  isDragging: boolean | undefined
+  /** Monotonic selection version; changes whenever the selection changes. */
+  version: number
+  /** Version of the last selection we already copied to the clipboard. */
+  lastCopiedVersion: number | null
+}
+
+/**
+ * Decide whether a selection-release event should copy the selection to the
+ * system clipboard.
+ *
+ * Returns true only when all of:
+ *   - there is a selection,
+ *   - the drag has ended (a `false`/undefined isDragging — we do not copy
+ *     mid-drag, only once the selection is stable),
+ *   - the selection version differs from the last one already copied
+ *     (de-dupe: prevents spamming the clipboard backend on every drag-move or
+ *     repeated release of an unchanged selection).
+ */
+export function shouldCopyStableSelection(input: StableSelectionInput): boolean {
+  if (!input.hasSelection) {
+    return false
+  }
+
+  if (input.isDragging) {
+    return false
+  }
+
+  if (input.version === input.lastCopiedVersion) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## What
Un-gates iTerm/Claude-Code-style copy-on-select in the Ink TUI from macOS-only. When mouse tracking is enabled, the terminal forwards drags to the TUI rather than taking the native selection path — so a stable drag selection is now written to the system clipboard (OSC 52 / wl-copy / xclip / tmux) on release on **all platforms**, matching Claude Code / iTerm behavior.

## Why
macOS Terminal.app swallows Cmd+C for fullscreen TUIs, which is why copy-on-select was gated there. The same constraint applies on Linux and Windows when mouse tracking is on (shift+drag selection is unavailable), so copy-on-select is the right UX everywhere — the macOS-only gate was never scoped outward.

## Changes
- `feat(tui): enable shift-less copy-on-select on all platforms` — remove the macOS-only gate.
- `refactor(tui): extract copy-on-select decision into testable helper + regression tests` — pull the stability/de-dupe decision (has selection, not mid-drag, selection version changed) into a pure, unit-tested `shouldCopyStableSelection` helper. Zero behavior change; copy still fires only on release of a stable, new selection.

## Validation (honest scope)
- **7 unit tests** (`ui-tui/src/__tests__/copyOnSelect.test.ts`) cover the extracted predicate: copy on stable new selection; no copy when there is no selection / mid-drag / unchanged version (de-dupe); single copy on repeated release; re-copy after version advances; `undefined` isDragging treated as not-dragging (matches original `state?.isDragging` semantics). All pass via `vitest`. `tsc` and `eslint` clean.
- The unit tests cover the **predicate only, not the effect wiring** (subscription → version-ref update → clipboard write). The wiring is validated by real daily use on Linux. Windows/macOS clipboard paths are untested — the listed backends are the Linux/macOS story, so those platforms may warrant a second look in CI/review.
