### PR TITLE
fix(cli): register one-shot workers in process-identity ledger

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21404,6 +21404,25 @@ def main(
     
     # Handle single query mode
     if query or image:
+        # Non-interactive one-shot: register in the process-identity ledger so
+        # machine-wide scans (`hermes update`, Desktop sweeps) can classify
+        # this process instead of guessing from cmdline archaeology. "worker"
+        # is deliberately NOT in REAPABLE_PURPOSES, so reapers leave it alone —
+        # registration is identification only. Windows: self-attach to a
+        # KILL_ON_JOB_CLOSE job so tool child trees die with this process
+        # (mirrors gateway/run.py). Best-effort + fail-safe by design.
+        try:
+            from hermes_cli.process_identity import (
+                attach_self_to_kill_on_close_job,
+                register_self,
+            )
+
+            register_self("worker")
+            if sys.platform == "win32":
+                attach_self_to_kill_on_close_job()
+        except Exception:
+            pass  # identity must never break a one-shot run
+
         # One-shot mode: no between-turns MCP late-binding refresh, so the
         # agent must wait the full MCP cold-start bound before its first
         # (and only) tool snapshot. See #51316.


### PR DESCRIPTION
## Summary

Non-interactive one-shot runs (`hermes -q` / `--query` — the same path that backs cron jobs and kanban workers) were invisible to the process-identity ledger (`hermes_cli/process_identity.py`). Machine-wide sweeps (`hermes update`, Desktop startup) had to guess their lineage from cmdline archaeology; a hung one-shot left no trace, and on Windows its tool child trees could outlive the one-shot.

## Fix

At the top of the single-query branch (`if query or image:` in `cli.py main()`), best-effort:

1. `register_self("worker")` — ledger entry so scans can classify the process.
2. On Windows, `attach_self_to_kill_on_close_job()` — child tool trees die with the one-shot (mirrors `gateway/run.py` / `hermes_cli/web_server.py`).

The import is scoped inside the branch, so interactive REPL startup pays zero import cost. Identity failures are fail-safe (never break a run).

## Design guardrail

`"worker"` is deliberately **NOT** added to `REAPABLE_PURPOSES` — reapers keep skipping these entries. Registration is identification + cleanup only; interactive and one-shot sessions stay out of reap scope. No TTY-heuristic sweep of interactive sessions was added.

## Verification

- `py_compile` clean.
- Targeted pytest (`test_tui_gateway_server.py`, `test_tui_gateway_loop_noise.py`, `test_process_identity.py`) — no regressions.