### PR TITLE
fix(mcp): tolerate empty list cache scope

### DIFF
--- a/tests/tools/test_mcp_cache_scope_compat.py
+++ b/tests/tools/test_mcp_cache_scope_compat.py
@@ -1,0 +1,154 @@
+"""Compatibility tests for legacy empty MCP list-result cache scopes."""
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+from pydantic import ValidationError
+
+from tools import mcp_tool
+
+
+class FakeDispatcher:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    async def send_raw_request(self, method, params, opts=None):
+        self.calls.append((method, params, opts))
+        if isinstance(self.results, Mapping):
+            return self.results
+        return self.results[method]
+
+
+class FakeSession:
+    def __init__(self, dispatcher):
+        self._dispatcher = dispatcher
+
+
+def _sdk_session(dispatcher):
+    assert mcp_tool._ensure_mcp_sdk()
+    session = mcp_tool.ClientSession(dispatcher=dispatcher)
+    return mcp_tool._install_list_cache_scope_compat(session)
+
+
+def _list_payload(method, **updates):
+    item_key = {
+        "tools/list": "tools",
+        "resources/list": "resources",
+        "resources/templates/list": "resourceTemplates",
+        "prompts/list": "prompts",
+    }[method]
+    payload = {item_key: [], **updates}
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("method", "call_name"),
+    [
+        ("tools/list", "list_tools"),
+        ("resources/list", "list_resources"),
+        ("resources/templates/list", "list_resource_templates"),
+        ("prompts/list", "list_prompts"),
+    ],
+)
+def test_empty_cache_scope_is_omitted_before_real_sdk_validation(method, call_name):
+    raw = _list_payload(method, cacheScope="")
+    session = _sdk_session(FakeDispatcher(raw))
+
+    result = asyncio.run(getattr(session, call_name)())
+
+    assert mcp_tool.mcp_field(result, "cache_scope", "cacheScope") == "private"
+    assert raw["cacheScope"] == ""
+
+
+@pytest.mark.parametrize("cache_scope", ["public", "private"])
+def test_valid_cache_scope_is_preserved_without_copy(cache_scope):
+    raw = _list_payload("tools/list", cacheScope=cache_scope)
+    dispatcher = FakeDispatcher(raw)
+    session = _sdk_session(dispatcher)
+
+    returned = asyncio.run(
+        session._dispatcher.send_raw_request("tools/list", None, {})
+    )
+    result = asyncio.run(session.list_tools())
+
+    assert returned is raw
+    assert mcp_tool.mcp_field(result, "cache_scope", "cacheScope") == cache_scope
+
+
+def test_missing_cache_scope_uses_sdk_private_default_without_copy():
+    raw = _list_payload("tools/list")
+    dispatcher = FakeDispatcher(raw)
+    session = _sdk_session(dispatcher)
+
+    returned = asyncio.run(
+        session._dispatcher.send_raw_request("tools/list", None, {})
+    )
+    result = asyncio.run(session.list_tools())
+
+    assert returned is raw
+    assert mcp_tool.mcp_field(result, "cache_scope", "cacheScope") == "private"
+
+
+def test_session_without_v2_dispatcher_is_left_untouched():
+    session = object()
+
+    assert mcp_tool._install_list_cache_scope_compat(session) is session
+
+
+@pytest.mark.parametrize("bad_scope", [" ", "shared", None, 1, [], {}])
+def test_other_invalid_cache_scopes_still_fail_sdk_validation(bad_scope):
+    session = _sdk_session(
+        FakeDispatcher(_list_payload("tools/list", cacheScope=bad_scope))
+    )
+
+    with pytest.raises(ValidationError):
+        asyncio.run(session.list_tools())
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"ttlMs": "forever"},
+        {"ttlMs": None},
+        {"tools": "not-a-list"},
+    ],
+)
+def test_other_malformed_list_fields_still_fail_sdk_validation(malformed):
+    raw = _list_payload("tools/list", cacheScope="", **malformed)
+    session = _sdk_session(FakeDispatcher(raw))
+
+    with pytest.raises(ValidationError):
+        asyncio.run(session.list_tools())
+
+
+def test_shim_is_narrow_non_mutating_and_shallow():
+    nested = {"keep": "same-object"}
+    raw = {"cacheScope": "", "nested": nested}
+    dispatcher = FakeDispatcher(raw)
+    session = FakeSession(dispatcher)
+    mcp_tool._install_list_cache_scope_compat(session)
+
+    normalized = asyncio.run(
+        session._dispatcher.send_raw_request("tools/list", None, {})
+    )
+
+    assert normalized == {"nested": nested}
+    assert normalized is not raw
+    assert normalized["nested"] is nested
+    assert raw == {"cacheScope": "", "nested": nested}
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["tools/call", "resources/read", "prompts/get", "initialize", "custom/list"],
+)
+def test_non_list_methods_are_never_rewritten(method):
+    raw = {"cacheScope": ""}
+    session = FakeSession(FakeDispatcher(raw))
+    mcp_tool._install_list_cache_scope_compat(session)
+
+    returned = asyncio.run(session._dispatcher.send_raw_request(method, None, {}))
+
+    assert returned is raw

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -95,6 +95,7 @@ Thread safety:
 """
 
 import asyncio
+from collections.abc import Mapping
 import contextvars
 import concurrent.futures
 import errno
@@ -533,6 +534,54 @@ def _check_logging_callback_support() -> bool:
         return "logging_callback" in inspect.signature(ClientSession).parameters
     except (TypeError, ValueError):
         return False
+
+
+_CACHE_SCOPE_COMPAT_LIST_METHODS = frozenset({
+    "tools/list",
+    "resources/list",
+    "resources/templates/list",
+    "prompts/list",
+})
+
+
+class _ListCacheScopeCompatDispatcher:
+    """Normalize one legacy list-result value before SDK validation."""
+
+    def __init__(self, dispatcher):
+        self._dispatcher = dispatcher
+
+    def __getattr__(self, name):
+        return getattr(self._dispatcher, name)
+
+    async def send_raw_request(self, method, params, opts=None):
+        raw = await self._dispatcher.send_raw_request(method, params, opts)
+        if (
+            method in _CACHE_SCOPE_COMPAT_LIST_METHODS
+            and isinstance(raw, Mapping)
+            and raw.get("cacheScope") == ""
+        ):
+            # Do not mutate transport-owned response mappings. Removing this
+            # exact legacy sentinel lets the SDK apply its private default;
+            # every other value and field still reaches normal validation.
+            normalized = dict(raw)
+            del normalized["cacheScope"]
+            return normalized
+        return raw
+
+
+def _install_list_cache_scope_compat(session):
+    """Wrap the MCP 2.x raw dispatcher; mcp 1.x sessions have no such seam."""
+    dispatcher = getattr(session, "_dispatcher", None)
+    if dispatcher is not None and not isinstance(
+        dispatcher, _ListCacheScopeCompatDispatcher
+    ):
+        session._dispatcher = _ListCacheScopeCompatDispatcher(dispatcher)
+    return session
+
+
+def _client_session(*args, **kwargs):
+    """Construct a ClientSession with Hermes' inbound compatibility shims."""
+    return _install_list_cache_scope_compat(ClientSession(*args, **kwargs))
 
 
 # MCP logging levels (RFC 5424 syslog severities) -> Python logging levels.
