### PR TITLE
fix(backup): prune only the root hermes-agent checkout from full archives

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -330,6 +330,8 @@ def _should_exclude(rel_path: Path) -> bool:
         # ``hermes-agent`` only matches at the root level (first component).
         # Nested directories with the same name — e.g.
         # ``skills/autonomous-ai-agents/hermes-agent/`` — must be preserved.
+        # NB: ``part != parts[0]`` compares against the first component's NAME
+        # (a value compare, not a positional one).
         if part == "hermes-agent" and part != parts[0]:
             continue
         return True

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1963,7 +1963,14 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            # ``hermes-agent`` is only pruned at the root level; nested dirs
+            # with the same name (e.g. in skills/) must be preserved -- this
+            # walk must agree with ``_should_exclude`` and ``_run_backup_locked``.
+            is_root = dp == hermes_root
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
+            ]
 
             for fname in filenames:
                 fpath = dp / fname

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -182,3 +182,9 @@ def test_full_backup_excludes_retained_quick_snapshots_and_keeps_nested_skill_re
     # user content: this walk must not prune it where ``_should_exclude`` keeps it.
     assert "hermes-agent/run_agent.py" not in names
     assert "skills/autonomous-ai-agents/hermes-agent/README.md" in names
+
+    # Tripwire BOTH predicates: the archive assertions above pin the full-zip
+    # walk; pin the incremental path's ``_should_exclude`` directly so the two
+    # implementations cannot silently drift apart.
+    assert backup._should_exclude(Path("hermes-agent/run_agent.py")) is True
+    assert backup._should_exclude(Path("skills/x/hermes-agent/y")) is False

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -103,3 +105,80 @@ def test_failed_automatic_backup_preserves_previous_archive(tmp_path, monkeypatc
     assert _write_full_zip_backup(archive, home) is None
     assert archive.read_bytes() == b"previous-valid-backup"
     assert list(tmp_path.glob(".*.partial")) == []
+
+
+def test_full_backup_excludes_retained_quick_snapshots_and_keeps_nested_skill_repos(
+    tmp_path, monkeypatch
+) -> None:
+    """The automatic full-zip walk must agree with ``_should_exclude``.
+
+    Retained quick snapshots are backup artifacts with their own keep-N policy:
+    re-shipping them can inflate a small rollback archive by gigabytes and can
+    fail on historical SQLite files that are intentionally read-only. Nested
+    skill repos that merely share the ``hermes-agent`` name are user content and
+    must survive -- only the root checkout is excluded.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+
+    live_db = home / "state.db"
+    with sqlite3.connect(live_db) as conn:
+        conn.execute("create table live_state (value text)")
+        conn.execute("insert into live_state values ('preserved')")
+
+    retained_db = home / "state-snapshots" / "old" / "state.db"
+    retained_db.parent.mkdir(parents=True)
+    retained_db.write_bytes(b"old snapshot that must not be reopened")
+
+    retained_profile_db = (
+        home / "profiles" / "coder" / "state-snapshots" / "old" / "state.db"
+    )
+    retained_profile_db.parent.mkdir(parents=True)
+    retained_profile_db.write_bytes(b"old profile snapshot that must not be reopened")
+    profile_config = home / "profiles" / "coder" / "config.yaml"
+    profile_config.write_text("model: test\n", encoding="utf-8")
+
+    nested_note = home / "skills" / "demo" / "state-snapshots" / "notes.txt"
+    nested_note.parent.mkdir(parents=True)
+    nested_note.write_text("nested snapshot dir", encoding="utf-8")
+
+    nested_repo = home / "skills" / "autonomous-ai-agents" / "hermes-agent" / "README.md"
+    nested_repo.parent.mkdir(parents=True)
+    nested_repo.write_text("skill repo content", encoding="utf-8")
+
+    root_repo = home / "hermes-agent" / "run_agent.py"
+    root_repo.parent.mkdir(parents=True)
+    root_repo.write_text("the codebase itself", encoding="utf-8")
+
+    from hermes_cli import backup
+
+    real_safe_copy = backup._safe_copy_db
+
+    def safe_copy(src: Path, dst: Path) -> bool:
+        # Tripwire: retained snapshot DBs must never be reopened by the walk.
+        if src in {retained_db, retained_profile_db}:
+            return False
+        return real_safe_copy(src, dst)
+
+    monkeypatch.setattr(backup, "_safe_copy_db", safe_copy)
+    archive = tmp_path / "automatic.zip"
+
+    assert _write_full_zip_backup(archive, home) == archive
+    with zipfile.ZipFile(archive) as zf:
+        names = set(zf.namelist())
+
+    assert "state.db" in names
+    assert "profiles/coder/config.yaml" in names
+
+    # Retained quick snapshots never re-ship, at the default root or per profile.
+    assert not any(name.startswith("state-snapshots/") for name in names)
+    assert not any(
+        name.startswith("profiles/coder/state-snapshots/") for name in names
+    )
+    # ``state-snapshots`` is in ``_EXCLUDED_DIRS``, so it is pruned at any depth.
+    assert "skills/demo/state-snapshots/notes.txt" not in names
+
+    # The root checkout is excluded, but a nested skill repo of the same name is
+    # user content: this walk must not prune it where ``_should_exclude`` keeps it.
+    assert "hermes-agent/run_agent.py" not in names
+    assert "skills/autonomous-ai-agents/hermes-agent/README.md" in names


### PR DESCRIPTION
**What.** The full-zip walk in `_write_full_zip_backup_locked` pruned every directory named
`hermes-agent` at any depth. Only the root-level codebase checkout is meant to be excluded
(re-clone instead); a nested directory that happens to share the name -- e.g. a user skill at
`skills/hermes-agent/` -- silently vanished from full backups while the incremental path
(`_should_exclude` / `_run_backup_locked`) preserved it. Restrict the prune to the archive root
so the two walks agree.

**Why.** Silent data loss from a full backup is exactly the failure a backup must not have.
Reproduction: create `~/.hermes/skills/hermes-agent/SKILL.md`, run a full backup, inspect the zip.

**Tests.** `pytest tests/hermes_cli/test_backup_stability.py` -> 7 passed (vanilla upstream main +
this commit), including a new regression test that builds a root with both the codebase dir and a
nested `skills/hermes-agent` dir and asserts the nested one is archived. Ruff clean.

**Platforms.** Path logic only; exercised on Linux/WSL2, no platform-specific calls.

**Production note.** Running on a private fork since 2026-08-06.
