### PR TITLE
fix(codex): sanitize replayed function_call.name to Responses API pattern (#31666)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -325,6 +325,24 @@ def _sanitize_replayed_fn_name(name: str) -> str:
     return coerced[:64] or "fn"
 
 
+def _canonical_call_id_from_fc(response_item_id: Any) -> Optional[str]:
+    """Map an ``fc_…`` response-item id to its canonical ``call_<suffix>``.
+
+    Both sides of a replayed pair — the assistant ``function_call`` and the
+    tool ``function_call_output`` — must derive the SAME call_id from an
+    fc_-only stored id, or an oversized pair clamps to two different
+    surrogates and the API rejects the output as unmatched.  Keep every
+    caller on this single helper.
+    """
+    if (
+        isinstance(response_item_id, str)
+        and response_item_id.startswith("fc_")
+        and len(response_item_id) > len("fc_")
+    ):
+        return f"call_{response_item_id[len('fc_'):]}"
+    return None
+
+
 def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
     """Split a stored tool id into (call_id, response_item_id)."""
     if not isinstance(raw_id, str):
@@ -704,13 +722,8 @@ def _chat_messages_to_responses_input(
                         if not isinstance(call_id, str) or not call_id.strip():
                             call_id = embedded_call_id
                         if not isinstance(call_id, str) or not call_id.strip():
-                            if (
-                                isinstance(embedded_response_item_id, str)
-                                and embedded_response_item_id.startswith("fc_")
-                                and len(embedded_response_item_id) > len("fc_")
-                            ):
-                                call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
-                            else:
+                            call_id = _canonical_call_id_from_fc(embedded_response_item_id)
+                            if call_id is None:
                                 _raw_args = str(fn.get("arguments", "{}"))
                                 call_id = _deterministic_call_id(fn_name, _raw_args, len(items))
                         call_id = call_id.strip()
@@ -747,15 +760,8 @@ def _chat_messages_to_responses_input(
                 # Legacy fc_-only stored ids: canonicalize to the same
                 # ``call_<suffix>`` the assistant branch synthesizes above, so
                 # a >64-char pair clamps to the SAME surrogate on both sides.
-                # Hashing the raw ``fc_…`` here while the call side hashed
-                # ``call_<suffix>`` would break the pairing and 400 the replay.
-                if (
-                    isinstance(tool_response_item_id, str)
-                    and tool_response_item_id.startswith("fc_")
-                    and len(tool_response_item_id) > len("fc_")
-                ):
-                    call_id = f"call_{tool_response_item_id[len('fc_'):]}"
-                elif isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
+                call_id = _canonical_call_id_from_fc(tool_response_item_id)
+                if call_id is None and isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
                     call_id = raw_tool_call_id.strip()
             if not isinstance(call_id, str) or not call_id.strip():
                 continue

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -742,9 +742,20 @@ def _chat_messages_to_responses_input(
 
         if role == "tool":
             raw_tool_call_id = msg.get("tool_call_id")
-            call_id, _ = _split_responses_tool_id(raw_tool_call_id)
+            call_id, tool_response_item_id = _split_responses_tool_id(raw_tool_call_id)
             if not isinstance(call_id, str) or not call_id.strip():
-                if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
+                # Legacy fc_-only stored ids: canonicalize to the same
+                # ``call_<suffix>`` the assistant branch synthesizes above, so
+                # a >64-char pair clamps to the SAME surrogate on both sides.
+                # Hashing the raw ``fc_…`` here while the call side hashed
+                # ``call_<suffix>`` would break the pairing and 400 the replay.
+                if (
+                    isinstance(tool_response_item_id, str)
+                    and tool_response_item_id.startswith("fc_")
+                    and len(tool_response_item_id) > len("fc_")
+                ):
+                    call_id = f"call_{tool_response_item_id[len('fc_'):]}"
+                elif isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
                     call_id = raw_tool_call_id.strip()
             if not isinstance(call_id, str) or not call_id.strip():
                 continue

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -288,6 +288,43 @@ def _clamp_responses_call_id(call_id: str) -> str:
     return f"call_{digest}"
 
 
+# The Responses API enforces the same 64-char cap on function names as on
+# input item ids (_MAX_RESPONSES_ITEM_ID_LENGTH) — names over the cap are
+# rejected with the same non-retryable 400 as pattern violations.
+_VALID_RESPONSES_FN_NAME_RE = re.compile(r"[a-zA-Z0-9_-]{1,64}")
+
+
+def _sanitize_replayed_fn_name(name: str) -> str:
+    """Coerce a *replayed* function_call name to the Responses API contract.
+
+    The Responses API requires ``function_call.name`` to match
+    ``^[a-zA-Z0-9_-]+$`` and rejects the whole request with a non-retryable
+    HTTP 400 otherwise (issue #31666).  A name with invalid characters (dots,
+    spaces, unicode — e.g. from an earlier model degeneration) stored in
+    conversation history therefore bricks every subsequent turn of the
+    session: the 400 replays forever until the user manually starts a new
+    conversation.
+
+    Invalid characters are replaced with ``_`` (runs collapsed) rather than
+    stripped, so an all-invalid name degrades to the ``"fn"`` placeholder
+    instead of an empty string — an empty name would just trade one
+    non-retryable 400 for a preflight ValueError.  Valid names pass through
+    unchanged, preserving prompt-cache prefixes.
+
+    Apply this ONLY to replayed function_call input items, never to live
+    tool definitions: tool schema names must match the dispatch registry
+    exactly.  Pairing with function_call_output is by call_id, so renaming
+    a replayed function_call is safe.
+    """
+    if not isinstance(name, str):
+        return "fn"
+    if _VALID_RESPONSES_FN_NAME_RE.fullmatch(name):
+        return name
+    coerced = re.sub(r"[^A-Za-z0-9_-]", "_", name.strip())
+    coerced = re.sub(r"_+", "_", coerced).strip("_")
+    return coerced[:64] or "fn"
+
+
 def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
     """Split a stored tool id into (call_id, response_item_id)."""
     if not isinstance(raw_id, str):
@@ -688,7 +725,7 @@ def _chat_messages_to_responses_input(
                         items.append({
                             "type": "function_call",
                             "call_id": _clamp_responses_call_id(call_id),
-                            "name": fn_name,
+                            "name": _sanitize_replayed_fn_name(fn_name),
                             "arguments": arguments,
                         })
                         item_sources.append(msg)
@@ -813,7 +850,7 @@ def _preflight_codex_input_items(
                 {
                     "type": "function_call",
                     "call_id": call_id.strip(),
-                    "name": name.strip(),
+                    "name": _sanitize_replayed_fn_name(name),
                     "arguments": arguments,
                 }
             )

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -285,7 +285,10 @@ def _is_post_tool_replay(messages: Optional[List[Dict[str, Any]]]) -> bool:
     legacy sessions and host-fed histories still use, and let the rejected
     payload through.
     """
-    from agent.codex_responses_adapter import _split_responses_tool_id
+    from agent.codex_responses_adapter import (
+        _canonical_call_id_from_fc,
+        _split_responses_tool_id,
+    )
 
     def _pair_ids(raw: Any, explicit: Any = None) -> set:
         """Every call id a stored tool id could pair on, converter-order."""
@@ -295,8 +298,9 @@ def _is_post_tool_replay(messages: Optional[List[Dict[str, Any]]]) -> bool:
             ids.add(explicit.strip())
         if not ids and isinstance(raw, str) and raw.strip():
             ids.add(raw.strip())
-        if isinstance(item_id, str) and item_id.startswith("fc_") and item_id[3:]:
-            ids.add(f"call_{item_id[3:]}")
+        canonical = _canonical_call_id_from_fc(item_id)
+        if canonical:
+            ids.add(canonical)
         return ids
 
     trailing = set()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -4,6 +4,7 @@ import pytest
 
 from agent.codex_responses_adapter import (
     _chat_messages_to_responses_input,
+    _sanitize_replayed_fn_name,
     _format_responses_error,
     _normalize_codex_response,
     _neutralize_harmony_tokens,
@@ -227,8 +228,6 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
     assert assistant_message.codex_reasoning_items is None
 
 
-
-
 # ---------------------------------------------------------------------------
 # Server-side built-in tool calls (xAI native web_search, code interpreter,
 # etc.) come back as discrete ``*_call`` output items that xAI's
@@ -243,10 +242,6 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
 # Replayed assistant message items with an oversized server-assigned ``id``
 # (Codex issues 400+ char base64 blobs) must never reach the API — the
@@ -259,10 +254,6 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
 
 _OVERSIZED_ITEM_ID = "x" * 408
 _VALID_ITEM_ID = "msg_abc123"
-
-
-
-
 
 
 # The codex app-server overflows the Responses 64-char call_id limit for
@@ -331,8 +322,96 @@ def test_chat_messages_to_responses_input_keeps_short_call_id():
     assert output["call_id"] == "call_abc123"
 
 
+def test_sanitize_replayed_fn_name_valid_passthrough():
+    """Valid names pass through unchanged (identity — cache-prefix safe)."""
+    for name in ("web_search", "exec-command", "a1_B2-c3", "x" * 64):
+        assert _sanitize_replayed_fn_name(name) == name
 
 
+def test_sanitize_replayed_fn_name_coerces_invalid_chars():
+    assert _sanitize_replayed_fn_name("exec.command") == "exec_command"
+    assert _sanitize_replayed_fn_name("run shell cmd") == "run_shell_cmd"
+    assert _sanitize_replayed_fn_name("weird..__name") == "weird_name"
+    assert _sanitize_replayed_fn_name("  tool!  ") == "tool"
+
+
+def test_sanitize_replayed_fn_name_degenerate_inputs():
+    """All-invalid / non-string names degrade to a placeholder, never empty —
+    an empty name would trade the API 400 for a preflight ValueError."""
+    assert _sanitize_replayed_fn_name("") == "fn"
+    assert _sanitize_replayed_fn_name("...") == "fn"
+    assert _sanitize_replayed_fn_name("日本語") == "fn"
+    assert _sanitize_replayed_fn_name(None) == "fn"
+    assert len(_sanitize_replayed_fn_name("a." * 100)) <= 64
+
+
+def test_chat_messages_to_responses_input_sanitizes_replayed_fn_name():
+    """A degenerate tool name stored in history must not brick the replay
+    with a non-retryable 400 (#31666)."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "call_abc123",
+                    "function": {"name": "exec.command", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_abc123",
+            "content": "some result",
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    call = next(i for i in items if i.get("type") == "function_call")
+    output = next(i for i in items if i.get("type") == "function_call_output")
+    assert call["name"] == "exec_command"
+    # Pairing is by call_id and must survive the rename.
+    assert call["call_id"] == output["call_id"] == "call_abc123"
+
+
+def test_preflight_codex_input_items_sanitizes_replayed_fn_name():
+    """The preflight choke-point also coerces invalid replayed names
+    (covers callers that build input items without the chat converter)."""
+    normalized = _preflight_codex_input_items(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "bad name!",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+        ]
+    )
+    call = next(i for i in normalized if i.get("type") == "function_call")
+    assert call["name"] == "bad_name"
+
+
+def test_preflight_codex_api_kwargs_leaves_tool_definition_names_alone():
+    """Live tool schema names must NOT be rewritten — they have to match the
+    dispatch registry exactly. Sanitization is replay-only."""
+    kwargs = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "x",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "my_tool",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+        }
+    )
+    assert kwargs["tools"][0]["name"] == "my_tool"
 
 
 def test_preflight_codex_input_items_drops_short_id_for_github_responses():
@@ -408,8 +487,6 @@ def test_preflight_passes_native_web_search_tool_through():
     assert any(t.get("type") == "function" and t.get("name") == "read_file" for t in tools)
 
 
-
-
 # ---------------------------------------------------------------------------
 # _format_responses_error — adapted from anomalyco/opencode#28757.
 # Provider failures should surface BOTH the code (rate_limit_exceeded /
@@ -419,23 +496,9 @@ def test_preflight_passes_native_web_search_tool_through():
 # ---------------------------------------------------------------------------
 
 
-
-
 def test_format_responses_error_message_only():
     err = {"message": "Upstream model unavailable"}
     assert _format_responses_error(err, "failed") == "Upstream model unavailable"
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def test_normalize_codex_response_failed_includes_code_in_error():
@@ -459,8 +522,6 @@ def test_normalize_codex_response_failed_includes_code_in_error():
     )
     with pytest.raises(RuntimeError, match=r"^rate_limit_exceeded: Slow down$"):
         _normalize_codex_response(response)
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -375,6 +375,37 @@ def test_chat_messages_to_responses_input_sanitizes_replayed_fn_name():
     assert call["call_id"] == output["call_id"] == "call_abc123"
 
 
+def test_chat_messages_to_responses_input_canonicalizes_fc_only_pair():
+    """A legacy fc_-only stored id must map the paired function_call and
+    function_call_output to the SAME call_id — including the oversized case
+    where both sides clamp to the same surrogate (#49224)."""
+    for fc_id in ("fc_short123", "fc_" + "a" * 64):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": fc_id,
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": fc_id,
+                "content": "some result",
+            },
+        ]
+
+        items = _chat_messages_to_responses_input(messages)
+
+        call = next(i for i in items if i.get("type") == "function_call")
+        output = next(i for i in items if i.get("type") == "function_call_output")
+        assert call["call_id"] == output["call_id"]
+        assert len(call["call_id"]) <= 64
+
+
 def test_preflight_codex_input_items_sanitizes_replayed_fn_name():
     """The preflight choke-point also coerces invalid replayed names
     (covers callers that build input items without the chat converter)."""


### PR DESCRIPTION
## Summary

A degenerate tool name stored in conversation history (dots, spaces, unicode from an earlier model degeneration) no longer bricks every subsequent Codex Responses turn with a non-retryable HTTP 400.

## Root cause

The Codex Responses API requires `function_call.name` to match `^[a-zA-Z0-9_-]+$`. When conversation history contains a tool call with an invalid name (e.g. `exec.command`, `run shell cmd`), every replay produces HTTP 400 `Invalid input[N].name: string does not match pattern` — non-retryable, so neither the retry loop nor credential pool recovers. The turn is lost permanently until the user manually starts `/new`.

## Changes

- `agent/codex_responses_adapter.py`: Add `_sanitize_replayed_fn_name()` — replaces invalid chars with `_` (runs collapsed), degrades all-invalid names to `"fn"` instead of empty (an empty name would trade one 400 for a preflight ValueError). Applied at both replay sites: the chat-message converter (`_chat_messages_to_responses_input`) and the preflight choke-point (`_preflight_codex_input_items`). Live tool-definition names are left untouched — they must match the dispatch registry exactly. Pairing is by `call_id`, so renaming a replayed function_call is safe.
- `tests/agent/test_codex_responses_adapter.py`: 7 new tests covering passthrough, coercion, degenerate inputs, end-to-end converter, preflight, and the tool-definition-no-mutation guard.

## Second commit: fc_-only pairing canonicalization

The sweeper review on #49224 identified a real residual defect: the assistant branch synthesizes `call_<suffix>` from an fc_-only stored id, but the tool-result branch kept the raw `fc_...` string — so an oversized pair hashed to two DIFFERENT clamped surrogates and the `function_call_output` arrived unmatched (HTTP 400). Commit 2 canonicalizes the tool-result side to the same `call_<suffix>` before clamping, also fixing the pre-existing short-fc_ pairing mismatch. Regression test covers both lengths.

## Third commit: shared canonicalization helper (/simplify-code)

The reuse+quality reviewers flagged the byte-identical fc_->call_ synthesis blocks in the assistant and tool-result branches as a correctness coupling (the two sites must stay in lockstep or pairing breaks). Extracted `_canonical_call_id_from_fc()` and routed both through it. Mutation-checked: the pairing regression test fails when the tool-branch call is stubbed, green after restore.

Commit 4 extends this to the third copy the reuse reviewer found in `agent/transports/codex.py` `_pair_ids` (spelled `item_id[3:]`, so pattern greps missed it) — all three sites now share the helper.

## What this does NOT do

- call_id overflow (the sibling half of #49224) was already fixed on main by #73492 (`_clamp_responses_call_id`, landed 2026-07-29). This PR does not duplicate that work.
- Tool-definition names in `_preflight_codex_api_kwargs` and `_responses_tools` are deliberately NOT sanitized — they must match the tool registry.

## Validation

| | Before | After |
|---|---|---|
| `exec.command` in replayed history | HTTP 400, session bricked | `exec_command` emitted, replay succeeds |
| `run shell cmd` in replayed history | HTTP 400, session bricked | `run_shell_cmd` emitted, replay succeeds |
| Valid name `web_search` | passes through | passes through (unchanged) |
| All-invalid name `...` | HTTP 400 | `fn` placeholder, replay succeeds |
| Targeted tests + codex responses suite (192 total) | — | 192 passed |
| ruff lint | — | clean |
| E2E real-import probe | — | all 7 assertions held |

## Credit

Salvage of #31678 (@Morad37 — identified the bug, the replay sites, and the regex contract) and #49224 (@lubosxyz — replace-not-strip semantics and `fn` fallback to avoid the empty-name trap). Both PRs were 13-16K commits behind main and the adapter has since been heavily refactored; this is a fresh commit on current main combining the best of both approaches.

Fixes #31666
