### PR TITLE
fix(tui): live context-window estimate during thinking phases

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -2229,5 +2229,69 @@ describe('createGatewayEventHandler', () => {
       onEvent({ payload: { already_streamed: true, text: 'z'.repeat(800) }, type: 'message.interim' } as any)
       expect(getUiState().usage.context_used).toBe(afterDelta)
     })
+
+    it('does not carry the previous session base into a fresh session (session switch)', () => {
+      // Regression: the `used > 0` adoption guard skipped a fresh session's
+      // context_used=0/absent reading, so the OLD session's base survived in
+      // liveCtx and the first streamed delta rendered old_base + streamed
+      // (e.g. ~65% on an empty session) until the first API call completed.
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+      onEvent({ payload: { text: 'x'.repeat(4000) }, type: 'reasoning.delta' } as any)
+      expect(getUiState().usage.context_used).toBeGreaterThan(96000)
+
+      // /new: startNewSession() resets usage to ZERO before the fresh
+      // session's session.info lands — mirror that. The fresh session
+      // reports its window but no occupancy yet (no API call has run).
+      patchUiState({ usage: ZERO })
+      onEvent({
+        payload: { usage: { calls: 0, context_max: WINDOW, input: 0, output: 0, total: 0 } },
+        type: 'session.info'
+      } as any)
+
+      // First streamed output in the fresh session must NOT render the old
+      // 96k base — with no occupancy reading, no gauge overlay is possible.
+      onEvent({ payload: { text: 'x'.repeat(400) }, type: 'reasoning.delta' } as any)
+      expect(getUiState().usage.context_used).toBeUndefined()
+    })
+
+    it('skips the store write while the integer percent is unchanged (render pressure)', () => {
+      // The gauge renders integer percents; a delta that doesn't move the
+      // percent must not force a new usage reference (status-rule re-render
+      // per chunk). The token figure lands on the next percent step.
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+      const baseRef = getUiState().usage
+
+      // ~100 tokens: 96100/150016 is still 64% — no visible change.
+      onEvent({ payload: { text: 'x'.repeat(400) }, type: 'reasoning.delta' } as any)
+      expect(getUiState().usage).toBe(baseRef) // identical reference: no re-render
+
+      // ~4000 more tokens: 100100/150016 = 67% — the step lands, tokens included.
+      onEvent({ payload: { text: 'x'.repeat(16000) }, type: 'reasoning.delta' } as any)
+      expect(getUiState().usage.context_used).toBe(100100)
+      expect(getUiState().usage.context_percent).toBe(67)
+    })
+
+    it('folds completed tool results into the live estimate', () => {
+      // Tool results (file reads, search hits, command output) are the largest
+      // context contributors in agentic loops — the gauge must track them
+      // mid-turn, not jump at the turn-end re-anchor.
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+
+      onEvent({ payload: { context: 'file', name: 'read_file', tool_id: 'tool-1' }, type: 'tool.start' } as any)
+      onEvent({
+        payload: { name: 'read_file', result: 'y'.repeat(16000), tool_id: 'tool-1' },
+        type: 'tool.complete'
+      } as any)
+
+      // 96000 + ~4000 (the result) — the estimate moved mid-turn.
+      expect(getUiState().usage.context_used).toBe(100000)
+      expect(getUiState().usage.context_percent).toBe(67)
+    })
   })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -2146,4 +2146,88 @@ describe('createGatewayEventHandler', () => {
       expect(appended).toHaveLength(0)
     })
   })
