### PR TITLE
fix(update): preserve pre-sync baseline through fork updates

### DIFF
--- a/contributors/emails/alan.harman-box@burningsuit.co.uk
+++ b/contributors/emails/alan.harman-box@burningsuit.co.uk
@@ -1,0 +1,2 @@
+AlanBurningsuit
+# PR #95043

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6416,10 +6416,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # commit_count == 0 branch, which returns immediately after: an update
         # that pulled hundreds of upstream commits printed "Already up to
         # date!" and verified nothing).
-        # Set when the fork-sync stage already advanced HEAD. Read by the
-        # post-pull movement guard below: once the sync has performed the
-        # update, the subsequent merge is legitimately a zero-move.
-        head_moved_before_pull = False
+        # Preserve the SHA from before the FIRST code mutation. A fork sync can
+        # advance HEAD before the normal merge, so a baseline captured only
+        # around that merge would miss the real update. The same baseline owns
+        # movement verification, syntax rollback, and dependency diffing.
+        pre_apply_sha = None
         if commit_count == 0 and is_fork and branch == "main":
             pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
             _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
@@ -6434,12 +6435,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # HEAD moving is itself proof of an update. Keep the update
                 # path active even if the informational count cannot be read.
                 commit_count = max(1, synced_count)
-                # The sync just performed the update; the merge below will
-                # legitimately not move HEAD. Record that so the #79678
-                # movement guard does not mistake the completed update for
-                # a stuck no-op and abort before dependency sync, skills
-                # sync, and gateway restart run.
-                head_moved_before_pull = True
+                pre_apply_sha = pre_sync_sha
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -6600,12 +6596,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print("→ Pulling updates...")
         update_succeeded = False
-        # Capture the pre-pull SHA so we can auto-roll-back if the new code
+        # Capture the pre-update SHA so we can auto-roll-back if the new code
         # has a syntax error in a critical-path file (PR #28452 incident:
-        # orphan merge-conflict markers in hermes_cli/config.py bricked
-        # every user who ran ``hermes update`` for the 7 minutes between
-        # the bad commit and the fix landing).
-        pre_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+        # orphan merge-conflict markers in hermes_cli/config.py bricked every
+        # user who updated before the fix landed). When the fork-sync stage
+        # already moved HEAD, use its pre-sync SHA instead of capturing the
+        # updated commit here; dependency diffing below relies on this same
+        # baseline to include every code mutation in the update.
+        if pre_apply_sha is None:
+            pre_apply_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
         try:
             # Merge the ref we already fetched above (→ Fetching updates...)
             # instead of `git pull`, which performs a SECOND network fetch of
@@ -6713,11 +6712,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # ~6 lines so the user sees the actual SyntaxError text.
                     for line in str(syntax_error).splitlines()[:6]:
                         print(f"    {line}")
-                if pre_pull_sha:
+                if pre_apply_sha:
                     print()
-                    print(f"→ Rolling back to {pre_pull_sha[:10]}...")
+                    print(f"→ Rolling back to {pre_apply_sha[:10]}...")
                     rollback_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", pre_pull_sha],
+                        git_cmd + ["reset", "--hard", pre_apply_sha],
                         cwd=_m().PROJECT_ROOT,
                         capture_output=True,
                         text=True, encoding="utf-8", errors="replace",
@@ -6727,7 +6726,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         print("  Try ``hermes update`` again later once a fix lands.")
                     else:
                         print("  ✗ Rollback failed. Recover manually with:")
