### PR TITLE
fix(desktop): New Cronjob dialog no longer shows '[object Object]' for roster-scoped bots (salvage #93572)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11251,7 +11251,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
               'Send results to',
               pickerSelect(target, setTarget, [
                 { id: 'history', label: 'Run history only' },
-                { id: 'bot-chat', label: `${displayName({ name: bot }, $botMeta.get()[bot])}\u2019s chat (bot responds)` }
+                { id: 'bot-chat', label: `${displayName(typeof bot === 'string' ? { name: bot } : bot, botRosterMeta(bot, $botMeta.get()))}\u2019s chat (bot responds)` }
               ])
             ),
             jsxs('label', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-dialog-owner-label.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-dialog-owner-label.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// #93572: CreateRoutineDialog's "Send results to" picker built its label with
+// `displayName({ name: bot }, $botMeta.get()[bot])`. The dialog's `bot` prop
+// is routineCreateTarget() output — an owner OBJECT for roster-scoped bots —
+// so the label rendered "[object Object]" and the meta lookup keyed the map
+// with an object. The label must resolve owner objects through the
+// object-aware botRosterMeta() path and only wrap bare strings.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('CreateRoutineDialog bot-chat label resolves owner objects via botRosterMeta', () => {
+  const start = pluginSource.indexOf('function CreateRoutineDialog(')
+  assert.ok(start >= 0, 'CreateRoutineDialog must exist')
+  const dialog = pluginSource.slice(start, start + 8000)
+
+  const label = dialog.match(/\{ id: 'bot-chat', label: `\$\{displayName\(([^`]+)\)\}/)
+  assert.ok(label, 'bot-chat picker label must be built through displayName()')
+
+  // Owner objects pass through untouched; only bare strings are wrapped.
+  assert.match(label[1], /typeof bot === 'string' \? \{ name: bot \} : bot/)
+  // Meta lookup must go through the object-aware resolver, never index
+  // $botMeta with a possibly-object key.
+  assert.match(label[1], /botRosterMeta\(bot, \$botMeta\.get\(\)\)/)
+  assert.ok(
+    !/\$botMeta\.get\(\)\[bot\]/.test(dialog),
+    'the dialog must not index bot meta with the raw bot prop'
+  )
+})


### PR DESCRIPTION
## Summary
The New Cronjob dialog's "Send results to" picker no longer renders "[object Object]" (and no longer mis-keys the meta lookup) when the pane's owner is a roster object rather than a bare profile name.

Root cause: `CreateRoutineDialog` receives `routineCreateTarget()` output — an owner OBJECT for roster-scoped bots — but the label builder wrapped it as `displayName({ name: bot }, $botMeta.get()[bot])`, stringifying the object and indexing the meta map with an object key.

Salvage of #93572 by @zhangfei1231231-sketch (call-site fix cherry-picked with authorship preserved). The original PR's defensive coercion inside `displayName()` was dropped — the call site is the bug, and masking non-string names at the shared renderer would hide future mis-callers.

## Changes
- `plugin.js`: the bot-chat picker label resolves owner objects directly and looks meta up via the object-aware `botRosterMeta()`; bare strings still get wrapped.
- `tests/routines-dialog-owner-label.test.mjs` (new, ours): pins the object-aware call shape and forbids indexing `$botMeta` with the raw prop.

## Validation
| | Before | After |
|---|---|---|
| Roster-scoped owner opens New Cronjob | label "[object Object]", wrong meta key | correct display name + meta |
| String owner (legacy path) | works | works (unchanged) |
| `node --test tests/*.test.mjs` | — | 558 pass / 0 fail |

## Infographic

![New Cronjob dialog owner label fix](https://v3b.fal.media/files/b/0aa7cbdc/lgdYqkwD6CY3WK60YQ2i3_2ixba0ho.png)


**Live repro:** real Electron + backend, CDP-driven. Before (origin/main): clicking Create Cronjob with a roster-object owner crashed the pane live: `"hermes-bots:routines" failed to render — (bot.name || "").trim is not a function`. After: dialog opens cleanly — "A recurring task Testbot runs on a schedule", correct bot-chat label, no `[object Object]`.
