### PR TITLE
feat: add on-demand skill offer policy

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -33,6 +33,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_offer_hidden_skill_names,
     iter_skill_index_files,
     org_id_of_path,
     parse_frontmatter,
@@ -1969,6 +1970,7 @@ def _build_skills_system_prompt_inner(
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
+    offer_hidden = get_offer_hidden_skill_names()
     project_dirs = project_dirs or []
     cache_key = (
         str(skills_dir),
@@ -1978,6 +1980,7 @@ def _build_skills_system_prompt_inner(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        tuple(sorted(offer_hidden)),
         tuple(sorted(compact_categories or ())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
@@ -2006,7 +2009,12 @@ def _build_skills_system_prompt_inner(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform_list(platforms):
                 continue
-            if frontmatter_name in disabled or skill_name in disabled:
+            if (
+                frontmatter_name in disabled
+                or skill_name in disabled
+                or frontmatter_name in offer_hidden
+                or skill_name in offer_hidden
+            ):
                 continue
             if not _skill_should_show(
                 entry.get("conditions") or {},
@@ -2028,7 +2036,12 @@ def _build_skills_system_prompt_inner(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            if (
+                entry["frontmatter_name"] in disabled
+                or skill_name in disabled
+                or entry["frontmatter_name"] in offer_hidden
+                or skill_name in offer_hidden
+            ):
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -2059,7 +2072,12 @@ def _build_skills_system_prompt_inner(
                     fm_name = entry["frontmatter_name"]
                     if fm_name in project_names:
                         continue
-                    if fm_name in disabled or entry["skill_name"] in disabled:
+                    if (
+                        fm_name in disabled
+                        or entry["skill_name"] in disabled
+                        or fm_name in offer_hidden
+                        or entry["skill_name"] in offer_hidden
+                    ):
                         continue
                     if not _skill_should_show(
                         extract_skill_conditions(frontmatter),
@@ -2158,7 +2176,12 @@ def _build_skills_system_prompt_inner(
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
                     continue
-                if frontmatter_name in disabled or skill_name in disabled:
+                if (
+                    frontmatter_name in disabled
+                    or skill_name in disabled
+                    or frontmatter_name in offer_hidden
+                    or skill_name in offer_hidden
+                ):
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
+_skill_commands_offer_hidden: frozenset[str] = frozenset()
 # Guards the (map, platform-tag, home-tag) triple so publication and the
 # freshness lookup always see a consistent snapshot. Scanning itself stays
 # outside this lock.
@@ -428,6 +429,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform, _skill_commands_home
+    global _skill_commands_offer_hidden
     platform = _resolve_skill_commands_platform()
     home = _resolve_skill_commands_home()
     # Build into a local map and publish once, at the end. Writing straight
@@ -437,9 +439,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     # published slugs, logging one bogus "already claimed" warning per skill —
     # each naming the same skill as its own incumbent (#74574).
     commands: Dict[str, Dict[str, Any]] = {}
+    offer_hidden: set[str] = set()
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
+            get_offer_hidden_skill_names,
             get_external_skills_dirs,
             get_project_skills_dirs,
             iter_project_skill_files,
@@ -447,6 +451,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         )
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
+        offer_hidden = get_offer_hidden_skill_names()
         seen_names: set = set()
 
         # Scan project dirs first (highest precedence), then local, then external.
@@ -480,7 +485,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     if name in seen_names:
                         continue
                     # Respect user's disabled skills config
-                    if name in disabled:
+                    if name in disabled or name in offer_hidden:
                         continue
                     description = frontmatter.get('description', '')
                     if not description:
@@ -544,6 +549,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         _skill_commands = commands
         _skill_commands_platform = platform
         _skill_commands_home = home
+        _skill_commands_offer_hidden = frozenset(offer_hidden)
     return commands
 
 
@@ -558,6 +564,9 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     """
     current_platform = _resolve_skill_commands_platform()
     current_home = _resolve_skill_commands_home()
+    from agent.skill_utils import get_offer_hidden_skill_names
+
+    current_offer_hidden = frozenset(get_offer_hidden_skill_names())
     # Read the map and its tags under the same lock that publishes them, so
     # the freshness decision is made against a consistent snapshot.
     with _publish_lock:
@@ -566,6 +575,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
             bool(commands)
             and _skill_commands_platform == current_platform
             and _skill_commands_home == current_home
+            and _skill_commands_offer_hidden == current_offer_hidden
         )
     if is_fresh:
         return commands

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -483,6 +483,31 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     return global_disabled - ESSENTIAL_SKILLS
 
 
+def get_offer_hidden_skill_names() -> Set[str]:
+    """Return canonical skill names hidden from offer-time surfaces.
+
+    ``skills.offer_hidden`` is intentionally a strict list-of-strings
+    configuration value.  Malformed values fail safe by returning no hidden
+    names rather than accidentally hiding or blocking a skill.  This helper is
+    the single policy boundary used by prompts, listings, and slash commands;
+    explicit ``skill_view``, preload, and cron skill loading do not call it.
+    """
+    parsed = _load_raw_config()
+    if not parsed:
+        return set()
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    configured = skills_cfg.get("offer_hidden")
+    if not isinstance(configured, list) or any(
+        not isinstance(name, str) for name in configured
+    ):
+        return set()
+    return {name.strip() for name in configured if name.strip()}
+
+
 def parse_config_string_list(value) -> List[str]:
     """Normalize a config value that may hold a JSON-array string into a list.
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -983,6 +983,12 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Canonical skill names hidden from the default offer surfaces (prompt index,
+  # skills_list, and slash/autocomplete). Explicit skill_view, --skills preload,
+  # and cron skill loading remain available.
+  # offer_hidden:
+  #   - my-on-demand-skill
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2130,6 +2130,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Canonical skill names hidden from offer-time surfaces (prompt index,
+        # skills_list, and slash/autocomplete). Explicit skill_view, --skills
+        # preload, and cron skill loading remain available.
+        "offer_hidden": [],
         # Project-local skill discovery: when a session starts inside a git
         # checkout, ``<root>/.hermes/skills/`` and ``<root>/.agents/skills/``
         # are sourced as the highest-precedence skill tier — but ONLY when the

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -999,7 +999,10 @@ def do_list(source_filter: str = "all",
     from tools.skills_hub import HubLockFile, ensure_hub_dirs
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
-    from agent.skill_utils import get_disabled_skill_names
+    from agent.skill_utils import (
+        get_disabled_skill_names,
+        get_offer_hidden_skill_names,
+    )
 
     c = console or _console
     ensure_hub_dirs()
@@ -1010,6 +1013,7 @@ def do_list(source_filter: str = "all",
     # Pull ALL skills (including disabled ones) so we can annotate status.
     all_skills = _find_all_skills(skip_disabled=True)
     disabled_names = get_disabled_skill_names()
+    offer_hidden_names = get_offer_hidden_skill_names()
 
     title = "Installed Skills"
     if enabled_only:
@@ -1021,6 +1025,7 @@ def do_list(source_filter: str = "all",
     table.add_column("Source", style="dim")
     table.add_column("Trust", style="dim")
     table.add_column("Status", style="dim")
+    table.add_column("Offer", style="dim")
 
     hub_count = 0
     builtin_count = 0
@@ -1067,9 +1072,22 @@ def do_list(source_filter: str = "all",
             disabled_count += 1
             status_cell = "[dim red]disabled[/]"
 
+        offer_cell = (
+            "[yellow]on-demand[/]"
+            if name in offer_hidden_names
+            else "[dim]default[/]"
+        )
+
         trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow", "local": "dim"}.get(trust, "dim")
         trust_label = "official" if source_display == "official" else trust
-        table.add_row(name, category, source_display, f"[{trust_style}]{trust_label}[/]", status_cell)
+        table.add_row(
+            name,
+            category,
+            source_display,
+            f"[{trust_style}]{trust_label}[/]",
+            status_cell,
+            offer_cell,
+        )
 
     c.print(table)
     summary = f"[dim]{hub_count} hub-installed, {builtin_count} builtin, {local_count} local"

--- a/tests/skills/test_skills_offer_hidden.py
+++ b/tests/skills/test_skills_offer_hidden.py
@@ -1,0 +1,343 @@
+"""RED regressions for the ``skills.offer_hidden`` offer-time policy.
+
+The production feature is intentionally not implemented in this branch.  These
+regressions define the contract for a canonical-name list under
+``skills.offer_hidden``:
+
+* hidden skills disappear from offer surfaces (prompt index, ``skills_list``,
+  slash/autocomplete);
+* explicit ``skill_view`` and ``--skills`` preload remain usable;
+* ``skills.disabled`` remains a hard block;
+* caches notice config changes;
+* malformed ``offer_hidden`` values fail safe; and
+* the administrative installed-skill listing keeps hidden skills visible while
+  identifying them as on-demand.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+import agent.prompt_builder as prompt_builder
+import agent.skill_commands as skill_commands
+import agent.skill_utils as skill_utils
+import tools.skills_tool as skills_tool
+
+
+_MISSING = object()
+
+
+def _write_skill(
+    skills_dir: Path,
+    directory_name: str,
+    canonical_name: str,
+    *,
+    description: str | None = None,
+) -> Path:
+    skill_dir = skills_dir / directory_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    description = description or f"Description for {canonical_name}."
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {canonical_name}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        f"# {canonical_name}\n\n"
+        f"Instructions for {canonical_name}.\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_config(
+    home: Path,
+    *,
+    offer_hidden=_MISSING,
+    disabled=_MISSING,
+) -> None:
+    lines = ["skills:"]
+    if offer_hidden is not _MISSING:
+        if isinstance(offer_hidden, list):
+            lines.append("  offer_hidden:")
+            lines.extend(f"    - {name}" for name in offer_hidden)
+        else:
+            lines.append(f"  offer_hidden: {offer_hidden}")
+    if disabled is not _MISSING:
+        if isinstance(disabled, list):
+            lines.append("  disabled:")
+            lines.extend(f"    - {name}" for name in disabled)
+        else:
+            lines.append(f"  disabled: {disabled}")
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Keep this helper from making the raw-config cache, rather than the
+    # offer-hidden cache boundary, determine the result of a test mutation.
+    skill_utils._raw_config_cache_clear()
+
+
+@pytest.fixture()
+def isolated_skills(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+    # Keep every surface on the same small, profile-local tree.  In particular,
+    # do not let the checkout's project skills or the user's real profile enter
+    # these contract tests.
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skills_tool, "_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skill_utils, "get_project_skills_dirs", lambda: [])
+    monkeypatch.setattr(prompt_builder, "get_all_skills_dirs", lambda: [skills_dir])
+
+    skills_tool._SKILLS_CACHE.clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    skill_utils._raw_config_cache_clear()
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_commands, "_skill_commands_home", None)
+
+    yield home, skills_dir
+
+    skills_tool._SKILLS_CACHE.clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    skill_utils._raw_config_cache_clear()
+
+
+def _names_from_skills_list(raw: str) -> set[str]:
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    return {entry["name"] for entry in payload["skills"]}
+
+
+def test_offer_hidden_excludes_canonical_name_from_system_prompt_index(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_skill(skills_dir, "visible-dir", "visible-skill")
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    prompt = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+
+    assert "visible-skill" in prompt
+    assert "hidden-canonical" not in prompt
+
+
+def test_offer_hidden_excludes_canonical_name_from_skills_list_tool(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_skill(skills_dir, "visible-dir", "visible-skill")
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    offered_names = _names_from_skills_list(skills_tool.skills_list())
+
+    assert "visible-skill" in offered_names
+    assert "hidden-canonical" not in offered_names
+
+
+def test_offer_hidden_excludes_canonical_name_from_slash_and_autocomplete(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_skill(skills_dir, "visible-dir", "visible-skill")
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    commands = skill_commands.scan_skill_commands()
+    autocomplete_commands = skill_commands.get_skill_commands()
+
+    assert "/visible-skill" in commands
+    assert "/hidden-canonical" not in commands
+    assert "/visible-skill" in autocomplete_commands
+    assert "/hidden-canonical" not in autocomplete_commands
+
+
+def test_offer_hidden_only_changes_offers_explicit_view_and_preload_still_work(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    commands = skill_commands.scan_skill_commands()
+    viewed = json.loads(skills_tool.skill_view("hidden-canonical"))
+    preloaded_prompt, loaded_names, missing = skill_commands.build_preloaded_skills_prompt(
+        ["hidden-canonical"]
+    )
+
+    assert "/hidden-canonical" not in commands
+    assert viewed["success"] is True
+    assert "Instructions for hidden-canonical." in viewed["content"]
+    assert loaded_names == ["hidden-canonical"]
+    assert missing == []
+    assert "hidden-canonical" in preloaded_prompt
+
+
+def test_skills_disabled_remains_hard_block_even_when_offer_hidden_is_set(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(
+        home,
+        offer_hidden=["hidden-canonical"],
+        disabled=["hidden-canonical"],
+    )
+
+    prompt = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+    offered_names = _names_from_skills_list(skills_tool.skills_list())
+    commands = skill_commands.scan_skill_commands()
+    viewed = json.loads(skills_tool.skill_view("hidden-canonical"))
+    _preloaded_prompt, loaded_names, missing = skill_commands.build_preloaded_skills_prompt(
+        ["hidden-canonical"]
+    )
+
+    assert "hidden-canonical" not in prompt
+    assert "hidden-canonical" not in offered_names
+    assert "/hidden-canonical" not in commands
+    assert viewed["success"] is False
+    assert "disabled" in viewed["error"].lower()
+    assert loaded_names == []
+    assert missing == ["hidden-canonical"]
+
+
+def test_offer_hidden_config_change_invalidates_system_prompt_cache(
+    isolated_skills,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(home, offer_hidden=[])
+
+    before = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+    assert "hidden-canonical" in before
+
+    _write_config(home, offer_hidden=["hidden-canonical"])
+    after = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+
+    assert "hidden-canonical" not in after
+
+
+def test_offer_hidden_config_change_invalidates_slash_cache(isolated_skills):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(home, offer_hidden=[])
+
+    before = skill_commands.get_skill_commands()
+    assert "/hidden-canonical" in before
+
+    _write_config(home, offer_hidden=["hidden-canonical"])
+    after = skill_commands.get_skill_commands()
+
+    assert "/hidden-canonical" not in after
+
+
+def test_offer_hidden_config_change_invalidates_skills_list_cache(isolated_skills):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(home, offer_hidden=[])
+
+    before = _names_from_skills_list(skills_tool.skills_list())
+    assert "hidden-canonical" in before
+
+    _write_config(home, offer_hidden=["hidden-canonical"])
+    after = _names_from_skills_list(skills_tool.skills_list())
+
+    assert "hidden-canonical" not in after
+
+
+@pytest.mark.parametrize(
+    "malformed_value",
+    [
+        "hidden-canonical",
+        "{unexpected: value}",
+        "42",
+    ],
+)
+def test_malformed_offer_hidden_fails_safe_without_hiding_skills(
+    isolated_skills,
+    malformed_value,
+):
+    home, skills_dir = isolated_skills
+    _write_skill(skills_dir, "alias-hidden", "hidden-canonical")
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    hidden_prompt = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+    assert "hidden-canonical" not in hidden_prompt
+
+    _write_config(home, offer_hidden=malformed_value)
+    restored_prompt = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=skills_dir,
+    )
+    restored_names = _names_from_skills_list(skills_tool.skills_list())
+    restored_commands = skill_commands.get_skill_commands()
+
+    assert "hidden-canonical" in restored_prompt
+    assert "hidden-canonical" in restored_names
+    assert "/hidden-canonical" in restored_commands
+
+
+def test_admin_list_keeps_installed_offer_hidden_skill_and_marks_on_demand(
+    isolated_skills,
+    monkeypatch,
+):
+    home, _skills_dir = isolated_skills
+    _write_config(home, offer_hidden=["hidden-canonical"])
+
+    import hermes_cli.skills_hub as cli_hub
+    import tools.skills_hub as tools_hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool_module
+
+    installed = [
+        {
+            "name": "hidden-canonical",
+            "category": "optional",
+            "description": "Only offered on demand.",
+        },
+        {
+            "name": "visible-skill",
+            "category": "core",
+            "description": "Shown by default.",
+        },
+    ]
+    monkeypatch.setattr(tools_hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(
+        tools_hub,
+        "HubLockFile",
+        lambda: type("Lock", (), {"list_installed": lambda self: []})(),
+    )
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+    monkeypatch.setattr(
+        skills_tool_module,
+        "_find_all_skills",
+        lambda **_kwargs: list(installed),
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+    cli_hub.do_list(console=console)
+    output = sink.getvalue().lower()
+
+    assert "hidden-canonical" in output
+    assert "visible-skill" in output
+    assert "on-demand" in output

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -83,6 +83,7 @@ from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    get_offer_hidden_skill_names as _get_offer_hidden_skill_names,
     is_skill_support_path as _is_skill_support_path,
 )
 
@@ -104,7 +105,7 @@ _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
 _SKILLS_CACHE_KEY_FILTERED = "filtered"
 
 
-def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
+def _skills_scan_signature(dirs_to_scan, disabled, offer_hidden=()) -> tuple:
     """Cheap change-signature for the skill scan inputs.
 
     O(#dirs + #categories) stat calls, not a recursive walk. Includes the
@@ -134,7 +135,7 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
         except OSError:
             pass
         sig.append((str(d), m))
-    return (tuple(sig), frozenset(disabled), platform)
+    return (tuple(sig), frozenset(disabled), frozenset(offer_hidden), platform)
 
 
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
@@ -711,6 +712,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
     disabled = set() if skip_disabled else _get_disabled_skill_names()
+    offer_hidden = set() if skip_disabled else _get_offer_hidden_skill_names()
 
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
@@ -724,7 +726,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         dirs_to_scan.append(active_skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    signature = _skills_scan_signature(dirs_to_scan, disabled, offer_hidden)
     now = time.monotonic()
 
     cached = _SKILLS_CACHE.get(cache_key)
@@ -770,7 +772,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
-                if name in disabled:
+                if name in disabled or name in offer_hidden:
                     continue
 
                 description = frontmatter.get("description", "")
@@ -836,6 +838,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
         # Find all skills
         all_skills = _find_all_skills()
+        offer_hidden = _get_offer_hidden_skill_names()
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
@@ -844,7 +847,10 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 frontmatter = plugin_skill.pop("frontmatter", {})
                 if not skill_matches_platform(frontmatter):
                     continue
-                if _is_skill_disabled(plugin_skill["name"]):
+                if (
+                    plugin_skill["name"] in offer_hidden
+                    or _is_skill_disabled(plugin_skill["name"])
+                ):
                     continue
                 all_skills.append(plugin_skill)
         except Exception:


### PR DESCRIPTION
## What does this PR do?

Adds the `skills.offer_hidden` on-demand policy. The setting is a list of canonical skill names that are hidden from offer surfaces without removing the skills or changing their names.

Offer surfaces filtered by this policy:

- the system-prompt skill index;
- the `skills_list` tool;
- slash-command discovery and autocomplete.

The contract intentionally preserves explicit access: `skill_view`, explicit `--skills` preloads, and cron `skills:` preloads continue to work. `skills.disabled` remains a hard block and takes precedence. Malformed `offer_hidden` values fail safe without hiding skills, and the prompt/slash/list caches observe config changes. The CLI administrative installed-skill listing keeps on-demand skills visible and labels them `on-demand`.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added canonical-name `offer_hidden` config handling and cache boundaries.
- Applied the policy to prompt, slash/autocomplete, and `skills_list` offer paths.
- Preserved explicit view/preload/cron paths and the `skills.disabled` hard block.
- Marked hidden installed skills as `on-demand` in the CLI administrative listing.
- Added the focused regression matrix in `tests/skills/test_skills_offer_hidden.py`.

## Verification (offline; no live)

- **RED on current base** `02c7ae956e42891d5e337a921b45de0a6067146d`: 12 regression cases ran; 1 passed and 11 failed on the expected missing-policy assertions.
- **GREEN on head** `a4c32e6a7a72d4b8aff056f956f831344b9733fe`: 12/12 new regression cases passed.
- **Affected suites:** 9 files, 189 passed, 1 skipped.
- `git diff --check` and commit check: passed.
- Python `py_compile`: passed for all changed Python files.
- `cli-config.yaml.example` YAML parse: passed.
- `gitleaks` over the commit range: no leaks found.
- Current base: `02c7ae956e42891d5e337a921b45de0a6067146d`.
- Current head: `a4c32e6a7a72d4b8aff056f956f831344b9733fe`.

No live install, restart, runtime canary, merge, or other live operation was performed.
