### PR TITLE
fix(xai): alias the reserved tool_search bridge on the wire (#95003)

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -8,7 +8,7 @@ streaming, or the _run_codex_stream() call path.
 import hashlib
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Cron fires build session_id as ``cron_<job_id>_<YYYYMMDD_HHMMSS>`` (see
 # cron/scheduler.py). The trailing timestamp is per-fire noise; stripped so
@@ -67,10 +67,24 @@ _XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
 # rename on the wire (hermes_<name>), map back in normalize_response so
 # Hermes dispatch is unaffected.
 _OPENCODE_RESERVED_TOOL_NAMES = ("web_search", "search_files")
+
+# xAI reserves ``tool_search`` server-side for Grok's own native Tool Search
+# and rejects *any* client function declared with that name:
+#   HTTP 400 {"code":"invalid-argument","error":"The function name
+#   tool_search is reserved for the tool_search tool"}
+# Hermes's progressive-disclosure bridge registers exactly that literal
+# (``tools.tool_search.TOOL_SEARCH_NAME``), and assembly is not provider
+# gated, so with ``tools.tool_search.enabled: auto`` a grok turn dies the
+# moment the catalog crosses the threshold — mid-session, and only for
+# sessions large enough to activate the bridge. Same treatment as the two
+# collisions above. ``tool_describe`` / ``tool_call`` are not reserved.
+# Refs #95003.
+_XAI_RESERVED_TOOL_NAMES = ("tool_search",)
+
 _RESERVED_TOOL_ALIAS_PREFIX = "hermes_"
 _RESERVED_ALIAS_TO_NAME = {
     f"{_RESERVED_TOOL_ALIAS_PREFIX}{name}": name
-    for name in _OPENCODE_RESERVED_TOOL_NAMES
+    for name in (*_OPENCODE_RESERVED_TOOL_NAMES, *_XAI_RESERVED_TOOL_NAMES)
 }
 
 
@@ -97,11 +111,19 @@ def _is_opencode_responses_backend(params: Dict[str, Any]) -> bool:
         return False
 
 
-def _rename_reserved_tools_for_opencode(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Alias OpenCode-reserved client function names on the wire."""
+def _alias_reserved_tools(
+    response_tools: List[Dict[str, Any]],
+    reserved_names: Tuple[str, ...],
+) -> List[Dict[str, Any]]:
+    """Alias provider-reserved client function names on the wire.
+
+    Single owner for every reserved-name collision on this transport; the
+    reverse mapping lives in :data:`_RESERVED_ALIAS_TO_NAME`, applied in
+    ``normalize_response`` so Hermes dispatch never sees the alias.
+    """
     rewritten: List[Dict[str, Any]] = []
     for tool in response_tools:
-        if isinstance(tool, dict) and tool.get("name") in _OPENCODE_RESERVED_TOOL_NAMES:
+        if isinstance(tool, dict) and tool.get("name") in reserved_names:
             aliased = dict(tool)
             aliased["name"] = f"{_RESERVED_TOOL_ALIAS_PREFIX}{tool['name']}"
             rewritten.append(aliased)
@@ -557,7 +579,17 @@ class ResponsesApiTransport(ProviderTransport):
         # function names (HTTP 400 "custom function name 'X' is reserved",
         # #85589). Alias them on the wire; normalize_response maps them back.
         if response_tools and _is_opencode_responses_backend(params):
-            response_tools = _rename_reserved_tools_for_opencode(response_tools)
+            response_tools = _alias_reserved_tools(
+                response_tools, _OPENCODE_RESERVED_TOOL_NAMES
+            )
+
+        # xAI reserves ``tool_search`` for its native server-side tool and
+        # rejects the client declaration outright (#95003). Alias it on the
+        # wire; normalize_response maps it back before dispatch.
+        if is_xai_responses and response_tools:
+            response_tools = _alias_reserved_tools(
+                response_tools, _XAI_RESERVED_TOOL_NAMES
+            )
 
         # ``tools`` MUST be omitted entirely when there are no functions to
         # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -937,6 +937,109 @@ class TestOpencodeReservedToolAliases:
         assert names == ["search_files", "web_search"]
 
 
+class TestXaiReservedToolSearchAlias:
+    """xAI reserves ``tool_search`` for Grok's native Tool Search and rejects
+    the client declaration with HTTP 400 (#95003). The transport aliases the
+    progressive-disclosure bridge on the wire and maps it back on dispatch."""
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    _TOOLS = [
+        {"type": "function", "function": {
+            "name": "tool_search", "description": "Search deferred tools.",
+            "parameters": {"type": "object",
+                           "properties": {"query": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "tool_describe", "description": "Describe a deferred tool.",
+            "parameters": {"type": "object",
+                           "properties": {"name": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "read_file", "description": "Read a file.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}}}},
+    ]
+
+    def _names(self, kw):
+        return [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
+
+    def test_xai_aliases_reserved_tool_search(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_xai_responses=True,
+        )
+        names = self._names(kw)
+        assert "hermes_tool_search" in names
+        assert "tool_search" not in names
+        # Only ``tool_search`` is reserved — the sibling bridge tools and
+        # ordinary tools go out untouched.
+        assert "tool_describe" in names
+        assert "read_file" in names
+
+    def test_non_xai_backend_keeps_tool_search_name(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_codex_backend=True,
+            base_url="https://api.openai.com/v1",
+        )
+        names = self._names(kw)
+        assert "tool_search" in names
+        assert "hermes_tool_search" not in names
+
+    def test_alias_composes_with_native_web_search_swap(self, transport, monkeypatch):
+        """The bridge alias must survive the xAI web_search branch (#48108)."""
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_xai_prefers_native_web_search", lambda: True)
+        tools = list(self._TOOLS) + [
+            {"type": "function", "function": {
+                "name": "web_search", "description": "Search the web.",
+                "parameters": {"type": "object",
+                               "properties": {"query": {"type": "string"}}}}},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            is_xai_responses=True,
+        )
+        assert any(t.get("type") == "web_search" for t in kw.get("tools", []))
+        names = self._names(kw)
+        assert "hermes_tool_search" in names
+        assert "tool_search" not in names
+
+    def test_normalize_maps_tool_search_alias_back(self, transport, monkeypatch):
+        msg = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1", call_id="call_1", response_item_id="fc_1",
+                    function=SimpleNamespace(
+                        name="hermes_tool_search",
+                        arguments='{"query":"create github issue"}',
+                    ),
+                ),
+            ],
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            reasoning_details=None,
+        )
+        response = SimpleNamespace(output=[], status="completed")
+        monkeypatch.setattr(
+            "agent.codex_responses_adapter._normalize_codex_response",
+            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+        )
+        normalized = transport.normalize_response(response)
+        assert [tc.name for tc in normalized.tool_calls] == ["tool_search"]
+
+
 class TestXaiWebSearchBackendPreference:
     """``_xai_prefers_native_web_search`` must honor web backend config."""
 


### PR DESCRIPTION
## Summary

xAI reserves the function name `tool_search` for Grok's native server-side Tool Search and rejects the client declaration outright:

```
HTTP 400 {"code":"invalid-argument","error":"The function name tool_search is reserved for the tool_search tool"}
```

Hermes's progressive-disclosure bridge registers exactly that literal (`TOOL_SEARCH_NAME`, `tools/tool_search.py`), and bridge assembly is not provider gated — so with the default `tools.tool_search.enabled: auto`, every grok turn fails the moment the catalog crosses the activation threshold. Because the bridge only activates part-way into a session, it presents as a mid-turn session reset rather than an obvious startup failure.

Reproduced against `xai-oauth` / `grok-4.6` on `https://api.x.ai/v1`.

- alias `tool_search` → `hermes_tool_search` on the wire for `is_xai_responses` requests
- map it back in `normalize_response`, so Hermes dispatch and the bridge contract are unchanged
- fold `_rename_reserved_tools_for_opencode` into a single `_alias_reserved_tools(response_tools, reserved_names)` owner, and extend the existing `_RESERVED_ALIAS_TO_NAME` reverse map so the dispatch-side un-aliasing needs no new branch

Same treatment as the two collisions already handled on this transport: the xAI `web_search` hijack (#48108) and the OpenCode reserved names (#85589). `tool_describe` / `tool_call` are not reserved by xAI and go out untouched.

Closes #95003.

## Scope

This covers the Responses transport, which is where every `api.x.ai` route lands by default (`_fallback_api_mode` maps `api.x.ai` → `codex_responses`, and the xai provider profile declares it). An xAI model explicitly forced onto `api_mode: chat_completions` would still hit the 400 — that path has no provider-specific tool rewriting today and would need the symmetric hook in `agent/transports/chat_completions.py` (rename at `build_kwargs`, remap at the `ToolCall` construction in `normalize_response`). Happy to fold that in here if you'd prefer both in one change.

Related: #83122 / #83126 are the OpenAI-Codex half of the same reserved-namespace class, gated on `is_codex_backend`. They do not overlap with this change; if #83126 lands first, its alias can move onto `_alias_reserved_tools` too.

## Tests

`pytest -q tests/agent/transports/ tests/agent/test_codex_responses_adapter.py tests/tools/test_tool_search.py` — 360 passed.

New `TestXaiReservedToolSearchAlias` covers:
- the wire alias, with sibling bridge tools and ordinary tools untouched
- non-xAI Responses backends keeping the canonical name
- composition with the native `web_search` swap (#48108)
- the `normalize_response` round trip back to `tool_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vLaAmnsdii3Gm9jMDs5gw