### PR TITLE
fix(desktop): stabilize assistant thread-list snapshots

### DIFF
--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -36,6 +36,50 @@ const shallowEqual = (a: object, b: object): boolean => {
 const getThreadListAdapter = (store: ExternalStoreAdapter) => store.adapters?.threadList ?? {}
 
 /**
+ * @assistant-ui/core 0.2.23 constructs thread-list state through a
+ * LazyMemoizeSubject, but ThreadListRuntimeImpl.subscribe() bypasses that
+ * subject and subscribes to the core directly. The subject therefore never
+ * becomes connected and getState() allocates a structurally identical object
+ * on every read. React 19's useSyncExternalStore tearing check correctly
+ * rejects that unstable snapshot and can take the whole chat surface down.
+ *
+ * Cache at the public runtime seam until the real thread-list subscription
+ * fires. This mirrors the upstream fix, where subscribe() now goes through the
+ * memoizing state binding, without pulling a broad assistant-ui minor upgrade
+ * into Desktop.
+ */
+function stabilizeThreadListSnapshot(runtime: AssistantRuntime): AssistantRuntime {
+  const threads = runtime.threads
+  const readSnapshot = threads.getState.bind(threads)
+  let dirty = false
+
+  // Runtime-lifetime subscription: `runtime` owns `threads`, and both become
+  // unreachable together when this hook unmounts. Register before the provider
+  // subscribes so a core publication marks the cache dirty first, and take the
+  // initial read only after registration so nothing published in between is
+  // ever missed.
+  threads.subscribe(() => {
+    dirty = true
+  })
+
+  let snapshot = readSnapshot()
+
+  Object.defineProperty(threads, 'getState', {
+    configurable: true,
+    value: () => {
+      if (dirty) {
+        snapshot = readSnapshot()
+        dirty = false
+      }
+
+      return snapshot
+    }
+  })
+
+  return runtime
+}
+
+/**
  * Write only the items whose (message, parentId) pair actually moved.
  *
  * `useRuntimeMessageRepository` caches normalized ThreadMessages by source
@@ -280,5 +324,5 @@ export function useIncrementalExternalStoreRuntime<T extends ThreadMessage>(
     return runtime.registerModelContextProvider(modelContext)
   }, [modelContext, runtime])
 
-  return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime])
+  return useMemo(() => stabilizeThreadListSnapshot(new AssistantRuntimeImpl(runtime)), [runtime])
 }

--- a/apps/desktop/src/lib/incremental-runtime-thread-list-snapshot.test.tsx
+++ b/apps/desktop/src/lib/incremental-runtime-thread-list-snapshot.test.tsx
@@ -1,0 +1,59 @@
+import type { ExportedMessageRepository, ExternalStoreAdapter } from '@assistant-ui/react'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from './incremental-external-store-runtime'
+
+const EMPTY_REPOSITORY: ExportedMessageRepository = {
+  headId: null,
+  messages: []
+}
+
+function adapter(threadId = 'DEFAULT_THREAD_ID'): ExternalStoreAdapter {
+  return {
+    messageRepository: EMPTY_REPOSITORY,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: async () => {},
+    onCancel: async () => {},
+    adapters: {
+      threadList: { threadId }
+    }
+  }
+}
+
+describe('incremental runtime thread-list snapshots', () => {
+  it('caches the snapshot until the thread-list runtime publishes a change', () => {
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) => useIncrementalExternalStoreRuntime(adapter(threadId)),
+      { initialProps: { threadId: 'thread-one' } }
+    )
+
+    const first = result.current.threads.getState()
+    const second = result.current.threads.getState()
+
+    expect(second).toBe(first)
+
+    rerender({ threadId: 'thread-two' })
+
+    const changed = result.current.threads.getState()
+
+    expect(changed).not.toBe(first)
+    expect(changed.mainThreadId).toBe('thread-two')
+    expect(result.current.threads.getState()).toBe(changed)
+  })
+
+  it('reflects a publication that fires before the first read', () => {
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) => useIncrementalExternalStoreRuntime(adapter(threadId)),
+      { initialProps: { threadId: 'thread-one' } }
+    )
+
+    rerender({ threadId: 'thread-two' })
+
+    const first = result.current.threads.getState()
+
+    expect(first.mainThreadId).toBe('thread-two')
+    expect(result.current.threads.getState()).toBe(first)
+  })
+})


### PR DESCRIPTION
## Problem

Desktop uses `useIncrementalExternalStoreRuntime` on current `main` with `@assistant-ui/core` 0.2.23. In that version, `ThreadListRuntimeImpl.getState()` reads through a lazy memoizing subject, but `subscribe()` bypasses that subject and subscribes directly to the core. Because the subject never becomes connected, consecutive `getState()` calls can return structurally identical but referentially different objects without a publication.

React 19's `useSyncExternalStore` stability check rejects that snapshot and can take the chat surface down with:

```text
The result of getSnapshot should be cached to avoid an infinite loop.
Maximum update depth exceeded.
```

This is distinct from the already-merged adapter no-op notification fix in #93080 and the adapter-identity work in #91172: those prevent unnecessary adapter publications/reinstalls; this change keeps the public thread-list snapshot stable between genuine publications.

## Solution

Cache the thread-list snapshot at the Hermes runtime seam for the lifetime of the assistant runtime. A real thread-list publication marks the cache dirty before downstream subscribers run; the next read refreshes it. This mirrors the current upstream assistant-ui subscription semantics without introducing a broad dependency upgrade.

The regression proves:

- consecutive reads return the same object identity without a publication;
- a real thread-list update invalidates the cache;
- subsequent reads stabilize on the updated snapshot.

## Verification

- Complete Desktop UI suite: **597 files / 5,733 tests passed**
- Focused runtime tests: **2 files / 6 tests passed**
- Desktop TypeScript: renderer, Electron and E2E checks passed
- Targeted ESLint passed
- `git diff --check` passed

The same compatibility change was also exercised in a clean packaged Linux Desktop during a real two-turn profile-rail Bot Chat acceptance: the previous React update-depth crash did not recur.
