### PR TITLE
fix(install): ship pre_update_backup: quick in the config template (#94944)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1797,10 +1797,14 @@ telemetry:
 # Update Behavior
 # =============================================================================
 updates:
-  # Create a full HERMES_HOME zip before every `hermes update`.
-  # Backups land in ~/.hermes/backups/ and can be restored with `hermes import`.
-  # Off by default because large homes can add minutes to every update.
-  pre_update_backup: false
+  # Safety snapshot taken before every `hermes update` (guards against an
+  # update wiping ~/.hermes). Tri-state:
+  #   quick - lightweight state snapshot (default; fast even on large homes)
+  #   full  - complete HERMES_HOME zip in ~/.hermes/backups/, restorable with
+  #           `hermes import` (can add minutes to every update on large homes)
+  #   off   - no snapshot at all (opt out of the safety net entirely)
+  # Legacy booleans are still honored: true -> full, false -> off.
+  pre_update_backup: quick
 
   # Number of pre-update backup zips to retain.
   backup_keep: 5

--- a/tests/test_pre_update_backup_template.py
+++ b/tests/test_pre_update_backup_template.py
@@ -1,0 +1,51 @@
+"""Regression: the shipped config template must not disable the pre-update
+backup safety net (#94944).
+
+Installers (scripts/install.sh, hermes doctor --fix, docker/stage2-hook.sh)
+copy cli-config.yaml.example verbatim to ~/.hermes/config.yaml, so whatever
+``updates.pre_update_backup`` the template ships becomes an EXPLICIT user
+setting that overrides the code default. The runtime default is ``quick``
+(#65754); the legacy boolean ``false`` maps to ``off``. A template still
+carrying ``false`` therefore silently disables the #48200 wipe safety net on
+every ``hermes update``, with no output, for users who never opted out.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli.update_cmd import _resolve_pre_update_backup_mode
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
+
+
+def _seed_from_template(hermes_home: Path) -> None:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def test_shipped_template_keeps_pre_update_backup_safety_net(tmp_path, monkeypatch):
+    """A fresh install seeded from the template must keep a backup snapshot
+    active — the resolved mode must not be ``off``."""
+    hermes_home = tmp_path / ".hermes"
+    _seed_from_template(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # No CLI flags — the config value alone decides.
+    args = SimpleNamespace(no_backup=False, backup=False)
+    mode = _resolve_pre_update_backup_mode(args)
+
+    assert mode != "off", "shipped template disables the pre-update backup safety net"
+    assert mode == "quick"
+
+
+def test_no_backup_flag_still_wins_over_template(tmp_path, monkeypatch):
+    """The fix must not take the choice away: an explicit --no-backup still
+    disables the snapshot even though the template now enables it."""
+    hermes_home = tmp_path / ".hermes"
+    _seed_from_template(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    args = SimpleNamespace(no_backup=True, backup=False)
+    assert _resolve_pre_update_backup_mode(args) == "off"


### PR DESCRIPTION
## Problem

`cli-config.yaml.example` still carried the pre-#65754 text:

```yaml
# Off by default because large homes can add minutes to every update.
pre_update_backup: false
```

The runtime default has been `"quick"` since #65754, and the legacy boolean `false` maps to `"off"` — **not** `"quick"`. Every installer copies the template verbatim to `~/.hermes/config.yaml`:

- `scripts/install.sh` — `cp cli-config.yaml.example $HERMES_HOME/config.yaml`
- `hermes_cli/doctor.py` — `hermes doctor --fix` recreates a missing config the same way
- `docker/stage2-hook.sh` — `seed_one "config.yaml" "cli-config.yaml.example"`

So every fresh install ships with an **explicit** `pre_update_backup: false`, which the resolver maps to `off` — silently disabling the lightweight pre-update snapshot that was introduced as the #48200 wipe safety net. The user never opted out; the template opted out for them. And the `off` path is deliberately silent (it assumes an explicit user opt-out), so this produces no output at all on every `hermes update`. `website/docs/**` already documents `quick` + the tri-state correctly — only the copied file was stale.

## Fix

Set the template to the documented default `quick` and rewrite the comment to describe the tri-state (`quick` / `full` / `off`) and the legacy-boolean mapping. Fixing the single template repairs all three seeding paths at once. Explicit `--no-backup` / `--backup` flags still override the config value, so nobody loses the ability to opt out.

## Tests

New `tests/test_pre_update_backup_template.py` (mirrors the existing `test_shipped_template_does_not_enable_auto_reset` invariant for the sibling drift bug):

- `test_shipped_template_keeps_pre_update_backup_safety_net` — seed `config.yaml` from the template and assert `_resolve_pre_update_backup_mode()` returns a non-`off` mode (`quick`). Fails on the pre-fix template (resolves to `off`).
- `test_no_backup_flag_still_wins_over_template` — `--no-backup` still resolves to `off`, proving the fix doesn't take the opt-out away.

Placed in a focused new file so the change stays minimal — one logical change, no churn in unrelated suites.

Fixes #94944
