### PR TITLE
fix(agent): recognize ACP session reset limits and preserve reset hints

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import enum
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, Optional, Sequence
@@ -133,11 +134,22 @@ _OVERLOADED_PATTERNS = (
 
 # Usage-limit patterns that need disambiguation (billing OR rate_limit), and
 # the signals that mark such a limit as transient (periodic quota, not billing).
-_USAGE_LIMIT_PATTERNS = ("usage limit", "quota", "limit exceeded", "key limit exceeded")
+_USAGE_LIMIT_PATTERNS = ("usage limit", "quota", "limit exceeded", "key limit exceeded", "session limit")
 _USAGE_LIMIT_TRANSIENT_SIGNALS = (
     "try again", "retry", "resets at", "reset in", "resets in", "reset after", "available in",
     "wait", "requests remaining", "periodic", "window", "per minute", "per second",
 )
+
+
+# A bare "resets" is prose unless followed by a concrete time-like token.
+_USAGE_LIMIT_TRANSIENT_RESETS_RE = re.compile(r"\bresets?\s+(?:at\s+)?\d", re.IGNORECASE)
+
+
+def _msg_has_usage_limit_transient_signal(error_msg: str) -> bool:
+    return any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS) or bool(
+        _USAGE_LIMIT_TRANSIENT_RESETS_RE.search(error_msg)
+    )
+
 
 # 413 detected from message text (proxies embed the status or re-wrap
 # Anthropic's "request_too_large" type without one).
@@ -743,9 +755,7 @@ def _status_5xx(c: _Ctx) -> Verdict:
 
 def _classify_402(error_msg: str, result_fn: Callable[..., Any]) -> Any:
     """Disambiguate 402: "usage limit, try again in 5 minutes" is a periodic quota, not billing."""
-    transient = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and any(
-        p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
-    )
+    transient = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and _msg_has_usage_limit_transient_signal(error_msg)
     return result_fn(**(_V_RATE_LIMIT if transient else _V_BILLING))
 
 
