### PR TITLE
fix(desktop): preserve profile across worktree handoffs

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $selectedStoredSessionId } from '@/store/session'
+
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
+import { useComposerBranch } from './use-composer-branch'
+
+const { knownOwnerForSession, requestStartWorkSession, startWorkInRepo } = vi.hoisted(() => ({
+  knownOwnerForSession: vi.fn(),
+  requestStartWorkSession: vi.fn(),
+  startWorkInRepo: vi.fn()
+}))
+
+vi.mock('@/store/projects', () => ({
+  listRepoBranches: vi.fn(async () => []),
+  requestStartWorkSession,
+  startWorkInRepo,
+  switchBranchInRepo: vi.fn()
+}))
+
+vi.mock('@/store/session-states', () => ({
+  knownOwnerForSession
+}))
+
+describe('useComposerBranch worktree ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $selectedStoredSessionId.set('main-source')
+  })
+
+  it('carries a tiled composer profile route into the fresh worktree session', () => {
+    const route = {
+      connectionId: 'remote-a',
+      mode: 'remote' as const,
+      profile: 'itb',
+      targetProfile: 'backend-itb'
+    }
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, owner: route }}>{children}</ComposerScopeProvider>
+    )
+
+    const clearDraft = vi.fn()
+    const draftRef = { current: 'close the remaining test gaps' }
+    const { result } = renderHook(() => useComposerBranch({ clearDraft, cwd: '/repo', draftRef }), { wrapper })
+
+    act(() => result.current.openInWorktree('/repo/.worktrees/tests'))
+
+    expect(clearDraft).toHaveBeenCalledTimes(1)
+    expect(requestStartWorkSession).toHaveBeenCalledWith('/repo/.worktrees/tests', 'close the remaining test gaps', {
+      owner: route
+    })
+  })
+
+  it('captures the exact focused main session owner when the composer has no explicit route', () => {
+    const owner = { connectionId: 'source-main', profile: 'itb' }
+
+    knownOwnerForSession.mockReturnValue(owner)
+
+    const clearDraft = vi.fn()
+    const draftRef = { current: 'continue in a worktree' }
+    const { result } = renderHook(() => useComposerBranch({ clearDraft, cwd: '/repo', draftRef }))
+
+    act(() => result.current.openInWorktree('/repo/.worktrees/main-tests'))
+
+    expect(knownOwnerForSession).toHaveBeenCalledWith('main-source')
+    expect(requestStartWorkSession).toHaveBeenLastCalledWith('/repo/.worktrees/main-tests', 'continue in a worktree', {
+      owner
+    })
+  })
+
+  it('keeps the main session owner captured before asynchronous worktree creation', async () => {
+    let resolveWorktree!: (value: { branch: string; path: string }) => void
+    const sourceOwner = { connectionId: 'source-main', profile: 'itb' }
+    const otherOwner = { connectionId: 'source-tile', profile: 'default' }
+
+    knownOwnerForSession.mockReturnValueOnce(sourceOwner).mockReturnValue(otherOwner)
+    startWorkInRepo.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveWorktree = resolve
+      })
+    )
+
+    const clearDraft = vi.fn()
+    const draftRef = { current: 'continue after creating the worktree' }
+    const { result } = renderHook(() => useComposerBranch({ clearDraft, cwd: '/repo', draftRef }))
+
+    let handoff!: Promise<void>
+
+    act(() => {
+      handoff = result.current.handleBranchOff('tests')
+    })
+
+    $selectedStoredSessionId.set('other-session')
+    resolveWorktree({ branch: 'tests', path: '/repo/.worktrees/tests' })
+
+    await act(async () => handoff)
+
+    expect(knownOwnerForSession).toHaveBeenCalledTimes(1)
+    expect(knownOwnerForSession).toHaveBeenCalledWith('main-source')
+    expect(requestStartWorkSession).toHaveBeenCalledWith(
+      '/repo/.worktrees/tests',
+      'continue after creating the worktree',
+      { owner: sourceOwner }
+    )
+  })
+
+  it('keeps an unresolved owner unresolved across asynchronous worktree creation', async () => {
+    let resolveWorktree!: (value: { branch: string; path: string }) => void
+
+    knownOwnerForSession.mockReturnValueOnce(undefined).mockReturnValue({
+      connectionId: 'late-source',
+      profile: 'default'
+    })
+    startWorkInRepo.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveWorktree = resolve
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useComposerBranch({ clearDraft: vi.fn(), cwd: '/repo', draftRef: { current: 'stay unowned' } })
+    )
+
+    let handoff!: Promise<void>
+
+    act(() => {
+      handoff = result.current.handleBranchOff('tests')
+    })
+
+    $selectedStoredSessionId.set('late-session')
+    resolveWorktree({ branch: 'tests', path: '/repo/.worktrees/tests' })
+    await act(async () => handoff)
+
+    expect(knownOwnerForSession).toHaveBeenCalledTimes(1)
+    expect(requestStartWorkSession).toHaveBeenCalledWith('/repo/.worktrees/tests', 'stay unowned', undefined)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
@@ -1,6 +1,9 @@
 import { type MutableRefObject, useCallback } from 'react'
 
 import { listRepoBranches, requestStartWorkSession, startWorkInRepo, switchBranchInRepo } from '@/store/projects'
+import { $selectedStoredSessionId } from '@/store/session'
+import type { SessionOwnerScope } from '@/store/session-request-router'
+import { knownOwnerForSession } from '@/store/session-states'
 
 import { useComposerScope } from '../scope'
 
@@ -20,17 +23,38 @@ interface UseComposerBranchOptions {
 export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBranchOptions) {
   const scope = useComposerScope()
 
+  const surfaceOwner = useCallback(() => {
+    if (scope.owner) {
+      return scope.owner
+    }
+
+    const storedSessionId =
+      scope.target === 'main'
+        ? $selectedStoredSessionId.get()
+        : scope.target.startsWith('tile:')
+          ? scope.target.slice('tile:'.length)
+          : null
+
+    return knownOwnerForSession(storedSessionId)
+  }, [scope.owner, scope.target])
+
+  const handOffWorktree = useCallback(
+    (path: string, owner: SessionOwnerScope) => {
+      const text = draftRef.current
+
+      clearDraft()
+      scope.attachments.clear()
+      requestStartWorkSession(path, text, owner ? { owner } : undefined)
+    },
+    [clearDraft, draftRef, scope.attachments]
+  )
+
   // Hand a worktree off to the controller: open a fresh session anchored there,
   // carrying the composer draft as its first turn. Clearing here means the draft
   // travels to the new session instead of getting stashed under this one.
   const openInWorktree = useCallback(
-    (path: string) => {
-      const text = draftRef.current
-      clearDraft()
-      scope.attachments.clear()
-      requestStartWorkSession(path, text)
-    },
-    [clearDraft, draftRef]
+    (path: string) => handOffWorktree(path, surfaceOwner()),
+    [handOffWorktree, surfaceOwner]
   )
 
   // Branch off into a NEW worktree (base = branch name, or current HEAD). A
@@ -39,13 +63,14 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
   const handleBranchOff = useCallback(
     async (branch: string, base?: string) => {
       const repoPath = cwd?.trim()
+      const owner = surfaceOwner()
       const result = repoPath && (await startWorkInRepo(repoPath, { base, branch, name: branch }))
 
       if (result) {
-        openInWorktree(result.path)
+        handOffWorktree(result.path, owner)
       }
     },
-    [cwd, openInWorktree]
+    [cwd, handOffWorktree, surfaceOwner]
   )
 
   // Convert an EXISTING branch into a fresh worktree + session (no new branch).
@@ -53,8 +78,10 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
   // anchored there carrying the draft.
   const handleConvertBranch = useCallback(
     async (branch: string, path?: null | string, isDefault?: boolean) => {
+      const owner = surfaceOwner()
+
       if (path?.trim()) {
-        openInWorktree(path)
+        handOffWorktree(path, owner)
 
         return
       }
@@ -63,7 +90,7 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
 
       if (repoPath && isDefault) {
         await switchBranchInRepo(repoPath, branch)
-        openInWorktree(repoPath)
+        handOffWorktree(repoPath, owner)
 
         return
       }
@@ -71,10 +98,10 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
       const result = repoPath && (await startWorkInRepo(repoPath, { existingBranch: branch }))
 
       if (result) {
-        openInWorktree(result.path)
+        handOffWorktree(result.path, owner)
       }
     },
-    [cwd, openInWorktree]
+    [cwd, handOffWorktree, surfaceOwner]
   )
 
   const handleListBranches = useCallback(async () => {

--- a/apps/desktop/src/app/chat/composer/scope.tsx
+++ b/apps/desktop/src/app/chat/composer/scope.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { type ComposerAttachmentScope, mainComposerScope } from '@/store/composer'
 import { $activeSessionAwaitingInput } from '@/store/prompts'
 import { $messages } from '@/store/session'
+import type { SessionOwnerScope } from '@/store/session-request-router'
 
 import type { ComposerTarget } from './focus'
 
@@ -27,6 +28,8 @@ export interface ComposerScope {
    *  keep streaming out of the composer's renders; subscribe only off-render
    *  (auto-speak) where the reply edge is the whole point. */
   $messages: ReadableAtom<ChatMessage[]>
+  /** Backend/profile that owns this surface's session. */
+  owner?: SessionOwnerScope
   /** Focus-bus routing key (`'main'` | `'tile:<id>'`). */
   target: ComposerTarget
 }

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -47,13 +47,14 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
-import { requestForSessionProfile } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTileDelegateRevision,
   $sessionTiles,
   closeSessionTile,
+  knownOwnerForSession,
   patchSessionTile,
+  requestForOwnedSession,
   type SessionTile,
   sessionTileDelegate,
   sessionTileOwnerRoute
@@ -158,11 +159,12 @@ function TileChat({
   const { gateway, requestGateway } = useGatewayRequest()
   const queryClient = useQueryClient()
   const ownerRoute = sessionTileOwnerRoute(storedSessionId)
+  const owner = ownerRoute ?? knownOwnerForSession(storedSessionId)
 
   const requestTileGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<T> =>
-      requestForSessionProfile<T>(ownerRoute, requestGateway, method, params, timeoutMs, signal),
-    [ownerRoute, requestGateway]
+      requestForOwnedSession<T>(storedSessionId, requestGateway, method, params, timeoutMs, signal),
+    [requestGateway, storedSessionId]
   )
 
   const { selectModel } = useModelControls({ queryClient, requestGateway: requestTileGateway })
@@ -178,9 +180,10 @@ function TileChat({
       $awaitingInput: sessionAwaitingInput(runtimeId),
       $messages: view.$messages,
       attachments,
+      owner,
       target: `tile:${storedSessionId}`
     }),
-    [attachments, runtimeId, storedSessionId, view.$messages]
+    [attachments, owner, runtimeId, storedSessionId, view.$messages]
   )
 
   // Tile actions must keep the persisted owner route. The ambient gateway hook

--- a/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/worktree-dialog.tsx
@@ -153,7 +153,7 @@ export function WorktreeDialog() {
 
   // Give the new worktree to a fresh session, then close the dialog.
   const started = (path: string) => {
-    requestStartWorkSession(path)
+    requestStartWorkSession(path, undefined, state?.owner ? { owner: state.owner } : undefined)
     closeWorktreeDialog()
   }
 

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -71,7 +71,7 @@ import { $bindings, bindingsFor } from '@/store/keybinds'
 import { $dismissedAutoProjectIds, filterVisibleProjects } from '@/store/layout'
 import { openPetGenerate } from '@/store/pet-generate'
 import { openBrowserTab } from '@/store/preview'
-import { $projectTree, goToProject, openFolderAsProject, requestStartWorkSession } from '@/store/projects'
+import { $projectTree, goToProject, openFolderAsProject } from '@/store/projects'
 import { $connection } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 import {
@@ -109,6 +109,7 @@ import { usePaletteContributions } from './contrib'
 import { HighlightWatcher } from './highlight-watcher'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
+import { startFocusedWorktreeSession } from './worktree-session'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -749,7 +750,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
                   id: `worktree-${wt.path}`,
                   keywords: ['branch', 'worktree', 'switch', name, wt.path],
                   label: t.commandCenter.startInBranch(name),
-                  run: () => requestStartWorkSession(wt.path)
+                  run: () => startFocusedWorktreeSession(wt.path)
                 }
               })
             }

--- a/apps/desktop/src/app/command-palette/worktree-session.test.ts
+++ b/apps/desktop/src/app/command-palette/worktree-session.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { startFocusedWorktreeSession } from './worktree-session'
+
+const { focusedStoredSessionId, knownOwnerForSession, requestStartWorkSession } = vi.hoisted(() => ({
+  focusedStoredSessionId: { get: vi.fn() },
+  knownOwnerForSession: vi.fn(),
+  requestStartWorkSession: vi.fn()
+}))
+
+vi.mock('@/store/projects', () => ({ requestStartWorkSession }))
+vi.mock('@/store/session-states', () => ({
+  $focusedStoredSessionId: focusedStoredSessionId,
+  knownOwnerForSession
+}))
+
+describe('startFocusedWorktreeSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    focusedStoredSessionId.get.mockReturnValue('remote-session')
+  })
+
+  it('publishes the exact owner of the focused surface', () => {
+    const owner = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    }
+
+    knownOwnerForSession.mockReturnValue(owner)
+
+    startFocusedWorktreeSession('/repo/.worktrees/tests')
+
+    expect(knownOwnerForSession).toHaveBeenCalledWith('remote-session')
+    expect(requestStartWorkSession).toHaveBeenCalledWith('/repo/.worktrees/tests', undefined, { owner })
+  })
+})