-                        print(f"    cd {_m().PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
+                        print(f"    cd {_m().PROJECT_ROOT} && git reset --hard {pre_apply_sha}")
                         if rollback_result.stderr.strip():
                             print(f"    ({rollback_result.stderr.strip().splitlines()[0]})")
                 else:
@@ -6778,68 +6777,70 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # commit afterward (the branch-switch step re-detaches to the SHA).
         # Before this guard, ``hermes update`` printed "✓ Code updated!" and
         # reinstalled deps + rebuilt the desktop app against the stale tree —
-        # no error, no warning, ``hermes doctor`` healthy. Compare pre-pull
-        # and post-pull HEAD; if they match, surface the no-op instead of
-        # claiming success.
+        # no error, no warning, ``hermes doctor`` healthy. Compare the SHA
+        # from before the first code mutation with the final HEAD; if they
+        # match, surface the no-op instead of claiming success.
         post_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
-        if pre_pull_sha and post_pull_sha == pre_pull_sha:
-            if head_moved_before_pull:
-                # The fork-sync stage already advanced HEAD to the target
-                # commit, so the merge itself is a legitimate zero-move.
-                # This is an update that happened one stage earlier — not a
-                # stuck checkout. Fall through and let the dependency sync,
-                # skills sync, and gateway restart run for the pulled code.
-                print("  ✓ Code updated by the upstream fork sync.")
+        if pre_apply_sha and post_pull_sha == pre_apply_sha:
+            target_probe = subprocess.run(
+                git_cmd + ["rev-parse", f"origin/{branch}"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            target_sha = (
+                target_probe.stdout.strip() if target_probe.returncode == 0 else ""
+            )
+            # A same-SHA anomaly is benign only when the working tree
+            # demonstrably contains the fetched target. Branch attachment by
+            # itself is not proof: an attached branch can still be stale after
+            # a concurrent ref/reset race.
+            if target_sha and post_pull_sha == target_sha:
+                print(
+                    f"  ℹ Code is already at origin/{branch} "
+                    f"({target_sha[:10]}) — nothing to pull."
+                )
             else:
-                branch_now = subprocess.run(
+                branch_probe = subprocess.run(
                     git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
                     cwd=_m().PROJECT_ROOT,
                     capture_output=True,
                     text=True,
                     encoding="utf-8",
                     errors="replace",
-                ).stdout.strip()
-                target_probe = subprocess.run(
-                    git_cmd + ["rev-parse", f"origin/{branch}"],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
                 )
-                target_sha = target_probe.stdout.strip()
-                # Benign only when the working tree demonstrably holds the
-                # updated code: either the fork-sync stage moved it there
-                # (head_moved_before_pull), HEAD is attached to the target
-                # branch (a successful ff-merge on an attached branch always
-                # moves the ref, so pre == post means it was already there),
-                # or HEAD sits exactly at origin/<branch>. A checkout pinned
-                # to a STALE raw SHA reports "HEAD" here and misses every
-                # condition — the original #79678 stuck-update case still
-                # fails loudly below.
-                if (
-                    head_moved_before_pull
-                    or branch_now == branch
-                    or (target_sha and post_pull_sha == target_sha)
-                ):
+                branch_now = (
+                    branch_probe.stdout.strip()
+                    if branch_probe.returncode == 0
+                    else ""
+                )
+                print()
+                print("✗ Code did not move — update was a no-op.")
+                if branch_now and branch_now != "HEAD":
                     print(
-                        f"  ℹ Code is already at origin/{branch} "
-                        f"({(target_sha or post_pull_sha)[:10]}) — nothing to pull."
+                        f"  Checkout is attached to '{branch_now}' at "
+                        f"{pre_apply_sha[:10]}; origin/{branch} is at "
+                        f"{target_sha[:10] or 'an unknown commit'}."
+                    )
+                    print(
+                        "  Complete the fast-forward and retry: "
+                        f"git -C {_m().PROJECT_ROOT} merge --ff-only "
+                        f"origin/{branch} && hermes update"
                     )
                 else:
-                    print()
-                    print("✗ Code did not move — update was a no-op.")
                     print(
-                        f"  Checkout is pinned to {pre_pull_sha[:10]} "
-                        f"(detached from '{branch}'); "
-                        f"origin/{branch} advanced but the working tree stayed put."
+                        f"  Checkout is pinned to {pre_apply_sha[:10]} "
+                        f"(detached from '{branch}'); origin/{branch} advanced "
+                        "but the working tree stayed put."
                     )
                     print(
                         "  Reattach to the branch and retry: "
                         f"git -C {_m().PROJECT_ROOT} checkout {branch} && hermes update"
                     )
-                    _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
-                    sys.exit(1)
+                _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(1)
 
         # And verify HEAD actually sits on the target branch. The parked-
         # branch guard above should make this unreachable, but if any path
@@ -6906,7 +6907,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # ``.[all]`` install completes — lazy refresh uses a separate marker.
         _write_update_incomplete_marker()
         deps_current = _editable_install_is_current(
-            git_cmd, _m().PROJECT_ROOT, pre_pull_sha
+            git_cmd, _m().PROJECT_ROOT, pre_apply_sha
         )
         if deps_current:
             print("→ Python dependencies unchanged — skipping reinstall")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6416,6 +6416,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # commit_count == 0 branch, which returns immediately after: an update
         # that pulled hundreds of upstream commits printed "Already up to
         # date!" and verified nothing).
+        # Set when the fork-sync stage already advanced HEAD. Read by the
+        # post-pull movement guard below: once the sync has performed the
+        # update, the subsequent merge is legitimately a zero-move.
+        head_moved_before_pull = False
         if commit_count == 0 and is_fork and branch == "main":
             pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
             _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
@@ -6430,6 +6434,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # HEAD moving is itself proof of an update. Keep the update
                 # path active even if the informational count cannot be read.
                 commit_count = max(1, synced_count)
+                # The sync just performed the update; the merge below will
+                # legitimately not move HEAD. Record that so the #79678
+                # movement guard does not mistake the completed update for
+                # a stuck no-op and abort before dependency sync, skills
+                # sync, and gateway restart run.
+                head_moved_before_pull = True
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -6773,18 +6783,63 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # claiming success.
         post_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
         if pre_pull_sha and post_pull_sha == pre_pull_sha:
-            print()
-            print("✗ Code did not move — update was a no-op.")
-            print(
-                f"  HEAD is pinned to {pre_pull_sha[:10]} (detached checkout); "
-                f"origin/{branch} advanced but the working tree stayed put."
-            )
-            print(
-                "  Reattach to the branch and retry: "
-                f"git -C {_m().PROJECT_ROOT} checkout {branch} && hermes update"
-            )
-            _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
-            sys.exit(1)
+            if head_moved_before_pull:
+                # The fork-sync stage already advanced HEAD to the target
+                # commit, so the merge itself is a legitimate zero-move.
+                # This is an update that happened one stage earlier — not a
+                # stuck checkout. Fall through and let the dependency sync,
+                # skills sync, and gateway restart run for the pulled code.
+                print("  ✓ Code updated by the upstream fork sync.")
+            else:
+                branch_now = subprocess.run(
+                    git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                ).stdout.strip()
+                target_probe = subprocess.run(
+                    git_cmd + ["rev-parse", f"origin/{branch}"],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
+                target_sha = target_probe.stdout.strip()
+                # Benign only when the working tree demonstrably holds the
+                # updated code: either the fork-sync stage moved it there
+                # (head_moved_before_pull), HEAD is attached to the target
+                # branch (a successful ff-merge on an attached branch always
+                # moves the ref, so pre == post means it was already there),
+                # or HEAD sits exactly at origin/<branch>. A checkout pinned
+                # to a STALE raw SHA reports "HEAD" here and misses every
+                # condition — the original #79678 stuck-update case still
+                # fails loudly below.
+                if (
+                    head_moved_before_pull
+                    or branch_now == branch
+                    or (target_sha and post_pull_sha == target_sha)
+                ):
+                    print(
+                        f"  ℹ Code is already at origin/{branch} "
+                        f"({(target_sha or post_pull_sha)[:10]}) — nothing to pull."
+                    )
+                else:
+                    print()
+                    print("✗ Code did not move — update was a no-op.")
+                    print(
+                        f"  Checkout is pinned to {pre_pull_sha[:10]} "
+                        f"(detached from '{branch}'); "
+                        f"origin/{branch} advanced but the working tree stayed put."
+                    )
+                    print(
+                        "  Reattach to the branch and retry: "
+                        f"git -C {_m().PROJECT_ROOT} checkout {branch} && hermes update"
+                    )
+                    _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+                    sys.exit(1)
 
         # And verify HEAD actually sits on the target branch. The parked-
         # branch guard above should make this unreachable, but if any path

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -188,18 +188,23 @@ def test_update_fails_loudly_when_head_pinned(monkeypatch, tmp_path, capsys):
 
 
 def _make_fork_sync_moves_head_side_effect(
-    sync_from="aaaaaaa", sync_to="bbbbbbb"
+    sync_from="aaaaaaa",
+    sync_to="bbbbbbb",
+    *,
+    install_files_changed=False,
 ):
     """Simulate a clean fork whose upstream-sync stage advances HEAD.
 
     rev-parse HEAD call order inside ``_cmd_update_impl``:
       1. pre-sync capture   -> sync_from
       2. post-sync capture  -> sync_to     (the sync DID move HEAD)
-      3. pre-pull capture   -> sync_to
-      4. post-pull capture  -> sync_to     (the merge is a legit zero-move)
+      3. post-pull capture  -> sync_to     (the merge is a legit zero-move)
 
     The first ``rev-list --count`` (behind vs the compare branch) returns 0
-    so the fork-sync block triggers; later counts return 3.
+    so the fork-sync block triggers; later counts return 3. When
+    ``install_files_changed`` is true, only a diff from the PRE-sync SHA sees
+    the changed ``pyproject.toml``. A post-sync baseline therefore reproduces
+    the stale-dependency skip from the live incident.
     """
     head_reads = {"n": 0}
     rev_lists = {"n": 0}
@@ -223,6 +228,11 @@ def _make_fork_sync_moves_head_side_effect(
                 )
             return SimpleNamespace(returncode=0, stdout=f"{sync_to}\n", stderr="")
 
+        if "diff --name-only" in joined:
+            changed = install_files_changed and f"{sync_from}..HEAD" in joined
+            stdout = "pyproject.toml\n" if changed else ""
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     return side_effect
@@ -239,7 +249,7 @@ def test_fork_sync_advances_head_and_update_completes(monkeypatch, tmp_path, cap
     _patch_update_deps(
         monkeypatch,
         tmp_path,
-        _make_fork_sync_moves_head_side_effect(),
+        _make_fork_sync_moves_head_side_effect(install_files_changed=True),
     )
     # ``is_fork`` resolves in update_cmd's own namespace (line 6049), not
     # through _m() — patch it there.
@@ -248,6 +258,12 @@ def test_fork_sync_advances_head_and_update_completes(monkeypatch, tmp_path, cap
     # subprocess.run above is what reports HEAD movement around it.
     monkeypatch.setattr(
         hermes_main, "_sync_with_upstream_if_needed", lambda *a, **k: None
+    )
+    dependency_installs = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_install_python_dependencies_with_optional_fallback",
+        lambda *a, **k: dependency_installs.append((a, k)),
     )
     # Hermetic stop: reaching the runtime-reload step IS the proof the
     # movement guard passed and the post-update pipeline is running (same
@@ -265,26 +281,60 @@ def test_fork_sync_advances_head_and_update_completes(monkeypatch, tmp_path, cap
 
     assert exc_info.value.code == 0
     out = capsys.readouterr().out
-    # The exact point where the bug used to abort now reports success.
-    assert "Code updated by the upstream fork sync" in out
+    # The update must diff dependencies from BEFORE the fork sync. Using the
+    # post-sync SHA reports an empty diff and silently skips this install.
+    assert dependency_installs
+    assert "Updating Python dependencies" in out
+    assert "Python dependencies unchanged" not in out
     assert "Code did not move" not in out
     assert "Already up to date" not in out
 
 
-def test_already_on_target_branch_with_no_move_is_benign(monkeypatch, tmp_path, capsys):
-    """Same live incident, second variant: HEAD attached to main, already at
-    origin/main, yet a stale behind-count sent the updater through the pull
-    path. pre == post with an ATTACHED target branch means the code is
-    current — not a stuck detached checkout. Must complete, not exit 1."""
+def test_fork_sync_syntax_failure_rolls_back_before_sync(
+    monkeypatch, tmp_path, capsys
+):
+    """A bad upstream-sync commit must roll back to the pre-sync SHA."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+    commands = []
+    fork_side_effect = _make_fork_sync_moves_head_side_effect()
+
+    def tracking_side_effect(cmd, **kwargs):
+        commands.append(list(cmd))
+        return fork_side_effect(cmd, **kwargs)
+
+    _patch_update_deps(monkeypatch, tmp_path, tracking_side_effect)
+    monkeypatch.setattr(update_cmd, "_is_fork", lambda *a, **k: True)
+    monkeypatch.setattr(
+        hermes_main, "_sync_with_upstream_if_needed", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_validate_critical_files_syntax",
+        lambda *a, **k: (False, "hermes_cli/main.py", "SyntaxError: bad sync"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
+
+    assert exc_info.value.code == 1
+    assert any(cmd[-3:] == ["reset", "--hard", "aaaaaaa"] for cmd in commands)
+    out = capsys.readouterr().out
+    assert "Rolling back to aaaaaaa" in out
+
+
+def test_no_move_is_benign_only_at_exact_target(monkeypatch, tmp_path, capsys):
+    """A same-SHA anomaly is safe only when HEAD equals origin/main."""
     args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
 
     def side_effect(cmd, **kwargs):
         joined = " ".join(str(c) for c in cmd)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
-            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="HEAD\n", stderr="")
         if "rev-list" in joined:
             return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
         if joined.endswith("rev-parse HEAD"):
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        if joined.endswith("rev-parse origin/main"):
             return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -302,3 +352,32 @@ def test_already_on_target_branch_with_no_move_is_benign(monkeypatch, tmp_path, 
     out = capsys.readouterr().out
     assert "already at origin/main" in out
     assert "Code did not move" not in out
+
+
+def test_attached_stale_branch_fails_with_safe_recovery(monkeypatch, tmp_path, capsys):
+    """Branch attachment alone is not proof that the target code landed."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list" in joined:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+        if joined.endswith("rev-parse HEAD"):
+            return SimpleNamespace(returncode=0, stdout="stale123\n", stderr="")
+        if joined.endswith("rev-parse origin/main"):
+            return SimpleNamespace(returncode=0, stdout="target456\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    _patch_update_deps(monkeypatch, tmp_path, side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Code did not move" in out
+    assert "Checkout is attached to 'main' at stale123" in out
+    assert "merge --ff-only origin/main" in out
+    assert "detached from 'main'" not in out

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from hermes_cli import main as hermes_main
+from hermes_cli import update_cmd
 
 
 def _make_head_moved_side_effect(pre_sha="abc123", post_sha="def456"):
@@ -119,18 +120,55 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(
         hermes_gateway, "find_profile_gateway_processes", lambda *a, **k: []
     )
+    # Newer restart-phase seams (added after this file was written): without
+    # these, a host with a live gateway leaks real PIDs into the run and the
+    # conftest live-system guard blocks os.kill — same mocks the newer
+    # test_cmd_update.py carries.
+    monkeypatch.setattr(hermes_gateway, "_get_service_pids", lambda *a, **k: set())
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions", lambda *a, **k: []
+    )
+    # Pre-update plan inventory also scans the real host; an empty plan keeps
+    # the fleet-expectation probe and plan-vs-execution reconciliation quiet.
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[]),
+    )
+    # Final hermeticity backstop: several post-update phases discover
+    # processes via direct /proc scanning rather than find_gateway_pids.
+    # Neutralise signalling entirely so a dev machine running a live
+    # gateway can neither be signalled nor trip the conftest live-system
+    # guard mid-test.
+    import os as _os
+
+    monkeypatch.setattr(_os, "kill", lambda pid, sig: None)
 
 
 def test_update_success_when_head_moves(monkeypatch, tmp_path, capsys):
-    """When the pull advances HEAD, the update proceeds normally."""
+    """When the pull advances HEAD, the movement guard lets the update
+    proceed through to the post-update pipeline."""
     args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
     _patch_update_deps(monkeypatch, tmp_path, _make_head_moved_side_effect())
+    # Hermetic stop (same seam as test_cmd_update.py): reaching the
+    # runtime-reload step proves the movement guard passed and the
+    # post-update pipeline is running. Everything after it (web build,
+    # desktop rebuild, skills sync, gateway restart, fleet check) acts on
+    # the real host, so abort with a success exit instead.
+    monkeypatch.setattr(
+        hermes_main,
+        "_reload_updated_runtime_modules",
+        lambda *a, **k: (_ for _ in ()).throw(SystemExit(0)),
+    )
 
-    hermes_main.cmd_update(args)  # completes normally (no SystemExit)
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
 
+    assert exc_info.value.code == 0
     out = capsys.readouterr().out
-    assert "✓ Code updated!" in out
+    # The pull ran and the guard did not mistake it for a no-op.
+    assert "Pulling updates..." in out
     assert "Code did not move" not in out
+    assert "Already up to date" not in out
 
 
 def test_update_fails_loudly_when_head_pinned(monkeypatch, tmp_path, capsys):
@@ -147,3 +185,120 @@ def test_update_fails_loudly_when_head_pinned(monkeypatch, tmp_path, capsys):
     assert "Code did not move" in out
     assert "✓ Code updated!" not in out
     assert "checkout main" in out
+
+
+def _make_fork_sync_moves_head_side_effect(
+    sync_from="aaaaaaa", sync_to="bbbbbbb"
+):
+    """Simulate a clean fork whose upstream-sync stage advances HEAD.
+
+    rev-parse HEAD call order inside ``_cmd_update_impl``:
+      1. pre-sync capture   -> sync_from
+      2. post-sync capture  -> sync_to     (the sync DID move HEAD)
+      3. pre-pull capture   -> sync_to
+      4. post-pull capture  -> sync_to     (the merge is a legit zero-move)
+
+    The first ``rev-list --count`` (behind vs the compare branch) returns 0
+    so the fork-sync block triggers; later counts return 3.
+    """
+    head_reads = {"n": 0}
+    rev_lists = {"n": 0}
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+
+        if "rev-list" in joined:
+            rev_lists["n"] += 1
+            count = "0" if rev_lists["n"] == 1 else "3"
+            return SimpleNamespace(returncode=0, stdout=f"{count}\n", stderr="")
+
+        if joined.endswith("rev-parse HEAD"):
+            head_reads["n"] += 1
+            if head_reads["n"] == 1:
+                return SimpleNamespace(
+                    returncode=0, stdout=f"{sync_from}\n", stderr=""
+                )
+            return SimpleNamespace(returncode=0, stdout=f"{sync_to}\n", stderr="")
+
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return side_effect
+
+
+def test_fork_sync_advances_head_and_update_completes(monkeypatch, tmp_path, capsys):
+    """Regression (live incident 2026-08-25): on a pristine fork whose main
+    mirrors upstream, the fork-sync stage itself fast-forwards HEAD. The
+    subsequent merge legitimately does not move it, but the #79678 guard saw
+    identical SHAs, aborted with a bogus 'detached checkout' diagnosis, and
+    skipped dependency sync, skills sync, and gateway restart. The guard
+    must treat a sync-stage move as a completed update."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+    _patch_update_deps(
+        monkeypatch,
+        tmp_path,
+        _make_fork_sync_moves_head_side_effect(),
+    )
+    # ``is_fork`` resolves in update_cmd's own namespace (line 6049), not
+    # through _m() — patch it there.
+    monkeypatch.setattr(update_cmd, "_is_fork", lambda *a, **k: True)
+    # The sync's internal git dance is irrelevant here; the mocked
+    # subprocess.run above is what reports HEAD movement around it.
+    monkeypatch.setattr(
+        hermes_main, "_sync_with_upstream_if_needed", lambda *a, **k: None
+    )
+    # Hermetic stop: reaching the runtime-reload step IS the proof the
+    # movement guard passed and the post-update pipeline is running (same
+    # seam as test_cmd_update.py). Everything after it (web build, desktop
+    # rebuild, skills sync, gateway restart, fleet check) would act on the
+    # real host, so abort with a success exit before any of that.
+    monkeypatch.setattr(
+        hermes_main,
+        "_reload_updated_runtime_modules",
+        lambda *a, **k: (_ for _ in ()).throw(SystemExit(0)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    # The exact point where the bug used to abort now reports success.
+    assert "Code updated by the upstream fork sync" in out
+    assert "Code did not move" not in out
+    assert "Already up to date" not in out
+
+
+def test_already_on_target_branch_with_no_move_is_benign(monkeypatch, tmp_path, capsys):
+    """Same live incident, second variant: HEAD attached to main, already at
+    origin/main, yet a stale behind-count sent the updater through the pull
+    path. pre == post with an ATTACHED target branch means the code is
+    current — not a stuck detached checkout. Must complete, not exit 1."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if "rev-list" in joined:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+        if joined.endswith("rev-parse HEAD"):
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    _patch_update_deps(monkeypatch, tmp_path, side_effect)
+    monkeypatch.setattr(
+        hermes_main,
+        "_reload_updated_runtime_modules",
+        lambda *a, **k: (_ for _ in ()).throw(SystemExit(0)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "already at origin/main" in out
+    assert "Code did not move" not in out


### PR DESCRIPTION
## Summary

On a clean fork whose `main` matches `origin/main` but trails upstream, `hermes update` can fast-forward `HEAD` during `_sync_with_upstream_if_needed()` and then abort at the later #79678 no-op guard because the normal merge no longer moves `HEAD`.

The update has already landed at that point, but the updater exits before dependency synchronization, bundled-skill synchronization, and gateway restart. In the live incident, that left new source running against stale dependencies.

This is an interaction between the upstream fork-sync path introduced by #92769 (for #73108) and the post-merge `HEAD` movement guard introduced by #86687 (for #79678), rather than a duplicate of either fix.

## Root cause

The updater captured `pre_pull_sha` only after the fork-sync stage. That made the post-sync commit look like the update baseline:

- movement verification compared the post-sync commit with itself and reported a false no-op;
- dependency diffing compared the post-sync commit with itself and could skip a required editable reinstall after `pyproject.toml` or `uv.lock` changed;
- syntax-error rollback reset to the already-broken post-sync commit while claiming the install was unchanged.

## Fix

Capture one `pre_apply_sha` from before the first possible code mutation and carry it through the whole update transaction:

- fork-sync movement is now visible to the final movement check without a stage-specific boolean bypass;
- syntax rollback restores the genuinely pre-update commit;
- `_editable_install_is_current()` sees dependency-defining changes made by the fork sync;
- a same-SHA anomaly is accepted only when final `HEAD` exactly equals the fetched `origin/<branch>` target. Merely being attached to a branch is no longer treated as proof that the target code landed.

The original #79678 protection remains: a checkout pinned to a stale raw SHA still fails loudly rather than claiming success.

## Live reproduction

On Linux, with a clean fork where local `main == origin/main` and upstream has advanced:

1. Run `hermes update`.
2. Fork sync fast-forwards local `HEAD` from upstream.
3. The subsequent `merge --ff-only origin/main` is correctly a zero-move.
4. Before this patch, the no-op guard exits 1 with `Code did not move`, and post-update dependency/restart work does not run.

## Testing

The regressions were observed failing before the production change:

- dependency-install assertion failed because the post-sync baseline produced an empty diff;
- rollback assertion failed because the updater reset to the post-sync SHA.

Verified on Linux 6.8.0 x86_64 with Python 3.13.13:

- `scripts/run_tests.sh tests/hermes_cli/test_update_head_moved_gate.py tests/hermes_cli/test_update_skip_unchanged_editable_install.py -q` — 17 passed
- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -k 'fork or upstream' -q` — 3 passed
- `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_head_moved_gate.py` — passed
- `scripts/check-windows-footguns.py hermes_cli/update_cmd.py tests/hermes_cli/test_update_head_moved_gate.py` — passed (2 files)
- `scripts/audit_pr_attribution.py` — passed

The full `tests/hermes_cli/test_cmd_update.py` file produced 32 passed and the same six environment/isolation failures on both clean current `main` and the rebased PR branch; this change introduces no new failure in that file.

## Scope and risk

The change is limited to update baseline ownership, its regression tests, and contributor attribution. It does not alter fork detection, upstream-sync mechanics, branch switching, or dependency selection.
