### PR TITLE
fix(browser): rebind stale provider daemons

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,6 +14,7 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
 import time
 
 import pytest
@@ -842,6 +843,23 @@ class TestSkillTextDescription:
 
 
 class TestBrowserExec:
+    @staticmethod
+    def _provider_owned_backend(monkeypatch):
+        def resolve(env, task_id, session_name=""):
+            env["BU_CDP_WS"] = "wss://managed.example/cdp/replacement"
+            env["_HERMES_BU_PRIVATE_BROWSER"] = "1"
+            env["_HERMES_BU_PROVIDER_BROWSER"] = "1"
+            return None
+
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", resolve)
+        monkeypatch.setattr(bu_cli, "_base_subprocess_env", lambda: {})
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["/fake/browser-use"])
+
+    @staticmethod
+    def _json_result(value):
+        assert isinstance(value, str)
+        return json.loads(value)
+
     def test_missing_cli_returns_install_hint(self, monkeypatch):
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: None)
         result = json.loads(bu_cli.browser_exec("print(page_info())"))
@@ -881,6 +899,152 @@ class TestBrowserExec:
         assert result["success"] is False
         assert result["exit_code"] == 3
         assert "boom" in result["stderr"]
+
+    def test_provider_daemon_failure_bootstraps_once_before_running_user_code(
+        self, monkeypatch
+    ):
+        self._provider_owned_backend(monkeypatch)
+        calls = []
+        ticks = iter((100.0, 105.0, 112.0))
+        monkeypatch.setattr(bu_cli.time, "monotonic", lambda: next(ticks))
+
+        def run(cmd, *, input, env, timeout, **kwargs):
+            calls.append({"input": input, "env": dict(env), "timeout": timeout})
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    "",
+                    "browser-harness: required daemon 'r7k2' is not running\n",
+                )
+            if len(calls) == 2:
+                return subprocess.CompletedProcess(cmd, 0, "BOOTSTRAPPED\n", "")
+            return subprocess.CompletedProcess(cmd, 0, "USER_CODE_OK\n", "")
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", run)
+
+        result = self._json_result(
+            bu_cli.browser_exec("print('payload')", session="r7k2", timeout_s=30)
+        )
+
+        assert result["success"] is True
+        assert result["output"] == "USER_CODE_OK\n"
+        assert len(calls) == 3
+        assert "HERMES_PROVIDER_DAEMON_PREFLIGHT" in calls[0]["input"]
+        assert calls[0]["env"]["BH_REQUIRE_EXISTING_DAEMON"] == "1"
+        assert "HERMES_PROVIDER_DAEMON_BOOTSTRAPPED" in calls[1]["input"]
+        assert "restart_daemon" not in calls[1]["input"]
+        assert "ensure_daemon()" not in calls[1]["input"]
+        assert "BH_REQUIRE_EXISTING_DAEMON" not in calls[1]["env"]
+        assert calls[2]["input"] == "print('payload')"
+        assert calls[2]["env"]["BH_REQUIRE_EXISTING_DAEMON"] == "1"
+        assert all("_HERMES_BU_PROVIDER_BROWSER" not in call["env"] for call in calls)
+        assert [call["timeout"] for call in calls] == [30, 25.0, 18.0]
+        assert sum(call["input"] == "print('payload')" for call in calls) == 1
+
+    def test_healthy_provider_daemon_runs_user_code_without_bootstrap(self, monkeypatch):
+        self._provider_owned_backend(monkeypatch)
+        calls = []
+
+        def run(cmd, *, input, env, timeout, **kwargs):
+            calls.append({"input": input, "env": dict(env)})
+            output = "PREFLIGHT_OK\n" if len(calls) == 1 else "OK\n"
+            return subprocess.CompletedProcess(cmd, 0, output, "")
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", run)
+
+        result = self._json_result(
+            bu_cli.browser_exec("print('payload')", session="r7k2", timeout_s=30)
+        )
+
+        assert result["success"] is True
+        assert result["output"] == "OK\n"
+        assert len(calls) == 2
+        assert "HERMES_PROVIDER_DAEMON_PREFLIGHT" in calls[0]["input"]
+        assert calls[0]["env"]["BH_REQUIRE_EXISTING_DAEMON"] == "1"
+        assert calls[1]["input"] == "print('payload')"
+        assert calls[1]["env"]["BH_REQUIRE_EXISTING_DAEMON"] == "1"
+
+    def test_unrelated_provider_user_failure_is_not_retried(self, monkeypatch):
+        self._provider_owned_backend(monkeypatch)
+        calls = []
+
+        def run(cmd, *, input, env, timeout, **kwargs):
+            calls.append(input)
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(cmd, 0, "PREFLIGHT_OK\n", "")
+            return subprocess.CompletedProcess(cmd, 3, "", "page script failed\n")
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", run)
+
+        result = self._json_result(
+            bu_cli.browser_exec("print('payload')", session="r7k2", timeout_s=30)
+        )
+
+        assert result["success"] is False
+        assert result["exit_code"] == 3
+        assert len(calls) == 2
+        assert "HERMES_PROVIDER_DAEMON_PREFLIGHT" in calls[0]
+        assert calls[1] == "print('payload')"
+
+    def test_required_daemon_text_from_user_code_is_not_retried(
+        self, monkeypatch
+    ):
+        self._provider_owned_backend(monkeypatch)
+        calls = []
+
+        def run(cmd, *, input, env, timeout, **kwargs):
+            calls.append(input)
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(cmd, 0, "PREFLIGHT_OK\n", "")
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                "SIDE_EFFECT_DONE\n",
+                "browser-harness: required daemon 'r7k2' is unhealthy: disconnected\n",
+            )
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", run)
+
+        result = self._json_result(
+            bu_cli.browser_exec("print('payload')", session="r7k2", timeout_s=30)
+        )
+
+        assert result["success"] is False
+        assert result["output"] == "SIDE_EFFECT_DONE\n"
+        assert len(calls) == 2
+        assert "HERMES_PROVIDER_DAEMON_PREFLIGHT" in calls[0]
+        assert calls[1] == "print('payload')"
+
+    def test_provider_daemon_bootstrap_failure_does_not_run_user_code(self, monkeypatch):
+        self._provider_owned_backend(monkeypatch)
+        calls = []
+
+        def run(cmd, *, input, env, timeout, **kwargs):
+            calls.append(input)
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    "",
+                    "browser-harness: required daemon 'r7k2' is unhealthy: disconnected\n",
+                )
+            return subprocess.CompletedProcess(cmd, 9, "", "bootstrap failed\n")
+
+        monkeypatch.setattr(bu_cli.subprocess, "run", run)
+
+        result = self._json_result(
+            bu_cli.browser_exec("print('payload')", session="r7k2", timeout_s=30)
+        )
+
+        assert result["success"] is False
+        assert result["exit_code"] == 9
+        assert "bootstrap failed" in result["stderr"]
+        assert "HERMES_PROVIDER_DAEMON_PREFLIGHT" in calls[0]
+        assert "HERMES_PROVIDER_DAEMON_BOOTSTRAPPED" in calls[1]
+        assert "restart_daemon" not in calls[1]
+        assert "ensure_daemon()" not in calls[1]
+        assert all(call != "print('payload')" for call in calls)
 
     def test_timeout_returns_actionable_error(self, tmp_path, monkeypatch):
         cli = _fake_cli(tmp_path, "cat > /dev/null\nsleep 30\n")

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -30,6 +30,29 @@ _SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 # subprocess launches — never exported to the CLI.
 _PRIVATE_BROWSER_SENTINEL = "_HERMES_BU_PRIVATE_BROWSER"
 
