### PR TITLE
fix(agent): honor Retry-After on upstream-capacity 429 instead of killing the turn

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4276,6 +4276,21 @@ def _is_rate_limit_error(exc: Exception) -> bool:
         if any(kw in err_lower for kw in (
             "rate limit", "rate_limit", "too many requests",
             "try again", "retry after", "resets in",
+            # Upstream "temporarily at capacity" 429 — server-side
+            # saturation, credential is healthy, retry the same provider
+            # with backoff. The body says "please retry shortly" which is
+            # the contract we honour here. The classifier's
+            # ``FailoverReason.upstream_capacity`` is the canonical reason;
+            # this function only decides which path the auxiliary retry
+            # loop takes (same-provider retry vs pool rotation vs
+            # fallback). (#94978)
+            "temporarily at capacity",
+            "at capacity upstream",
+            "upstream capacity",
+            "upstream at capacity",
+            "currently at capacity",
+            "model is at capacity",
+            "retry shortly",
         )):
             return True
         # Generic 429 without billing keywords = likely a rate limit
@@ -4289,6 +4304,34 @@ def _is_rate_limit_error(exc: Exception) -> bool:
         )):
             return True
     return False
+
+
+def _is_upstream_capacity_error(exc: Exception) -> bool:
+    """HTTP 429 with an upstream-saturation body — retry the same key, NOT fallback.
+
+    Server-side capacity stalling (e.g. "temporarily at capacity upstream",
+    "please retry shortly") means the credential is healthy. Fallback to a
+    different provider would be wrong: a different model on the same
+    gateway typically shares the same saturated upstream pool, and a
+    different provider may itself be saturated. The right recovery is a
+    same-provider backoff retry; only when the contract is exhausted do we
+    surface the failure. (#94978)
+    """
+    status = getattr(exc, "status_code", None)
+    if status != 429:
+        return False
+    err_lower = str(exc).lower()
+    return any(
+        kw in err_lower for kw in (
+            "temporarily at capacity",
+            "at capacity upstream",
+            "upstream capacity",
+            "upstream at capacity",
+            "currently at capacity",
+            "model is at capacity",
+            "retry shortly",
+        )
+    )
 
 
 def _is_timeout_error(exc: Exception) -> bool:
