### PR TITLE
fix(browser): stop truncating regex-escaped URLs in the exec pre-scan

### DIFF
--- a/tests/tools/test_browser_use_cli_url_prescan.py
+++ b/tests/tools/test_browser_use_cli_url_prescan.py
@@ -1,0 +1,81 @@
+"""Regression tests for the browser_exec URL pre-scan (#95027).
+
+``_blocked_url_in_code`` extracts http(s) literals from exec code and checks
+each against ``evaluate_url_safety``. The old extraction pattern cut the
+candidate at the first backslash, so a regex-escaped public literal like
+``r"https://go\\.solupay\\.com/payment"`` was checked as the bare host
+``go`` — whose DNS failure surfaced as a bogus "private or internal address"
+block. The fix captures backslashes, unescapes regex-escaped punctuation
+before evaluation, and skips candidates whose authority still carries regex
+syntax (patterns a browser can never navigate). Concrete URLs — including
+escaped private ones — are checked unchanged.
+"""
+
+from unittest.mock import patch
+
+
+def _capture(monkeypatch):
+    seen = []
+
+    def _fake_evaluate(url):
+        seen.append(url)
+        return None
+
+    monkeypatch.setattr(
+        "tools.browser_tool.evaluate_url_safety", _fake_evaluate
+    )
+    return seen
+
+
+def test_escaped_public_url_evaluated_unescaped(monkeypatch):
+    seen = _capture(monkeypatch)
+    from tools.browser_use_cli import _blocked_url_in_code
+
+    code = r'pattern = re.compile(r"https://go\.solupay\.com/payment")'
+    assert _blocked_url_in_code(code) is None
+    assert seen == ["https://go.solupay.com/payment"]
+
+
+def test_escaped_private_url_still_reaches_evaluation(monkeypatch):
+    seen = _capture(monkeypatch)
+    from tools.browser_use_cli import _blocked_url_in_code
+
+    code = r'pattern = re.compile(r"https://127\.0\.0\.1/admin")'
+    _blocked_url_in_code(code)
+    # The escaped private host must normalize to the concrete literal and go
+    # through the safety check — unescaping must not bypass the policy.
+    assert seen == ["https://127.0.0.1/admin"]
+
+
+def test_regex_authority_is_skipped_without_dns_lookup(monkeypatch):
+    seen = _capture(monkeypatch)
+    from tools.browser_use_cli import _blocked_url_in_code
+
+    code = r'pattern = re.compile(r"https://(?:www\.)?example\.com/path")'
+    assert _blocked_url_in_code(code) is None
+    assert seen == [], "regex-shaped authorities must not reach DNS evaluation"
+
+
+def test_plain_concrete_url_checked_unchanged(monkeypatch):
+    seen = _capture(monkeypatch)
+    from tools.browser_use_cli import _blocked_url_in_code
+
+    _blocked_url_in_code('x = "https://example.com/page?a=1"')
+    assert seen == ["https://example.com/page?a=1"]
+
+
+def test_unescape_only_strips_backslash_pairs(monkeypatch):
+    from tools.browser_use_cli import _normalize_url_candidate
+
+    assert _normalize_url_candidate(r"https://a\.b\.c/x") == "https://a.b.c/x"
+    # A plain Windows-style path with no scheme passes through normalization
+    # untouched is out of scope here (only URL candidates reach it).
+    assert _normalize_url_candidate("https://example.com/x") == "https://example.com/x"
+
+
+def test_pattern_authority_returns_none():
+    from tools.browser_use_cli import _normalize_url_candidate
+
+    assert _normalize_url_candidate(r"https://(?:www\.)?example\.com/p") is None
+    assert _normalize_url_candidate(r"https://[a-z]+\.example\.com/p") is None
+    assert _normalize_url_candidate("https://example.com/p") == "https://example.com/p"

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -89,15 +89,42 @@ _IMAGE_PATH_RE = re.compile(
     r"((?:[A-Za-z]:[\\/]|/)[^\s\"']+?\.(?:png|jpe?g|webp))", re.IGNORECASE
 )
 