+# Internal marker set when Hermes, rather than Browser Use CLI itself, owns
+# the provider CDP endpoint. Browser Harness 0.1.10's
+# BH_REQUIRE_EXISTING_DAEMON contract lets each model-authored call prove it
+# is still talking to the exact daemon Hermes provisioned. Popped before the
+# subprocess launches.
+_PROVIDER_BROWSER_SENTINEL = "_HERMES_BU_PROVIDER_BROWSER"
+
+_PROVIDER_DAEMON_PREFLIGHT_CODE = """\
+# HERMES_PROVIDER_DAEMON_PREFLIGHT: strict health check happens before this
+pass
+"""
+
+_PROVIDER_DAEMON_BOOTSTRAP_CODE = """\
+# HERMES_PROVIDER_DAEMON_BOOTSTRAPPED: ensure_daemon self-heals before this
+pass
+"""
+
+_REQUIRED_DAEMON_FAILURE_PHRASES = (
+    "is not running",
+    "is unhealthy",
+    "failed its CDP health check",
+)
+
 # Preamble prepended to the model's code for named sessions on SHARED
 # browsers (local Chrome / CDP override). The harness daemon attaches to the
 # first existing page at startup, so two fresh named daemons can land on the
@@ -102,6 +125,16 @@ def _blocked_url_in_code(code: str) -> Optional[str]:
         if err:
             return err.get("error", "Blocked: unsafe URL")
     return None
