### PR TITLE
fix(bluebubbles): stop .env credentials from disabling YAML mention gating

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2539,7 +2539,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "webhook_path": getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
             "send_read_receipts": is_truthy_value(getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true")),
         })
-        bluebubbles_require_mention = getenv("BLUEBUBBLES_REQUIRE_MENTION")
+        # ``getenv`` is ``_getenv_str``, which returns "" (not None) for an
+        # unset variable. Using it here made the ``is not None`` guard always
+        # true, so simply having BLUEBUBBLES_SERVER_URL/PASSWORD in .env
+        # overwrote an explicit ``require_mention: true`` from config.yaml
+        # with False. Read through ``_getenv`` so an unset variable stays None
+        # and the YAML value survives.
+        bluebubbles_require_mention = _getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:
             config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] = (
                 bluebubbles_require_mention.lower() in {"true", "1", "yes", "on"}

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -43,6 +43,54 @@ class TestBlueBubblesConfigLoading:
         assert bc.extra["require_mention"] is True
         assert bc.extra["mention_patterns"] == ["(?i)^amos\\b"]
 
+    def test_env_credentials_do_not_disable_yaml_mention_gating(self, monkeypatch):
+        """Credentials in .env must not clobber require_mention from config.yaml.
+
+        ``getenv`` inside ``_apply_env_overrides`` is ``_getenv_str``, which
+        returns "" rather than None for an unset variable. That made the
+        ``is not None`` guard always true, so merely having
+        BLUEBUBBLES_SERVER_URL/PASSWORD in .env silently rewrote an explicit
+        ``require_mention: true`` to False and the bot answered every message
+        in every group chat.
+        """
+        monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+        monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+        monkeypatch.delenv("BLUEBUBBLES_REQUIRE_MENTION", raising=False)
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig(
+            platforms={
+                Platform.BLUEBUBBLES: PlatformConfig(
+                    enabled=True,
+                    extra={"require_mention": True},
+                )
+            }
+        )
+
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] is True
+
+    def test_env_still_overrides_yaml_when_explicitly_set(self, monkeypatch):
+        """The env var keeps precedence when the user actually sets it."""
+        monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+        monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+        monkeypatch.setenv("BLUEBUBBLES_REQUIRE_MENTION", "false")
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig(
+            platforms={
+                Platform.BLUEBUBBLES: PlatformConfig(
+                    enabled=True,
+                    extra={"require_mention": True},
+                )
+            }
+        )
+
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.BLUEBUBBLES].extra["require_mention"] is False
+
 
 class TestBlueBubblesHelpers:
     def test_check_requirements(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a config-precedence bug where simply having BlueBubbles **credentials** in `.env` silently disables mention gating that the user explicitly enabled in `config.yaml` — so the bot replies to **every message in every group chat** instead of only when mentioned.

`_apply_env_overrides()` aliases `getenv = _getenv_str` (`gateway/config.py:1970`), and `_getenv_str` returns `""` rather than `None` for an unset variable. The BlueBubbles branch guarded on `is not None`:

```python
bluebubbles_require_mention = getenv("BLUEBUBBLES_REQUIRE_MENTION")
if bluebubbles_require_mention is not None:          # always true: "" is not None
    ...extra["require_mention"] = (... in {"true","1","yes","on"})   # "" -> False
```

The guard was always true, so an unset `BLUEBUBBLES_REQUIRE_MENTION` resolved to `""` → `False` and overwrote the YAML value.

Note the branch is only entered when `BLUEBUBBLES_SERVER_URL` **and** `BLUEBUBBLES_PASSWORD` are set — i.e. every working BlueBubbles install configured via `.env`, which is the documented setup path. So this triggers on a normal configuration, not an exotic one.

The fix reads through `_getenv`, which returns `None` when unset. YAML survives; an explicitly set env var still wins.

### Scope

I checked whether this is a wider bug class. `is not None` guards fed by the `_getenv_str` alias in `gateway/config.py`:

```
2542-  bluebubbles_require_mention = getenv("BLUEBUBBLES_REQUIRE_MENTION")
2543:  if bluebubbles_require_mention is not None:
```

This is the only one. The other ~40 `getenv(...)` calls in `_apply_env_overrides` are truthiness checks (`if token:`) or carry explicit defaults, where the `""`-vs-`None` distinction is harmless. One-line fix, no sibling call paths to sweep.

## Related Issue

No existing issue — found while debugging why a `require_mention: true` group setting had no effect.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py` — read `BLUEBUBBLES_REQUIRE_MENTION` via `_getenv` instead of the `_getenv_str` alias, with a comment explaining the `""`-vs-`None` trap.
- `tests/gateway/test_bluebubbles.py` — two regression tests:
  - `test_env_credentials_do_not_disable_yaml_mention_gating` — credentials present, `BLUEBUBBLES_REQUIRE_MENTION` unset → YAML `require_mention: true` survives.
  - `test_env_still_overrides_yaml_when_explicitly_set` — env var set to `false` → still wins over YAML `true` (guards against over-correcting into "YAML always wins").

## How to Test

Reproduce on `main` (no config files needed):

```python
import os
os.environ["BLUEBUBBLES_SERVER_URL"] = "http://localhost:1234"
os.environ["BLUEBUBBLES_PASSWORD"] = "secret"
os.environ.pop("BLUEBUBBLES_REQUIRE_MENTION", None)

from gateway.config import GatewayConfig, PlatformConfig, Platform, _apply_env_overrides

config = GatewayConfig(platforms={
    Platform.BLUEBUBBLES: PlatformConfig(enabled=True, extra={"require_mention": True})
})
_apply_env_overrides(config)
print(config.platforms[Platform.BLUEBUBBLES].extra["require_mention"])
```

- Before: `False` ← YAML silently discarded
- After: `True`

Test suite:

```bash
pytest tests/gateway/test_bluebubbles.py -q          # 21 passed
pytest tests/gateway/ -k "config or bluebubbles or authz or multiplex" -q   # 637 passed, 1 skipped
```

I also verified the new test genuinely catches the bug: reverting the one-line fix makes `test_env_credentials_do_not_disable_yaml_mention_gating` fail, and restoring it makes it pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config keys changed; this restores the already-documented behaviour)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure config-resolution logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A
