### PR TITLE
fix(gateway): make sample_memory() cross-platform via psutil fallback (#94936)

### DIFF
--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #94987 (issue #94936) attribution mapping

--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -77,9 +78,33 @@ def get_lifecycle_sentinel_path(home: Optional[Path] = None) -> Path:
 def sample_memory() -> Dict[str, Any]:
     """Cheap memory snapshot: own RSS + system availability + swap.
 
-    Pure ``/proc`` reads, Linux-only (returns ``{}`` elsewhere), never
-    raises.  Values in KiB to match the kernel's units.
+    Linux hosts read ``/proc`` directly (cheap, <1ms).  Non-Linux hosts fall
+    back to ``psutil`` — the same pattern already used by
+    :mod:`gateway.status` and :mod:`gateway.memory_monitor`.  When
+    ``psutil`` is unavailable the fallback returns whatever keys it could
+    fill, never raises: a forensics failure must not affect the gateway
+    lifecycle it is observing.
+
+    Returns a dict with the same key shape on every platform so the OOM
+    heuristic and heartbeat consumers downstream need no changes:
+
+    * ``rss_kib``              — own resident-set size in KiB
+    * ``mem_total_kib``        — total system memory in KiB
+    * ``mem_available_kib``    — available system memory in KiB
+    * ``swap_used_kib``        — used swap in KiB
+
+    Values are in KiB to match the kernel's units.  Missing keys mean the
+    platform/backend could not supply that specific value; the OOM
+    heuristic in :func:`detect_unclean_exit` treats every missing key as
+    "no measurement", which is the safe default.
     """
+    if sys.platform.startswith("linux"):
+        return _sample_memory_proc()
+    return _sample_memory_psutil()
+
+
+def _sample_memory_proc() -> Dict[str, Any]:
+    """Linux fast-path: pure ``/proc`` reads."""
     sample: Dict[str, Any] = {}
     try:
         with open("/proc/self/status", encoding="utf-8") as fh:
@@ -106,6 +131,38 @@ def sample_memory() -> Dict[str, Any]:
         if "SwapTotal" in meminfo and "SwapFree" in meminfo:
             sample["swap_used_kib"] = meminfo["SwapTotal"] - meminfo["SwapFree"]
     except (OSError, ValueError, IndexError):
+        pass
+    return sample
+
+
+def _sample_memory_psutil() -> Dict[str, Any]:
+    """Cross-platform fallback: ``psutil`` for RSS, virtual_memory, swap.
+
+    ``psutil`` is already a runtime dependency elsewhere in the gateway
+    (e.g. :mod:`gateway.status`, :mod:`gateway.memory_monitor`); this adds
+    no new dependency.  When ``psutil`` is unavailable the function
+    returns an empty dict — never raises — per the module's stated
+    contract that a forensics failure must not affect the lifecycle it is
+    observing.
+    """
+    sample: Dict[str, Any] = {}
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return sample
+    try:
+        sample["rss_kib"] = psutil.Process(os.getpid()).memory_info().rss // 1024
+    except Exception:
+        pass
+    try:
+        vm = psutil.virtual_memory()
+        sample["mem_total_kib"] = vm.total // 1024
+        sample["mem_available_kib"] = vm.available // 1024
+    except Exception:
+        pass
+    try:
+        sample["swap_used_kib"] = psutil.swap_memory().used // 1024
+    except Exception:
         pass
     return sample
 

--- a/tests/gateway/test_lifecycle_ledger.py
+++ b/tests/gateway/test_lifecycle_ledger.py
@@ -76,6 +76,140 @@ def test_sample_memory_has_expected_keys_on_linux() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Cross-platform sample_memory (issue #94936)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_KEYS = {"rss_kib", "mem_total_kib", "mem_available_kib", "swap_used_kib"}
+
+
+def test_sample_memory_returns_same_key_shape_on_current_platform() -> None:
+    """Whatever platform the test runs on, ``sample_memory()`` returns a
+    dict with the documented key shape (issue #94936).  Pre-fix this
+    returned ``{}`` on Windows / macOS and the OOM heuristic in
+    ``detect_unclean_exit`` was a structural constant ``False``.
+    """
+    sample = sample_memory()
+    assert isinstance(sample, dict)
+    # All documented keys must be present — the consumer heuristic in
+    # detect_unclean_exit reads mem_total_kib / mem_available_kib.
+    assert _EXPECTED_KEYS.issubset(sample.keys()), (
+        f"missing keys: {_EXPECTED_KEYS - set(sample.keys())}"
+    )
+    for key in _EXPECTED_KEYS:
+        assert isinstance(sample[key], int), f"{key} must be int (KiB)"
+        assert sample[key] >= 0
+
+
+def test_sample_memory_uses_psutil_when_platform_is_not_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force the non-Linux fallback path on any CI host (issue #94936).
+
+    The dispatcher is ``sys.platform.startswith('linux')``; we patch
+    ``sys.platform`` to ``win32`` to verify the psutil branch is reached
+    even when the test runner is Linux, then assert the same key shape
+    comes back.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    sample = sample_memory()
+    assert _EXPECTED_KEYS.issubset(sample.keys()), (
+        f"psutil fallback missing keys: {_EXPECTED_KEYS - set(sample.keys())}"
+    )
+    assert isinstance(sample.get("rss_kib"), int)
+    assert sample["rss_kib"] > 0
+
+
+def test_sample_memory_uses_proc_when_platform_is_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the Linux /proc fast-path is still reached on Linux hosts
+    (regression guard for the dispatcher swap).
+
+    Runs on any host by patching ``sys.platform`` AND stubbing
+    ``_sample_memory_proc`` to return a known sample — that proves the
+    dispatcher routes Linux to the proc backend without depending on the
+    host actually having ``/proc``.
+    """
+    import gateway.lifecycle_ledger as ledger_mod
+
+    captured = {"called": False}
+    sentinel_sample = {
+        "rss_kib": 12345,
+        "mem_total_kib": 1024 * 1024,
+        "mem_available_kib": 512 * 1024,
+        "swap_used_kib": 1024,
+    }
+
+    def _fake_proc() -> Dict[str, Any]:
+        captured["called"] = True
+        return sentinel_sample
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(ledger_mod, "_sample_memory_proc", _fake_proc)
+
+    sample = sample_memory()
+    assert captured["called"] is True, "Linux dispatcher did not call _sample_memory_proc"
+    assert sample == sentinel_sample
+    assert _EXPECTED_KEYS.issubset(sample.keys())
+
+
+def test_sample_memory_falls_back_gracefully_when_psutil_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the non-Linux fallback cannot import ``psutil`` it must still
+    return a dict — never raise — per the module's stated contract that
+    a forensics failure must not affect the lifecycle it is observing.
+
+    On Windows CI psutil is normally available; we simulate "missing" by
+    patching ``sys.platform`` away from ``linux`` AND poisoning the
+    ``psutil`` import inside the fallback to raise ``ImportError``.
+    """
+    import builtins
+
+    monkeypatch.setattr(sys, "platform", "darwin")  # force psutil branch
+
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("simulated psutil unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    # Must not raise — that's the entire contract.
+    sample = sample_memory()
+    assert isinstance(sample, dict)
+    # Empty dict is acceptable; partial dict is acceptable; what is NOT
+    # acceptable is an exception or a non-dict return.
+    for key, value in sample.items():
+        assert isinstance(key, str)
+        assert isinstance(value, int)
+
+
+def test_sample_memory_oom_heuristic_sees_measurement_on_non_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: on a non-Linux host, the OOM heuristic in
+    ``detect_unclean_exit`` must receive a real ``mem_available_kib``
+    value, not ``None``.  Pre-fix the value was always ``None`` and
+    ``suspected_oom`` was a structural constant ``False``.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    # Capture the heartbeat dict the way write_loop_heartbeat writes it.
+    sample = sample_memory()
+    assert "mem_available_kib" in sample
+    # Hand it to the heuristic exactly as detect_unclean_exit does.
+    total = sample.get("mem_total_kib")
+    avail = sample.get("mem_available_kib")
+    # The heuristic's safe default: missing or zero values simply do not
+    # fire — but here we have real values and want to prove the plumbing
+    # is no longer hard-disabled.
+    assert avail is not None and avail > 0
+    assert total is not None and total > 0
+
+
+# ---------------------------------------------------------------------------
 # First boot / clean lifecycle
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What Problem This Solves

`gateway/lifecycle_ledger.sample_memory()` reads `/proc/self/status` and `/proc/meminfo` directly with no fallback. On Windows and macOS it returns `{}` unconditionally, which propagates into the 30s gateway heartbeat and into the `suspected_oom` heuristic at the bottom of `detect_unclean_exit`: `mem.get("mem_available_kib")` is always `None`, so the comparison never fires and `suspected_oom` is a structural constant `False` on every non-Linux host.

That makes the unclean-death report — the primary deliverable of this module — useless for OOM diagnosis on Windows/macOS. Every `gateway.previous_unclean_exit` record in `gateway-exit-diag.log` carries `last_mem=None`, so there is no way to distinguish an OOM kill from a `taskkill`, a supervisor restart, or a VM death from the evidence this module produces.

This PR abstracts platform-specific memory sampling so Windows/macOS/Linux return the **same key shape** and the OOM heuristic / heartbeat consumers downstream need no changes.

## Evidence

**Pre-fix (Windows 11, this PR's host):**

```text
>>> from gateway.lifecycle_ledger import sample_memory
>>> sample_memory()
{}
```

**Post-fix (same host, same import):**

```text
>>> from gateway.lifecycle_ledger import sample_memory
>>> sample_memory()
{'rss_kib': 41280, 'mem_total_kib': 33235692, 'mem_available_kib': 11293504, 'swap_used_kib': 757916}
```

### Test results

`tests/gateway/test_lifecycle_ledger.py` — `D:/code/venvs/hermes-dev/Scripts/python.exe -m pytest tests/gateway/test_lifecycle_ledger.py -v`

```text
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_has_expected_keys_on_linux SKIPPED [  7%]
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_returns_same_key_shape_on_current_platform PASSED [ 14%]
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_uses_psutil_when_platform_is_not_linux PASSED [ 21%]
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_uses_proc_when_platform_is_linux PASSED [ 28%]
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_falls_back_gracefully_when_psutil_missing PASSED [ 35%]
tests/gateway/test_lifecycle_ledger.py::test_sample_memory_oom_heuristic_sees_measurement_on_non_linux PASSED [ 42%]
tests/gateway/test_lifecycle_ledger.py::test_first_boot_reports_nothing_and_claims_sentinel PASSED [ 50%]
tests/gateway/test_lifecycle_ledger.py::test_clean_exit_then_boot_reports_nothing PASSED [ 57%]
tests/gateway/test_lifecycle_ledger.py::test_running_sentinel_from_dead_pid_is_unclean PASSED [ 64%]
tests/gateway/test_lifecycle_ledger.py::test_record_startup_persists_unclean_report_and_reclaims PASSED [ 71%]
tests/gateway/test_lifecycle_ledger.py::test_record_startup_carries_unclean_flags_onto_new_sentinel PASSED [ 78%]
tests/gateway/test_lifecycle_ledger.py::test_record_startup_clean_boot_has_no_prior_flags PASSED [ 85%]
tests/gateway/test_lifecycle_ledger.py::test_mark_exited_leaves_pid_none_sentinel_alone PASSED [ 92%]
tests/gateway/test_lifecycle_ledger.py::test_prior_exit_label_survives_corrupt_sentinel PASSED [100%]

======================== 13 passed, 1 skipped in 1.29s ========================
```

The 1 SKIPPED is the pre-existing `test_sample_memory_has_expected_keys_on_linux` (gated on `sys.platform == "linux"`) — unrelated to this PR.

### Red baseline (pre-fix, demonstrating the bug)

Before the fix, on this Windows host:

- `sample_memory()` returned `{}` (verified by direct import — see `Evidence` above).
- `test_sample_memory_returns_same_key_shape_on_current_platform` would fail on `assert _EXPECTED_KEYS.issubset({})` because the 4 documented keys are absent.
- `test_sample_memory_uses_psutil_when_platform_is_not_linux`, `test_sample_memory_falls_back_gracefully_when_psutil_missing`, and `test_sample_memory_oom_heuristic_sees_measurement_on_non_linux` would all fail because `rss_kib`, `mem_total_kib`, `mem_available_kib`, `swap_used_kib` are all missing.

### Related suite

`tests/gateway/test_lifecycle_ledger.py` (this PR's file) + `tests/gateway/test_shutdown_watchdog.py` + `tests/gateway/test_status.py`:

```text
84 passed, 1 skipped
```

The single skipped test is the Linux-only `test_sample_memory_has_expected_keys_on_linux` — unrelated.

One unrelated pre-existing failure exists in `tests/gateway/test_status.py::TestReadProcessCmdlinePsFallback::test_ps_fallback_when_proc_unavailable` and was verified to fail identically on `origin/main` without this PR applied — not introduced by these changes.

## Fix Design

`gateway/lifecycle_ledger.py` — refactor `sample_memory()` into a dispatcher over two private helpers, both preserving the module's stated "never raise" contract:

- `_sample_memory_proc()` — Linux fast-path. The original /proc read code, unchanged.
- `_sample_memory_psutil()` — Non-Linux fallback. Uses `psutil`, which is already a runtime dependency elsewhere in the gateway (e.g. `gateway.status`, `gateway.memory_monitor`) — no new dependency.

The dispatcher:

```python
def sample_memory() -> Dict[str, Any]:
    if sys.platform.startswith("linux"):
        return _sample_memory_proc()
    return _sample_memory_psutil()
```

Both backends return the same key shape (`rss_kib`, `mem_total_kib`, `mem_available_kib`, `swap_used_kib`) and swallow per-key failures independently, so the OOM heuristic in `detect_unclean_exit` continues to read the same fields with no change.

When `psutil` is unavailable on the fallback path, the function returns an empty dict — never raises — per the module's stated contract that a forensics failure must not affect the lifecycle it is observing. Downstream consumers treat missing keys as "no measurement", which is the safe default.

Closes #94936