### PR TITLE
fix: correct inverted liveness check in _stdio_children_dead

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -62,6 +62,36 @@ def _make_mock_server(name, session=None, tools=None):
     return server
 
 
+class TestStdioChildrenDead:
+    """Regression tests for the fast-fail liveness probe (#81995).
+
+    ``_stdio_children_dead`` must return True only when EVERY captured
+    stdio child pid has exited, so a live subprocess never gets an
+    in-flight tool call failed instantly with "has exited".
+    """
+
+    def test_returns_false_when_a_child_is_alive(self, monkeypatch):
+        server = _make_mock_server("jira")
+        server._stdio_child_pids = {12345}
+        monkeypatch.setattr(
+            "psutil.pid_exists", lambda pid: True,
+        )
+        assert server._stdio_children_dead() is False
+
+    def test_returns_true_when_all_children_exited(self, monkeypatch):
+        server = _make_mock_server("jira")
+        server._stdio_child_pids = {12345, 23456}
+        monkeypatch.setattr(
+            "psutil.pid_exists", lambda pid: False,
+        )
+        assert server._stdio_children_dead() is True
+
+    def test_returns_false_unknown_when_no_pids_captured(self):
+        server = _make_mock_server("jira")
+        server._stdio_child_pids = set()
+        assert server._stdio_children_dead() is False
+
+
 class TestFilterMCPChildren:
     def test_filters_gateway_children_by_argv_marker(self, monkeypatch):
         """Non-MCP children start with an interpreter/binary, not the marker."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,8 +2994,7 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
+            return False  # alive (signal permission irrelevant for liveness)
         return True
 
     async def _watch_stdio_children(self) -> None:


### PR DESCRIPTION
## Summary

`MCPServerTask._stdio_children_dead()` is meant to return `True` only when every stdio child the MCP server spawned has exited, so the fast-fail path (#81995) can fail a tool call immediately against a known-dead process instead of waiting out the full tool timeout.

The loop had its return values inverted: as soon as it found a **live** pid (`psutil.pid_exists()` True), it returned `True` ("all dead") instead of `False` ("at least one still alive"). The intended `False` branch sat right after an unconditional `return`, so it was unreachable dead code.

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True  # <- wrong: process is ALIVE, should not report "dead"
    return False  # <- unreachable dead code
return True
```

### Impact

Any stdio MCP server with a captured child PID fails its **very first real tool call** with:

```
MCP stdio subprocess for '<name>' has exited; failing the call fast instead of waiting 300s
```

even though the subprocess is alive and would answer normally. Connection/tool-discovery (`hermes mcp test`, initial tool list) is unaffected because it doesn't go through this fast-fail path — which is why the server looks perfectly healthy right up until the first tool call, making this look like an auth/connectivity problem rather than a liveness-check bug.

Reproduced end-to-end with `sooperset/mcp-atlassian` (Jira) run over stdio via `uvx`: every `jira_*` tool call failed immediately post-connect until this fix was applied (verified against the live Jira REST API in parallel — credentials/auth were fine the whole time). Tool calls succeed normally after the fix.

## Changes

- `tools/mcp_tool.py`: fix the inverted return value, drop the unreachable duplicate `return`.
- `tests/tools/test_mcp_tool.py`: add `TestStdioChildrenDead` covering the three states (child alive, all children exited, no pids captured).

## Test Plan

- [x] New unit tests pass: `pytest tests/tools/test_mcp_tool.py -k TestStdioChildrenDead -v` (3 passed)
- [x] Full file suite green: `pytest tests/tools/test_mcp_tool.py -q` (101 passed)
- [x] Manually verified against a real stdio MCP server (mcp-atlassian/Jira) before and after the fix