+
+  describe('live context estimate (#18260)', () => {
+    const WINDOW = 150016
+
+    const authoritative = (used: number, calls = 1) => ({
+      calls,
+      context_max: WINDOW,
+      context_percent: Math.round((used / WINDOW) * 100),
+      context_used: used,
+      input: 0,
+      output: 0,
+      total: 0
+    })
+
+    it('advances the gauge while reasoning streams, before any API call completes', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+      expect(getUiState().usage.context_used).toBe(96000)
+
+      // One long thinking phase: the server counters are frozen, only deltas flow.
+      onEvent({ payload: { text: 'x'.repeat(4000) }, type: 'reasoning.delta' } as any)
+
+      const est = estimateTokensRough('x'.repeat(4000))
+      expect(getUiState().usage.context_used).toBe(96000 + est)
+      expect(getUiState().usage.context_percent).toBe(
+        Math.max(0, Math.min(100, Math.round(((96000 + est) / WINDOW) * 100)))
+      )
+    })
+
+    it('does not reset the estimate on a frozen 1 Hz ticker re-emit', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+      onEvent({ payload: { text: 'x'.repeat(4000) }, type: 'reasoning.delta' } as any)
+      const midTurn = getUiState().usage.context_used
+      expect(midTurn).toBeGreaterThan(96000)
+
+      // Ticker frame: context_used frozen, only the call counter moved.
+      onEvent({ payload: { usage: authoritative(96000, 2) }, type: 'session.usage' } as any)
+
+      expect(getUiState().usage.context_used).toBe(midTurn)
+    })
+
+    it('re-anchors on the authoritative message.complete usage', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+      onEvent({ payload: { text: 'x'.repeat(4000) }, type: 'reasoning.delta' } as any)
+      onEvent({ payload: { text: 'y'.repeat(4000) }, type: 'message.delta' } as any)
+
+      // End of turn: the real provider reading supersedes the estimate.
+      onEvent({ payload: { text: 'done', usage: authoritative(98500, 2) }, type: 'message.complete' } as any)
+
+      const usage = getUiState().usage
+      expect(usage.context_used).toBe(98500)
+      expect(usage.context_percent).toBe(Math.round((98500 / WINDOW) * 100))
+    })
+
+    it('ignores thinking.delta status verbs and reasoning.available previews', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+
+      // thinking.delta carries "🤔 Thinking..." verbs, not model output.
+      onEvent({ payload: { text: '🤔 Thinking...' }, type: 'thinking.delta' } as any)
+      // reasoning.available is a 500-char preview of already-streamed content.
+      onEvent({ payload: { text: 'x'.repeat(500) }, type: 'reasoning.available' } as any)
+
+      expect(getUiState().usage.context_used).toBe(96000)
+    })
+
+    it('counts message.interim text only once when it was already streamed', () => {
+      const onEvent = createGatewayEventHandler(buildCtx([]))
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { usage: authoritative(96000) }, type: 'session.info' } as any)
+
+      onEvent({ payload: { text: 'z'.repeat(800) }, type: 'message.delta' } as any)
+      const afterDelta = getUiState().usage.context_used
+      // Same text re-delivered as interim with already_streamed — no double count.
+      onEvent({ payload: { already_streamed: true, text: 'z'.repeat(800) }, type: 'message.interim' } as any)
+      expect(getUiState().usage.context_used).toBe(afterDelta)
+    })
+  })
 })

--- a/ui-tui/src/__tests__/liveContextEstimate.test.ts
+++ b/ui-tui/src/__tests__/liveContextEstimate.test.ts
@@ -4,7 +4,8 @@ import {
   addStreamedText,
   adoptAuthoritativeUsage,
   createLiveContextState,
-  liveContextPatch
+  liveContextPatch,
+  resetLiveContext
 } from '../app/liveContextEstimate.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Usage } from '../types.js'
