### PR TITLE
feat(bluebubbles): honor reply_prefix so agent replies are identifiable

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -166,6 +166,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    # Empty by default: iMessage threads are personal and most users do not
+    # want a banner on every reply. Opt in via config.yaml `reply_prefix` or
+    # BLUEBUBBLES_REPLY_PREFIX.
+    DEFAULT_REPLY_PREFIX: str = ""
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
@@ -193,6 +197,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if _require_mention is None:
             _require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
         self.require_mention = str(_require_mention).strip().lower() in {"true", "1", "yes", "on"}
+        # Prefix prepended to every outbound bubble so users can tell agent
+        # replies apart in a shared thread. None means "not configured", which
+        # is distinct from "" (explicitly configured to no prefix).
+        _reply_prefix = extra.get("reply_prefix")
+        if _reply_prefix is None:
+            _reply_prefix = os.getenv("BLUEBUBBLES_REPLY_PREFIX")
+        self._reply_prefix: Optional[str] = _reply_prefix
         self._mention_patterns = self._compile_mention_patterns(
             extra["mention_patterns"]
             if "mention_patterns" in extra
@@ -532,6 +543,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chunks = BasePlatformAdapter.truncate_message(content, max_length)
         return [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
 
+    def _effective_reply_prefix(self) -> str:
+        """Prefix prepended to each outbound bubble ("" disables it).
+
+        Mirrors the WhatsApp adapter's contract: ``\\n`` in the configured
+        value is treated as a newline so a multi-line banner can be expressed
+        in a single .env line.
+        """
+        if self._reply_prefix is not None:
+            return self._reply_prefix.replace("\\n", "\n")
+        return self.DEFAULT_REPLY_PREFIX
+
+    def _outgoing_chunk_limit(self) -> int:
+        """Reserve room for the reply prefix so the final message still fits."""
+        prefix_len = len(self._effective_reply_prefix())
+        if prefix_len:
+            prefix_len += 1  # the space joining prefix and body
+        # Keep a floor so a pathologically long prefix cannot drive the limit
+        # to zero and stall chunking.
+        return max(512, self.MAX_MESSAGE_LENGTH - prefix_len)
+
     async def send(
         self,
         chat_id: str,
@@ -542,18 +573,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         text = self.format_message(content)
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
+        prefix = self._effective_reply_prefix()
+        chunk_limit = self._outgoing_chunk_limit()
         # Split on paragraph breaks first (double newlines) so each thought
         # becomes its own iMessage bubble, then truncate any that are still
         # too long.
         paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
         chunks: List[str] = []
         for para in (paragraphs or [text]):
-            if len(para) <= self.MAX_MESSAGE_LENGTH:
+            if len(para) <= chunk_limit:
                 chunks.append(para)
             else:
-                chunks.extend(self.truncate_message(para, max_length=self.MAX_MESSAGE_LENGTH))
+                chunks.extend(self.truncate_message(para, max_length=chunk_limit))
         last = SendResult(success=True)
         for chunk in chunks:
+            if prefix:
+                chunk = f"{prefix} {chunk}"
             guid = await self._resolve_chat_guid(chat_id)
             if not guid:
                 # If the target looks like an address, try creating a new chat

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -479,3 +479,109 @@ class TestBlueBubblesWebhookRegistration:
         assert len(deleted_ids) == 2
 
 
+
+
+class TestBlueBubblesReplyPrefix:
+    @staticmethod
+    def _wire(adapter, monkeypatch):
+        """Capture outbound payloads instead of hitting the REST API."""
+        payloads = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "any;+;family-group"
+
+        async def fake_api_post(path, payload):
+            assert path == "/api/v1/message/text"
+            payloads.append(payload)
+            return {"data": {"guid": f"reply-{len(payloads)}"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        return payloads
+
+    @pytest.mark.asyncio
+    async def test_no_prefix_by_default(self, monkeypatch):
+        """Default behaviour is unchanged: no prefix is added."""
+        monkeypatch.delenv("BLUEBUBBLES_REPLY_PREFIX", raising=False)
+        adapter = _make_adapter(monkeypatch)
+        payloads = self._wire(adapter, monkeypatch)
+
+        result = await adapter.send("any;+;family-group", "First para\n\nSecond para")
+
+        assert result.success is True
+        assert [p["message"] for p in payloads] == ["First para", "Second para"]
+
+    @pytest.mark.asyncio
+    async def test_prefix_from_config_applies_to_every_bubble(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_REPLY_PREFIX", raising=False)
+        adapter = _make_adapter(monkeypatch, reply_prefix="[bot]")
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "First para\n\nSecond para")
+
+        assert [p["message"] for p in payloads] == [
+            "[bot] First para",
+            "[bot] Second para",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_prefix_from_env(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_REPLY_PREFIX", "[env]")
+        adapter = _make_adapter(monkeypatch)
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "Hello")
+
+        assert [p["message"] for p in payloads] == ["[env] Hello"]
+
+    @pytest.mark.asyncio
+    async def test_config_takes_precedence_over_env(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_REPLY_PREFIX", "[env]")
+        adapter = _make_adapter(monkeypatch, reply_prefix="[yaml]")
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "Hello")
+
+        assert [p["message"] for p in payloads] == ["[yaml] Hello"]
+
+    @pytest.mark.asyncio
+    async def test_empty_string_disables_prefix(self, monkeypatch):
+        """"" is 'explicitly no prefix', distinct from unset."""
+        monkeypatch.setenv("BLUEBUBBLES_REPLY_PREFIX", "[env]")
+        adapter = _make_adapter(monkeypatch, reply_prefix="")
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "Hello")
+
+        assert [p["message"] for p in payloads] == ["Hello"]
+
+    @pytest.mark.asyncio
+    async def test_escaped_newline_becomes_real_newline(self, monkeypatch):
+        """Matches the WhatsApp contract so a banner fits on one .env line."""
+        monkeypatch.delenv("BLUEBUBBLES_REPLY_PREFIX", raising=False)
+        adapter = _make_adapter(monkeypatch, reply_prefix="line1\\nline2")
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "Body")
+
+        assert [p["message"] for p in payloads] == ["line1\nline2 Body"]
+
+    @pytest.mark.asyncio
+    async def test_prefixed_chunks_stay_within_message_limit(self, monkeypatch):
+        """The chunk budget reserves room for the prefix."""
+        monkeypatch.delenv("BLUEBUBBLES_REPLY_PREFIX", raising=False)
+        adapter = _make_adapter(monkeypatch, reply_prefix="[bot]")
+        payloads = self._wire(adapter, monkeypatch)
+
+        await adapter.send("any;+;family-group", "x" * 9000)
+
+        assert payloads
+        for payload in payloads:
+            assert len(payload["message"]) <= adapter.MAX_MESSAGE_LENGTH
+
+    def test_absurdly_long_prefix_keeps_a_usable_chunk_budget(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_REPLY_PREFIX", raising=False)
+        adapter = _make_adapter(monkeypatch, reply_prefix="p" * 10_000)
+
+        assert adapter._outgoing_chunk_limit() >= 512
+

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -63,6 +63,27 @@ platforms:
         - '(?<![\w@])@?amos\b[,:\-]?'
 ```
 
+#### Optional: Prefix agent replies
+
+In a shared iMessage thread it can be hard to tell an agent reply from a person's message, because everything Hermes sends appears as your own blue bubble. Set a `reply_prefix` to mark them:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      reply_prefix: "🤖"
+```
+
+Or in `~/.hermes/.env`:
+
+```bash
+BLUEBUBBLES_REPLY_PREFIX=🤖
+```
+
+The prefix is prepended to **every** outbound bubble, separated by a space. `config.yaml` wins over the environment variable. A literal `\n` becomes a newline, so a multi-line banner fits on one `.env` line (same convention as WhatsApp's `reply_prefix`).
+
+No prefix is added by default. Set it to an empty string to explicitly disable it.
+
 ### 4. Authorize Users
 
 Choose one approach:


### PR DESCRIPTION
## What does this PR do?

Makes BlueBubbles honor the shared `reply_prefix` config key, so agent replies can be visually distinguished in an iMessage thread.

Everything Hermes sends over BlueBubbles arrives as the **account owner's own blue bubble**. In a shared family/team thread there is no way to tell "the agent answered" from "the owner typed this" — unlike Telegram or Slack, iMessage exposes no separate bot identity.

`gateway/config.py:1698` already bridges `reply_prefix` from `config.yaml` into `PlatformConfig.extra` for **every** platform, and the WhatsApp adapters consume it (`whatsapp_common.py:_effective_reply_prefix`). BlueBubbles just ignored it, so the key silently did nothing there.

This wires it up following the existing WhatsApp contract rather than inventing a new shape:

- `_effective_reply_prefix()` — resolves `extra["reply_prefix"]` → `BLUEBUBBLES_REPLY_PREFIX` → `DEFAULT_REPLY_PREFIX`
- `\n` in the configured value expands to a real newline (so a multi-line banner fits on one `.env` line)
- `_outgoing_chunk_limit()` — reserves room for the prefix so a prefixed bubble can't exceed `MAX_MESSAGE_LENGTH`, with a floor so a pathologically long prefix can't drive the budget to zero

### Backward compatibility

`DEFAULT_REPLY_PREFIX = ""` for BlueBubbles (unlike WhatsApp's banner), so **default behavior is byte-identical** — no prefix unless the user opts in. `None` (unset) stays distinct from `""` (explicitly no prefix), so an empty string disables an inherited value.

Since `_shared_loop_targets` is `list(Platform)`, the YAML bridge already covers BlueBubbles — no `gateway/config.py` change needed.

I also checked the `_create_chat_for_handle` fallback (first message to a new address): it receives the already-prefixed `chunk`, so that path is covered rather than silently unprefixed.

## Related Issue

Related to #30656 (same request for Signal — still open). This PR only covers BlueBubbles; happy to follow up for Signal if the approach looks right.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/bluebubbles.py`
  - `DEFAULT_REPLY_PREFIX: str = ""` class attribute
  - parse `reply_prefix` from `extra`, falling back to `BLUEBUBBLES_REPLY_PREFIX`
  - `_effective_reply_prefix()` / `_outgoing_chunk_limit()` helpers
  - `send()` prefixes each bubble and chunks against the reserved budget
- `tests/gateway/test_bluebubbles.py` — `TestBlueBubblesReplyPrefix` (8 tests)
- `website/docs/user-guide/messaging/bluebubbles.md` — documents the option

## How to Test

```yaml
platforms:
  bluebubbles:
    extra:
      reply_prefix: "🤖"
```

Every outbound bubble becomes `🤖 <text>`. Multi-paragraph replies get the prefix on **each** bubble.

```bash
pytest tests/gateway/test_bluebubbles.py -q                                   # 27 passed
pytest tests/gateway/ -k "bluebubbles or config or authz or send_message" -q   # 504 passed, 1 skipped
pytest tests/tools/ -k "send_message or bluebubbles" -q                       # 62 passed, 1 skipped
```

Behaviours covered by the new tests:

| Case | Expected |
|---|---|
| no config | no prefix (unchanged) |
| `reply_prefix` in `extra` | applied to every bubble |
| `BLUEBUBBLES_REPLY_PREFIX` | applied |
| both set | `config.yaml` wins |
| `reply_prefix: ""` | explicitly disabled |
| `"line1\nline2"` | real newline |
| 9000-char message | no chunk exceeds `MAX_MESSAGE_LENGTH` |
| 10000-char prefix | chunk budget stays ≥ 512 |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/bluebubbles.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (the file has no BlueBubbles block; `reply_prefix` is an existing shared key, not a new one)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (BlueBubbles is macOS-only by nature; no OS-specific code paths touched)
- [x] I've updated tool descriptions/schemas — N/A
