### PR TITLE
fix(mcp): use mcp_field() for inputSchema and readOnlyHint reads (#94970)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4602,7 +4602,7 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if isinstance(annotations, dict):
         hint = annotations.get("readOnlyHint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = mcp_field(annotations, "read_only_hint", "readOnlyHint")
     return hint is True
 
 
@@ -7333,7 +7333,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             for mcp_tool in server._tools:
                 if not _should_register(mcp_tool.name):
                     continue
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
                 tools_payload.append({
                     "name": mcp_tool.name,
                     "description": mcp_tool.description or "",


### PR DESCRIPTION
## Summary

Fixes two `getattr` call sites in `tools/mcp_tool.py` that used bare camelCase field names instead of the `mcp_field()` compat helper. On mcp 2.x (which is the hard-pinned version in `pyproject.toml`), these attributes don't exist — `getattr` returns its default silently.

### Affected lines

1. **Schema cache write path** (line ~7336): `getattr(mcp_tool, "inputSchema", None)` → always `None` on mcp 2.x. Every MCP tool was written to `mcp_schema_cache.json` with `inputSchema: {}`. On next startup, cache-registered tools had **no parameters**, so the model couldn't pass arguments.

2. **Read-only hint** (line ~4605): `getattr(annotations, "readOnlyHint", None)` → always `None` on mcp 2.x. Read-only tools never received their intended treatment (failed safe, but incorrectly).

### Fix

Both replaced with `mcp_field()` which checks snake_case first, then camelCase — correct on both mcp 1.x and 2.x:

```python
# Line ~4605
hint = mcp_field(annotations, "read_only_hint", "readOnlyHint")

# Line ~7336
schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
```

`mcp_field()` (line 489) already exists for exactly this purpose and its docstring predicts this failure mode. `_convert_mcp_schema` (line ~6484) already uses it correctly — only these two sites were missed.

### Note

Existing `mcp_schema_cache.json` files written by affected builds stay poisoned after this code fix and must be deleted (or a cache-version bump could invalidate them).

Closes #94970