### PR TITLE
fix(delegate): bound parent retry loop on stale subagent (closes #94858)

### DIFF
--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #94956 (issue #94858) attribution mapping

--- a/tests/tools/test_delegate_stale_subagent_loop.py
+++ b/tests/tools/test_delegate_stale_subagent_loop.py
@@ -1,0 +1,418 @@
+"""Regression tests for #94858 — parent-agent retry loop against a dead subagent.
+
+Original symptom (from the issue's agent.log):
+  - Parent spawns a subagent, the child finishes.
+  - Parent keeps calling delegate_task(action='steer'/'stop',
+    subagent_id='sa-0-...') against the already-finished child.
+  - The tool keeps returning a recoverable-looking
+    "No live subagent 'sa-0-...' ..." error.
+  - The model interprets the error as something to retry, and the parent
+    burns tokens in an unbounded loop until the operator kills the
+    gateway.
+
+The fix has two halves (one test each):
+  1. **Bounded retry** — after a small per-(parent, target) cap, the
+     error text explicitly names the loop and stops inviting retries.
+  2. **Always-on, structured non-retryable surface** — every "subagent
+     is gone / no longer accepting" error is JSON-tagged with
+     ``recoverable=False`` and ``do_not_retry=True`` so a well-behaved
+     model stops on the first failure, not the fourth.
+
+Pre-fix behavior:
+  - The error string never changes shape no matter how many times the
+    parent calls. Tests that drive the stub for N>=4 attempts and
+    expect the error text to evolve would FAIL pre-fix and PASS
+    post-fix — that is the regression we are pinning.
+
+Post-fix behavior:
+  - Attempt #1: tagged non-retryable, plain "subagent is gone" reason.
+  - Attempts #2..#limit: same tagged shape (no escalation yet, the
+    model is expected to honour the first one).
+  - Attempts #limit+1..: loop-detected, names the offending call and
+    points at action='list' / spawn / completion-message as the
+    real alternatives.
+"""
+
+import json
+import threading
+import weakref
+
+import pytest
+
+from tools.delegate_tool import (
+    _dead_subagent_hits,
+    _record_dead_subagent_hit,
+    _reset_dead_subagent_hits,
+    _STALE_SUBAGENT_RETRY_LIMIT,
+    _handle_control_action,
+    _non_retryable_subagent_error,
+    _register_subagent,
+    _unregister_subagent,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubChild:
+    """Weakref-able stand-in for a live child AIAgent.
+
+    `accept_steer=False` makes the underlying steer() return False —
+    i.e. the child is registered but has closed its steering window.
+    That is the second terminal class from the issue log: the model
+    thinks the child is alive, but the registry no longer accepts work
+    for it. The first terminal class (target missing entirely) is
+    exercised by simply NOT registering the child.
+    """
+
+    def __init__(self, parent=None, accept_steer: bool = False):
+        self.steered: list[str] = []
+        self.accept_steer = accept_steer
+        self._live_transcript_path = "/tmp/live/loop-94858.log"
+        if parent is not None:
+            self._delegate_parent_ref = weakref.ref(parent)
+
+    def steer(self, text: str) -> bool:
+        if not self.accept_steer:
+            return False
+        self.steered.append(text)
+        return True
+
+
+class _StubParent:
+    """Minimal parent agent with a session_id for the durable spine."""
+
+    def __init__(self, session_id: str = "sess-94858"):
+        self.session_id = session_id
+
+
+def _register(sid: str, child, **extra) -> None:
+    record = {
+        "subagent_id": sid,
+        "parent_id": None,
+        "depth": 0,
+        "goal": "loop regression",
+        "model": "test-model",
+        "started_at": 1000.0,
+        "status": "running",
+        "tool_count": 0,
+        "agent": child,
+    }
+    record.update(extra)
+    _register_subagent(record)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_loop_counter():
+    """Wipe the module-level loop counter around every test.
+
+    The counter is keyed on (parent_session_id, subagent_id) and lives
+    for the lifetime of the process, so cross-test bleed would silently
+    pre-bias the assertions (a previous test's misses would push the
+    next test straight into the loop-detected branch).
+    """
+    with _counter_lock():
+        _dead_subagent_hits.clear()
+    yield
+    with _counter_lock():
+        _dead_subagent_hits.clear()
+
+
+def _counter_lock():
+    # Same lock the production helpers use; imported here so the fixture
+    # and the production code can never disagree about which lock guards
+    # the dict.
+    from tools.delegate_tool import _dead_subagent_hits_lock
+
+    return _dead_subagent_hits_lock
+
+
+# ---------------------------------------------------------------------------
+# 1. Bounded retry — counter helpers
+# ---------------------------------------------------------------------------
+
+
+def test_counter_increments_per_target():
+    """Each (parent, subagent_id) miss is counted independently.
+
+    Pre-fix: there was no counter, so this assertion was structurally
+    impossible — pre-fix code would not even have _record_dead_subagent_hit
+    to call. Post-fix: same parent targeting two different dead ids
+    keeps each counter at 1.
+    """
+    parent_sid = "sess-counter-1"
+    a_count = _record_dead_subagent_hit(parent_sid, "sa-0-aaa")
+    b_count = _record_dead_subagent_hit(parent_sid, "sa-0-bbb")
+    assert a_count == 1
+    assert b_count == 1
+    a_count_2 = _record_dead_subagent_hit(parent_sid, "sa-0-aaa")
+    assert a_count_2 == 2
+    # Different parent sees its own counter
+    other_count = _record_dead_subagent_hit("sess-counter-2", "sa-0-aaa")
+    assert other_count == 1
+
+
+def test_counter_resets_when_child_re_registers():
+    """A recycled public id (new child run) wipes the miss counter.
+
+    Without this, a parent that retried a dead id earlier in the same
+    session would inherit the per-(parent, target) count and trip the
+    loop detector on the very first call against the new, healthy
+    child. The reset lives in _register_subagent.
+    """
+    parent = _StubParent("sess-counter-reset")
+    _record_dead_subagent_hit(parent.session_id, "sa-0-recycle")
+    _record_dead_subagent_hit(parent.session_id, "sa-0-recycle")
+    _record_dead_subagent_hit(parent.session_id, "sa-0-recycle")
+    assert _record_dead_subagent_hit(parent.session_id, "sa-0-recycle") == 4
+
+    # Now the SAME public id is taken over by a brand-new child run.
+    new_child = _StubChild(parent, accept_steer=True)
+    _register(
+        "sa-0-recycle",
+        new_child,
+        owner_agent_session_id=parent.session_id,
+    )
+    try:
+        # The counter was wiped at register time. A first failure against
+        # the new child starts back at 1.
+        assert _record_dead_subagent_hit(parent.session_id, "sa-0-recycle") == 1
+    finally:
+        _unregister_subagent("sa-0-recycle")
+
+
+# ---------------------------------------------------------------------------
+# 2. Always-on, structured non-retryable surface
+# ---------------------------------------------------------------------------
+
+
+def test_missing_target_error_is_marked_non_retryable():
+    """The very FIRST failure against a dead/missing target is tagged
+    non-retryable. This is the half of the fix that addresses a
+    well-behaved model: a single attempt should be enough.
+    """
+    parent = _StubParent("sess-surface-1")
+    out = _handle_control_action("steer", "sa-0-ghost", "hello", parent)
+    payload = json.loads(out)
+    assert payload["error"]
+    assert payload["recoverable"] is False
+    assert payload["do_not_retry"] is True
+    assert payload["subagent_id"] == "sa-0-ghost"
+    # The hint is hard-line about not retrying — pre-fix this was a
+    # soft "use action='list'" suggestion that the model interpreted as
+    # "try list, then try steer again".
+    assert "do not retry" in payload["hint"].lower()
+    # The plain first-attempt reason does NOT yet trip the loop detector.
+    assert "loop_detected" not in payload
+
+
+def test_closed_acceptance_error_is_marked_non_retryable():
+    """A child that is registered but has closed its steering window
+    produces the same non-retryable surface. Same loop class from the
+    model's point of view: retrying will never flip the answer.
+    """
+    parent = _StubParent("sess-surface-2")
+    child = _StubChild(parent, accept_steer=False)  # steer() always returns False
+    _register("sa-0-closed", child, owner_agent_session_id=parent.session_id)
+    try:
+        out = _handle_control_action("steer", "sa-0-closed", "nudge", parent)
+        payload = json.loads(out)
+        assert payload["recoverable"] is False
+        assert payload["do_not_retry"] is True
+        assert "no longer accepting" in payload["error"].lower()
+        assert child.steered == []  # we never actually wrote to it
+    finally:
+        _unregister_subagent("sa-0-closed")
+
+
+def test_stop_unknown_id_is_marked_non_retryable():
+    """The stop path also goes through the new surface. A parent that
+    keeps issuing stop on a finished child hits the same loop class
+    as steer (#94858's log shows both `steer` and `stop` errors in the
+    same runaway conversation)."""
+    parent = _StubParent("sess-surface-3")
+    out = _handle_control_action("stop", "sa-0-finished", None, parent)
+    payload = json.loads(out)
+    assert payload["recoverable"] is False
+    assert payload["do_not_retry"] is True
+    assert payload["subagent_id"] == "sa-0-finished"
+
+
+# ---------------------------------------------------------------------------
+# 3. Bounded retry — end-to-end: stub steer that always fails
+# ---------------------------------------------------------------------------
+
+
+def _drive_n_steers(n: int, parent_sid: str, child_sid: str) -> list[dict]:
+    """Helper: invoke _handle_control_action n times against the same
+    (parent, dead child) and parse each result.
+
+    Pre-fix this returned n identical "No live subagent ..." strings.
+    Post-fix the first three are tagged non-retryable; from the fourth
+    onward the payload escalates to loop_detected=True.
+    """
+    parent = _StubParent(parent_sid)
+    payloads: list[dict] = []
+    for _ in range(n):
+        raw = _handle_control_action("steer", child_sid, "nudge", parent)
+        payloads.append(json.loads(raw))
+    return payloads
+
+
+def test_retry_against_dead_target_is_bounded_and_obvious():
+    """The headline regression for #94858.
+
+    Pre-fix: any number of calls against a dead subagent return the
+    same recoverable-looking error and the model has no way to know it
+    is in a loop. The error payload never carries loop_detected.
+
+    Post-fix: attempts 1..limit are tagged non-retryable, attempt
+    limit+1 and beyond are explicitly flagged as a retry loop and
+    point at action='list' / spawn / completion-message.
+
+    This test runs enough attempts to cross the loop threshold and
+    asserts the payload's *shape* changed, not just its text. A model
+    that pattern-matches on `loop_detected` will stop the instant it
+    sees the field flip — no text parsing required.
+    """
+    parent_sid = "sess-94858"
+    child_sid = "sa-0-b392cfae"  # the dead id from the original log
+    attempts = _STALE_SUBAGENT_RETRY_LIMIT + 3  # well past the threshold
+    payloads = _drive_n_steers(attempts, parent_sid, child_sid)
+
+    assert len(payloads) == attempts
+
+    # First N attempts: non-retryable, but the model is still given the
+    # benefit of the doubt — no loop_detected yet, the assumption is it
+    # will read the do_not_retry hint and stop.
+    for i, p in enumerate(payloads[:_STALE_SUBAGENT_RETRY_LIMIT]):
+        assert p["recoverable"] is False, f"attempt {i + 1} not non-retryable"
+        assert p["do_not_retry"] is True
+        assert "loop_detected" not in p
+        assert "do not retry" in p["hint"].lower()
+
+    # Attempt limit+1 and beyond: the loop detector trips. The reason
+    # text names the offending call so the model can see exactly which
+    # call it is making and stop making it.
+    for i, p in enumerate(payloads[_STALE_SUBAGENT_RETRY_LIMIT:], start=_STALE_SUBAGENT_RETRY_LIMIT):
+        assert p["recoverable"] is False
+        assert p["do_not_retry"] is True
+        assert p["loop_detected"] is True, f"attempt {i + 1} should be flagged"
+        # Names the exact call the model made.
+        assert child_sid in p["error"]
+        assert f"action='steer'" in p["error"]
+        # Names a real alternative.
+        assert "action='list'" in p["hint"]
+        # Tells the model the prior failures were the same error.
+        assert p["attempts"] == i + 1
+
+
+def test_loop_detected_payload_uses_stable_keys():
+    """The loop-detected payload is structured for programmatic use,
+    not just prose. A future prompt-builder or guardrail can match on
+    these keys without parsing free text.
+    """
+    parent_sid = "sess-stable-keys"
+    child_sid = "sa-0-stable"
+    payloads = _drive_n_steers(_STALE_SUBAGENT_RETRY_LIMIT + 1, parent_sid, child_sid)
+    tripped = payloads[-1]
+    for key in (
+        "error",
+        "recoverable",
+        "subagent_id",
+        "do_not_retry",
+        "hint",
+        "loop_detected",
+        "attempts",
+    ):
+        assert key in tripped, f"missing key: {key}"
+
+
+def test_loop_counter_is_per_parent_session():
+    """Two parents hammering the same dead id each get their own
+    counter, so a long-running operator session with many parallel
+    parents doesn't accidentally trip the breaker for the wrong
+    conversation. The original log shows the parent session was
+    `session_parent_main`; sibling sessions must be unaffected.
+    """
+    p1 = "sess-parent-a"
+    p2 = "sess-parent-b"
+    same_dead = "sa-0-shared"
+
+    # Drive p1 well past the loop threshold.
+    p1_payloads = _drive_n_steers(_STALE_SUBAGENT_RETRY_LIMIT + 2, p1, same_dead)
+    assert p1_payloads[-1]["loop_detected"] is True
+
+    # p2 against the same dead id sees its own counter starting at 1.
+    # Below the threshold the helper omits `loop_detected` entirely
+    # (the first attempts are not yet escalated to a loop) — assert
+    # the key is absent rather than testing a sentinel False.
+    p2_payloads = _drive_n_steers(2, p2, same_dead)
+    assert "loop_detected" not in p2_payloads[0]
+    assert p2_payloads[0]["recoverable"] is False
+
+
+def test_help_non_retryable_helper_includes_loop_metadata_only_after_threshold():
+    """Direct test of the JSON-shape helper. Pre-fix there was no
+    non-retryable marker at all; the helper itself is part of the fix.
+    """
+    plain = _non_retryable_subagent_error(
+        subagent_id="sa-0",
+        reason="gone",
+        hint="do not retry",
+        loop_count=_STALE_SUBAGENT_RETRY_LIMIT,  # exactly at threshold
+    )
+    plain_payload = json.loads(plain)
+    # At-or-below threshold: no loop_detected key.
+    assert "loop_detected" not in plain_payload
+    assert plain_payload["recoverable"] is False
+    assert plain_payload["do_not_retry"] is True
+
+    tripped = _non_retryable_subagent_error(
+        subagent_id="sa-0",
+        reason="loop",
+        hint="see list",
+        loop_count=_STALE_SUBAGENT_RETRY_LIMIT + 1,  # past threshold
+    )
+    tripped_payload = json.loads(tripped)
+    assert tripped_payload["loop_detected"] is True
+    assert tripped_payload["attempts"] == _STALE_SUBAGENT_RETRY_LIMIT + 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Pre-fix behaviour, captured as a delta test
+# ---------------------------------------------------------------------------
+#
+# The text below documents what the *old* tool_error() payload looked
+# like for the same call. We keep this delta test here so a future
+# refactor that accidentally regresses the structured surface (e.g. by
+# replacing the new helper with a bare tool_error(...)) trips a
+# readable failure, and so the diff between the two shapes is captured
+# once in code rather than only in a PR description.
+#
+# Pre-fix payload (one attempt against a dead subagent):
+#   '{"error": "No live subagent \\'sa-0-...\\' ... Use action=\\'list\\' ..."}'
+# Post-fix payload (same one attempt):
+#   '{"error": "No live subagent \\'sa-0-...\\' ...",
+#     "recoverable": false,
+#     "subagent_id": "sa-0-...",
+#     "do_not_retry": true,
+#     "hint": "Do not retry delegate_task(...) ..."}'
+
+
+def test_error_payload_is_structured_not_plain():
+    """The payload MUST have a structured recoverable flag — a plain
+    ``{"error": "..."}`` is the exact regression that lets the loop
+    continue. This test pins the contract."""
+    parent = _StubParent("sess-structured")
+    out = _handle_control_action("steer", "sa-0-b392cfae", "nudge", parent)
+    payload = json.loads(out)
+    # Required keys for downstream tooling / guardrails.
+    for key in ("error", "recoverable", "do_not_retry", "subagent_id", "hint"):
+        assert key in payload, f"missing structured key: {key}"
+    # And a plain `error` key with a recognizable message is preserved
+    # so existing log scrapers and the operator-facing TUI overlay
+    # keep working.
+    assert "No live subagent" in payload["error"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -161,6 +161,35 @@ _active_subagents: Dict[str, Dict[str, Any]] = {}
 _RECENT_SUBAGENTS_CAP = 200
 _recent_subagents: Dict[str, Dict[str, Any]] = {}
 
+# Per-parent-session circuit breaker for delegate_task control actions whose
+# target subagent no longer exists or has closed steering. The original bug
+# (#94858) was the model repeatedly calling delegate_task(action='steer',
+# subagent_id='sa-0-X') against an already-finished child; the tool kept
+# returning a recoverable-looking error ("No live subagent 'sa-0-X' ...")
+# and the model kept retrying, burning tokens and CPU until the operator
+# killed the gateway. The fix has two halves:
+#   1. The control-path error is always marked non-retryable (recoverable=False
+#      + an explicit "do not retry" hint) so a well-behaved model stops on
+#      the first failure.
+#   2. This counter tracks how many times the SAME parent-session has failed
+#      against the SAME subagent_id; once the count exceeds
+#      _STALE_SUBAGENT_RETRY_LIMIT, every further attempt short-circuits with
+#      an obvious "you are in a retry loop" message that names the loop and
+#      points at action='list' as the alternative. This catches the actual
+#      misbehaving model that ignored the recoverable=False marker.
+#
+# Keyed by (parent_session_id, subagent_id) so siblings and grandchildren
+# don't share state, and the live agent object identity isn't required (a
+# parent-agent rebuild in the CLI mid-session would orphan anything keyed on
+# the AIAgent instance). Cleared automatically when the child re-registers
+# (a recycled public id maps to a new run) because we look it up at every
+# call rather than caching success counts.
+_dead_subagent_hits: Dict[tuple, int] = {}
+_dead_subagent_hits_lock = threading.Lock()
+# Bound is intentionally small: one transient miss is plausible, two is
+# already suspicious, three is a loop. The model is given no slack past three.
+_STALE_SUBAGENT_RETRY_LIMIT = 3
+
 
 def get_subagent_attribution(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """Resolve a process task_id to its originating delegation, if any.
@@ -215,6 +244,14 @@ def _register_subagent(record: Dict[str, Any]) -> None:
     record.setdefault("accepting_steer", True)
     with _active_subagents_lock:
         _active_subagents[sid] = record
+    # A recycled public id means a brand-new run with a clean miss
+    # counter. Without this, a parent that retried a dead id earlier in
+    # the same session would inherit the per-(parent, target) count
+    # and trip the loop detector on the very first call against the
+    # new, perfectly healthy child. See #94858.
+    owner_sid = str(record.get("owner_agent_session_id") or "")
+    if owner_sid:
+        _reset_dead_subagent_hits(owner_sid, sid)
 
 
 def _retain_recent_subagent(record: Dict[str, Any]) -> None:
@@ -261,6 +298,73 @@ def _close_subagent_steering(subagent_id: str, agent: Any) -> Optional[str]:
             logger.debug("final steer drain for %s failed: %s", subagent_id, exc)
             return None
         return pending if isinstance(pending, str) and pending.strip() else None
+
+
+def _record_dead_subagent_hit(parent_session_id: Optional[str], subagent_id: str) -> int:
+    """Increment the per-(parent, target) miss counter and return the new total.
+
+    Bounded FIFO eviction keeps the dict small even under spam: a runaway
+    loop hits the same key forever, so the eviction is defensive against
+    fresh ids that arrive while the breaker is already tripped.
+    """
+    if not subagent_id:
+        return 0
+    key = (str(parent_session_id or ""), subagent_id)
+    with _dead_subagent_hits_lock:
+        count = _dead_subagent_hits.get(key, 0) + 1
+        _dead_subagent_hits[key] = count
+        # Defensive trim: drop a non-matching entry if the dict balloons.
+        if len(_dead_subagent_hits) > 1024:
+            stale = next(iter(_dead_subagent_hits))
+            if stale != key:
+                _dead_subagent_hits.pop(stale, None)
+        return count
+
+
+def _reset_dead_subagent_hits(parent_session_id: Optional[str], subagent_id: str) -> None:
+    """Drop the (parent, target) miss counter when the child re-registers.
+
+    A recycled public id means a brand-new run, so any previous "stale"
+    misses against the same string are no longer evidence of a loop.
+    """
+    if not subagent_id:
+        return
+    key = (str(parent_session_id or ""), subagent_id)
+    with _dead_subagent_hits_lock:
+        _dead_subagent_hits.pop(key, None)
+
+
+def _non_retryable_subagent_error(
+    *,
+    subagent_id: str,
+    reason: str,
+    hint: str,
+    loop_count: Optional[int] = None,
+) -> str:
+    """Build the structured JSON error for an unreachable / closed subagent.
+
+    The model treats any ``{"error": "..."}`` result as "I should fix this
+    and try again" unless the payload makes the terminal nature explicit.
+    This helper always tags the error with ``recoverable=False`` and a
+    hard-line "do not retry" message; when the per-session circuit breaker
+    has tripped (loop_count > _STALE_SUBAGENT_RETRY_LIMIT), it additionally
+    flags ``loop_detected=True`` and names the offending call so the model
+    can see exactly what went wrong.
+
+    The shape is stable JSON so a future prompt-builder or guardrail can
+    pattern-match on the keys without re-parsing the prose.
+    """
+    payload: Dict[str, Any] = {
+        "error": reason,
+        "recoverable": False,
+        "subagent_id": subagent_id,
+        "do_not_retry": True,
+        "hint": hint,
+    }
+    if loop_count is not None and loop_count > _STALE_SUBAGENT_RETRY_LIMIT:
+        payload["loop_detected"] = True
+        payload["attempts"] = loop_count
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def interrupt_subagent(subagent_id: str) -> bool:
@@ -520,13 +624,18 @@ def _handle_control_action(
             f"action='{action}' requires subagent_id (from the spawn dispatch "
             "response or action='list')."
         )
+    # The parent session id is the durable spine the rest of delegate_tool
+    # uses (a CLI rebuild swaps the AIAgent instance mid-session but keeps
+    # session_id). Using the live agent object directly would orphan the
+    # counter on the very first rebuild and let a fresh instance re-enter
+    # the loop with a clean slate.
+    parent_sid = str(getattr(parent_agent, "session_id", "") or "")
     with _active_subagents_lock:
         record = _active_subagents.get(sid)
     if record is None or not _owns_subagent_record(record, parent_agent):
-        return tool_error(
-            f"No live subagent '{sid}' in this conversation's spawn tree. It "
-            "may have already finished (its result arrives as a normal "
-            "completion message). Use action='list' to see live children."
+        return _stale_subagent_error(
+            parent_sid, sid, action,
+            target_missing=True,
         )
 
     if action == "stop":
@@ -545,9 +654,13 @@ def _handle_control_action(
                 },
                 ensure_ascii=False,
             )
-        return tool_error(
-            f"Could not interrupt '{sid}' — it likely finished in the last "
-            "moment. Its result arrives as a normal completion message."
+        # The child was registered a moment ago but vanished between the
+        # ownership check and the interrupt call — same loop class as a
+        # missing target, same structured surface so the model sees
+        # "recoverable=False" and stops calling.
+        return _stale_subagent_error(
+            parent_sid, sid, action,
+            target_missing=False,
         )
 
     if action == "steer":
@@ -573,13 +686,86 @@ def _handle_control_action(
                 },
                 ensure_ascii=False,
             )
-        return tool_error(
-            f"Subagent '{sid}' is no longer accepting steering (finishing or "
-            "already finished). Its result arrives as a normal completion "
-            "message; re-delegate a follow-up task if more work is needed."
+        # Record still exists and we own it, but the child closed its
+        # steer window (finishing or already finished). Same terminal
+        # class as a missing target from the model's point of view —
+        # retrying will never flip the answer, and the issue (#94858)
+        # showed models WILL retry unless the error is unambiguous.
+        return _stale_subagent_error(
+            parent_sid, sid, action,
+            target_missing=False,
         )
 
     return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, or stop.")
+
+
+def _stale_subagent_error(
+    parent_session_id: Optional[str],
+    subagent_id: str,
+    action: str,
+    *,
+    target_missing: bool,
+) -> str:
+    """Build the structured, non-retryable error for a dead/closed subagent.
+
+    One entry point so the per-(parent, target) circuit breaker and the
+    ``recoverable=False`` JSON shape stay in lockstep — any future change
+    to the loop-detection wording has exactly one site to update.
+
+    ``target_missing=True`` is the original #94858 case (no record at all,
+    or the parent doesn't own it); ``target_missing=False`` is the
+    "record exists but is no longer accepting" case (closed steering or
+    a child that vanished between checks). Both are terminal: retrying
+    will never flip the answer, so both go through the same bounded
+    counter and structured payload.
+    """
+    miss_count = _record_dead_subagent_hit(parent_session_id, subagent_id)
+    if target_missing:
+        reason = (
+            f"No live subagent '{subagent_id}' in this conversation's "
+            "spawn tree. It may have already finished (its result "
+            "arrives as a normal completion message)."
+        )
+    else:
+        reason = (
+            f"Subagent '{subagent_id}' is no longer accepting "
+            f"{action} (finishing or already finished). Its result "
+            "arrives as a normal completion message."
+        )
+    if miss_count > _STALE_SUBAGENT_RETRY_LIMIT:
+        # Loop detected: same parent keeps hitting the same dead id. The
+        # regular "do not retry" hint isn't enough — the model is ignoring
+        # it, so name the loop and point at the actual alternative.
+        reason = (
+            f"RETRY LOOP DETECTED: you have called "
+            f"delegate_task(action='{action}', subagent_id='{subagent_id}') "
+            f"{miss_count} times against a subagent that no longer exists "
+            f"or has already finished. The previous {miss_count - 1} "
+            f"attempt(s) already returned this error and you ignored the "
+            f"'do_not_retry' flag. Do not call delegate_task with this "
+            f"subagent_id again."
+        )
+        hint = (
+            "If you still need work done, call delegate_task(action='list') "
+            "to see any live children, or spawn a fresh subagent with "
+            "delegate_task(action='spawn', goal=...). The dead subagent's "
+            "result, if any, is already in the conversation as a normal "
+            "completion message — re-reading it does not require a tool call."
+        )
+    else:
+        hint = (
+            f"Do not retry delegate_task(action='{action}', "
+            f"subagent_id='{subagent_id}'). The subagent is gone. If you "
+            "need to know its current state, call "
+            "delegate_task(action='list') for live children, or wait for "
+            "its completion message to arrive."
+        )
+    return _non_retryable_subagent_error(
+        subagent_id=subagent_id,
+        reason=reason,
+        hint=hint,
+        loop_count=miss_count,
+    )
 
 
 def _extract_output_tail(


### PR DESCRIPTION
## What Problem This Solves

Fixes #94858 — the parent agent gets stuck in an unbounded retry loop hammering `delegate_task(action='steer' | 'stop', subagent_id='sa-0-...')` against a subagent that has already finished. The tool returned a recoverable-looking "No live subagent 'sa-0-...' ..." string every time, the model treated that as a fixable transient error and kept calling, and the parent burned tokens in an infinite loop until the operator killed the gateway by hand (the in-app stop button did not work, per the issue).

The root cause is two-layered:

1. **The error was structurally ambiguous.** A bare `{"error": "..."}` is what the model is trained to interpret as "I should fix this and try again" — same shape as a transient API blip, a missing file path, or a permission failure that the operator can correct.
2. **Nothing bounded the loop.** The conversation's `max_iterations` is `sys.maxsize` by default; the outer-loop exception cap only fires on raised exceptions, and a `tool_error` JSON return is not an exception. So the model could issue the same call thousands of times per minute and nothing in the tool layer or the agent loop would say "stop".

## What Changes

**`tools/delegate_tool.py` — the `delegate_task` control plane (`list` / `steer` / `stop`):**

- Every "subagent is gone / not accepting" error is now returned as a **structured, non-retryable** JSON payload. Pre-fix the shape was `{"error": "..."}`. Post-fix it carries:
  - `recoverable: false`
  - `do_not_retry: true`
  - `subagent_id: "sa-0-..."`
  - `hint: "Do not retry delegate_task(action='steer', subagent_id='sa-0-...'). The subagent is gone. ..."`
  - A plain `error` key is preserved so existing log scrapers and the TUI overlay keep working without changes.
- A **per-(parent_session_id, subagent_id) circuit breaker** tracks how many times the same parent has failed against the same dead target. The first `_STALE_SUBAGENT_RETRY_LIMIT = 3` failures carry the structured non-retryable surface; from the 4th failure onward the payload adds:
  - `loop_detected: true`
  - `attempts: <count>`
  - A reason that **names the exact call the model made** (`"RETRY LOOP DETECTED: you have called delegate_task(action='steer', subagent_id='sa-0-...') N times ..."`) and points at `action='list'` / `action='spawn', goal=...` / the completion message as the real alternatives.
- The counter is **scoped per parent session id** (not per agent object identity) so a CLI rebuild that swaps the `AIAgent` instance mid-session keeps the breaker engaged — same bug class as the durable ownership spine in the existing `#88454b70 / sa-0-dc0100f4` regression test.
- The counter is **wiped when a child re-registers the same public id** (a recycled id means a brand-new run, so prior misses are no longer evidence of a loop).
- The new structured payload is built by a single helper, `_non_retryable_subagent_error`, with one entry point, `_stale_subagent_error`, threading the action+id+counter through it. Any future change to the loop-detection wording has exactly one site to update.

## Evidence

### Tests

10 new tests in `tests/tools/test_delegate_stale_subagent_loop.py` (all green):

- `test_counter_increments_per_target` — counter is per-(parent, target), not global.
- `test_counter_resets_when_child_re_registers` — recycled public id wipes the counter; a fresh child does not inherit a tripped breaker.
- `test_missing_target_error_is_marked_non_retryable` — first attempt against a dead id carries `recoverable: false`, `do_not_retry: true`, no `loop_detected` yet.
- `test_closed_acceptance_error_is_marked_non_retryable` — child registered but `steer()` returns False produces the same structured surface.
- `test_stop_unknown_id_is_marked_non_retryable` — `action='stop'` against a finished child is also non-retryable (the issue's log shows both `steer` and `stop` errors in the same runaway conversation).
- `test_retry_against_dead_target_is_bounded_and_obvious` — driving the SAME dead subagent through more than `_STALE_SUBAGENT_RETRY_LIMIT + 1` attempts, asserts the payload's shape flips to `loop_detected: true` past the threshold and that the `error` text names the exact call.
- `test_loop_detected_payload_uses_stable_keys` — the tripped payload has all of `error`, `recoverable`, `subagent_id`, `do_not_retry`, `hint`, `loop_detected`, `attempts` as stable keys (a future prompt-builder can pattern-match without parsing prose).
- `test_loop_counter_is_per_parent_session` — two parent sessions hammering the same dead id each get their own counter.
- `test_help_non_retryable_helper_includes_loop_metadata_only_after_threshold` — at-or-below threshold omits `loop_detected`; past threshold adds it.
- `test_error_payload_is_structured_not_plain` — pins the structured-vs-plain contract so a future refactor that accidentally regresses to a bare `tool_error(...)` trips a readable failure.

### Pre-fix vs post-fix (the regression contract)

Pre-fix payload (one attempt against a dead subagent) — model sees this and retries:

```json
{"error": "No live subagent 'sa-0-...' in this conversation's spawn tree. ... Use action='list' to see live children."}
```

Post-fix payload (one attempt, same dead subagent) — model sees `do_not_retry: true` and stops:

```json
{
  "error": "No live subagent 'sa-0-...' in this conversation's spawn tree. ...",
  "recoverable": false,
  "subagent_id": "sa-0-...",
  "do_not_retry": true,
  "hint": "Do not retry delegate_task(action='steer', subagent_id='sa-0-...'). The subagent is gone. ..."
}
```

Post-fix payload (5th attempt, same dead subagent) — model sees `loop_detected: true` and **why**:

```json
{
  "error": "RETRY LOOP DETECTED: you have called delegate_task(action='steer', subagent_id='sa-0-...') 5 times against a subagent that no longer exists or has already finished. The previous 4 attempt(s) already returned this error and you ignored the 'do_not_retry' flag. Do not call delegate_task with this subagent_id again.",
  "recoverable": false,
  "subagent_id": "sa-0-...",
  "do_not_retry": true,
  "hint": "If you still need work done, call delegate_task(action='list') to see any live children, or spawn a fresh subagent with delegate_task(action='spawn', goal=...). ...",
  "loop_detected": true,
  "attempts": 5
}
```

### Test runs

```
$ pytest tests/tools/test_delegate_stale_subagent_loop.py -v
============================== 10 passed in 1.70s ==============================

$ pytest tests/tools/test_delegate_control_actions.py tests/tools/test_delegate_stale_subagent_loop.py
============================= 44 passed in 3.41s ==============================

$ pytest tests/tools/test_delegate_*.py
============================ 110 passed in 40.02s =============================
```

All 34 pre-existing `test_delegate_control_actions.py` tests still pass — the new payload preserves the `"No live subagent"` and `"completion message"` substrings the existing assertions check for, and the durable-ownership / compression-lineage regression tests are unaffected.

Closes #94858
