### PR TITLE
fix(mcp): keep HTTP servers working with GNOME SOCKS proxies

### DIFF
--- a/tests/tools/test_mcp_proxy_env.py
+++ b/tests/tools/test_mcp_proxy_env.py
@@ -1,0 +1,64 @@
+"""MCP HTTP transports normalize environment proxy aliases before use."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def _set_bare_socks_proxy_env(monkeypatch, key: str) -> None:
+    for env_key in (
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "ALL_PROXY",
+        "https_proxy",
+        "http_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv(key, "SOCKS://127.0.0.1:10808")
+    monkeypatch.setenv("NO_PROXY", "example.com")
+
+
+@pytest.mark.parametrize("proxy_key", ["ALL_PROXY", "all_proxy"])
+def test_http_proxy_aliases_are_normalized_before_preflight(monkeypatch, proxy_key):
+    from tools.mcp_tool import MCPServerTask, NonMcpEndpointError
+
+    _set_bare_socks_proxy_env(monkeypatch, proxy_key)
+    server = MCPServerTask("remote")
+
+    async def _capture_preflight(self, *args, **kwargs):
+        import os
+
+        assert os.environ[proxy_key] == "socks5://127.0.0.1:10808"
+        assert os.environ["NO_PROXY"] == "example.com"
+        raise NonMcpEndpointError("stop after proxy assertion")
+
+    monkeypatch.setattr(MCPServerTask, "_preflight_content_type", _capture_preflight)
+
+    asyncio.run(server.run({"url": "https://example.com/mcp"}))
+
+
+@pytest.mark.parametrize("proxy_key", ["ALL_PROXY", "all_proxy"])
+def test_http_proxy_aliases_are_normalized_when_preflight_is_skipped(
+    monkeypatch, proxy_key
+):
+    from tools.mcp_tool import MCPServerTask
+
+    _set_bare_socks_proxy_env(monkeypatch, proxy_key)
+    server = MCPServerTask("remote")
+    seen: dict[str, str] = {}
+
+    async def _capture_transport(self, config):
+        import os
+
+        seen["proxy"] = os.environ[proxy_key]
+        server._shutdown_event.set()
+        return "shutdown"
+
+    monkeypatch.setattr(MCPServerTask, "_run_http", _capture_transport)
+
+    asyncio.run(server.run({"url": "https://example.com/mcp", "skip_preflight": True}))
+
+    assert seen == {"proxy": "socks5://127.0.0.1:10808"}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -119,6 +119,7 @@ from urllib.parse import urlparse
 
 from tools.registry import tool_error
 from tools.ansi_strip import strip_unicode_tags
+from utils import normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
 
@@ -3947,6 +3948,12 @@ class MCPServerTask:
         # critically, no reconnect-backoff burn.  (Ported from
         # anomalyco/opencode#25019.)
         if self._is_http():
+            # GNOME manual SOCKS proxy settings commonly export the bare
+            # ``socks://`` alias. httpx/httpx2 validate environment proxies
+            # before applying NO_PROXY and accept only the explicit
+            # ``socks5://`` scheme, so normalize before either the preflight
+            # client or the MCP transport constructs an HTTP client.
+            normalize_proxy_env_vars()
             try:
                 _validate_remote_mcp_url(self.name, config.get("url"))
             except InvalidMcpUrlError as exc:


### PR DESCRIPTION
## What does this PR do?

HTTP and SSE MCP servers no longer fail during client construction when GNOME exports a manual SOCKS proxy as `socks://...`. MCP now applies Hermes' existing proxy URL normalization before either the content-type preflight or transport client reads environment proxies.

### Symptom

With `ALL_PROXY=socks://127.0.0.1:10808`, MCP connection startup raises `ValueError: Unknown scheme for proxy URL URL('socks://127.0.0.1:10808')`, even when `NO_PROXY` matches the target.

### Impact

Users in environments that export the bare SOCKS alias cannot connect to any HTTP or SSE MCP server until another subsystem happens to normalize the process environment.

### Bug Cause

**Trigger:** `tools/mcp_tool.py:3949` / `MCPServerTask.run()` handling an HTTP MCP configuration while a proxy environment variable uses `socks://`.

**Causal chain:**
1. GNOME exports a manual SOCKS proxy using the bare `socks://` alias.
2. MCP constructs an environment-aware httpx/httpx2 client without invoking the shared proxy normalizer.
3. httpx validates every environment proxy before applying `NO_PROXY`, rejects the alias, and aborts MCP startup.

**Why it is wrong:** Hermes already canonicalizes this supported alias to `socks5://`, but MCP had an independent HTTP lifecycle that skipped that normalization.

**Working sibling / contrast:** Agent and auxiliary HTTP client paths already invoke `utils.normalize_proxy_env_vars()` before client construction.

**Ruled out:** `NO_PROXY` matching is not the cause; direct construction with a matching target still fails while eagerly parsing the invalid proxy scheme.

### Fix

Invoke the shared proxy environment normalizer once at the start of the MCP HTTP lifecycle, before both preflight and transport client construction. Regression tests cover preflight-enabled and preflight-skipped paths plus uppercase and lowercase proxy environment keys.

## Related Issue

Closes #95042

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - normalize supported proxy aliases before any MCP HTTP client is constructed.
- `tests/tools/test_mcp_proxy_env.py` - verify normalization ordering for preflight and direct transport paths.

## How to Test

1. Export `ALL_PROXY=socks://127.0.0.1:10808` and set `NO_PROXY` to the MCP target host.
2. Construct the MCP HTTP lifecycle and verify the proxy environment is canonicalized before preflight and transport setup.
3. Run the targeted regression suite:

```bash
scripts/run_tests.sh tests/tools/test_mcp_proxy_env.py tests/tools/test_mcp_streamable_http_arity.py tests/tools/test_mcp_sse_transport.py tests/tools/test_mcp_preflight_content_type.py -q
```

Result: 28 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 with the project's httpx and httpx2 dependencies

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; this restores existing proxy compatibility
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; normalization covers case variants and existing Linux/Windows environment behavior
- [x] Tool description/schema updates are N/A; no model-facing tool contract changed

## Screenshots / Logs

N/A; the automated regression suite exercises the failure boundary and both MCP HTTP startup paths.