@@ -3311,7 +3360,7 @@ class MCPServerTask:
                 # fast-fail of in-flight calls when the subprocess dies
                 # (#81995).
                 self._stdio_child_pids = set(new_pids)
-                async with ClientSession(
+                async with _client_session(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     # Bound the MCP handshake. A stdio server that never
@@ -3693,7 +3742,7 @@ class MCPServerTask:
                 _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
             try:
                 async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
-                    async with ClientSession(
+                    async with _client_session(
                         read_stream, write_stream, **sampling_kwargs
                     ) as session:
                         # Bound the handshake — same orphaned-task hang as the
@@ -3763,7 +3812,7 @@ class MCPServerTask:
                     # and get_session_id was never used here.
                     async with streamable_http_client(url, http_client=http_client) as _streams:
                         read_stream, write_stream = _streams[0], _streams[1]
-                        async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                        async with _client_session(read_stream, write_stream, **sampling_kwargs) as session:
                             # Bound the handshake (#59349) — see stdio path.
                             self.initialize_result = await self._negotiate_session(
                                 session, float(connect_timeout)
@@ -3810,7 +3859,7 @@ class MCPServerTask:
                 async with streamablehttp_client(url, **_http_kwargs) as (
                     read_stream, write_stream, _get_session_id,
                 ):
-                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                    async with _client_session(read_stream, write_stream, **sampling_kwargs) as session:
                         # Bound the handshake (#59349) — see stdio path.
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)


### PR DESCRIPTION
## Summary

Fixes #94992.

Some remote MCP servers return an invalid empty cache hint on cacheable list responses:

```json
"cacheScope": ""
```

The MCP SDK correctly rejects that value because the 2026-07-28 schema permits only `"public"` or `"private"`. Today that optional malformed hint aborts discovery and disables every tool from an otherwise authenticated, reachable server.

This change adds a narrow inbound compatibility shim before SDK validation:

- Applies only to `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list`.
- Treats an exact top-level `cacheScope: ""` as omitted, allowing the SDK's fail-closed `private` default.
- Preserves valid scopes without copying.
- Continues rejecting whitespace, unknown strings, null/wrong types, invalid TTLs, unrelated malformed fields, and empty scopes on non-list methods.
- Is transport-wide rather than vendor-specific and leaves MCP 1.x sessions without the 2.x dispatcher seam untouched.

The server-side protocol violation was also reported directly to Upwork MCP support.

## Verification

- Regression test sabotage: **5 expected failures** when the exact normalization condition is disabled.
- Focused regression suite: **23 passed**.
- All MCP-named tests: **741 passed across 73 files**.
- Ruff on changed files: **passed**.
- `git diff --check`: **passed**.
- Live read-only verification against `https://mcp.upwork.com/mcp` using existing OAuth:
  - Connected in **1.734s**.
  - Discovered **30 tools**.
  - No Upwork write action was performed.

## Risk

Low and fail-closed. The shim removes only one exact invalid optional sentinel on four cacheable list methods. It never converts a response to public caching and leaves every other value and field to normal SDK validation.
