### PR TITLE
fix(codex): a tool call confirmed under a new item id ran twice

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1306,6 +1306,24 @@ def _consume_codex_event_stream(
                 # Confirmed by the authoritative per-item done event; remove
                 # from pending so it is not settled twice.
                 pending_function_calls.pop(done_id, None)
+                # Some OpenAI-compatible backends (GitHub Copilot's Responses
+                # surface) announce a function_call under one item id and
+                # confirm it under another — or omit the item id on `.done`
+                # entirely. Identity-by-item-id then fails to clear the
+                # pending entry, and settlement re-emits the SAME call a
+                # second time with empty arguments. The duplicate executes,
+                # fails on a missing required field, and trips the
+                # repeated-failure guardrail, halting the turn. call_id is
+                # the stable identity of a call across both frames, so clear
+                # pending by call_id too.
+                done_call_id = str(_item_field(done_item, "call_id", "") or "")
+                if done_call_id:
+                    for pending_id, pending_entry in list(pending_function_calls.items()):
+                        pending_call_id = str(
+                            _item_field(pending_entry.get("item"), "call_id", "") or ""
+                        )
+                        if pending_call_id and pending_call_id == done_call_id:
+                            pending_function_calls.pop(pending_id, None)
                 done_phase = _item_field(done_item, "phase", None)
                 done_phase = done_phase.strip().lower() if isinstance(done_phase, str) else None
                 if done_phase == "commentary" and on_commentary_message is not None:

--- a/tests/agent/test_codex_responses_settle_pending_tool_calls.py
+++ b/tests/agent/test_codex_responses_settle_pending_tool_calls.py
@@ -397,3 +397,36 @@ def test_announced_non_function_item_precedes_pending_call():
     assert types == ["message", "function_call"], (
         f"announced message lost its leading position: {types}"
     )
+
+
+def test_done_with_different_item_id_does_not_duplicate_the_call():
+    """Copilot's Responses surface confirms a function call under a different
+    item id than it announced. Clearing pending by item id alone leaves the
+    announced entry behind, so settlement re-emits the SAME call_id a second
+    time with empty arguments; the duplicate fails on a missing required
+    field and trips the repeated-failure guardrail, halting the turn."""
+    events = _stream_completed_without_done()
+    events.insert(
+        -1,
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_DIFFERENT",
+                call_id="call_1",
+                name="get_weather",
+                arguments='{"city": "SF"}',
+            ),
+        ),
+    )
+    final = _consume_codex_event_stream(events, model="gpt-test")
+
+    calls = [
+        item for item in final.output if getattr(item, "type", "") == "function_call"
+    ]
+    assert len(calls) == 1, (
+        "the same call_id was emitted twice — the second copy carries empty "
+        "arguments and blocks the turn on the tool guardrail"
+    )
+    assert calls[0].arguments == '{"city": "SF"}'


### PR DESCRIPTION
fix(codex): a tool call confirmed under a new item id ran twice

Some OpenAI-compatible Responses backends (observed on GitHub Copilot with
gpt-5.6) announce a function_call via `response.output_item.added` under one
item id and then confirm it via `response.output_item.done` under a different
one. `_consume_codex_event_stream` cleared its pending-call map by item id
only, so the announced entry survived confirmation and was "settled" at
`response.completed` — re-emitting the SAME call_id a second time with empty
arguments `{}`.

The duplicate executes, fails on a missing required field ("path required",
"command required"), and three such failures in a row trip the repeated-failure
tool guardrail, which halts the turn. To the operator this reads as the agent
inexplicably giving up mid-task.

Observed across 6 local sessions, all gpt-5.6 on Copilot; in the worst one 84
of 124 tool-call groups were duplicated, every pair being (real arguments, {})
under an identical call_id.

`call_id` is the stable identity of a call across both frames, so also clear
pending entries by call_id. Confirmed `.done` items remain authoritative; the
existing settlement path for backends that omit `.done` entirely is unchanged.
