### PR TITLE
fix(cli): answer clarify headless in single-query turns

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -21,6 +21,34 @@ from rich.markup import escape as _escape
 from utils import base_url_host_matches
 
 
+def _single_query_clarify_callback(question: str, choices=None, multi_select=False) -> str:
+    """Clarify has no interactive surface in a single-query (-q) turn.
+
+    ``hermes chat -q`` runs one turn without ever building the
+    prompt_toolkit application, so the interactive clarify modal can never
+    be painted or answered — the CLI callback would poll its response queue
+    until ``agent.clarify_timeout`` expires (default 3600 s, 0 = unlimited)
+    while the gateway/cron/kanban-dispatcher caller sees a silent hang. The
+    oneshot path answers immediately via ``_oneshot_clarify_callback``;
+    single-query turns need the same headless behavior (#94943)."""
+    if choices:
+        if multi_select:
+            return (
+                f"[single-query mode: no user available to answer {question!r}. "
+                f"Pick the best subset from {choices} using your own judgment "
+                f"and continue.]"
+            )
+        return (
+            f"[single-query mode: no user available to answer {question!r}. "
+            f"Pick the best option from {choices} using your own judgment "
+            f"and continue.]"
+        )
+    return (
+        f"[single-query mode: no user available to answer {question!r}. Make "
+        f"the most reasonable assumption you can and continue.]"
+    )
+
+
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
@@ -521,7 +549,15 @@ class CLIAgentSetupMixin:
                 session_id=self.session_id,
                 platform="cli",
                 session_db=self._session_db,
-                clarify_callback=self._clarify_callback,
+                # A -q turn never builds the prompt_toolkit application, so
+                # the interactive modal can never be painted or answered —
+                # answer headless instead of polling until clarify_timeout
+                # (#94943; mirrors _oneshot_clarify_callback on the -z path).
+                clarify_callback=(
+                    _single_query_clarify_callback
+                    if getattr(self, "_single_query_mode", False)
+                    else self._clarify_callback
+                ),
                 reasoning_callback=self._current_reasoning_callback(),
 
                 fallback_model=self._fallback_model,

