### PR TITLE
feat(cron): stage paused jobs atomically from manifests

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -116,6 +116,8 @@ _fire_fence_locks_guard = threading.Lock()
 _JOBS_LOCK_TIMEOUT_SECONDS = 30.0
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+MAX_PAUSED_REASON_LENGTH = 240
+DEFAULT_INITIAL_PAUSED_REASON = "created paused"
 
 
 @dataclass(frozen=True)
@@ -264,14 +266,21 @@ def _job_running_in_this_process(job_id: str) -> bool:
         return True
 
 
+class JobsLockError(RuntimeError):
+    """Raised when a mutation requires an unavailable cross-process lock."""
+
+
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
     return _current_cron_store().cron_dir / ".jobs.lock"
 
 
 @contextlib.contextmanager
-def _jobs_lock():
+def _jobs_lock(*, require_cross_process: bool = False):
     """Serialize a load_jobs→modify→save_jobs critical section.
+
+    ``require_cross_process`` is reserved for closed-manifest transactions that
+    must fail without the OS advisory lock rather than enter degraded mode.
 
     Combines the in-process threading lock (cheap mutual exclusion between
     the gateway's parallel tick threads) with a cross-process advisory file
@@ -291,6 +300,10 @@ def _jobs_lock():
     """
     depth = getattr(_jobs_lock_state, "depth", 0)
     if depth:
+        if require_cross_process and not getattr(
+            _jobs_lock_state, "cross_process_held", False
+        ):
+            raise JobsLockError("cross_process_lock_required")
         _jobs_lock_state.depth = depth + 1
         try:
             yield
@@ -306,6 +319,7 @@ def _jobs_lock():
         # section read it. Reset on entry/exit so stale stamps from unlocked
         # loads or prior sections can never suppress a needed merge.
         _jobs_lock_state.load_stamp = None
+        _jobs_lock_state.cross_process_held = False
         lock_fd = None
         try:
             try:
