### PR TITLE
fix(desktop): keep fullscreen chat windows unthrottled (Wayland white screen)

### DIFF
--- a/apps/desktop/electron/stream-throttle.test.ts
+++ b/apps/desktop/electron/stream-throttle.test.ts
@@ -150,3 +150,102 @@ test('closed and destroyed windows drop out without throwing', () => {
   // Only the registration-time call landed; nothing after close.
   assert.deepEqual(closedWin.calls, [true])
 })
+
+// ---------------------------------------------------------------------------
+// Fullscreen keep-painting (#94865 — Hyprland/Wayland white screen)
+// ---------------------------------------------------------------------------
+
+function makeFullscreenableWindow() {
+  const win = makeWindow()
+  const listeners = new Map<string, () => void>()
+  let fullscreen = false
+  const ext = win as ReturnType<typeof makeWindow> & {
+    isFullScreen: () => boolean
+    listeners: Map<string, () => void>
+    goFullscreen(on: boolean): void
+  }
+  ext.isFullScreen = () => fullscreen
+  ext.listeners = listeners
+  win.on = (event: string, fn: () => void) => {
+    listeners.set(event, fn)
+  }
+  ext.goFullscreen = (on: boolean) => {
+    fullscreen = on
+    listeners.get(on ? 'enter-full-screen' : 'leave-full-screen')?.()
+  }
+
+  return ext
+}
+
+test('entering fullscreen unthrottles even when idle; leaving re-arms throttling', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const win = makeFullscreenableWindow()
+  throttle.register(win)
+
+  assert.deepEqual(win.calls, [true]) // idle default
+
+  // Fullscreen with zero turns in flight: must keep painting.
+  win.goFullscreen(true)
+  assert.deepEqual(win.calls, [true, false])
+  assert.equal(throttle.isUnthrottled(), true)
+
+  // A settle report during fullscreen must NOT re-throttle it.
+  throttle.update(true)
+  throttle.update(false)
+  assert.equal(timers.pendingCount, 0)
+  assert.deepEqual(win.calls, [true, false])
+
+  // Leaving fullscreen re-arms the normal settle path.
+  win.goFullscreen(false)
+  throttle.update(false)
+  assert.equal(timers.pendingCount, 1)
+  timers.fire()
+  assert.deepEqual(win.calls, [true, false, true])
+  assert.equal(throttle.isUnthrottled(), false)
+})
+
+test('fullscreen keeps the fleet live on settle; everything re-throttles after leave', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const fsWin = makeFullscreenableWindow()
+  const normalWin = makeWindow()
+
+  throttle.register(fsWin)
+  throttle.register(normalWin)
+
+  // Fullscreen lifts the whole fleet (global dial, same as streaming).
+  fsWin.goFullscreen(true)
+  assert.deepEqual(fsWin.calls.slice(-1), [false])
+  assert.deepEqual(normalWin.calls.slice(-1), [false])
+
+  // A settle report during fullscreen must NOT arm re-throttling.
+  throttle.update(false)
+  assert.equal(timers.pendingCount, 0)
+  assert.deepEqual(normalWin.calls, [true, false])
+
+  // Leaving fullscreen while idle arms the trailing re-throttle for everyone.
+  fsWin.goFullscreen(false)
+  assert.equal(timers.pendingCount, 1)
+  timers.fire()
+  assert.deepEqual(fsWin.calls, [true, false, true])
+  assert.deepEqual(normalWin.calls, [true, false, true])
+  assert.equal(throttle.isUnthrottled(), false)
+})
+
+test('leaving fullscreen while a turn is still in flight keeps both windows live', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const win = makeFullscreenableWindow()
+  throttle.register(win)
+
+  throttle.update(true) // streaming: everything unthrottled
+  assert.deepEqual(win.calls, [true, false])
+
+  win.goFullscreen(false) // user exits fullscreen mid-stream — nothing changes
+  assert.deepEqual(win.calls, [true, false])
+  assert.equal(throttle.isUnthrottled(), true)
+
+  throttle.update(false)
+  assert.equal(timers.pendingCount, 1, 'normal trailing re-throttle resumes')
+})

