### PR TITLE
fix(desktop): isolate loopback auth from public dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -700,6 +700,26 @@ def _dashboard_public_hosts() -> frozenset[str]:
     return frozenset({hostname.lower()})
 
 
+def _server_trusted_public_hosts(
+    host: str, *, headless: bool
+) -> frozenset[str]:
+    """Return the public hosts that apply to this server instance.
+
+    The Desktop app owns a headless loopback ``serve`` process and connects to
+    it directly with the per-process session token. A separately configured
+    public dashboard may still use ``dashboard.public_url`` and its auth gate,
+    but that declaration must not turn the Desktop-only loopback server into a
+    cookie-authenticated reverse-proxy endpoint.
+    """
+    if (
+        headless
+        and os.getenv("HERMES_DESKTOP") == "1"
+        and host in _LOOPBACK_HOST_VALUES
+    ):
+        return frozenset()
+    return _dashboard_public_hosts()
+
+
 def should_require_auth(host: str, allow_public: bool = False) -> bool:
     """Return True iff the dashboard auth gate must be active.
 
@@ -19447,7 +19467,9 @@ def start_server(
     # request middleware never reloads config. Any non-loopback public hostname
     # engages the auth gate even when the backend itself remains on loopback;
     # otherwise the SPA's local session token would become remotely reachable.
-    app.state.trusted_public_hosts = _dashboard_public_hosts()
+    app.state.trusted_public_hosts = _server_trusted_public_hosts(
+        host, headless=headless
+    )
     # Stash the auth-gate flag on app.state so middleware / SPA-token injection /
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -158,7 +158,7 @@ def test_start_server_loopback_sets_auth_required_false(monkeypatch):
     # Force a fresh state to detect that start_server actually set it.
     web_server.app.state.auth_required = None
     web_server.start_server(
-        host="127.0.0.1", port=9119,
+        host="127.0.0.1", port=0,
         open_browser=False, allow_public=False,
     )
     assert web_server.app.state.auth_required is False
@@ -276,7 +276,7 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
     )
     try:
         web_server.start_server(
-            host="127.0.0.1", port=9119,
+            host="127.0.0.1", port=0,
             open_browser=False, allow_public=False,
         )
         assert web_server.app.state.auth_required is True
@@ -284,6 +284,72 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
             {"dashboard.example.test"}
         )
         assert captured["kwargs"].get("host") == "127.0.0.1"
+        assert captured["kwargs"].get("proxy_headers") is True
+    finally:
+        clear_providers()
+
+
+def test_desktop_headless_loopback_ignores_public_dashboard_url(monkeypatch):
+    """Desktop's private serve process keeps token auth on loopback."""
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        allow_public=False,
+        headless=True,
+    )
+
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset()
+    assert captured["kwargs"].get("proxy_headers") is False
+
+
+def test_non_desktop_headless_loopback_still_honors_public_url(monkeypatch):
+    """The exception is owned by Desktop, not every headless serve caller."""
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    register_provider(StubAuthProvider())
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+    try:
+        web_server.start_server(
+            host="127.0.0.1",
+            port=0,
+            open_browser=False,
+            allow_public=False,
+            headless=True,
+        )
+        assert web_server.app.state.auth_required is True
+        assert web_server.app.state.trusted_public_hosts == frozenset(
+            {"dashboard.example.test"}
+        )
         assert captured["kwargs"].get("proxy_headers") is True
     finally:
         clear_providers()


### PR DESCRIPTION
## What does this PR do?

Prevents a configured public dashboard URL from changing the auth mode of the private loopback `hermes serve` process owned by Hermes Desktop.

Desktop connects to that child directly with a per-process session token. When `dashboard.public_url` names a non-loopback host, the current startup path treats every loopback server as the public reverse-proxy backend and enables cookie auth. The Desktop WebSocket still sends its session token, so `/api/ws` is rejected and the app reports that it cannot connect to the gateway.

This change scopes the exception to the exact Desktop-owned shape: `HERMES_DESKTOP=1`, headless mode, and a loopback bind. Public dashboards and non-Desktop headless callers continue to honor `dashboard.public_url` and remain auth-gated.

## Related Issue

No existing issue or PR found for this specific Desktop/public-URL interaction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add a server-instance trust resolver in `hermes_cli/web_server.py`.
- Preserve public-dashboard authentication for normal headless callers.
- Add regression coverage for both sides of the boundary.
- Use ephemeral ports in the touched startup tests.

## How to Test

1. Set `HERMES_DASHBOARD_PUBLIC_URL` to a non-loopback HTTPS URL.
2. Start a headless loopback server with `HERMES_DESKTOP=1`; verify session-token mode remains active and proxy headers remain disabled.
3. Start the same headless loopback server without `HERMES_DESKTOP`; verify public-host trust and the auth gate remain active.

Test-first evidence: before the production change, the focused run produced 1 failed and 1 passed. After the change:

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py -q` — 32 passed
- `ruff check hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_gate.py` — passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing open and closed PRs/issues for duplicates
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test wrapper for the affected test file
- [x] I've added tests for the bug fix
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing API or config change
- [x] `cli-config.yaml.example` update — N/A; no config key change
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A; no architecture/workflow change
- [x] Cross-platform impact considered; behavior is environment/bind scoped and platform-neutral
- [x] Tool descriptions/schemas update — N/A
