### PR TITLE
feat: fall back to a default channel_overrides key

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -601,6 +601,11 @@ class ChannelOverride:
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
     models and personas without running separate gateway instances.
+
+    The key ``"default"`` is reserved: if no specific chat_id/thread_id/
+    parent_id entry matches, ``_get_channel_override`` falls back to it, so a
+    single entry can apply to every channel on a platform without listing
+    each chat_id.
     """
     model: Optional[str] = None
     provider: Optional[str] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3806,6 +3806,9 @@ def _get_channel_override(
 
     Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
     ``parent_id`` (forum threads / child channels inherit the parent entry).
+    Falls back to a ``"default"`` entry, if configured, when none of those
+    match — lets a platform-wide override apply to every channel without
+    enumerating each chat_id individually.
     """
     platforms = getattr(config, "platforms", None)
     if not platforms:
@@ -3820,7 +3823,7 @@ def _get_channel_override(
         ov = overrides.get(key)
         if ov is not None:
             return ov
-    return None
+    return overrides.get("default")
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -51,6 +51,37 @@ class TestGetChannelOverride:
         assert result.system_prompt == "You are a summarizer."
 
 
+    def test_falls_back_to_default_when_no_specific_match(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "default": ChannelOverride(system_prompt="Applies everywhere."),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(config, Platform.DISCORD, "any_chat_id")
+        assert result is not None
+        assert result.system_prompt == "Applies everywhere."
+
+    def test_specific_match_wins_over_default(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "default": ChannelOverride(system_prompt="Generic."),
+                        "chan_1": ChannelOverride(system_prompt="Specific."),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(config, Platform.DISCORD, "chan_1")
+        assert result is not None
+        assert result.system_prompt == "Specific."
+
     def test_thread_id_lookup_when_chat_id_misses(self):
         config = GatewayConfig(
             platforms={


### PR DESCRIPTION
## Summary
- `channel_overrides` currently requires enumerating every chat_id/thread_id individually, even when the same override should apply to every channel on a platform.
- `_get_channel_override` now falls back to a reserved `"default"` key when no specific chat_id/thread_id/parent_id entry matches, so one entry can cover an entire platform.
- Specific entries still take priority over `default` when both are present.

## Test plan
- [x] `pytest tests/gateway/test_channel_overrides.py` — 8/8 passing, including two new cases (`test_falls_back_to_default_when_no_specific_match`, `test_specific_match_wins_over_default`)
- [x] Verified against a real multi-channel config: loaded a config with 4 near-identical per-chat_id `system_prompt` overrides, collapsed to a single `default` entry, and confirmed `_get_channel_override` resolves the same content for all 4 original chat_ids plus a previously-unconfigured one

https://claude.ai/code/session_018UCv7yKSfHGfn4kCQe2UHj