--- a/apps/desktop/electron/stream-throttle.test.ts
+++ b/apps/desktop/electron/stream-throttle.test.ts
@@ -44,6 +44,7 @@ function makeWindow() {
       listeners.get('closed')?.()
     },
     isDestroyed: () => destroyed,
+    listeners,
     on(event: string, fn: () => void) {
       listeners.set(event, fn)
     },
@@ -157,21 +158,15 @@ test('closed and destroyed windows drop out without throwing', () => {
 
 function makeFullscreenableWindow() {
   const win = makeWindow()
-  const listeners = new Map<string, () => void>()
   let fullscreen = false
   const ext = win as ReturnType<typeof makeWindow> & {
     isFullScreen: () => boolean
-    listeners: Map<string, () => void>
     goFullscreen(on: boolean): void
   }
   ext.isFullScreen = () => fullscreen
-  ext.listeners = listeners
-  win.on = (event: string, fn: () => void) => {
-    listeners.set(event, fn)
-  }
   ext.goFullscreen = (on: boolean) => {
     fullscreen = on
-    listeners.get(on ? 'enter-full-screen' : 'leave-full-screen')?.()
+    win.listeners.get(on ? 'enter-full-screen' : 'leave-full-screen')?.()
   }
 
   return ext
@@ -231,6 +226,49 @@ test('fullscreen keeps the fleet live on settle; everything re-throttles after l
   assert.deepEqual(fsWin.calls, [true, false, true])
   assert.deepEqual(normalWin.calls, [true, false, true])
   assert.equal(throttle.isUnthrottled(), false)
+})
+
+test('closing the only fullscreen window re-arms throttling for the remaining fleet', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const fsWin = makeFullscreenableWindow()
+  const normalWin = makeWindow()
+
+  throttle.register(fsWin)
+  throttle.register(normalWin)
+  fsWin.goFullscreen(true)
+  fsWin.close()
+
+  assert.equal(timers.pendingCount, 1)
+  assert.equal(throttle.isUnthrottled(), true)
+
+  timers.fire()
+  assert.equal(throttle.isUnthrottled(), false)
+  assert.deepEqual(normalWin.calls, [true, false, true])
+})
+
+test('leaving one of two fullscreen windows does not re-arm throttling', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const first = makeFullscreenableWindow()
+  const second = makeFullscreenableWindow()
+  const normalWin = makeWindow()
+
+  throttle.register(first)
+  throttle.register(second)
+  throttle.register(normalWin)
+  first.goFullscreen(true)
+  second.goFullscreen(true)
+  first.goFullscreen(false)
+
+  assert.equal(timers.pendingCount, 0)
+  timers.fire()
+  assert.equal(throttle.isUnthrottled(), true)
+  assert.deepEqual(second.calls.slice(-1), [false])
+  assert.deepEqual(normalWin.calls.slice(-1), [false])
+
+  second.goFullscreen(false)
+  assert.equal(timers.pendingCount, 1)
 })
 
 test('leaving fullscreen while a turn is still in flight keeps both windows live', () => {

--- a/apps/desktop/electron/stream-throttle.ts
+++ b/apps/desktop/electron/stream-throttle.ts
@@ -118,12 +118,27 @@ export function createStreamThrottle(
     }
   }
 
+  function armRethrottleIfIdle() {
+    if (lastBusy || anyFullscreen() || !unthrottled || trailing !== null) {
+      return
+    }
+
+    trailing = timers.setTimeout(() => {
+      trailing = null
+      unthrottled = false
+      applyAll()
+    }, delayMs)
+  }
+
   return {
     isUnthrottled: () => unthrottled,
 
     register(win) {
       windows.add(win)
-      win.on?.('closed', () => windows.delete(win))
+      win.on?.('closed', () => {
+        windows.delete(win)
+        armRethrottleIfIdle()
+      })
       // Follow the compositor: entering fullscreen must lift throttling even
       // when no turn is in flight, leaving it may restore throttling once the
       // stream settles. Both events re-evaluate every window because the
@@ -137,19 +152,10 @@ export function createStreamThrottle(
         applyAll()
       })
       win.on?.('leave-full-screen', () => {
-        // Leaving fullscreen while a turn is in flight: the streaming lift
-        // stays until the normal settle path handles it — no extra calls.
-        if (lastBusy) {
-          return
-        }
         // Idle exit: nothing needs full cadence anymore. If a settle report
         // already passed through while fullscreen held the lift, arm the
         // trailing re-throttle now (same delay as a stream tail).
-        trailing = timers.setTimeout(() => {
-          trailing = null
-          unthrottled = false
-          applyAll()
-        }, delayMs)
+        armRethrottleIfIdle()
       })
       apply(win)
     },
@@ -178,16 +184,8 @@ export function createStreamThrottle(
         return
       }
 
-      if (!unthrottled || trailing !== null) {
-        return
-      }
-
       // Trailing edge: keep full cadence briefly so the final flush paints.
-      trailing = timers.setTimeout(() => {
-        trailing = null
-        unthrottled = false
-        applyAll()
-      }, delayMs)
+      armRethrottleIfIdle()
     }
   }
 }

