### PR TITLE
fix(tui-gateway): bypass config read cache on write-back

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5049,6 +5049,14 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
 
 
 def _write_config_key(key_path: str, value):
+    # Write-path cache bypass: `_load_cfg_raw` caches keyed on mtime, and the
+    # read-mutate-save round-trip below must always merge the file's true
+    # current state - a manual edit that landed ahead of a stale cache fill
+    # (same-mtime window) would otherwise be silently clobbered on save.
+    # Force a fresh disk read on every write; behavioral reads keep the cache.
+    global _cfg_cache, _cfg_mtime
+    _cfg_cache = None
+    _cfg_mtime = None
     # Write-back round-trip: raw read is mandatory — saving the managed-
     # overlaid / env-expanded view would persist those values into the file.
     cfg = _load_cfg_raw()


### PR DESCRIPTION
## Summary

`_write_config_key()` (the write path behind every `/settings` toggle) uses `_load_cfg_raw()`, which caches `config.yaml` keyed on mtime. Its read → mutate → save round-trip could persist a copy that missed a manual `config.yaml` edit landing within the mtime granularity window (or ahead of a stale cache fill) — silently clobbering the user's hand-edit with no warning.

## Fix

Reset the config read cache (`_cfg_cache = None; _cfg_mtime = None`) before every write, so the round-trip always merges the file's true current state. Behavioral reads keep the cache; only the write path pays the extra disk read. The `_cfg_lock`-guarded re-check in `_load_cfg_raw` already handles thread-safety of the reset-then-read.

## Scope note

A concurrent edit landing *between* our read and `_save_cfg` is a pre-existing TOCTOU outside this patch's scope — stated explicitly so reviewers can decide whether a follow-up (write-while-edit conflict detection) is wanted.

## Verification

- `py_compile` clean.
- Targeted pytest (`test_tui_gateway_server.py`, `test_tui_gateway_loop_noise.py`, `test_process_identity.py`) — no regressions.