### PR TITLE
fix(cron): preserve scheduled execution context

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3101,6 +3101,7 @@ def claim_job_for_fire(
     claim_ttl_seconds: int = 300,
     force: bool = False,
     return_job: bool = False,
+    scheduled_at_utc: Optional[str] = None,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
@@ -3110,6 +3111,7 @@ def claim_job_for_fire(
             claim_ttl_seconds=claim_ttl_seconds,
             force=force,
             return_job=return_job,
+            scheduled_at_utc=scheduled_at_utc,
         )
 
 
@@ -3119,6 +3121,7 @@ def _claim_job_for_fire_locked(
     claim_ttl_seconds: int = 300,
     force: bool = False,
     return_job: bool = False,
+    scheduled_at_utc: Optional[str] = None,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
@@ -3139,6 +3142,10 @@ def _claim_job_for_fire_locked(
     ``mark_job_run`` clears the claim on completion so a re-armed recurring job
     is claimable again next fire.
 
+    ``scheduled_at_utc`` lets a delayed worker preserve the due time from the
+    scheduler's pre-advance snapshot. External providers normally omit it and
+    capture the record's current ``next_run_at`` under this same lock.
+
     The stale-claim TTL means a machine that crashed after claiming but before
     completing doesn't wedge the job forever — after the TTL another fire can
     reclaim it.
@@ -3158,6 +3165,11 @@ def _claim_job_for_fire_locked(
                 return False
             now = _hermes_now()
             existing = job.get("fire_claim")
+            claimed_scheduled_at = (
+                scheduled_at_utc
+                if isinstance(scheduled_at_utc, str) and scheduled_at_utc.strip()
+                else job.get("next_run_at")
+            )
             if existing:
                 try:
                     claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
@@ -3170,6 +3182,8 @@ def _claim_job_for_fire_locked(
                     _age = (now - claimed_at).total_seconds()
                     if 0 <= _age < claim_ttl_seconds:
                         return False  # someone holds a fresh claim
+                    if isinstance(existing.get("scheduled_at"), str) and existing["scheduled_at"].strip():
+                        claimed_scheduled_at = existing["scheduled_at"]
                 except Exception:
                     pass  # malformed claim → overwrite
             if force:
@@ -3181,7 +3195,11 @@ def _claim_job_for_fire_locked(
             # stale lease, and the previous runner must not heartbeat the new
             # claim merely because hostname + PID are unchanged.
             owner = f"{_machine_id()}:{uuid.uuid4().hex}"
-            job["fire_claim"] = {"at": now.isoformat(), "by": owner}
+            job["fire_claim"] = {
+                "at": now.isoformat(),
+                "by": owner,
+                "scheduled_at": claimed_scheduled_at,
+            }
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3926,6 +3926,7 @@ def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    execution_context: Optional[dict[str, str]] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -4056,6 +4057,16 @@ def _run_job_script(
             }
         env = build_subprocess_env()
         env.update(env_overlay)
+        for key in (
+            "HERMES_CRON_JOB_ID",
+            "HERMES_CRON_EXECUTION_ID",
+            "HERMES_CRON_SCHEDULED_AT_UTC",
+        ):
+            env.pop(key, None)
+            if execution_context:
+                value = execution_context.get(key)
+                if value is not None:
+                    env[key] = value
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into
@@ -4114,6 +4125,28 @@ def _run_job_script(
         return False, f"Script execution failed: {exc}"
 
 
+def _cron_script_execution_context(job: dict) -> dict[str, str]:
+    """Project one fire's non-secret durable identity into a fixed env allowlist."""
+    job_id = str(job.get("id") or "")
+    execution_id = str(job.get("execution_id") or "")
+    scheduled_at = str(job.get("scheduled_at_utc") or "")
+    if re.fullmatch(r"[0-9a-f]{12}", job_id) is None:
+        return {}
+    if re.fullmatch(r"[0-9a-f]{32}", execution_id) is None:
+        return {}
+    try:
+        planned = datetime.fromisoformat(scheduled_at.replace("Z", "+00:00"))
+    except ValueError:
+        return {}
+    if planned.tzinfo is None or planned.utcoffset() is None:
+        return {}
+    return {
+        "HERMES_CRON_JOB_ID": job_id,
+        "HERMES_CRON_EXECUTION_ID": execution_id,
+        "HERMES_CRON_SCHEDULED_AT_UTC": planned.astimezone(timezone.utc).isoformat(),
+    }
+
+
 def _run_job_script_with_claim_heartbeat(
     job: dict,
     script_path: str,
@@ -4132,6 +4165,7 @@ def _run_job_script_with_claim_heartbeat(
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
     """
+    execution_context = _cron_script_execution_context(job)
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -4140,7 +4174,12 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            execution_context=execution_context,
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -4171,10 +4210,20 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            execution_context=execution_context,
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            execution_context=execution_context,
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -6765,7 +6814,14 @@ def _run_one_job_body(
 
     execution_id = job.get("execution_id")
     if not execution_id:
+        job["scheduled_at_utc"] = _hermes_now().astimezone(timezone.utc).isoformat()
         execution_id = create_execution(job["id"], source="direct")["id"]
+    elif not job.get("scheduled_at_utc"):
+        claim = job.get("fire_claim")
+        scheduled_at = claim.get("scheduled_at") if isinstance(claim, dict) else None
+        if isinstance(scheduled_at, str) and scheduled_at.strip():
+            job["scheduled_at_utc"] = scheduled_at
+    job["execution_id"] = str(execution_id)
     delivery_attempted = False
     delivery_error = None
     try:
@@ -7431,6 +7487,8 @@ def tick(
         # cron-kind jobs both compute the same next occurrence; interval jobs
         # re-anchor from their own "now" at claim time (harmless for
         # at-most-once — mark_job_run re-anchors at completion regardless).
+        for job in due_jobs:
+            job["scheduled_at_utc"] = job.get("next_run_at")
         advance_next_runs([job["id"] for job in due_jobs])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
@@ -7468,7 +7526,11 @@ def tick(
             # Acquire the durable claim only when this worker actually starts,
             # not while it may wait behind other work in an executor queue.
             # This prevents a queued lease from expiring before execution.
-            claimed = claim_job_for_fire(job["id"], return_job=True)
+            claimed = claim_job_for_fire(
+                job["id"],
+                return_job=True,
+                scheduled_at_utc=job.get("scheduled_at_utc"),
+            )
             if not claimed:
                 finish_execution(
                     job["execution_id"],

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -202,6 +202,10 @@ class CronScheduler(ABC):
                 error="Fire claim was not acquired",
             )
             return None
+        claim = claimed_job.get("fire_claim")
+        scheduled_at = claim.get("scheduled_at") if isinstance(claim, dict) else None
+        if isinstance(scheduled_at, str) and scheduled_at.strip():
+            claimed_job["scheduled_at_utc"] = scheduled_at
         claimed_job["execution_id"] = execution["id"]
         return claimed_job
 

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -32,7 +32,10 @@ def test_claim_succeeds_once_then_blocks(temp_home):
 
     assert claim_job_for_fire(jid) is True
     assert claim_job_for_fire(jid) is False
-    assert get_job(jid)["next_run_at"] != before
+    claimed = get_job(jid)
+    assert claimed is not None
+    assert claimed["next_run_at"] != before
+    assert claimed["fire_claim"]["scheduled_at"] == before
 
 
 def test_claim_oneshot_cannot_be_double_claimed(temp_home):
@@ -84,8 +87,38 @@ def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
     job = create_job(prompt="x", schedule="every 5m", name="s")
     jid = job["id"]
     assert claim_job_for_fire(jid) is True
+    from cron.jobs import get_job
+
+    first_claim = get_job(jid)
+    assert first_claim is not None
+    original_due = first_claim["fire_claim"]["scheduled_at"]
     # With a 0s TTL, the existing claim is always considered stale.
     assert claim_job_for_fire(jid, claim_ttl_seconds=0) is True
+    reclaimed = get_job(jid)
+    assert reclaimed is not None
+    assert reclaimed["fire_claim"]["scheduled_at"] == original_due
+    assert reclaimed["next_run_at"] != original_due
+
+
+def test_claim_preserves_scheduler_due_snapshot_after_pre_advance(temp_home):
+    from cron.jobs import advance_next_runs, claim_job_for_fire, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="snapshot")
+    original_due = job["next_run_at"]
+    assert advance_next_runs([job["id"]]) == 1
+    persisted = get_job(job["id"])
+    assert persisted is not None
+    persisted_advanced_due = persisted["next_run_at"]
+
+    claimed = claim_job_for_fire(
+        job["id"],
+        return_job=True,
+        scheduled_at_utc=original_due,
+    )
+
+    assert isinstance(claimed, dict)
+    assert claimed["fire_claim"]["scheduled_at"] == original_due
+    assert claimed["next_run_at"] != persisted_advanced_due
 
 
 def test_mark_job_run_clears_claim(temp_home):

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -131,6 +131,62 @@ class TestRunJobScript:
         assert success is True
         assert output == "ABSENT"
 
+    def test_job_script_receives_bounded_execution_identity(self, cron_env):
+        from cron.scheduler import _run_job_script_with_claim_heartbeat
+
+        script = cron_env / "scripts" / "execution_context.py"
+        script.write_text(
+            "import json, os\n"
+            "print(json.dumps({key: os.environ.get(key) for key in ("
+            "'HERMES_CRON_JOB_ID', 'HERMES_CRON_EXECUTION_ID', "
+            "'HERMES_CRON_SCHEDULED_AT_UTC')}))\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "a1b2c3d4e5f6",
+            "execution_id": "0123456789abcdef0123456789abcdef",
+            "scheduled_at_utc": "2026-08-25T14:00:00+02:00",
+            "next_run_at": "2026-08-25T14:30:00+02:00",
+            "schedule": {"kind": "once", "at": "2026-08-25T14:00:00+02:00"},
+            "run_claim": {"by": "test-owner"},
+        }
+
+        success, output = _run_job_script_with_claim_heartbeat(
+            job,
+            "execution_context.py",
+        )
+
+        assert success is True
+        assert json.loads(output) == {
+            "HERMES_CRON_JOB_ID": "a1b2c3d4e5f6",
+            "HERMES_CRON_EXECUTION_ID": "0123456789abcdef0123456789abcdef",
+            "HERMES_CRON_SCHEDULED_AT_UTC": "2026-08-25T12:00:00+00:00",
+        }
+
+    def test_plain_script_cannot_inherit_stale_execution_identity(
+        self,
+        cron_env,
+        monkeypatch,
+    ):
+        from cron.scheduler import _run_job_script
+
+        monkeypatch.setenv("HERMES_CRON_JOB_ID", "stale-job")
+        monkeypatch.setenv("HERMES_CRON_EXECUTION_ID", "stale-execution")
+        monkeypatch.setenv("HERMES_CRON_SCHEDULED_AT_UTC", "stale-time")
+        script = cron_env / "scripts" / "stale_context.py"
+        script.write_text(
+            "import os\n"
+            "print('PRESENT' if any(os.environ.get(key) for key in ("
+            "'HERMES_CRON_JOB_ID', 'HERMES_CRON_EXECUTION_ID', "
+            "'HERMES_CRON_SCHEDULED_AT_UTC')) else 'ABSENT')\n",
+            encoding="utf-8",
+        )
+
+        success, output = _run_job_script("stale_context.py")
+
+        assert success is True
+        assert output == "ABSENT"
+
     @pytest.mark.windows_only
     def test_windows_uv_venv_python_script_bypasses_launcher(self, cron_env, tmp_path, monkeypatch):
         # Windows-only: the fake ``sys.platform`` could not reproduce the

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -243,6 +244,34 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     assert events[0] == ("running", "exec-3")
     assert events[-1][0:2] == ("finish", "exec-3")
     assert events[-1][2]["success"] is True
+
+
+def test_direct_run_stamps_invocation_time_before_execution(monkeypatch):
+    import cron.scheduler as scheduler
+
+    captured = []
+    fixed = datetime(2026, 8, 25, 14, 5, tzinfo=UTC)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: fixed)
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda job_id, source: {"id": "0123456789abcdef0123456789abcdef"},
+    )
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, **_kwargs: captured.append(dict(job))
+        or (True, "output", "response", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    assert scheduler.run_one_job({"id": "direct-job"}) is True
+    assert captured[0]["scheduled_at_utc"] == "2026-08-25T14:05:00+00:00"
 
 
 def test_provider_start_recovers_interrupted_records_before_tick(monkeypatch):

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -131,7 +131,15 @@ class TestRunningJobGuard:
         result = callback()
         future.set_result(result)
 
-        assert claim_calls == [("queued-job", {"return_job": True})]
+        assert claim_calls == [
+            (
+                "queued-job",
+                {
+                    "return_job": True,
+                    "scheduled_at_utc": "2020-01-01T00:00:00",
+                },
+            )
+        ]
         assert "queued-job" not in sched._running_job_ids
 
 
@@ -402,7 +410,25 @@ class TestTickBatchAdvance:
         monkeypatch.setattr(
             sched, "advance_next_runs",
             lambda ids: advance_calls.append(list(ids)) or len(list(ids)))
-        monkeypatch.setattr(sched, "run_job", lambda j, **_kw: (True, "out", "resp", None))
+        monkeypatch.setattr(
+            sched,
+            "claim_job_for_fire",
+            lambda job_id, **kwargs: {
+                **next(job for job in jobs if job["id"] == job_id),
+                "fire_claim": {
+                    "by": f"owner-{job_id}",
+                    "scheduled_at": kwargs["scheduled_at_utc"],
+                },
+            },
+        )
+        monkeypatch.setattr(sched, "heartbeat_fire_claim", lambda *_a, **_kw: True)
+        fired = []
+        monkeypatch.setattr(
+            sched,
+            "run_job",
+            lambda j, **_kw: fired.append(j["scheduled_at_utc"])
+            or (True, "out", "resp", None),
+        )
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
         monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
@@ -412,5 +438,6 @@ class TestTickBatchAdvance:
         assert n == 4
         assert advance_calls == [["job-0", "job-1", "job-2", "job-3"]], (
             f"tick must batch-advance the due set in ONE call; got {advance_calls}")
+        assert fired == ["2020-01-01T00:00:00"] * 4
 
         sched._shutdown_parallel_pool()

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -374,18 +374,27 @@ def test_fire_due_default_claims_then_runs(monkeypatch):
         jobs,
         "claim_job_for_fire",
         lambda jid, **kw: claims.append((jid, kw))
-        or {"id": jid, "name": "t", "fire_claim": {"by": "exact-owner"}},
+        or {
+            "id": jid,
+            "name": "t",
+            "fire_claim": {
+                "by": "exact-owner",
+                "scheduled_at": "2026-08-25T12:00:00+00:00",
+            },
+        },
         raising=False,
     )
     monkeypatch.setattr(
         sched,
         "run_one_job",
-        lambda job, **kw: ran.append((job["id"], job["fire_claim"]["by"])) or True,
+        lambda job, **kw: ran.append(
+            (job["id"], job["fire_claim"]["by"], job["scheduled_at_utc"])
+        ) or True,
     )
 
     assert InProcessCronScheduler().fire_due("j1") is True
     assert claims == [("j1", {"return_job": True})]
-    assert ran == [("j1", "exact-owner")]
+    assert ran == [("j1", "exact-owner", "2026-08-25T12:00:00+00:00")]
 
 
 def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):


### PR DESCRIPTION
## What changed

- preserve the original scheduled timestamp across delayed claim acquisition and stale-claim recovery
- assign a durable execution ID for each claimed cron execution
- expose only `HERMES_CRON_JOB_ID`, `HERMES_CRON_EXECUTION_ID`, and `HERMES_CRON_SCHEDULED_AT_UTC` to script jobs
- clear inherited values for those variables before constructing the child environment

## Why

Script jobs need scheduler-owned execution context to correlate a subprocess with its durable cron execution and the instant it was originally scheduled for. Inferring that identity from ambient environment or acquisition time is unsafe when workers are delayed or stale claims are recovered.

## Security impact

This is security-sensitive environment handling. The child environment uses a strict allowlist, inherited values for the three reserved variables are removed, and only scheduler-validated values are injected. No secret values are introduced.

## Compatibility

The change retains current force/resume, cancellation, process-drain, claim-heartbeat, scheduler-provider, and per-acquisition claim-owner behavior.

## How to test

Automated:

```bash
pytest -q tests/cron
```

Manual no-agent script smoke:

1. Create a script under `$HERMES_HOME/scripts/` that prints the three `HERMES_CRON_*` variables.
2. Create it as a local no-agent cron job with `hermes cron create ... --script <name> --no-agent --deliver local`.
3. Trigger it with `hermes cron run <job-id>` and run `hermes cron tick`.
4. Verify that job ID, execution ID, and scheduled UTC timestamp are all non-empty and match the durable execution.

Observed manual result: `CRON_CONTEXT_MANUAL_SMOKE=PASS`.

## Platforms tested

- Linux 6.17, aarch64, Python 3.11: automated and manual smoke passed
- macOS and Windows/WSL2: not locally available; awaiting the repository CI/maintainer workflow approval

## Verification

- `946 passed, 5 skipped` across the cron test surface before publication metadata rewrite
- final publication tree is byte-identical to the reviewed/tested tree
- Ruff, compile, and `git diff --check` passed

## Related work and duplicate search

Searched current source plus open and closed issues/PRs before submission.

- #90395 adds broader native routine/API execution identity, but does not expose these script environment variables or preserve the original scheduled timestamp.
- #78248 previously proposed script execution IDs and is closed. This PR additionally carries job identity and original scheduled time through the current claim/provider paths.

No open PR found that implements this exact three-variable scheduled-execution-context contract.