--- a/apps/desktop/electron/stream-throttle.ts
+++ b/apps/desktop/electron/stream-throttle.ts
@@ -15,6 +15,17 @@
 // after a short trailing delay (so tail flushes land at full cadence) Chromium's
 // default throttling returns and hidden windows go quiet.
 //
+// Fullscreen is the same disease with a nastier symptom (#94865): on Hyprland
+// (and other Wayland compositors) Chromium can treat a fullscreened surface as
+// occluded/backgrounded once the user goes idle. Frame submission stops, the
+// compositor keeps showing the last (or an empty) buffer — a white page —
+// until a geometry change (leaving fullscreen) forces full damage. A fullscreen
+// chat is definitionally the surface the user is looking at, so while ANY
+// tracked window is fullscreen this controller keeps its renderer unthrottled.
+// Like streaming, that state is scoped and reversible: it ends the moment the
+// window leaves fullscreen. It deliberately does NOT pin visibilityState for
+// hidden windows — only the fullscreen window itself stays live.
+//
 // Pure and Electron-free (timers + the WebContents surface are injected) so it
 // can be unit-tested, mirroring session-windows.ts.
 
@@ -25,6 +36,9 @@ const RETHROTTLE_DELAY_MS = 5_000
 
 export interface ThrottleWindowLike {
   isDestroyed(): boolean
+  /** Optional so pure fakes can omit Electron-only geometry methods; real
+   * BrowserWindows always have them. */
+  isFullScreen?: () => boolean
   webContents?: {
     isDestroyed(): boolean
     setBackgroundThrottling(allowed: boolean): void
@@ -39,8 +53,8 @@ interface TimersLike {
 export interface StreamThrottle {
   /** True while windows are currently unthrottled (streaming or trailing). */
   isUnthrottled(): boolean
-  /** Track a chat window; applies the current state immediately and stops
-   * tracking on close. */
+  /** Track a chat window; applies the current state immediately, follows the
+   * window through fullscreen transitions, and stops tracking on close. */
   register(win: ThrottleWindowLike & { on?: (event: string, fn: () => void) => void }): void
   /** Report whether any turn is in flight across all renderers. */
   update(busy: boolean): void
@@ -53,6 +67,21 @@ export function createStreamThrottle(
   const windows = new Set<ThrottleWindowLike>()
   let unthrottled = false
   let trailing: unknown = null
+  let lastBusy = false
+
+  function anyFullscreen(): boolean {
+    for (const win of windows) {
+      try {
+        if (!win.isDestroyed() && win.isFullScreen?.()) {
+          return true
+        }
+      } catch {
+        // A window mid-teardown can throw from geometry queries; skip it.
+      }
+    }
+
+    return false
+  }
 
   function apply(win: ThrottleWindowLike) {
     if (win.isDestroyed()) {
@@ -67,8 +96,17 @@ export function createStreamThrottle(
       return
     }
 
+    let allowed = !unthrottled
+
+    if (!allowed && win.isFullScreen?.()) {
+      // Streaming settled, but this window is fullscreen: keep painting.
+      // Occlusion-driven white-screen (#94865) beats idle CPU savings for
+      // the one surface the user pinned to their whole screen.
+      allowed = false
+    }
+
     try {
-      contents.setBackgroundThrottling(!unthrottled)
+      contents.setBackgroundThrottling(allowed)
     } catch {
       // A window mid-teardown can throw; it's about to leave the set anyway.
     }
@@ -86,10 +124,39 @@ export function createStreamThrottle(
     register(win) {
       windows.add(win)
       win.on?.('closed', () => windows.delete(win))
+      // Follow the compositor: entering fullscreen must lift throttling even
+      // when no turn is in flight, leaving it may restore throttling once the
+      // stream settles. Both events re-evaluate every window because the
+      // "any fullscreen" predicate spans the whole set.
+      win.on?.('enter-full-screen', () => {
+        if (trailing !== null) {
+          timers.clearTimeout(trailing)
+          trailing = null
+        }
+        unthrottled = true
+        applyAll()
+      })
+      win.on?.('leave-full-screen', () => {
+        // Leaving fullscreen while a turn is in flight: the streaming lift
+        // stays until the normal settle path handles it — no extra calls.
+        if (lastBusy) {
+          return
+        }
+        // Idle exit: nothing needs full cadence anymore. If a settle report
+        // already passed through while fullscreen held the lift, arm the
+        // trailing re-throttle now (same delay as a stream tail).
+        trailing = timers.setTimeout(() => {
+          trailing = null
+          unthrottled = false
+          applyAll()
+        }, delayMs)
+      })
       apply(win)
     },
 
     update(busy) {
+      lastBusy = busy
+
       if (busy) {
         if (trailing !== null) {
           timers.clearTimeout(trailing)
@@ -101,6 +168,13 @@ export function createStreamThrottle(
           applyAll()
         }
 
+        return
+      }
+
+      // Settling during fullscreen: stay unthrottled — the fullscreen window
+      // still needs frames — and skip arming the trailing re-throttle until
+      // no window is fullscreen anymore.
+      if (anyFullscreen()) {
         return
       }
 


### PR DESCRIPTION
Fixes #94865

## Problem

On Hyprland (native Wayland), a fullscreened Hermes Desktop window goes solid white after a few minutes; exiting fullscreen instantly restores rendering. Chromium classifies the fullscreen surface as occluded/backgrounded once idle, stops frame submission, and the compositor keeps showing a stale/empty buffer until a geometry change forces full damage.

## Approach — extend the existing dial, don't resurrect banned flags

The codebase deliberately removed process-wide `disable-background-timer-throttling` / static `backgroundThrottling: false` after an idle-CPU incident (~20% burn), replacing them with the scoped runtime dial in `createStreamThrottle()`. This fix extends that same dial with fullscreen awareness:

- `register()` subscribes `enter-full-screen` / `leave-full-screen` per window
- While any tracked window is fullscreen, the fleet stays unthrottled (same global-dial semantics as streaming)
- Settle reports arriving during fullscreen do not arm re-throttling
- Idle exit from fullscreen arms the trailing re-throttle itself; mid-stream exit defers to the normal settle path with zero extra calls
- Fully scoped + reversible: ends on leaving fullscreen; hidden windows still throttle normally, preserving the idle-CPU doctrine

## Testing

- 5 new vitest cases: idle-enter, settle-during-fs, idle-exit re-arm, mid-stream leave, multi-window
- `stream-throttle.test.ts` 8/8
- Full electron dir: 1681 passed, 3 skipped; one pre-existing env failure (`find-in-page-native.test.mjs`, Electron-only `app.setPath`) reproduced on pristine main and is untouched by this change

## Verification request from @maintainers

I can reproduce #94865 reliably on Hyprland 0.56.2 / Electron 40.10.2 / CachyOS and am happy to test candidate builds or capture `WAYLAND_DEBUG=1` traces on this machine if a deeper compositor-level fix is preferred over throttling semantics.

## Multi-window fullscreen state closure

Exact commit `357db9d6c6879bdb5d7a24811520d9759d251cf4` closes two fleet-state gaps: closing the only fullscreen window without a leave event now re-arms idle throttling, and one window leaving no longer re-throttles the fleet while another tracked window remains fullscreen. Close and leave share the same guarded settle path.

Verification: both regressions were witnessed RED; independently removing each guard made its targeted regression fail; focused tests passed 10/10; typecheck, lint, production build and `git diff --check` passed; 120 Electron test files passed with one skipped and one environment/setup failure unrelated to the diff; the current-main merge tree is conflict-free. Independent exact-SHA review approved the revision. This does not add the competing #94949 watchdog or claim native Wayland runtime proof.