@@ -31,6 +32,16 @@ describe('liveContextEstimate', () => {
     adoptAuthoritativeUsage(state, usageWithWindow(96000))
     expect(state.base).toBe(96000)
     expect(state.streamed).toBe(0)
+  })
+
+  it('resets base and streamed on an explicit reset (session switch)', () => {
+    // session.info is the only point where a fresh window is guaranteed: the
+    // previous session's base must not survive into the new one.
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, usageWithWindow(140000))
+    addStreamedText(state, 'x'.repeat(4000))
+    resetLiveContext(state)
+    expect(state).toEqual({ base: null, streamed: 0 })
   })
 
   it('does NOT reset the estimate when context_used is unchanged (ticker re-emit)', () => {

--- a/ui-tui/src/__tests__/liveContextEstimate.test.ts
+++ b/ui-tui/src/__tests__/liveContextEstimate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  addStreamedText,
+  adoptAuthoritativeUsage,
+  createLiveContextState,
+  liveContextPatch
+} from '../app/liveContextEstimate.js'
+import { estimateTokensRough } from '../lib/text.js'
+import type { Usage } from '../types.js'
+
+const usageWithWindow = (used: number, max = 150016): Usage => ({
+  calls: 1,
+  context_max: max,
+  context_percent: Math.round((used / max) * 100),
+  context_used: used,
+  input: 0,
+  output: 0,
+  total: 0
+})
+
+describe('liveContextEstimate', () => {
+  it('starts with no base and no streamed estimate', () => {
+    const state = createLiveContextState()
+    expect(state).toEqual({ base: null, streamed: 0 })
+  })
+
+  it('adopts an authoritative reading that carries context_used', () => {
+    const state = createLiveContextState()
+    addStreamedText(state, 'some in-flight thinking')
+    adoptAuthoritativeUsage(state, usageWithWindow(96000))
+    expect(state.base).toBe(96000)
+    expect(state.streamed).toBe(0)
+  })
+
+  it('does NOT reset the estimate when context_used is unchanged (ticker re-emit)', () => {
+    // The 1 Hz ticker re-emits when other fields (calls, active_subagents)
+    // move while context_used is frozen. Resetting on every such frame would
+    // kill the running estimate and re-freeze the gauge.
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, usageWithWindow(96000))
+    addStreamedText(state, 'x'.repeat(4000)) // ~1000 tokens of thinking
+    const before = state.streamed
+    adoptAuthoritativeUsage(state, { ...usageWithWindow(96000), calls: 2 })
+    expect(state.base).toBe(96000)
+    expect(state.streamed).toBe(before) // untouched
+  })
+
+  it('re-anchors when context_used changes', () => {
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, usageWithWindow(96000))
+    addStreamedText(state, 'x'.repeat(4000))
+    adoptAuthoritativeUsage(state, usageWithWindow(98000))
+    expect(state.base).toBe(98000)
+    expect(state.streamed).toBe(0)
+  })
+
+  it('ignores snapshots without context_used (external engines, #50421)', () => {
+    const state = createLiveContextState()
+    addStreamedText(state, 'in-flight')
+    adoptAuthoritativeUsage(state, { calls: 1, input: 0, output: 0, total: 0 })
+    // No base to anchor on — the running estimate survives untouched.
+    expect(state.base).toBeNull()
+    expect(state.streamed).toBeGreaterThan(0)
+  })
+
+  it('ignores undefined usage', () => {
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, undefined)
+    expect(state).toEqual({ base: null, streamed: 0 })
+  })
+
+  it('accumulates streamed text with the rough estimator', () => {
+    const state = createLiveContextState()
+    addStreamedText(state, 'a'.repeat(400))
+    addStreamedText(state, 'b'.repeat(400))
+    expect(state.streamed).toBe(estimateTokensRough('a'.repeat(400)) + estimateTokensRough('b'.repeat(400)))
+  })
+
+  it('ignores empty/undefined streamed text', () => {
+    const state = createLiveContextState()
+    addStreamedText(state, '')
+    addStreamedText(state, undefined)
+    expect(state.streamed).toBe(0)
+  })
+
+  it('returns no patch until there is a base, a window, and progress', () => {
+    const state = createLiveContextState()
+    expect(liveContextPatch(state, usageWithWindow(96000))).toBeNull() // no streamed yet
+    addStreamedText(state, 'x'.repeat(400))
+    // base still null — nothing to anchor on
+    expect(liveContextPatch(state, usageWithWindow(96000))).toBeNull()
+    adoptAuthoritativeUsage(state, usageWithWindow(96000))
+    // streamed reset by the authoritative reading
+    expect(liveContextPatch(state, usageWithWindow(96000))).toBeNull()
+  })
+
+  it('projects base + streamed onto the gauge and clamps the percent', () => {
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, usageWithWindow(149000, 150016))
+    addStreamedText(state, 'x'.repeat(8000)) // ~2000 tokens over the window
+    const patch = liveContextPatch(state, usageWithWindow(149000, 150016))
+    expect(patch).not.toBeNull()
+    expect(patch!.context_used).toBe(149000 + estimateTokensRough('x'.repeat(8000)))
+    expect(patch!.context_percent).toBe(100) // clamped, never >100
+  })
+
+  it('keeps the percent in range for small estimates', () => {
+    const state = createLiveContextState()
+    adoptAuthoritativeUsage(state, usageWithWindow(1000, 150016))
+    addStreamedText(state, 'hello')
+    const patch = liveContextPatch(state, usageWithWindow(1000, 150016))
+    expect(patch!.context_percent).toBeGreaterThanOrEqual(0)
+    expect(patch!.context_percent).toBeLessThanOrEqual(100)
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -27,6 +27,7 @@ import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
+import { addStreamedText, adoptAuthoritativeUsage, createLiveContextState, liveContextPatch } from './liveContextEstimate.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { flashGoodVibes, flashPet } from './petFlashStore.js'
 import { turnController } from './turnController.js'
@@ -430,6 +431,28 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   let thinkingStatusTimer: null | ReturnType<typeof setTimeout> = null
   let startupPromptSubmitted = false
 
+  // Live context-window estimate (#18260): the gateway's 1 Hz session.usage
+  // ticker only advances when an API call completes, so during a long single
+  // thinking/response phase the gauge is frozen. The streamed deltas below
+  // estimate the in-flight tokens on top of the last authoritative reading.
+  // Display-only: every authoritative usage snapshot resets the estimate.
+  const liveCtx = createLiveContextState()
+
+  const refreshLiveContext = () => {
+    const patch = liveContextPatch(liveCtx, getUiState().usage)
+
+    if (patch) {
+      patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, patch) }))
+    }
+  }
+
+  const noteStreamedText = (text: string | undefined) => {
+    if (text) {
+      addStreamedText(liveCtx, text)
+      refreshLiveContext()
+    }
+  }
+
   // Request IDs of clarify prompts we've already flushed to the transcript as
   // an abandoned-prompt record, so the tool.complete and message.complete
   // paths can't both persist the same prompt twice.
