### PR TITLE
Windows auto-update no longer stalls 11 min on cua-driver's interactive installer (#87703, salvage #94296)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1190,12 +1190,19 @@ def install_cua_driver(
             return True
         if _state is not None and _state.get("update_available"):
             if is_windows and require_confirmed_update:
-                _latest = _state.get("latest_version") or "a newer version"
-                _print_info(
-                    f"    {driver_cmd} {_latest} is available; keeping the "
-                    "installed version because its Windows installer may "
-                    "require interactive consent."
-                )
+                _latest = _state.get("latest_version")
+                if _latest:
+                    _print_info(
+                        f"    {driver_cmd} {_latest} is available; keeping the "
+                        "installed version because its Windows installer may "
+                        "require interactive consent."
+                    )
+                else:
+                    _print_info(
+                        f"    A newer {driver_cmd} release is available; "
+                        "keeping the installed version because its Windows "
+                        "installer may require interactive consent."
+                    )
                 _print_info(
                     "    Update it from an interactive terminal with: "
                     "hermes computer-use install --upgrade"
@@ -1213,6 +1220,22 @@ def install_cua_driver(
             _latest = str(_state.get("latest_version") or "").strip().lstrip("vV")
             if _re.fullmatch(r"\d+(\.\d+)*", _latest):
                 confirmed_version = _latest
+
+    if is_windows and require_confirmed_update and not binary:
+        # Missing-binary path (driver enabled in config but never installed,
+        # or wiped by a failed install). Same rule as the repair and
+        # confirmed-update branches above: an automatic Windows update must
+        # never launch install.ps1, which can demand console/UAC consent the
+        # hidden updater cannot provide (#87703).
+        _print_info(
+            "    cua-driver is not installed; automatic Windows updates "
+            "cannot safely run its interactive installer."
+        )
+        _print_info(
+            "    Install it from an interactive terminal with: "
+            "hermes computer-use install --upgrade"
+        )
+        return False
 
     if binary:
         # Show before/after version when we have a baseline. Best-effort.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1005,7 +1005,9 @@ def install_cua_driver(
     ``_CUA_INSTALLER_TIMEOUT`` and install.ps1's concurrency lock can add
     a further ~600s wait on Windows). ``hermes computer-use install
     --upgrade`` leaves it False — an explicit upgrade request should still
-    reinstall when the check is indeterminate.
+    reinstall when the check is indeterminate. On Windows this flag also
+    prevents every installer run, because install.ps1 may require console or
+    UAC consent; automatic updates instead point at the explicit command.
 
     ``show_installer_progress`` controls the installer's own progress line.
     ``hermes update`` already prints a contextual line before its update
@@ -1123,6 +1125,16 @@ def install_cua_driver(
                 "the override and run: hermes computer-use install --upgrade"
             )
             return False
+        if is_windows and require_confirmed_update:
+            _print_info(
+                "    Automatic Windows updates cannot safely run cua-driver's "
+                "interactive repair installer."
+            )
+            _print_info(
+                "    Repair it from an interactive terminal with: "
+                "hermes computer-use install --upgrade"
+            )
+            return False
         _print_info("    Repairing it with the current upstream installer.")
 
     # upgrade=True path — refresh to the latest upstream release.
@@ -1177,6 +1189,18 @@ def install_cua_driver(
             )
             return True
         if _state is not None and _state.get("update_available"):
+            if is_windows and require_confirmed_update:
+                _latest = _state.get("latest_version") or "a newer version"
+                _print_info(
+                    f"    {driver_cmd} {_latest} is available; keeping the "
+                    "installed version because its Windows installer may "
+                    "require interactive consent."
+                )
+                _print_info(
+                    "    Update it from an interactive terminal with: "
+                    "hermes computer-use install --upgrade"
+                )
+                return True
             # Pin the installer to the release check-update just confirmed.
             # `latest_version` comes from the GitHub Releases API, so its
             # assets are published — unlike the installer script's baked

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7409,7 +7409,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # An indeterminate check (offline, rate-limited, old
                 # driver) keeps the installed version — `hermes update`
                 # must stay fast; `hermes computer-use install --upgrade`
-                # remains the force path.
+                # remains the force path. Windows also defers confirmed
+                # updates and contract repairs to that explicit command
+                # because the upstream installer may prompt for console/UAC
+                # consent that this hidden updater cannot provide.
                 install_cua_driver(
                     upgrade=True,
                     require_confirmed_update=True,

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -6,8 +6,9 @@ must:
 
 * Be supported-platform-only — no-op silently elsewhere so ``hermes update``
   can call it unconditionally without warning unsupported-platform users.
-* Re-run the installer even when the binary is already on PATH (this is the
-  fix for the "we only pulled cua-driver once on enable" complaint).
+* Re-run the installer for explicit upgrades even when the binary is already
+  on PATH (this is the fix for the "we only pulled cua-driver once on enable"
+  complaint). Automatic Windows updates defer because the installer can prompt.
 * For ``upgrade=False``, keep compatible installations, repair old or
   incomplete installations, and install when missing.
 
@@ -439,7 +440,7 @@ class TestRequireConfirmedUpdate:
     still reinstall when the check can't answer.
     """
 
-    def _install(self, check_state, require_confirmed):
+    def _install(self, check_state, require_confirmed, contract_status=None):
         """Drive ``install_cua_driver`` on the host, whatever it is.
 
         The old signature took a ``system`` string and faked
@@ -463,7 +464,11 @@ class TestRequireConfirmedUpdate:
              patch.object(
                  tools_config,
                  "_cua_driver_contract_status",
-                 return_value={"ready": True, "version": "0.20.0", "reason": ""},
+                 return_value=contract_status or {
+                     "ready": True,
+                     "version": "0.20.0",
+                     "reason": "",
+                 },
              ), \
              patch("tools.computer_use.cua_backend.cua_driver_update_check",
                    return_value=check_state), \
@@ -497,12 +502,49 @@ class TestRequireConfirmedUpdate:
             for call in info.call_args_list
         )
 
-    def test_confirmed_update_still_runs_installer(self):
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="automatic Windows updates must not launch an interactive installer",
+    )
+    def test_confirmed_update_still_runs_installer_on_posix(self):
         state = {"current_version": "0.5.0", "latest_version": "0.6.0",
                  "update_available": True}
         ok, runner, _ = self._install(state, require_confirmed=True)
         assert ok is True
         runner.assert_called_once()
