### PR TITLE
fix(tools): spillover references the sandbox path on remote backends even before the first terminal command

### DIFF
--- a/contributors/emails/james47kjv@pm.me
+++ b/contributors/emails/james47kjv@pm.me
@@ -1,0 +1,1 @@
+james47kjv

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -361,6 +361,48 @@ class TestSpillover:
         assert spill_file.read_text(encoding="utf-8") == content
         assert str(spill_file) in result
 
+    def test_env_none_on_a_remote_backend_hands_out_the_sandbox_path(
+            self, monkeypatch):
+        """A spill BEFORE the session's first terminal command must not hand
+        a remote-backend session the host path: its read_file resolves in
+        the sandbox, and cache/spillover is auto-synced there as soon as the
+        environment is created. Previously env=None always took the
+        host-side branch, so an ssh-backend session that spilled a large
+        MCP result early was pointed at a file it could never read."""
+        import tools.terminal_tool as tt
+
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="tool_call",
+            tool_use_id="tc_mcp_ssh_1",
+            env=None,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        spill_file = get_spillover_dir() / "tc_mcp_ssh_1.txt"
+        assert spill_file.exists()
+        assert str(spill_file) not in result
+        assert "~/.hermes/cache/spillover/tc_mcp_ssh_1.txt" in result
+
+    def test_env_none_on_the_local_backend_keeps_the_host_path(
+            self, monkeypatch):
+        import tools.terminal_tool as tt
+
+        monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="tool_call",
+            tool_use_id="tc_mcp_loc_1",
+            env=None,
+            threshold=30_000,
+        )
+        assert str(get_spillover_dir() / "tc_mcp_loc_1.txt") in result
+
     def test_local_env_persists_to_spillover_not_sandbox(self):
         """LocalEnvironment routes host-side: no env.execute() shell-out."""
         from tools.environments.local import LocalEnvironment

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -123,17 +123,40 @@ def _prune_spillover_once() -> None:
         logger.debug("Spillover prune failed: %s", exc)
 
 
+def _configured_backend_is_local() -> bool:
+    """True when the CONFIGURED terminal backend is local.
+
+    Used when no environment is active yet: the configured backend, not the
+    absence of an env, decides where the agent will later read files from.
+    Bridges terminal.* config into TERMINAL_* env vars first, the same way
+    terminal_tool does, so in-process launches (serve/desktop/cron/ACP) see
+    their config.yaml selection rather than defaulting to local.
+    """
+    try:
+        from tools.terminal_tool import _ensure_terminal_env_bridged
+
+        _ensure_terminal_env_bridged()
+    except Exception as exc:
+        logger.debug("Terminal config bridge failed: %s", exc)
+    backend = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    return backend == "local"
+
+
 def _is_host_side_env(env) -> bool:
     """True when the spill file should be written by this process directly.
 
-    Covers ``env=None`` (no sandbox environment active — e.g. a session
-    that has not run a terminal command yet) and the local backend
-    (where env.execute() runs on this same host anyway). Remote backends
-    (docker/ssh/modal/daytona) return False: their read_file resolves
-    inside the sandbox, so the spill must be written there.
+    Covers the local backend (where env.execute() runs on this same host
+    anyway), and ``env=None`` (no sandbox environment active — e.g. a
+    session that has not run a terminal command yet) ONLY when the
+    configured backend is local too. Remote backends (docker/ssh/modal/
+    daytona) return False: their read_file resolves inside the sandbox, so
+    the reference handed to the model must be sandbox-visible. Before this
+    check, a remote-backend session that spilled a large MCP result BEFORE
+    its first terminal command was handed the host path — which its
+    read_file could never resolve.
     """
     if env is None:
-        return True
+        return _configured_backend_is_local()
     try:
         from tools.environments.local import LocalEnvironment
 
@@ -359,12 +382,25 @@ def maybe_persist_tool_result(
                 tool_name, tool_use_id, len(content), host_path,
             )
             return _build_persisted_message(preview, has_more, len(content), host_path)
-    elif env is not None:
+    else:
         # Remote backend: the spillover dir is auto-mounted (docker) or
         # file-synced (modal/ssh/daytona) into the sandbox, so reference the
-        # translated path when the sandbox can actually read it.
+        # translated path when the sandbox can actually read it. With no env
+        # yet (a spill before the session's first terminal command), trust
+        # the translation without probing: cache/spillover is in the
+        # auto-mount/sync list, so the file is visible at that path as soon
+        # as the environment is created.
         if host_path is not None:
-            visible = _sandbox_visible_spillover_path(host_path, env)
+            if env is not None:
+                visible = _sandbox_visible_spillover_path(host_path, env)
+            else:
+                try:
+                    from tools.credential_files import to_agent_visible_cache_path
+
+                    visible = to_agent_visible_cache_path(host_path)
+                except Exception as exc:
+                    logger.debug("Spillover path translation failed: %s", exc)
+                    visible = None
             if visible is not None:
                 logger.info(
                     "Persisted large tool result: %s (%s, %d chars -> %s [host: %s])",
@@ -372,11 +408,13 @@ def maybe_persist_tool_result(
                 )
                 return _build_persisted_message(preview, has_more, len(content), visible)
         # Fallback: write into the sandbox temp dir (pre-existing containers
-        # without the spillover mount, translation/probe failures).
+        # without the spillover mount, translation/probe failures). Needs a
+        # live environment to execute in; with none, fall through to the
+        # inline truncation below.
         storage_dir = _resolve_storage_dir(env)
         remote_path = f"{storage_dir}/{filename}"
         try:
-            if _write_to_sandbox(content, remote_path, env):
+            if env is not None and _write_to_sandbox(content, remote_path, env):
                 logger.info(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,


### PR DESCRIPTION
## Problem

When a tool result spills before the session has run any terminal command, `get_active_env()` is still `None` and `maybe_persist_tool_result` takes the host-side branch unconditionally (`_is_host_side_env(None) == True`). A session configured for a remote backend (ssh/docker/modal/daytona) is then handed the **host** path — which its `read_file`, running inside the sandbox, can never resolve. The module docstring already states remote backends must reference the spill inside the sandbox; the `env=None` case slipped past that rule.

Seen in production on an ssh-backend fleet: a 52 KB MCP reply spilled at session start (before any terminal call), the model was told the `$HERMES_HOME/cache/spillover/…` host path, and its `read_file` in the sandbox failed — even though the file sync had already delivered the bytes to the sandbox side.

## Fix

- `_is_host_side_env` now consults the **configured** backend when `env is None`: it bridges `terminal.*` config into `TERMINAL_*` env vars the same way `terminal_tool` does (`_ensure_terminal_env_bridged`), then treats "no env yet" as host-side only when `TERMINAL_ENV` is local.
- In the remote branch of `maybe_persist_tool_result`, when there is no env yet, the reference handed to the model is the `to_agent_visible_cache_path` translation **without** a readability probe: `cache/spillover` is in the auto-mount/sync list, so the file is visible at that path as soon as the environment is created. The sandbox-temp fallback is guarded to require a live env (it needs `env.execute`), falling through to the existing inline truncation otherwise.
- Local-backend behaviour (and `env=None` on a local-configured install — MCP-only/cron sessions) is unchanged.

## Tests

Two new tests in `tests/tools/test_tool_result_storage.py`: `env=None` + `TERMINAL_ENV=ssh` must reference `~/.hermes/cache/spillover/…` and never the host path; `env=None` + local keeps the host path. Full file: 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)