### PR TITLE
fix(terminal): drain stdout with poll() so output survives pipe fds >= FD_SETSIZE (#94928)

### DIFF
--- a/tests/tools/test_terminal_drain_high_fd.py
+++ b/tests/tools/test_terminal_drain_high_fd.py
@@ -1,0 +1,61 @@
+"""Regression: the POSIX stdout drain must not lose output when a command's
+pipe fd exceeds FD_SETSIZE (1024).
+
+A long-lived backend (Desktop/gateway) accumulates open fds over uptime. Once a
+command's stdout pipe fd is >= 1024, the drain's old ``select.select()`` call
+raised ``ValueError: filedescriptor out of range in select()``; that ValueError
+was caught and turned into an immediate ``break``, so the command ran and its
+exit code was kept but ALL stdout/stderr was silently discarded — ``terminal``
+and ``read_file`` returned an empty string with no error signal (issue #94928).
+The drain now waits with ``select.poll()``, which has no FD_SETSIZE ceiling.
+"""
+
+import os
+import resource
+import select
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from tools.environments.local import LocalEnvironment
+
+# Enough low fds to push the next pipe fd past FD_SETSIZE (1024).
+_TARGET_LOW_FDS = 1100
+
+
+@pytest.mark.skipif(not hasattr(select, "poll"), reason="poll() unavailable (Windows)")
+def test_terminal_output_survives_pipe_fd_above_fd_setsize():
+    # Best-effort raise of the soft fd limit so we can actually hold >1024 fds;
+    # skip cleanly on hosts whose hard limit is too low to reproduce.
+    want = _TARGET_LOW_FDS + 200
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft < want:
+        new_soft = want if hard == resource.RLIM_INFINITY else min(hard, want)
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+        except (ValueError, OSError):
+            pass
+        soft, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < want:
+            pytest.skip(f"fd limit too low to reproduce (soft={soft}, need>{want})")
+
+    held: list[int] = []
+    try:
+        while len(held) < _TARGET_LOW_FDS:
+            held.append(os.open(os.devnull, os.O_RDONLY))
+        # Guard: if fds never crossed FD_SETSIZE the test proves nothing.
+        assert held[-1] >= 1024, "setup failed to push fds above FD_SETSIZE"
+
+        env = LocalEnvironment()
+        result = env.execute("echo hello-high-fd")
+    finally:
+        for fd in held:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    assert result["returncode"] == 0
+    assert "hello-high-fd" in result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1178,10 +1178,25 @@ class BaseEnvironment(ABC):
                         pass
                 return
             idle_after_exit = 0
+            # Wait for readability with poll(), NOT select.select(): a
+            # long-lived backend (Desktop/gateway) can accumulate >1024 open
+            # fds, and CPython's select.select() raises
+            # ``ValueError: filedescriptor out of range in select()`` the
+            # moment a pipe fd is >= FD_SETSIZE (1024). That ValueError landed
+            # in the ``break`` below and silently discarded ALL output —
+            # terminal/read_file returned an empty string with the correct
+            # exit code, losing data with no error signal (issue #94928).
+            # poll() has no FD_SETSIZE ceiling. POLLHUP/POLLERR count as
+            # readable so the os.read() below observes the real EOF (b"").
             try:
-                while True:
+                poller = select.poll()
+                poller.register(fd, select.POLLIN)
+            except (ValueError, OSError):
+                poller = None  # fd already closed — nothing to drain
+            try:
+                while poller is not None:
                     try:
-                        ready, _, _ = select.select([fd], [], [], 0.1)
+                        ready = bool(poller.poll(100))
                     except (ValueError, OSError):
                         break  # fd already closed
                     if ready:


### PR DESCRIPTION
## Summary

On a long-lived backend (Desktop, or the gateway) that accumulates more than
1024 open file descriptors over uptime, a command's stdout pipe fd can land at
or above `FD_SETSIZE` (1024). The POSIX drain in `tools/environments/base.py`
waited on that fd with `select.select()`, which raises
`ValueError: filedescriptor out of range in select()` for any fd `>= 1024`.

That `ValueError` was caught by the drain's `except (ValueError, OSError): break`
(commented "fd already closed"), so the loop exited **before reading a single
byte**. The command still ran and its exit code was still captured, but all of
stdout/stderr was silently discarded:

- `terminal` returned `{"output": "", "exit_code": <correct>, "error": null}`
- `read_file` returned empty content / `file_size: 0` for non-empty files
- `execute_code` (a separate subprocess path) kept working, so the agent got no
  error signal and just continued on empty data.

Fixes #94928.

## Fix

Switch the readability wait from `select.select()` to `select.poll()`, which has
no `FD_SETSIZE` ceiling. `POLLHUP`/`POLLERR` count as readable, so the existing
`os.read()` still observes the real EOF (`b""`) and the idle-after-exit /
grandchild-pipe handling is unchanged. The Windows branch (blocking `os.read` in
a thread) is untouched.

## Test

`tests/tools/test_terminal_drain_high_fd.py` holds >1024 low fds so the bash
stdout pipe lands above `FD_SETSIZE`, runs `echo`, and asserts the output
survives. It **fails on the old `select.select()` code** (output is `""`) and
passes with `poll()`. It skips cleanly on hosts whose fd rlimit is too low to
reproduce.

Verified locally: the new test plus `test_base_environment.py`,
`test_terminal_timeout_output.py`, `test_read_shell_line_clamp.py`, and
`test_snapshot_session_id_leak.py` all pass (40 tests). Windows-footgun and
subprocess-stdin gates pass; no dependency / `uv.lock` change.