+
+    @pytest.mark.windows_only
+    def test_windows_confirmed_update_defers_interactive_installer(self):
+        state = {"current_version": "0.5.0", "latest_version": "0.6.0",
+                 "update_available": True}
+        ok, runner, info = self._install(state, require_confirmed=True)
+
+        assert ok is True
+        runner.assert_not_called()
+        assert any(
+            "computer-use install --upgrade" in call.args[0]
+            for call in info.call_args_list
+        )
+
+    @pytest.mark.windows_only
+    def test_windows_incompatible_driver_defers_interactive_repair(self):
+        incompatible = {
+            "ready": False,
+            "version": "0.19.3",
+            "reason": "Hermes computer use requires cua-driver 0.20.0 or newer",
+        }
+        ok, runner, info = self._install(
+            None,
+            require_confirmed=True,
+            contract_status=incompatible,
+        )
+
+        assert ok is False
+        runner.assert_not_called()
+        assert any(
+            "computer-use install --upgrade" in call.args[0]
+            for call in info.call_args_list
+        )
 
     def test_up_to_date_short_circuits(self):
         state = {"current_version": "0.6.0", "latest_version": "0.6.0",
@@ -518,7 +560,11 @@ class TestRequireConfirmedUpdate:
         assert ok is True
         runner.assert_called_once()
 
-    def test_incompatible_driver_repairs_despite_indeterminate_check(self):
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="automatic Windows updates must not launch an interactive repair",
+    )
+    def test_incompatible_driver_repairs_on_posix_despite_indeterminate_check(self):
         """Hermes' own version floor is the confirmation. When the installed
         driver fails the runtime contract, the `hermes update` refresh must
         repair it even though ``check-update`` can't confirm a newer release
@@ -1106,13 +1152,7 @@ class TestConfirmedVersionPinning:
     """
 
     def _install(self, check_state):
-        """Host-agnostic: version pinning is string handling, not an OS branch.
-
-        The old ``platform.system`` → "Windows" fake was incidental — the
-        pin flows into ``CUA_DRIVER_RS_VERSION`` identically on every host
-        (both upstream installers honour it), and this test never reaches the
-        installer anyway because ``_run_cua_driver_installer`` is mocked.
-        """
+        """Version pinning also applies to explicit installer runs."""
         from unittest.mock import MagicMock
 
         from hermes_cli import tools_config
@@ -1139,7 +1179,7 @@ class TestConfirmedVersionPinning:
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"):
             ok = tools_config.install_cua_driver(
-                upgrade=True, require_confirmed_update=True
+                upgrade=True, require_confirmed_update=False
             )
         return ok, runner
 

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -440,7 +440,8 @@ class TestRequireConfirmedUpdate:
     still reinstall when the check can't answer.
     """
 
-    def _install(self, check_state, require_confirmed, contract_status=None):
+    def _install(self, check_state, require_confirmed, contract_status=None,
+                 binary_missing=False):
         """Drive ``install_cua_driver`` on the host, whatever it is.
 
         The old signature took a ``system`` string and faked
