### PR TITLE
fix(dashboard): make profile model picker searchable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6372,6 +6372,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -19593,6 +19607,8 @@
       "devDependencies": {
         "@babel/core": "8.0.1",
         "@rolldown/plugin-babel": "0.2.3",
+        "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.1",
         "@types/babel__core": "7.20.5",
         "@types/node": "22.20.1",
         "@types/qrcode": "1.5.6",
@@ -19601,6 +19617,7 @@
         "@vitejs/plugin-react": "6.0.3",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint-plugin-react-refresh": "0.5.3",
+        "jsdom": "29.1.1",
         "three": "0.180.0",
         "typescript": "6.0.3",
         "vite": "8.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "@babel/core": "8.0.1",
     "@rolldown/plugin-babel": "0.2.3",
+    "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
     "@types/babel__core": "7.20.5",
     "@types/node": "22.20.1",
     "@types/qrcode": "1.5.6",
@@ -50,6 +52,7 @@
     "@vitejs/plugin-react": "6.0.3",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint-plugin-react-refresh": "0.5.3",
+    "jsdom": "29.1.1",
     "three": "0.180.0",
     "typescript": "6.0.3",
     "vite": "8.2.0",

--- a/web/src/components/ProfileModelPicker.test.tsx
+++ b/web/src/components/ProfileModelPicker.test.tsx
@@ -1,5 +1,8 @@
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileModelPicker } from "./ProfileModelPicker";
 import {
   filterProfileModelChoices,
@@ -18,6 +21,20 @@ const choices: ProfileModelChoice[] = [
     label: "OpenAI Codex · GPT-5.6 Codex",
   },
 ];
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  scrollIntoView.mockReset();
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("ProfileModelPicker", () => {
   it.each([
@@ -34,22 +51,78 @@ describe("ProfileModelPicker", () => {
     },
   );
 
-  it("renders every selectable row as a native button", () => {
-    const html = renderToStaticMarkup(
+  it("filters choices and selects a result", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
       <ProfileModelPicker
         choices={choices}
         emptyLabel="No models"
         inheritLabel="Use default"
         loadingLabel="Loading models"
         selected={"nous\u0000deepseek-v4-pro"}
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Search models" }), "codex");
+
+    expect(screen.queryByRole("option", { name: /DeepSeek/ })).toBeNull();
+    const result = screen.getByRole("option", { name: /GPT-5.6 Codex/ });
+    await user.click(result);
+
+    expect(onSelect).toHaveBeenCalledWith("openai-codex\u0000gpt-5.6-codex");
+  });
+
+  it("uses single-select semantics and keyboard navigation", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <ProfileModelPicker
+        choices={choices}
+        emptyLabel="No models"
+        inheritLabel="Use default"
+        loadingLabel="Loading models"
+        selected={"nous\u0000deepseek-v4-pro"}
+        onSelect={onSelect}
+      />,
+    );
+
+    const search = screen.getByRole("textbox", { name: "Search models" });
+    const selected = screen.getByRole("option", { name: /DeepSeek/ });
+    const options = screen.getAllByRole("option");
+    expect(screen.getByRole("listbox", { name: "Models" })).toBeTruthy();
+    expect(options.every((option) => option.tagName === "BUTTON")).toBe(true);
+    expect(options.every((option) => option.getAttribute("type") === "button")).toBe(
+      true,
+    );
+    expect(selected.getAttribute("aria-selected")).toBe("true");
+    expect(selected.getAttribute("aria-pressed")).toBeNull();
+
+    await user.click(search);
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(selected);
+
+    await user.click(search);
+    await user.clear(search);
+    await user.type(search, "codex");
+    await user.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenLastCalledWith(
+      "openai-codex\u0000gpt-5.6-codex",
+    );
+  });
+
+  it("scrolls the selected option into view", () => {
+    render(
+      <ProfileModelPicker
+        choices={choices}
+        emptyLabel="No models"
+        loadingLabel="Loading models"
+        selected={"openai-codex\u0000gpt-5.6-codex"}
         onSelect={() => undefined}
       />,
     );
 
-    expect(html).toContain('aria-label="Search models"');
-    expect(html).toContain("max-h-80");
-    expect(html.match(/<button/g)).toHaveLength(3);
-    expect(html.match(/type="button"/g)).toHaveLength(3);
-    expect(html).toContain('aria-pressed="true"');
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
   });
 });

--- a/web/src/components/ProfileModelPicker.test.tsx
+++ b/web/src/components/ProfileModelPicker.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ProfileModelPicker } from "./ProfileModelPicker";
+import {
+  filterProfileModelChoices,
+  type ProfileModelChoice,
+} from "@/lib/profile-model-picker";
+
+const choices: ProfileModelChoice[] = [
+  {
+    provider: "nous",
+    model: "deepseek-v4-pro",
+    label: "Nous Portal · DeepSeek V4 Pro",
+  },
+  {
+    provider: "openai-codex",
+    model: "gpt-5.6-codex",
+    label: "OpenAI Codex · GPT-5.6 Codex",
+  },
+];
+
+describe("ProfileModelPicker", () => {
+  it.each([
+    ["NOUS", "deepseek-v4-pro"],
+    ["V4-PRO", "deepseek-v4-pro"],
+    ["deepseek v4 pro", "deepseek-v4-pro"],
+    ["OPENAI-CODEX", "gpt-5.6-codex"],
+  ])(
+    "matches provider, model id, and rendered label case-insensitively",
+    (query, model) => {
+      expect(
+        filterProfileModelChoices(choices, query).map((choice) => choice.model),
+      ).toEqual([model]);
+    },
+  );
+
+  it("renders every selectable row as a native button", () => {
+    const html = renderToStaticMarkup(
+      <ProfileModelPicker
+        choices={choices}
+        emptyLabel="No models"
+        inheritLabel="Use default"
+        loadingLabel="Loading models"
+        selected={"nous\u0000deepseek-v4-pro"}
+        onSelect={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Search models"');
+    expect(html).toContain("max-h-80");
+    expect(html.match(/<button/g)).toHaveLength(3);
+    expect(html.match(/type="button"/g)).toHaveLength(3);
+    expect(html).toContain('aria-pressed="true"');
+  });
+});

--- a/web/src/components/ProfileModelPicker.tsx
+++ b/web/src/components/ProfileModelPicker.tsx
@@ -1,5 +1,12 @@
 import { Check, Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { Input } from "@nous-research/ui/ui/components/input";
 import { cn } from "@/lib/utils";
 import {
@@ -28,10 +35,36 @@ export function ProfileModelPicker({
   selected,
 }: ProfileModelPickerProps) {
   const [query, setQuery] = useState("");
+  const listboxId = useId();
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectedOptionRef = useRef<HTMLButtonElement | null>(null);
   const filteredChoices = useMemo(
     () => filterProfileModelChoices(choices ?? [], query),
     [choices, query],
   );
+  const modelOptionOffset = inheritLabel && choices !== null ? 1 : 0;
+  const optionCount = modelOptionOffset + filteredChoices.length;
+
+  useEffect(() => {
+    selectedOptionRef.current?.scrollIntoView({ block: "nearest" });
+  }, [choices, selected]);
+
+  const focusOption = (index: number) => {
+    optionRefs.current[index]?.focus();
+  };
+
+  const handleOptionKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusOption(Math.min(index + 1, optionCount - 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusOption(Math.max(index - 1, 0));
+    }
+  };
 
   const rowClass = (active: boolean) =>
     cn(
@@ -51,21 +84,44 @@ export function ProfileModelPicker({
         <Input
           id={searchInputId}
           aria-label="Search models"
+          aria-controls={listboxId}
           className="h-8 pl-8 text-sm"
           disabled={choices === null}
           placeholder="Filter models…"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowDown" && optionCount > 0) {
+              event.preventDefault();
+              focusOption(
+                filteredChoices.length > 0 ? modelOptionOffset : 0,
+              );
+            } else if (event.key === "Enter" && filteredChoices.length > 0) {
+              event.preventDefault();
+              onSelect(profileModelKey(filteredChoices[0]));
+            }
+          }}
         />
       </div>
 
-      <div className="max-h-80 overflow-y-auto rounded border border-border">
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label="Models"
+        className="max-h-80 overflow-y-auto rounded border border-border"
+      >
         {inheritLabel && choices !== null && (
           <button
             type="button"
-            aria-pressed={selected === ""}
+            role="option"
+            aria-selected={selected === ""}
+            ref={(element) => {
+              optionRefs.current[0] = element;
+              if (selected === "") selectedOptionRef.current = element;
+            }}
             className={rowClass(selected === "")}
             onClick={() => onSelect("")}
+            onKeyDown={(event) => handleOptionKeyDown(event, 0)}
           >
             <Check
               aria-hidden
@@ -87,16 +143,25 @@ export function ProfileModelPicker({
             No models match your search.
           </p>
         ) : (
-          filteredChoices.map((choice) => {
+          filteredChoices.map((choice, choiceIndex) => {
             const key = profileModelKey(choice);
             const active = selected === key;
+            const optionIndex = choiceIndex + modelOptionOffset;
             return (
               <button
                 key={key}
                 type="button"
-                aria-pressed={active}
+                role="option"
+                aria-selected={active}
+                ref={(element) => {
+                  optionRefs.current[optionIndex] = element;
+                  if (active) selectedOptionRef.current = element;
+                }}
                 className={rowClass(active)}
                 onClick={() => onSelect(key)}
+                onKeyDown={(event) =>
+                  handleOptionKeyDown(event, optionIndex)
+                }
               >
                 <Check
                   aria-hidden

--- a/web/src/components/ProfileModelPicker.tsx
+++ b/web/src/components/ProfileModelPicker.tsx
@@ -1,0 +1,116 @@
+import { Check, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { cn } from "@/lib/utils";
+import {
+  filterProfileModelChoices,
+  profileModelKey,
+  type ProfileModelChoice,
+} from "@/lib/profile-model-picker";
+
+interface ProfileModelPickerProps {
+  choices: ProfileModelChoice[] | null;
+  emptyLabel: string;
+  inheritLabel?: string;
+  loadingLabel: string;
+  onSelect(value: string): void;
+  searchInputId?: string;
+  selected: string;
+}
+
+export function ProfileModelPicker({
+  choices,
+  emptyLabel,
+  inheritLabel,
+  loadingLabel,
+  onSelect,
+  searchInputId,
+  selected,
+}: ProfileModelPickerProps) {
+  const [query, setQuery] = useState("");
+  const filteredChoices = useMemo(
+    () => filterProfileModelChoices(choices ?? [], query),
+    [choices, query],
+  );
+
+  const rowClass = (active: boolean) =>
+    cn(
+      "flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+      active
+        ? "bg-primary/10 text-primary"
+        : "text-foreground hover:bg-muted/50",
+    );
+
+  return (
+    <div className="grid gap-2">
+      <div className="relative">
+        <Search
+          aria-hidden
+          className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          id={searchInputId}
+          aria-label="Search models"
+          className="h-8 pl-8 text-sm"
+          disabled={choices === null}
+          placeholder="Filter models…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </div>
+
+      <div className="max-h-80 overflow-y-auto rounded border border-border">
+        {inheritLabel && choices !== null && (
+          <button
+            type="button"
+            aria-pressed={selected === ""}
+            className={rowClass(selected === "")}
+            onClick={() => onSelect("")}
+          >
+            <Check
+              aria-hidden
+              className={cn(
+                "h-3 w-3 shrink-0",
+                selected === "" ? "text-primary" : "text-transparent",
+              )}
+            />
+            <span className="truncate">{inheritLabel}</span>
+          </button>
+        )}
+
+        {choices === null ? (
+          <p className="p-3 text-xs text-muted-foreground">{loadingLabel}</p>
+        ) : choices.length === 0 ? (
+          <p className="p-3 text-xs text-muted-foreground">{emptyLabel}</p>
+        ) : filteredChoices.length === 0 ? (
+          <p className="p-3 text-xs text-muted-foreground">
+            No models match your search.
+          </p>
+        ) : (
+          filteredChoices.map((choice) => {
+            const key = profileModelKey(choice);
+            const active = selected === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={active}
+                className={rowClass(active)}
+                onClick={() => onSelect(key)}
+              >
+                <Check
+                  aria-hidden
+                  className={cn(
+                    "h-3 w-3 shrink-0",
+                    active ? "text-primary" : "text-transparent",
+                  )}
+                />
+                <span className="truncate">{choice.label}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/profile-model-picker.ts
+++ b/web/src/lib/profile-model-picker.ts
@@ -1,0 +1,23 @@
+export interface ProfileModelChoice {
+  provider: string;
+  model: string;
+  label: string;
+}
+
+export function profileModelKey(choice: ProfileModelChoice): string {
+  return `${choice.provider}\u0000${choice.model}`;
+}
+
+export function filterProfileModelChoices(
+  choices: readonly ProfileModelChoice[],
+  query: string,
+): ProfileModelChoice[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...choices];
+
+  return choices.filter((choice) =>
+    [choice.provider, choice.model, choice.label].some((value) =>
+      value.toLowerCase().includes(normalizedQuery),
+    ),
+  );
+}

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -28,6 +28,11 @@ import { api } from "@/lib/api";
 import type { ActiveProfileInfo, ProfileInfo } from "@/lib/api";
 import { copyTextToClipboard } from "@/lib/clipboard";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
+import { ProfileModelPicker } from "@/components/ProfileModelPicker";
+import {
+  profileModelKey,
+  type ProfileModelChoice,
+} from "@/lib/profile-model-picker";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
@@ -303,7 +308,6 @@ export default function ProfilesPage() {
         p.modelNone ?? "No authenticated providers — set a key first",
       editModel: p.editModel ?? "Change model",
       modelSaved: p.modelSaved ?? "Model updated",
-      modelSelect: p.modelSelect ?? "Select a model",
       actions: p.actions ?? "Actions",
       manageSkills: p.manageSkills ?? "Manage skills & tools",
       activeSetHint:
@@ -322,9 +326,9 @@ export default function ProfilesPage() {
   const [creating, setCreating] = useState(false);
   // Model picker (lazy-loaded the first time a picker is opened). modelChoice
   // is a "slug\u0000model" key, or "" to inherit from clone/default.
-  const [modelChoices, setModelChoices] = useState<
-    { provider: string; model: string; label: string }[] | null
-  >(null);
+  const [modelChoices, setModelChoices] = useState<ProfileModelChoice[] | null>(
+    null,
+  );
   const modelChoicesLoading = useRef(false);
   const [modelChoice, setModelChoice] = useState("");
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
@@ -375,7 +379,7 @@ export default function ProfilesPage() {
     api
       .getModelOptions()
       .then((res) => {
-        const flat: { provider: string; model: string; label: string }[] = [];
+        const flat: ProfileModelChoice[] = [];
         for (const prov of res.providers ?? []) {
           for (const m of prov.models ?? []) {
             flat.push({
@@ -898,29 +902,15 @@ export default function ProfilesPage() {
               <div className="grid gap-2">
                 <Label htmlFor="profile-model">{L.modelOptional}</Label>
 
-                <Select
-                  id="profile-model"
-                  value={modelChoice}
-                  disabled={modelChoices === null}
-                  onValueChange={setModelChoice}
-                >
-                  <SelectOption value="">
-                    {modelChoices === null ? L.modelLoading : L.modelInherit}
-                  </SelectOption>
-
-                  {(modelChoices ?? []).map((c) => (
-                    <SelectOption
-                      key={`${c.provider}\u0000${c.model}`}
-                      value={`${c.provider}\u0000${c.model}`}
-                    >
-                      {c.label}
-                    </SelectOption>
-                  ))}
-                </Select>
-
-                {modelChoices !== null && modelChoices.length === 0 && (
-                  <p className="text-xs text-muted-foreground">{L.modelNone}</p>
-                )}
+                <ProfileModelPicker
+                  choices={modelChoices}
+                  emptyLabel={L.modelNone}
+                  inheritLabel={L.modelInherit}
+                  loadingLabel={L.modelLoading}
+                  searchInputId="profile-model"
+                  selected={modelChoice}
+                  onSelect={setModelChoice}
+                />
               </div>
 
               <fieldset className="grid gap-3 border-t border-border pt-4">
@@ -1273,48 +1263,35 @@ export default function ProfilesPage() {
                 editorKind === "soul" && "min-h-0 overflow-y-auto",
               )}
             >
-              {editorKind === "model" &&
-                (modelChoices !== null && modelChoices.length === 0 ? (
-                  <p className="text-xs text-muted-foreground">{L.modelNone}</p>
-                ) : (
-                  <>
-                    <Select
-                      value={modelEditChoice}
-                      disabled={modelChoices === null}
-                      placeholder={
-                        modelChoices === null ? L.modelLoading : L.modelSelect
-                      }
-                      onValueChange={setModelEditChoice}
-                    >
-                      {(modelChoices ?? []).map((c) => (
-                        <SelectOption
-                          key={`${c.provider}\u0000${c.model}`}
-                          value={`${c.provider}\u0000${c.model}`}
-                        >
-                          {c.label}
-                        </SelectOption>
-                      ))}
-                    </Select>
+              {editorKind === "model" && (
+                <>
+                  <ProfileModelPicker
+                    choices={modelChoices}
+                    emptyLabel={L.modelNone}
+                    loadingLabel={L.modelLoading}
+                    searchInputId="profile-model-editor"
+                    selected={modelEditChoice}
+                    onSelect={setModelEditChoice}
+                  />
 
-                    <div className="flex justify-end">
-                      <Button
-                        size="sm"
-                        className="uppercase"
-                        onClick={() => handleSaveModel(editorName)}
-                        disabled={
-                          modelSaving ||
-                          !modelChoices?.some(
-                            (c) =>
-                              `${c.provider}\u0000${c.model}` ===
-                              modelEditChoice,
-                          )
-                        }
-                      >
-                        {modelSaving ? t.common.saving : t.common.save}
-                      </Button>
-                    </div>
-                  </>
-                ))}
+                  <div className="flex justify-end">
+                    <Button
+                      size="sm"
+                      className="uppercase"
+                      onClick={() => handleSaveModel(editorName)}
+                      disabled={
+                        modelSaving ||
+                        !modelChoices?.some(
+                          (choice) =>
+                            profileModelKey(choice) === modelEditChoice,
+                        )
+                      }
+                    >
+                      {modelSaving ? t.common.saving : t.common.save}
+                    </Button>
+                  </div>
+                </>
+              )}
 
               {editorKind === "desc" && (
                 <>


### PR DESCRIPTION
## Problem

When users configure both a Nous Portal/Nous subscription and an OpenAI Codex subscription, the combined model catalog makes the Profiles model dropdown difficult to use. The non-searchable picker is constrained enough that it can appear not to expose the full catalog, including models such as DeepSeek V4 Pro.

Fixes #40963

## Example

Before

https://github.com/user-attachments/assets/c953745b-758f-4451-b514-1c5f7900f177

After

https://github.com/user-attachments/assets/b8fedb09-9721-4dee-90ac-d3fcdd0c9146


## Solution

- Replace the Profiles **Change model** dropdown with a searchable, scrollable inline picker.
- Use the same picker in the quick **Create profile** flow so the sibling catalog surface does not retain the same usability bug.
- Match provider slug, model ID, and rendered label case-insensitively.
- Preserve loading, empty, inherited/default, selected, save/create, and modal reset behavior.
- Render every selectable row as a native `button type="button"` with `aria-pressed` selected state and visible keyboard focus styling. This incorporates @teknium1's accessibility feedback on #43987 rather than carrying forward its clickable-`div` implementation.

## Tests

- `npm run check --workspace web` — passed (typecheck, 37 test files / 283 tests, lint with 26 pre-existing warnings and no errors)
- `npm run build --workspace web` — passed
- `npx eslint web/src/components/ProfileModelPicker.tsx web/src/components/ProfileModelPicker.test.tsx web/src/lib/profile-model-picker.ts web/src/pages/ProfilesPage.tsx --quiet` — passed
- Regression test covers case-insensitive provider/model/label matching, scroll containment, selected state, and native button rows. It was verified to fail when provider matching and `type="button"` were removed, then pass with the fix restored.

## Prior work

This is a current-main replacement for the stale #43987. It carries forward that PR's searchable-list direction while addressing the accessibility review feedback and covering both Profiles creation and editing flows.
