### PR TITLE
feat(desktop): show active todo when task list is collapsed

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -22,9 +22,13 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
     $todosBySession.set({})
   })
 
-  it('shows a running indicator next to the collapsed todo label', () => {
+  it('shows only the active todo next to the collapsed todo label', () => {
     $todosBySession.set({
-      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+      'session-1': [
+        { content: 'Finished setup', id: '1', status: 'completed' },
+        { content: 'Wire the status stack', id: '2', status: 'in_progress' },
+        { content: 'Run verification', id: '3', status: 'pending' }
+      ]
     })
 
     render(
@@ -33,20 +37,32 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
       </MemoryRouter>
     )
 
-    const button = screen.getByRole('button', { name: /Tasks 0\/1/ })
+    const button = screen.getByRole('button', { name: /Tasks 1\/3/ })
+
+    expect(screen.getByText('Finished setup')).toBeTruthy()
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+    expect(screen.getByText('Run verification')).toBeTruthy()
+
     fireEvent.click(button)
 
-    const label = screen.getByText('Tasks 0/1')
+    const label = screen.getByText('Tasks 1/3')
     const indicator = screen.getByRole('status')
+    const activeTodo = screen.getByText('Wire the status stack')
 
-    expect(screen.queryByText('Wire the status stack')).toBeNull()
+    expect(screen.queryByText('Finished setup')).toBeNull()
+    expect(screen.queryByText('Run verification')).toBeNull()
     expect(button.contains(indicator)).toBe(true)
+    expect(button.contains(activeTodo)).toBe(true)
     expect(label.compareDocumentPosition(indicator) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(indicator.compareDocumentPosition(activeTodo) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('does not show a collapsed todo indicator when no todo is running', () => {
+  it('tracks the active todo while the section stays collapsed', () => {
     $todosBySession.set({
-      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'completed' }]
+      'session-1': [
+        { content: 'First active task', id: '1', status: 'in_progress' },
+        { content: 'Next active task', id: '2', status: 'pending' }
+      ]
     })
 
     render(
@@ -55,9 +71,44 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
       </MemoryRouter>
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /Tasks 1\/1/ }))
+    const button = screen.getByRole('button', { name: /Tasks 0\/2/ })
+    fireEvent.click(button)
 
-    expect(screen.queryByText('Wire the status stack')).toBeNull()
+    expect(button.contains(screen.getByText('First active task'))).toBe(true)
+    expect(screen.queryByText('Next active task')).toBeNull()
+
+    act(() => {
+      $todosBySession.set({
+        'session-1': [
+          { content: 'First active task', id: '1', status: 'completed' },
+          { content: 'Next active task', id: '2', status: 'in_progress' }
+        ]
+      })
+    })
+
+    expect(screen.queryByText('First active task')).toBeNull()
+    expect(button.contains(screen.getByText('Next active task'))).toBe(true)
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+  })
+
+  it('does not show inactive todos or a collapsed indicator when no todo is running', () => {
+    $todosBySession.set({
+      'session-1': [
+        { content: 'Finished setup', id: '1', status: 'completed' },
+        { content: 'Run verification', id: '2', status: 'pending' }
+      ]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Tasks 1\/2/ }))
+
+    expect(screen.queryByText('Finished setup')).toBeNull()
+    expect(screen.queryByText('Run verification')).toBeNull()
     expect(screen.queryByRole('status')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -70,8 +70,10 @@ const groupLabel = (group: StatusGroup, s: Translations['statusStack']) => {
   return group.type === 'subagent' ? s.subagents(group.items.length) : s.background(group.items.length)
 }
 
-const hasRunningTodo = (group: StatusGroup) =>
-  group.type === 'todo' && group.items.some(item => item.todoStatus === 'in_progress' && item.state === 'running')
+const activeTodoForGroup = (group: StatusGroup) =>
+  group.type === 'todo'
+    ? group.items.find(item => item.todoStatus === 'in_progress' && item.state === 'running')
+    : undefined
 
 interface ComposerStatusStackProps {
   /** The queue, built by the composer (it owns the queue's callbacks). Rendered
@@ -155,6 +157,8 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   }
 
   for (const group of groups) {
+    const activeTodo = activeTodoForGroup(group)
+
     sections.push({
       key: group.type,
       node: (
@@ -175,12 +179,15 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
             ) : undefined
           }
           collapsedIndicator={
-            hasRunningTodo(group) ? (
-              <GlyphSpinner
-                ariaLabel={t.statusStack.running}
-                className="text-[0.8rem] leading-none text-muted-foreground/80"
-                spinner="braille"
-              />
+            activeTodo ? (
+              <>
+                <GlyphSpinner
+                  ariaLabel={t.statusStack.running}
+                  className="shrink-0 text-[0.8rem] leading-none text-muted-foreground/80"
+                  spinner="braille"
+                />
+                <span className="min-w-0 truncate text-foreground/92">{activeTodo.title}</span>
+              </>
             ) : undefined
           }
           defaultCollapsed={group.type !== 'todo' && group.type !== 'goal'}

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -41,8 +41,10 @@ export function StatusSection({
         >
           <DisclosureCaret className="shrink-0" open={!collapsed} size="1em" />
           {icon && <span className="flex shrink-0 items-center">{icon}</span>}
-          <span className="min-w-0 truncate">{label}</span>
-          {collapsed && collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
+          <span className={collapsed && collapsedIndicator ? 'shrink-0' : 'min-w-0 truncate'}>{label}</span>
+          {collapsed && collapsedIndicator && (
+            <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">{collapsedIndicator}</span>
+          )}
         </button>
         {accessory && <div className="flex shrink-0 items-center gap-1">{accessory}</div>}
       </div>


### PR DESCRIPTION
## Summary

- show the current `in_progress` todo title beside the running indicator when the Desktop task section is collapsed
- keep completed, cancelled, and pending todos hidden in the compact state
- update the compact label reactively when the active todo changes

## Motivation

Collapsing the task list currently hides every todo and leaves only an activity spinner. That saves space, but it also removes the description of what Hermes is doing. The collapsed state should stay compact while preserving the one piece of information that matters most: the active task.

## Changes

- derive the active todo from the existing composer status group
- render its title in the existing collapsed indicator slot with overflow-safe truncation
- keep the task count label fixed while the active title uses the remaining width
- expand the regression coverage for mixed statuses, live active-task transitions, and lists without an active item

## Test Plan

- [x] verified the new regression test fails against the old behavior
- [x] focused collapsed-todo tests: 3 passed
- [x] status-stack UI tests: 16 passed
- [x] Desktop TypeScript typecheck
- [x] ESLint and Prettier on all changed files
- [x] production Desktop build (`dist/index.html`, renderer assets, Electron bundles, native dependency staging)
- [x] full Desktop UI suite exercised: 5,686 passed; 47 failed in 17 unrelated files under parallel load
- [x] all 17 failed files rerun serially: 202 passed; the remaining 4 failures are `de-DE` number/currency expectations in 3 unrelated files

## Notes for Reviewers

The expanded task list is unchanged. Only the existing collapsed indicator is enriched, so there is no new store or persisted state.
