### PR TITLE
feat: reconcile canonical skill usage aliases

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -857,6 +858,78 @@ def _cmd_usage(args) -> int:
     return 0
 
 
+def _safe_reconcile_display_name(name: str) -> Optional[str]:
+    """Allow only a bounded canonical skill name in CLI output."""
+    try:
+        if Path(name).expanduser().is_absolute():
+            return None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if not name or any(unicodedata.category(char).startswith("C") for char in name):
+        return None
+    return name[:128]
+
+
+def _cmd_reconcile_usage(args) -> int:
+    """Report or explicitly apply local usage alias reconciliation."""
+    from tools import skill_usage
+
+    apply = bool(getattr(args, "apply", False))
+    try:
+        report = (
+            skill_usage.reconcile_usage_apply()
+            if apply
+            else skill_usage.reconcile_usage_report()
+        )
+    except skill_usage.UsageReconcileError as exc:
+        # The exception deliberately carries only an allowlisted code. Never
+        # print the JSON payload, exception text, or sidecar path here.
+        print(f"curator: reconcile-usage: {exc.code}", file=sys.stderr)
+        return 2
+    except Exception:
+        # Fail closed around discovery/parser regressions without turning a
+        # user sidecar into command output.
+        print("curator: reconcile-usage: report_failed", file=sys.stderr)
+        return 2
+
+    counts = report["counts"]
+    if apply:
+        if report["status"] == "clean":
+            print("curator: reconcile-usage clean (no changes)")
+        else:
+            print("curator: reconcile-usage applied")
+        print(f"  records:            {counts['records']}")
+        print(f"  canonical groups:   {counts['groups']}")
+        print(f"  aliases removed:    {counts['aliases']}")
+        print(f"  skipped:            {counts['skipped']}")
+        return 0
+
+    if report["status"] == "clean":
+        print("curator: reconcile-usage clean (no usage records)")
+        return 0
+
+    print("curator: reconcile-usage report (dry-run; no changes)")
+    print(f"  records:            {counts['records']}")
+    print(f"  canonical groups:   {counts['groups']}")
+    print(f"  aliases:            {counts['aliases']}")
+    print(f"  possible conflicts: {counts['possible_conflicts']}")
+    skipped = report["skipped"]
+    print(
+        "  skipped:            "
+        f"{counts['skipped']} (unknown={skipped['unknown']} "
+        f"ambiguous={skipped['ambiguous']} plugin={skipped['plugin']})"
+    )
+
+    names = []
+    for group in report["groups"]:
+        display_name = _safe_reconcile_display_name(group["canonical"])
+        if display_name is not None:
+            names.append(display_name)
+    if names:
+        print("  canonical names:    " + ", ".join(names))
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # argparse wiring (called from hermes_cli.main)
 # ---------------------------------------------------------------------------
@@ -891,6 +964,18 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
         help="Emit the full report as JSON instead of a table",
     )
     p_usage.set_defaults(func=_cmd_usage)