-# http(s) URL literals in exec code checked against browser_navigate's policy
-_URL_RE = re.compile(r"https?://[^\s'\"\\)]+", re.IGNORECASE)
+# http(s) URL literals in exec code checked against browser_navigate's policy.
+# Backslashes are INCLUDED in the candidate: regex-escaped literals like
+# r"https://go\.solupay\.com/payment" are ordinary code content, and cutting
+# at the first backslash truncated them to a bare "https://go" whose DNS
+# failure was then misreported as a private-address block (#95027).
+_URL_RE = re.compile(r"https?://[^\s'\")]+", re.IGNORECASE)
+
+# Regex engines escape URL punctuation with backslashes; a browser never sees
+# them. Unescape before safety evaluation so the host is checked as written
+# (go\.solupay\.com -> go.solupay.com), and treat a candidate whose authority
+# still carries regex syntax after unescaping ((?:…), […], quantifiers) as a
+# search pattern rather than a concrete navigation target — resolving it only
+# yields a misleading DNS-failure block (#95027).
+_URL_ESCAPE_RE = re.compile(r"\\(.)")
+_URL_AUTHORITY_RE = re.compile(r"https?://([^/?#]+)", re.IGNORECASE)
+_REGEX_SYNTAX_CHARS = frozenset("(?*+[]|^$")
+
+
+def _normalize_url_candidate(url: str) -> Optional[str]:
+    """Normalize a regex-escaped URL literal; None marks a non-concrete pattern."""
+    candidate = _URL_ESCAPE_RE.sub(r"\1", url)
+    m = _URL_AUTHORITY_RE.match(candidate)
+    authority = m.group(1) if m else candidate
+    if any(ch in _REGEX_SYNTAX_CHARS for ch in authority):
+        return None  # regex pattern, not something a browser can navigate
+    return candidate
 
 
 def _blocked_url_in_code(code: str) -> Optional[str]:
     """Return an error if a URL literal fails the built-in navigation checks."""
     from tools.browser_tool import evaluate_url_safety
 
-    for url in _URL_RE.findall(code or ""):
+    for raw in _URL_RE.findall(code or ""):
+        url = _normalize_url_candidate(raw)
+        if url is None:
+            continue
         err = evaluate_url_safety(url)
         if err:
             return err.get("error", "Blocked: unsafe URL")


### PR DESCRIPTION
## What does this PR do?

The `browser_exec` URL pre-scan truncated every URL candidate at the first backslash: `_URL_RE = r"https?://[^\s'\"\\)]+"` excluded `\` from the character class, so a regex-escaped public literal in exec code — `r"https://go\.solupay\.com/payment"`, ordinary Python that only defines a pattern and navigates nowhere — was extracted as the bare `https://go`. `evaluate_url_safety()` then tried to resolve the unrelated single-label host `go`, and the DNS failure surfaced as `Blocked: URL targets a private or internal address`, falsely rejecting harmless code (#95027).

The fix follows the report's tested direction: capture the whole candidate including backslashes, unescape regex-escaped punctuation (`\.` → `.`) before safety evaluation, and skip candidates whose authority still carries regex syntax after unescaping (`(?:…)`, `[…]`, quantifiers) — those are search patterns a browser can never navigate, and resolving them only yields misleading DNS-failure blocks. Concrete URLs are checked unchanged, and escaped private literals normalize to their concrete form and stay blockable.

## Related Issue

Fixes #95027

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_use_cli.py` — widen `_URL_RE` to include backslashes in candidates; add `_normalize_url_candidate()` (unescape `\x` → `x`, return `None` when the authority still contains regex syntax); `_blocked_url_in_code()` now normalizes each candidate and skips pattern-shaped ones.
- `tests/tools/test_browser_use_cli_url_prescan.py` — six regression tests covering the report's four-case matrix plus unescape/pattern unit pins: escaped public URL is evaluated unescaped, escaped private URL (`127\.0\.0\.1`) still reaches evaluation, regex authority (`(?:www\.)?example\.com`, `[a-z]+`) is skipped without DNS, plain concrete URL checked unchanged.

## How to Test

1. `.venv/bin/python -m pytest tests/tools -k url_prescan -v` — should pass (6 passed).
2. `.venv/bin/python -m pytest tests/tools/test_browser_use_cli.py -q` — should pass (95 passed; the reporter's local run of this suite was 99/99 with the fix).
3. Fail-on-main control: `git checkout HEAD~1 -- tools/browser_use_cli.py` and rerun the new file — should fail (5 failed: escaped URLs truncate to bare hosts and the normalizer does not exist), then restore. Observed result: `5 failed, 1 passed` pre-fix (the plain-concrete-URL test passes on both sides by design — that path is unchanged), `6 passed` post-fix.
4. Live check from the report: `browser_exec` with `code=r'import re; pattern = re.compile(r"https://go\.solupay\.com/payment"); print("ok")'` — should execute and print `ok` instead of being blocked with a private-address error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#84999 adds the post-landing URL recheck — a separate function with no overlap on the pre-scan extraction path this fixes)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python parsing logic, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (policy unchanged; only candidate extraction/normalization)