+
+
+def _is_required_daemon_failure(proc: subprocess.CompletedProcess) -> bool:
+    """Whether a trusted preflight was refused by Browser Harness."""
+    stderr = str(proc.stderr or "")
+    return (
+        proc.returncode != 0
+        and "browser-harness: required daemon " in stderr
+        and any(phrase in stderr for phrase in _REQUIRED_DAEMON_FAILURE_PHRASES)
+    )
 
 
 def _base_subprocess_env() -> dict:
@@ -591,6 +624,7 @@ def _resolve_backend_cdp(
             "the built-in browser tools for this provider."
         )
     env["BU_CDP_URL" if cdp.startswith(("http://", "https://")) else "BU_CDP_WS"] = cdp
+    env[_PROVIDER_BROWSER_SENTINEL] = "1"
     # A provider browser keyed bu-named-<name> is exclusive to this session —
     # the own-tab preamble is unnecessary there (it would just leak a blank
     # tab into a browser nobody else touches).
@@ -650,6 +684,7 @@ def browser_exec(
     # the model's code. Private per-name browsers (provider-keyed or BU
     # cloud) skip this: no one to collide with, and the extra tab would leak.
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
+    provider_browser = env.pop(_PROVIDER_BROWSER_SENTINEL, None)
     if session and not private_browser:
         code = _OWN_TAB_PREAMBLE + code
 
@@ -667,6 +702,12 @@ def browser_exec(
     except (TypeError, ValueError):
         timeout = _DEFAULT_TIMEOUT_S
 
+    # Browser Harness 0.1.10+ fails closed when an orchestrator-owned daemon
+    # is missing or unhealthy. Older releases ignore this variable, preserving
+    # compatibility until the hardened harness is published.
+    if provider_browser:
+        env["BH_REQUIRE_EXISTING_DAEMON"] = "1"
+
     # Windows: hide the console the .cmd shim would flash (as browser_tool does)
     popen_extra: dict = {}
     if os.name == "nt":
@@ -681,16 +722,69 @@ def browser_exec(
             logger.debug("Windows hide-flags unavailable: %s", e)
 
     started = time.time()
+    deadline = time.monotonic() + timeout
     try:
-        proc = subprocess.run(
-            cmd,
-            input=code,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-            **popen_extra,
-        )
+        proc = None
+        if provider_browser:
+            # Health-check the exact orchestrator-owned daemon before any
+            # model-authored code can run. This trusted preflight is the only
+            # result eligible to trigger recovery, so user code is never
+            # retried after a partial or completed side effect.
+            preflight = subprocess.run(
+                cmd,
+                input=_PROVIDER_DAEMON_PREFLIGHT_CODE,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+                **popen_extra,
+            )
+            if _is_required_daemon_failure(preflight):
+                # Without strict mode, Browser Harness ensure_daemon() already
+                # performs one CDP health probe and self-heals a missing or
+                # stale daemon under the current provider endpoint. The
+                # bootstrap body is deliberately a no-op: an explicit
+                # restart_daemon()/ensure_daemon() here would rebind twice.
+                bootstrap_env = dict(env)
+                bootstrap_env.pop("BH_REQUIRE_EXISTING_DAEMON", None)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+                bootstrap = subprocess.run(
+                    cmd,
+                    input=_PROVIDER_DAEMON_BOOTSTRAP_CODE,
+                    capture_output=True,
+                    text=True,
+                    timeout=remaining,
+                    env=bootstrap_env,
+                    **popen_extra,
+                )
+                if bootstrap.returncode != 0:
+                    proc = subprocess.CompletedProcess(
+                        bootstrap.args,
+                        bootstrap.returncode,
+                        bootstrap.stdout,
+                        "browser daemon bootstrap failed after required-daemon check:\n"
+                        + str(bootstrap.stderr or ""),
+                    )
+            elif preflight.returncode != 0:
+                proc = preflight
+
+        if proc is None:
+            command_timeout = timeout
+            if provider_browser:
+                command_timeout = deadline - time.monotonic()
+                if command_timeout <= 0:
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+            proc = subprocess.run(
+                cmd,
+                input=code,
+                capture_output=True,
+                text=True,
+                timeout=command_timeout,
+                env=env,
+                **popen_extra,
+            )
     except subprocess.TimeoutExpired:
         return tool_error(
             f"browser-use exec timed out after {timeout}s. The daemon may "


### PR DESCRIPTION
## Problem

Hermes-owned cloud provider sessions can be replaced after expiry while a same-name local Browser Harness daemon remains alive on the old CDP endpoint. Reusing that daemon causes dead-CDP reconnects, `about:blank` state, stale references, and eventual command/screenshot timeouts.

Browser Harness PR browser-use/browser-harness#640 adds a fail-closed `BH_REQUIRE_EXISTING_DAEMON` contract, but Hermes must adopt it and rebind its provider daemon when the exact daemon is missing or unhealthy.

## Approach

- Mark CDP endpoints provisioned by Hermes' browser provider internally; never export that sentinel.
- Run provider-owned `browser_exec` calls with `BH_REQUIRE_EXISTING_DAEMON=1`.
- Run a trusted strict preflight before any model-authored payload.
- If that preflight reports a missing or unhealthy daemon, run one non-strict no-op bootstrap. Browser Harness's own `ensure_daemon()` performs the single self-heal under the current provider CDP endpoint.
- Run the original model-authored payload byte-for-byte once under strict mode. User-code failures are never classified as recovery signals and are never retried.
- Keep preflight, optional bootstrap, and the one user execution inside the caller's original timeout budget.
- Leave local, user-supplied CDP, and direct Browser Use cloud paths unchanged.

Browser Harness 0.1.9 ignores `BH_REQUIRE_EXISTING_DAEMON`, so this remains compatible before 0.1.10 lands. The recovery path activates with browser-use/browser-harness#640.

## Verification

- RED→GREEN regressions cover:
  - strict provider-daemon refusal → one Harness-owned self-heal → one user execution;
  - healthy provider daemon → no bootstrap and one user execution;
  - unrelated user failure → no retry;
  - required-daemon text from user code → no retry;
  - failed bootstrap → no user-code execution;
  - all subprocess work remains inside the original timeout budget.
- Canonical affected modules: **103 passed**
  - `tests/tools/test_browser_use_cli.py`
  - `tests/tools/test_browser_use_session_expiry.py`
- Ruff lint, `py_compile`, and `git diff --check`: passed.
- Browser Harness #640 focused contract suite: passed.
- Live managed replacement test:
  - browser A usable, then externally stopped;
  - browser B created under the same logical session name;
  - Hermes automatically rebound the stale daemon;
  - each model-authored payload executed once;
  - both cloud browsers read back `stopped`.

## Platform tested

- Linux Nous-hosted Hermes Cloud (`x86_64` managed browser path)
- Cross-platform logic remains standard-library-only; macOS/Windows were not exercised live.

## Related work

- NousResearch/hermes-agent#93944 — canonical managed-provider selection
- NousResearch/hermes-agent#94183 — timeout poisoning and wedged-daemon recovery
- NousResearch/hermes-agent#91175 — Browser Harness 0.1.10 integration work
- browser-use/browser-harness#639 — CDP log redaction
- browser-use/browser-harness#640 — orchestrator-owned daemon contract
- browser-use/browser-harness#641 — long screenshot response budget

## Scope

This PR does not modify provider routing, Browser Harness IPC timeout constants, viewport creation, or managed runtime bytes. Those are covered by the related focused changes above.
