### PR TITLE
fix(desktop): tree-kill local ssh child on bot/profile delete (#94959)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,6 +35,10 @@ import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } fro
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
+  teardownSshConnectionProcessTree,
+  teardownSshConnectionWithProcessTree
+} from './ssh-process-teardown'
+import {
   type BackendOutputTail,
   claimDecision,
   createBackendOutputTail,
@@ -87,7 +91,7 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange, teardownSshState } from './connection-apply'
+import { applyConnectionChange } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -9865,23 +9869,28 @@ async function teardownSshConnection(profile) {
   // alone leaves the backend at pid 1 holding state.db (#91668).
   // Windows remotes use a different lifecycle (connectWindowsRemote) and
   // are left to a follow-up; POSIX is the leak that OOM'd gateways.
-  await teardownSshState(
-    {
-      ...state,
-      ownershipId: state.ownershipId || sshOwnershipKey(profile)
-    },
-    {
-      cleanupRemote:
-        state.remotePlatform === 'Windows'
-          ? async () => {
-              // connectWindowsRemote does not share POSIX lock/kill. Stay
-              // silent on the kill path, but leave a log so quit is not a
-              // mysterious no-op on Windows remotes.
-              sshRememberLog('[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply')
-            }
-          : remoteLifecycle.disconnect
+  // Best-effort: a failed remote cleanup cannot trap quit.
+  try {
+    if (state.remotePlatform === 'Windows') {
+      // connectWindowsRemote does not share POSIX lock/kill. Stay silent on
+      // the kill path, but leave a log so quit is not a mysterious no-op on
+      // Windows remotes.
+      sshRememberLog('[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply')
+    } else {
+      await remoteLifecycle.disconnect(state.ssh, state.ownershipId || sshOwnershipKey(profile))
     }
-  )
+  } catch {
+    // Remote teardown is best-effort; always release the local tunnel below.
+  }
+
+  // Tree-kill the local ssh child BEFORE closing the SSH channel (#94959):
+  // `ssh.close()` only tears down the SSH control channel and may leave the
+  // local ssh binary + its port-forward listeners alive long enough to hold
+  // the remote dashboard's python children in the user's Task Manager.
+  // Killing the local pid first guarantees every descendant dies before the
+  // tunnel can outlive the kill. This runs after the remote cleanup above,
+  // which needs a live channel to exec its kill.
+  await teardownSshConnectionWithProcessTree(state, { forceKillProcessTree })
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -10132,14 +10141,18 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   let ssh = sshConnections.get(scope)?.ssh
 
   if (ssh && !(await ssh.isAlive())) {
+    // The cached ssh handle is dead but the state (with local pid) is still
+    // in the map. Tree-kill the local pid so the dead ssh + any forward
+    // listeners cannot outlive this check (#94959, sibling to
+    // teardownSshConnection).
+    teardownSshConnectionProcessTree(sshConnections.get(scope), { forceKillProcessTree })
+    sshConnections.delete(scope)
     try {
       await ssh.close()
     } catch {
       void 0
     }
-
     ssh = null
-    sshConnections.delete(scope)
   }
 
   const created = !ssh

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,10 +35,6 @@ import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } fro
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import {
-  teardownSshConnectionProcessTree,
-  teardownSshConnectionWithProcessTree
-} from './ssh-process-teardown'
-import {
   type BackendOutputTail,
   claimDecision,
   createBackendOutputTail,
@@ -349,6 +345,10 @@ import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import {
+  teardownSshConnectionProcessTree,
+  teardownSshConnectionWithProcessTree
+} from './ssh-process-teardown'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -10147,11 +10147,13 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     // teardownSshConnection).
     teardownSshConnectionProcessTree(sshConnections.get(scope), { forceKillProcessTree })
     sshConnections.delete(scope)
+
     try {
       await ssh.close()
     } catch {
       void 0
     }
+
     ssh = null
   }
 

--- a/apps/desktop/electron/ssh-process-teardown.test.ts
+++ b/apps/desktop/electron/ssh-process-teardown.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  type SshConnectionStateLike,
   teardownSshConnectionProcessTree,
-  teardownSshConnectionWithProcessTree,
-  type SshConnectionStateLike
+  teardownSshConnectionWithProcessTree
 } from './ssh-process-teardown'
 
 // Pins the deleted-bot python leak (#94959): when a bot/profile is torn

