### PR TITLE
docs(windows): correct gateway Scheduled Task name and launch mechanism (#94941)

### DIFF
--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -177,10 +177,10 @@ hermes gateway install
 What happens under the hood:
 
 1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN Hermes_Gateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt. (Named profiles register `Hermes_Gateway_<profile>`.)
-2. If schtasks is blocked by group policy, falls back to writing a small `Hermes_Gateway.vbs` launcher (run hidden via `wscript.exe`) into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same effect, slightly cruder. A VBScript is used rather than a `cmd.exe` shortcut because a console allocated at logon can receive a close event that kills the gateway before it finishes starting.
+2. If schtasks is blocked by group policy, falls back to persisting the **same** console-less `<task-name>.vbs` launcher — chained through `wscript.exe` exactly as in step 3 — as a Startup-folder entry under `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same hidden-console mechanism, just triggered on login by the Startup folder instead of a Scheduled Task (the old `cmd.exe` shortcut is gone).
 3. Spawns the gateway by running a hidden-console `.vbs` launcher through **`wscript.exe`** — not `cmd.exe`, and not `pythonw.exe`. `wscript.exe` is a GUI-subsystem executable with no console, so it receives no console control events; it launches the console `python.exe` with a hidden window (style 0) that the gateway and all its console-subsystem descendants inherit, so nothing ever flashes. Immunity to `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` broadcasts from sibling processes then comes from the gateway process itself, independent of which interpreter binary is used: the launcher sets `HERMES_GATEWAY_DETACHED=1`, and the gateway responds by calling the native `SetConsoleCtrlHandler(NULL, TRUE)` to ignore console control signals.
 
-Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
+Flags used when the CLI spawns the gateway process **directly** — an immediate `hermes gateway start`, not the Scheduled Task / Startup-folder path, which route through `wscript.exe` as described above: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
 
 ### Manage
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -176,9 +176,9 @@ hermes gateway install
 
 What happens under the hood:
 
-1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN Hermes_Gateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt.
+1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN Hermes_Gateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt. (Named profiles register `Hermes_Gateway_<profile>`.)
 2. If schtasks is blocked by group policy, falls back to writing a small `Hermes_Gateway.vbs` launcher (run hidden via `wscript.exe`) into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same effect, slightly cruder. A VBScript is used rather than a `cmd.exe` shortcut because a console allocated at logon can receive a close event that kills the gateway before it finishes starting.
-3. Spawns the gateway **detached via `pythonw.exe`** — not `python.exe`. `pythonw.exe` has no console attached, which immunizes it against `CTRL_C_EVENT` broadcasts from sibling processes (a real issue that used to kill the gateway when you Ctrl+C'd anything in the same process group).
+3. Spawns the gateway by running a hidden-console `.vbs` launcher through **`wscript.exe`** — not `cmd.exe`, and not `pythonw.exe`. `wscript.exe` is a GUI-subsystem executable with no console, so it receives no console control events; it launches the console `python.exe` with a hidden window (style 0) that the gateway and all its console-subsystem descendants inherit, so nothing ever flashes. Immunity to `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` broadcasts from sibling processes then comes from the gateway process itself, independent of which interpreter binary is used: the launcher sets `HERMES_GATEWAY_DETACHED=1`, and the gateway responds by calling the native `SetConsoleCtrlHandler(NULL, TRUE)` to ignore console control signals.
 
 Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
 


### PR DESCRIPTION
## What does this PR do?

Corrects two verified factual errors in the Windows native autostart docs (`website/docs/user-guide/windows-native.md`), reported in #94941.

### 1. Scheduled Task name
The doc named the task `HermesGateway`, but the installer registers **`Hermes_Gateway`** (and `Hermes_Gateway_<profile>` for named profiles):

- `hermes_cli/gateway_windows.py`: `_TASK_NAME_DEFAULT = "Hermes_Gateway"`, `get_task_name()` → `Hermes_Gateway` / `Hermes_Gateway_<profile>`.
- `hermes_cli/gateway.py:1879-1886` explicitly warns never to hardcode `HermesGateway` because the real name is `Hermes_Gateway`.

So the install walkthrough's `/TN HermesGateway` and the troubleshooting `schtasks /Query /TN HermesGateway` both find nothing on a real install. Fixed both.

### 2. Launch mechanism / signal immunity
The doc said the gateway is spawned **detached via `pythonw.exe`** and attributed `CTRL_C_EVENT` immunity to pythonw's lack of a console. That's the *previous, rejected* approach. The current launcher (`_build_gateway_vbs_script` in `gateway_windows.py`):

- runs a hidden-console `.vbs` through **`wscript.exe`** (GUI-subsystem, no console → receives no console control events), which launches the console **`python.exe`** with a hidden window (style 0) — the docstring explicitly contrasts this with "the previous console-less pythonw.exe gateway";
- real immunity to `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` comes from the gateway setting `HERMES_GATEWAY_DETACHED=1` → native `SetConsoleCtrlHandler(NULL, TRUE)` (`gateway.py:5871-5910`), independent of the interpreter binary.

Rewrote paragraph 3 to describe the actual mechanism (the doc's *conclusion* — that the gateway is immune to sibling console-control broadcasts — was already correct; only the named mechanism was wrong).

## Scope
Docs-only; no code change. The issue also suggests a Windows `hermes doctor` Gateway-Service check (`doctor.py`); that's a separate, testable-on-Windows feature and is intentionally left out of this docs-only PR.

Fixes #94941