@@ -331,9 +345,16 @@ def _jobs_lock():
                     while True:
                         try:
                             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            _jobs_lock_state.cross_process_held = True
                             break
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
+                                if require_cross_process:
+                                    lock_fd.close()
+                                    lock_fd = None
+                                    raise JobsLockError(
+                                        "cross_process_lock_timeout"
+                                    ) from None
                                 logger.error(
                                     "Timed out after %.0fs waiting for the cron "
                                     "jobs lock (%s) — another process is holding "
@@ -351,7 +372,17 @@ def _jobs_lock():
                             time.sleep(0.1)
                 elif msvcrt is not None:
                     getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+                    _jobs_lock_state.cross_process_held = True
+                elif require_cross_process:
+                    lock_fd.close()
+                    lock_fd = None
+                    raise JobsLockError("cross_process_lock_unavailable")
             except (OSError, IOError) as e:
+                if require_cross_process:
+                    if lock_fd is not None:
+                        lock_fd.close()
+                        lock_fd = None
+                    raise JobsLockError("cross_process_lock_unavailable") from None
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
@@ -372,6 +403,7 @@ def _jobs_lock():
         finally:
             _jobs_lock_state.depth = 0
             _jobs_lock_state.load_stamp = None
+            _jobs_lock_state.cross_process_held = False
 
 
 @contextlib.contextmanager
@@ -729,9 +761,14 @@ def parse_duration(s: str) -> int:
     return value * multipliers[unit]
 
 
-def parse_schedule(schedule: str) -> Dict[str, Any]:
+def parse_schedule(
+    schedule: str, *, relative_base: Optional[datetime] = None
+) -> Dict[str, Any]:
     """
     Parse schedule string into structured format.
+
+    ``relative_base`` deterministically anchors duration one-shots; omitted
+    callers retain the normal current-time behavior.
     
     Returns dict with:
         - kind: "once" | "interval" | "cron"
@@ -811,7 +848,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     # Duration like "30m", "2h", "1d" → one-shot from now
     try:
         minutes = parse_duration(schedule)
-        run_at = _hermes_now() + timedelta(minutes=minutes)
+        run_at = (relative_base or _hermes_now()) + timedelta(minutes=minutes)
         return {
             "kind": "once",
             "run_at": run_at.isoformat(),
@@ -1912,7 +1949,7 @@ def _validate_job_mode_invariants(
         raise ValueError(NO_AGENT_WITHOUT_SCRIPT_ERROR)
 
 
-def create_job(
+def _build_job_record(
     prompt: Optional[str],
     schedule: str,
     name: Optional[str] = None,
@@ -1933,9 +1970,16 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    initial_paused: bool = False,
+    paused_reason: Optional[str] = None,
+    *,
+    job_id: Optional[str] = None,
+    created_at: Optional[str] = None,
+    validate_oneshot_eligibility: bool = True,
+    relative_schedule_base: Optional[datetime] = None,
 ) -> Dict[str, Any]:
     """
-    Create a new cron job.
+    Validate inputs and build a new cron job record without persisting it.
 
     Args:
         prompt: The prompt to run (must be self-contained, or a task instruction when skill is set).
@@ -2000,11 +2044,28 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        relative_schedule_base: Optional immutable base for resolving a
+                relative one-shot schedule. Existing callers default to now.
 
     Returns:
         The created job dict
     """
-    parsed_schedule = parse_schedule(schedule)
+    if type(initial_paused) is not bool:
+        raise ValueError("initial_paused must be a boolean")
+    if paused_reason is not None and not isinstance(paused_reason, str):
+        raise ValueError("paused_reason must be a string or null")
+    if not initial_paused and paused_reason is not None:
+        raise ValueError("paused_reason requires initial_paused=True")
+    normalized_paused_reason = (paused_reason or "").strip()
+    if len(normalized_paused_reason) > MAX_PAUSED_REASON_LENGTH:
+        raise ValueError(
+            f"paused_reason must be at most {MAX_PAUSED_REASON_LENGTH} characters"
+        )
+    if initial_paused and not normalized_paused_reason:
+        normalized_paused_reason = DEFAULT_INITIAL_PAUSED_REASON
+
+    now = created_at or _hermes_now().isoformat()
+    parsed_schedule = parse_schedule(schedule, relative_base=relative_schedule_base)
 
     # Normalize repeat: treat 0 or negative values as None (infinite)
     if repeat is not None and repeat <= 0:
@@ -2018,8 +2079,7 @@ def create_job(
     if deliver is None:
         deliver = "origin" if origin else "local"
 
-    job_id = uuid.uuid4().hex[:12]
-    now = _hermes_now().isoformat()
+    job_id = job_id or uuid.uuid4().hex[:12]
 
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_model = _normalize_job_optional_text(model)
@@ -2082,7 +2142,11 @@ def create_job(
     )
 
     next_run_at = compute_next_run(parsed_schedule)
-    if parsed_schedule.get("kind") == "once" and next_run_at is None:
+    if (
+        validate_oneshot_eligibility
+        and parsed_schedule.get("kind") == "once"
+        and next_run_at is None
+    ):
         run_at = parsed_schedule.get("run_at") or schedule
         logger.warning(
             "Rejecting one-shot cron job '%s': run_at %s is outside the %ss grace window",
@@ -2123,12 +2187,12 @@ def create_job(
             "times": repeat,  # None = forever
             "completed": 0
         },
-        "enabled": True,
-        "state": "scheduled",
-        "paused_at": None,
-        "paused_reason": None,
+        "enabled": not initial_paused,
+        "state": "paused" if initial_paused else "scheduled",
+        "paused_at": now if initial_paused else None,
+        "paused_reason": normalized_paused_reason if initial_paused else None,
         "created_at": now,
-        "next_run_at": next_run_at,
+        "next_run_at": None if initial_paused else next_run_at,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,
@@ -2150,11 +2214,66 @@ def create_job(
     if normalized_reasoning_effort is not None:
         job["reasoning_effort"] = normalized_reasoning_effort
 
+    return job
+
+
+def create_job(
+    prompt: Optional[str],
+    schedule: str,
+    name: Optional[str] = None,
+    repeat: Optional[int] = None,
+    deliver: Optional[str] = None,
+    origin: Optional[Dict[str, Any]] = None,
+    skill: Optional[str] = None,
+    skills: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    script: Optional[str] = None,
+    context_from: Optional[Union[str, List[str]]] = None,
+    enabled_toolsets: Optional[List[str]] = None,
+    workdir: Optional[str] = None,
+    no_agent: bool = False,
+    attach_to_session: Optional[bool] = None,
+    monitor_script: Optional[str] = None,
+    monitor_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    initial_paused: bool = False,
+    paused_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create and durably persist one cron job under the jobs-file lock.
+
+    ``initial_paused=True`` is an atomic create-paused operation: the first
+    persisted record is disabled/paused and has no ``next_run_at``.
+    """
+    job = _build_job_record(
+        prompt=prompt,
+        schedule=schedule,
+        name=name,
+        repeat=repeat,
+        deliver=deliver,
+        origin=origin,
+        skill=skill,
+        skills=skills,
+        model=model,
+        provider=provider,
+        base_url=base_url,
+        script=script,
+        context_from=context_from,
+        enabled_toolsets=enabled_toolsets,
+        workdir=workdir,
+        no_agent=no_agent,
+        attach_to_session=attach_to_session,
+        monitor_script=monitor_script,
+        monitor_url=monitor_url,
+        reasoning_effort=reasoning_effort,
+        initial_paused=initial_paused,
+        paused_reason=paused_reason,
+    )
     with _jobs_lock():
         jobs = load_jobs()
         jobs.append(job)
         save_jobs(jobs)
-
     return job
 
 

--- a/cron/paused_manifest.py
+++ b/cron/paused_manifest.py
@@ -1,0 +1,451 @@
+"""Fail-closed, create-only staging for paused cron-job manifests.
+
+A manifest transaction validates every job before taking the registry lock, then
+creates all missing jobs with one jobs.json write. Existing jobs must be exact
+replays of the manifest-derived record (apart from their original creation
+instant); collisions or drift abort without mutation.
+
+Agent jobs must pin both ``provider`` and ``model``. This keeps replay
+validation deterministic instead of depending on whatever provider/model is
+configured when the manifest is replayed. No-agent jobs need no such pins.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+from cron import jobs as cron_jobs
+from hermes_time import now as _hermes_now
+
+CONTRACT = "hermes-paused-cron-manifest.v1"
+_SAFE_ID_RE = re.compile(r"[0-9a-f]{12}")
+_TOP_LEVEL_KEYS = frozenset({"contract", "schema_version", "paused_reason", "jobs"})
+_REQUIRED_JOB_KEYS = frozenset({"id", "name", "schedule"})
+_JOB_KEYS = frozenset({
+    "id",
+    "name",
+    "schedule",
+    "prompt",
+    "repeat",
+    "deliver",
+    "skills",
+    "model",
+    "provider",
+    "base_url",
+    "script",
+    "context_from",
+    "enabled_toolsets",
+    "workdir",
+    "no_agent",
+    "attach_to_session",
+    "monitor_script",
+    "monitor_url",
+    "reasoning_effort",
+})
+_OPTIONAL_TEXT_KEYS = frozenset({
+    "deliver",
+    "model",
+    "provider",
+    "base_url",
+    "script",
+    "workdir",
+    "monitor_script",
+    "monitor_url",
+    "reasoning_effort",
+})
+
+
+class PausedManifestError(ValueError):
+    """Fail-closed manifest or existing-registry mismatch."""
+
+
+def _fail(code: str) -> NoReturn:
+    raise PausedManifestError(code)
+
+
+def _read_target_bytes(target: Path) -> bytes | None:
+    try:
+        return target.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def _required_ownership(target: Path, target_exists: bool) -> tuple[int, int]:
+    source = target if target_exists else target.parent
+    stat_result = source.stat()
+    return stat_result.st_uid, stat_result.st_gid
+
+
+def _preserve_ownership(fd: int, required: tuple[int, int]) -> os.stat_result:
+    staged = os.fstat(fd)
+    if (staged.st_uid, staged.st_gid) != required:
+        fchown = getattr(os, "fchown", None)
+        if fchown is None:
+            _fail("jobs_registry_ownership_failed")
+        try:
+            fchown(fd, *required)
+            staged = os.fstat(fd)
+        except BaseException:
+            _fail("jobs_registry_ownership_failed")
+        if (staged.st_uid, staged.st_gid) != required:
+            _fail("jobs_registry_ownership_failed")
+    return staged
+
+
+def _fsync_parent_directory(target: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    directory_fd = os.open(target.parent, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _resolved_registry_target() -> Path:
+    logical_target = cron_jobs._current_cron_store().jobs_file
+    return (
+        Path(os.path.realpath(logical_target))
+        if logical_target.is_symlink()
+        else logical_target
+    )
+
+
+def _cleanup_staged_temp(tmp_path: str | None, staged: os.stat_result | None) -> None:
+    """Remove only the still-present inode created by this transaction."""
+    if tmp_path is None or staged is None:
+        return
+    try:
+        residue = os.stat(tmp_path, follow_symlinks=False)
+        if (residue.st_dev, residue.st_ino) == (staged.st_dev, staged.st_ino):
+            os.unlink(tmp_path)
+    except OSError:
+        pass
+
+
+def _commit_registry(records: list[dict[str, Any]]) -> None:
+    """Commit one manifest transaction without any non-atomic fallback.
+
+    The normal cron writer tolerates unusual filesystems by copying over the
+    live target when ``replace(2)`` cannot cross a device boundary.  Manifest
+    staging has a stricter contract. Resolve a jobs.json symlink first, create
+    the temporary file beside that real target, fsync it, atomically replace,
+    then fsync the target directory while the cross-process lock is still held.
+
+    A failure proven by readback to have left the old bytes returns
+    ``jobs_registry_commit_failed``. If the new bytes landed, or readback sees
+    anything else, return ``jobs_registry_commit_uncertain``: callers must
+    replay the same manifest, whose exact-record comparison safely converges
+    without another write when the staged payload did land.
+    """
+    target = _resolved_registry_target()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        old_payload = _read_target_bytes(target)
+        ownership = _required_ownership(target, old_payload is not None)
+    except OSError:
+        _fail("jobs_registry_commit_failed")
+
+    staged_payload = json.dumps(
+        {"jobs": records, "updated_at": _hermes_now().isoformat()},
+        indent=2,
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    fd: int | None = None
+    tmp_path: str | None = None
+    staged_stat: os.stat_result | None = None
+    replace_started = False
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(target.parent), suffix=".tmp", prefix=".jobs_manifest_"
+        )
+        staged_stat = os.fstat(fd)
+        staged_stat = _preserve_ownership(fd, ownership)
+        with os.fdopen(fd, "wb") as stream:
+            fd = None
+            stream.write(staged_payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        cron_jobs._record_load_stamp(None)
+        replace_started = True
+        os.replace(tmp_path, target)
+        _fsync_parent_directory(target)
+    except BaseException as error:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        _cleanup_staged_temp(tmp_path, staged_stat)
+        if isinstance(error, PausedManifestError) and not replace_started:
+            raise
+        try:
+            landed_payload = _read_target_bytes(target)
+        except OSError:
+            _fail("jobs_registry_commit_uncertain")
+        if landed_payload == staged_payload:
+            _fail("jobs_registry_commit_uncertain")
+        if landed_payload == old_payload:
+            _fail("jobs_registry_commit_failed")
+        _fail("jobs_registry_commit_uncertain")
+
+
+def _load_manifest(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        if not path.is_file() or path.is_symlink():
+            _fail("manifest_not_regular")
+        raw = path.read_bytes()
+        manifest = json.loads(raw.decode("utf-8"))
+    except PausedManifestError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        _fail("manifest_invalid_json")
+    if not isinstance(manifest, dict) or set(manifest) != _TOP_LEVEL_KEYS:
+        _fail("manifest_shape_invalid")
+    manifest = cast(dict[str, Any], manifest)
+    canonical = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return manifest, hashlib.sha256(canonical).hexdigest()
+
+
+def _strict_optional_text(spec: dict[str, Any], key: str) -> None:
+    if key not in spec or spec[key] is None:
+        return
+    value = spec[key]
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(f"job_{key}_invalid")
+
+
+def _strict_string_list(spec: dict[str, Any], key: str) -> None:
+    if key not in spec or spec[key] is None:
+        return
+    values = spec[key]
+    if not isinstance(values, list):
+        _fail(f"job_{key}_invalid")
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not value or value != value.strip():
+            _fail(f"job_{key}_invalid")
+        normalized.append(value)
+    if len(normalized) != len(set(normalized)):
+        _fail(f"job_{key}_invalid")
+
+
+def _validate_job_spec(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        _fail("job_shape_invalid")
+    keys = set(item)
+    if not _REQUIRED_JOB_KEYS <= keys or not keys <= _JOB_KEYS:
+        _fail("job_shape_invalid")
+    spec = cast(dict[str, Any], item)
+
+    job_id = spec["id"]
+    if not isinstance(job_id, str) or _SAFE_ID_RE.fullmatch(job_id) is None:
+        _fail("job_id_invalid")
+    name = spec["name"]
+    if not isinstance(name, str) or not name or name != name.strip() or len(name) > 200:
+        _fail("job_name_invalid")
+    schedule = spec["schedule"]
+    if not isinstance(schedule, str) or not schedule or schedule != schedule.strip():
+        _fail("job_schedule_invalid")
+    try:
+        cron_jobs.parse_schedule(schedule)
+    except (TypeError, ValueError):
+        _fail("job_schedule_invalid")
+
+    if "prompt" in spec and not isinstance(spec["prompt"], str):
+        _fail("job_prompt_invalid")
+    repeat = spec.get("repeat")
+    if repeat is not None and (type(repeat) is not int or repeat < 1):
+        _fail("job_repeat_invalid")
+    for key in _OPTIONAL_TEXT_KEYS:
+        _strict_optional_text(spec, key)
+    for key in ("skills", "enabled_toolsets"):
+        _strict_string_list(spec, key)
+
+    context_from = spec.get("context_from")
+    if context_from is not None:
+        if isinstance(context_from, str):
+            if not context_from or context_from != context_from.strip():
+                _fail("job_context_from_invalid")
+        elif isinstance(context_from, list):
+            _strict_string_list(spec, "context_from")
+        else:
+            _fail("job_context_from_invalid")
+
+    if "no_agent" in spec and type(spec["no_agent"]) is not bool:
+        _fail("job_no_agent_invalid")
+    attach = spec.get("attach_to_session")
+    if attach is not None and type(attach) is not bool:
+        _fail("job_attach_to_session_invalid")
+
+    no_agent = spec.get("no_agent", False)
+    if not no_agent and (not spec.get("provider") or not spec.get("model")):
+        _fail("job_provider_model_pins_required")
+    return dict(spec)
+
+
+def _validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if (
+        manifest.get("contract") != CONTRACT
+        or type(manifest.get("schema_version")) is not int
+        or manifest["schema_version"] != 1
+    ):
+        _fail("manifest_contract_invalid")
+    reason = manifest.get("paused_reason")
+    if (
+        not isinstance(reason, str)
+        or not reason
+        or reason != reason.strip()
+        or len(reason) > cron_jobs.MAX_PAUSED_REASON_LENGTH
+    ):
+        _fail("paused_reason_invalid")
+    raw_specs = manifest.get("jobs")
+    if not isinstance(raw_specs, list) or not raw_specs:
+        _fail("jobs_invalid")
+
+    seen_ids: set[str] = set()
+    seen_names: set[str] = set()
+    validated: list[dict[str, Any]] = []
+    for item in raw_specs:
+        spec = _validate_job_spec(item)
+        job_id = spec["id"]
+        folded_name = spec["name"].casefold()
+        if job_id in seen_ids:
+            _fail("duplicate_job_id")
+        if folded_name in seen_names:
+            _fail("duplicate_job_name")
+        seen_ids.add(job_id)
+        seen_names.add(folded_name)
+        validated.append(spec)
+    return validated
+
+
+def _expected_record(
+    spec: dict[str, Any],
+    *,
+    paused_reason: str,
+    created_at: str,
+    validate_oneshot_eligibility: bool,
+) -> dict[str, Any]:
+    kwargs = dict(spec)
+    job_id = kwargs.pop("id")
+    try:
+        relative_schedule_base = datetime.fromisoformat(
+            created_at.replace("Z", "+00:00")
+        )
+    except ValueError:
+        _fail("job_spec_invalid")
+    try:
+        return cron_jobs._build_job_record(
+            **kwargs,
+            initial_paused=True,
+            paused_reason=paused_reason,
+            job_id=job_id,
+            created_at=created_at,
+            validate_oneshot_eligibility=validate_oneshot_eligibility,
+            relative_schedule_base=relative_schedule_base,
+        )
+    except (TypeError, ValueError):
+        _fail("job_spec_invalid")
+
+
+def _existing_matches(
+    existing: dict[str, Any], spec: dict[str, Any], *, paused_reason: str
+) -> bool:
+    created_at = existing.get("created_at")
+    if not isinstance(created_at, str) or existing.get("paused_at") != created_at:
+        return False
+    expected = _expected_record(
+        spec,
+        paused_reason=paused_reason,
+        created_at=created_at,
+        validate_oneshot_eligibility=False,
+    )
+    return existing == expected
+
+
+def stage_paused_manifest(path: str | Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """Validate and atomically create every missing job in a paused state.
+
+    The operation requires the jobs registry's OS cross-process lock. Its
+    bounded outcomes are a durable registry write, a proven no-write failure,
+    or ``jobs_registry_commit_uncertain`` when an atomic replace may have landed
+    but its durability could not be established. Replay is the recovery
+    operation. Replaying the same manifest is a no-op; target identity
+    collisions and any stored-record drift are rejected.
+    """
+    if type(dry_run) is not bool:
+        _fail("dry_run_must_be_boolean")
+    manifest, manifest_sha256 = _load_manifest(Path(path))
+    specs = _validate_manifest(manifest)
+    paused_reason = cast(str, manifest["paused_reason"])
+
+    with cron_jobs._jobs_lock(require_cross_process=True):
+        current = cron_jobs._peek_jobs_unlocked()
+        if current is None:
+            _fail("jobs_registry_invalid")
+        current = cast(list[dict[str, Any]], current)
+        by_id: dict[str, dict[str, Any]] = {}
+        by_name: dict[str, list[dict[str, Any]]] = {}
+        for job in current:
+            if not isinstance(job, dict):
+                _fail("jobs_registry_invalid")
+            job_id = job.get("id")
+            if isinstance(job_id, str):
+                if job_id in by_id:
+                    _fail("existing_duplicate_job_id")
+                by_id[job_id] = job
+            name = job.get("name")
+            if isinstance(name, str):
+                by_name.setdefault(name.casefold(), []).append(job)
+
+        missing: list[dict[str, Any]] = []
+        staged_at = _hermes_now().isoformat()
+        for spec in specs:
+            id_match = by_id.get(spec["id"])
+            name_matches = by_name.get(spec["name"].casefold(), [])
+            if id_match is None:
+                if name_matches:
+                    _fail("existing_job_name_collision")
+                missing.append(
+                    _expected_record(
+                        spec,
+                        paused_reason=paused_reason,
+                        created_at=staged_at,
+                        validate_oneshot_eligibility=True,
+                    )
+                )
+                continue
+            if name_matches != [id_match]:
+                _fail("existing_job_identity_mismatch")
+            if not _existing_matches(id_match, spec, paused_reason=paused_reason):
+                _fail("existing_job_drift")
+
+        if missing and not dry_run:
+            _commit_registry(current + missing)
+        elif not missing and not dry_run:
+            try:
+                _fsync_parent_directory(_resolved_registry_target())
+            except BaseException:
+                _fail("jobs_registry_commit_uncertain")
+
+    job_count = len(specs)
+    return {
+        "contract": CONTRACT,
+        "manifest_sha256": manifest_sha256,
+        "job_count": job_count,
+        "matching_count": job_count - len(missing),
+        "create_count": len(missing),
+        "mutated": bool(missing) and not dry_run,
+        "dry_run": dry_run,
+        "job_ids": sorted(spec["id"] for spec in specs),
+    }

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7245,6 +7245,8 @@ def create_job_with_scheduler_registration(**kwargs) -> dict:
     from cron.scheduler_provider import resolve_cron_scheduler
 
     job = create_job(**kwargs)
+    if not job.get("enabled", True) or job.get("state") == "paused":
+        return job
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -411,6 +411,8 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        initial_paused=getattr(args, "initial_paused", False),
+        paused_reason=getattr(args, "paused_reason", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -433,7 +435,10 @@ def cron_create(args):
         print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
-    print(f"  Next run: {result['next_run_at']}")
+    if result.get("state") == "paused":
+        print("  State: paused")
+    else:
+        print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -71,6 +71,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--paused",
+        dest="initial_paused",
+        action="store_true",
+        default=False,
+        help="Create paused atomically; never arm the first scheduler trigger.",
+    )
+    cron_create.add_argument(
+        "--paused-reason",
+        help="Reason for --paused (maximum 240 characters).",
+    )
+    cron_create.add_argument(
         "--monitor-script",
         dest="monitor_script",
         help=(

--- a/tests/cron/test_create_paused_manifest.py
+++ b/tests/cron/test_create_paused_manifest.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import errno
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cron.jobs import create_job, load_jobs, use_cron_store
+from cron.paused_manifest import CONTRACT, PausedManifestError, stage_paused_manifest
+from cron.scheduler import create_job_with_scheduler_registration
+from hermes_cli.cron import cron_command
+from hermes_cli.subcommands.cron import build_cron_parser
+from tools.cronjob_tools import CRONJOB_SCHEMA, cronjob
+
+
+def test_create_paused_is_atomic_from_first_save(tmp_path, monkeypatch):
+    import cron.jobs as jobs
+
+    snapshots = []
+    real_save = jobs.save_jobs
+
+    def capture(records, **kwargs):
+        snapshots.append(copy.deepcopy(records))
+        return real_save(records, **kwargs)
+
+    monkeypatch.setattr(jobs, "save_jobs", capture)
+    with use_cron_store(tmp_path):
+        job = create_job(
+            prompt="held",
+            schedule="every 5m",
+            initial_paused=True,
+            paused_reason="readiness hold",
+        )
+        stored = load_jobs()
+
+    assert snapshots == [stored] and stored == [job]
+    assert job["enabled"] is False
+    assert job["state"] == "paused"
+    assert job["paused_at"] == job["created_at"]
+    assert job["paused_reason"] == "readiness hold"
+    assert job["next_run_at"] is None
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, "false", [], {}])
+def test_create_paused_requires_strict_bool(tmp_path, value):
+    with use_cron_store(tmp_path):
+        with pytest.raises(ValueError, match="initial_paused must be a boolean"):
+            create_job(prompt="held", schedule="every 5m", initial_paused=value)
+        assert load_jobs() == []
+
+
+@pytest.mark.parametrize("reason", ["", "   "])
+def test_unpaused_create_rejects_any_supplied_paused_reason(tmp_path, reason):
+    with use_cron_store(tmp_path):
+        with pytest.raises(
+            ValueError, match="paused_reason requires initial_paused=True"
+        ):
+            create_job(
+                prompt="held",
+                schedule="every 5m",
+                initial_paused=False,
+                paused_reason=reason,
+            )
+        assert load_jobs() == []
+
+
+def test_paused_create_does_not_arm_scheduler_provider(tmp_path, monkeypatch):
+    provider = MagicMock()
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler", lambda: provider
+    )
+    with use_cron_store(tmp_path):
+        job = create_job_with_scheduler_registration(
+            prompt="held", schedule="every 5m", initial_paused=True
+        )
+    provider.register_job.assert_not_called()
+    assert job["state"] == "paused"
+
+
+def test_cronjob_tool_exposes_and_validates_atomic_pause(tmp_path):
+    prop = CRONJOB_SCHEMA["parameters"]["properties"]["initial_paused"]
+    assert prop["type"] == "boolean"
+    with use_cron_store(tmp_path):
+        bad = json.loads(
+            cronjob(
+                action="create",
+                prompt="held",
+                schedule="every 5m",
+                initial_paused="false",
+            )
+        )
+        good = json.loads(
+            cronjob(
+                action="create",
+                prompt="held",
+                schedule="every 5m",
+                initial_paused=True,
+                paused_reason="operator hold",
+            )
+        )
+    assert bad["success"] is False
+    assert bad["error"] == "initial_paused must be a boolean"
+    assert good["success"] is True
+    assert good["state"] == "paused"
+    assert good["next_run_at"] is None
+
+
+def test_cli_parser_exposes_atomic_pause_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_cron_parser(subparsers, cmd_cron=cron_command)
+    args = parser.parse_args([
+        "cron",
+        "create",
+        "every 5m",
+        "held",
+        "--paused",
+        "--paused-reason",
+        "operator hold",
+    ])
+    assert args.initial_paused is True
+    assert args.paused_reason == "operator hold"
+
+
+def _manifest(tmp_path: Path, *, count: int = 3) -> tuple[Path, dict]:
+    specs = []
+    for index in range(count):
+        specs.append({
+            "id": f"{index + 1:012x}",
+            "name": f"generic-paused-job-{index + 1}",
+            "schedule": f"{index} * * * *",
+            "prompt": f"perform generic task {index + 1}",
+            "repeat": None,
+            "deliver": "local",
+            "provider": "openai",
+            "model": "gpt-5",
+        })
+    data = {
+        "contract": CONTRACT,
+        "schema_version": 1,
+        "paused_reason": "staged pending explicit activation",
+        "jobs": specs,
+    }
+    path = tmp_path / "paused-jobs.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path, data
+
+
+@pytest.mark.parametrize("count", [1, 3])
+def test_generic_manifest_stages_any_nonzero_count_and_replays_exactly(
+    tmp_path, monkeypatch, count
+):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, manifest = _manifest(tmp_path, count=count)
+    save_calls = 0
+    real_commit = paused_manifest._commit_registry
+
+    def count_save(records):
+        nonlocal save_calls
+        save_calls += 1
+        return real_commit(records)
+
+    monkeypatch.setattr(paused_manifest, "_commit_registry", count_save)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        dry = stage_paused_manifest(manifest_path, dry_run=True)
+        assert not (home / "cron" / "jobs.json").exists()
+        first = stage_paused_manifest(manifest_path)
+        first_bytes = (home / "cron" / "jobs.json").read_bytes()
+        stored = load_jobs()
+        second = stage_paused_manifest(manifest_path)
+        second_bytes = (home / "cron" / "jobs.json").read_bytes()
+
+    assert dry["create_count"] == count and dry["mutated"] is False
+    assert first["create_count"] == count and first["mutated"] is True
+    assert second["create_count"] == 0 and second["mutated"] is False
+    assert first["job_count"] == count
+    assert save_calls == 1
+    assert first_bytes == second_bytes
+    assert {job["id"] for job in stored} == {item["id"] for item in manifest["jobs"]}
+    assert all(job["enabled"] is False for job in stored)
+    assert all(job["state"] == "paused" for job in stored)
+    assert all(job["next_run_at"] is None for job in stored)
+    assert all(job["paused_at"] == job["created_at"] for job in stored)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink semantics require POSIX")
+def test_manifest_stages_beside_resolved_symlink_target(tmp_path, monkeypatch):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    external = tmp_path / "external-store"
+    external.mkdir()
+    real_target = external / "jobs.json"
+    real_target.write_text('{"jobs": [], "updated_at": "seed"}', encoding="utf-8")
+    staged_dirs = []
+    real_mkstemp = paused_manifest.tempfile.mkstemp
+
+    def capture_mkstemp(*args, **kwargs):
+        staged_dirs.append(Path(kwargs["dir"]))
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(paused_manifest.tempfile, "mkstemp", capture_mkstemp)
+    with use_cron_store(home):
+        registry = home / "cron" / "jobs.json"
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.symlink_to(real_target)
+        stage_paused_manifest(manifest_path)
+
+    assert registry.is_symlink()
+    assert staged_dirs == [real_target.parent]
+    assert json.loads(real_target.read_text(encoding="utf-8"))["jobs"]
+
+
+def test_manifest_replace_exdev_fails_without_copy_or_registry_mutation(
+    tmp_path, monkeypatch
+):
+    import cron.paused_manifest as paused_manifest
+    import shutil
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        create_job(prompt="unrelated", schedule="every 1h")
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+
+        def fail_replace(_source, _target):
+            raise OSError(errno.EXDEV, "cross-device link")
+
+        def forbidden_copy(*_args, **_kwargs):
+            raise AssertionError("manifest commit must never copy over live registry")
+
+        monkeypatch.setattr(paused_manifest.os, "replace", fail_replace)
+        monkeypatch.setattr(shutil, "copyfile", forbidden_copy)
+        with pytest.raises(PausedManifestError, match="jobs_registry_commit_failed"):
+            stage_paused_manifest(manifest_path)
+
+        assert registry.read_bytes() == before
+        assert not list(registry.parent.glob(".jobs_manifest_*.tmp"))
+
+
+@pytest.mark.parametrize("fault", ["after_replace", "directory_fsync"])
+def test_manifest_landed_replace_failure_is_uncertain_and_exactly_replayable(
+    tmp_path, monkeypatch, fault
+):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        create_job(prompt="unrelated", schedule="every 1h")
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+
+        if fault == "after_replace":
+            real_replace = paused_manifest.os.replace
+
+            def replace_then_fail(source, target):
+                real_replace(source, target)
+                raise OSError("injected interruption after replace")
+
+            monkeypatch.setattr(paused_manifest.os, "replace", replace_then_fail)
+        else:
+
+            def fail_directory_fsync(_target):
+                raise OSError("injected directory fsync failure")
+
+            monkeypatch.setattr(
+                paused_manifest, "_fsync_parent_directory", fail_directory_fsync
+            )
+
+        with pytest.raises(
+            PausedManifestError, match="^jobs_registry_commit_uncertain$"
+        ):
+            stage_paused_manifest(manifest_path)
+
+        landed = registry.read_bytes()
+        assert landed != before
+        assert not list(registry.parent.glob(".jobs_manifest_*.tmp"))
+
+        monkeypatch.undo()
+        replay = stage_paused_manifest(manifest_path)
+        assert replay["mutated"] is False
+        assert replay["create_count"] == 0
+        assert registry.read_bytes() == landed
+
+
+def test_manifest_uncertain_commit_converges_via_replay_parent_fsync(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    real_fsync_parent = paused_manifest._fsync_parent_directory
+    fsync_targets = []
+    lock_states = []
+
+    def fail_first_parent_fsync(target):
+        fsync_targets.append(target)
+        lock_states.append(jobs._jobs_lock_state.cross_process_held)
+        if len(fsync_targets) == 1:
+            raise OSError("injected directory fsync failure")
+        real_fsync_parent(target)
+
+    monkeypatch.setattr(
+        paused_manifest, "_fsync_parent_directory", fail_first_parent_fsync
+    )
+    with use_cron_store(home):
+        with pytest.raises(
+            PausedManifestError, match="^jobs_registry_commit_uncertain$"
+        ):
+            stage_paused_manifest(manifest_path)
+
+        registry = home / "cron" / "jobs.json"
+        landed = registry.read_bytes()
+        replay = stage_paused_manifest(manifest_path)
+
+        assert replay["mutated"] is False
+        assert replay["create_count"] == 0
+        assert registry.read_bytes() == landed
+        assert fsync_targets == [registry, registry]
+        assert lock_states == [True, True]
+
+
+def test_manifest_exact_replay_parent_fsync_failure_is_uncertain(tmp_path, monkeypatch):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        stage_paused_manifest(manifest_path)
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+
+        def fail_parent_fsync(_target):
+            raise OSError("injected replay directory fsync failure")
+
+        monkeypatch.setattr(
+            paused_manifest, "_fsync_parent_directory", fail_parent_fsync
+        )
+        with pytest.raises(
+            PausedManifestError, match="^jobs_registry_commit_uncertain$"
+        ):
+            stage_paused_manifest(manifest_path)
+
+        assert registry.read_bytes() == before
+
+
+def test_manifest_exact_dry_run_replay_does_not_fsync(tmp_path, monkeypatch):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        stage_paused_manifest(manifest_path)
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+
+        def forbidden_parent_fsync(_target):
+            raise AssertionError("dry-run must not fsync the registry directory")
+
+        monkeypatch.setattr(
+            paused_manifest, "_fsync_parent_directory", forbidden_parent_fsync
+        )
+        replay = stage_paused_manifest(manifest_path, dry_run=True)
+
+        assert replay["mutated"] is False
+        assert replay["create_count"] == 0
+        assert registry.read_bytes() == before
+
+
+def test_manifest_required_fchown_failure_is_precommit_and_byte_identical(
+    tmp_path, monkeypatch
+):
+    import cron.paused_manifest as paused_manifest
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        create_job(prompt="unrelated", schedule="every 1h")
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+        monkeypatch.setattr(
+            paused_manifest,
+            "_required_ownership",
+            lambda _target, _exists: (os.getuid() + 1, os.getgid()),
+        )
+
+        def fail_fchown(_fd, _uid, _gid):
+            raise OSError("injected fchown failure")
+
+        monkeypatch.setattr(paused_manifest.os, "fchown", fail_fchown)
+        with pytest.raises(
+            PausedManifestError, match="^jobs_registry_ownership_failed$"
+        ):
+            stage_paused_manifest(manifest_path)
+
+        assert registry.read_bytes() == before
+        assert not list(registry.parent.glob(".jobs_manifest_*.tmp"))
+
+
+def test_paused_oneshot_manifest_replays_after_creation_grace_expires(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs
+    import cron.paused_manifest as paused_manifest
+
+    initial_now = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    delayed_now = initial_now + timedelta(minutes=10)
+    manifest_path, data = _manifest(tmp_path, count=1)
+    data["jobs"][0]["schedule"] = (initial_now + timedelta(minutes=1)).isoformat()
+    manifest_path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: initial_now)
+    monkeypatch.setattr(paused_manifest, "_hermes_now", lambda: initial_now)
+
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        first = stage_paused_manifest(manifest_path)
+        registry = home / "cron" / "jobs.json"
+        created = registry.read_bytes()
+
+        monkeypatch.setattr(jobs, "_hermes_now", lambda: delayed_now)
+        monkeypatch.setattr(paused_manifest, "_hermes_now", lambda: delayed_now)
+        replay = stage_paused_manifest(manifest_path)
+
+        assert first["mutated"] is True
+        assert replay["mutated"] is False
+        assert replay["create_count"] == 0
+        assert registry.read_bytes() == created
+
+
+def test_relative_paused_oneshot_manifest_replays_from_immutable_created_at(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs
+    import cron.paused_manifest as paused_manifest
+
+    initial_now = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    delayed_now = initial_now + timedelta(hours=1)
+    manifest_path, data = _manifest(tmp_path, count=1)
+    data["jobs"][0]["schedule"] = "30m"
+    manifest_path.write_text(json.dumps(data), encoding="utf-8")
+    # The manifest's captured creation instant is the deterministic base even
+    # if a later clock read has advanced while the transaction is constructed.
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: initial_now + timedelta(seconds=5))
+    monkeypatch.setattr(paused_manifest, "_hermes_now", lambda: initial_now)
+
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        first = stage_paused_manifest(manifest_path)
+        registry = home / "cron" / "jobs.json"
+        created = registry.read_bytes()
+        stored = load_jobs()[0]
+        assert stored["created_at"] == initial_now.isoformat()
+        assert (
+            stored["schedule"]["run_at"]
+            == (initial_now + timedelta(minutes=30)).isoformat()
+        )
+
+        monkeypatch.setattr(jobs, "_hermes_now", lambda: delayed_now)
+        monkeypatch.setattr(paused_manifest, "_hermes_now", lambda: delayed_now)
+        replay = stage_paused_manifest(manifest_path)
+
+        assert first["mutated"] is True
+        assert replay["mutated"] is False
+        assert replay["create_count"] == 0
+        assert registry.read_bytes() == created
+
+
+def test_new_paused_oneshot_manifest_still_rejects_expired_schedule(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs
+    import cron.paused_manifest as paused_manifest
+
+    current = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    manifest_path, data = _manifest(tmp_path, count=1)
+    data["jobs"][0]["schedule"] = (current - timedelta(minutes=10)).isoformat()
+    manifest_path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: current)
+    monkeypatch.setattr(paused_manifest, "_hermes_now", lambda: current)
+
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        with pytest.raises(PausedManifestError, match="^job_spec_invalid$"):
+            stage_paused_manifest(manifest_path)
+        assert not (home / "cron" / "jobs.json").exists()
+
+
+@pytest.mark.parametrize("schema_version", [True, 1.0, "1", None])
+def test_manifest_requires_strict_integer_schema_version(tmp_path, schema_version):
+    manifest_path, data = _manifest(tmp_path)
+    data["schema_version"] = schema_version
+    manifest_path.write_text(json.dumps(data), encoding="utf-8")
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        with pytest.raises(PausedManifestError, match="manifest_contract_invalid"):
+            stage_paused_manifest(manifest_path)
+        assert not (home / "cron" / "jobs.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (lambda data: data["jobs"].clear(), "jobs_invalid"),
+        (
+            lambda data: data["jobs"].__setitem__(1, dict(data["jobs"][0])),
+            "duplicate_job_id",
+        ),
+        (
+            lambda data: data["jobs"][0].__setitem__("secret", "do-not-report"),
+            "job_shape_invalid",
+        ),
+        (
+            lambda data: data["jobs"][0].__setitem__("no_agent", 1),
+            "job_no_agent_invalid",
+        ),
+        (
+            lambda data: data["jobs"][0].pop("provider"),
+            "job_provider_model_pins_required",
+        ),
+    ],
+)
+def test_manifest_validation_failure_leaves_registry_byte_identical(
+    tmp_path, mutate, error
+):
+    manifest_path, data = _manifest(tmp_path)
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        seed = create_job(prompt="unrelated", schedule="every 1h")
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+        mutate(data)
+        manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(PausedManifestError) as exc_info:
+            stage_paused_manifest(manifest_path)
+        after = registry.read_bytes()
+    assert str(exc_info.value) == error
+    assert "do-not-report" not in str(exc_info.value)
+    assert before == after
+    assert seed["id"] in before.decode()
+
+
+def test_manifest_rejects_existing_drift_without_write(tmp_path):
+    manifest_path, data = _manifest(tmp_path)
+    first = data["jobs"][0]
+    home = tmp_path / "home"
+    with use_cron_store(home):
+        create_job(
+            prompt=first["prompt"],
+            schedule=first["schedule"],
+            name=first["name"],
+            deliver=first["deliver"],
+            provider=first["provider"],
+            model=first["model"],
+            initial_paused=True,
+            paused_reason="different hold",
+        )
+        registry = home / "cron" / "jobs.json"
+        payload = json.loads(registry.read_text(encoding="utf-8"))
+        payload["jobs"][0]["id"] = first["id"]
+        registry.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        before = registry.read_bytes()
+        with pytest.raises(PausedManifestError, match="existing_job_drift"):
+            stage_paused_manifest(manifest_path)
+        assert registry.read_bytes() == before
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock contention proof")
+def test_manifest_lock_contention_fails_without_registry_mutation(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs
+
+    manifest_path, _ = _manifest(tmp_path)
+    home = tmp_path / "home"
+    ready = tmp_path / "lock-ready"
+    release = tmp_path / "lock-release"
+    child = None
+    with use_cron_store(home):
+        create_job(prompt="unrelated", schedule="every 1h")
+        registry = home / "cron" / "jobs.json"
+        before = registry.read_bytes()
+        lock_path = jobs._jobs_lock_file()
+        child_code = f"""
+import fcntl, pathlib, time
+path = pathlib.Path({str(lock_path)!r})
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open('a+') as fd:
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    pathlib.Path({str(ready)!r}).write_text('ready')
+    deadline = time.monotonic() + 10
+    while not pathlib.Path({str(release)!r}).exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+"""
+        child = subprocess.Popen([sys.executable, "-c", child_code])
+        try:
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ready.exists(), "child did not acquire jobs lock"
+            monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+            with pytest.raises(jobs.JobsLockError, match="cross_process_lock_timeout"):
+                stage_paused_manifest(manifest_path)
+            assert registry.read_bytes() == before
+        finally:
+            release.write_text("release")
+            if child is not None:
+                child.wait(timeout=15)

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -1,5 +1,6 @@
 """Tests for tools/cronjob_tools.py — prompt scanning, schedule/list/remove dispatchers."""
 
+import inspect
 import json
 import pytest
 
@@ -8,6 +9,18 @@ from tools.cronjob_tools import (
     check_cronjob_requirements,
     cronjob,
 )
+
+
+def test_cronjob_new_paused_parameters_preserve_existing_positional_order():
+    """New options must not rebind the legacy task/session positional slots."""
+    names = list(inspect.signature(cronjob).parameters)
+
+    assert names[-4:] == [
+        "task_id",
+        "session_id",
+        "initial_paused",
+        "paused_reason",
+    ]
 
 
 # =========================================================================

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1283,6 +1283,8 @@ def cronjob(
     reasoning_effort: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    initial_paused: bool = False,
+    paused_reason: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -1293,6 +1295,8 @@ def cronjob(
         if normalized == "create":
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
+            if type(initial_paused) is not bool:
+                return tool_error("initial_paused must be a boolean", success=False)
             canonical_skills = _canonical_skills(skill, skills)
             _no_agent = bool(no_agent)
             # Job-shape validation differs by mode:
@@ -1393,6 +1397,8 @@ def cronjob(
                     # dispatch below: models do not make model-config
                     # decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    initial_paused=initial_paused,
+                    paused_reason=paused_reason,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1416,6 +1422,7 @@ def cronjob(
                 "repeat": _repeat_display(job),
                 "deliver": job.get("deliver", "local"),
                 "next_run_at": job["next_run_at"],
+                "state": job["state"],
                 "job": _format_job(job),
                 "message": _create_message,
                 **_gateway_liveness_notice(),
@@ -1812,6 +1819,16 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                     "WHEN TO USE False (default): anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human, follow conditional logic based on content."
                 ),
             },
+            "initial_paused": {
+                "type": "boolean",
+                "default": False,
+                "description": "Create the job paused from its first durable write. The scheduler is not armed and next_run_at is null. Resume remains a separate explicit action.",
+            },
+            "paused_reason": {
+                "type": "string",
+                "maxLength": 240,
+                "description": "Optional reason recorded only when initial_paused=True. Omit for the explicit default 'created paused'.",
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1911,6 +1928,8 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        initial_paused=args.get("initial_paused", False),
+        paused_reason=args.get("paused_reason"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),


### PR DESCRIPTION
## What changed

- support atomic `initial_paused` creation through the cron library, CLI, and tool API
- add the generic `hermes-paused-cron-manifest.v1` staging API
- require a fail-closed OS cross-process lock for the full validate-and-commit transaction
- provide all-or-nothing staging, exact idempotent replay, identity-collision detection, and stored-drift rejection
- preserve crash consistency with resolved-target atomic replacement, ownership checks, parent-directory durability, and explicit uncertain-result recovery
- keep dry runs byte-identical and side-effect free

## Why

Creating a job and pausing it afterward leaves a window in which the scheduler can execute it. Operators and integrations need a generic way to persist a complete set of jobs in a disabled state on their first durable write, with deterministic replay and no partial registry mutation.

## Security and durability impact

This PR changes security-sensitive filesystem and concurrency behavior around `jobs.json`:

- the complete transaction holds a required OS cross-process lock
- symlinked registry paths are resolved before staging
- the staged file is written beside the resolved target, ownership is verified, file and parent directory durability are established, and no copy-over-live fallback is allowed
- pre-commit failures are proven byte-identical; landed or ambiguous replacements return `jobs_registry_commit_uncertain` and converge through exact replay
- manifest validation is closed-world and strictly typed

## Compatibility

Existing cron creation remains enabled by default. New tool parameters are appended after existing positional compatibility parameters. Relative one-shot replay uses an explicit immutable base without changing the default parser behavior for other callers.

## How to test

Automated:

```bash
pytest -q tests/cron tests/tools/test_cronjob_tools.py \
  tests/hermes_cli/test_cron.py tests/hermes_cli/test_cron_parser_builder.py
```

Manual manifest smoke:

1. Create a `hermes-paused-cron-manifest.v1` JSON manifest with one or more jobs, explicit provider/model pins, and a paused reason.
2. Call `stage_paused_manifest(path)` in an isolated `HERMES_HOME`.
3. Verify every created record is disabled, in `paused` state, and has `next_run_at: null` on its first durable write.
4. Replay the same manifest and verify `create_count == 0`, `mutated == false`, and byte-identical `jobs.json`.

Observed manual results:

- `PAUSED_MANIFEST_MANUAL_SMOKE=PASS`
- `REPLAY_BYTE_IDENTICAL=PASS`

## Platforms tested

- Linux 6.17, aarch64, Python 3.11: automated, fault-injection, process-contention, and manual replay smokes passed
- macOS and Windows/WSL2: not locally available; cross-platform filesystem/locking behavior is awaiting repository CI/maintainer workflow approval

## Verification

- `1064 passed, 5 skipped` across cron, CLI, and cron-tool tests before publication metadata/history cleanup
- final publication tree is byte-identical to the reviewed/tested tree
- fault injection covers lock contention, cross-device replacement refusal, ownership failure, landed-but-uncertain replacement, replay durability, schema typing, and delayed one-shot replay
- Ruff, compile, and `git diff --check` passed

## Related work and duplicate search

Searched current source plus open and closed issues/PRs before submission.

- #78935 included atomic paused creation but was closed because its branch was based on a broad local integration lineage. Its author explicitly planned a clean upstream-based replacement. This PR is independently implemented on a clean upstream base and adds the generic strict manifest/replay contract.

No open PR found that implements this complete atomic paused-manifest contract.
