### PR TITLE
fix(scripts): fall back to the invoking Python when no pytest venv is found

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,8 @@
 #   * Env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running pytest outside our
 #     conftest path — e.g. on a single file)
-#   * Proper venv activation (probes .venv, venv, then ~/.hermes/...)
+#   * Python selection: pytest-capable local/shared venv, HERMES_PYTHON,
+#     then the invoking `python` command from PATH
 #
 # Usage:
 #   scripts/run_tests.sh                            # full suite
@@ -80,6 +81,8 @@ if [ -n "$SKIPPED_VENVS" ]; then
   done
 fi
 
+PATH_PYTHON="$(command -v python 2>/dev/null || true)"
+
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
 elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
@@ -88,13 +91,29 @@ elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
   # venv (no pytest) when inherited from a wrapped `hermes` binary rather
   # than the devShell hook.
   PYTHON="$HERMES_PYTHON"
-  echo "▶ no local venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
+  echo "▶ no local venv — using configured HERMES_PYTHON: $PYTHON"
+elif [ -n "$PATH_PYTHON" ] && "$PATH_PYTHON" -c 'import pytest' 2>/dev/null; then
+  # The active Hermes worker/runtime interpreter is generated and its path is
+  # intentionally not stable. Resolve the `python` command the caller actually
+  # invoked instead of growing another hardcoded installation-path list.
+  PYTHON="$("$PATH_PYTHON" -c 'import sys; print(sys.executable)')"
+  echo "▶ no configured pytest venv matched — using invoking Python from PATH: $PYTHON"
 else
-  echo "error: no virtualenv with pytest found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
-  echo "       and HERMES_PYTHON is not a python with pytest (enter the Nix devShell or create a venv)" >&2
+  echo "error: no Python interpreter with pytest was found." >&2
+  echo "       Probed virtualenvs:" >&2
+  echo "         $REPO_ROOT/.venv" >&2
+  echo "         $REPO_ROOT/venv" >&2
+  echo "         $HOME/.hermes/hermes-agent/venv" >&2
+  echo "       Probed HERMES_PYTHON: ${HERMES_PYTHON:-<unset>}" >&2
+  echo "       Probed invoking Python from PATH: ${PATH_PYTHON:-<not found>}" >&2
   if [ -n "$SKIPPED_VENVS" ]; then
-    echo "       (skipped for missing pytest:$SKIPPED_VENVS — install dev extras there, or create $REPO_ROOT/.venv)" >&2
+    echo "       Existing venvs skipped because pytest was not importable:$SKIPPED_VENVS" >&2
   fi
+  echo "       Direct equivalent (requires pytest in that interpreter):" >&2
+  printf '         %s -m pytest' "${PATH_PYTHON:-python}" >&2
+  printf ' %q' "$@" >&2
+  printf '\n' >&2
+  echo "       Select a Python that can import pytest or set HERMES_PYTHON to one." >&2
   exit 1
 fi
 

--- a/tests/test_run_tests_shell.py
+++ b/tests/test_run_tests_shell.py
@@ -1,0 +1,115 @@
+"""Behavioral tests for the canonical shell test runner."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _isolated_runner_repo(tmp_path: Path) -> Path:
+    """Copy the executable runner into a repo with no virtualenv."""
+    source_root = Path(__file__).resolve().parent.parent
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(source_root / "scripts" / "run_tests.sh", scripts / "run_tests.sh")
+    (scripts / "run_tests_parallel.py").write_text(
+        "import pytest, sys\n"
+        "print(f'RUNNER_PYTHON={sys.executable}')\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return repo
+
+
+def test_shell_runner_falls_back_to_python_on_path(tmp_path: Path) -> None:
+    """A checkout without a configured venv uses the invoking Python command."""
+    bash = shutil.which("bash")
+    python = shutil.which("python")
+    assert bash is not None, "run_tests.sh requires bash"
+    assert python is not None, "test requires the invoking python command"
+
+    expected = subprocess.run(
+        [python, "-c", "import sys; print(sys.executable)"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ).stdout.strip()
+    repo = _isolated_runner_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.pop("HERMES_PYTHON", None)
+
+    proc = subprocess.run(
+        [bash, str(repo / "scripts" / "run_tests.sh")],
+        cwd=repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, proc.stdout
+    assert "using invoking Python from PATH" in proc.stdout
+    runner_python = next(
+        line.removeprefix("RUNNER_PYTHON=")
+        for line in proc.stdout.splitlines()
+        if line.startswith("RUNNER_PYTHON=")
+    )
+    assert os.path.normcase(runner_python) == os.path.normcase(expected)
+
+
+def test_shell_runner_failure_lists_every_probe_and_direct_command(
+    tmp_path: Path,
+) -> None:
+    """A missing pytest interpreter reports evidence and a direct equivalent."""
+    bash = shutil.which("bash")
+    assert bash is not None, "run_tests.sh requires bash"
+
+    repo = _isolated_runner_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = "/usr/bin"
+    env["HERMES_PYTHON"] = "/usr/bin/false"
+
+    proc = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "run_tests.sh"),
+            "tests/test_example.py",
+            "-q",
+        ],
+        cwd=repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+    assert proc.returncode == 1, proc.stdout
+    assert "no Python interpreter with pytest was found" in proc.stdout
+    assert "Probed virtualenvs:" in proc.stdout
+    rendered = proc.stdout.replace("\\", "/")
+    assert "/repo/.venv" in rendered
+    assert "/repo/venv" in rendered
+    assert "/home/.hermes/hermes-agent/venv" in rendered
+    assert "Probed HERMES_PYTHON: /usr/bin/false" in proc.stdout
+    assert "Probed invoking Python from PATH: <not found>" in proc.stdout
+    assert "python -m pytest tests/test_example.py -q" in proc.stdout


### PR DESCRIPTION
`scripts/run_tests.sh` refuses to start unless it finds pytest in `.venv`, `venv`, or `HERMES_PYTHON`. On setups where the interpreter lives somewhere else — a generated runtime path, a system install, a conda env — the runner fails even though `python -m pytest` works fine in that same shell.

This adds one fallback after the existing probes: resolve the `python` command from PATH and use it if it can import pytest. Existing precedence is unchanged — local venv, then `HERMES_PYTHON`, then this.

The failure message now lists every location that was probed and prints the direct `python -m pytest` equivalent. The previous wording ("no virtualenv with pytest found") reads as "pytest is unavailable", which sends people looking for a missing dependency rather than a path mismatch.

## Verification

On current `main`, same invocation, same shell:

**Before**
```
error: no virtualenv with pytest found in <repo>/.venv or <repo>/venv,
```

**After**
```
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) ===
```

Adds `tests/test_run_tests_shell.py` covering both the fallback selection and the diagnostic output.

## Notes

- No existing behaviour is removed; this is purely an added fallback plus a clearer error.
- Developed and verified on Windows. The change is shell-level and should be platform-neutral, but a Linux/macOS check from a maintainer would be worthwhile.
- Happy to adjust naming, message wording, or test placement to match your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