@@ -454,11 +455,15 @@ class TestRequireConfirmedUpdate:
 
         from hermes_cli import tools_config
 
+        _which_names = {"curl", "powershell"}
+        if not binary_missing:
+            _which_names.add("cua-driver")
         with patch.object(tools_config.shutil, "which",
                           side_effect=lambda n: "/x/" + n
-                          if n in {"cua-driver", "curl", "powershell"} else None), \
+                          if n in _which_names else None), \
              patch.object(tools_config, "_resolved_cua_driver_cmd",
-                          return_value="/x/cua-driver"), \
+                          return_value=None if binary_missing
+                          else "/x/cua-driver"), \
              patch.object(tools_config, "_cua_install_target_writable",
                           return_value=True), \
              patch.object(
@@ -545,6 +550,38 @@ class TestRequireConfirmedUpdate:
             "computer-use install --upgrade" in call.args[0]
             for call in info.call_args_list
         )
+
+    @pytest.mark.windows_only
+    def test_windows_missing_binary_defers_interactive_install(self):
+        """Driver enabled but never installed (or wiped by a failed install):
+        the automatic update must not launch install.ps1 either — this path
+        reached the installer before the top-level guard (#94296 review)."""
+        ok, runner, info = self._install(
+            None,
+            require_confirmed=True,
+            binary_missing=True,
+        )
+
+        assert ok is False
+        runner.assert_not_called()
+        assert any(
+            "computer-use install --upgrade" in call.args[0]
+            for call in info.call_args_list
+        )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX installers are non-interactive; missing binary installs",
+    )
+    def test_posix_missing_binary_still_installs(self):
+        ok, runner, _ = self._install(
+            None,
+            require_confirmed=True,
+            binary_missing=True,
+        )
+
+        assert ok is True
+        runner.assert_called_once()
 
     def test_up_to_date_short_circuits(self):
         state = {"current_version": "0.6.0", "latest_version": "0.6.0",


### PR DESCRIPTION
## Summary
`hermes update` on Windows no longer stalls for 11 minutes on cua-driver's interactive installer — automatic updates now defer every interactive CUA install/repair to the explicit `hermes computer-use install --upgrade` command (#87703, salvage of #94296 by @royalaid).

Root cause: the hidden, non-interactive updater invoked cua's `install.ps1`, which can demand console/UAC consent nobody can answer; the run sat until the 660s ceiling and then failed anyway. Observed live on Teknium's box today: a 15-minute update where 11 minutes was this timeout.

## Changes
- `hermes_cli/tools_config.py`: on Windows with `require_confirmed_update=True` (the `hermes update` path), defer instead of launching the installer in all three branches: contract repair, confirmed-newer-release, and — added in the follow-up commit, closing the gap flagged in the #94296 review — the missing-binary fresh-install path, which previously still reached `_run_cua_driver_installer()`.
- Confirmed-update message now reads naturally when `latest_version` is unknown ("A newer cua-driver release is available…" instead of "cua-driver a newer version is available").
- `hermes_cli/update_cmd.py`: comment documenting the Windows defer at the call site.
- `tests/hermes_cli/test_install_cua_driver.py`: platform-split coverage — Windows defers (confirmed update, repair, missing binary), POSIX still installs/repairs; harness gains a `binary_missing` knob.

## Validation
| | Before | After |
|---|---|---|
| Windows auto-update, CUA update available | launches install.ps1, hangs to 660s timeout | defers with pointer to `computer-use install --upgrade` |
| Windows auto-update, driver missing | still launched installer (gap in #94296) | defers |
| Windows auto-update, contract repair needed | launches installer | defers |
| POSIX auto-update, any of the above | installs | installs (unchanged) |

Targeted tests: 53 passed, 13 skipped (platform-gated). E2E: real `install_cua_driver()` calls with `platform.system` faked to Windows/Linux across all five scenarios — installer never invoked on the Windows auto-update paths, still invoked on POSIX.

**Live repro:** symptom captured from a real Windows update today (2026-08-25, `desktop-update-handoff.log`): `cua-driver refreshing timed out after 660s` inside a 15-minute hand-off; the after-side is exercised via the E2E harness above (Windows-path behavior cannot run natively on this Linux box — Windows CI job covers the `windows_only` tests).

Credit: @royalaid (#94296) for the core fix; review-gap follow-up (missing-binary branch + wording) added on top.

Closes #94296. Fixes #87703.

## Infographic

![CUA defer infographic](https://v3b.fal.media/files/b/0aa7cb6c/nLIhN2ZQNu-rcVrQbDk3V_84sku64R.png)
