### PR TITLE
fix(hindsight): flatten retained conversation messages

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -500,6 +500,18 @@ def _normalize_retain_tags(value: Any) -> List[str]:
     return normalized
 
 
+def _serialize_conversation_turns(turns: list[list[dict[str, str]]]) -> str:
+    """Serialize buffered user/assistant pairs as one flat conversation.
+
+    Hindsight recognizes a JSON array of message objects as structured
+    conversation input. Keeping each pair as a nested array instead produces
+    ``[[user, assistant], ...]``; that misses Hindsight's conversation parser
+    and prevents append mode from merging successive JSON arrays.
+    """
+    messages = [message for turn in turns for message in turn]
+    return json.dumps(messages, ensure_ascii=False)
+
+
 _OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations"}
 
 
@@ -857,7 +869,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_retain_drain_timeout = 10.0
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
-        self._session_turns: list[str] = []  # accumulates ALL turns for the session
+        self._session_turns: list[list[dict[str, str]]] = []
+        # Accumulates all user/assistant pairs for the session.
         # How many turns the last append-mode retain already shipped. Used to
         # send only the new delta on subsequent retains when the API supports
         # update_mode='append' (legacy/overwrite path still sends everything).
@@ -2095,7 +2108,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
+        turn = self._build_turn_messages(user_content, assistant_content)
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter
@@ -2119,10 +2132,9 @@ class HindsightMemoryProvider(MemoryProvider):
         else:
             turns_to_retain = list(self._session_turns)
 
+        content = _serialize_conversation_turns(turns_to_retain)
         logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
-                     len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
+                     len(turns_to_retain), len(self._session_turns), len(content))
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -2335,7 +2347,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 old_lineage_tags.append(f"session:{old_session_id}")
             if old_parent_session_id:
                 old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
+            old_content = _serialize_conversation_turns(old_turns)
             # Resolve doc_id + update_mode against the OLD session BEFORE
             # we rotate _session_id, so the flush lands in the old
             # session's document either way (legacy: per-process unique;

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -925,11 +925,12 @@ class TestSyncTurn:
         assert item["context"] == "conversation between Hermes Agent and the User"
         assert item["tags"] == ["conv", "session1", "session:session-1"]
         content = json.loads(item["content"])
-        assert len(content) == 1
-        assert content[0][0]["role"] == "user"
-        assert content[0][0]["content"] == "User (fakeusername): hello"
-        assert content[0][1]["role"] == "assistant"
-        assert content[0][1]["content"] == "Assistant (fakeassistantname): hi there"
+        assert len(content) == 2
+        assert all(isinstance(message, dict) for message in content)
+        assert content[0]["role"] == "user"
+        assert content[0]["content"] == "User (fakeusername): hello"
+        assert content[1]["role"] == "assistant"
+        assert content[1]["content"] == "Assistant (fakeassistantname): hi there"
         assert item["metadata"]["source"] == "hermes"
         assert item["metadata"]["session_id"] == "session-1"
         assert item["metadata"]["platform"] == "discord"
@@ -942,8 +943,8 @@ class TestSyncTurn:
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"
-        assert content[0][0]["timestamp"] == event_time.isoformat(timespec="seconds")
-        assert content[0][1]["timestamp"] == event_time.isoformat(timespec="seconds")
+        assert content[0]["timestamp"] == event_time.isoformat(timespec="seconds")
+        assert content[1]["timestamp"] == event_time.isoformat(timespec="seconds")
         assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", item["metadata"]["retained_at"])
         assert item["timestamp"] == event_time.isoformat(timespec="seconds")
 
@@ -1126,8 +1127,13 @@ class TestSessionSwitchBufferFlush:
         kw = p._client.aretain_batch.call_args.kwargs
         assert kw["document_id"] == old_doc
         item = kw["items"][0]
-        # Both buffered turns must be present in the flushed payload.
+        # Both buffered turns must be present as one flat conversation.
         content = json.loads(item["content"])
+        assert len(content) == 4
+        assert all(isinstance(message, dict) for message in content)
+        assert [message["role"] for message in content] == [
+            "user", "assistant", "user", "assistant",
+        ]
         flat = json.dumps(content)
         assert "turn1-user" in flat
         assert "turn2-user" in flat
@@ -1269,6 +1275,27 @@ class TestUpdateModeAppendCapability:
         assert kw["document_id"] == "test-session"
         item = kw["items"][0]
         assert item["update_mode"] == "append"
+
+    def test_append_sends_only_new_messages_as_flat_conversation(self, provider, monkeypatch):
+        """Each append is a flat JSON message array Hindsight can merge and chunk."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+
+        provider.sync_turn("first user", "first assistant")
+        provider._retain_queue.join()
+        provider.sync_turn("second user", "second assistant")
+        provider._retain_queue.join()
+
+        assert provider._client.aretain_batch.call_count == 2
+        second_item = provider._client.aretain_batch.call_args_list[1].kwargs["items"][0]
+        content = json.loads(second_item["content"])
+        assert [message["role"] for message in content] == ["user", "assistant"]
+        assert content[0]["content"].endswith("second user")
+        assert content[1]["content"].endswith("second assistant")
+        assert second_item["update_mode"] == "append"
 
 
     def test_session_switch_flush_picks_capability_against_old_session(


### PR DESCRIPTION
## What does this PR do?

Hermes currently serializes each retained user/assistant pair as a JSON array and then wraps buffered pairs in another array, producing `[[user, assistant], ...]`.

Hindsight's structured conversation chunker and append-array merge both expect one flat JSON array of message objects. The nested payload therefore falls back to plain-text chunking; after multiple appends, the stored document can become newline-concatenated JSON arrays instead of one valid conversation.

This change keeps buffered pairs structured in memory and flattens them only when serializing the retain payload. Both normal retain dispatch and flush-on-session-switch now send `[user, assistant, ...]`.

## Related Issue

No matching issue or PR found after searching the repository.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - buffer user/assistant pairs as structured messages instead of pre-serialized arrays;
  - serialize buffered pairs as one flat conversation for both regular retain and session-switch flush;
  - preserve existing append watermark, metadata, timestamps, tags, and legacy replace behavior.
- `tests/plugins/memory/test_hindsight_provider.py`
  - assert metadata-rich retains use a flat message array;
  - assert buffered session-switch flushes remain flat and ordered;
  - assert append mode sends only the new user/assistant pair as a mergeable flat array.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q` — 85 tests pass.
2. Run `scripts/run_tests.sh tests/plugins/memory/ -q` — 363 tests pass across 24 files.
3. Against a real self-hosted Hindsight 0.9.2 instance, retain two turns through the patched provider with `update_mode="append"`; read the stored document and verify it parses as four flat message objects in `user, assistant, user, assistant` order. Recall the synthetic facts, then delete the canary bank.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository's required `scripts/run_tests.sh` wrapper and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on macOS arm64 against a Linux arm64 Hindsight service

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is internal and covered by the helper docstring/tests
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; change is stdlib JSON/list handling
- [x] Tool descriptions/schemas update — N/A; no tool schema changed

## Screenshots / Logs

Real canary verification:

```text
message_count=4
all_flat_dicts=true
roles=[user, assistant, user, assistant]
recall_count=4
```