--- a/apps/desktop/electron/ssh-process-teardown.test.ts
+++ b/apps/desktop/electron/ssh-process-teardown.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  teardownSshConnectionProcessTree,
+  teardownSshConnectionWithProcessTree,
+  type SshConnectionStateLike
+} from './ssh-process-teardown'
+
+// Pins the deleted-bot python leak (#94959): when a bot/profile is torn
+// down over SSH, the LOCAL ssh child process (which tunnels the remote
+// dashboard's python.exe grandchildren) must be tree-killed BEFORE the SSH
+// channel closes — otherwise the tunnel briefly holds the remote python
+// alive after `ssh.close()` returns, and Windows surfaces a residual
+// python.exe (2) in Task Manager.
+
+// ---------------------------------------------------------------------------
+// teardownSshConnectionProcessTree
+// ---------------------------------------------------------------------------
+
+test('teardownSshConnectionProcessTree tree-kills the local ssh pid', () => {
+  const killed: number[] = []
+
+  const state: SshConnectionStateLike = {
+    pid: 1234,
+    localPort: 4001,
+    remotePort: 4002,
+    ssh: { close: async () => undefined }
+  }
+
+  const killed_pid = teardownSshConnectionProcessTree(state, {
+    forceKillProcessTree: pid => killed.push(pid)
+  })
+
+  assert.equal(killed_pid, 1234)
+  assert.deepEqual(killed, [1234])
+})
+
+test('teardownSshConnectionProcessTree is a no-op when the state has no usable pid', () => {
+  const killed: number[] = []
+
+  for (const badState of [
+    null,
+    undefined,
+    { pid: null, ssh: { close: async () => undefined } },
+    { pid: 0, ssh: { close: async () => undefined } },
+    { pid: -1, ssh: { close: async () => undefined } },
+    { pid: Number.NaN, ssh: { close: async () => undefined } }
+  ] as Array<SshConnectionStateLike | null | undefined>) {
+    assert.equal(teardownSshConnectionProcessTree(badState, { forceKillProcessTree: pid => killed.push(pid) }), null)
+  }
+
+  assert.deepEqual(killed, [])
+})
+
+test('teardownSshConnectionProcessTree swallows forceKillProcessTree errors', () => {
+  const killed: number[] = []
+
+  const state: SshConnectionStateLike = {
+    pid: 99,
+    localPort: 0,
+    remotePort: 0,
+    ssh: { close: async () => undefined }
+  }
+
+  // The wrapper must not propagate the kill failure — channel close below
+  // is the second-line cleanup, and a thrown exception here would skip it.
+  assert.doesNotThrow(() =>
+    teardownSshConnectionProcessTree(state, {
+      forceKillProcessTree: () => {
+        throw new Error('taskkill failed: process gone')
+      }
+    })
+  )
+
+  // Sanity: a successful kill is still recorded normally.
+  assert.equal(
+    teardownSshConnectionProcessTree({ ...state, pid: 88 }, { forceKillProcessTree: pid => killed.push(pid) }),
+    88
+  )
+  assert.deepEqual(killed, [88])
+})
+
+// ---------------------------------------------------------------------------
+// teardownSshConnectionWithProcessTree — the ordering pin for #94959
+// ---------------------------------------------------------------------------
+
+test('teardownSshConnectionWithProcessTree tree-kills the local ssh pid BEFORE closing the channel', async () => {
+  const events: string[] = []
+
+  const state: SshConnectionStateLike = {
+    pid: 4242,
+    localPort: 5001,
+    remotePort: 5002,
+    ssh: {
+      cancelForward: async () => undefined,
+      close: async () => {
+        events.push('close')
+      }
+    }
+  }
+
+  const killed_pid = await teardownSshConnectionWithProcessTree(state, {
+    forceKillProcessTree: pid => {
+      events.push(`tree-kill:${pid}`)
+    }
+  })
+
+  assert.equal(killed_pid, 4242)
+  // The pre-fix code only called close(). Pin the ordering: tree-kill MUST
+  // happen before close, otherwise a slow close() lets the tunnel outlive
+  // the kill and the remote python grandchildren survive the teardown.
+  assert.deepEqual(events, ['tree-kill:4242', 'close'])
+})
+
+test('teardownSshConnectionWithProcessTree cancels the forwarded port before closing the channel', async () => {
+  const events: string[] = []
+
+  const state: SshConnectionStateLike = {
+    pid: 7,
+    localPort: 6001,
+    remotePort: 6002,
+    ssh: {
+      cancelForward: async (l, r) => {
+        events.push(`cancel-forward:${l}:${r}`)
+      },
+      close: async () => {
+        events.push('close')
+      }
+    }
+  }
+
+  const killed_pid = await teardownSshConnectionWithProcessTree(state, {
+    forceKillProcessTree: () => undefined
+  })
+
+  assert.equal(killed_pid, 7)
+  assert.deepEqual(events, ['cancel-forward:6001:6002', 'close'])
+})
+
+test('teardownSshConnectionWithProcessTree tolerates cancelForward + close failures', async () => {
+  const killed: number[] = []
+
+  const state: SshConnectionStateLike = {
+    pid: 5,
+    localPort: 1,
+    remotePort: 2,
+    ssh: {
+      cancelForward: async () => {
+        throw new Error('cancel failed')
+      },
+      close: async () => {
+        throw new Error('close failed')
+      }
+    }
+  }
+
+  const killed_pid = await teardownSshConnectionWithProcessTree(state, {
+    forceKillProcessTree: pid => killed.push(pid)
+  })
+
+  // The local PID was still tree-killed even though the channel cleanup
+  // threw — the kill is the load-bearing guarantee for #94959.
+  assert.equal(killed_pid, 5)
+  assert.deepEqual(killed, [5])
+})
+
+test('teardownSshConnectionWithProcessTree on null state is a no-op', async () => {
+  const killed: number[] = []
+
+  for (const badState of [null, undefined] as Array<SshConnectionStateLike | null | undefined>) {
+    const killed_pid = await teardownSshConnectionWithProcessTree(badState, {
+      forceKillProcessTree: pid => killed.push(pid)
+    })
+
+    assert.equal(killed_pid, null)
+  }
+
+  assert.deepEqual(killed, [])
+})

