### PR TITLE
fix(lsp): terminate language-server process groups

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -205,6 +206,7 @@ class LSPClient:
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
+        self._process_group_id: Optional[int] = None
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
         self._cleanup_lock = asyncio.Lock()
@@ -338,6 +340,8 @@ class LSPClient:
                 start_new_session=True,
                 creationflags=creationflags,
             )
+            if sys.platform != "win32":
+                self._process_group_id = self._proc.pid
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
@@ -518,8 +522,13 @@ class LSPClient:
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
             proc = self._proc
+            process_group_id = self._process_group_id
             self._proc = None
+            self._process_group_id = None
             if proc is None:
+                return
+            if process_group_id is not None:
+                await self._cleanup_process_group(proc, process_group_id)
                 return
             if proc.returncode is None:
                 try:
@@ -532,6 +541,50 @@ class LSPClient:
                             await proc.wait()
                         except ProcessLookupError:
                             pass
+                except ProcessLookupError:
+                    pass
+
+    @staticmethod
+    def _process_group_exists(process_group_id: int) -> bool:
+        try:
+            os.killpg(process_group_id, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    async def _cleanup_process_group(
+        self,
+        proc: asyncio.subprocess.Process,
+        process_group_id: int,
+    ) -> None:
+        """Terminate the isolated LSP process group, including descendants."""
+        try:
+            os.killpg(process_group_id, signal.SIGTERM)
+        except ProcessLookupError:
+            if proc.returncode is None:
+                await proc.wait()
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + SHUTDOWN_GRACE
+        while self._process_group_exists(process_group_id) and loop.time() < deadline:
+            await asyncio.sleep(0.05)
+
+        if self._process_group_exists(process_group_id):
+            try:
+                os.killpg(process_group_id, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        if proc.returncode is None:
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.wait()
                 except ProcessLookupError:
                     pass
 

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -29,6 +29,10 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   process and stdin alive.
 - ``"malformed_frame"`` — writes an invalid frame after ``didOpen``,
   then keeps the process and stdin alive.
+- ``"process_tree_exit"`` — spawns a child that ignores SIGTERM, then
+  exits normally when the client sends the LSP exit notification.
+- ``"process_tree_hang"`` — spawns the same child but keeps the leader
+  alive after the exit notification.
 
 The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
@@ -38,6 +42,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -68,6 +73,25 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    if script.startswith("process_tree_"):
+        child_pid_file = os.environ["MOCK_LSP_CHILD_PID_FILE"]
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import os, pathlib, signal, sys, time; "
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                    "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                    "time.sleep(300)"
+                ),
+                child_pid_file,
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
 
     while True:
         msg = read_message()
@@ -200,6 +224,8 @@ def main():
             continue
 
         if msg.get("method") == "exit":
+            if script == "process_tree_hang":
+                continue
             return 0
 
         # Unknown request: respond with method-not-found.

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import sys
 from pathlib import Path
 
@@ -90,6 +91,65 @@ async def test_reader_exit_at_end_of_initialization_retires_client(tmp_path: Pat
     assert not client.is_running
     assert client._proc is None
     await client.shutdown()
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except FileNotFoundError:
+        return False
+    return stat.split()[2] != "Z"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group behavior")
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.asyncio
+@pytest.mark.parametrize("script", ["process_tree_exit", "process_tree_hang"])
+async def test_client_shutdown_kills_process_group_descendants(tmp_path: Path, script: str):
+    """A worker must not survive whether the LSP leader exits or hangs."""
+    child_pid_file = tmp_path / "child.pid"
+    client = LSPClient(
+        server_id="mock-process-tree",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        env={
+            "MOCK_LSP_SCRIPT": script,
+            "MOCK_LSP_CHILD_PID_FILE": str(child_pid_file),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        },
+        cwd=str(tmp_path),
+    )
+    await client.start()
+    assert client._proc is not None
+    leader_pid = client._proc.pid
+    child_pid: int | None = None
+    child_survived = True
+    try:
+        deadline = asyncio.get_running_loop().time() + 3.0
+        while not child_pid_file.exists() and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.02)
+        assert child_pid_file.exists(), "mock LSP child did not start"
+        child_pid = int(child_pid_file.read_text())
+
+        await client.shutdown()
+        deadline = asyncio.get_running_loop().time() + 3.0
+        while _pid_is_alive(child_pid) and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.02)
+        child_survived = _pid_is_alive(child_pid)
+    finally:
+        if child_pid is not None and _pid_is_alive(child_pid):
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        if client.is_running:
+            await client.shutdown()
+        try:
+            os.killpg(leader_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    assert not child_survived, "LSP child survived process-group cleanup"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug Description

An LSP server can spawn worker processes that survive after the server leader exits. Hermes currently terminates only the leader PID during cleanup, so descendants can retain deleted working directories and continue consuming memory.

## Root Cause

LSP servers already start in an isolated POSIX session, but `LSPClient` does not retain that process-group ID. `_cleanup_process()` signals only `self._proc`, and returns immediately when the leader has already exited.

## Fix

- Track the isolated POSIX process-group ID when the server starts.
- Send `SIGTERM` to the full process group during cleanup.
- Wait one shared grace period, then send `SIGKILL` if any group member remains.
- Preserve the existing single-process cleanup path on Windows.
- Add regression coverage for both important cases:
  - the leader exits normally while a worker ignores `SIGTERM`;
  - the leader remains alive while a worker ignores `SIGTERM`.

This is the focused descendant-cleanup portion discussed in closed PR #62995. The idle reaper from #74058 does not remove descendants after the leader exits.

## How to Verify

1. Start the mock LSP in its isolated process group.
2. Let it spawn a worker that ignores `SIGTERM`.
3. Test both a cleanly exiting leader and a hanging leader.
4. Shut down the client.
5. Confirm the worker no longer exists.

## Test Plan

- [x] Added live process-tree regression tests
- [x] Existing LSP tests pass
- [x] Ruff and diff checks pass
- [x] Confirmed no mock LSP process remains after tests

Verification:

```text
scripts/run_tests.sh tests/agent/lsp
68 passed, 1 skipped
```

## Risk Assessment

Medium. This changes POSIX process termination from one PID to the isolated LSP process group. `start_new_session=True` already guarantees the group is separate from Hermes. Windows retains the existing cleanup path.