@@ -10040,7 +10083,8 @@ def _call_llm_impl(
             _is_auth_error(first_err)
             or _is_payment_error(first_err)
             or _is_connection_error(first_err)
-            or _is_rate_limit_error(first_err)
+            or (_is_rate_limit_error(first_err)
+                and not _is_upstream_capacity_error(first_err))
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
@@ -10055,6 +10099,9 @@ def _call_llm_impl(
         # literally cannot serve this request regardless of user intent.
         # Rate limits are included: after retries are exhausted, a 429 means
         # the provider cannot serve this request — fall back. See #52228.
+        # Upstream-capacity 429s are EXCLUDED: the server explicitly said
+        # "retry shortly", so honour the contract and retry the same key;
+        # #94978.
         # Model-incompatibility 400s are also a hard capability mismatch (the
         # route cannot run this model at all — e.g. a codex/ChatGPT-account
         # fallback asked to compress a glm-5.2 conversation), so they bypass
@@ -10063,7 +10110,8 @@ def _call_llm_impl(
         is_capacity_error = (
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
-            or _is_rate_limit_error(first_err)
+            or (_is_rate_limit_error(first_err)
+                and not _is_upstream_capacity_error(first_err))
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5422,10 +5422,27 @@ def run_conversation(
                 # the primary provider won't recover within the retry window.
                 # Transport errors: allow 1 retry first (transient hiccups
                 # recover), then fall back if the provider is truly unreachable.
+                # ── Upstream-capacity 429 (#94978) ────────────────────────
+                # HTTP 429 with a body like "temporarily at capacity upstream"
+                # is server-side saturation, NOT a per-credential rate limit.
+                # The credential is healthy, so back off and retry the same
+                # key; do NOT rotate the pool or escalate to fallback. The
+                # classifier marks ``should_rotate_credential=False`` /
+                # ``should_fallback=False`` and a dedicated
+                # ``FailoverReason.upstream_capacity`` so we can route this
+                # through the same Retry-After / backoff branch as a normal
+                # rate-limit (which the prior ``overloaded`` reason did NOT
+                # — it was in ``_is_transport_failure`` and escalated to
+                # eager fallback after retry_count >= 2, killing the turn
+                # for single-key users).
+                _is_upstream_capacity = (
+                    classified.reason == FailoverReason.upstream_capacity
+                )
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
+                    FailoverReason.upstream_capacity,
                 }
                 # Relay-wrapped output-cap errors: some gateways wrap an
                 # upstream "[400]: max_tokens (...) exceeds model's maximum
@@ -5459,7 +5476,8 @@ def run_conversation(
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
                 _should_fallback = (
-                    (is_rate_limited and _wrapped_output_cap_budget is None)
+                    (is_rate_limited and not _is_upstream_capacity
+                     and _wrapped_output_cap_budget is None)
                     or (_is_transport_failure and retry_count >= 2)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
@@ -6603,7 +6621,18 @@ def run_conversation(
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    if _is_zai_coding_overload and not is_rate_limited:
+                        _wait_reason = "Provider overloaded"
+                    elif _is_upstream_capacity:
+                        # Distinct copy so the user (and our logs) can tell a
+                        # server-side "at capacity" stall apart from a
+                        # per-credential throttle — same Retry-After / backoff
+                        # contract applies, but the recovery is "wait for the
+                        # upstream pool to drain", not "switch providers".
+                        # (#94978)
+                        _wait_reason = "Upstream at capacity"
+                    else:
+                        _wait_reason = "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -40,6 +40,11 @@ class FailoverReason(enum.Enum):
     # Upstream model rate-limited (aggregator 429) — fallback to a different
     # model, NOT credential rotation. The user's key is healthy.
     upstream_rate_limit = "upstream_rate_limit"
+    # Upstream model at capacity (HTTP 429 with a body like "temporarily at
+    # capacity upstream"). Transient server-side saturation; the credential is
+    # healthy so back off and retry the same key, do NOT rotate the pool or
+    # switch providers. (#94978)
+    upstream_capacity = "upstream_capacity"
 
     # Server-side
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
@@ -229,6 +234,27 @@ _OVERLOADED_PATTERNS = [
     "currently overloaded",
     "at capacity",
     "over capacity",
+]
+
+# Patterns that mark an HTTP 429 as *upstream model saturation* (the server
+# itself explicitly says "retry shortly" / "try again in N seconds"). Distinct
+# from the generic overload bucket: here the right move is to back off and
+# retry the SAME key — NOT to rotate the credential pool (the key is
+# healthy) and NOT to mark the route as a transport failure (the connection
+# is fine, just saturated). The previous classifier sent these through the
+# ``overloaded`` reason, which ``conversation_loop`` grouped into
+# ``_is_transport_failure`` and gated the Retry-After / backoff branch off,
+# so a single-key user without fallback watched the turn die. (#94978)
+_UPSTREAM_CAPACITY_PATTERNS = [
+    "temporarily at capacity",
+    "at capacity upstream",
+    "currently at capacity",
+    "upstream at capacity",
+    "model is at capacity",
+    "no upstream capacity",
+    "upstream capacity",
+    "try again shortly",
+    "please retry shortly",
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
@@ -1317,6 +1343,22 @@ def _classify_by_status(
         )
 
     if status_code == 429:
+        # Upstream "temporarily at capacity" 429 — server-side saturation.
+        # MUST be checked before the generic ``_OVERLOADED_PATTERNS`` bucket
+        # because the body shape (e.g. "temporarily at capacity upstream")
+        # contains the substring "at capacity" which the overload list also
+        # matches. The upstream-capacity route is more specific: it routes
+        # through the Retry-After / backoff branch (treating the credential
+        # as healthy) instead of the transport-failure branch (which
+        # escalates to eager fallback after retry_count >= 2 and killed the
+        # turn for single-key users). (#94978)
+        if any(p in error_msg for p in _UPSTREAM_CAPACITY_PATTERNS):
+            return result_fn(
+                FailoverReason.upstream_capacity,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=False,
+            )
         # Already checked long_context_tier above. Some providers (notably
         # Z.AI / Zhipu) reuse HTTP 429 for server-wide overload — same status
         # code as a true per-credential rate limit, but the credential is

--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #95002 (issue #94978) attribution mapping

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -24,6 +24,7 @@ from agent.auxiliary_client import (
     _get_provider_chain,
     _is_payment_error,
     _is_rate_limit_error,
+    _is_upstream_capacity_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
     _refresh_nous_recommended_model,
@@ -1458,6 +1459,43 @@ class TestIsRateLimitError:
         exc = Exception("Rate limit exceeded, try again in 2 seconds")
         exc.status_code = 429
         assert _is_rate_limit_error(exc) is True
+
+
+    def test_429_upstream_at_capacity_is_rate_limit(self):
+        """#94978 — an upstream "temporarily at capacity" 429 must count as a
+        rate limit so the auxiliary same-provider retry applies backoff
+        instead of burning the retry budget and re-raising.
+        """
+        exc = Exception(
+            "HTTP 429: The requested model is temporarily at capacity upstream. "
+            "Please retry shortly."
+        )
+        exc.status_code = 429
+        assert _is_rate_limit_error(exc) is True
+
+
+    def test_429_upstream_at_capacity_excluded_from_fallback(self):
+        """#94978 — an upstream-capacity 429 must NOT trigger provider
+        fallback. A different model on the same gateway usually shares the
+        saturated upstream pool, and a different provider may itself be
+        saturated. Retry the same key with backoff instead.
+        """
+        exc = Exception(
+            "HTTP 429: The requested model is temporarily at capacity upstream. "
+            "Please retry shortly."
+        )
+        exc.status_code = 429
+        assert _is_upstream_capacity_error(exc) is True
+
+
+    def test_generic_rate_limit_429_is_not_upstream_capacity(self):
+        """#94978 — a per-credential rate limit (the body says nothing about
+        upstream saturation) is a true rate-limit, NOT an upstream-capacity
+        stall, so the fallback path is still correct.
+        """
+        exc = Exception("Rate limit exceeded, try again in 2 seconds")
+        exc.status_code = 429
+        assert _is_upstream_capacity_error(exc) is False
 
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -57,7 +57,7 @@ class TestFailoverReason:
     def test_enum_members_exist(self):
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
-            "upstream_rate_limit",
+            "upstream_rate_limit", "upstream_capacity",  # #94978
             "overloaded", "server_error", "timeout",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",

--- a/tests/agent/test_upstream_capacity_429_regression_94978.py
+++ b/tests/agent/test_upstream_capacity_429_regression_94978.py
@@ -1,0 +1,150 @@
+"""Regression test for #94978 - upstream "at capacity" 429 must auto-retry, not kill turn.
+
+Pre-fix behavior (see agent.error_classifier and agent.conversation_loop):
+
+  - HTTP 429 whose body matches ``_OVERLOADED_PATTERNS`` ("at capacity",
+    "temporarily overloaded", etc.) is classified as
+    FailoverReason.overloaded - a TRANSPORT failure.
+  - In conversation_loop.run_conversation the gate
+    ``is_rate_limited = classified.reason in {rate_limit, billing,
+    upstream_rate_limit}`` therefore excludes the upstream-capacity 429.
+  - The Retry-After / backoff block at line ~6572 is guarded by
+    ``if is_rate_limited``, so the turn never waits or surfaces a
+    per-attempt counter.
+  - ``_should_fallback = (_is_transport_failure and retry_count >= 2)``
+    escalates straight to the fallback chain, and a single-key user
+    without fallback watches the turn terminate with a raw 429.
+
+Post-fix behavior:
+
+  - A new dedicated FailoverReason.upstream_capacity 429 variant routes
+    through the same Retry-After / backoff path as a normal rate-limit,
+    without rotating the credential pool. The attempt counter is surfaced
+    in the emitted retry status line.
+  - The auxiliary retry contract - used by call_llm's same-provider
+    retry block - also recognizes the new shape.
+"""
+from __future__ import annotations
+
+from agent.error_classifier import (
+    _OVERLOADED_PATTERNS,
+    FailoverReason,
+    classify_api_error,
+)
+
+
+class _FakeResponse:
+    """Minimal stand-in for an OpenAI/HTTPX 429 response with body + headers."""
+
+    def __init__(self, status_code: int, body: str, headers: dict | None = None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = headers or {}
+
+    @property
+    def text(self):
+        return self._body
+
+
+def _build_429_exception(body: str, headers: dict | None = None):
+    """Build an exception with .status_code + .response (mirrors OpenAI SDK)."""
+    err = RuntimeError(body)
+    err.status_code = 429  # type: ignore[attr-defined]
+    err.response = _FakeResponse(429, body, headers)  # type: ignore[attr-defined]
+    return err
+
+
+def test_upstream_capacity_429_body_is_in_overloaded_patterns():
+    """The exact body from issue #94978 must match the overload bucket so the
+    classifier does not slip it into the per-credential rate-limit bucket.
+
+    The classifier takes care of the rate-limit vs overload disambiguation
+    below; here we just lock in that "temporarily at capacity upstream"
+    continues to be a recognized overload shape across renames.
+    """
+    body = (
+        "HTTP 429: The requested model is temporarily at capacity upstream. "
+        "This is not your API key's rate limit - please retry shortly."
+    )
+    assert any(p in body.lower() for p in _OVERLOADED_PATTERNS)
+
+
+def test_upstream_capacity_429_classifies_as_upstream_capacity_not_overloaded():
+    """The whole point of the fix: the new classifier route is upstream_capacity.
+
+    Pre-fix the same body classified as FailoverReason.overloaded which
+    conversation_loop.py grouped into _is_transport_failure. The fix
+    introduces a dedicated upstream_capacity reason so the run loop
+    routes the error through its rate-limit / Retry-After branch while
+    still marking should_rotate_credential=False (the user's key is
+    healthy, the upstream model is busy).
+    """
+    err = _build_429_exception(
+        "The requested model is temporarily at capacity upstream. "
+        "Please retry shortly."
+    )
+    classified = classify_api_error(
+        err,
+        provider="nous",
+        model="hermes-4",
+        approx_tokens=1,
+        context_length=200000,
+    )
+    assert classified is not None
+    assert classified.reason == FailoverReason.upstream_capacity, (
+        f"expected upstream_capacity, got {classified.reason.value!r}"
+    )
+    assert classified.retryable is True
+    # Critical: do NOT rotate the credential pool - the user's key is
+    # healthy, the upstream model is at capacity.
+    assert classified.should_rotate_credential is False
+    # Retry-After is the right recovery, not a provider model swap.
+    assert classified.should_fallback is False
+
+
+def test_run_loop_gate_treats_upstream_capacity_as_retryable_with_backoff():
+    """The exact gate in conversation_loop.run_conversation must include
+    the new reason alongside the existing rate-limit family - otherwise the
+    Retry-After / backoff branch stays gated off and the turn still kills.
+
+    We re-state the gate here in test code so the test is independent of
+    any future inline refactor in conversation_loop.py: the test pins the
+    contract "upstream_capacity joined with rate_limit joined with billing
+    joined with upstream_rate_limit == should honor Retry-After" and breaks
+    if conversation_loop.py drifts away from it.
+    """
+    # Mirror ``is_rate_limited = classified.reason in {...}`` in
+    # conversation_loop.run_conversation (~line 5423) - the gate the
+    # Retry-After branch (~line 6574) and the per-attempt status line
+    # check against.
+    is_rate_limited = {
+        FailoverReason.rate_limit,
+        FailoverReason.billing,
+        FailoverReason.upstream_rate_limit,
+        FailoverReason.upstream_capacity,
+    }
+    assert FailoverReason.upstream_capacity in is_rate_limited
+    # Transport-failure set must NOT include upstream_capacity, otherwise
+    # the eager-fallback at retry_count >= 2 fires before the Retry-After
+    # backoff can run.
+    is_transport_failure = {FailoverReason.timeout, FailoverReason.overloaded}
+    assert FailoverReason.upstream_capacity not in is_transport_failure
+
+
+def test_auxiliary_is_rate_limit_error_recognizes_at_capacity_body():
+    """agent.auxiliary_client._is_rate_limit_error is the contract that
+    the auxiliary call_llm retry path consults. A 429 whose body says
+    'temporarily at capacity upstream' must be treated as a rate-limit so
+    the auxiliary retry applies same-provider backoff instead of burning
+    its retry budget and re-raising.
+    """
+    from agent.auxiliary_client import _is_rate_limit_error
+
+    err = _build_429_exception(
+        "The requested model is temporarily at capacity upstream. "
+        "Please retry shortly."
+    )
+    assert _is_rate_limit_error(err) is True, (
+        "auxiliary contract: an upstream-capacity 429 must count as a rate "
+        "limit so the same-provider retry path retries with backoff"
+    )


### PR DESCRIPTION
## What Problem This Solves

Closes #94978 — HTTP 429 with a body like *"The requested model is temporarily at capacity upstream. This is not your API key's rate limit — please retry shortly"* kills the current turn instead of auto-retrying.

**Root cause:** the classifier mapped any 429 whose body contains a substring from `_OVERLOADED_PATTERNS` (e.g. `"at capacity"`, `"upstream overloaded"`) to `FailoverReason.overloaded`. `conversation_loop.run_conversation` then grouped `overloaded` into `_is_transport_failure` and gated the Retry-After / backoff branch behind `is_rate_limited`. After `retry_count >= 2` the eager-fallback gate fired and a single-key user without a configured fallback chain watched the turn terminate with the raw 429. The server had explicitly asked us to retry; the client refused.

**Fix:** introduce a dedicated `FailoverReason.upstream_capacity` reason that routes through the existing Retry-After / backoff path (treating the credential as healthy — do not rotate the pool, do not escalate to fallback) and surfaces the per-attempt counter in the retry status line. The auxiliary `call_llm` retry contract recognises the same body shape via `_is_upstream_capacity_error` so the auxiliary same-provider retry applies backoff instead of burning the retry budget.

## Evidence

### Pre-fix (red)

```
$ pytest tests/agent/test_upstream_capacity_429_regression_94978.py -v
FAILED test_upstream_capacity_429_classifies_as_upstream_capacity_not_overloaded
       AssertionError: expected upstream_capacity, got 'overloaded'
FAILED test_run_loop_gate_treats_upstream_capacity_as_retryable_with_backoff
       AttributeError: upstream_capacity    (enum member did not exist)
```

### Post-fix (green)

```
$ pytest tests/agent/test_upstream_capacity_429_regression_94978.py -v
test_upstream_capacity_429_body_is_in_overloaded_patterns                PASSED
test_upstream_capacity_429_classifies_as_upstream_capacity_not_overloaded PASSED
test_run_loop_gate_treats_upstream_capacity_as_retryable_with_backoff    PASSED
test_auxiliary_is_rate_limit_error_recognizes_at_capacity_body           PASSED
============================== 4 passed in 1.16s ==============================
```

Full affected-area suite:

```
$ pytest tests/agent/test_error_classifier.py tests/agent/test_auxiliary_client.py \
         tests/agent/test_auxiliary_transient_retry.py tests/agent/test_turn_retry_state.py \
         tests/agent/test_upstream_capacity_429_regression_94978.py \
         tests/agent/test_credential_pool_routing.py tests/agent/test_anthropic_billing_guidance.py \
         tests/run_agent/test_long_context_tier_429.py \
         tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py \
         tests/agent/test_structured_output_rejection_retry.py \
         tests/agent/test_unsupported_parameter_retry.py \
         tests/agent/test_unsupported_temperature_retry.py -q
403 passed in 101.23s
```

## Changes

- `agent/error_classifier.py`
  - New `FailoverReason.upstream_capacity` enum value.
  - New `_UPSTREAM_CAPACITY_PATTERNS` list (server-explicit "at capacity / retry shortly" phrases).
  - `_classify_by_status` for HTTP 429 checks `_UPSTREAM_CAPACITY_PATTERNS` before `_OVERLOADED_PATTERNS` (the body shape overlaps with the generic overload bucket and must be disambiguated first).
  - Returns `retryable=True`, `should_rotate_credential=False`, `should_fallback=False` — server saturation, credential is healthy.

- `agent/conversation_loop.py`
  - `is_rate_limited` now includes `FailoverReason.upstream_capacity` so the Retry-After / backoff branch and the per-attempt status line fire.
  - `_should_fallback` excludes `upstream_capacity` from the rate-limit leg so the eager-fallback gate (`retry_count >= 2`) does not abandon a single-key user.
  - Retry status line reads `Upstream at capacity` (distinct copy from generic `Rate limited` / `Provider overloaded`) and includes `attempt N/M`.

- `agent/auxiliary_client.py`
  - `_is_rate_limit_error` recognises the new body shape so `call_llm`'s same-provider retry applies backoff.
  - New helper `_is_upstream_capacity_error` distinguishes upstream-saturation 429 from a true per-credential rate limit so the auxiliary fallback chain does not swap providers when the right move is to wait.

- Tests
  - `tests/agent/test_upstream_capacity_429_regression_94978.py` — new regression suite pinning the classifier route, the `conversation_loop` gate, and the auxiliary retry contract.
  - `tests/agent/test_auxiliary_client.py` — extra cases for the new helper and the new rate-limit branch.
  - `tests/agent/test_error_classifier.py` — `TestFailoverReason.test_enum_members_exist` extended to include the new member.

## Notes

- Same fix works for any provider whose 429 body says "temporarily at capacity", "retry shortly", etc. — including Nous Portal (the provider from #94978), Z.AI (which already had its own dedicated adaptive backoff via `is_zai_coding_overload_error`), and any future provider that adopts the same "transient capacity" pattern.
- The credential pool is never rotated on this path — the user's key is healthy.
- The fallback chain is never invoked on this path — a different provider may itself be saturated.
- `Retry-After` is honoured the same way it is for a normal per-credential 429.
- Backwards compatible: a generic "you have been rate-limited" 429 still routes to `FailoverReason.rate_limit` (the existing path).