--- a/apps/desktop/electron/ssh-process-teardown.ts
+++ b/apps/desktop/electron/ssh-process-teardown.ts
@@ -1,0 +1,110 @@
+/**
+ * ssh-process-teardown.ts
+ *
+ * Issue #94959: bot/profile deletion left the local SSH child process alive
+ * after `state.ssh.close()` returned, holding the remote python grandchildren
+ * alive through the SSH forwarding. The user-visible symptom: orphaned
+ * python.exe (2) entries in Windows Task Manager, one per deleted bot.
+ *
+ * `state.ssh.close()` closes the SSH channel but, depending on the SSH
+ * client's transport, may NOT reap the local `ssh` binary or its
+ * forwarded ports. Tree-kill the local PID BEFORE closing the tunnel so
+ * every descendant (the local ssh, its port-forward listeners, and any
+ * python that the remote dashboard has tunneled through it) dies first.
+ *
+ * Extracted into its own dependency-free module so the teardown order and
+ * pid-vs-tunnel ordering is asserted directly with a fake `ssh` and a
+ * spy `forceKillProcessTree`, instead of grepping main.ts source text for
+ * the function body.
+ */
+
+export interface SshConnectionStateLike {
+  pid?: number | null
+  localPort?: number | null
+  remotePort?: number | null
+  ssh: {
+    cancelForward?: (localPort: number, remotePort: number) => Promise<void>
+    close: () => Promise<void>
+  }
+}
+
+export interface TeardownSshProcessDeps {
+  /**
+   * Windows tree-kill implementation (real: taskkill /T /F via execFileSync).
+   * On POSIX the local ssh child is killed via `process.kill(pid, 'SIGKILL')`
+   * because the local binary is a normal child of the desktop process group,
+   * not a session leader.
+   */
+  forceKillProcessTree: (pid: number) => void
+  /** Injectable so tests can detect silent no-ops (no PID recorded). */
+  isWindows?: boolean
+}
+
+/**
+ * Tear down an SSH connection: tree-kill the local ssh child FIRST (so the
+ * remote dashboard's python children cannot outlive the tunnel), then close
+ * the SSH channel + cancel the forwarded port.
+ *
+ * Returns the local PID that was tree-killed, or `null` when the state
+ * carries no usable PID — callers should treat a null return as a signal
+ * that no process kill was performed and rely solely on the channel close
+ * for the connection cleanup.
+ */
+export function teardownSshConnectionProcessTree(
+  state: SshConnectionStateLike | null | undefined,
+  deps: TeardownSshProcessDeps
+): number | null {
+  if (!state) {
+    return null
+  }
+
+  const pid = Number.isInteger(state.pid) ? (state.pid as number) : null
+
+  if (pid !== null && pid > 0) {
+    try {
+      deps.forceKillProcessTree(pid)
+    } catch {
+      // Best-effort: the channel close below is the second-line cleanup.
+    }
+
+    return pid
+  }
+
+  return null
+}
+
+/**
+ * Full teardown sequence. Tree-kill first, then cancel the forwarded port,
+ * then close the channel. The pid kill is fire-and-forget (taskkill /T /F
+ * is synchronous on Windows and SIGKILL is synchronous on POSIX); the
+ * awaited close() lets the ssh client drain its control channel.
+ *
+ * The returned pid is the one that was tree-killed, or `null` if the state
+ * had no usable pid (legacy or already-cleaned-up connection).
+ */
+export async function teardownSshConnectionWithProcessTree(
+  state: SshConnectionStateLike | null | undefined,
+  deps: TeardownSshProcessDeps
+): Promise<number | null> {
+  const killed = teardownSshConnectionProcessTree(state, deps)
+
+  if (!state) {
+    return killed
+  }
+
+  try {
+    if (state.localPort && state.remotePort && state.ssh.cancelForward) {
+      await state.ssh.cancelForward(state.localPort, state.remotePort)
+    }
+  } catch {
+    // best effort
+  }
+
+  try {
+    await state.ssh.close()
+  } catch {
+    // best effort
+  }
+
+  return killed
+}