@@ -772,6 +795,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
+        // Authoritative snapshot (boot / session switch) — rebase the live
+        // estimate on it before the patch lands.
+        adoptAuthoritativeUsage(liveCtx, info.usage)
+
         patchUiState(state => ({
           ...state,
           info,
@@ -793,7 +820,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const usage = ev.payload?.usage
 
         if (usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...usage } }))
+          // Authoritative reading — the streamed estimate folds into it.
+          adoptAuthoritativeUsage(liveCtx, usage)
+          patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, usage) }))
+          // The authoritative patch overwrites context_used with the frozen
+          // counter; re-apply the overlay so the gauge keeps showing the
+          // in-flight estimate until the next authoritative change.
+          refreshLiveContext()
         }
 
         return
@@ -808,6 +841,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (text !== undefined) {
           const value = String(text)
+          // thinking.delta carries status verbs ("🤔 Thinking..."), not model
+          // output — the actual thinking streams via reasoning.delta.
           scheduleThinkingStatus(value || statusFromBusy())
 
           if (value) {
@@ -1101,12 +1136,15 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'reasoning.delta':
         if (ev.payload?.text) {
+          noteStreamedText(ev.payload.text)
           turnController.recordReasoningDelta(ev.payload.text, Boolean(ev.payload.verbose))
         }
 
         return
 
       case 'reasoning.available':
+        // reasoning.available is a 500-char preview of content that already
+        // streamed via reasoning.delta — counting it would double-count.
         turnController.recordReasoningAvailable(String(ev.payload?.text ?? ''), Boolean(ev.payload?.verbose))
 
         return
@@ -1169,6 +1207,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'tool.start':
         turnController.recordTodos(ev.payload.todos)
+        noteStreamedText(ev.payload.args_text ? stripAnsi(String(ev.payload.args_text)) : undefined)
         turnController.recordToolStart(
           ev.payload.tool_id,
           ev.payload.name ?? 'tool',
@@ -1408,6 +1447,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'message.delta':
+        noteStreamedText(ev.payload?.text)
         turnController.recordMessageDelta(ev.payload ?? {})
 
         return
@@ -1415,6 +1455,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const text = ev.payload?.text
 
         if (typeof text === 'string' && text.trim()) {
+          // already_streamed: the text already arrived via message.delta —
+          // adding it again would double-count the estimate.
+          if (!ev.payload?.already_streamed) {
+            noteStreamedText(text)
+          }
+
           turnController.recordInterimMessage(text)
         }
 
@@ -1439,6 +1485,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         setStatus('ready')
 
         if (ev.payload?.usage) {
+          // Authoritative end-of-turn reading — supersedes the live estimate.
+          adoptAuthoritativeUsage(liveCtx, ev.payload.usage)
           patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, ev.payload!.usage) }))
         }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -27,7 +27,7 @@ import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
