### PR TITLE
fix(gateway): continue interrupted interactive turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1286,13 +1286,10 @@ def build_resume_recovery_note(
     startup auto-resume turn synthesized by
     ``_schedule_resume_pending_sessions`` with no human message attached.
 
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
+    ``interactive`` is retained for adapter and call-site compatibility.  An
+    empty synthesized startup turn has the same contract on every platform:
+    continue the interrupted work without requiring a human to type
+    ``continue``.  A real new user message still takes precedence.
     """
     reason_phrase = (
         "a gateway restart"
@@ -1310,26 +1307,20 @@ def build_resume_recovery_note(
             "Do NOT re-execute old tool calls — skip any "
             "unfinished work from the conversation history."
         )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
     else:
         resume_guidance = (
-            "No user is present on this non-interactive platform, "
-            "so do NOT emit a 'session restored' acknowledgement "
-            "or ask questions. Review the conversation history and "
-            "CONTINUE the interrupted task to completion."
+            "No new user message is attached. Review the conversation "
+            "history and CONTINUE the interrupted task to completion. "
+            "Do not stop at a 'session restored' acknowledgement or require "
+            "the user to type 'continue'. If continuation needs a genuinely "
+            "new approval or an unavailable fact, state that exact blocker."
         )
         tail_guidance = (
-            "Do NOT re-run tool calls whose results already "
-            "appear in the history — resume from the first step "
-            "that has no recorded result."
+            "Do NOT re-run tool calls whose results already appear in the "
+            "history — resume from the first step that has no recorded "
+            "result. If a side effect may have happened but its result was "
+            "not persisted, inspect live state before deciding whether to "
+            "retry it."
         )
     return (
         f"[System note: The previous turn was interrupted by "

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -301,11 +301,14 @@ class TestResumePendingSystemNote:
         )
 
 
-    def test_empty_message_noninteractive_note_continues_task(self):
-        """Non-interactive platforms (webhook, API server): nobody can answer
-        'what next?', so the resumed turn must complete the interrupted work
-        instead of acknowledging (#57056)."""
-        note = build_resume_recovery_note("restart_timeout", "", interactive=False)
+    @pytest.mark.parametrize("interactive", [True, False])
+    def test_empty_message_continues_interrupted_task(self, interactive):
+        """A synthesized startup turn must finish interrupted work on every
+        platform.  Interactive users should not have to type ``continue``
+        after the gateway already has a durable recovery checkpoint."""
+        note = build_resume_recovery_note(
+            "restart_timeout", "", interactive=interactive
+        )
         assert "CONTINUE the interrupted task" in note
         assert "session was restored" not in note
         assert "ask what they would like to do next" not in note
@@ -315,10 +318,13 @@ class TestResumePendingSystemNote:
         assert "already appear in the history" in note
 
 
-    def test_resume_note_is_persisted_instead_of_original_empty_message(self):
+    @pytest.mark.parametrize("interactive", [True, False])
+    def test_resume_note_is_persisted_instead_of_original_empty_message(
+        self, interactive
+    ):
         """The auto-resume note must not leave an empty row in state.db."""
         message, persisted = _prepare_resume_pending_message(
-            "restart_timeout", "", interactive=False
+            "restart_timeout", "", interactive=interactive
         )
 
         assert message


### PR DESCRIPTION
## What does this PR do?

Makes synthesized startup-resume turns continue interrupted work on interactive gateways instead of stopping after a restoration acknowledgement and asking the user to type `continue`.

Hermes already persists the exact interrupted routing entry, schedules `resume_pending` sessions on startup, and protects the full agent load/run/flush region with a SQLite turn lease. The remaining policy mismatch was in `build_resume_recovery_note()`: empty startup turns continued work on non-interactive adapters, but interactive adapters abandoned the interrupted task and required a manual handoff.

This keeps the existing recovery machinery and changes only the empty-message guidance. Real new user messages still take precedence.

## Related Issue

Follow-up to #57056 and #56262. Related persistence fix: #86580.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Give empty synthesized startup resumes the same continuation contract on interactive and non-interactive adapters.
  - Keep the existing precedence for real new user messages.
  - Preserve replay safety: do not rerun recorded tool results; inspect live state before retrying an unrecorded possible side effect.
  - Retain the `interactive` argument for adapter and call-site compatibility.
- `tests/gateway/test_restart_resume_pending.py`
  - Parameterize empty-message recovery tests across both interactive modes.
  - Verify both modes continue interrupted work and persist a non-empty recovery note.

## How to Test

1. Run the recovery and lease suites:

   ```bash
   python -m pytest -q \
     tests/gateway/test_restart_resume_pending.py \
     tests/state/test_session_turn_lease.py \
     tests/run_agent/test_cross_process_turn_lease.py
   ```

   Verified locally: `69 passed in 10.05s`.

2. Run syntax and lint checks:

   ```bash
   python -m py_compile gateway/run.py tests/gateway/test_restart_resume_pending.py
   ruff check gateway/run.py tests/gateway/test_restart_resume_pending.py
   ```

   Verified locally: both passed.

3. Inspect an empty startup resume for `interactive=True` and `interactive=False`; both should contain `CONTINUE the interrupted task`, should not ask what to do next, and should persist the recovery note instead of an empty user row.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted recovery/lease suites passed; full repository suite was not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in the function docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing recovery architecture is unchanged
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure recovery-note policy and tests; no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool changes

## Screenshots / Logs

Not applicable; this changes gateway recovery guidance and adds regression coverage.