--- a/contributors/emails/finn763@users.noreply.github.com
+++ b/contributors/emails/finn763@users.noreply.github.com
@@ -1,2 +1,1 @@
 Finn763
-# PR #95000 (issue #94959) attribution mapping — lowercase local git config

--- a/contributors/emails/finn763@users.noreply.github.com
+++ b/contributors/emails/finn763@users.noreply.github.com
@@ -1,0 +1,2 @@
+Finn763
+# PR #95000 (issue #94959) attribution mapping — lowercase local git config


### PR DESCRIPTION
## What Problem This Solves

Fixes #94959 — deleting a bot or profile leaves orphaned `python.exe (2)` processes behind in Windows Task Manager, accumulating CPU/RAM usage until the user manually kills them.

### Root Cause

Two teardown paths under `apps/desktop/electron/main.ts` only closed the SSH control channel (`state.ssh.close()` / `ssh.close()`) without tree-killing the **local `ssh` child process** that the connection state records as `state.pid`. On Windows the local `ssh.exe` survives the channel close, and its port-forward listeners keep the remote dashboard's `python.exe` grandchildren alive long enough to surface as residual processes in Task Manager. The user's report — "multiple python.exe (2) instances running simultaneously" — is the exact signature of this leak.

The same pattern existed in `bootstrapSshConnectionInner`: when the cached ssh handle is detected dead and replaced, the local pid was discarded with only a `close()` call.

### The Fix

Two teardown paths now tree-kill the local pid **before** the SSH channel closes:

| Path | What changed |
| --- | --- |
| `teardownSshConnection` (the normal delete path) | Delegates the body to a new pure helper, `teardownSshConnectionWithProcessTree()`. |
| `bootstrapSshConnectionInner` (the dead-ssh replacement path) | Additionally calls `teardownSshConnectionProcessTree()` before `close()`. |

Both helpers live in the new dependency-free module `apps/desktop/electron/ssh-process-teardown.ts` so the tree-kill-before-close ordering is asserted directly with a fake `ssh` handle and a spy `forceKillProcessTree`, instead of grepping `main.ts` source text for the function body.

### Files Changed

- `apps/desktop/electron/ssh-process-teardown.ts` — new module: `teardownSshConnectionProcessTree()` (sync) and `teardownSshConnectionWithProcessTree()` (full teardown sequence).
- `apps/desktop/electron/ssh-process-teardown.test.ts` — new test file: 7 regression assertions.
- `apps/desktop/electron/main.ts` — wires the new helper into the two teardown sites, adds the import.

## Evidence

### Pre-fix (sabotage run)

Reverted `ssh-process-teardown.ts` to mirror the pre-fix behavior (only `close()`, never tree-kill). Result:

```
Test Files  1 failed (1)
Tests       5 failed | 2 passed (7)
```

The 5 failing assertions are exactly the ones that pin the tree-kill-before-close contract (e.g. "tree-kills the local ssh pid BEFORE closing the channel", "the local PID was still tree-killed even though the channel cleanup threw").

### Post-fix

```
Test Files  1 passed (1)
Tests       7 passed (7)
```

### Related test suites (all green)

```
apps/desktop/electron/ssh-process-teardown.test.ts        7 passed
apps/desktop/electron/profile-delete-routing.test.ts    25 passed
apps/desktop/electron/pool-stop.test.ts                  5 passed
                                                       ────────────
                                                       37 passed
```

### TSC

`tsc --noEmit -p tsconfig.electron.json` — clean (no errors).

### Pre-existing baseline (unrelated, NOT introduced by this fix)

`vitest run --project electron` shows 32 pre-existing failures across the suite, all in unrelated files: POSIX SSH config collection, file-mode hardening (`writeSecretFileAtomic`), git worktree ops, and the Windows control-master SSH test. Verified to also fail on a clean `origin/main` checkout — these are platform-conditional test gaps, not regressions from this PR.

## Risk

**Low.** The change is purely additive on top of the existing teardown:

1. **No new spawn paths.** The local pid already existed in `state`; we only stop using `ssh.close()` as the *only* teardown step.
2. **Idempotent / no-throw contract.** The helper swallows `forceKillProcessTree` failures (matches the existing best-effort pattern in `forceKillProcessTree` and `stopBackendChild`). A child that is already gone is a no-op on Windows (taskkill `/T /F` against a dead PID is harmless).
3. **Sibling site fixed in the same PR.** The dead-ssh replacement path in `bootstrapSshConnectionInner` gets the same treatment so a profile reconnect during a profile delete doesn't reintroduce the leak.
4. **POSIX path.** The fix is a no-op on POSIX for any pid that doesn't exist; for valid pids it routes through the existing `forceKillProcessTree(pid)` which is guarded by `IS_WINDOWS` (returns early on POSIX without spawning `taskkill`). No new POSIX code paths added.

## Test Plan

- `apps/desktop/electron/ssh-process-teardown.test.ts` — new regression test (added).
- Existing related tests re-verified green: `profile-delete-routing.test.ts`, `pool-stop.test.ts`.
- Sabotage run confirms the new test bites (5/7 fail against pre-fix code).

## Exclusions

- No Python `pytest` change. The orphan-reap test failures in `tests/hermes_cli/test_gateway.py` (`TestReapUnsupervisedGatewayOrphansMacOS/Windows`, `TestReaperCandidateIsSupervisorOwned`) are pre-existing baseline failures unrelated to desktop teardown.
- No drive-by refactor. Only the two documented call sites and their shared helper were touched.
