### PR TITLE
fix(cron): gateway-liveness check self-excludes the gateway process

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -77,9 +77,13 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
-        from hermes_cli.gateway import find_gateway_pids
+        # Use the pid-file check (no self-exclusion) rather than
+        # find_gateway_pids(): that helper excludes os.getpid(), and when the
+        # cron tool runs INSIDE the gateway process os.getpid() IS the gateway
+        # PID, so it always self-excluded and reported a false "not running".
+        from gateway.status import is_gateway_running
 
-        return bool(find_gateway_pids())
+        return is_gateway_running()
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

Fixes a false "gateway not running" warning emitted by the `cronjob` tool on every `create`/`list` action.

`_builtin_gateway_liveness()` (in `hermes_cli/cron.py`) called `find_gateway_pids()`, which deliberately self-excludes the current process via `if pid == os.getpid(): return` (see `hermes_cli/gateway.py`). That exclusion is correct for CLI use (`hermes gateway status` shouldn't count itself), but the `cronjob` model tool executes **inside** the gateway process — so `os.getpid()` *is* the gateway PID, the scan always excluded the gateway itself, and the helper returned `False` every time.

## Symptom

Every `cronjob` create/list result carried:

```
"gateway_running": false,
"warning": "The Hermes gateway is not running — this job is saved but will NOT fire until the gateway is started ..."
```

…while the gateway was provably healthy (all platforms connected, `/health` → `{"status":"ok"}`, and scheduled jobs firing with `last_status: ok`). The warning is cosmetic — jobs fire correctly — but it's alarming and wrong.

## Repro

1. Start the gateway (builtin cron provider).
2. Ask the agent to create or list a cron job.
3. Observe `"gateway_running": false` in the tool result despite the gateway being up.

Verified on `main` (02c7ae956e) after a clean `hermes update` + gateway restart.

## Fix

Switch `_builtin_gateway_liveness()` to `is_gateway_running()` — the pid-file-based check with no self-exclusion, already used correctly by `send_message_tool.py`.

## Test Plan

- [x] `_builtin_gateway_liveness()` returns `True` when the gateway is running (verified in-process)
- [x] No behavior change for the external-provider (Chronos) early-return path
- [x] No change to CLI `_warn_if_gateway_not_running` semantics

## Notes

- 2-line change (plus explanatory comment), low risk.
- No new dependencies.
