### PR TITLE
fix(tools): scope the web-search TTL memo by profile

### DIFF
--- a/tests/tools/test_web_result_cache.py
+++ b/tests/tools/test_web_result_cache.py
@@ -83,6 +83,27 @@ def test_search_memo_miss_across_providers_and_buckets():
     assert memo.lookup("firecrawl", "other", 5) is None   # different query
 
 
+def test_search_memo_isolates_by_profile():
+    """A multiplexed gateway process serves several profiles; profile B must
+    never receive profile A's cached response for the same provider/query,
+    since that response was fetched (and paid for) under A's credentials."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    memo = SearchMemo()
+    token_a = set_hermes_home_override("/profiles/a")
+    try:
+        memo.store("firecrawl", "q", 5, _ok_response())
+        assert memo.lookup("firecrawl", "q", 5) is not None
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override("/profiles/b")
+    try:
+        assert memo.lookup("firecrawl", "q", 5) is None
+    finally:
+        reset_hermes_home_override(token_b)
+
+
 def test_search_memo_expires_after_ttl(monkeypatch):
     memo = SearchMemo()
     memo.store("firecrawl", "q", 5, _ok_response())

--- a/tools/web_result_cache.py
+++ b/tools/web_result_cache.py
@@ -2,8 +2,11 @@
 
 Two caches, both TTL-bounded (default 20 minutes, ``web.cache_ttl_minutes``):
 
-* **Search memo** — in-memory, per-process. Keyed by (provider, normalized
-  query, bucketed limit). Concurrent identical queries are single-flighted:
+* **Search memo** — in-memory, per-process. Keyed by (profile, provider,
+  normalized query, bucketed limit) — the profile component keeps a
+  multiplexed gateway serving several profiles from one process from
+  handing one profile's cached results (and paid-provider attribution) to
+  another. Concurrent identical queries are single-flighted:
   the first caller performs the paid request while the rest wait and share
   the response. Requested limits are bucketed up to 10/20/50/100 so
   near-identical requests (limit=5 vs limit=8) share one entry; callers get
@@ -111,7 +114,13 @@ class SearchMemo:
         self._key_locks: Dict[tuple, threading.Lock] = {}
 
     def _key(self, provider: str, query: str, limit: int) -> tuple:
-        return (provider, normalize_query(query), bucket_limit(limit))
+        # Scope by profile: this store is a process-global singleton, but a
+        # multiplexed gateway serves several profiles from one process, each
+        # with its own provider credentials. Without the profile component,
+        # profile B's query would silently hit profile A's cached response
+        # within the TTL — content A paid its own provider account for.
+        from hermes_constants import hermes_home_key
+        return (hermes_home_key(), provider, normalize_query(query), bucket_limit(limit))
 
     def lookup(self, provider: str, query: str, limit: int) -> Optional[dict]:
         if not cache_enabled():


### PR DESCRIPTION
## Summary
- `SearchMemo` (the new in-memory TTL cache for `web_search`, added in #94569-ish / \`04603fc040\`) keys its store on `(provider, normalized_query, bucketed_limit)` only — no profile component.
- The store is a process-global singleton (`search_memo = SearchMemo()`). In a multiplexed gateway serving several profiles from one process, two profiles can configure the same provider name (e.g. `"tavily"`) under different accounts/API keys. Within the 20-minute TTL, profile B's `web_search` could silently be served profile A's cached response — content fetched (and paid for) under A's credentials.
- The sibling disk-backed extract cache in the same file is *not* affected: it already isolates by profile through `_cache_dir()` → `get_hermes_dir()` → `get_hermes_home()`, which follows the per-request context override.
- Fix: scope `SearchMemo._key()` by `hermes_home_key()`, the existing helper this codebase's registries already use to isolate per-profile entries in a process-global store.

## Test plan
- [x] Added `test_search_memo_isolates_by_profile`, which stores under one profile override and asserts a lookup under a different profile override misses.
- [x] Mutation-verified: reverted only the source fix (kept the new test) and confirmed the test fails with the exact cross-profile leak (`AssertionError`); restored the fix and confirmed it passes.
- [x] Full existing suite: `pytest tests/tools/test_web_result_cache.py` — 44 passed (43 pre-existing + 1 new).
- [x] Broader consumer suites (`test_web_tools_truncate.py`, `test_web_tools_tavily.py`, `test_web_tools_config.py`, `test_web_tools_dict_urls.py`, `tests/integration/test_web_tools.py`, `tests/plugins/web/test_web_search_provider_plugins.py`) — no regressions. Two pre-existing failures in `test_web_tools_config.py::TestParallelClientConfig` are unrelated (missing `parallel-web` optional dependency under `security.allow_lazy_installs=false`); confirmed present identically with the fix reverted.