+
+    p_reconcile = subs.add_parser(
+        "reconcile-usage",
+        help="Report local skill-usage aliases without changing the sidecar",
+    )
+    p_reconcile.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Apply reconciliation atomically (report-only by default)",
+    )
+    p_reconcile.set_defaults(func=_cmd_reconcile_usage)
 
     p_run = subs.add_parser("run", help="Trigger a curator review now")
     p_run.add_argument(

--- a/tests/hermes_cli/test_curator_reconcile_usage.py
+++ b/tests/hermes_cli/test_curator_reconcile_usage.py
@@ -1,0 +1,534 @@
+"""RED tests for ``hermes curator reconcile-usage``.
+
+The command is intentionally absent from upstream/main.  The assertions below
+pin the on-disk contract before any production implementation is added.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def reconcile_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    import tools.skill_usage as skill_usage
+
+    importlib.reload(hermes_constants)
+    importlib.reload(skill_usage)
+    monkeypatch.setattr(skill_usage, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def _write_skill(
+    home: Path,
+    *,
+    category: str,
+    directory: str,
+    name: str,
+) -> Path:
+    skill_dir = home / "skills" / category / directory
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: reconcile fixture\n"
+        "---\n\n"
+        "# fixture\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _record(**overrides):
+    record = {
+        "created_by": None,
+        "use_count": 0,
+        "view_count": 0,
+        "patch_count": 0,
+        "last_used_at": None,
+        "last_viewed_at": None,
+        "last_patched_at": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "patch_generation": 0,
+        "last_reused_patch_generation": 0,
+        "state": "active",
+        "pinned": False,
+        "archived_at": None,
+    }
+    record.update(overrides)
+    return record
+
+
+def _usage_path(home: Path) -> Path:
+    return home / "skills" / ".usage.json"
+
+
+def _write_usage(home: Path, records: dict) -> Path:
+    path = _usage_path(home)
+    path.write_text(json.dumps(records, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _read_usage(home: Path) -> dict:
+    return json.loads(_usage_path(home).read_text(encoding="utf-8"))
+
+
+def _run_reconcile(*, apply: bool) -> int:
+    """Invoke the CLI boundary, turning absent parser wiring into a RED assert."""
+    from hermes_cli import curator
+
+    argv = ["reconcile-usage"] + (["--apply"] if apply else [])
+    try:
+        return curator.cli_main(argv)
+    except SystemExit as exc:  # argparse's current upstream behavior
+        pytest.fail(
+            "reconcile-usage is not implemented/registered; expected a "
+            f"controlled command result (argparse exit {exc.code})"
+        )
+
+
+def _tree_snapshot(root: Path) -> dict[str, tuple[bytes, int]]:
+    snapshot = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            snapshot[str(path.relative_to(root))] = (
+                path.read_bytes(),
+                stat.S_IMODE(path.stat().st_mode),
+            )
+    return snapshot
+
+
+def _matching_backup_files(home: Path, original: bytes) -> list[Path]:
+    return [
+        path
+        for path in home.rglob("*")
+        if path.is_file()
+        and path != _usage_path(home)
+        and path.read_bytes() == original
+        and path.parent != home / "skills"
+    ]
+
+
+def test_default_reconcile_is_dry_run_and_hash_invariant(reconcile_home, capsys):
+    skill_dir = _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(
+                use_count=2,
+                created_by="agent",
+                token="DO-NOT-PRINT",
+            ),
+            str(skill_dir): _record(view_count=3, state="stale"),
+        },
+    )
+    before_bytes = usage.read_bytes()
+    before_hash = hashlib.sha256(before_bytes).hexdigest()
+    before_tree = _tree_snapshot(reconcile_home)
+
+    assert _run_reconcile(apply=False) == 0
+
+    assert usage.read_bytes() == before_bytes
+    assert hashlib.sha256(usage.read_bytes()).hexdigest() == before_hash
+    assert _tree_snapshot(reconcile_home) == before_tree
+    captured = capsys.readouterr()
+    report = captured.out + captured.err
+    assert "DO-NOT-PRINT" not in report
+
+
+def test_apply_merges_aliases_and_removes_keys_only_after_private_backup(
+    reconcile_home,
+    capsys,
+):
+    skill_dir = _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    original = {
+        "research/directory-alias": _record(
+            use_count=2,
+            view_count=3,
+            patch_count=4,
+            created_at="2026-01-03T00:00:00+00:00",
+            last_used_at="2026-02-01T00:00:00+00:00",
+            patch_generation=2,
+            last_reused_patch_generation=2,
+            created_by="agent",
+            pinned=False,
+            state="archived",
+            archived_at="2026-02-02T00:00:00+00:00",
+            token="DO-NOT-PRINT",
+        ),
+        "research:canonical-skill": _record(
+            use_count=5,
+            view_count=7,
+            patch_count=11,
+            created_at="2026-01-01T00:00:00+00:00",
+            last_viewed_at="2026-03-01T00:00:00+00:00",
+            last_patched_at="2026-04-01T00:00:00+00:00",
+            patch_generation=5,
+            last_reused_patch_generation=99,
+            created_by="installed",
+            pinned=True,
+            state="stale",
+            archived_at=None,
+            token="DO-NOT-PRINT",
+        ),
+        str(skill_dir / "SKILL.md"): _record(
+            use_count=1,
+            created_at="2026-01-02T00:00:00+00:00",
+            last_used_at="2026-02-15T00:00:00+00:00",
+            state="active",
+        ),
+    }
+    usage = _write_usage(reconcile_home, original)
+    before_bytes = usage.read_bytes()
+
+    assert _run_reconcile(apply=True) == 0
+
+    merged = _read_usage(reconcile_home)
+    assert set(merged) == {"canonical-skill"}
+    record = merged["canonical-skill"]
+    assert record["use_count"] == 8
+    assert record["view_count"] == 10
+    assert record["patch_count"] == 15
+    assert record["created_at"] == "2026-01-01T00:00:00+00:00"
+    assert record["last_used_at"] == "2026-02-15T00:00:00+00:00"
+    assert record["last_viewed_at"] == "2026-03-01T00:00:00+00:00"
+    assert record["last_patched_at"] == "2026-04-01T00:00:00+00:00"
+    assert record["patch_generation"] == 5
+    assert record["last_reused_patch_generation"] == 5
+    # Provenance follows the actual local skill. A stale alias marked
+    # ``installed`` must not evict an existing ``agent`` ownership marker and
+    # silently remove the skill from Curator management.
+    assert record["created_by"] == "agent"
+    assert record["pinned"] is True
+    # active outranks stale and archived; archived_at is only legal for an
+    # archived result.
+    assert record["state"] == "active"
+    assert record["archived_at"] is None
+
+    backups = _matching_backup_files(reconcile_home, before_bytes)
+    assert backups, "apply must create a byte-identical private backup first"
+    backup = backups[0]
+    assert stat.S_IMODE(backup.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    report = capsys.readouterr().out
+    assert "DO-NOT-PRINT" not in report
+
+
+def test_archived_group_retains_archived_at_only_when_result_is_archived(reconcile_home):
+    _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="archived-skill",
+    )
+    _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(
+                state="archived",
+                archived_at="2026-02-01T00:00:00+00:00",
+            ),
+            "research:archived-skill": _record(
+                state="archived",
+                archived_at="2026-03-01T00:00:00+00:00",
+            ),
+        },
+    )
+
+    assert _run_reconcile(apply=True) == 0
+
+    merged = _read_usage(reconcile_home)["archived-skill"]
+    assert merged["state"] == "archived"
+    assert merged["archived_at"] is not None
+
+
+def test_apply_is_idempotent_without_a_second_backup(reconcile_home):
+    skill_dir = _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(use_count=3),
+            str(skill_dir): _record(view_count=4),
+        },
+    )
+    original_bytes = usage.read_bytes()
+
+    assert _run_reconcile(apply=True) == 0
+    after_first = usage.read_bytes()
+    backups_after_first = _matching_backup_files(reconcile_home, original_bytes)
+    assert backups_after_first
+
+    assert _run_reconcile(apply=True) == 0
+    assert usage.read_bytes() == after_first
+    assert _matching_backup_files(reconcile_home, original_bytes) == backups_after_first
+
+
+def test_conflicting_unknown_fields_block_apply_without_mutation(reconcile_home):
+    _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(extension_payload="one"),
+            "research:canonical-skill": _record(extension_payload="two"),
+        },
+    )
+    before = usage.read_bytes()
+
+    assert _run_reconcile(apply=True) != 0
+    assert usage.read_bytes() == before
+    assert set(_read_usage(reconcile_home)) == {
+        "research/directory-alias",
+        "research:canonical-skill",
+    }
+
+
+def test_ambiguous_unknown_and_plugin_groups_are_preserved_while_safe_groups_merge(
+    reconcile_home,
+):
+    _write_skill(
+        reconcile_home,
+        category="one",
+        directory="same-dir",
+        name="ambiguous-skill",
+    )
+    _write_skill(
+        reconcile_home,
+        category="two",
+        directory="same-dir",
+        name="ambiguous-skill",
+    )
+    _write_skill(
+        reconcile_home,
+        category="local",
+        directory="skill",
+        name="skill",
+    )
+    _write_skill(
+        reconcile_home,
+        category="safe",
+        directory="directory-alias",
+        name="safe-skill",
+    )
+    _write_usage(
+        reconcile_home,
+        {
+            "ambiguous-skill": _record(use_count=1),
+            "unknown-alias": _record(view_count=1),
+            "plugin:skill": _record(patch_count=1),
+            "skill": _record(use_count=2),
+            "safe/directory-alias": _record(use_count=3),
+            "safe:safe-skill": _record(view_count=4),
+        },
+    )
+
+    assert _run_reconcile(apply=True) == 0
+
+    after = _read_usage(reconcile_home)
+    assert after["ambiguous-skill"]["use_count"] == 1
+    assert after["unknown-alias"]["view_count"] == 1
+    assert after["plugin:skill"]["patch_count"] == 1
+    assert after["skill"]["use_count"] == 2
+    assert "plugin:skill" in after
+    assert "skill" in after
+    assert "safe/directory-alias" not in after
+    assert "safe:safe-skill" not in after
+    assert after["safe-skill"]["use_count"] == 3
+    assert after["safe-skill"]["view_count"] == 4
+
+
+@pytest.mark.parametrize("payload", [b"{not-json", b"[]", b'{"alias": []}'])
+def test_corrupted_or_malformed_sidecar_fails_controlled_and_preserves_bytes(
+    reconcile_home,
+    payload,
+    capsys,
+):
+    usage = _usage_path(reconcile_home)
+    usage.write_bytes(payload)
+
+    assert _run_reconcile(apply=True) != 0
+    assert usage.read_bytes() == payload
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "Traceback" not in output
+    assert "not-json" not in output
+
+
+def test_apply_save_usage_false_without_write_is_nonzero_and_preserves_source(
+    reconcile_home,
+    monkeypatch,
+):
+    skill_dir = _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(use_count=2),
+            str(skill_dir): _record(view_count=3),
+        },
+    )
+    before_bytes = usage.read_bytes()
+
+    from tools import skill_usage
+
+    monkeypatch.setattr(skill_usage, "save_usage", lambda data: False)
+
+    apply_rc = _run_reconcile(apply=True)
+    assert apply_rc != 0
+    assert usage.read_bytes() == before_bytes
+    assert set(_read_usage(reconcile_home)) == {
+        "research/directory-alias",
+        str(skill_dir),
+    }
+
+
+def test_apply_accepts_save_usage_false_after_original_commit(
+    reconcile_home,
+    monkeypatch,
+):
+    skill_dir = _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(use_count=2),
+            str(skill_dir): _record(view_count=3),
+        },
+    )
+
+    from tools import skill_usage
+
+    original_save_usage = skill_usage.save_usage
+
+    def save_then_report_false(data):
+        assert original_save_usage(data) is True
+        return False
+
+    monkeypatch.setattr(skill_usage, "save_usage", save_then_report_false)
+
+    assert _run_reconcile(apply=True) == 0
+    assert set(_read_usage(reconcile_home)) == {"canonical-skill"}
+    assert stat.S_IMODE(usage.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    "unsafe_name",
+    [
+        "\\x01canonical-skill",
+        "\\x1b[31mcanonical-skill\\x1b[0m",
+        "canonical\\tname",
+        "canonical\\x7fname",
+        "canonical\\x80name",
+    ],
+)
+def test_cli_reconcile_never_emits_control_chars_in_canonical_name(
+    reconcile_home,
+    monkeypatch,
+    capsys,
+    unsafe_name,
+):
+    unsafe_name = bytes(unsafe_name, "ascii").decode("unicode_escape")
+    from hermes_cli import curator
+    from tools import skill_usage
+
+    monkeypatch.setattr(
+        skill_usage,
+        "reconcile_usage_report",
+        lambda: {
+            "status": "ok",
+            "counts": {
+                "records": 1,
+                "groups": 1,
+                "aliases": 1,
+                "possible_conflicts": 0,
+                "skipped": 0,
+            },
+            "skipped": {"unknown": 0, "ambiguous": 0, "plugin": 0},
+            "groups": [
+                {
+                    "canonical": unsafe_name,
+                    "aliases": ["research/directory-alias"],
+                    "record_count": 1,
+                    "possible_conflicts": 0,
+                }
+            ],
+        },
+    )
+
+    control = next(
+        char
+        for char in unsafe_name
+        if ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F
+    )
+    safe_name = curator._safe_reconcile_display_name(unsafe_name)
+    assert safe_name is None or control not in safe_name
+
+    assert _run_reconcile(apply=False) == 0
+    output = capsys.readouterr().out
+    assert control not in output
+
+
+def test_unknown_extension_numeric_types_conflict_in_apply_and_dry_run(
+    reconcile_home,
+    capsys,
+):
+    _write_skill(
+        reconcile_home,
+        category="research",
+        directory="directory-alias",
+        name="canonical-skill",
+    )
+    usage = _write_usage(
+        reconcile_home,
+        {
+            "research/directory-alias": _record(extension_value=1),
+            "research:canonical-skill": _record(extension_value=1.0),
+        },
+    )
+    before_bytes = usage.read_bytes()
+
+    assert _run_reconcile(apply=False) == 0
+    report = capsys.readouterr().out
+    assert "possible conflicts: 1" in report
+
+    apply_rc = _run_reconcile(apply=True)
+    after_bytes = usage.read_bytes()
+    assert apply_rc != 0 and after_bytes == before_bytes

--- a/tests/tools/test_skill_usage_alias_reconcile.py
+++ b/tests/tools/test_skill_usage_alias_reconcile.py
@@ -1,0 +1,267 @@
+"""RED contract tests for canonical skill-usage aliases.
+
+These tests intentionally target behavior that is not present on upstream/main.
+They exercise the real telemetry sidecar and the future ``reconcile-usage`` CLI
+without adding a production implementation in this change.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def usage_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    import tools.skill_usage as skill_usage
+
+    importlib.reload(hermes_constants)
+    importlib.reload(skill_usage)
+    monkeypatch.setattr(skill_usage, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def _write_skill(
+    skills_dir: Path,
+    *,
+    category: str,
+    directory: str,
+    frontmatter_name: str,
+) -> Path:
+    skill_dir = skills_dir / category / directory
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {frontmatter_name}\n"
+        "description: alias reconciliation fixture\n"
+        "---\n\n"
+        "# fixture\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_usage(home: Path, records: dict) -> Path:
+    path = home / "skills" / ".usage.json"
+    path.write_text(json.dumps(records, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _record(**overrides):
+    record = {
+        "created_by": None,
+        "use_count": 0,
+        "view_count": 0,
+        "patch_count": 0,
+        "last_used_at": None,
+        "last_viewed_at": None,
+        "last_patched_at": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "patch_generation": 0,
+        "last_reused_patch_generation": 0,
+        "state": "active",
+        "pinned": False,
+        "archived_at": None,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_all_telemetry_writes_resolve_aliases_to_frontmatter_name(usage_home):
+    """Bare, category, path, directory, and frontmatter aliases share one key."""
+    from tools import skill_usage
+
+    skill_dir = _write_skill(
+        usage_home / "skills",
+        category="research",
+        directory="directory-alias",
+        frontmatter_name="canonical-skill",
+    )
+    skill_md = skill_dir / "SKILL.md"
+
+    # Each write path is intentionally different so every telemetry writer is
+    # covered, including the two trusted absolute-path forms.
+    aliases_and_writers = [
+        ("canonical-skill", skill_usage.bump_view),
+        ("research/canonical-skill", skill_usage.bump_use),
+        ("research:canonical-skill", skill_usage.bump_patch),
+        (str(skill_dir), skill_usage.bump_view),
+        (str(skill_md), skill_usage.bump_use),
+        ("directory-alias", skill_usage.bump_patch),
+    ]
+    for alias, writer in aliases_and_writers:
+        writer(alias)
+
+    data = skill_usage.load_usage()
+    assert set(data) == {"canonical-skill"}
+    assert data["canonical-skill"]["view_count"] == 2
+    assert data["canonical-skill"]["use_count"] == 2
+    assert data["canonical-skill"]["patch_count"] == 2
+
+
+def test_ambiguous_and_unknown_aliases_keep_events_without_collapsing(usage_home):
+    """Fail-safe lookup must preserve an event when no unique local target exists."""
+    from tools import skill_usage
+
+    skills = usage_home / "skills"
+    _write_skill(
+        skills,
+        category="one",
+        directory="same-dir",
+        frontmatter_name="ambiguous-skill",
+    )
+    _write_skill(
+        skills,
+        category="two",
+        directory="same-dir",
+        frontmatter_name="ambiguous-skill",
+    )
+
+    # Neither alias can be safely assigned to one local skill. The original
+    # event key is the lossless fallback; it must not disappear or be guessed.
+    skill_usage.bump_view("ambiguous-skill")
+    skill_usage.bump_use("unknown-skill-alias")
+
+    data = skill_usage.load_usage()
+    assert data["ambiguous-skill"]["view_count"] == 1
+    assert data["unknown-skill-alias"]["use_count"] == 1
+
+
+def test_plugin_namespace_is_never_collapsed_into_local_bare_name(usage_home):
+    from tools import skill_usage
+
+    _write_skill(
+        usage_home / "skills",
+        category="local",
+        directory="skill",
+        frontmatter_name="skill",
+    )
+    skill_usage.bump_view("plugin:skill")
+    skill_usage.bump_use("plugin:skill")
+    skill_usage.bump_patch("plugin:skill")
+
+    data = skill_usage.load_usage()
+    assert "plugin:skill" in data
+    assert data["plugin:skill"]["view_count"] == 1
+    assert data["plugin:skill"]["use_count"] == 1
+    assert data["plugin:skill"]["patch_count"] == 1
+    assert "skill" not in data
+
+
+def test_identity_cache_discovers_new_category_path_alias_without_root_touch(
+    usage_home,
+):
+    from tools import skill_usage
+
+    skills = usage_home / "skills"
+    _write_skill(
+        skills,
+        category="cat",
+        directory="one",
+        frontmatter_name="one",
+    )
+
+    # Index the category while it contains only the first skill. A later skill
+    # is created below the existing category directory, so the skills-root
+    # signature itself does not change.
+    assert skill_usage._canonicalize_skill_name("cat/one") == "one"
+    root_signature = skill_usage._skills_root_signature(skills)
+    _write_skill(
+        skills,
+        category="cat",
+        directory="two",
+        frontmatter_name="two",
+    )
+    assert skill_usage._skills_root_signature(skills) == root_signature
+
+    assert skill_usage._canonicalize_skill_name("cat/two") == "two"
+    skill_usage.bump_use("cat/two")
+    data = skill_usage.load_usage()
+    assert data["two"]["use_count"] == 1
+    assert "cat/two" not in data
+
+
+def test_identity_cache_watches_empty_category_after_last_skill_deleted(
+    usage_home, monkeypatch
+):
+    from agent import skill_utils
+    from tools import skill_usage
+
+    skills = usage_home / "skills"
+    first = _write_skill(
+        skills,
+        category="cat",
+        directory="one",
+        frontmatter_name="one",
+    )
+    assert skill_usage._canonicalize_skill_name("cat/one") == "one"
+
+    (first / "SKILL.md").unlink()
+    first.rmdir()
+    assert skill_usage._canonicalize_skill_name("cat/one") == "cat/one"
+
+    root_signature = skill_usage._skills_root_signature(skills)
+    _write_skill(
+        skills,
+        category="cat",
+        directory="two",
+        frontmatter_name="two",
+    )
+    assert skill_usage._skills_root_signature(skills) == root_signature
+    assert skill_usage._canonicalize_skill_name("cat/two") == "two"
+
+    real_iter = skill_utils.iter_skill_index_files
+    calls = 0
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(skill_utils, "iter_skill_index_files", counted)
+    assert skill_usage._canonicalize_skill_name("cat/two") == "two"
+    assert calls == 0
+
+
+def test_reconcile_cli_is_registered_and_defaults_to_report_only(usage_home):
+    """The new command must exist before its filesystem behavior is exercised."""
+    import argparse
+
+    from hermes_cli import curator
+
+    parser = argparse.ArgumentParser(prog="hermes curator")
+    curator.register_cli(parser)
+    try:
+        args = parser.parse_args(["reconcile-usage"])
+    except SystemExit as exc:  # current upstream: command is absent
+        pytest.fail(
+            "reconcile-usage is not registered; expected a report-only default "
+            f"(argparse exit {exc.code})"
+        )
+    assert args.curator_command == "reconcile-usage"
+    assert args.apply is False
+
+
+def test_reconcile_cli_has_explicit_apply_switch(usage_home):
+    import argparse
+
+    from hermes_cli import curator
+
+    parser = argparse.ArgumentParser(prog="hermes curator")
+    curator.register_cli(parser)
+    try:
+        args = parser.parse_args(["reconcile-usage", "--apply"])
+    except SystemExit as exc:
+        pytest.fail(
+            "reconcile-usage --apply is not registered; explicit apply is "
+            f"required (argparse exit {exc.code})"
+        )
+    assert args.apply is True

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -27,11 +27,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import secrets
+import stat
 import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
@@ -424,8 +426,236 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
     return fallback
 
 
+# The identity index is deliberately scoped to the active profile's local
+# skills root. Known SKILL.md files and their ancestor directories are watched
+# with cheap stat calls; a new nested skill changes one of those parent dirs.
+# The recursive walk is therefore amortized across bumps rather than paid on
+# every event. The root path remains part of the key so switching HERMES_HOME
+# (including profile overrides in one process) cannot leak names.
+_SKILL_IDENTITY_CACHE: Dict[
+    Path,
+    Tuple[
+        Tuple[Tuple[str, int, int, int, int, int], ...],
+        Dict[str, Set[Path]],
+        Dict[Path, str],
+        Tuple[Path, ...],
+    ],
+] = {}
+
+
+def _identity_watch_signature(
+    paths: Iterable[Path],
+) -> Tuple[Tuple[str, int, int, int, int, int], ...]:
+    """Fingerprint known skill files and the dirs that can gain children."""
+    signature = []
+    for path in sorted(set(paths), key=lambda item: str(item)):
+        try:
+            path_stat = os.stat(path, follow_symlinks=False)
+            row = (
+                str(path),
+                path_stat.st_dev,
+                path_stat.st_ino,
+                path_stat.st_mtime_ns,
+                path_stat.st_ctime_ns,
+                path_stat.st_size,
+            )
+        except OSError:
+            row = (str(path), -1, -1, -1, -1, -1)
+        signature.append(row)
+    return tuple(signature)
+
+
+def _skills_root_signature(root: Path) -> Optional[Tuple[int, int, int, int]]:
+    """Return the root-only signature kept for diagnostics/backward compatibility."""
+    try:
+        root_stat = root.stat()
+    except OSError:
+        return None
+    return (
+        root_stat.st_dev,
+        root_stat.st_ino,
+        root_stat.st_mtime_ns,
+        root_stat.st_ctime_ns,
+    )
+
+
+def _add_identity_alias(
+    aliases: Dict[str, Set[Path]], alias: str, skill_dir: Path
+) -> None:
+    if alias:
+        aliases.setdefault(alias, set()).add(skill_dir)
+
+
+def _build_skill_identity_index(
+    root: Path,
+) -> Tuple[Dict[str, Set[Path]], Dict[Path, str], Tuple[Path, ...]]:
+    """Build aliases for local skills, preserving ambiguity as a set of paths."""
+    aliases: Dict[str, Set[Path]] = {}
+    canonical_by_dir: Dict[Path, str] = {}
+    watched_paths: Set[Path] = set()
+    try:
+        from agent.skill_utils import iter_skill_index_files
+
+        resolved_root = root.resolve()
+        watched_paths.add(resolved_root)
+        # Preserve empty category directories in the watch set. This walk runs
+        # only while rebuilding an already-invalidated index; stable cache hits
+        # perform stat calls over watched paths and never recurse the tree.
+        for directory, child_dirs, _ in os.walk(resolved_root, followlinks=False):
+            child_dirs[:] = [name for name in child_dirs if not name.startswith(".")]
+            watched_paths.add(Path(directory))
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
+            try:
+                resolved_md = skill_md.resolve()
+                resolved_md.relative_to(resolved_root)
+                skill_dir = resolved_md.parent
+            except (OSError, RuntimeError, ValueError):
+                # Absolute paths are trusted only when they resolve inside the
+                # active profile's skills root. This also rejects symlink escapes.
+                continue
+            if is_excluded_skill_path(skill_md) or is_external_skill_path(skill_md):
+                continue
+
+            watched_paths.add(resolved_md)
+            parent = skill_dir
+            while True:
+                watched_paths.add(parent)
+                if parent == resolved_root or resolved_root not in parent.parents:
+                    break
+                parent = parent.parent
+
+            canonical = _read_skill_name(skill_md, fallback=skill_dir.name)
+            if not canonical:
+                continue
+            canonical_by_dir[skill_dir] = canonical
+
+            # The frontmatter name and on-disk directory basename are both
+            # accepted bare aliases. The relative directory path is also a
+            # trusted alias (e.g. ``research/directory-alias``).
+            _add_identity_alias(aliases, canonical, skill_dir)
+            _add_identity_alias(aliases, skill_dir.name, skill_dir)
+            try:
+                relative_dir = skill_dir.relative_to(resolved_root)
+            except ValueError:
+                continue
+            relative_alias = relative_dir.as_posix()
+            _add_identity_alias(aliases, relative_alias, skill_dir)
+
+            # Categorized callers use either category/name or category:name.
+            # Accept the canonical frontmatter name as well as the directory
+            # alias in both forms; only a unique path may canonicalize.
+            if len(relative_dir.parts) >= 2:
+                category = "/".join(relative_dir.parts[:-1])
+                for name in (canonical, skill_dir.name):
+                    _add_identity_alias(aliases, f"{category}/{name}", skill_dir)
+                    _add_identity_alias(aliases, f"{category}:{name}", skill_dir)
+    except Exception as e:
+        # Telemetry must never make a skill operation fail because discovery is
+        # unavailable or a malformed skill tree was encountered.
+        logger.debug("Failed to build skill identity index: %s", e, exc_info=True)
+    return aliases, canonical_by_dir, tuple(watched_paths)
+
+
+def _skill_identity_index() -> Tuple[Dict[str, Set[Path]], Dict[Path, str]]:
+    """Return the cached local identity index for the active Hermes profile."""
+    root = _skills_dir()
+    try:
+        cache_root = root.expanduser().resolve()
+    except (OSError, RuntimeError):
+        cache_root = root.expanduser()
+    cached = _SKILL_IDENTITY_CACHE.get(cache_root)
+    if cached is not None and cached[0] == _identity_watch_signature(cached[3]):
+        return cached[1], cached[2]
+
+    aliases, canonical_by_dir, watched_paths = _build_skill_identity_index(root)
+    _SKILL_IDENTITY_CACHE[cache_root] = (
+        _identity_watch_signature(watched_paths),
+        aliases,
+        canonical_by_dir,
+        watched_paths,
+    )
+    return aliases, canonical_by_dir
+
+
+def _refresh_identity_cache_signature() -> None:
+    """Account for the first sidecar creation without rescanning skills."""
+    root = _skills_dir()
+    try:
+        cache_root = root.expanduser().resolve()
+    except (OSError, RuntimeError):
+        cache_root = root.expanduser()
+    cached = _SKILL_IDENTITY_CACHE.get(cache_root)
+    if cached is not None:
+        _SKILL_IDENTITY_CACHE[cache_root] = (
+            _identity_watch_signature(cached[3]),
+            cached[1],
+            cached[2],
+            cached[3],
+        )
+
+
+def _registered_plugin_skill(skill_name: str) -> bool:
+    """Whether a qualified key belongs to a registered plugin skill."""
+    if ":" not in skill_name:
+        return False
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        return get_plugin_manager().find_plugin_skill(skill_name) is not None
+    except Exception:
+        # Plugin discovery is optional from the telemetry module's perspective.
+        return False
+
+
+def _canonicalize_skill_name(skill_name: str) -> str:
+    """Resolve a local skill alias to its unique frontmatter ``name``.
+
+    This is intentionally fail-safe: plugin-qualified names, unknown aliases,
+    ambiguous aliases, and paths outside the active local skills root are
+    returned byte-for-byte unchanged so an event is never lost or attributed
+    to the wrong skill.
+    """
+    if not skill_name:
+        return skill_name
+    raw = os.fspath(skill_name) if isinstance(skill_name, os.PathLike) else str(skill_name)
+    if not raw:
+        return raw
+
+    # A registered plugin skill always owns its qualified namespace. Do this
+    # before local category matching so a local ``plugin/skill`` directory can
+    # never collapse ``plugin:skill`` into a local record.
+    if _registered_plugin_skill(raw):
+        return raw
+
+    aliases, canonical_by_dir = _skill_identity_index()
+    target_dirs: Optional[Set[Path]] = None
+
+    # Trusted absolute skill directory and SKILL.md forms are resolved through
+    # the path index, not by accepting arbitrary filesystem paths.
+    try:
+        candidate_path = Path(raw).expanduser()
+        if candidate_path.is_absolute():
+            resolved = candidate_path.resolve(strict=False)
+            if resolved.name == "SKILL.md":
+                resolved = resolved.parent
+            if resolved in canonical_by_dir:
+                target_dirs = {resolved}
+    except (OSError, RuntimeError, TypeError, ValueError):
+        target_dirs = None
+
+    if target_dirs is None:
+        target_dirs = aliases.get(raw)
+
+    # A path can have several matching skill directories (same directory alias
+    # or duplicate frontmatter names). Refuse to guess and retain the event key.
+    if target_dirs is None or len(target_dirs) != 1:
+        return raw
+    return canonical_by_dir.get(next(iter(target_dirs)), raw)
+
+
 def is_agent_created(skill_name: str) -> bool:
     """Whether *skill_name* is neither bundled nor hub-installed."""
+    skill_name = _canonicalize_skill_name(skill_name)
     off_limits = _read_bundled_manifest_names() | _read_hub_installed_names()
     if skill_name in off_limits:
         return False
@@ -437,11 +667,13 @@ def is_agent_created(skill_name: str) -> bool:
 
 def is_hub_installed(skill_name: str) -> bool:
     """Whether *skill_name* was installed via the Skills Hub."""
+    skill_name = _canonicalize_skill_name(skill_name)
     return skill_name in _read_hub_installed_names()
 
 
 def is_bundled(skill_name: str) -> bool:
     """Whether *skill_name* was seeded from the bundled repo skills."""
+    skill_name = _canonicalize_skill_name(skill_name)
     return skill_name in _read_bundled_manifest_names()
 
 
@@ -466,6 +698,7 @@ def is_curation_eligible(skill_name: str, skill_path: Optional[Path] = None) -> 
     regardless of any flag — they back load-bearing UX and must never be
     archived or consolidated.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     if skill_path is not None and is_external_skill_path(skill_path):
         return False
     if is_protected_builtin(skill_name):
@@ -606,6 +839,7 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
     Returns (ok, message). Refuses hub-installed, external, and protected
     built-in skills, which have an owner other than the user.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     if not skill_name:
         return False, "no skill name given"
     if is_protected_builtin(skill_name):
@@ -689,10 +923,21 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> bool:
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
+                # The usage sidecar contains operational history and may carry
+                # extension fields.  Keep the replacement private before it is
+                # made visible, rather than relying on the process umask.
+                if hasattr(os, "fchmod"):
+                    os.fchmod(f.fileno(), 0o600)
                 json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
                 f.flush()
                 os.fsync(f.fileno())
             os.replace(tmp_path, path)
+            # fchmod above is the normal path; chmod is retained for platforms
+            # without fchmod and makes the postcondition explicit.
+            try:
+                os.chmod(path, 0o600, follow_symlinks=False)
+            except (NotImplementedError, TypeError):  # pragma: no cover - Windows
+                os.chmod(path, 0o600)
             return True
         except BaseException:
             try:
@@ -707,6 +952,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> bool:
 
 def get_record(skill_name: str) -> Dict[str, Any]:
     """Return the record for *skill_name*, creating a fresh one if missing."""
+    skill_name = _canonicalize_skill_name(skill_name)
     data = load_usage()
     rec = data.get(skill_name)
     if not isinstance(rec, dict):
@@ -727,15 +973,18 @@ def seed_record_if_missing(skill_name: str) -> None:
     archive/stale clock measures non-use FROM THEN — not from epoch. No-op when
     a record already exists or the skill isn't curation-eligible.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     if not skill_name or not is_curation_eligible(skill_name):
         return
     try:
         with _usage_file_lock():
+            usage_file_existed = _usage_file().exists()
             data = load_usage()
             if isinstance(data.get(skill_name), dict):
                 return
             data[skill_name] = _empty_record()
-            save_usage(data)
+            if save_usage(data) and not usage_file_existed:
+                _refresh_identity_cache_signature()
     except Exception as e:
         logger.debug("skill_usage.seed_record_if_missing(%s) failed: %s", skill_name, e, exc_info=True)
 
@@ -751,12 +1000,14 @@ def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False
     onto a skill the curator can't manage (e.g. an ``archived`` flag on a
     hub-installed skill).
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     if not skill_name:
         return None
     try:
         if require_curation_eligible and not is_curation_eligible(skill_name):
             return None
         with _usage_file_lock():
+            usage_file_existed = _usage_file().exists()
             data = load_usage()
             rec = data.get(skill_name)
             if not isinstance(rec, dict):
@@ -765,6 +1016,8 @@ def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False
             data[skill_name] = rec
             if not save_usage(data):
                 return None
+            if not usage_file_existed:
+                _refresh_identity_cache_signature()
             return result
     except Exception as e:
         logger.debug("skill_usage._mutate(%s) failed: %s", skill_name, e, exc_info=True)
@@ -785,6 +1038,7 @@ def telemetry_provenance(
     record: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Return the bounded provenance used by shared skill metrics."""
+    skill_name = _canonicalize_skill_name(skill_name)
     if is_hub_installed(skill_name) or is_bundled(skill_name):
         return "installed"
     if ":" in skill_name:
@@ -855,6 +1109,8 @@ def bump_view(skill_name: str) -> None:
     Tracks every skill regardless of provenance — built-ins and hub skills
     included. Usage telemetry is observability, not a curation signal.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> None:
         rec["view_count"] = _non_negative_int(rec.get("view_count")) + 1
         rec["last_viewed_at"] = _now_iso()
@@ -872,6 +1128,8 @@ def bump_use(
 
     Tracks every skill regardless of provenance.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
         previous_use_count = _non_negative_int(rec.get("use_count"))
         patch_generation = _non_negative_int(rec.get("patch_generation"))
@@ -919,6 +1177,7 @@ def bump_patch(
 
     Tracks every skill regardless of provenance.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     lifecycle_action = "patched" if action == "patch" else "edited"
 
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
@@ -946,6 +1205,8 @@ def record_created(
     session_id: Optional[str] = None,
 ) -> None:
     """Persist explicit creation provenance and emit a successful create fact."""
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
         # A successful create is a new logical skill even if stale sidecar
         # state survived an earlier deletion or manual filesystem change.
@@ -968,6 +1229,8 @@ def record_created(
 
 def record_installed(skill_name: str) -> None:
     """Record a successful Skills Hub install without exporting its name."""
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
         rec["created_by"] = "installed"
         rec["state"] = STATE_ACTIVE
@@ -985,6 +1248,8 @@ def mark_agent_created(skill_name: str) -> None:
     Viewing or invoking a manually authored skill may still create telemetry,
     but only this explicit marker makes it eligible for automatic curation.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> None:
         rec["created_by"] = "agent"
     _mutate(skill_name, _apply, require_curation_eligible=True)
@@ -993,6 +1258,7 @@ def mark_agent_created(skill_name: str) -> None:
 def set_state(skill_name: str, state: str) -> None:
     """Set lifecycle state. No-op if *state* is invalid or the skill isn't
     curator-manageable (hub skills, or built-ins with pruning disabled)."""
+    skill_name = _canonicalize_skill_name(skill_name)
     if state not in _VALID_STATES:
         logger.debug("set_state: invalid state %r for %s", state, skill_name)
         return
@@ -1028,6 +1294,8 @@ def set_pinned(skill_name: str, pinned: bool) -> bool:
     """Set/clear the pin flag. Returns False when the write did not land
     (skill not curation-eligible), True on success — so callers can report
     failure instead of a false success (issue #92993)."""
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> Any:
         rec["pinned"] = bool(pinned)
         return True  # non-None sentinel: _mutate propagates the mutator result
@@ -1044,6 +1312,8 @@ def set_sync(skill_name: str, sync: bool) -> None:
     eligibility so bundled/hub/external skills (which never sync) can't be
     marked. Provisional per the M1-D default.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
+
     def _apply(rec: Dict[str, Any]) -> None:
         rec["sync"] = bool(sync)
     _mutate(skill_name, _apply, require_curation_eligible=True)
@@ -1056,6 +1326,7 @@ def is_sync_enabled(skill_name: str) -> bool:
 
 def forget(skill_name: str) -> None:
     """Drop a skill's usage entry entirely. Called when the skill is deleted."""
+    skill_name = _canonicalize_skill_name(skill_name)
     if not skill_name:
         return
     try:
@@ -1080,6 +1351,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     local_skill_dir = _find_skill_dir(skill_name)
     if local_skill_dir is None and _find_external_skill_dir(skill_name) is not None:
         return False, _external_read_only_message(skill_name)
@@ -1162,6 +1434,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     # Hub skills always have an external upstream owner — never shadow them.
     if is_hub_installed(skill_name):
         return False, (
@@ -1284,6 +1557,632 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
 # Reporting — for the curator CLI / slash command
 # ---------------------------------------------------------------------------
 
+
+class UsageReconcileError(ValueError):
+    """A controlled, user-safe error while inspecting the usage sidecar."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        # Do not retain the underlying exception or path: callers may safely
+        # render this exception at a CLI boundary without leaking sidecar data.
+        super().__init__(code)
+
+
+_RECONCILE_RECORD_FIELDS = {
+    "created_by",
+    "use_count",
+    "view_count",
+    "last_used_at",
+    "last_viewed_at",
+    "patch_count",
+    "patch_generation",
+    "last_reused_patch_generation",
+    "last_patched_at",
+    "created_at",
+    "state",
+    "pinned",
+    "archived_at",
+    "sync",
+}
+_RECONCILE_SKIP_REASONS = ("unknown", "ambiguous", "plugin")
+
+
+def _strict_json_object_pairs(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    """Reject duplicate JSON keys instead of silently taking the last value."""
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject NaN/Infinity, which are not valid JSON sidecar values."""
+    raise ValueError(value)
+
+
+def _strict_usage_bytes() -> Tuple[bytes, bool]:
+    """Read the usage sidecar as bytes without following a symlink."""
+    path = _usage_file()
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        return b"", False
+    except OSError:
+        raise UsageReconcileError("usage_sidecar_unreadable")
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+        raise UsageReconcileError("usage_sidecar_type")
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except (OSError, ValueError):
+        raise UsageReconcileError("usage_sidecar_unreadable")
+    try:
+        opened_stat = os.fstat(fd)
+        if stat.S_ISLNK(opened_stat.st_mode) or not stat.S_ISREG(opened_stat.st_mode):
+            raise UsageReconcileError("usage_sidecar_type")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            return handle.read(), True
+    except UsageReconcileError:
+        raise
+    except (OSError, ValueError):
+        raise UsageReconcileError("usage_sidecar_unreadable")
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _strict_parse_usage(raw: bytes) -> Dict[str, Dict[str, Any]]:
+    """Parse a complete usage sidecar without lossy coercions."""
+    try:
+        data = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_strict_json_object_pairs,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeError, ValueError, TypeError):
+        raise UsageReconcileError("invalid_usage_sidecar")
+    if not isinstance(data, dict):
+        raise UsageReconcileError("usage_sidecar_not_dict")
+    for record in data.values():
+        if not isinstance(record, dict):
+            raise UsageReconcileError("usage_record_not_dict")
+    return data
+
+
+def _read_usage_strict_for_reconcile() -> Tuple[Dict[str, Dict[str, Any]], bool]:
+    """Read the sidecar without the forgiving behavior of :func:`load_usage`."""
+    raw, present = _strict_usage_bytes()
+    if not present:
+        return {}, False
+    return _strict_parse_usage(raw), True
+
+
+def _reconcile_alias_target(raw_key: str) -> Tuple[str, str]:
+    """Return ``(canonical_name, disposition)`` for one raw sidecar key."""
+    try:
+        canonical = _canonicalize_skill_name(raw_key)
+    except Exception:
+        # Preserve an event that cannot be classified rather than aborting the
+        # whole report because one skill tree entry is malformed.
+        return raw_key, "unknown"
+
+    try:
+        if _registered_plugin_skill(raw_key):
+            return canonical, "plugin"
+
+        aliases, canonical_by_dir = _skill_identity_index()
+        target_dirs: Optional[Set[Path]] = None
+        candidate_path = Path(raw_key).expanduser()
+        if candidate_path.is_absolute():
+            resolved = candidate_path.resolve(strict=False)
+            if resolved.name == "SKILL.md":
+                resolved = resolved.parent
+            if resolved in canonical_by_dir:
+                target_dirs = {resolved}
+        if target_dirs is None:
+            target_dirs = aliases.get(raw_key)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return raw_key, "unknown"
+
+    if target_dirs is None:
+        return raw_key, "unknown"
+    if len(target_dirs) != 1:
+        return raw_key, "ambiguous"
+    return canonical, "local"
+
+
+def _safe_reconcile_alias(raw_key: str) -> Optional[str]:
+    """Return a non-sensitive alias suitable for report metadata."""
+    try:
+        if Path(raw_key).expanduser().is_absolute():
+            return None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if not raw_key or "\n" in raw_key or "\r" in raw_key:
+        return None
+    return raw_key[:256]
+
+
+def _reconcile_group_conflict_count(records: List[Dict[str, Any]]) -> int:
+    """Count groups needing review before a future mutating merge."""
+    if len(records) < 2:
+        return 0
+    unknown_fields = set().union(
+        *(set(record) - _RECONCILE_RECORD_FIELDS for record in records)
+    )
+    for field in unknown_fields:
+        values = [record[field] for record in records if field in record]
+        if any(not _reconcile_values_equal(values[0], value) for value in values[1:]):
+            return 1
+    return 0
+
+
+_RECONCILE_COUNTER_FIELDS = ("use_count", "view_count", "patch_count")
+_RECONCILE_ACTIVITY_FIELDS = (
+    "last_used_at",
+    "last_viewed_at",
+    "last_patched_at",
+)
+_RECONCILE_BOOL_FIELDS = ("pinned", "sync")
+_RECONCILE_TIMESTAMP_FIELDS = (
+    "created_at",
+    *_RECONCILE_ACTIVITY_FIELDS,
+    "archived_at",
+)
+_RECONCILE_STATE_PRIORITY = {
+    STATE_ARCHIVED: 0,
+    STATE_STALE: 1,
+    STATE_ACTIVE: 2,
+}
+
+
+def _reconcile_groups_for_data(
+    data: Dict[str, Dict[str, Any]],
+) -> Tuple[List[Tuple[str, List[Tuple[str, Dict[str, Any]]]]], Dict[str, int]]:
+    """Classify one already-read sidecar into safe groups and skipped rows."""
+    groups_by_name: Dict[str, List[Tuple[str, Dict[str, Any]]]] = {}
+    skipped = {reason: 0 for reason in _RECONCILE_SKIP_REASONS}
+    for raw_key, record in data.items():
+        canonical, disposition = _reconcile_alias_target(raw_key)
+        if disposition != "local":
+            skipped[disposition] += 1
+            continue
+        groups_by_name.setdefault(canonical, []).append((raw_key, record))
+
+    groups = []
+    for canonical in sorted(groups_by_name):
+        entries = groups_by_name[canonical]
+        if any(raw_key != canonical for raw_key, _ in entries):
+            groups.append((canonical, entries))
+    return groups, skipped
+
+
+def _reconcile_validate_record(record: Dict[str, Any]) -> None:
+    """Validate known fields before any backup or write is attempted."""
+    for field in _RECONCILE_COUNTER_FIELDS + (
+        "patch_generation",
+        "last_reused_patch_generation",
+    ):
+        if field not in record:
+            continue
+        value = record[field]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise UsageReconcileError("invalid_known_field")
+
+    for field in _RECONCILE_BOOL_FIELDS:
+        if field in record and not isinstance(record[field], bool):
+            raise UsageReconcileError("invalid_known_field")
+
+    if "state" in record and record["state"] not in _VALID_STATES:
+        raise UsageReconcileError("invalid_known_field")
+
+    if "created_by" in record:
+        value = record["created_by"]
+        if value is not None and not isinstance(value, str):
+            raise UsageReconcileError("invalid_known_field")
+
+    for field in _RECONCILE_TIMESTAMP_FIELDS:
+        if field not in record:
+            continue
+        value = record[field]
+        if value is None and field in _RECONCILE_ACTIVITY_FIELDS + ("archived_at",):
+            continue
+        if not isinstance(value, str) or _parse_iso_timestamp(value) is None:
+            raise UsageReconcileError("invalid_known_timestamp")
+
+
+def _reconcile_values_equal(left: Any, right: Any) -> bool:
+    """Compare JSON values strictly, preserving numeric JSON representation."""
+    try:
+        return json.dumps(
+            left, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+        ) == json.dumps(
+            right, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+def _usage_commit_matches(expected: Dict[str, Dict[str, Any]]) -> bool:
+    """Verify whether a reportedly failed save already committed *expected*."""
+    try:
+        path_stat = os.lstat(_usage_file())
+        if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+            return False
+        if os.name != "nt" and stat.S_IMODE(path_stat.st_mode) != 0o600:
+            return False
+        raw, present = _strict_usage_bytes()
+        return present and _reconcile_values_equal(_strict_parse_usage(raw), expected)
+    except (OSError, UsageReconcileError):
+        return False
+
+
+def _reconcile_timestamp_result(
+    records: List[Dict[str, Any]],
+    field: str,
+    *,
+    minimum: bool = False,
+) -> Optional[str]:
+    values = [record[field] for record in records if field in record]
+    valid = [(dt, str(raw)) for raw in values if (dt := _parse_iso_timestamp(raw)) is not None]
+    if not valid:
+        return None
+    return (min if minimum else max)(valid, key=lambda item: item[0])[1]
+
+
+def _reconcile_merge_record(
+    canonical: str,
+    records: List[Dict[str, Any]],
+    *,
+    bundled_names: Set[str],
+    hub_names: Set[str],
+) -> Dict[str, Any]:
+    """Merge one safe local identity group according to field-specific rules."""
+    for record in records:
+        _reconcile_validate_record(record)
+
+    merged: Dict[str, Any] = {}
+    unknown_fields = sorted(
+        set().union(*(set(record) - _RECONCILE_RECORD_FIELDS for record in records))
+    )
+    for field in unknown_fields:
+        values = [record[field] for record in records if field in record]
+        if any(not _reconcile_values_equal(values[0], value) for value in values[1:]):
+            raise UsageReconcileError("conflicting_unknown_fields")
+        # JSON values are immutable for this operation; save_usage serializes a
+        # fresh representation, so retaining this value cannot mutate the read.
+        merged[field] = values[0]
+
+    for field in _RECONCILE_COUNTER_FIELDS:
+        if any(field in record for record in records):
+            merged[field] = sum(record.get(field, 0) for record in records)
+
+    if any("created_at" in record for record in records):
+        merged["created_at"] = _reconcile_timestamp_result(
+            records, "created_at", minimum=True
+        )
+
+    for field in _RECONCILE_ACTIVITY_FIELDS:
+        if any(field in record for record in records):
+            merged[field] = _reconcile_timestamp_result(records, field)
+
+    if any("patch_generation" in record for record in records):
+        merged["patch_generation"] = max(
+            record.get("patch_generation", 0) for record in records
+        )
+    if any("last_reused_patch_generation" in record for record in records):
+        merged["last_reused_patch_generation"] = min(
+            max(record.get("last_reused_patch_generation", 0) for record in records),
+            merged.get("patch_generation", 0),
+        )
+
+    created_by_values = [
+        record["created_by"] for record in records if "created_by" in record
+    ]
+    if canonical in bundled_names or canonical in hub_names:
+        merged["created_by"] = "installed"
+    elif any(value == "agent" for value in created_by_values):
+        merged["created_by"] = "agent"
+    elif any(value == "installed" for value in created_by_values):
+        merged["created_by"] = "installed"
+    elif created_by_values:
+        first = created_by_values[0]
+        if any(not _reconcile_values_equal(first, value) for value in created_by_values[1:]):
+            raise UsageReconcileError("conflicting_created_by")
+        merged["created_by"] = first
+
+    if any("pinned" in record for record in records):
+        merged["pinned"] = any(record.get("pinned", False) for record in records)
+
+    if any("state" in record for record in records):
+        merged_state = max(
+            (record.get("state", STATE_ACTIVE) for record in records),
+            key=lambda state: _RECONCILE_STATE_PRIORITY[state],
+        )
+        merged["state"] = merged_state
+    else:
+        merged_state = STATE_ACTIVE
+
+    if any("archived_at" in record for record in records) or merged_state == STATE_ARCHIVED:
+        merged["archived_at"] = (
+            _reconcile_timestamp_result(records, "archived_at")
+            if merged_state == STATE_ARCHIVED
+            else None
+        )
+
+    if any("sync" in record for record in records):
+        merged["sync"] = any(record.get("sync", False) for record in records)
+
+    return merged
+
+
+def _reconcile_plan_counts(
+    data: Dict[str, Dict[str, Any]],
+    groups: List[Tuple[str, List[Tuple[str, Dict[str, Any]]]]],
+    skipped: Dict[str, int],
+) -> Dict[str, int]:
+    aliases = sum(
+        sum(1 for raw_key, _ in entries if raw_key != canonical)
+        for canonical, entries in groups
+    )
+    return {
+        "records": len(data),
+        "groups": len(groups),
+        "aliases": aliases,
+        "possible_conflicts": sum(
+            _reconcile_group_conflict_count([record for _, record in entries])
+            for _, entries in groups
+        ),
+        "skipped": sum(skipped.values()),
+    }
+
+
+def _open_private_backup_dir() -> Tuple[Path, int]:
+    """Open ``.usage_backups`` after rejecting symlinks and wrong types."""
+    skills_dir = _skills_dir()
+    try:
+        skills_stat = os.lstat(skills_dir)
+    except OSError:
+        raise UsageReconcileError("backup_directory_unavailable")
+    if stat.S_ISLNK(skills_stat.st_mode) or not stat.S_ISDIR(skills_stat.st_mode):
+        raise UsageReconcileError("backup_directory_type")
+
+    backup_dir = skills_dir / ".usage_backups"
+    try:
+        os.mkdir(backup_dir, 0o700)
+    except FileExistsError:
+        pass
+    except OSError:
+        raise UsageReconcileError("backup_directory_unavailable")
+
+    try:
+        backup_stat = os.lstat(backup_dir)
+    except OSError:
+        raise UsageReconcileError("backup_directory_unavailable")
+    if stat.S_ISLNK(backup_stat.st_mode) or not stat.S_ISDIR(backup_stat.st_mode):
+        raise UsageReconcileError("backup_directory_type")
+    try:
+        os.chmod(backup_dir, 0o700, follow_symlinks=False)
+    except (NotImplementedError, TypeError):  # pragma: no cover - Windows
+        os.chmod(backup_dir, 0o700)
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(backup_dir, flags)
+        opened_stat = os.fstat(fd)
+    except (OSError, ValueError):
+        raise UsageReconcileError("backup_directory_unavailable")
+    if stat.S_ISLNK(opened_stat.st_mode) or not stat.S_ISDIR(opened_stat.st_mode):
+        os.close(fd)
+        raise UsageReconcileError("backup_directory_type")
+    return backup_dir, fd
+
+
+def _create_usage_backup(raw: bytes) -> None:
+    """Create a collision-safe, byte-identical private sidecar backup."""
+    backup_dir, directory_fd = _open_private_backup_dir()
+    try:
+        for index in range(128):
+            suffix = "" if index == 0 else f"-{index}"
+            name = (
+                "usage-"
+                f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}-"
+                f"{secrets.token_hex(8)}{suffix}.json"
+            )
+            candidate = backup_dir / name
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            try:
+                fd = os.open(candidate, flags, 0o600)
+            except FileExistsError:
+                continue
+            try:
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, 0o600)
+                with os.fdopen(fd, "wb") as handle:
+                    fd = -1
+                    handle.write(raw)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                try:
+                    os.chmod(candidate, 0o600, follow_symlinks=False)
+                except (NotImplementedError, TypeError):  # pragma: no cover - Windows
+                    os.chmod(candidate, 0o600)
+                os.fsync(directory_fd)
+                return
+            except BaseException:
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                try:
+                    candidate.unlink()
+                except OSError:
+                    pass
+                raise UsageReconcileError("backup_failed")
+        raise UsageReconcileError("backup_collision")
+    finally:
+        try:
+            os.close(directory_fd)
+        except OSError:
+            pass
+
+
+def reconcile_usage_report() -> Dict[str, Any]:
+    """Build a sanitized, read-only alias reconciliation report.
+
+    Only keys that resolve to one local skill directory enter ``groups``.
+    Unknown, ambiguous, and registered-plugin keys remain untouched and are
+    represented only by disposition counts. The report contains no record
+    values, extension field names, or absolute paths.
+    """
+    data, present = _read_usage_strict_for_reconcile()
+    groups_by_name: Dict[str, List[Tuple[str, Dict[str, Any]]]] = {}
+    skipped = {reason: 0 for reason in _RECONCILE_SKIP_REASONS}
+
+    for raw_key, record in data.items():
+        canonical, disposition = _reconcile_alias_target(raw_key)
+        if disposition != "local":
+            skipped[disposition] += 1
+            continue
+        groups_by_name.setdefault(canonical, []).append((raw_key, record))
+
+    groups: List[Dict[str, Any]] = []
+    possible_conflicts = 0
+    alias_count = 0
+    for canonical in sorted(groups_by_name):
+        entries = groups_by_name[canonical]
+        noncanonical_entries = [
+            (raw_alias, record)
+            for raw_alias, record in entries
+            if raw_alias != canonical
+        ]
+        if not noncanonical_entries:
+            continue
+        safe_aliases: List[str] = []
+        for raw_alias, _ in sorted(noncanonical_entries, key=lambda item: item[0]):
+            safe_alias = _safe_reconcile_alias(raw_alias)
+            if safe_alias is not None:
+                safe_aliases.append(safe_alias)
+        conflict = _reconcile_group_conflict_count([record for _, record in entries])
+        possible_conflicts += conflict
+        alias_count += len(noncanonical_entries)
+        groups.append(
+            {
+                "canonical": canonical,
+                "aliases": safe_aliases,
+                "record_count": len(entries),
+                "possible_conflicts": conflict,
+            }
+        )
+
+    skipped_total = sum(skipped.values())
+    counts = {
+        "records": len(data),
+        "groups": len(groups),
+        "aliases": alias_count,
+        "possible_conflicts": possible_conflicts,
+        "skipped": skipped_total,
+    }
+    return {
+        "status": "clean" if not data else "ok",
+        "dry_run": True,
+        "source_present": present,
+        "counts": counts,
+        "groups": groups,
+        "skipped": skipped,
+        "possible_conflicts": possible_conflicts,
+    }
+
+
+def reconcile_usage_apply() -> Dict[str, Any]:
+    """Apply a freshly planned, fail-closed alias reconciliation.
+
+    The lock deliberately surrounds the strict byte read, planning, backup, and
+    save.  A report made before this function is only advisory; the apply path
+    always re-reads and re-plans the current sidecar before creating a backup.
+    """
+    try:
+        with _usage_file_lock():
+            raw, present = _strict_usage_bytes()
+            if not present:
+                return {
+                    "status": "clean",
+                    "dry_run": False,
+                    "source_present": False,
+                    "counts": {
+                        "records": 0,
+                        "groups": 0,
+                        "aliases": 0,
+                        "possible_conflicts": 0,
+                        "skipped": 0,
+                    },
+                    "skipped": {reason: 0 for reason in _RECONCILE_SKIP_REASONS},
+                }
+
+            data = _strict_parse_usage(raw)
+            # Validate skipped records too.  An apply must never silently carry
+            # a malformed known field forward while mutating another group.
+            for record in data.values():
+                _reconcile_validate_record(record)
+
+            groups, skipped = _reconcile_groups_for_data(data)
+            counts = _reconcile_plan_counts(data, groups, skipped)
+            if not groups:
+                # Unknown/ambiguous/plugin records are intentionally preserved;
+                # with no safe alias there is no mutation and no backup.
+                return {
+                    "status": "clean",
+                    "dry_run": False,
+                    "source_present": True,
+                    "counts": counts,
+                    "skipped": skipped,
+                }
+
+            bundled_names = _read_bundled_manifest_names()
+            hub_names = _read_hub_installed_names()
+            merged_by_canonical: Dict[str, Dict[str, Any]] = {}
+            for canonical, entries in groups:
+                merged_by_canonical[canonical] = _reconcile_merge_record(
+                    canonical,
+                    [record for _, record in entries],
+                    bundled_names=bundled_names,
+                    hub_names=hub_names,
+                )
+
+            replanned = dict(data)
+            for canonical, entries in groups:
+                for raw_key, _ in entries:
+                    if raw_key != canonical:
+                        replanned.pop(raw_key, None)
+                replanned[canonical] = merged_by_canonical[canonical]
+
+            # The backup is the exact byte sequence that was parsed and is made
+            # only after every group has passed validation/conflict checks.
+            _create_usage_backup(raw)
+            if not save_usage(replanned) and not _usage_commit_matches(replanned):
+                raise UsageReconcileError("save_failed")
+            return {
+                "status": "applied",
+                "dry_run": False,
+                "source_present": True,
+                "counts": counts,
+                "skipped": skipped,
+            }
+    except UsageReconcileError:
+        raise
+    except Exception:
+        # Keep the CLI boundary free of filesystem paths, values, and tracebacks.
+        raise UsageReconcileError("apply_failed")
+
+
 def curated_report() -> List[Dict[str, Any]]:
     """Return a list of {name, provenance, state, pinned, last_activity_at, ...}
     records for every curator-managed skill. Missing usage records are
@@ -1346,6 +2245,7 @@ def provenance(skill_name: str) -> str:
     'agent' covers both agent-authored and local manually-authored skills —
     anything not seeded from the bundled repo or installed via the hub.
     """
+    skill_name = _canonicalize_skill_name(skill_name)
     if is_hub_installed(skill_name):
         return "hub"
     if is_bundled(skill_name):


### PR DESCRIPTION
## What does this PR do?

Adds `hermes curator reconcile-usage` to reconcile historical skill-usage sidecar keys with canonical skill names read from skill frontmatter, without losing usage telemetry.

## Behavior

- Report/dry-run is the default and does not modify the usage sidecar.
- Writes require the explicit `--apply` switch.
- Apply creates a byte-identical private backup before replacing the sidecar, uses private backup directory/file modes (`0700`/`0600`), and is idempotent: a repeat apply is a no-op and does not create a second backup.
- Safe alias groups merge into the canonical frontmatter name.
- Unknown, ambiguous, and `plugin:` groups are preserved rather than guessed or collapsed.
- The implementation fixes four apply blockers: conflicting unknown fields, malformed/corrupt sidecars, a failed save that did not write, and conflicting unknown extension types. Empty-category discovery after the last skill is deleted is also covered.

## Validation

- The new coverage was developed RED-first and is now GREEN: 24 new tests pass.
- Current expanded regression selection: 98 tests pass.
- `ruff check` passes for all four changed paths.
- Python byte-compilation and `git diff --check` pass.
- `gitleaks git --log-opts='upstream/main..HEAD'` reports no leaks.
- No live `--apply` run was performed.

## Scope

Four paths changed: `hermes_cli/curator.py`, `tools/skill_usage.py`, and the two new reconciliation test modules. No unrelated changes are included.
