### PR TITLE
fix(desktop): Cronjobs pane no longer shows 'unavailable' for every bot (#94516, salvage #94670)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -402,7 +402,6 @@ function fallbackFocusedBotOwner(profile = $focusedBotProfile.get?.()) {
   }
 }
 
-const hasFocusedSessionOwnerSupport = Boolean(host.state.focusedSessionOwner)
 const $focusedBotOwner = host.state.focusedSessionOwner || {
   get: () => fallbackFocusedBotOwner(),
   listen: listener => {
@@ -11280,19 +11279,24 @@ function bindProfileSync(ownerStore) {
 }
 
 function resolveRoutineOwner(roster, focusedOwner, selected) {
-  if (hasFocusedSessionOwnerSupport && !focusedOwner) {
-    return null
-  }
-
+  // A null focused owner is NOT a failure: the SDK fails closed to null
+  // whenever the focused session has no unique bot owner (a normal chat,
+  // ambiguous owner hints) — the common case while the user browses the
+  // Bots pane. Fall through to the roster-clicked bot (the previously
+  // working scope) instead of dead-ending the pane on the unavailable
+  // placeholder for every agent (#94516).
+  const selectedBot = roster.find(bot => botSelectionKey(bot) === selected)
   const focusedBot = focusedOwner
     ? roster.find(bot => isActiveRosterBot(bot, focusedOwner))
     : null
 
   if (focusedOwner?.authoritative) {
+    // An authoritative focused owner wins, but only through its exact roster
+    // row. If that row is absent, fail closed instead of routing cron
+    // reads/mutations through a stale selection or an unscoped profile name.
     return focusedBot || null
   }
 
-  const selectedBot = roster.find(bot => botSelectionKey(bot) === selected)
   return focusedBot || selectedBot || (focusedOwner ? { name: focusedOwner.name } : null)
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
@@ -10,6 +10,14 @@ import vm from 'node:vm'
 // left $selectedBot pointed at whichever bot was active before the plugin was
 // disabled. bindProfileSync() reseeds $selectedBot from the store's CURRENT
 // value before attaching the listener, so every register() starts in sync.
+//
+// #94516 regression: the same ladder must not dead-end the Routines pane.
+// The SDK's focusedSessionOwner store fails closed to null whenever the
+// focused session has no unique bot owner (normal chat, ambiguous owner
+// hints) — the common case while the user browses the Bots pane. The pane
+// must fall back to the bot the user clicked in the roster (the previously
+// working scope) instead of pinning every bot on the "Cronjobs are
+// unavailable until this agent appears in the roster." placeholder.
 
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
@@ -126,16 +134,29 @@ test('unit: an authoritative focused owner missing from the roster fails closed'
   assert.equal(resolveRoutineOwner(roster, focusedOwner, 'source-a::default'), null)
 })
 
-test('unit: an authoritative null focused owner disables routines instead of using selection', () => {
+test('regression #94516: a null focused owner falls back to the roster-clicked bot', () => {
+  // The focused session has no bot owner (a normal chat, or ambiguous owner
+  // hints — the SDK fails closed to null), but the user just clicked a bot in
+  // the populated roster. The Routines pane must scope to THAT bot instead of
+  // pinning every agent on the unavailable placeholder (#94516).
   const { resolveRoutineOwner } = load({ focusedSessionOwnerSupported: true }).__api
-  const roster = [{
-    connectionId: 'source-a',
-    name: 'default',
-    remoteSource: true,
-    sourceScoped: true
-  }]
+  const roster = [
+    { connectionId: 'source-a', name: 'default', remoteSource: true, sourceScoped: true },
+    { connectionId: 'source-a', name: 'blog-writer', remoteSource: true, sourceScoped: true }
+  ]
 
-  assert.equal(resolveRoutineOwner(roster, null, 'source-a::default'), null)
+  assert.equal(resolveRoutineOwner(roster, null, 'source-a::blog-writer'), roster[1])
+})
+
+test('regression #94516: a null focused owner with no matching selection still fails closed', () => {
+  // No focused owner AND the selection has no roster row: there is nothing to
+  // scope cron reads/mutations to, so the pane keeps its fail-closed state.
+  const { resolveRoutineOwner } = load({ focusedSessionOwnerSupported: true }).__api
+  const roster = [
+    { connectionId: 'source-a', name: 'default', remoteSource: true, sourceScoped: true }
+  ]
+
+  assert.equal(resolveRoutineOwner(roster, null, 'source-a::missing'), null)
 })
 
 test('unit: a legacy SDK without focused owner support may use selection', () => {


### PR DESCRIPTION
## Summary
The Desktop Cronjobs (Routines) pane works again for every bot: a null focused-session owner no longer dead-ends the pane on the "Cronjobs are unavailable until this agent appears in the roster." placeholder (#94516, #94483's primary symptom).

Root cause: `resolveRoutineOwner()` treated a null `focusedSessionOwner` as a hard failure, but the SDK store fails closed to null for any focused session without a unique bot owner — the normal case while browsing the Bots pane. Every bot therefore resolved no owner and Create Cronjob silently no-oped.

Salvage of #94670 by @Finn763 (authorship preserved via cherry-pick).

## Changes
- `plugin.js`: null focused owner falls back to the roster-clicked bot (the previously working scope); an authoritative focused owner still resolves only through its exact roster row (fail closed preserved).
- `tests/routines-selected-bot.test.mjs`: regression tests — null-owner fallback to selection, and null-owner + no matching selection still fails closed.

## Validation
| | Before | After |
|---|---|---|
| Bot clicked in roster, non-bot session focused | "unavailable" placeholder, Create no-ops | Pane scopes to clicked bot |
| Authoritative owner missing from roster | fails closed | fails closed (unchanged) |
| `node --test tests/*.test.mjs` | — | 557 pass / 0 fail |

Fixes #94516. Primary fix for #94483 (boot-ordering half lands separately as the #94549 salvage).

## Infographic

![Cronjobs pane owner resolution fixed](https://v3b.fal.media/files/b/0aa7cb86/0Q3nroApvoWyxrrq-QKEd_wm7kGKE5.png)


**Live repro:** real Electron + real `hermes serve` backend, Testbot profile, CDP-driven. Before (origin/main): roster visibly populated (Testbot + Hermes) while the Cronjobs pane stayed pinned on the "unavailable" placeholder through 30s+ of hydration. After (this fix + #95013): pane renders "Testbot · CRONJOBS · Create Cronjob" and follows roster selection. Note: this fix and #95013 are co-dependent halves — live testing confirmed neither alone clears the symptom.
