### PR TITLE
fix(desktop): scope boot reauth logout to active gateway

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -12,9 +12,9 @@ import { BootFailureOverlay } from './boot-failure-overlay'
 // to an in-line connect form — instead of stranding them (the old bug forced a
 // hand-edit of connection.json).
 
-function failBoot() {
+function failBoot(error = 'Could not connect to Hermes gateway') {
   $desktopBoot.set({
-    error: 'Could not connect to Hermes gateway',
+    error,
     fakeMode: false,
     message: 'boot failed',
     phase: 'renderer.error',
@@ -25,11 +25,11 @@ function failBoot() {
   })
 }
 
-function stubDesktop(config: Record<string, unknown>) {
+function stubDesktop(config: Record<string, unknown>, extra: Record<string, unknown> = {}) {
   const original = window.hermesDesktop
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getRecentLogs: async () => ({ lines: [] }), getConnectionConfig: async () => config }
+    value: { getRecentLogs: async () => ({ lines: [] }), getConnectionConfig: async () => config, ...extra }
   })
 
   return () => Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
@@ -45,6 +45,12 @@ const remoteToken = {
   remoteTokenSet: true,
   remoteUrl: 'http://100.116.104.53:9191',
   cloudOrg: ''
+}
+
+const remoteOauth = {
+  ...remoteToken,
+  remoteAuthMode: 'oauth',
+  remoteUrl: 'https://gateway-b.example.test'
 }
 
 beforeEach(() => {
@@ -94,6 +100,30 @@ describe('BootFailureOverlay', () => {
       await waitFor(() => expect(screen.queryByRole('button', { name: /repair/i })).toBeNull())
       expect(screen.getByRole('button', { name: /gateway settings/i })).toBeTruthy()
       expect(screen.getByRole('button', { name: /use local gateway/i })).toBeTruthy()
+    } finally {
+      restore()
+    }
+  })
+
+  it('scopes boot-failure reauth logout to the active remote gateway', async () => {
+    const logout = vi.fn().mockResolvedValue(undefined)
+    const login = vi.fn().mockResolvedValue({ connected: false })
+    const restore = stubDesktop(remoteOauth, {
+      oauthLoginConnectionConfig: login,
+      oauthLogoutConnectionConfig: logout,
+      probeConnectionConfig: vi.fn().mockResolvedValue({ providers: null })
+    })
+
+    failBoot('Your remote gateway session has expired. Open Settings and sign in again.')
+
+    try {
+      render(<BootFailureOverlay />)
+      const signIn = await screen.findByRole('button', { name: /sign out and sign in/i })
+
+      fireEvent.click(signIn)
+
+      await waitFor(() => expect(logout).toHaveBeenCalledWith(remoteOauth.remoteUrl))
+      expect(login).toHaveBeenCalledWith(remoteOauth.remoteUrl)
     } finally {
       restore()
     }

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -163,12 +163,11 @@ export function BootFailureOverlay() {
     setBusy(null)
   }
 
-  // Clear the OAuth partition first, then open the gateway's login window
-  // (username/password form or OAuth redirect — the desktop drives both). A
-  // partition-wide sign-out drops stale gateway AND identity-provider cookies so
-  // an expired session can't silently bounce us back into the same state. On a
-  // successful sign-in the cookie is re-established; reload so boot mints a fresh
-  // ticket against a live session.
+  // Clear this gateway's stale OAuth state first, then open its login window
+  // (username/password form or OAuth redirect — the desktop drives both).
+  // Keep the cleanup scoped to the active remote URL: all gateways share the
+  // same persistent partition, so a partition-wide clear logs every other
+  // registered gateway out as a side effect.
   const signInRemote = async () => {
     if (!remoteReauth) {
       return
@@ -177,7 +176,7 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
+      await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
 
       if (result?.connected) {


### PR DESCRIPTION
Fixes #94856.

## Problem
The boot-failure reauth action called `oauthLogoutConnectionConfig()` without a URL before reopening login. All remote gateways share the same persistent OAuth partition, so the empty filter cleared cookies for every registered gateway, not just the one being reauthenticated.

## Fix
Pass `remoteReauth.url` to the existing logout API before login. This keeps stale-session cleanup scoped to the active gateway while preserving other hosts' sessions.

## Regression coverage
Adds a focused `BootFailureOverlay` test that drives an OAuth-shaped remote boot failure, clicks the reauth action, and asserts both logout and login receive the active remote URL.

The automation environment does not have a runnable repository checkout, so hosted CI is the execution gate for the added component test. The branch is based directly on current `main` (`02c7ae9`) and the final duplicate check found no open PR for #94856.