### PR TITLE
fix(auxiliary): detect contracted unsupported parameter errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4377,7 +4377,11 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
     param_lower = (param or "").lower()
     if not param_lower:
         return False
-    err_lower = str(exc).lower()
+    # Some providers/proxies render contractions with a typographic
+    # apostrophe ("doesn’t support", U+2019). Normalize it once so every
+    # present and future contraction marker below matches both styles
+    # (review feedback on PR #94977).
+    err_lower = str(exc).lower().replace("\u2019", "'")
     if param_lower not in err_lower:
         return False
     return any(marker in err_lower for marker in (

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4385,6 +4385,7 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
         "unsupported_parameter",
         "not supported",
         "does not support",
+        "doesn't support",
         "unknown parameter",
         "unrecognized request argument",
         "unrecognized parameter",

--- a/tests/agent/test_unsupported_parameter_retry.py
+++ b/tests/agent/test_unsupported_parameter_retry.py
@@ -37,6 +37,10 @@ class TestIsUnsupportedParameterError:
         ("temperature", "Error code: 400 - {'error': {'code': 'unsupported_parameter', 'param': 'temperature'}}"),
         ("temperature", "this model does not support temperature"),
         ("temperature", "this model doesn't support temperature"),
+        # curly (typographic) apostrophe variant — U+2019 — as rendered by
+        # several providers/proxies (review feedback on PR #94977)
+        ("temperature", "this model doesn’t support temperature"),
+        ("max_tokens", "The model doesn’t support max_tokens"),
         # max_tokens phrasings
         ("max_tokens", "HTTP 400: Unsupported parameter: max_tokens"),
         ("max_tokens", "Unknown parameter: max_tokens — use max_completion_tokens"),

--- a/tests/agent/test_unsupported_parameter_retry.py
+++ b/tests/agent/test_unsupported_parameter_retry.py
@@ -36,6 +36,7 @@ class TestIsUnsupportedParameterError:
         ("temperature", "HTTP 400: Unsupported parameter: temperature"),
         ("temperature", "Error code: 400 - {'error': {'code': 'unsupported_parameter', 'param': 'temperature'}}"),
         ("temperature", "this model does not support temperature"),
+        ("temperature", "this model doesn't support temperature"),
         # max_tokens phrasings
         ("max_tokens", "HTTP 400: Unsupported parameter: max_tokens"),
         ("max_tokens", "Unknown parameter: max_tokens — use max_completion_tokens"),


### PR DESCRIPTION
## Summary
- recognize provider errors phrased as `doesn't support <parameter>` in the auxiliary unsupported-parameter retry detector
- add behavioral regression coverage for `This model doesn't support temperature`

## Why

The detector already accepts the semantically equivalent `does not support` phrasing. Without the contraction, an affected auxiliary request fails rather than retrying without the rejected parameter. The existing requested-parameter-name guard remains unchanged.

## Validation

- [x] Added the regression test before the implementation and observed it fail against the clean `main` baseline
- [x] `.venv/bin/python -m pytest tests/agent/test_unsupported_parameter_retry.py -q` — 12 passed
- [x] `.venv/bin/python -m ruff check agent/auxiliary_client.py tests/agent/test_unsupported_parameter_retry.py` — passed
- [x] `git diff --check` — passed

Fixes #94976