### PR TITLE
fix(tui-gateway): exit when spawning TUI process dies

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -253,6 +253,68 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
+# Orphan guard for the stdio TUI gateway. The gateway is a child of the TUI
+# host process (node launcher on the classic `hermes --tui` path, dashboard
+# pty host, or desktop build). If the host dies without closing our stdin —
+# a shared/wrapper-held descriptor keeps the pipe open past the host's death
+# — this loop would otherwise run forever: a stale gateway holding session
+# leases, config locks, and (on Windows) .pyd handle chains.
+#
+# Mirrors the slash_worker watchdog (same parent-death idea, simpler policy):
+# on POSIX a dead parent reparents us, so os.getppid() changing is a reliable
+# orphan signal (pid-reuse false-positives are vanishingly rare inside a
+# single boot). On Windows there is no reparenting — os.getppid() keeps
+# returning the dead pid — so this watchdog is POSIX-only there; Windows
+# relies on stdin-EOF (the fast path) plus the KILL_ON_JOB_CLOSE self-attach
+# below. Fail-safe: any exception in the poll loop keeps the gateway alive
+# rather than crashing it.
+_WATCHDOG_POLL_S = 1.0
+
+
+def _start_parent_death_watchdog() -> None:
+    try:
+        original_ppid = os.getppid()
+    except (OSError, AttributeError):
+        return
+    if not original_ppid or original_ppid <= 0:
+        return
+
+    def _loop() -> None:
+        while True:
+            time.sleep(_WATCHDOG_POLL_S)
+            try:
+                if os.getppid() == original_ppid:
+                    continue
+            except (OSError, AttributeError):
+                continue
+            _log_exit(
+                f"parent (pid {original_ppid}) died — orphaned, exiting"
+            )
+            os._exit(0)
+
+    threading.Thread(target=_loop, name="tui-parent-watchdog", daemon=True).start()
+
+
+def _attach_job_object_on_windows() -> None:
+    """Windows: kill our child tree with us via KILL_ON_JOB_CLOSE.
+
+    Best-effort mirror of the gateway/run.py + web_server.py call site: the
+    gateway is put into its own job so every descendant tool process dies
+    atomically with it — no two-hop child chains left holding .pyd locks
+    after the gateway is killed. No-op elsewhere. Never blocks startup.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        from hermes_cli.process_identity import (
+            attach_self_to_kill_on_close_job,
+        )
+
+        attach_self_to_kill_on_close_job()
+    except Exception:
+        pass
+
+
 def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     """Block until background MCP discovery finishes, up to the resolved bound.
 
@@ -421,6 +483,12 @@ def ensure_mcp_discovery_started() -> None:
 
 def main():
     _install_sidecar_publisher()
+
+    # Die with our spawning host instead of lingering as an orphan: the
+    # ppid watchdog covers POSIX; the job-object self-attach covers the
+    # Windows child-tree cleanup (killed-with-parent comes from stdin-EOF).
+    _start_parent_death_watchdog()
+    _attach_job_object_on_windows()
 
     # One-time sweep of session rows orphaned by a previous gateway process
     # (#65194) — the in-process WS-orphan reap timer dies with the process.


### PR DESCRIPTION
## Summary

The stdio TUI gateway had no parent-death protection. If the host TUI process (node launcher on the classic `hermes --tui` path, dashboard pty host, or desktop build) was killed without closing the shared stdin descriptor, `main()`'s `readline` loop never sees EOF and the gateway runs forever — a stale process holding session leases, config locks, and (on Windows) `.pyd` handle chains. It is also invisible to the process-identity ledger.

## Fix

Mirrors the existing `tui_gateway/slash_worker.py` watchdog pattern, called at the top of `main()` (Desktop/WebSocket paths import `entry` without running `main()`, so they are unaffected):

1. **POSIX parent-death watchdog** — a daemon thread polls `os.getppid()` every 1 s; if it changes from the recorded parent, log the exit reason and `os._exit(0)`. POSIX reparenting makes `getppid()` change a reliable orphan signal (pid-reuse false-positives are vanishingly rare inside a single boot). Exceptions in the poll loop never crash the gateway (fail-safe).
2. **Windows KILL_ON_JOB_CLOSE self-attach** — best-effort mirror of the `gateway/run.py` + `hermes_cli/web_server.py` call site, so the gateway's descendant tool processes die atomically with it instead of lingering as `.pyd`-lock holders.

## Windows honesty (documented in the code)

Windows has no reparenting — `os.getppid()` keeps returning the dead PID, so the ppid poll is effectively POSIX-only there. Windows relies on the existing stdin-EOF fast path plus the job-object self-attach for child-tree cleanup. The docstring states this explicitly so maintainers don't assume parity.

## Verification

- `py_compile` clean.
- Targeted pytest (`test_tui_gateway_server.py`, `test_tui_gateway_loop_noise.py`, `test_process_identity.py`) — no regressions.

## Open question for reviewers

Should this ship with a unit test (monkeypatched `os.getppid` + captured `os._exit`) mirroring `tests/test_slash_worker_watchdog.py`? I can add it in a follow-up commit if desired.