@@ -824,7 +834,7 @@ _RESET_HEADERS = ("retry-after", "Retry-After", "x-ratelimit-reset", "X-RateLimi
 
 def _has_usage_limit_transient_signal(error_msg: str, body: dict, response_headers) -> bool:
     """Whether a usage-limit response identifies a reset window (message, body fields, or headers)."""
-    if any(pattern in error_msg for pattern in _USAGE_LIMIT_TRANSIENT_SIGNALS):
+    if _msg_has_usage_limit_transient_signal(error_msg):
         return True
     payloads = [p for p in (body, _error_obj(body)) if isinstance(p, dict)]
     if any(payload.get(f) not in (None, "") for payload in payloads for f in _RESET_FIELDS):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -382,7 +382,7 @@ _GATEWAY_AUTH_ERROR_RE = re.compile(
     re.IGNORECASE)
 
 _GATEWAY_RATE_LIMIT_RE = re.compile(
-    r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)", re.IGNORECASE)
+    r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit|session\s+limit)", re.IGNORECASE)
 
 # Connection-failure markers: the first 8 also anchor the provider-failure envelope shape below.
 _CONNECTION_ERROR_MARKERS = (
@@ -615,6 +615,12 @@ def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     for pattern, reply in _PROVIDER_ERROR_REPLIES:
         if pattern.search(text):
+            if pattern is _GATEWAY_RATE_LIMIT_RE:
+                from gateway.run_reset_hint import extract_gateway_reset_hint
+
+                hint = extract_gateway_reset_hint(text)
+                if hint:
+                    return f"⏱️ The model provider hit its usage/session limit — {hint}. Please try again after that."
             return reply
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "

--- a/gateway/run_reset_hint.py
+++ b/gateway/run_reset_hint.py
@@ -1,0 +1,48 @@
+"""Bounded reset hints for sanitized provider failure replies."""
+
+import re
+from typing import Optional
+
+
+# Captures the reset hint from a provider usage/session-limit envelope, e.g.
+# "… session limit · resets 5:20pm (America/New_York)" → "resets 5:20pm
+# (America/New_York)". Stops at line breaks and sentence-ending periods so we
+# never leak a long raw body into chat, but keeps dotted time tokens whole:
+# a period survives when the next char continues the token ("p.m", URLs) or
+# when it closes a single-letter abbreviation ("p.m. ET" — period preceded by
+# a lone word char). Input is already secret-redacted at the call site.
+_GATEWAY_RESET_HINT_RE = re.compile(
+    r"reset[s]?\b(?:[^\n.]|\.(?![\s])(?!$)|(?<=\b\w)\.){0,48}", re.IGNORECASE
+)
+
+
+def extract_gateway_reset_hint(text: str) -> Optional[str]:
+    """Extract a short, whole-token reset hint from a provider error body.
+
+    The regex character budget can land mid-token; surfacing "resets 5:20 p"
+    or a dangling "(America/New_Yo" reads as a bug in chat. Snap the slice
+    back to the last whole token and drop any unbalanced trailing
+    parenthetical before handing the hint to the user-facing message.
+    """
+    match = _GATEWAY_RESET_HINT_RE.search(text)
+    if not match:
+        return None
+    hint = match.group(0)
+    end = match.end()
+    if (
+        end < len(text)
+        and not text[end].isspace()
+        and text[end] != "."
+        and hint
+        and not hint[-1].isspace()
+    ):
+        # The budget ran out mid-token: keep only whole tokens.
+        parts = hint.rsplit(None, 1)
+        if len(parts) == 2:
+            hint = parts[0]
+    hint = hint.strip().rstrip(" .·-")
+    while hint.count("(") > hint.count(")"):
+        # A parenthetical opened inside the budget but never closed
+        # (long timezone tails); an unbalanced "(" must not reach chat.
+        hint = hint[: hint.rindex("(")].rstrip(" .·-")
+    return hint or None

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1792,3 +1792,17 @@ class TestNousWelcomeTier:
         result = classify_api_error(MockAPIError("forbidden", status_code=403, body={"message": "forbidden"}), provider="nous")
         assert result.reason == FailoverReason.auth
         assert "welcome_route" not in result.error_context
+
+@pytest.mark.parametrize("status", [None, 402, 429])
+@pytest.mark.parametrize("message, transient", [
+    ("You've hit your session limit · resets 5:20pm (America/New_York)", True),
+    ("API call failed after 2 retries. Session limit · reset at 9:00", True),
+    ("You've hit your session limit", False),
+    ("Your trial quota never resets — upgrade to continue", False),
+    ("Usage limit exceeded. The free plan resets monthly; upgrade.", False),
+])
+def test_session_limit_requires_concrete_reset_signal(status, message, transient):
+    result = classify_api_error(MockAPIError(message, status_code=status), provider="claude-acp")
+    assert result.reason == (FailoverReason.rate_limit if transient else FailoverReason.billing)
+    assert result.retryable is transient
+    assert result.should_fallback is True

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -343,3 +343,25 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+@pytest.mark.parametrize("surface", ["final", "status"])
+@pytest.mark.parametrize("reset, expected", [
+    ("resets 5:20pm (America/New_York)", "resets 5:20pm (America/New_York)"),
+    ("resets 5:20 p.m. ET", "resets 5:20 p.m. ET"),
+    ("resets 5:20pm (America/Argentina/ComodRivadavia_Daylight_Saving_Region)", "resets 5:20pm"),
+])
+def test_chat_session_limit_preserves_whole_reset_hint(surface, reset, expected):
+    raw = "API call failed after 2 retries. Internal error: session limit · " + reset + ". private provider detail"
+    if surface == "final":
+        sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+    else:
+        sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw)
+    assert sanitized is not None
+    assert "usage/session limit" in sanitized
+    assert expected in sanitized
+    assert "Internal error" not in sanitized
+    assert "private provider detail" not in sanitized
+    assert sanitized.count("(") == sanitized.count(")")
+    if "ComodRivadavia" in reset:
+        assert "America/" not in sanitized


### PR DESCRIPTION
ACP periodic session caps such as `session limit · resets 5:20pm` were not consistently classified as transient rate limits. Recognize session limits and concrete reset times through the classifier's message, HTTP 402, and HTTP 429 paths, preserving billing classification for hard caps and vague reset prose.

Chat error replies retain a bounded reset hint, including dotted times, without raw provider details or truncated timezone fragments. Existing authentication and policy reply precedence is preserved. The reset-hint helper lives in `gateway/run_reset_hint.py`.

Validation: the 12 regression cases fail on upstream `45a6101f36` before the fix. `scripts/run_tests.sh -j 2 tests/agent/test_error_classifier.py tests/gateway/test_telegram_noise_filter.py` passes all 313 tests after the fix. Refreshed onto upstream `45a6101f36`, preserving the newer welcome-tier classifier and tests.
