### PR TITLE
fix(desktop): close profile spawn deletion race

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -253,6 +253,7 @@ import {
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import {
   assertLocalProfileCanStart,
+  awaitProfileSpawnPreparation,
   decideProfileDeleteAction,
   dispatchConnectionScopedProfileDelete,
   localProfilePoolKeys,
@@ -10517,11 +10518,22 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     directoryExists(path.join(HERMES_HOME, 'profiles', key))
   )
 
-  rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
+  // This is intentionally the LAST async boundary before spawn. The earlier
+  // directory/gate check is a fast rejection, but a profile delete can start
+  // while the parent identity probe is awaiting; without this second check,
+  // teardown evicts an entry whose process is still null and the resumed spawn
+  // becomes an unowned Python backend.
+  const parentStartMarker = await awaitProfileSpawnPreparation(
+    profile,
+    profileDeletionGate,
+    key => directoryExists(path.join(HERMES_HOME, 'profiles', key)),
+    () => desktopParentStartMarker()
+  )
 
-  const parentStartMarker = await desktopParentStartMarker()
   const backendNonce = crypto.randomBytes(16).toString('hex')
   const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
+
+  rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const child = spawn(
     backend.command,
@@ -10900,12 +10912,20 @@ async function startHermes() {
     const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
-    rememberLog(`Starting Hermes backend via ${backend.label}`)
 
     const profile = primaryProfileKey()
-    const parentStartMarker = await desktopParentStartMarker()
+
+    const parentStartMarker = await awaitProfileSpawnPreparation(
+      profile,
+      profileDeletionGate,
+      key => directoryExists(path.join(HERMES_HOME, 'profiles', key)),
+      () => desktopParentStartMarker()
+    )
+
     const backendNonce = crypto.randomBytes(16).toString('hex')
     const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
+
+    rememberLog(`Starting Hermes backend via ${backend.label}`)
 
     const hermesProcess = spawn(
       backend.command,

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   assertLocalProfileCanStart,
+  awaitProfileSpawnPreparation,
   decideProfileDeleteAction,
   dispatchConnectionScopedProfileDelete,
   localProfilePoolKeys,
@@ -142,6 +143,40 @@ test('assertLocalProfileCanStart rejects a delayed retry after the profile direc
   assert.throws(() => assertLocalProfileCanStart('selena', gate, () => false), /Profile "selena" no longer exists/)
   assert.doesNotThrow(() => assertLocalProfileCanStart('default', gate, () => false))
   assert.doesNotThrow(() => assertLocalProfileCanStart('selena', gate, profile => profile === 'selena'))
+})
+
+test('awaitProfileSpawnPreparation runs the final guard after async preparation', async () => {
+  const gate = new ProfileDeletionGate()
+
+  let continuePreparation = (_marker: string) => undefined
+
+  const preparation = new Promise<string>(resolve => {
+    continuePreparation = resolve
+  })
+
+  const start = awaitProfileSpawnPreparation('selena', gate, () => true, () => preparation)
+  const release = gate.acquire('selena')
+
+  continuePreparation('marker')
+  await assert.rejects(start, /Profile "selena" is being deleted/)
+  release()
+})
+
+test('awaitProfileSpawnPreparation rejects when the profile directory disappears during preparation', async () => {
+  const gate = new ProfileDeletionGate()
+  let exists = true
+
+  let continuePreparation = (_marker: string) => undefined
+
+  const preparation = new Promise<string>(resolve => {
+    continuePreparation = resolve
+  })
+
+  const start = awaitProfileSpawnPreparation('selena', gate, () => exists, () => preparation)
+  exists = false
+  continuePreparation('marker')
+
+  await assert.rejects(start, /Profile "selena" no longer exists/)
 })
 
 test('localProfilePoolKeys returns every local process scope for one profile', () => {

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -198,6 +198,26 @@ export function assertLocalProfileCanStart(
 }
 
 /**
+ * Complete asynchronous backend preparation before performing the final spawn
+ * guard. A deletion can begin while preparation is awaiting (for example,
+ * while resolving the Desktop parent identity); checking before that await
+ * leaves a window where the delete evicts an entry with no process handle and
+ * the resumed start creates an unowned backend. The returned value must be
+ * consumed synchronously by the caller before it invokes ``spawn``.
+ */
+export async function awaitProfileSpawnPreparation<T>(
+  profile: unknown,
+  gate: ProfileDeletionGate,
+  profileDirectoryExists: (profile: string) => boolean,
+  prepare: () => Promise<T>
+): Promise<T> {
+  const prepared = await prepare()
+  assertLocalProfileCanStart(profile, gate, profileDirectoryExists)
+
+  return prepared
+}
+
+/**
  * A local profile can occupy the legacy bare pool slot or the explicit-local
  * registry slot when the v1 route points elsewhere. Both processes own the
  * same on-disk profile and must be stopped before deleting it.


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows Desktop lifecycle race where deleting a bot/profile can leave a profile backend spawn unowned. The profile deletion gate was checked before an asynchronous parent-identity probe; deletion could evict the pool entry while `entry.process` was still `null`, then the resumed operation spawned `python.exe` after teardown had finished.

The fix moves the authoritative profile/deletion check to the last asynchronous boundary before `spawn()`, for both pooled profile backends and the primary backend. A stale or concurrently deleted profile is rejected before a process can be created without an owner.

### Confirmed root cause

1. `spawnPoolBackend()` performed `assertLocalProfileCanStart()`.
2. It awaited `desktopParentStartMarker()`.
3. The DELETE path could acquire `ProfileDeletionGate`, remove the pool entry with no process handle yet, delete the profile, and release the gate.
4. The suspended spawn resumed and created a backend that `poolStopper` could no longer reach.

The primary `startHermes()` path had the same check-before-await shape and is hardened by the same helper.

### Non-duplicate scope

This is intentionally not a copy or replacement of existing lifecycle work:

- #88775 / merged fix `fix(desktop): fail-stop deleted-profile reconnects and evict the stale rail badge` stops renderer retry loops after a profile is already gone.
- #88739 / merged pool-stop work retains process handles through bounded teardown and prevents orphaned pooled backends.
- #88727 releases Windows memory-store handles before profile directory removal.

Those changes cover reconnect classification, teardown retention, and SQLite handles. This PR owns a distinct missing enforcement boundary: the final synchronous check after the last await and immediately before process creation.

## Related Issue

Fixes #94959

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a lifecycle race)
- [x] ✅ Tests (adding regression coverage)

## Changes Made

- `apps/desktop/electron/profile-delete-routing.ts`
  - Added `awaitProfileSpawnPreparation()`, which completes async preparation and then performs the final gate/directory validation.
- `apps/desktop/electron/main.ts`
  - Applied the final guard to pooled profile backend creation.
  - Applied the same guard to primary backend creation.
  - Moved the “Starting Hermes backend” log after the final guard so rejected starts do not claim a process was launched.
- `apps/desktop/electron/profile-delete-routing.test.ts`
  - Added a gate-race regression where deletion begins during async preparation.
  - Added a directory-removal regression where the profile disappears during async preparation.

## Hardening review

- **GitHub priority:** `P2` from #94959; escalated to three passes because this is Windows process lifecycle/concurrency work.
- **Pass 1 — premise/root cause:** traced Bot deletion, Electron IPC interception, pool teardown, primary teardown, `spawnPoolBackend()`, and `startHermes()`; compared open/merged duplicate candidates by state transition and changed files.
- **Pass 2 — failure modes:** checked deletion during parent-marker await, missing profile directory, primary vs pooled creation, forced-local pool keys, stale renderer retry, PID/handle retention, and remote/process-less descriptors.
- **Pass 3 — simplification/regression:** kept one shared helper, preserved the existing fast guard, added behavioral tests rather than source-text assertions, and avoided changes to reapers, routing policy, or process-kill primitives already covered upstream.

## How to Test

Focused validation performed on Windows:

1. `profile-delete-routing.test.ts`, `pool-stop.test.ts`, and `backend-ownership.test.ts` with a minimal Vitest configuration: **49 passed** after rebase onto current `origin/main`.
2. `npm exec -- eslint electron/main.ts electron/profile-delete-routing.ts electron/profile-delete-routing.test.ts`: passed with no errors or warnings.
3. `npm exec -- tsc -p tsconfig.electron.json --noEmit --pretty false`: passed before the local workspace dependency installation became incomplete.
4. RED proof: the new regression failed on the old implementation with `TypeError: awaitProfileSpawnPreparation is not a function` and `1 failed, 25 passed`; it passed after the implementation.
5. `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k 'TestDeleteProfile or profile_bound_backends' -q`: **5 passed**.
6. `scripts/run_tests.sh tests/hermes_cli/test_profiles_s6_hooks.py -q`: **3 passed**.

Known environment limitations, not caused by this diff:

- The full `tests/hermes_cli/test_profiles.py` run was `50 passed, 6 failed` on this Windows host because existing tests require POSIX file modes/wrappers or symlink privilege (`WinError 1314`). No Python file is changed here.
- The dashboard lifecycle test was blocked by an existing process occupying `127.0.0.1:9119` (`python.exe -m hermes_cli.main -p default dashboard ...`); it exited before the mocked exec boundary.
- A full Desktop check could not be repeated after npm 11.4/yarn workspace installation removed optional/workspace modules (`electron`, `@rolldown/plugin-babel`, `simple-git`, `node-pty`). The focused tests and lint above ran against the final rebased commit.

## Checklist

- [x] Read the contributing and Desktop engineering guidance.
- [x] Commit follows Conventional Commits: `fix(desktop): close profile spawn deletion race`.
- [x] Searched open/closed/merged related issues and PRs; this is a distinct enforcement boundary.
- [x] PR contains only the three intentional files.
- [ ] Full `pytest tests/ -q` — not run; canonical wrapper limitations are documented above.
- [x] Added regression tests for both deletion-gate and directory-removal races.
- [x] Considered Windows, macOS, and Linux behavior; the helper is platform-neutral and only closes a lifecycle window around existing platform-specific spawning.
- [x] No secrets, credentials, new dependencies, config keys, or generated artifacts.

## Documentation & Housekeeping

- [x] Updated production docstrings/comments explaining the race and ownership invariant.
- [x] No config, CLI, tool schema, or user-facing setting changed.
- [x] No generated image is committed to the repository.

## Screenshots / Logs

The issue screenshot establishes multiple `python.exe (2)` rows consuming roughly 101–129 MB each, but does not identify PIDs, command lines, profiles, or ownership. The public debug dump also contains a separate environment declaration (Windows 10 / Python 3.11.16) from the issue's stated Windows 11 / Python 3.14.3, so it was treated as corroborating lifecycle evidence rather than an exact reproduction.

## Infographic

![Profile deletion spawn race](https://files.catbox.moe/z2zi5x.png)

The PNG is hosted externally because the repository rejects committed infographic binaries. It was verified with HTTP `200 OK`, `Content-Type: image/png`, and a valid PNG signature before being referenced here.
