### PR TITLE
fix: preserve update receipts across module purge

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -116,6 +116,12 @@ def _purge_stale_hermes_modules() -> None:
         import importlib
 
         importlib.invalidate_caches()
+        receipt_module = _m().sys.modules.get("hermes_cli.update_receipt")
+        active_receipt = (
+            getattr(receipt_module, "_current", None)
+            if receipt_module is not None
+            else None
+        )
         purged = []
         for name in list(_m().sys.modules):
             if name in _STALE_PURGE_PROTECTED:
@@ -133,6 +139,18 @@ def _purge_stale_hermes_modules() -> None:
             logger.debug(
                 "Purged %d stale Hermes module(s) after checkout update", len(purged)
             )
+        if active_receipt is not None:
+            try:
+                fresh_receipt_module = importlib.import_module(
+                    "hermes_cli.update_receipt"
+                )
+                setattr(fresh_receipt_module, "_current", active_receipt)
+            except Exception:
+                # Preserve the original recorder rather than silently losing the
+                # only receipt if the freshly pulled module cannot be imported.
+                if receipt_module is not None:
+                    _m().sys.modules["hermes_cli.update_receipt"] = receipt_module
+                raise
     except Exception as exc:
         logger.debug("Could not purge stale Hermes modules: %s", exc)
 

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -16,6 +16,8 @@ module graph from the updated checkout.
 
 from __future__ import annotations
 
+import importlib
+import json
 import sys
 import types
 
@@ -23,23 +25,40 @@ import pytest
 
 from hermes_cli import main as cli_main
 from hermes_cli import update_cmd
+from hermes_cli import update_receipt
 
 
 @pytest.fixture(autouse=True)
 def _restore_sys_modules():
-    """Snapshot & restore sys.modules around each test.
-
-    The purge under test evicts real Hermes modules from the cache; later
-    tests in the same process may hold references to the evicted module
-    objects (e.g. `patch.object` targets), so put the originals back.
-    """
+    """Restore module-cache entries and parent-package bindings after purge."""
     snapshot = dict(sys.modules)
+    missing = object()
+    parent_attrs = []
+    for name in snapshot:
+        parent_name, separator, child_name = name.rpartition(".")
+        if not separator or not name.startswith(
+            ("hermes_cli.", "gateway.", "tools.", "tui_gateway.", "agent.")
+        ):
+            continue
+        parent = snapshot.get(parent_name)
+        if parent is not None:
+            parent_attrs.append(
+                (parent, child_name, getattr(parent, child_name, missing))
+            )
+
     yield
+
     for name, mod in snapshot.items():
         sys.modules[name] = mod
     for name in list(sys.modules):
         if name not in snapshot:
             del sys.modules[name]
+    for parent, child_name, original in parent_attrs:
+        if original is missing:
+            if hasattr(parent, child_name):
+                delattr(parent, child_name)
+        else:
+            setattr(parent, child_name, original)
 
 
 def _fake_module(name: str) -> types.ModuleType:
@@ -80,6 +99,35 @@ def test_purge_protects_executing_modules():
     assert sys.modules.get("hermes_cli.update_cmd") is update_cmd
     assert sys.modules.get("hermes_cli.main") is cli_main
     assert "hermes_cli" in sys.modules
+
+
+def test_purge_preserves_active_update_receipt(tmp_path, monkeypatch):
+    """A code-changing update must still publish the receipt it started."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    update_receipt._current = None
+    update_receipt.begin_update_receipt()
+    update_receipt.record_step("git_pull", True, "updated checkout")
+
+    try:
+        update_cmd._purge_stale_hermes_modules()
+        refreshed_receipt = importlib.import_module("hermes_cli.update_receipt")
+        assert refreshed_receipt is not update_receipt
+        path = refreshed_receipt.finalize_update_receipt("success")
+
+        assert path is not None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert len(payload["steps"]) == 1
+        step = payload["steps"][0]
+        assert {key: step[key] for key in ("name", "ok", "detail")} == {
+            "name": "git_pull",
+            "ok": True,
+            "detail": "updated checkout",
+        }
+    finally:
+        update_receipt._current = None
+        refreshed = sys.modules.get("hermes_cli.update_receipt")
+        if refreshed is not None:
+            setattr(refreshed, "_current", None)
 
 
 def test_purge_leaves_prefix_lookalikes_alone():


### PR DESCRIPTION
## Summary

- preserve the in-progress update receipt while stale Hermes modules are refreshed
- transfer the active receipt state into the refreshed module
- restore the original receipt module if refresh or state transfer fails
- add an end-to-end regression test that finalizes and persists a receipt after module purge

## Problem

`begin_update_receipt()` creates the active receipt before `_purge_stale_hermes_modules()` runs. The purge removed `hermes_cli.update_receipt`, so later finalization could import a fresh module whose active receipt was empty. A code-changing update could therefore complete without writing its receipt.

## Approach

Refresh the receipt module separately from the general stale-module purge, preserve its active recorder across the refresh, and fail safely back to the original module if the refresh cannot be completed.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_update_stale_module_purge.py tests/hermes_cli/test_update_receipt.py tests/hermes_cli/test_update_receipt_endpoint.py -q` — 35 passed
- `git diff --check`
- Python compilation for the changed source and test files
