### PR TITLE
fix(desktop): bound getConnection() on the boot and soft-switch paths (#93454)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { $gatewaySwitching } from '@/store/gateway-switch'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $connection, $currentCwd, $gatewayState } from '@/store/session'
@@ -555,6 +556,69 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(callsBeforeDrop)
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout, not only when main eventually gives up (#93454)', async () => {
+    // boot()'s getConnection() had no bound of its own — only main's own
+    // eventual timeout (e.g. waitForHermes, ~45s) ever settled it. A wedge
+    // that main never resolves (not even a rejection) must not hang
+    // "Starting Hermes…" forever; the renderer needs to own its own bound
+    // here too, same as attemptReconnect() and softSwitch().
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(() => new Promise(() => undefined))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeNull()
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // stalled await must reject on its own so boot()'s catch runs instead of
+    // waiting indefinitely on main.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($desktopBoot.get().error).toBeTruthy()
+  })
+
+  it('softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever (#93454)', async () => {
+    // Repro: main applies a new connection (onConnectionApplied), softSwitch()
+    // re-dials via getConnection(), and the IPC round-trip wedges. Without an
+    // internal timeout, the try block never settles, so the `finally` that
+    // clears $gatewaySwitching never runs — the switch UI stays frozen until
+    // the app is restarted.
+    const desktop = fakeDesktop()
+    const originalGetConnection = desktop.getConnection
+    let callCount = 0
+
+    desktop.getConnection = vi.fn((profile?: null | string) => {
+      callCount += 1
+
+      // Initial boot succeeds; the switch triggered below hangs indefinitely.
+      return callCount === 1 ? originalGetConnection(profile) : new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(connectionApplied).not.toBeNull()
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    expect($gatewaySwitching.get()).toBe(true)
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // stalled await must reject so the `finally` clears $gatewaySwitching
+    // instead of latching the switch UI frozen forever.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($gatewaySwitching.get()).toBe(false)
   })
 
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -494,7 +494,14 @@ export function useGatewayBoot({
 
         // Same override rule as boot(): a profile-pinned helper window stays
         // on its pinned profile's backend across a soft switch.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // Bounded for the same reason as attemptReconnect() (#93454): a wedged
+        // main-process round-trip must not latch $gatewaySwitching stuck —
+        // the `finally` below only runs once this promise settles.
+        const conn = await withTimeout(
+          desktop.getConnection(windowProfileOverride() ?? undefined),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
 
         if (cancelled) {
           return
@@ -770,7 +777,13 @@ export function useGatewayBoot({
         // A profile-pinned helper window (the HUD) dials its target profile's
         // backend directly — ensureBackend spawns/reuses it from the pool.
         // Everything else keeps dialing the primary.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // Bounded like the reconnect path (#93454): a wedged main-process
+        // round-trip must not hang "Starting Hermes…" forever.
+        const conn = await withTimeout(
+          desktop.getConnection(windowProfileOverride() ?? undefined),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out connecting to Hermes backend'
+        )
 
         if (cancelled) {
           return


### PR DESCRIPTION
## Summary
- #93454 identified that `desktop.revalidateConnection()` / `getConnection()` / `resolveGatewayWsUrl()` are IPC round-trips into the main process with no timeout of their own — a wedged main-process round-trip (e.g. a stuck revalidation after a liveness-probe trip) hangs these awaits forever, and the fix (merged as #93662) bounded all three in `attemptReconnect()`.
- A follow-up commit extended the `resolveGatewayWsUrl()` bound to `boot()` and the soft gateway-switch handler (`softSwitch()`) as well — but the `getConnection()` call immediately preceding it in both functions was left unbounded.
- Failure mode:
  - **`boot()`**: if `getConnection()` wedges, `bootCompleted` never flips and nothing hits `catch` — the "Starting Hermes…" screen hangs forever with no retry, no timeout, no error.
  - **`softSwitch()`**: the same wedge means the `try` block never settles, so its `finally { $gatewaySwitching.set(false) }` never runs — the gateway/profile-switch UI freezes permanently.
- Fix: wrap both calls with the same `withTimeout()` / `RECONNECT_ATTEMPT_TIMEOUT_MS` (20s) pattern already used for every sibling IPC call in this file.

## Test plan
- [x] Added two regression tests mirroring the existing `#93454` hang-repro pattern:
  - `a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout...` — asserts `$desktopBoot.get().error` surfaces after 20s instead of staying `null` forever.
  - `softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever...` — asserts `$gatewaySwitching` unlatches to `false` after 20s instead of staying `true` forever.
- [x] Mutation-verified: reverted only the source fix (kept the two new tests) and confirmed both fail with the exact latch symptoms described above; restored the fix and confirmed both pass.
- [x] Full file: `vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx` — 26 passed (24 pre-existing + 2 new).
- [x] Broader sweep: `src/app/gateway`, `src/store/gateway.test.ts`, `src/store/gateway-switch.test.ts` — 37 passed, no regressions.
- [x] `tsc --noEmit` on the desktop workspace — clean.