--- a/tests/cli/test_single_query_clarify.py
+++ b/tests/cli/test_single_query_clarify.py
@@ -1,0 +1,77 @@
+"""Regression tests for the single-query clarify guard (#94943).
+
+``hermes chat -q`` wires the interactive prompt_toolkit clarify callback
+unconditionally: a -q turn never builds the prompt_toolkit application, so
+``CLIApp._clarify_callback`` polls its response queue with nothing able to
+answer it — the turn hangs until ``agent.clarify_timeout`` expires (default
+3600 s, 0 = unlimited). The gateway, cron jobs, the kanban dispatcher and
+inter-agent wakeups all deliver work as ``hermes chat -q``, so an agent that
+calls ``clarify`` in those turns stalls silently. The oneshot (-z) path
+already answers immediately via ``_oneshot_clarify_callback``; this pins the
+same headless behavior for -q, wired at the ``CLIAgentSetupMixin`` agent
+construction site that already knows it is in single-query mode.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_no_choices_returns_immediate_headless_answer():
+    from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+    result = _single_query_clarify_callback("Which timezone should I use?")
+    assert result.startswith("[single-query mode: no user available")
+    assert "most reasonable assumption" in result
+
+
+def test_choices_return_pick_best_guidance():
+    from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+    result = _single_query_clarify_callback(
+        "Format?", choices=["json", "yaml"]
+    )
+    assert result.startswith("[single-query mode: no user available")
+    assert "Pick the best option from ['json', 'yaml']" in result
+
+
+def test_multi_select_choices_return_subset_guidance():
+    from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+    result = _single_query_clarify_callback(
+        "Which checks?", choices=["lint", "types", "tests"], multi_select=True
+    )
+    assert result.startswith("[single-query mode: no user available")
+    assert "Pick the best subset from ['lint', 'types', 'tests']" in result
+
+
+def test_callback_signature_matches_oneshot_contract():
+    """The headless callback must be a drop-in wherever a clarify callback is
+    accepted — same (question, choices, multi_select) shape as the oneshot
+    one and the interactive CLIApp one."""
+    from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+    from hermes_cli import oneshot
+
+    ours = inspect.signature(_single_query_clarify_callback)
+    oneshot_cb = inspect.signature(oneshot._oneshot_clarify_callback)
+    assert list(ours.parameters) == list(oneshot_cb.parameters)
+
+
+def test_agent_construction_gates_clarify_callback_on_single_query_mode():
+    """The mixin's AIAgent construction site must route -q turns to the
+    headless callback — the regression this pins is wiring the blocking
+    interactive callback unconditionally (#94943). Source-level pin modeled
+    on test_cli_active_agent_ref_wiring: _init_agent is too integration-heavy
+    to drive with a stub, but the wiring contract is one expression."""
+    from hermes_cli import cli_agent_setup_mixin as mixin_mod
+
+    src = inspect.getsource(mixin_mod)
+    assert "_single_query_clarify_callback" in src, (
+        "the headless single-query clarify callback disappeared from the mixin"
+    )
+    init_agent_src = inspect.getsource(mixin_mod.CLIAgentSetupMixin._init_agent)
+    assert 'clarify_callback=' in init_agent_src
+    assert '"_single_query_mode"' in init_agent_src or "'_single_query_mode'" in init_agent_src, (
+        "the clarify_callback wiring no longer consults _single_query_mode — "
+        "-q turns would hang on the interactive modal again (#94943)"
+    )


### PR DESCRIPTION
## What does this PR do?

`hermes chat -q` wired the interactive prompt_toolkit clarify callback unconditionally. A `-q` turn never builds the prompt_toolkit application (`CLIApp.run()` is never entered, so `self._app` stays `None` and `_paint_now()` is a no-op), which means the clarify modal can never be painted and its response queue has no writers — `CLIApp._clarify_callback` polls in a 1-second loop until `agent.clarify_timeout` expires (default 3600 s, `0` documented as unlimited). Since the gateway, cron jobs, the kanban dispatcher and inter-agent wakeups all deliver work as `hermes chat -q`, any agent that calls `clarify` in those turns stalls silently for up to an hour (the report observed 18 min 27 s in production).

This routes the single-query case to a headless callback at the agent-construction site in `CLIAgentSetupMixin._init_agent` — the same call site that already consults `self._single_query_mode` 157 lines above for MCP discovery. The callback mirrors `_oneshot_clarify_callback` on the `-z` path (same signature and three-branch shape: no choices → "make the most reasonable assumption", choices → "pick the best option", multi-select → "pick the best subset"), so the turn finishes immediately and the question, if it still matters, comes back as plain text in the final answer. This is the third member of the family: #86909 made `approvals.single_query_mode` deterministic for `-q`, #88013 covers the protected-instruction gate, this covers `clarify`.

## Related Issue

Fixes #94943

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py` — add module-level `_single_query_clarify_callback` (headless, mirrors `_oneshot_clarify_callback`) and gate the `clarify_callback=` kwarg at the `AIAgent(...)` construction site on `getattr(self, "_single_query_mode", False)`.
- `tests/cli/test_single_query_clarify.py` — five regression tests: the three headless-answer branches, a signature pin against `_oneshot_clarify_callback` (drop-in contract), and a source-level wiring pin modeled on `test_cli_active_agent_ref_wiring` asserting `_init_agent` routes `clarify_callback` through `_single_query_mode`.

## How to Test

1. `.venv/bin/python -m pytest tests/cli/test_single_query_clarify.py -q` — should pass (5 passed).
2. Fail-on-main control: `git checkout HEAD~1 -- hermes_cli/cli_agent_setup_mixin.py` and rerun — should fail (5 failed: helper gone, wiring pin trips), then restore with `git checkout HEAD -- hermes_cli/cli_agent_setup_mixin.py`. Observed result: 5 failed pre-fix, 5 passed post-fix.
3. Adjacent suites stay green: `.venv/bin/python -m pytest tests/cli/test_cli_active_agent_ref_wiring.py tests/cli/test_cli_clarify_batch.py tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_oneshot_surrogate.py tests/hermes_cli/test_oneshot_usage_file.py tests/cli/test_oneshot_resumed_session_persist.py -q` — should pass (36 passed).
4. Live check on any profile: `hermes chat -q "Ask me a clarifying question about an ambiguous task before starting, e.g. call clarify with choices"` — the turn should now complete immediately with the agent's judgment instead of hanging until `agent.clarify_timeout`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#88013 touches only the protected-instruction gate in `tools/file_tools.py`, zero clarify overlap)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior now matches the documented oneshot semantics; docstring on the new callback explains the mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code paths; the headless callback is pure Python
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (clarify tool contract unchanged; only which callback is injected)
