### PR TITLE
fix(memory): Hindsight daemon fails to start under multiplexer (#94933)

### DIFF
--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #94948 (issue #94933) attribution mapping

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -45,8 +45,13 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.secret_scope import get_secret
-
+from agent.secret_scope import (
+    UnscopedSecretError,
+    current_secret_scope,
+    get_secret,
+    reset_secret_scope,
+    set_secret_scope,
+)
 from agent.memory_provider import MemoryProvider, RecallStatus
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
@@ -445,7 +450,7 @@ def _load_config() -> dict:
 
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
-        "apiKey": get_secret("HINDSIGHT_API_KEY", ""),
+        "apiKey": _get_scoped_secret("HINDSIGHT_API_KEY", ""),
         "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
         "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
@@ -587,6 +592,79 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
+def _get_scoped_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Scope-aware read for HINDSIGHT_* credentials under a multiplexer.
+
+    Mirrors ``gateway/platforms/whatsapp_common.py::_get_wsecret`` (Slack
+    pattern #59739 / WhatsApp ``_get_wsecret``). The Hindsight plugin's
+    daemon-start thread does NOT inherit the caller's per-turn secret
+    scope (issue #94933), so reads must be safe under both:
+
+    - **scope installed** (secondary profile turn): the scope is
+      authoritative; a scoped miss returns ``default`` and we do NOT
+      borrow from ``os.environ`` (that would leak the default profile's
+      key into this profile).
+    - **unscoped under multiplex** (default profile's own startup loop):
+      a bare ``get_secret`` would raise ``UnscopedSecretError`` and crash
+      the daemon. Here ``os.environ`` IS the active profile's value (no
+      other profile to leak from), so fall back to it.
+
+    For the daemon-start thread specifically, ``initialize()`` /
+    ``_start_daemon()`` additionally wraps the whole flow in
+    ``set_secret_scope(...)`` so the helper always sees a scope on this
+    code path under multiplexing.
+    """
+    try:
+        value = get_secret(name, default)
+    except UnscopedSecretError:
+        value = os.getenv(name)
+    return value if value is not None else default
+
+
+def _build_hindsight_scope(config: dict[str, Any]) -> dict[str, str]:
+    """Build the secret scope the Hindsight daemon-start thread runs under.
+
+    Threads do not inherit contextvars, so the per-turn scope that wrapped
+    ``initialize()`` does not propagate into ``hindsight-daemon-start``.
+    That thread calls ``_get_client()`` and
+    ``_build_embedded_profile_env()``, both of which read
+    ``HINDSIGHT_LLM_API_KEY`` (and ``HINDSIGHT_API_KEY``). Under
+    ``gateway.multiplex_profiles`` a bare read raises
+    ``UnscopedSecretError`` and the daemon never binds its port — memory
+    silently stops working for ALL profiles (issue #94933).
+
+    We build the scope from the **merged** env: main ``<hermes_home>/.env``
+    first, then overlay the profile daemon env at
+    ``~/.hindsight/profiles/<name>.env``. That file only carries ~5
+    daemon runtime keys (LLM provider/model/idle-timeout), so reading it
+    alone is insufficient — the LLM key lives in the main ``.env`` and
+    must come first.
+    """
+    from pathlib import Path
+
+    scope: dict[str, str] = {}
+    main_env = _load_simple_env(get_hermes_home() / ".env")
+    scope.update(main_env)
+
+    try:
+        profile_env_path = _embedded_profile_env_path(config)
+        profile_env = _load_simple_env(profile_env_path)
+    except Exception:
+        profile_env = {}
+    # Overlay only non-empty profile values so a stale or missing
+    # profile env does not blank out the main .env's LLM key.
+    scope.update({k: v for k, v in profile_env.items() if v})
+
+    # Strip genuinely-global vars; ``get_secret`` reads those from
+    # ``os.environ`` directly, so copying them in is wasted and noisy.
+    try:
+        from agent.secret_scope import _is_global_env
+        scope = {k: v for k, v in scope.items() if not _is_global_env(k)}
+    except Exception:
+        pass
+    return scope
+
+
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
@@ -594,7 +672,7 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         current_key = (
             config.get("llmApiKey")
             or config.get("llm_api_key")
-            or get_secret("HINDSIGHT_LLM_API_KEY", "")
+            or _get_scoped_secret("HINDSIGHT_LLM_API_KEY", "")
         )
 
     current_provider = config.get("llm_provider", "")
@@ -900,7 +978,7 @@ class HindsightMemoryProvider(MemoryProvider):
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
-                or get_secret("HINDSIGHT_API_KEY", "")
+                or _get_scoped_secret("HINDSIGHT_API_KEY", "")
             )
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
             return has_key or has_url
@@ -1029,7 +1107,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Step 3: Mode-specific config
         if mode == "cloud":
             print("\n  Get your API key at https://ui.hindsight.vectorize.io\n")
-            existing_key = get_secret("HINDSIGHT_API_KEY", "") or ""
+            existing_key = _get_scoped_secret("HINDSIGHT_API_KEY", "") or ""
             if existing_key:
                 masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else "set"
                 sys.stdout.write(f"  API key (current: {masked}, blank to keep): ")
@@ -1257,7 +1335,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or _get_scoped_secret("HINDSIGHT_LLM_API_KEY", ""),
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:
@@ -1662,7 +1740,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
                 self._mode = "disabled"
                 return
-        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or get_secret("HINDSIGHT_API_KEY", "")
+        self._api_key = self._config.get("apiKey") or self._config.get("api_key") or _get_scoped_secret("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in {"local_embedded", "local_external"} else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
         self._llm_base_url = self._config.get("llm_base_url", "")
@@ -1801,39 +1879,60 @@ class HindsightMemoryProvider(MemoryProvider):
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
+                # Threads do NOT inherit contextvars, so the per-turn secret
+                # scope that wrapped initialize() does not propagate here.
+                # Build a fresh scope from the merged env (main .env + the
+                # profile daemon env at ~/.hindsight/profiles/<name>.env) so
+                # subsequent reads of HINDSIGHT_LLM_API_KEY /
+                # HINDSIGHT_API_KEY inside _get_client() and
+                # _build_embedded_profile_env() resolve to this profile's
+                # values instead of failing closed with
+                # ``UnscopedSecretError`` under gateway.multiplex_profiles.
+                # Issue #94933: daemon never started under multiplexing.
+                scope_token = None
                 try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+                    scope_env = _build_hindsight_scope(self._config or {})
+                    if scope_env:
+                        scope_token = set_secret_scope(scope_env)
+                    try:
+                        # Redirect the daemon manager's Rich console to our log file
+                        # instead of stderr. This avoids global fd redirects that
+                        # would capture output from other threads.
+                        import hindsight_embed.daemon_embed_manager as dem
+                        from rich.console import Console
+                        dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
+                        client = self._get_client()
+                        profile = self._config.get("profile", "hermes")
 
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                        # Update the profile .env to match our current config so
+                        # the daemon always starts with the right settings.
+                        # If the config changed and the daemon is running, stop it.
+                        profile_env = _embedded_profile_env_path(self._config)
+                        expected_env = _build_embedded_profile_env(self._config)
+                        saved = _load_simple_env(profile_env)
+                        config_changed = saved != expected_env
 
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                        if config_changed:
+                            profile_env = _materialize_embedded_profile_env(self._config)
+                            if client._manager.is_running(profile):
+                                with open(log_path, "a", encoding="utf-8") as f:
+                                    f.write("\n=== Config changed, restarting daemon ===\n")
+                                client._manager.stop(profile)
 
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
+                        client._ensure_started()
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Daemon started successfully ===\n")
+                    except Exception as e:
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                            traceback.print_exc(file=f)
+                finally:
+                    if scope_token is not None:
+                        try:
+                            reset_secret_scope(scope_token)
+                        except Exception:
+                            pass
 
             t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
             t.start()

--- a/tests/plugins/memory/test_hindsight_multiplex_secret_scope.py
+++ b/tests/plugins/memory/test_hindsight_multiplex_secret_scope.py
@@ -1,0 +1,339 @@
+"""Regression tests for #94933 — Hindsight daemon fails to start under multiplexer.
+
+Class-closure follow-up to the profile secret-scope cluster (#76462, Slack
+pattern #59739, WhatsApp ``_get_wsecret``). The Hindsight memory daemon runs
+on a background thread that does NOT inherit the caller's per-turn secret
+scope, so under ``gateway.multiplex_profiles`` any bare ``get_secret(...)``
+read inside ``initialize()`` / ``_start_daemon()`` / ``_get_client()`` /
+``_build_embedded_profile_env()`` raises ``UnscopedSecretError`` and the
+embedded daemon never starts. Memory silently stops working for ALL profiles.
+
+The migrated module now carries a module-level ``_get_scoped_secret`` helper
+mirroring ``gateway/platforms/whatsapp_common.py::_get_wsecret``:
+
+- scope installed → scope is authoritative; scoped miss returns the
+  default (NO borrow from ``os.environ``)
+- unscoped under multiplex (the default profile's own startup loop) →
+  fall back to ``os.getenv`` without raising ``UnscopedSecretError``
+
+And the daemon-start thread wraps its whole flow in ``set_secret_scope`` so
+thread-local reads of ``HINDSIGHT_API_KEY`` / ``HINDSIGHT_LLM_API_KEY``
+inside ``_get_client`` and ``_build_embedded_profile_env`` honor the same
+scope the caller installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import secret_scope as ss
+from plugins.memory.hindsight import (
+    HindsightMemoryProvider,
+    _build_embedded_profile_env,
+    _get_scoped_secret,
+    _load_config,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_provider(tmp_path, monkeypatch, *, mode: str, config_overrides=None, config_has_key: bool = True):
+    """Build an initialized HindsightMemoryProvider pointed at tmp_path.
+
+    ``config_has_key=False`` removes the config-file apiKey so the
+    provider falls through to the env var / secret scope. Mirrors the
+    real-world #94933 reproduction (user sets ``HINDSIGHT_LLM_API_KEY``
+    in their profile ``.env`` rather than embedding it in
+    ``hindsight/config.json``).
+    """
+    config = {
+        "mode": mode,
+        "api_url": "http://localhost:9999",
+        "bank_id": "test-bank",
+        "budget": "mid",
+        "memory_mode": "hybrid",
+        "profile": "test-profile",
+    }
+    if config_has_key:
+        config["apiKey"] = "test-api-key"
+    if config_overrides:
+        config.update(config_overrides)
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
+    provider = HindsightMemoryProvider()
+    provider.initialize(session_id="test-session", platform="cli")
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    """Multiplex mode off before and after every test."""
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(tmp_path, monkeypatch):
+    """No stale env vars, isolated home — same as the broader provider tests."""
+    for key in (
+        "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
+        "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
+        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    isolated_home = tmp_path / "user-home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: isolated_home))
+
+
+# ── helper existence / shape ───────────────────────────────────────────────
+
+
+class TestScopedSecretHelper:
+    """The module MUST expose ``_get_scoped_secret`` so plugin code never
+    hits a bare ``get_secret`` that fails closed under multiplexing."""
+
+    def test_helper_exists(self):
+        assert callable(_get_scoped_secret), (
+            "plugins/memory/hindsight must define the module-level "
+            "_get_scoped_secret helper (WhatsApp _get_wsecret pattern)."
+        )
+
+    def test_scoped_value_wins_over_environ(self, monkeypatch):
+        """Secondary profile: scope is authoritative, scope value used."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"HINDSIGHT_API_KEY": "secondary-profile-key"})
+        try:
+            assert _get_scoped_secret("HINDSIGHT_API_KEY") == "secondary-profile-key"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_miss_returns_default_not_environ(self, monkeypatch):
+        """Secondary profile with key absent from scope: default wins, NOT
+        a borrow from ``os.environ`` (that would leak another profile's key)."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"UNRELATED": "x"})
+        try:
+            assert _get_scoped_secret("HINDSIGHT_API_KEY") is None
+            assert _get_scoped_secret("HINDSIGHT_API_KEY", "") == ""
+            assert _get_scoped_secret("HINDSIGHT_API_KEY", "fallback") == "fallback"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_unscoped_under_multiplex_falls_back_to_environ(self, monkeypatch):
+        """The DEFAULT profile constructs its adapter unscoped under multiplexing.
+        A bare ``get_secret`` would raise ``UnscopedSecretError`` and crash
+        startup; the helper must fall back to ``os.environ`` (that profile's
+        own value) instead."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "default-profile-own-key")
+        ss.set_multiplex_active(True)
+        assert ss.current_secret_scope() is None
+        assert _get_scoped_secret("HINDSIGHT_API_KEY") == "default-profile-own-key"
+
+        monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+        assert _get_scoped_secret("HINDSIGHT_API_KEY", "fallback") == "fallback"
+
+    def test_single_profile_legacy_environ_read(self, monkeypatch):
+        """Multiplex off, no scope: legacy ``os.environ`` read keeps working
+        (no behavior change for non-multiplex deployments)."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "legacy-env-value")
+        assert _get_scoped_secret("HINDSIGHT_API_KEY") == "legacy-env-value"
+        monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+        assert _get_scoped_secret("HINDSIGHT_API_KEY", "d") == "d"
+
+
+# ── initialize() is scope-safe under multiplex ────────────────────────────
+
+
+class TestInitializeScopeSafe:
+    """``initialize()`` reads ``HINDSIGHT_API_KEY`` from the secret scope.
+    Under multiplex it must NOT raise ``UnscopedSecretError`` (the default
+    profile starts unscoped, but with multiplex active, the helper falls
+    back to ``os.environ``). For a secondary profile the caller has already
+    installed a scope, so the scope value must be honored."""
+
+    def test_default_profile_unscoped_under_multiplex_uses_own_env(self, monkeypatch, tmp_path):
+        """Reproduces the issue's #94933 default-profile branch:
+        ``initialize()`` runs unscoped (gateway's default-profile startup
+        loop), multiplex is on. Before the fix this would raise
+        ``UnscopedSecretError`` and the daemon never started."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        # No apiKey in config — falls through to env/scope (matches real repro).
+        provider = _make_provider(tmp_path, monkeypatch, mode="cloud", config_has_key=False)
+        # initialize() must have populated the api key without raising
+        assert provider._api_key == "default-profile-key"
+
+    def test_secondary_profile_scoped_value_wins(self, monkeypatch, tmp_path):
+        """Secondary profile: its scope value wins over ``os.environ`` —
+        no cross-profile leak."""
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "default-profile-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"HINDSIGHT_API_KEY": "secondary-profile-key"})
+        try:
+            provider = _make_provider(tmp_path, monkeypatch, mode="cloud", config_has_key=False)
+            assert provider._api_key == "secondary-profile-key"
+        finally:
+            ss.reset_secret_scope(tok)
+
+
+# ── daemon-start thread: scope wrapping ───────────────────────────────────
+
+
+class TestDaemonStartThreadScope:
+    """The daemon-start thread (``hindsight-daemon-start``) calls
+    ``self._get_client()`` and ``_build_embedded_profile_env()`` —
+    both read ``HINDSIGHT_LLM_API_KEY`` from the secret scope. Without
+    a scope installed for the thread, the daemon fails to start under
+    multiplex and memory silently stops working for ALL profiles."""
+
+    def test_daemon_start_thread_uses_scope_not_environ(self, monkeypatch, tmp_path):
+        """End-to-end repro from the issue: install a profile scope, then
+        ``initialize()`` (which spawns the daemon-start thread). The thread's
+        call into ``_get_client()`` and ``_build_embedded_profile_env()``
+        must resolve ``HINDSIGHT_LLM_API_KEY`` from the scope built from
+        the merged .env, not from ``os.environ`` of some other profile.
+
+        Before the fix this raised ``UnscopedSecretError`` and the daemon
+        never bound its port (#94933). After the fix the thread installs
+        its own scope (from the merged main + profile daemon .env) so
+        the helper sees a scope and resolves the LLM key to the active
+        profile's value.
+        """
+        import plugins.memory.hindsight as hs
+
+        ss.set_multiplex_active(True)
+
+        # Seed the main HERMES_HOME/.env with the LLM key — this is where
+        # ``_build_hindsight_scope`` reads the profile's LLM key from.
+        # Note the profile daemon env at ~/.hindsight/profiles/<name>.env
+        # does NOT carry the LLM key (only provider/model/idle-timeout),
+        # so reading it alone would be insufficient (per the issue body).
+        main_env = tmp_path / ".env"
+        main_env.write_text("HINDSIGHT_LLM_API_KEY=active-profile-llm-key\n")
+
+        # Another (default) profile's key in the process env — must NOT bleed in.
+        monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "default-profile-llm-key")
+
+        captured = {"llm_keys": [], "scopes": []}
+
+        def fake_get_client(self):
+            from agent.secret_scope import current_secret_scope
+            scope = current_secret_scope()
+            captured["scopes"].append(scope)
+            captured["llm_keys"].append(
+                _get_scoped_secret("HINDSIGHT_LLM_API_KEY", "")
+            )
+            client = MagicMock()
+            client._ensure_started = MagicMock()
+            client._manager = MagicMock()
+            client._manager.is_running = MagicMock(return_value=False)
+            return client
+
+        monkeypatch.setattr(HindsightMemoryProvider, "_get_client", fake_get_client)
+        monkeypatch.setattr(hs, "_check_local_runtime", lambda: (True, None))
+
+        # Also stub the daemon's Rich-console setup and the embed-manager
+        # import path so the thread body completes without actually trying
+        # to launch a daemon.
+        import sys as _sys
+        sys_backup = {}
+        for mod_name in ("hindsight_embed", "hindsight_embed.daemon_embed_manager"):
+            sys_backup[mod_name] = _sys.modules.get(mod_name)
+            _sys.modules[mod_name] = MagicMock()
+        try:
+            from rich.console import Console  # noqa: F401
+        except Exception:
+            _sys.modules["rich"] = MagicMock()
+            _sys.modules["rich.console"] = MagicMock(Console=MagicMock())
+
+        try:
+            provider = _make_provider(tmp_path, monkeypatch, mode="local_embedded")
+
+            # Wait for the daemon-start thread to invoke _get_client().
+            import time as _time
+            for _ in range(60):
+                if captured["llm_keys"]:
+                    break
+                _time.sleep(0.05)
+
+            assert captured["llm_keys"], (
+                "daemon-start thread never invoked _get_client() — see "
+                f"hindsight-embed.log tail: "
+                f"{((tmp_path / 'logs' / 'hindsight-embed.log').read_text(errors='replace') or '<empty>')[-600:]}"
+            )
+            # Scope was installed on the thread (proves the new
+            # set_secret_scope wrapping is in effect, not a fallback).
+            assert captured["scopes"][0] is not None, (
+                "daemon-start thread ran without a secret scope — the "
+                "issue #94933 fix's set_secret_scope wrapping was not "
+                "applied."
+            )
+            # And it resolved to the active profile's key from the .env,
+            # NOT the default-profile-llm-key bleeding in from os.environ.
+            assert captured["llm_keys"][0] == "active-profile-llm-key"
+        finally:
+            for mod_name, mod in sys_backup.items():
+                if mod is None:
+                    _sys.modules.pop(mod_name, None)
+                else:
+                    _sys.modules[mod_name] = mod
+
+
+# ── _build_embedded_profile_env is scope-safe ─────────────────────────────
+
+
+class TestBuildEmbeddedProfileEnvScopeSafe:
+    """``_build_embedded_profile_env`` reads ``HINDSIGHT_LLM_API_KEY``.
+    It must use the scoped helper so a scope miss under multiplex does
+    NOT raise and a scope hit returns the profile's value."""
+
+    def test_unscoped_under_multiplex_uses_env(self, monkeypatch, tmp_path):
+        """Default profile: env value used (the helper's fallback path)."""
+        monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "default-profile-llm-key")
+        ss.set_multiplex_active(True)
+        env = _build_embedded_profile_env(
+            {"profile": "test-profile", "llm_provider": "openai", "llm_model": "x"}
+        )
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "default-profile-llm-key"
+
+    def test_scoped_value_wins(self, monkeypatch, tmp_path):
+        """Secondary profile: scope wins over env."""
+        monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "default-profile-llm-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"HINDSIGHT_LLM_API_KEY": "secondary-profile-llm-key"})
+        try:
+            env = _build_embedded_profile_env(
+                {"profile": "test-profile", "llm_provider": "openai", "llm_model": "x"}
+            )
+            assert env["HINDSIGHT_API_LLM_API_KEY"] == "secondary-profile-llm-key"
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_miss_under_multiplex_returns_empty_not_environ(self, monkeypatch):
+        """Scope installed but key absent: returns ``""`` (the default
+        passed in) — NOT the cross-profile env value."""
+        monkeypatch.setenv("HINDSIGHT_LLM_API_KEY", "default-profile-llm-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"UNRELATED_KEY": "x"})
+        try:
+            env = _build_embedded_profile_env(
+                {"profile": "test-profile", "llm_provider": "openai", "llm_model": "x"}
+            )
+            # The profile daemon env carries empty LLM key — no leak.
+            assert env["HINDSIGHT_API_LLM_API_KEY"] == ""
+        finally:
+            ss.reset_secret_scope(tok)


### PR DESCRIPTION
## What Problem This Solves

Hindsight's embedded memory daemon (`local_embedded` mode) fails to start when `gateway.multiplex_profiles` is enabled. The daemon-start thread calls `get_secret("HINDSIGHT_LLM_API_KEY")` / `get_secret("HINDSIGHT_API_KEY")` with no profile secret scope installed, hits the multiplexer's fail-closed `UnscopedSecretError`, and never binds its port. Memory silently stops working for **every** profile under multiplexing.

The Hindsight plugin was not updated when the multiplexer's fail-closed scope guard was rolled out (`docs/design/multiplexing-gateway.md` Workstream A, `#76462` cluster). It is the same class of issue as the Slack-pattern `#59739` migration that landed a `_get_scoped_secret` helper in WhatsApp / IRC / Mattermost / SMS / DingTalk / Feishu / Wecom / Photon / Buzz / HASS / NTFY / Line / Teams / api_server adapters, but the Hindsight plugin was missed.

There are three call sites (all bare `get_secret(...)`, none scope-safe):

- `_load_config()` — `apiKey` fallback (`HINDSIGHT_API_KEY`)
- `initialize()` — `self._api_key` (`HINDSIGHT_API_KEY`)
- `_get_client()` — `llm_api_key` for the embedded client (`HINDSIGHT_LLM_API_KEY`)
- `_build_embedded_profile_env()` — the env the standalone `hindsight-embed` daemon consumes (`HINDSIGHT_LLM_API_KEY`)
- `is_available()` / `memory_setup()` — `HINDSIGHT_API_KEY` (cloud-mode availability probe + CLI key lookup)

The daemon-start thread specifically does **not** inherit the caller's per-turn contextvar scope, so even if a per-turn scope wraps `initialize()`, the background thread's reads inside `_get_client()` and `_build_embedded_profile_env()` see no scope and fail closed.

## Evidence

### Fix

1. **Module-level `_get_scoped_secret(name, default)`** mirroring `gateway/platforms/whatsapp_common.py::_get_wsecret`:
   - scope installed → scope is authoritative, scoped miss returns `default` (no `os.environ` borrow — that would leak another profile's key)
   - unscoped under multiplex (default profile's own startup loop) → fall back to `os.getenv` instead of raising `UnscopedSecretError`

2. **Module-level `_build_hindsight_scope(config)`** builds the scope the daemon-start thread runs under, from the **merged** env: main `<hermes_home>/.env` first, then overlay `~/.hindsight/profiles/<name>.env`. The profile daemon env only carries ~5 daemon runtime keys (provider/model/idle-timeout) and does **not** contain the LLM key — so reading it alone is insufficient (per the issue body).

3. **Every bare `get_secret(...)` in `plugins/memory/hindsight/__init__.py` now goes through `_get_scoped_secret(...)`.** 6 call sites migrated (`_load_config`, `initialize`, `is_available`, `memory_setup`, `_get_client`, `_build_embedded_profile_env`).

4. **`_start_daemon()` thread wraps the whole flow in `set_secret_scope(...)`** built from `_build_hindsight_scope(...)`, with `try/finally reset_secret_scope`. The thread's `_get_client()` and `_build_embedded_profile_env()` reads now resolve against the active profile's LLM key, not the default profile's `os.environ`.

### Regression tests

`tests/plugins/memory/test_hindsight_multiplex_secret_scope.py` — 11 tests, all green on the fix, **all fail / collection-error on the unfixed code** (verified `ImportError: cannot import name '_get_scoped_secret' from 'plugins.memory.hindsight'` on `origin/main`):

```
TestScopedSecretHelper (5)
  test_helper_exists
  test_scoped_value_wins_over_environ
  test_scoped_miss_returns_default_not_environ
  test_unscoped_under_multiplex_falls_back_to_environ
  test_single_profile_legacy_environ_read

TestInitializeScopeSafe (2)
  test_default_profile_unscoped_under_multiplex_uses_own_env   # the issue's repro branch
  test_secondary_profile_scoped_value_wins

TestDaemonStartThreadScope (1)
  test_daemon_start_thread_uses_scope_not_environ             # end-to-end thread test

TestBuildEmbeddedProfileEnvScopeSafe (3)
  test_unscoped_under_multiplex_uses_env
  test_scoped_value_wins
  test_scoped_miss_under_multiplex_returns_empty_not_environ
```

### Pre-existing failures (NOT caused by this fix)

`tests/plugins/memory/test_hindsight_provider.py` has 6 pre-existing failures on `origin/main` due to a missing `hindsight_client_api` package in this environment (`ModuleNotFoundError: No module named 'hindsight_client_api'`). Verified by running the same tests against `origin/main` with my changes reverted — the same 6 failures appear. One unrelated `openviking` test fails for the same environmental reason. None of my changes touch those code paths.

### Workaround verification

Mirrors the workaround described in the issue body. After the patch:
- daemon-start thread runs under a fresh scope (no longer no-scope)
- `_get_client()` resolves `HINDSIGHT_LLM_API_KEY` from the active profile's merged `.env`, not from `os.environ`
- secondary profile's scope wins over `os.environ` (no cross-profile leak)
- scoped miss returns `""` / `default`, never borrows from another profile's env
- non-multiplex deployments behave exactly as before (legacy `os.environ` reads keep working)

Closes #94933.