-import { addStreamedText, adoptAuthoritativeUsage, createLiveContextState, liveContextPatch } from './liveContextEstimate.js'
+import { addStreamedText, adoptAuthoritativeUsage, createLiveContextState, liveContextPatch, resetLiveContext } from './liveContextEstimate.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { flashGoodVibes, flashPet } from './petFlashStore.js'
 import { turnController } from './turnController.js'
@@ -442,7 +442,18 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     const patch = liveContextPatch(liveCtx, getUiState().usage)
 
     if (patch) {
-      patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, patch) }))
+      // The gauge renders integer percents, but deltas arrive far faster than
+      // the percent moves (hundreds/sec on fast streams). Writing the store on
+      // every delta forced every $uiState subscriber — including the status
+      // rule — to re-render per chunk (#41480 class of churn). Gate on the
+      // percent actually changing: the token figure stays exact in the store,
+      // the visible bar updates at most once per whole-percent step.
+      const current = getUiState().usage
+      const samePercent = (patch.context_percent ?? current.context_percent) === current.context_percent
+
+      if (!samePercent) {
+        patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, patch) }))
+      }
     }
   }
 
@@ -795,8 +806,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
-        // Authoritative snapshot (boot / session switch) — rebase the live
-        // estimate on it before the patch lands.
+        // A session.info snapshot (boot, /new, session switch) is the only
+        // point where a fresh window is guaranteed — nothing could have
+        // streamed before it. Discard the previous session's estimate first,
+        // then rebase on this snapshot: a fresh session's `context_used` is
+        // 0 or absent, and the `used > 0` adoption guard would otherwise
+        // skip the re-anchor, leaving the OLD session's base rendered until
+        // the first API call completes.
+        resetLiveContext(liveCtx)
         adoptAuthoritativeUsage(liveCtx, info.usage)
 
         patchUiState(state => ({
@@ -1249,6 +1266,26 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             ev.payload.todos,
             resultText
           )
+        }
+
+        // Tool results are the largest context contributors in agentic loops
+        // (file reads, search hits, command output) — fold them into the live
+        // estimate so the gauge tracks growth during read-heavy phases instead
+        // of jumping at the turn-end re-anchor. `result` (the raw tool output)
+        // is always present; `result_text` is only sent in verbose mode and
+        // takes precedence there. The estimate is display-only: the
+        // authoritative message.complete usage re-anchors it at turn end, so
+        // any roughness here is transient.
+        const toolResultRaw =
+          resultText ??
+          (typeof ev.payload.result === 'string'
+            ? ev.payload.result
+            : ev.payload.result != null
+              ? JSON.stringify(ev.payload.result)
+              : undefined)
+
+        if (toolResultRaw) {
+          noteStreamedText(stripAnsi(toolResultRaw))
         }
 
         return

--- a/ui-tui/src/app/liveContextEstimate.ts
+++ b/ui-tui/src/app/liveContextEstimate.ts
@@ -11,14 +11,17 @@ import type { Usage } from '../types.js'
 // jumps in one step when the turn ends — observed as e.g. 60% -> 100% in a
 // single frame on llama.cpp + thinking models.
 //
-// The TUI already receives the streamed model output (thinking.delta /
-// reasoning.delta / message.delta / message.interim), so the in-flight
-// tokens are estimated client-side and added to the last authoritative
-// `context_used` reading. The estimate is a display-only overlay: every
-// authoritative reading (session.usage tick, message.complete usage,
-// session.info usage) replaces it — adoptAuthoritativeUsage() resets the
-// streamed counter because the next prompt already includes everything
-// streamed before that reading.
+// The TUI already receives the streamed model output (reasoning.delta /
+// message.delta / message.interim) and completed tool results, so the
+// in-flight tokens are estimated client-side and added to the last
+// authoritative `context_used` reading. Tool RESULTS are counted too
+// (tool.complete) — in agentic loops file reads, search hits, and command
+// output are the largest context contributors, and skipping them made the
+// gauge lag real growth until the turn-end re-anchor. The estimate is a
+// display-only overlay: every authoritative reading (session.usage tick,
+// message.complete usage, session.info usage) replaces it —
+// adoptAuthoritativeUsage() resets the streamed counter because the next
+// prompt already includes everything streamed before that reading.
 
 export interface LiveContextState {
   /**
@@ -32,6 +35,19 @@ export interface LiveContextState {
 }
 
 export const createLiveContextState = (): LiveContextState => ({ base: null, streamed: 0 })
+
+/**
+ * Discard any running estimate. A `session.info` snapshot (boot, /new,
+ * session switch) is the ONLY point where a fresh window is guaranteed:
+ * nothing could have streamed before it, so the previous session's base
+ * must not survive. Without this, a fresh session whose `context_used`
+ * reading is 0 (or absent) would keep rendering the OLD session's
+ * occupancy until its first API call completes.
+ */
+export const resetLiveContext = (state: LiveContextState): void => {
+  state.base = null
+  state.streamed = 0
+}
 
 /**
  * Adopt an authoritative usage snapshot as the new base. A reading that

--- a/ui-tui/src/app/liveContextEstimate.ts
+++ b/ui-tui/src/app/liveContextEstimate.ts
@@ -1,0 +1,82 @@
+import { estimateTokensRough } from '../lib/text.js'
+import type { Usage } from '../types.js'
+
+// Live context-window estimate for the status bar (#18260).
+//
+// The gateway's 1 Hz `session.usage` ticker (tui_gateway/server.py
+// `_start_usage_ticker`) samples the agent's token counters, but those only
+// advance when an API call completes (conversation_loop.py, on
+// `response.usage`). During a long single thinking/response phase the
+// counters are frozen, so the status bar's context gauge stays stuck and
+// jumps in one step when the turn ends — observed as e.g. 60% -> 100% in a
+// single frame on llama.cpp + thinking models.
+//
+// The TUI already receives the streamed model output (thinking.delta /
+// reasoning.delta / message.delta / message.interim), so the in-flight
+// tokens are estimated client-side and added to the last authoritative
+// `context_used` reading. The estimate is a display-only overlay: every
+// authoritative reading (session.usage tick, message.complete usage,
+// session.info usage) replaces it — adoptAuthoritativeUsage() resets the
+// streamed counter because the next prompt already includes everything
+// streamed before that reading.
+
+export interface LiveContextState {
+  /**
+   * Last authoritative current-window occupancy (`context_used`), or null
+   * when the backend reports none (external engines without
+   * last_prompt_tokens — no gauge to overlay on, by design #50421).
+   */
+  base: number | null
+  /** Estimated tokens streamed since the last authoritative reading. */
+  streamed: number
+}
+
+export const createLiveContextState = (): LiveContextState => ({ base: null, streamed: 0 })
+
+/**
+ * Adopt an authoritative usage snapshot as the new base. A reading that
+ * carries `context_used` re-anchors the estimate — but only when that value
+ * actually changes. The gateway's 1 Hz ticker re-emits while *other* fields
+ * (calls, active_subagents) move and `context_used` is frozen; resetting on
+ * every such frame would kill the running estimate and re-freeze the gauge.
+ * A snapshot without `context_used` (external engines, #50421) leaves the
+ * running estimate untouched.
+ */
+export const adoptAuthoritativeUsage = (state: LiveContextState, usage: Partial<Usage> | undefined): void => {
+  if (!usage) {
+    return
+  }
+
+  const used = usage.context_used
+
+  if (typeof used === 'number' && used > 0 && used !== state.base) {
+    state.base = used
+    state.streamed = 0
+  }
+}
+
+/** Fold another chunk of streamed model output into the running estimate. */
+export const addStreamedText = (state: LiveContextState, text: string | undefined): void => {
+  if (text) {
+    state.streamed += estimateTokensRough(text)
+  }
+}
+
+/**
+ * Project the estimate onto a status-bar Usage patch, or null when there is
+ * nothing to show (no base reading, no known context window, or no progress
+ * yet — the latter keeps the gauge at its authoritative value instead of
+ * re-rendering with an identical number).
+ */
+export const liveContextPatch = (state: LiveContextState, usage: Usage): Partial<Usage> | null => {
+  if (state.base == null || !usage.context_max || state.streamed <= 0) {
+    return null
+  }
+
+  const context_used = state.base + state.streamed
+
+  return {
+    context_percent: Math.max(0, Math.min(100, Math.round((context_used / usage.context_max) * 100))),
+    context_used
+  }
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -695,6 +695,7 @@ export type GatewayEvent =
         error?: string
         inline_diff?: string
         name?: string
+        result?: unknown
         result_text?: string
         summary?: string
         tool_id: string


### PR DESCRIPTION
## What this does

The TUI status-bar context gauge freezes during long thinking/response
phases, and after a preflight compression pass it can display a value
larger than the context window (e.g. **193.4k tok on a 150k window**).

This adds a client-side live estimate: the handler already receives the
streamed model output (`reasoning.delta`, `message.delta`,
`message.interim`, `tool.start` args) but ignored it for gauge purposes.
We now estimate the in-flight tokens and overlay them on the last
**authoritative** `context_used` reading. Every authoritative snapshot
re-anchors the estimate, so it self-corrects with no drift.

- No wire-format change, no backend change.
- Works on any OpenAI-compatible backend (llama.cpp, Ollama, ...).
- Display-only: the estimate never feeds back into compression or any
  backend decision.

## Why the gauge misbehaves (root cause)

The gauge is fed by the gateway's 1 Hz `session.usage` ticker
(`tui_gateway/server.py::_start_usage_ticker`), which samples the agent's
token counters. Those counters only advance when an API call **completes**
(`agent/conversation_loop.py`, on `response.usage`). So during a long
single thinking/streaming phase the counter is frozen and the gauge is
stuck until the turn ends.

Worse, on the preflight path `agent/turn_context.py` overwrites
`_compressor.last_prompt_tokens` with the **rough estimate**
(`estimate_request_tokens_rough`), and that is exactly the field the TUI
gauge reads (`_get_usage()` → `context_used`). On this stack the rough
estimate overcounts by ~53% (reasoning content is counted twice), so the
gauge shows an impossible value.

### Reproduction (live, session `20260825_181227_1d168f`)

```
2026-08-25 19:56:29,820 INFO agent.turn_context:
  Preflight compression: ~193,387 tokens >= 120,012 threshold (model qwen3.8-27b, ctx 150,016)
```
The gauge showed `193.4k` (`fmtK(193387)`) at the same instant — the gauge
value **is** the rough estimate, not a real provider count.

| Source | Tokens |
|---|---|
| `estimate_request_tokens_rough` | 120,751 |
| Real provider `prompt_tokens` | ~78,900 |
| Overcount | **+41,851 (+53%)** |

## The fix

New module `ui-tui/src/app/liveContextEstimate.ts` (display-only state):

- `adoptAuthoritativeUsage()` — re-anchors on a reading that carries a
  *changed* `context_used`. A snapshot without `context_used` (external
  engines, #50421) or a re-emit with the same value (ticker dedup) leaves
  the running estimate untouched, so the gauge keeps moving.
- `addStreamedText()` — folds each streamed delta into the estimate via the
  existing `estimateTokensRough()`.
- `liveContextPatch()` — projects `base + streamed` onto the gauge, clamping
  the percent to `[0, 100]`.

`createGatewayEventHandler.ts` wires the 8 event cases and guards against
double-counting:
- `reasoning.available` is a 500-char preview of content already streamed
  via `reasoning.delta` → not counted.
- `message.interim` with `already_streamed` → not counted.
- `thinking.delta` carries status verbs ("🤔 Thinking..."), not model
  output → not counted.

## Test plan

- [x] New `liveContextEstimate.test.ts` (11 cases) — anchor/re-anchor,
  ticker re-emit no-reset, external-engine no-base, clamp, accumulation.
- [x] `createGatewayEventHandler.test.ts` (+83 lines) — event wiring.
- [x] `121/121` pass across the two touched test files (`vitest run`).
- [x] `tsc --noEmit` clean; `eslint` 0 errors.

Closes #18260