--- a/apps/desktop/src/app/command-palette/worktree-session.ts
+++ b/apps/desktop/src/app/command-palette/worktree-session.ts
@@ -1,0 +1,9 @@
+import { requestStartWorkSession } from '@/store/projects'
+import { $focusedStoredSessionId, knownOwnerForSession } from '@/store/session-states'
+
+/** Capture the focused surface owner at palette selection time. */
+export function startFocusedWorktreeSession(path: string): void {
+  const owner = knownOwnerForSession($focusedStoredSessionId.get())
+
+  requestStartWorkSession(path, undefined, owner ? { owner } : undefined)
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -54,9 +54,11 @@ import {
   $profileScope,
   ALL_PROFILES,
   ensureGatewayProfile,
+  type NewChatOwner,
   newSessionInProfile,
   normalizeProfileKey,
-  refreshActiveProfile
+  refreshActiveProfile,
+  setNewChatOwner
 } from '@/store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
 import {
@@ -126,7 +128,7 @@ import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
-import { startWorkspaceSession } from '../session/workspace-session-target'
+import { handleStartWorkSessionRequest, startWorkspaceSession } from '../session/workspace-session-target'
 import { PluginInstallModal } from '../settings/plugin-install-modal'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
@@ -622,10 +624,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // "branch off into a new worktree" flow keeps the fresh-draft path — it
   // prefills the MAIN composer right after, so it has to own that surface.
   const startSessionInWorkspace = useCallback(
-    (path: null | string, options?: { openTab?: boolean }) => {
+    (path: null | string, options?: { openTab?: boolean; owner?: NewChatOwner }) => {
       setWorkspaceScope('sessions')
 
       if (options?.openTab && mainChatOccupied(activeSessionIdRef.current, $selectedStoredSessionId.get())) {
+        if (options.owner !== undefined) {
+          setNewChatOwner(options.owner)
+        }
+
         void openNewSessionTile('center', { cwd: path, listed: false })
 
         return
@@ -635,6 +641,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         activeSessionIdRef,
         followActiveSessionCwd,
         onExplicitWorkspace: restoreWorktree,
+        owner: options?.owner,
         path,
         requestGateway,
         startFreshSessionDraft
@@ -655,11 +662,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     lastStartWorkTokenRef.current = startWorkSessionRequest.token
-    startSessionInWorkspace(startWorkSessionRequest.path, { openTab: startWorkSessionRequest.openTab })
-
-    if (startWorkSessionRequest.draft) {
-      requestComposerInsert(startWorkSessionRequest.draft, { target: 'main' })
-    }
+    handleStartWorkSessionRequest(startWorkSessionRequest, startSessionInWorkspace, draft =>
+      requestComposerInsert(draft, { target: 'main' })
+    )
   }, [startSessionInWorkspace, startWorkSessionRequest])
 
   const composer = useComposerActions({ activeSessionId, currentCwd, requestGateway })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -20,7 +20,13 @@ import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/stor
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent } from '@/store/gateway'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
-import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
+import {
+  $projectScope,
+  $projectTree,
+  $startWorkSessionRequest,
+  ALL_PROJECTS,
+  requestStartWorkSession
+} from '@/store/projects'
 import {
   $activeSessionId,
   $activeSessionStoredIdRotation,
@@ -57,6 +63,7 @@ import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-re
 import { deferred } from '../../../test/deferred'
 import { sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
+import { handleStartWorkSessionRequest, startWorkspaceSession } from '../workspace-session-target'
 
 import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
@@ -539,12 +546,15 @@ describe('createBackendSessionForSend profile routing', () => {
     $activeGatewayProfile.set('default')
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
+    setSelectedStoredSessionId(null)
+    setSessions([])
     $currentCwd.set('')
     $currentFastMode.set(false)
     $currentModel.set('')
     $currentProvider.set('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    $startWorkSessionRequest.set(null)
     vi.restoreAllMocks()
   })
 
@@ -568,6 +578,41 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ profile: 'analyst' })
+  })
+
+  it('routes the published worktree handoff through its source owner into session.create', async () => {
+    const params = await createWith(
+      () => {
+        $activeGatewayProfile.set('default')
+        $newChatProfile.set('default')
+      },
+      handle => {
+        requestStartWorkSession('C:/repo/.worktrees/automated-tests-update', undefined, { owner: 'itb' })
+        const request = $startWorkSessionRequest.get()
+
+        expect(request).toMatchObject({
+          owner: 'itb',
+          path: 'C:/repo/.worktrees/automated-tests-update'
+        })
+        handleStartWorkSessionRequest(
+          request!,
+          (path, options) =>
+            startWorkspaceSession({
+              activeSessionIdRef: { current: null },
+              owner: options.owner,
+              path,
+              requestGateway: vi.fn(async () => ({}) as never),
+              startFreshSessionDraft: handle.startFreshSessionDraft
+            }),
+          vi.fn()
+        )
+      }
+    )
+
+    expect(params).toMatchObject({
+      cwd: 'C:/repo/.worktrees/automated-tests-update',
+      profile: 'itb'
+    })
   })
 
   it('passes the default profile for single-profile users (backend resolves it to launch)', async () => {
@@ -607,8 +652,6 @@ describe('createBackendSessionForSend profile routing', () => {
       stored_session_id: null
     } as never)
 
-    $newChatProfile.set(route.profile)
-    $newChatRoute.set({ ...route })
     $activeGatewayProfile.set('other-connection-profile')
 
     let handle: HarnessHandle | null = null
@@ -616,6 +659,7 @@ describe('createBackendSessionForSend profile routing', () => {
     await waitFor(() => expect(handle).not.toBeNull())
 
     await act(async () => {
+      handle!.startFreshSessionDraft({ owner: route, workspaceTarget: '/remote/worktree' })
       await handle!.createBackendSessionForSend()
     })
 
@@ -623,7 +667,7 @@ describe('createBackendSessionForSend profile routing', () => {
       'source-a',
       'default',
       'session.create',
-      expect.objectContaining({ profile: 'backend-default', source: 'desktop' })
+      expect.objectContaining({ cwd: '/remote/worktree', profile: 'backend-default', source: 'desktop' })
     )
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
   })
@@ -3201,8 +3245,11 @@ describe('createBackendSessionForSend workspace target', () => {
 describe('openNewSessionTile workspace target', () => {
   afterEach(() => {
     cleanup()
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
+    $sessionTiles.set([])
     vi.restoreAllMocks()
   })
 
@@ -3243,6 +3290,43 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     expect(createParams).not.toHaveProperty('cwd')
+  })
+
+  it('keeps an openTab tile pinned to its exact request-captured owner', async () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    }
+
+    $newChatProfile.set('worker')
+    $newChatRoute.set(route)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({
+      info: { cwd: '/remote/worktree', model: 'test-model', skills: {}, tools: {} },
+      session_id: RUNTIME_SESSION_ID,
+      stored_session_id: 'stored-remote-tile'
+    } as never)
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: '/remote/worktree', listed: false })
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'worker',
+      'session.create',
+      expect.objectContaining({ cwd: '/remote/worktree', profile: 'backend-worker' })
+    )
+    expect($sessionTiles.get()).toContainEqual(
+      expect.objectContaining({ ownerRoute: route, storedSessionId: 'stored-remote-tile' })
+    )
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -35,7 +35,9 @@ import {
   type AgentProfileRoute,
   ensureGatewayAgent,
   ensureGatewayProfile,
-  normalizeProfileKey
+  type NewChatOwner,
+  normalizeProfileKey,
+  setNewChatOwner
 } from '@/store/profile'
 import {
   $projectScope,
@@ -248,6 +250,7 @@ async function desktopSessionCreateParams(
 }
 
 interface FreshSessionDraftOptions {
+  owner?: NewChatOwner
   preserveRoute?: boolean
   replaceRoute?: boolean
   workspaceTarget?: NewChatWorkspaceTarget
@@ -372,6 +375,10 @@ export function useSessionActions({
       const workspaceTarget = hasWorkspaceTarget
         ? normalizeNewChatWorkspaceTarget(draftOptions.workspaceTarget)
         : undefined
+
+      if (draftOptions.owner !== undefined) {
+        setNewChatOwner(draftOptions.owner)
+      }
 
       resetViewSync()
       busyRef.current = false
@@ -661,7 +668,13 @@ export function useSessionActions({
         const runtimeInfo = applyRuntimeInfo(created.info, { foreground: false })
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
-        openSessionTile(stored, dir, undefined, undefined, workspaceScope)
+        openSessionTile(
+          stored,
+          dir,
+          undefined,
+          undefined,
+          capturedRoute ? { ...workspaceScope, ownerRoute: capturedRoute } : workspaceScope
+        )
         patchSessionTile(stored, { runtimeId: created.session_id })
 
         if (dir === 'center' && runtimeInfo?.cwd) {

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
+import type { NewChatOwner } from '@/store/profile'
+import {
+  $projectScope,
+  $projectTree,
+  $startWorkSessionRequest,
+  ALL_PROJECTS,
+  requestStartWorkSession
+} from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
@@ -13,7 +20,30 @@ import {
 
 import { deferred } from '../../test/deferred'
 
-import { startWorkspaceSession } from './workspace-session-target'
+import { handleStartWorkSessionRequest, startWorkspaceSession } from './workspace-session-target'
+
+describe('handleStartWorkSessionRequest', () => {
+  afterEach(() => $startWorkSessionRequest.set(null))
+
+  it('passes the published owner/openTab/draft through the controller bridge', () => {
+    const owner = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'itb',
+      targetProfile: 'backend-itb'
+    }
+
+    requestStartWorkSession('C:/repo/.worktrees/tests', 'continue the tests', { openTab: true, owner })
+    const request = $startWorkSessionRequest.get()
+    const startSessionInWorkspace = vi.fn()
+    const insertDraft = vi.fn()
+
+    handleStartWorkSessionRequest(request!, startSessionInWorkspace, insertDraft)
+
+    expect(startSessionInWorkspace).toHaveBeenCalledWith('C:/repo/.worktrees/tests', { openTab: true, owner })
+    expect(insertDraft).toHaveBeenCalledWith('continue the tests')
+  })
+})
 
 describe('startWorkspaceSession', () => {
   afterEach(() => {
@@ -36,10 +66,12 @@ describe('startWorkspaceSession', () => {
 
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
-      setNewChatWorkspaceTarget(options?.workspaceTarget)
-      setCurrentCwd(options?.workspaceTarget || '')
-    })
+    const startFreshSessionDraft = vi.fn(
+      (options?: { owner?: NewChatOwner; workspaceTarget?: NewChatWorkspaceTarget }) => {
+        setNewChatWorkspaceTarget(options?.workspaceTarget)
+        setCurrentCwd(options?.workspaceTarget || '')
+      }
+    )
 
     const followActiveSessionCwd = vi.fn()
 
@@ -90,10 +122,12 @@ describe('startWorkspaceSession', () => {
     const requestGateway = vi.fn()
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
-      setNewChatWorkspaceTarget(options?.workspaceTarget)
-      setCurrentCwd(options?.workspaceTarget || '')
-    })
+    const startFreshSessionDraft = vi.fn(
+      (options?: { owner?: NewChatOwner; workspaceTarget?: NewChatWorkspaceTarget }) => {
+        setNewChatWorkspaceTarget(options?.workspaceTarget)
+        setCurrentCwd(options?.workspaceTarget || '')
+      }
+    )
 
     startWorkspaceSession({
       activeSessionIdRef,
@@ -106,5 +140,22 @@ describe('startWorkspaceSession', () => {
     expect(requestGateway).not.toHaveBeenCalled()
     expect($newChatWorkspaceTarget.get()).toBeNull()
     expect($currentCwd.get()).toBe('')
+  })
+
+  it('carries the source owner into the fresh worktree draft', () => {
+    const startFreshSessionDraft = vi.fn()
+
+    startWorkspaceSession({
+      activeSessionIdRef: { current: null },
+      owner: 'itb',
+      path: 'C:/repo/.worktrees/tests',
+      requestGateway: vi.fn(async () => ({}) as never),
+      startFreshSessionDraft
+    })
+
+    expect(startFreshSessionDraft).toHaveBeenCalledWith({
+      owner: 'itb',
+      workspaceTarget: 'C:/repo/.worktrees/tests'
+    })
   })
 })

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from 'react'
 
-import { followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
+import type { NewChatOwner } from '@/store/profile'
+import { followActiveSessionCwd, resolveNewSessionCwd, type StartWorkSessionRequest } from '@/store/projects'
 import {
   $newChatWorkspaceTargetGeneration,
   type NewChatWorkspaceTarget,
@@ -13,15 +14,32 @@ interface WorkspaceSessionOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   followActiveSessionCwd?: (cwd: string) => void | Promise<void>
   onExplicitWorkspace?: (cwd: string) => void
+  owner?: NewChatOwner
   path: null | string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
-  startFreshSessionDraft: (options?: { workspaceTarget: NewChatWorkspaceTarget }) => void
+  startFreshSessionDraft: (options?: { owner?: NewChatOwner; workspaceTarget?: NewChatWorkspaceTarget }) => void
+}
+
+export function handleStartWorkSessionRequest(
+  request: StartWorkSessionRequest,
+  startSessionInWorkspace: (path: string, options: { openTab?: boolean; owner?: NewChatOwner }) => void,
+  insertDraft: (draft: string) => void
+): void {
+  startSessionInWorkspace(request.path, {
+    openTab: request.openTab,
+    owner: request.owner
+  })
+
+  if (request.draft) {
+    insertDraft(request.draft)
+  }
 }
 
 export function startWorkspaceSession({
   activeSessionIdRef,
   followActiveSessionCwd: followCwd = followActiveSessionCwd,
   onExplicitWorkspace,
+  owner,
   path,
   requestGateway,
   startFreshSessionDraft
@@ -31,7 +49,7 @@ export function startWorkspaceSession({
   // return a default/remembered project folder and re-attach the last repo
   // (digitwo: New session in Home still shows `main`).
   if (path === null) {
-    startFreshSessionDraft({ workspaceTarget: null })
+    startFreshSessionDraft({ ...(owner !== undefined ? { owner } : {}), workspaceTarget: null })
 
     return
   }
@@ -41,7 +59,13 @@ export function startWorkspaceSession({
   const explicitTarget = path.trim()
   const target = explicitTarget || resolveNewSessionCwd()
 
-  startFreshSessionDraft(target ? { workspaceTarget: target } : undefined)
+  startFreshSessionDraft(
+    target
+      ? { ...(owner !== undefined ? { owner } : {}), workspaceTarget: target }
+      : owner !== undefined
+        ? { owner }
+        : undefined
+  )
 
   if (!target) {
     return

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -7,13 +7,16 @@ import {
   $repoStatusByCwd,
   $repoStatusLoading,
   _resetCodingStatusForTests,
+  openWorktreeDialog,
   refreshAllRepoStatuses,
   refreshRepoStatus,
   registerRepoStatusCwd,
   repoChangeKindForPath,
   repoStatusForCwd
 } from './coding-status'
-import { $currentCwd, $selectedStoredSessionId } from './session'
+import { $worktreeDialog } from './projects'
+import { $currentCwd, $selectedStoredSessionId, $sessions, setActiveSessionId } from './session'
+import { $sessionStates } from './session-states'
 
 const sampleStatus: HermesRepoStatus = {
   branch: 'feature/login',
@@ -254,6 +257,78 @@ describe('refreshRepoStatus', () => {
     expect(repoStatusForCwd('/main').get()).toEqual(sampleStatus)
 
     release?.()
+  })
+})
+
+describe('worktree dialog ownership', () => {
+  afterEach(() => {
+    $worktreeDialog.set(null)
+    setActiveSessionId(null)
+    $selectedStoredSessionId.set(null)
+    $sessionStates.set({})
+    $sessions.set([])
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('keeps the owner of the surface that opened it after focus changes', async () => {
+    let resolveProbe!: (status: HermesRepoStatus | null) => void
+
+    stubProbe(
+      () =>
+        new Promise(resolve => {
+          resolveProbe = resolve
+        })
+    )
+    $sessions.set([
+      {
+        connection_id: 'source-itb',
+        ended_at: null,
+        id: 'itb-source',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        profile: 'itb',
+        source: 'desktop',
+        started_at: 1,
+        title: 'ITB source',
+        tool_call_count: 0
+      },
+      {
+        connection_id: 'source-default',
+        ended_at: null,
+        id: 'other-source',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 1,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        profile: 'default',
+        source: 'desktop',
+        started_at: 1,
+        title: 'Other source',
+        tool_call_count: 0
+      }
+    ])
+    $selectedStoredSessionId.set('itb-source')
+    setActiveSessionId('runtime-itb')
+    $sessionStates.set({ 'runtime-itb': { cwd: 'C:/repo', storedSessionId: 'itb-source' } as never })
+
+    const opening = openWorktreeDialog()
+
+    $selectedStoredSessionId.set('other-source')
+    resolveProbe(sampleStatus)
+    await opening
+
+    expect($worktreeDialog.get()).toMatchObject({
+      owner: { connectionId: 'source-itb', profile: 'itb' },
+      repoPath: 'C:/repo'
+    })
   })
 })
 

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -18,7 +18,7 @@ import {
   $workspaceCwdOwner,
   workspaceCwdBelongsToSelectedSession
 } from './session'
-import { $focusedRuntimeId, $sessionStates } from './session-states'
+import { $focusedRuntimeId, $focusedStoredSessionId, $sessionStates, knownOwnerForSession } from './session-states'
 import { $workspaceChangeTick } from './workspace-events'
 
 // Live working-tree status for every git surface on screen — the data backbone
@@ -518,9 +518,10 @@ export async function resolveWorktreeRepoPath(): Promise<string> {
 }
 
 export async function openWorktreeDialog(options?: { base?: string; repoPath?: string }): Promise<void> {
+  const owner = knownOwnerForSession($focusedStoredSessionId.get())
   const repoPath = options?.repoPath?.trim() || (await resolveWorktreeRepoPath())
 
   if (repoPath) {
-    $worktreeDialog.set({ base: options?.base, repoPath })
+    $worktreeDialog.set({ base: options?.base, ...(owner ? { owner } : {}), repoPath })
   }
 }

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -9,10 +9,17 @@ import type { ProfileInfo } from '@/types/hermes'
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayConnectionId,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile
+}))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()
@@ -23,6 +30,7 @@ vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 const {
   $activeGatewayProfile,
   $profiles,
+  activeNewChatOwner,
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
@@ -57,6 +65,7 @@ beforeEach(() => {
   openGatewayForProfile.mockClear()
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
+  activeGatewayConnectionId.mockReturnValue(null)
   $connection.set(localConn())
   $profiles.set([])
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
@@ -67,6 +76,21 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   $connection.set(null)
+})
+
+describe('activeNewChatOwner', () => {
+  it('returns a profile for the local profile pool', () => {
+    $activeGatewayProfile.set('itb')
+
+    expect(activeNewChatOwner()).toBe('itb')
+  })
+
+  it('preserves the registry connection when the active source is connection-qualified', () => {
+    $activeGatewayProfile.set('worker')
+    activeGatewayConnectionId.mockReturnValue('source-a')
+
+    expect(activeNewChatOwner()).toEqual({ connectionId: 'source-a', profile: 'worker' })
+  })
 })
 
 describe('ensureGatewayProfile → $connection sync (#46651)', () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -206,9 +206,49 @@ export interface AgentProfileRoute {
   targetProfile?: string
 }
 
+export type NewChatOwner = string | AgentProfileRoute
+
+/** Snapshot the backend that owns a new-chat action at its interaction boundary. */
+export function activeNewChatOwner(): NewChatOwner {
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+  const connectionId = activeGatewayConnectionId()
+
+  return connectionId ? { connectionId, profile } : profile
+}
+
 // A draft remembers the source it was created for. The active gateway may
 // change before the first Send; the draft's owner must not change with it.
 export const $newChatRoute = atom<AgentProfileRoute | null>(null)
+
+function normalizeAgentProfileRoute(owner: AgentProfileRoute): AgentProfileRoute {
+  const captured = {
+    ...owner,
+    connectionId: owner.connectionId.trim(),
+    profile: normalizeProfileKey(owner.profile),
+    ...(owner.targetProfile ? { targetProfile: normalizeProfileKey(owner.targetProfile) } : {})
+  }
+
+  if (!captured.connectionId) {
+    throw new Error('Agent profile route is missing connectionId')
+  }
+
+  return captured
+}
+
+/** Pin a fresh draft to the profile/backend that initiated it. */
+export function setNewChatOwner(owner: NewChatOwner): void {
+  if (typeof owner === 'string') {
+    $newChatProfile.set(normalizeProfileKey(owner))
+    $newChatRoute.set(null)
+
+    return
+  }
+
+  const captured = normalizeAgentProfileRoute(owner)
+
+  $newChatProfile.set(captured.profile)
+  $newChatRoute.set(captured)
+}
 
 // Bumped whenever the open session should be dropped for a fresh new-session
 // draft: a profile switch/create (below), or deleting the project that owns the
@@ -561,19 +601,9 @@ export function newSessionInProfile(name: string): void {
  * only a presentation step; the route stays attached to the draft for the
  * eventual session.create request. */
 export function newSessionInAgent(route: AgentProfileRoute): void {
-  const captured = {
-    ...route,
-    connectionId: route.connectionId.trim(),
-    profile: normalizeProfileKey(route.profile),
-    ...(route.targetProfile ? { targetProfile: normalizeProfileKey(route.targetProfile) } : {})
-  }
+  const captured = normalizeAgentProfileRoute(route)
 
-  if (!captured.connectionId) {
-    throw new Error('Agent profile route is missing connectionId')
-  }
-
-  $newChatProfile.set(captured.profile)
-  $newChatRoute.set(captured)
+  setNewChatOwner(captured)
   requestFreshSession()
   void ensureGatewayAgent(captured.connectionId, captured.profile)
 }

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -14,6 +14,7 @@ import {
   $projectTree,
   $removedSessionIds,
   $sessionMutationsInFlight,
+  $startWorkSessionRequest,
   $worktreeRefreshToken,
   ALL_PROJECTS,
   beginSessionMutation,
@@ -22,6 +23,8 @@ import {
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
+  goToProject,
+  openFolderAsProject,
   openProjectCreate,
   pickProjectFolder,
   projectIdForCwd,
@@ -29,6 +32,7 @@ import {
   refreshProjects,
   refreshProjectTree,
   refreshWorktrees,
+  requestStartWorkSession,
   resolveNewSessionCwd,
   scanAndRecordRepos,
   startWorkInRepo,
@@ -53,6 +57,7 @@ vi.mock('@/lib/desktop-fs', () => ({
 vi.mock('@/store/gateway', () => ({
   $gateway: atom(null),
   activeGateway: vi.fn(),
+  activeGatewayConnectionId: vi.fn(() => null),
   ensureActiveGatewayOpen: vi.fn()
 }))
 
@@ -76,6 +81,7 @@ const selectDesktopPaths = vi.mocked(fs.selectDesktopPaths)
 
 const gw = await import('@/store/gateway')
 const activeGateway = vi.mocked(gw.activeGateway)
+const activeGatewayConnectionId = vi.mocked(gw.activeGatewayConnectionId)
 const gatewayAtom = gw.$gateway
 
 const git = await import('@/lib/desktop-git')
@@ -127,6 +133,64 @@ describe('project scope', () => {
   it('persists the scope to localStorage', () => {
     enterProject('p_abc')
     expect(window.localStorage.getItem('hermes.desktop.projectScope')).toBe('p_abc')
+  })
+})
+
+describe('worktree session handoff ownership', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    activeGatewayConnectionId.mockReturnValue(null)
+    activeGateway.mockReset()
+    gatewayAtom.set(null)
+    $projectTree.set([])
+    $startWorkSessionRequest.set(null)
+  })
+
+  it('preserves the source owner after the initiating surface changes', () => {
+    requestStartWorkSession('C:/repo/.worktrees/tests', undefined, { owner: 'itb' })
+
+    expect($startWorkSessionRequest.get()).toMatchObject({
+      owner: 'itb',
+      path: 'C:/repo/.worktrees/tests'
+    })
+  })
+
+  it('uses the exact active connection for a project-palette new session', () => {
+    $activeGatewayProfile.set('itb')
+    activeGatewayConnectionId.mockReturnValue('source-itb')
+    $projectTree.set([{ id: 'p-itb', label: 'ITB', path: 'C:/repo', repos: [], sessionCount: 0 }])
+
+    goToProject('p-itb', { newSession: true })
+
+    expect($startWorkSessionRequest.get()).toMatchObject({
+      openTab: true,
+      owner: { connectionId: 'source-itb', profile: 'itb' },
+      path: 'C:/repo'
+    })
+  })
+
+  it('captures the folder-open owner before asynchronous project refresh', async () => {
+    const tree = deferred<{ active_id: null; projects: []; scoped_session_ids: [] }>()
+    const gateway = { connectionState: 'open', request: vi.fn(() => tree.promise) }
+
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    $activeGatewayProfile.set('itb')
+    activeGatewayConnectionId.mockReturnValue('source-itb')
+    $projectTree.set([{ id: 'p-itb', label: 'ITB', path: 'C:/repo', repos: [], sessionCount: 0 }])
+
+    const opening = openFolderAsProject('C:/repo')
+
+    $activeGatewayProfile.set('default')
+    activeGatewayConnectionId.mockReturnValue('source-default')
+    tree.resolve({ active_id: null, projects: [], scoped_session_ids: [] })
+    await opening
+
+    expect($startWorkSessionRequest.get()).toMatchObject({
+      openTab: true,
+      owner: { connectionId: 'source-itb', profile: 'itb' },
+      path: 'C:/repo'
+    })
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -19,7 +19,9 @@ import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
   $profileScope,
+  activeNewChatOwner,
   ALL_PROFILES,
+  type NewChatOwner,
   normalizeProfileKey,
   requestFreshSession
 } from '@/store/profile'
@@ -198,7 +200,10 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
   const cwd = projectRootCwd($projectTree.get().find(node => node.id === id))
 
   if (cwd) {
-    requestStartWorkSession(cwd, undefined, { openTab: true })
+    requestStartWorkSession(cwd, undefined, {
+      openTab: true,
+      owner: activeNewChatOwner()
+    })
   } else {
     requestFreshSession()
   }
@@ -1264,6 +1269,8 @@ export interface StartWorkSessionRequest {
   draft?: string
   /** Stack the fresh session as a tab when main already holds a chat (palette/⌘O opens-from-nowhere). */
   openTab?: boolean
+  /** Session/profile route that owns the draft which initiated this hand-off. */
+  owner?: NewChatOwner
   path: string
   token: number
 }
@@ -1284,6 +1291,8 @@ export interface WorktreeDialogState {
   repoPath: string
   /** The base branch selected in a "branch off from X" menu. */
   base?: string
+  /** Owner of the surface that opened the dialog, captured before focus can move. */
+  owner?: NewChatOwner
 }
 
 export const $worktreeDialog = atom<null | WorktreeDialogState>(null)
@@ -1294,7 +1303,11 @@ export function closeWorktreeDialog(): void {
 
 let startWorkToken = 0
 
-export function requestStartWorkSession(path: string, draft?: string, options?: { openTab?: boolean }): void {
+export function requestStartWorkSession(
+  path: string,
+  draft?: string,
+  options?: { openTab?: boolean; owner?: NewChatOwner }
+): void {
   const target = path.trim()
 
   if (!target) {
@@ -1302,9 +1315,11 @@ export function requestStartWorkSession(path: string, draft?: string, options?: 
   }
 
   startWorkToken += 1
+
   $startWorkSessionRequest.set({
     draft: draft?.trim() || undefined,
     openTab: options?.openTab || undefined,
+    ...(options?.owner ? { owner: options.owner } : {}),
     path: target,
     token: startWorkToken
   })
@@ -1359,6 +1374,7 @@ export async function pickProjectFolder(): Promise<null | string> {
 // one-keystroke version of new project → enter → new session. Like goToProject,
 // this is an open-from-nowhere: an occupied main gets a stacked tab, not stolen.
 export async function openFolderAsProject(dir?: string): Promise<void> {
+  const owner = activeNewChatOwner()
   const target = (dir ?? (await pickProjectFolder()) ?? '').trim()
 
   if (!target) {
@@ -1394,5 +1410,8 @@ export async function openFolderAsProject(dir?: string): Promise<void> {
     }
   }
 
-  requestStartWorkSession(target, undefined, { openTab: true })
+  requestStartWorkSession(target, undefined, {
+    openTab: true,
+    owner
+  })
 }

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import type * as GatewayModule from '@/store/gateway'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $selectedStoredSessionId, setSessions } from '@/store/session'
+import { $selectedStoredSessionId, setSessionOwnerHint, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
@@ -27,6 +29,11 @@ import {
   setSessionTileDelegate,
   setSessionTileWorkspaceScope
 } from '@/store/session-states'
+
+vi.mock('@/store/gateway', async importActual => ({
+  ...(await importActual<typeof GatewayModule>()),
+  requestGatewayForAgent: vi.fn()
+}))
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
@@ -243,6 +250,15 @@ describe('SessionTile workspace scope', () => {
       workspaceMode: 'bots',
       workspaceOwnerKey: 'connection-b::default'
     })
+  })
+
+  it('keeps a regular tile owner route when a plain Sessions focus re-scopes it', () => {
+    const ownerRoute = { connectionId: 'source-a', mode: 'remote' as const, profile: 'worker' }
+
+    openSessionTile('remote-chat', 'center', undefined, undefined, { ownerRoute, workspaceMode: 'sessions' })
+
+    expect(setSessionTileWorkspaceScope('remote-chat', { workspaceMode: 'sessions' })).toBe(false)
+    expect(sessionTileOwnerRoute('remote-chat')).toEqual(ownerRoute)
   })
 
   it('preserves workspace scope while dropping a stale runtime binding', () => {
@@ -571,6 +587,19 @@ describe('sessionTileOwnerRoute', () => {
     expect(sessionTileOwnerRoute('plain')).toBeUndefined()
   })
 
+  it('persists an exact route for a regular session tile when one is known', () => {
+    openSessionTile('remote-plain', 'center', undefined, undefined, {
+      ownerRoute: { connectionId: 'source-a', mode: 'remote', profile: 'worker' },
+      workspaceMode: 'sessions'
+    })
+
+    expect(sessionTileOwnerRoute('remote-plain')).toEqual({
+      connectionId: 'source-a',
+      mode: 'remote',
+      profile: 'worker'
+    })
+  })
+
   it('returns undefined when the session has no tile', () => {
     $sessionTiles.set([])
 
@@ -588,6 +617,7 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
   afterEach(() => {
     $sessionTiles.set([])
     setSessions([])
+    vi.mocked(requestGatewayForAgent).mockReset()
   })
 
   it('resolves the tile owner route first, translating a runtime id to its stored id', () => {
@@ -607,6 +637,48 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
     setSessions([{ id: 'stored-2', profile: 'loki' } as never])
 
     expect(knownOwnerForSession('stored-2')).toBe('loki')
+  })
+
+  it('preserves a unique connection-qualified session row owner', () => {
+    setSessions([{ connection_id: 'source-a', id: 'stored-remote', profile: 'worker' } as never])
+
+    expect(knownOwnerForSession('stored-remote')).toEqual({ connectionId: 'source-a', profile: 'worker' })
+  })
+
+  it('routes an ordinary connection-qualified session through its exact owner', async () => {
+    const params = { choice: 'once', session_id: 'runtime-remote' }
+    const ambient = vi.fn()
+
+    setSessions([{ connection_id: 'source-a', id: 'stored-remote', profile: 'worker' } as never])
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({ ok: true } as never)
+
+    await requestForOwnedSession('stored-remote', ambient as never, 'approval.respond', params)
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'worker', 'approval.respond', params)
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('preserves a unique exact owner hint including its backend target', () => {
+    const route = {
+      connectionId: 'source-b',
+      mode: 'remote' as const,
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    }
+
+    setSessionOwnerHint('stored-hinted', route)
+    setSessions([{ connection_id: 'source-b', id: 'stored-hinted', profile: 'worker' } as never])
+
+    expect(knownOwnerForSession('stored-hinted')).toEqual(route)
+  })
+
+  it('fails closed when the same stored id has conflicting connection owners', () => {
+    setSessions([
+      { connection_id: 'source-a', id: 'stored-ambiguous', profile: 'worker' } as never,
+      { connection_id: 'source-b', id: 'stored-ambiguous', profile: 'worker' } as never
+    ])
+
+    expect(knownOwnerForSession('stored-ambiguous')).toBeUndefined()
   })
 
   it('returns undefined (ambient) when no owner is known, and for null ids', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,7 +42,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
-  knownSessionProfile,
+  getSessionOwnerHints,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
@@ -743,9 +743,10 @@ export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRo
 
 /**
  * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
- * Tile route first (exact connectionId+profile, survives relaunch), then the
- * known session profile (row or open-time hint). Returns undefined when no
- * owner is known — the caller falls back to ambient, never to "active".
+ * Tile route first (exact connectionId+profile, survives relaunch), then a
+ * unique open-time hint, then a unique connection-qualified/profile row.
+ * Ambiguous claims remain unresolved instead of collapsing to a profile name
+ * that could select a same-named profile on another connection.
  */
 export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
   if (!sessionId) {
@@ -753,8 +754,36 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   }
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
+  const tileRoute = sessionTileOwnerRoute(storedSessionId)
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+  if (tileRoute) {
+    return tileRoute
+  }
+
+  const hints = getSessionOwnerHints(storedSessionId)
+
+  if (hints.length !== 0) {
+    return hints.length === 1 ? hints[0] : undefined
+  }
+
+  const owners = new Map<string, Exclude<SessionOwnerScope, null | undefined>>()
+
+  for (const session of $sessions.get().filter(row => sessionMatchesStoredId(row, storedSessionId))) {
+    const connectionId = session.connection_id?.trim()
+    const rawProfile = session.profile?.trim()
+
+    if (connectionId) {
+      const profile = normalizeProfileKey(rawProfile)
+
+      owners.set(`route:${connectionId}\0${profile}`, { connectionId, profile })
+    } else if (rawProfile) {
+      const profile = normalizeProfileKey(rawProfile)
+
+      owners.set(`profile:${profile}`, profile)
+    }
+  }
+
+  return owners.size === 1 ? [...owners.values()][0] : undefined
 }
 
 /**
@@ -811,7 +840,7 @@ export function storedSessionIdForRuntimeId(sessionId: string): null | string {
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
-  const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : undefined
+  const ownerRoute = scope.ownerRoute ?? (scope.workspaceMode === 'sessions' ? tile?.ownerRoute : undefined)
   const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
 
   if (
@@ -1066,7 +1095,7 @@ export function openSessionTile(
         anchor: dock,
         before,
         dir,
-        ownerRoute: workspaceScope.workspaceMode === 'bots' ? workspaceScope.ownerRoute : undefined,
+        ownerRoute: workspaceScope.ownerRoute,
         storedSessionId,
         workspaceMode: workspaceScope.workspaceMode,
         workspaceOwnerKey,


### PR DESCRIPTION
## What does this PR do?

Keeps a new Hermes Desktop session on the profile/backend that owned the session surface which initiated a Git worktree hand-off.

The failing sequence was:

1. A named-profile session opens or creates a linked worktree.
2. `requestStartWorkSession()` carries only `path`, `draft`, and `openTab`.
3. The controller resets the selected session for the fresh draft, losing the only remaining owner identity.
4. `session.create` falls back to mutable new-chat/active-gateway state and can run on `default`.

In the reproduced case, the named-profile WebSocket opened but sent no request; `session.create` ran on the default backend. The resulting row was present only in default `state.db` with `profile_name = NULL`, so its worktree cwd produced a default-profile auto-project and no named-profile glyph.

This change captures an immutable owner at the interaction boundary (a profile name or exact connection route), carries it through the worktree request and fresh-draft transition, and applies it before `session.create`. Main composers, session tiles, the worktree dialog, command-palette worktree entries, and project/open-folder entry points all preserve the appropriate owner.

Existing misrouted sessions are intentionally not migrated or restarted. This fixes future hand-offs without interrupting active work.

## Related work

- Complements #89736 / #89731. That PR preserves profile metadata in `projects.tree` for rows already stored under the correct named profile. It cannot repair this case because the row was created in the default database with no profile identity; this PR does not duplicate its projection change.
- Distinct from #81817, which covers a profile-switch / Cmd+N gateway-swap race.
- Distinct from #86822, which creates automatic worktrees for new sessions but does not preserve the initiating session owner across an existing worktree hand-off.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a normalized `NewChatOwner` boundary for profile names and exact connection routes.
- Preserve unique connection-qualified rows/owner hints instead of collapsing them to a same-named profile on another connection; leave ambiguous claims unresolved.
- Route regular session tiles through the behaviorally-tested owned-session dispatcher and persist exact routes on newly-created unlisted/openTab tiles.
- Resolve a main composer from the main selected session (never the focused tile), and capture its owner before asynchronous worktree creation.
- Capture folder/project and worktree-dialog owners before asynchronous pick/probe/refresh work can switch the active surface or gateway.
- Carry owner identity through `StartWorkSessionRequest` and `startWorkspaceSession` into the fresh draft.
- Route profile-only and connection-qualified session creation through the existing new-chat routing path.
- Cover main/tiled composers, delayed worktree dialogs, command-palette worktree starts, and project/open-folder starts.
- Leave existing rows and live sessions untouched.

## How to Test

Regression before the production change:

```text
routes a worktree handoff by its source session instead of a stale default draft
expected profile: "itb"
received profile: "default"
```

A mutation run that temporarily removed only the new owner application reproduced the same failure; restoring the line made the test pass again.

An independent staged review additionally caught two follow-ups before publication: an `undefined` owner snapshot could be re-resolved after an await, and the first integration test bypassed the controller bridge. Dedicated regressions now keep an unresolved snapshot unresolved and exercise the same `handleStartWorkSessionRequest` bridge used by the wiring effect.

Automated verification on current upstream `main` (`f751a8c546`):

```text
Focused affected files:
  13 files, 233 tests passed

Additional UI tests changed by the upstream rebases:
  7 files, 106 tests passed

Desktop TypeScript:
  renderer + Electron + E2E typechecks passed

Changed-file ESLint:
  0 errors, 0 warnings

Changed-file Prettier:
  all files formatted

Production build:
  vite build + Electron bundles + native dependency staging passed
  assert-dist-built passed

git diff --check:
  passed
```

Full Desktop UI run on this Windows host before the subsequent conflict-free upstream rebases (starting from `5b82658b3c`; `--maxWorkers=2` to limit the host's worker-saturation timeouts):

```text
598 files: 592 passed, 6 failed
5753 tests: 5741 passed, 12 failed
```

The failures are not introduced by this diff:

- 8 worker-saturation/time-out follow-ons across gateway settings, unread tiles, and messaging all pass on immediate isolated rerun (12/12 tests).
- The remaining 4 locale-sensitive assertions (`1,234,567`, `5,000`, and currency spacing) reproduce identically on a clean current-upstream worktree under this host's `de-DE` locale (4 failed / 110 passed).

## Checklist

### Code

- [x] I've read the Contributing Guide and Desktop Engineering Guide
- [x] My commit follows Conventional Commits
- [x] I searched open PRs/issues and documented adjacent work above
- [x] The PR contains only changes for worktree hand-off ownership
- [x] Regression tests fail without the fix and pass with it
- [x] Typecheck, changed-file lint/format, focused tests, and production build pass
- [ ] Full Desktop UI suite is zero-failure on this host (baseline-identical locale failures documented above)

### Documentation & Housekeeping

- [x] User-facing docs: N/A; no command/configuration semantics changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changed
- [x] Cross-platform impact considered; renderer-only TypeScript and generic path fixtures
- [x] Tool descriptions/schemas: N/A
