### PR TITLE
fix(time): resolve the timezone per profile instead of freezing one per process (#94945)

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -27,11 +27,19 @@ except ImportError:
     # Python 3.8 fallback (shouldn't be needed — Hermes requires 3.9+)
     from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
-# Cached state — resolved once, reused on every call.
-# Call reset_cache() to force re-resolution (e.g. after config changes).
-_cached_tz: Optional[ZoneInfo] = None
-_cached_tz_name: Optional[str] = None
-_cache_resolved: bool = False
+# Cached ZoneInfo (or None for server-local), keyed by the resolution context.
+#
+# The timezone is resolved from two profile-sensitive inputs: the
+# ``HERMES_TIMEZONE`` env var and ``config.yaml`` at ``get_config_path()`` —
+# and the latter is ``get_hermes_home() / "config.yaml"``, which the
+# multiplexed gateway scopes per profile via ``set_hermes_home_override()``
+# (a ContextVar). A single process-global cache resolved once at first use
+# would freeze whichever zone the *first* ``now()`` saw — typically the root
+# home at unscoped startup — and hand it to every profile forever, ignoring
+# each profile's own ``timezone:`` key. Keying by (env, resolved config path)
+# lets each profile resolve and cache its own zone independently.
+# Call reset_cache() to force re-resolution (e.g. after a config edit).
+_tz_cache: dict = {}
 
 
 def _resolve_timezone_name() -> str:
@@ -93,17 +101,31 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
 
 
+def _tz_cache_key() -> str:
+    """Identity of the current timezone-resolution context.
+
+    Both inputs to :func:`_resolve_timezone_name` are folded in: the
+    ``HERMES_TIMEZONE`` env var and the resolved ``config.yaml`` path (which is
+    profile-scoped via ``get_hermes_home()``). Two profiles with distinct homes
+    get distinct keys, so one profile's zone can never be served to another.
+    """
+    try:
+        config_path = str(get_config_path())
+    except Exception:
+        config_path = ""
+    return f"{os.getenv('HERMES_TIMEZONE', '').strip()}\x00{config_path}"
+
+
 def get_timezone() -> Optional[ZoneInfo]:
     """Return the user's configured ZoneInfo, or None (meaning server-local).
 
-    Resolved once and cached. Call ``reset_cache()`` after config changes.
+    Cached per resolution context (env + profile-scoped config path). Call
+    ``reset_cache()`` after config changes.
     """
-    global _cached_tz, _cached_tz_name, _cache_resolved
-    if not _cache_resolved:
-        _cached_tz_name = _resolve_timezone_name()
-        _cached_tz = _get_zoneinfo(_cached_tz_name)
-        _cache_resolved = True
-    return _cached_tz
+    key = _tz_cache_key()
+    if key not in _tz_cache:
+        _tz_cache[key] = _get_zoneinfo(_resolve_timezone_name())
+    return _tz_cache[key]
 
 
 def reset_cache() -> None:
@@ -113,10 +135,7 @@ def reset_cache() -> None:
     config edit or ``HERMES_TIMEZONE`` update) to force ``get_timezone()`` /
     ``now()`` to read the new value instead of the value cached at first use.
     """
-    global _cached_tz, _cached_tz_name, _cache_resolved
-    _cached_tz = None
-    _cached_tz_name = None
-    _cache_resolved = False
+    _tz_cache.clear()
 
 
 def now() -> datetime:

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -21,10 +21,8 @@ import hermes_time
 
 
 def _reset_hermes_time_cache():
-    """Reset the hermes_time module cache (replacement for removed reset_cache)."""
-    hermes_time._cached_tz = None
-    hermes_time._cached_tz_name = None
-    hermes_time._cache_resolved = False
+    """Reset the hermes_time module cache between tests."""
+    hermes_time.reset_cache()
 
 
 # =========================================================================
@@ -272,3 +270,61 @@ class TestCronTimezone:
 
         next_run = datetime.fromisoformat(job["next_run_at"])
         assert next_run.tzinfo is not None
+
+
+class TestPerProfileTimezoneCache:
+    """The timezone cache must be keyed by resolution context, not frozen once
+    per process. The multiplexed gateway scopes each profile tick with
+    ``set_hermes_home_override()``; a process-global cache would freeze the
+    zone the first ``now()`` saw (typically the root home at unscoped startup)
+    and serve it to every profile forever (#94945)."""
+
+    def setup_method(self):
+        _reset_hermes_time_cache()
+
+    def teardown_method(self):
+        _reset_hermes_time_cache()
+        os.environ.pop("HERMES_TIMEZONE", None)
+
+    def _home(self, tmp_path, name, tz):
+        home = tmp_path / name
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text(f"timezone: {tz}\n", encoding="utf-8")
+        return home
+
+    def test_profile_zone_not_frozen_by_unscoped_startup(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        root = self._home(tmp_path, "root", "UTC")
+        alpha = self._home(tmp_path / "root" / "profiles", "alpha", "Europe/Paris")
+        monkeypatch.setenv("HERMES_HOME", str(root))
+
+        # First now()/get_timezone() happens unscoped, at the root home.
+        assert hermes_time.get_timezone() == ZoneInfo("UTC")
+
+        # A profile tick scopes to the profile home — it must see its OWN zone,
+        # not the root zone frozen by the unscoped startup call.
+        tok = set_hermes_home_override(str(alpha))
+        try:
+            assert hermes_time.get_timezone() == ZoneInfo("Europe/Paris")
+        finally:
+            reset_hermes_home_override(tok)
+
+        # Back outside the scope, the root zone is still correct (and cached).
+        assert hermes_time.get_timezone() == ZoneInfo("UTC")
+
+    def test_reset_cache_reresolves_after_config_edit(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        home = self._home(tmp_path, "h", "UTC")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert hermes_time.get_timezone() == ZoneInfo("UTC")
+
+        # Same path, edited content — the per-key cache holds until reset.
+        (home / "config.yaml").write_text("timezone: Asia/Tokyo\n", encoding="utf-8")
+        hermes_time.reset_cache()
+        assert hermes_time.get_timezone() == ZoneInfo("Asia/Tokyo")


### PR DESCRIPTION
## Problem

`hermes_time` resolves the configured timezone **once per process** and freezes it in module globals. `HERMES_TIMEZONE` aside, the zone is read from `config.yaml` at `get_config_path()` = `get_hermes_home() / "config.yaml"` — and `HERMES_HOME` is **context-local**: the multiplexed gateway scopes every profile tick with `set_hermes_home_override()` (a `ContextVar`).

The process's first `now()` happens at startup, outside any profile scope, so it reads the *root* home's config and freezes that zone for the lifetime of the process. A `timezone:` key in a profile's own `config.yaml` is written to a file nothing re-reads. `reset_cache()` existed for exactly this and was **called nowhere in the runtime**.

Consequences (all verified present on `main`):
- `compute_next_run()` computes cron `next_run_at` in the wrong zone;
- `cron/jobs.py`'s migration-repair branch then rewrites correctly-offset `next_run_at` values into the wrong offset and swallows the occurrence, so the corruption self-propagates;
- `agent/system_prompt.py` reports a zone that depends on whether the turn was started by the gateway or the CLI.
- Symmetric hazard (arguably worse): if the first `now()` ever lands *inside* a profile scope, that profile's zone is frozen for **every** profile — including ones that deliberately set no `timezone:`.

## Fix

Key the cache by the **resolution context** — `(HERMES_TIMEZONE, resolved config path)` — instead of a single process-global. Each profile resolves and caches its own zone independently, so neither startup order nor cross-profile ticks can serve one profile's zone to another. `reset_cache()` now clears the keyed cache (still the declared hook after a config edit).

This mirrors the pattern the codebase already uses for the same cross-profile bleed class (e.g. the ContextVar-backed credential registry in `tools/credential_files.py`): profile-sensitive process state must be keyed to its resolution context, never frozen once.

## Tests

`TestPerProfileTimezoneCache` reproduces the issue's scenario as a deterministic unit test:
- `test_profile_zone_not_frozen_by_unscoped_startup` — unscoped startup at a `UTC` root home, then a profile tick scoped to a `Europe/Paris` home; the profile sees `Europe/Paris`, not the frozen `UTC`. Fails on the pre-fix code (profile gets `UTC`), passes after.
- `test_reset_cache_reresolves_after_config_edit` — `reset_cache()` re-resolves after a same-path config edit.

The existing `tests/test_timezone.py` suite passes; its stale reset helper (which poked the removed globals and was commented "replacement for removed reset_cache") now calls the real `reset_cache()`.

Fixes #94945
