### PR TITLE
test(mcp): cover wrapped disconnects and cancellation precedence

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -407,3 +407,33 @@ def test_non_tool_handlers_also_reconnect_on_session_expired(
     finally:
         mcp_tool._servers.pop(f"srv-{op_label}", None)
         mcp_tool._server_error_counts.pop(f"srv-{op_label}", None)
+
+
+@pytest.mark.parametrize('error_kind', ['closed', 'broken', 'eof', 'stale-pipe'])
+@pytest.mark.parametrize('wrapper', ['plain', 'group', 'cause', 'context'])
+def test_session_expiry_recognizes_wrapped_transport_failures(error_kind, wrapper):
+    from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+    from tools.mcp_tool_errors import _is_session_expired_error
+
+    error = {'closed': ClosedResourceError, 'broken': BrokenResourceError,
+             'eof': EndOfStream, 'stale-pipe': lambda: RuntimeError('broken pipe')}[error_kind]()
+    if wrapper == 'group':
+        error = ExceptionGroup('request failed', [ValueError('other'), error])
+    elif wrapper in ('cause', 'context'):
+        outer = RuntimeError('MCP request failed')
+        setattr(outer, '__cause__' if wrapper == 'cause' else '__context__', error)
+        error = outer
+    assert _is_session_expired_error(error) is True
+
+
+@pytest.mark.parametrize('interrupted', [False, True])
+def test_session_expiry_cycles_terminate_and_cancellation_wins(interrupted):
+    from anyio import ClosedResourceError
+    from tools.mcp_tool_errors import _is_session_expired_error
+
+    outer = RuntimeError('request failed')
+    transport = ClosedResourceError()
+    outer.__cause__ = transport
+    transport.__context__ = outer
+    error = ExceptionGroup('batch', [outer, InterruptedError('user cancelled')]) if interrupted else outer
+    assert _is_session_expired_error(error) is (not interrupted)


### PR DESCRIPTION
Message-less AnyIO disconnects must remain recognizable as expired MCP sessions when transports wrap them in exception groups, causes, or contexts. This adds parametrized coverage against `tools.mcp_tool_errors`, including cyclic exception graphs and cancellation precedence.

Refreshed onto upstream `af4a3eba0a36` on 2026-09-15. The conflict resolution retains upstream tests that prevent replaying write-capable calls, alongside the original disconnect/cancellation tests. No production behavior changes.

Validation: canonical `scripts/run_tests.sh -j 2` run covering session expiry, transport groups, cancellation propagation, failure classification, circuit breaker, reconnect retry reset, stdio fast-failure recovery, and empty error messages: 74 tests passed across 8 files, zero failures and no retries reported. The session-expiry file itself passed all 36 cases. Upstream CI still requires maintainer approval.
