### PR TITLE
fix(tools): availability-gated tools appear when their credential/daemon does (salvage #92693, part 2)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -376,9 +376,9 @@ def _tool_search_scoped_names(agent) -> frozenset:
     set: the deferrable subset of the session's own enabled/disabled toolset
     scope.
 
-    Result is cached on the agent and refreshed when the tool registry's
-    generation changes (e.g. an MCP server reconnects), so the common case is
-    a dict lookup, not a full tool-defs rebuild on every tool call.
+    Result is cached on the agent and refreshed when the registry generation,
+    availability snapshot, or config fingerprint changes, so the common case
+    is a dict lookup, not a full tool-defs rebuild on every tool call.
     """
     try:
         import model_tools
@@ -389,11 +389,31 @@ def _tool_search_scoped_names(agent) -> frozenset:
 
     enabled = getattr(agent, "enabled_toolsets", None)
     disabled = getattr(agent, "disabled_toolsets", None)
+    try:
+        from hermes_cli.config import get_config_path
+
+        cfg_stat = get_config_path().stat()
+        cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
+    except (FileNotFoundError, OSError, ImportError):
+        cfg_fp = None
+    try:
+        # Same staleness class as get_tool_definitions' memo: the generation
+        # only moves on registry MUTATIONS, but a check_fn verdict can flip
+        # without one (credential lands, daemon starts). Without the verdict
+        # snapshot in this key, the unwrap kept rejecting a tool the bridge
+        # could already discover — or kept admitting one whose availability
+        # probe had gone false. The snapshot is memoized in the registry, so
+        # the common case stays a dict lookup.
+        verdicts = _registry.check_fn_verdict_snapshot()
+    except Exception:
+        verdicts = ()
     cache_key = (
         _registry.current_scope_key(),
         getattr(_registry, "_generation", 0),
         frozenset(enabled) if enabled is not None else None,
         frozenset(disabled) if disabled is not None else None,
+        cfg_fp,
+        verdicts,
     )
     cached = getattr(agent, "_tool_search_scope_cache", None)
     if cached is not None and cached[0] == cache_key:
@@ -409,7 +429,13 @@ def _tool_search_scoped_names(agent) -> frozenset:
     except Exception:
         names = frozenset()
     try:
-        agent._tool_search_scope_cache = (cache_key, names)
+        # TOCTOU guard (same as get_tool_definitions' memo): the verdicts in
+        # cache_key were snapshotted BEFORE the rebuild above. If a verdict
+        # flipped during it, `names` reflects the new state but the key
+        # carries the old — storing would poison the old key. Skip the store;
+        # the next call re-keys coherently.
+        if _registry.check_fn_verdict_snapshot() == verdicts:
+            agent._tool_search_scope_cache = (cache_key, names)
     except Exception:
         pass
     return names

--- a/model_tools.py
+++ b/model_tools.py
@@ -297,9 +297,11 @@ _LEGACY_TOOLSET_MAP = {
 # because quiet_mode=False has stdout side effects (tool-selection prints).
 #
 # Invalidation happens transparently via the registry's _generation counter,
-# which bumps on register() / deregister() / register_toolset_alias(). The
-# inner check_fn TTL cache in registry.py handles environment drift (Docker
-# daemon start/stop, env var changes, etc.) on a 30 s horizon.
+# which bumps on register() / deregister() / register_toolset_alias(), plus a
+# Short-TTL aggregate snapshot of every cached check_fn verdict in the cache
+# key. The snapshot lets external availability drift propagate through THIS
+# cache on the combined probe/snapshot TTL horizon — the generation counter
+# alone never re-probes on a hit.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 _tool_defs_cache_lock = threading.Lock()
 
@@ -353,6 +355,8 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
+    verdict_snapshot: tuple = ()
+    key_generation: int = -1
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -363,17 +367,37 @@ def get_tool_definitions(
             cfg_fp = None
         profile_scope = check_fn_cache_scope()
         if profile_scope != CHECK_FN_CACHE_BYPASS:
+            # check_fn verdicts: the registry generation only captures
+            # registry MUTATIONS. An availability probe can flip without
+            # one (Docker daemon starts, credential lands, OAuth login),
+            # and before this key member a memo hit skipped probing
+            # entirely — the tool list stayed stale for the process
+            # lifetime. The aggregate is TTL-cached, so hits cost one lookup; a flip
+            # changes the tuple and forces a recompute within ~35 s worst case.
+            # Held in a named local (not just a key slot) because the
+            # TOCTOU guard below re-checks it after compute.
+            verdict_snapshot = registry.check_fn_verdict_snapshot()
+            key_generation = registry._generation
+            if verdict_snapshot != registry.check_fn_verdict_snapshot():
+                # Probes executed by the first snapshot can lazily import
+                # and register tools, bumping the generation — the first
+                # snapshot then describes a registry state older than the
+                # key's. Re-take once so key_generation and the snapshot
+                # agree; the second pass runs no new registrations.
+                key_generation = registry._generation
+                verdict_snapshot = registry.check_fn_verdict_snapshot()
             cache_key = (
                 registry.current_scope_key(),
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
                 frozenset(disabled_toolsets) if disabled_toolsets else None,
-                registry._generation,
+                key_generation,
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
                 bool(skip_tool_search_assembly),
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                verdict_snapshot,
             )
         with _tool_defs_cache_lock:
             cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
@@ -389,6 +413,22 @@ def get_tool_definitions(
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
     if quiet_mode and cache_key is not None:
+        # TOCTOU guard: the verdict snapshot in cache_key was taken BEFORE
+        # compute. If a verdict flipped (and the snapshot cache was
+        # invalidated) while compute ran — with NO registry mutation — the
+        # result reflects the NEW verdicts but cache_key carries the OLD
+        # ones; caching would poison the old key (flip back later and the
+        # memo serves this mismatched list). Skip caching in that case.
+        # When the GENERATION moved during compute (first call in a process
+        # triggers lazy tool registration), the old key can never be looked
+        # up again, so caching under it is harmless — and skipping would
+        # leave the first call permanently uncached. (cache_key is not None
+        # implies verdict_snapshot was bound above.)
+        if (
+            registry._generation == key_generation
+            and verdict_snapshot != registry.check_fn_verdict_snapshot()
+        ):
+            return list(result)
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a

--- a/tests/tools/test_availability_cache_staleness.py
+++ b/tests/tools/test_availability_cache_staleness.py
@@ -1,0 +1,274 @@
+"""Availability-cache staleness: behavior regression suite.
+
+Pins the fix for the ``check_fn`` staleness class: a verdict flip
+(credential appears, Docker daemon starts, OAuth login lands) never
+invalidated the ``get_tool_definitions`` memo or the executor's
+bridge-scope cache — the stale tool list survived until an unrelated
+registry mutation. Both cache sites now key on an aggregate TTL-cached
+snapshot of every probe's verdict, with a TOCTOU re-check before store.
+
+Tests assert at public seams (``get_tool_definitions`` output, scope-cache
+behavior), not private implementation details.
+"""
+
+import json
+from types import SimpleNamespace
+
+
+def _td(name, desc="", params=None, required=None):
+    parameters = {"type": "object", "properties": params or {}}
+    if required:
+        parameters["required"] = required
+    return {
+        "type": "function",
+        "function": {"name": name, "description": desc, "parameters": parameters},
+    }
+
+
+class TestCheckFnFlipBustsToolDefsMemo:
+    """Fix 5: an availability flip propagates without a registry mutation."""
+
+    def test_verdict_flip_changes_tool_definitions(self, monkeypatch):
+        import model_tools
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        available = {"value": False}
+
+        def _flip_check():
+            return available["value"]
+
+        registry.register(
+            name="flip_gated_tool",
+            toolset="fliptest",
+            schema=_td("flip_gated_tool", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_flip_check,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            # skip_tool_search_assembly: assert on the raw exposed list —
+            # deferral would otherwise (correctly) fold a plugin tool into
+            # the bridge and hide the name we're asserting on. The memo
+            # path under test is identical for both shapes.
+            names_before = {
+                t["function"]["name"]
+                for t in model_tools.get_tool_definitions(
+                    enabled_toolsets=["fliptest"], quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            }
+            assert "flip_gated_tool" not in names_before
+
+            # The flip: credential lands / daemon starts. No registry
+            # mutation. Config untouched. Same toolsets. The TTL cache is
+            # cleared the way `hermes tools enable` / config writers do.
+            available["value"] = True
+            invalidate_check_fn_cache()
+
+            names_after = {
+                t["function"]["name"]
+                for t in model_tools.get_tool_definitions(
+                    enabled_toolsets=["fliptest"], quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            }
+            assert "flip_gated_tool" in names_after
+        finally:
+            registry.deregister("flip_gated_tool")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_scope_cache_observes_verdict_flip(self):
+        """Sibling site of the same staleness class: the executor's per-agent
+        deferred-scope cache must also observe an availability flip, or the
+        bridge unwrap keeps rejecting (or admitting) a tool whose probe
+        verdict changed with no registry mutation."""
+        from types import SimpleNamespace as NS
+
+        import model_tools
+        from agent.tool_executor import _tool_search_scoped_names
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        available = {"value": False}
+
+        registry.register(
+            name="mcp__scopeflip__gated",
+            toolset="mcp-scopeflip",
+            schema=_td("mcp__scopeflip__gated", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=lambda: available["value"],
+        )
+        agent = NS(enabled_toolsets=["mcp-scopeflip"], disabled_toolsets=None)
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            assert "mcp__scopeflip__gated" not in _tool_search_scoped_names(agent)
+
+            available["value"] = True
+            invalidate_check_fn_cache()
+
+            assert "mcp__scopeflip__gated" in _tool_search_scoped_names(agent)
+        finally:
+            registry.deregister("mcp__scopeflip__gated")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_scope_cache_observes_config_fingerprint(self, monkeypatch, tmp_path):
+        import model_tools
+        from agent.tool_executor import _tool_search_scoped_names
+        from tools.registry import (
+            _NO_CACHE_CHECK_FNS,
+            invalidate_check_fn_cache,
+            no_cache_check_fn,
+            registry,
+        )
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("off", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+
+        def _config_check():
+            return config_path.read_text(encoding="utf-8") == "enabled"
+
+        no_cache_check_fn(_config_check)
+        tool_name = "mcp__configscope__gated"
+        registry.register(
+            name=tool_name,
+            toolset="mcp-configscope",
+            schema=_td(tool_name, "Config-gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_config_check,
+        )
+        agent = SimpleNamespace(
+            enabled_toolsets=["mcp-configscope"],
+            disabled_toolsets=None,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+            # Warm-up: the first rebuild can lazily register tools, which
+            # flips the verdict snapshot mid-build and makes the TOCTOU
+            # guard skip the store. The second call stores deterministically.
+            _tool_search_scoped_names(agent)
+            assert tool_name not in _tool_search_scoped_names(agent)
+            cache_before = agent._tool_search_scope_cache
+            assert cache_before is not None
+
+            config_path.write_text("enabled", encoding="utf-8")
+            assert tool_name in _tool_search_scoped_names(agent)
+            # The config fingerprint is part of the cache key: a config write
+            # must re-key the scope cache, never serve the pre-write entry.
+            # Asserting the key change keeps this test red on a key that
+            # omits the fingerprint even when an unrelated cache miss makes
+            # the membership assert above pass by recomputation.
+            assert agent._tool_search_scope_cache[0] != cache_before[0]
+        finally:
+            registry.deregister(tool_name)
+            _NO_CACHE_CHECK_FNS.discard(_config_check)
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_snapshot_coalesces_grace_probe_and_invalidation(self, monkeypatch):
+        import tools.registry as registry_module
+        from tools.registry import ToolRegistry, invalidate_check_fn_cache
+
+        local_registry = ToolRegistry()
+        available = {"value": True}
+        probe_calls = {"n": 0}
+        clock = {"now": 1000.0}
+
+        def _probe():
+            probe_calls["n"] += 1
+            return available["value"]
+
+        monkeypatch.setattr(registry_module.time, "monotonic", lambda: clock["now"])
+        local_registry.register(
+            name="snapshot_gated_tool",
+            toolset="snapshottest",
+            schema=_td("snapshot_gated_tool", "Snapshot test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_probe,
+        )
+        try:
+            invalidate_check_fn_cache()
+            assert local_registry.check_fn_verdict_snapshot()[0][1] is True
+
+            available["value"] = False
+            clock["now"] += registry_module._CHECK_FN_TTL_SECONDS + 1
+            calls_before_grace = probe_calls["n"]
+            grace_snapshots = [
+                local_registry.check_fn_verdict_snapshot()
+                for _ in range(8)
+            ]
+
+            assert probe_calls["n"] - calls_before_grace == 1
+            assert all(snapshot == grace_snapshots[0] for snapshot in grace_snapshots)
+            assert grace_snapshots[0][0][1] is True
+
+            invalidate_check_fn_cache()
+            refreshed = local_registry.check_fn_verdict_snapshot()
+            assert probe_calls["n"] - calls_before_grace == 2
+            assert refreshed[0][1] is False
+        finally:
+            invalidate_check_fn_cache()
+
+    def test_memo_still_hits_within_ttl(self, monkeypatch):
+        """The fix must not disable memoization: with stable verdicts, repeat
+        calls must be served from cache (probes may run; compute must not).
+
+        A warmup call settles lazy registration first — the first compute
+        after registry churn registers dynamic tools itself, which bumps the
+        generation and changes the key. That warmup miss predates this fix;
+        what this test pins is that the verdict-snapshot key member does not
+        introduce PERPETUAL misses.
+        """
+        import model_tools
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        probe_calls = {"n": 0}
+
+        def _steady_check():
+            probe_calls["n"] += 1
+            return True
+
+        registry.register(
+            name="steady_gated_tool",
+            toolset="steadytest",
+            schema=_td("steady_gated_tool", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_steady_check,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            # Warmup: let lazy registration inside compute settle the
+            # generation, then once more to seed the settled key.
+            for _ in range(2):
+                model_tools.get_tool_definitions(
+                    enabled_toolsets=["steadytest"], quiet_mode=True)
+
+            compute_calls = {"n": 0}
+            real_compute = model_tools._compute_tool_definitions
+
+            def _counting_compute(*args, **kwargs):
+                compute_calls["n"] += 1
+                return real_compute(*args, **kwargs)
+
+            monkeypatch.setattr(model_tools, "_compute_tool_definitions", _counting_compute)
+
+            first = model_tools.get_tool_definitions(
+                enabled_toolsets=["steadytest"], quiet_mode=True)
+            second = model_tools.get_tool_definitions(
+                enabled_toolsets=["steadytest"], quiet_mode=True)
+
+            assert compute_calls["n"] == 0
+            assert [t["function"]["name"] for t in first] == \
+                   [t["function"]["name"] for t in second]
+        finally:
+            registry.deregister("steady_gated_tool")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -272,8 +272,11 @@ _CHECK_FN_TTL_SECONDS = 30.0
 # so a genuinely-down backend is reflected within a couple of turns.
 _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _CHECK_FN_CACHE_MAX = 512
+_VERDICT_SNAPSHOT_TTL_SECONDS = 5.0
 _check_fn_cache: Dict[tuple[Callable, Optional[str]], tuple[float, bool]] = {}
 _check_fn_last_good: Dict[tuple[Callable, Optional[str]], float] = {}
+_verdict_snapshot_cache: Dict[tuple, tuple[float, tuple]] = {}
+_verdict_snapshot_epoch = 0
 _check_fn_cache_lock = threading.Lock()
 CHECK_FN_CACHE_BYPASS = ""
 _NO_CACHE_CHECK_FNS: Set[Callable] = set()
@@ -298,6 +301,8 @@ def _prune_check_fn_caches(now: float) -> None:
             _check_fn_last_good.pop(key, None)
     while len(_check_fn_cache) >= _CHECK_FN_CACHE_MAX:
         _check_fn_cache.pop(next(iter(_check_fn_cache)))
+    # Same hard cap as _check_fn_cache: TTL pruning alone leaves last-good
+    # unbounded under high (fn, scope) churn inside one grace window.
     while len(_check_fn_last_good) >= _CHECK_FN_CACHE_MAX:
         _check_fn_last_good.pop(next(iter(_check_fn_last_good)))
 
@@ -418,11 +423,16 @@ def _check_fn_cached(fn: Callable) -> bool:
 
 
 def invalidate_check_fn_cache() -> None:
-    """Drop all cached ``check_fn`` results. Call after config changes that
-    affect tool availability (e.g. ``hermes tools enable``)."""
+    """Drop cached probes and aggregate verdict snapshots.
+
+    Call after config changes that affect tool availability.
+    """
+    global _verdict_snapshot_epoch
     with _check_fn_cache_lock:
         _check_fn_cache.clear()
         _check_fn_last_good.clear()
+        _verdict_snapshot_cache.clear()
+        _verdict_snapshot_epoch += 1
 
 
 def get_cached_check_fn_result(fn: Callable) -> Optional[bool]:
@@ -508,6 +518,67 @@ class ToolRegistry:
     def _snapshot_entries(self) -> List[ToolEntry]:
         """Return a stable snapshot of registered tool entries."""
         return self._snapshot_state()[0]
+
+    def check_fn_verdict_snapshot(self, scope: Optional[str] = None) -> tuple:
+        """Return a hashable snapshot of every availability probe's verdict.
+
+        Built for outer memo keys (``get_tool_definitions``' cache): the
+        registry generation captures registry *mutations*, but a ``check_fn``
+        verdict can flip without any mutation — a daemon starts, a credential
+        file appears, an OAuth login lands. Before this existed, an outer
+        memo keyed only on the generation served stale tool lists
+        indefinitely after such a flip, because nothing on the cache-hit
+        path ever re-probed.
+
+        Aggregate snapshots are cached briefly per registry and profile, so a
+        hot-path hit is one dictionary lookup. On a snapshot miss, each
+        distinct probe runs through :func:`_check_fn_cached`. A verdict flip
+        changes the tuple after the probe TTL plus the snapshot TTL (~35 s),
+        or immediately after :func:`invalidate_check_fn_cache`, which clears
+        both layers. Request-bound cache-bypass scopes are never aggregated.
+
+        Probes marked :func:`no_cache_check_fn` are skipped: they are local,
+        config-backed checks that execute UNCACHED on every call (some with
+        deliberate side effects, e.g. the memory tool's flag snapshot), and
+        their verdicts only change when config changes — which the outer
+        memo key already captures through the config-file fingerprint.
+        """
+        registry_scope = scope or self.current_scope_key()
+        probe_scope = check_fn_cache_scope()
+        cache_key = (self, registry_scope, probe_scope, self._generation)
+        now = time.monotonic()
+        snapshot_epoch = -1
+        if probe_scope != CHECK_FN_CACHE_BYPASS:
+            with _check_fn_cache_lock:
+                snapshot_epoch = _verdict_snapshot_epoch
+                cached = _verdict_snapshot_cache.get(cache_key)
+                if cached is not None and now - cached[0] < _VERDICT_SNAPSHOT_TTL_SECONDS:
+                    return cached[1]
+
+        entries, toolset_checks = self._snapshot_state(registry_scope)
+        fns: Dict[Callable, str] = {}
+        for entry in entries:
+            if entry.check_fn is not None and entry.check_fn not in fns:
+                fns[entry.check_fn] = getattr(
+                    entry.check_fn, "__qualname__", repr(entry.check_fn)
+                )
+        for fn in toolset_checks.values():
+            if fn is not None and fn not in fns:
+                fns[fn] = getattr(fn, "__qualname__", repr(fn))
+        verdicts = [
+            (label, id(fn), _check_fn_cached(fn))
+            for fn, label in fns.items()
+            if fn not in _NO_CACHE_CHECK_FNS
+        ]
+        verdicts.sort(key=lambda item: (item[0], item[1]))
+        snapshot = tuple((label, value) for label, _, value in verdicts)
+        if probe_scope != CHECK_FN_CACHE_BYPASS:
+            with _check_fn_cache_lock:
+                if snapshot_epoch == _verdict_snapshot_epoch:
+                    while len(_verdict_snapshot_cache) >= _CHECK_FN_CACHE_MAX:
+                        _verdict_snapshot_cache.pop(next(iter(_verdict_snapshot_cache)))
+                    _verdict_snapshot_cache[cache_key] = (time.monotonic(), snapshot)
+        return snapshot
 
     def _toolset_has_exposable_tools(
         self,


### PR DESCRIPTION
## Summary
Availability-gated tools (Docker-gated, credential-gated, OAuth-gated) now appear/disappear when their `check_fn` verdict actually flips, instead of the tool list staying stale for the process lifetime. Split out of #92693 as its own PR because it is the one fix in that set with a caching consequence worth reviewing separately: when the environment genuinely changes mid-conversation, the tool list changes with it — a one-time prompt-prefix bust for that conversation. Stable environments see zero change; the memo keeps hitting and the tool list stays byte-identical.

Root cause: both memo sites keyed on the registry `_generation` counter, which only moves on registry mutations — a `check_fn` verdict can flip (credential lands, daemon starts) without any mutation, so the memo kept serving the stale list forever.

Salvaged from #92693 by @alt-glitch, authorship preserved.

## Changes
- `tools/registry.py`: `check_fn_verdict_snapshot()` — aggregate snapshot of every cached probe verdict, with its own short-TTL memo (keyed on registry scope, probe scope, generation; cleared by `invalidate_check_fn_cache()`). Hot-path hit is one dict lookup; a flaky probe coalesces to at most one live re-probe per window.
- `model_tools.py`: `get_tool_definitions` memo key includes the verdict snapshot; TOCTOU guard re-checks the snapshot after compute and skips the store on mismatch (a flip mid-compute can't park a fresh result under a stale key); generation re-take handles probes that lazily register tools.
- `agent/tool_executor.py`: the executor's bridge-scope cache (which tools a session may reach through `tool_call`) gains the same snapshot + config-fingerprint key members and the same TOCTOU guard — the second site of the identical staleness class.
- `tests/tools/test_availability_cache_staleness.py`: 5 behavior-level tests (verdict flip changes tool definitions, scope cache observes flips and config changes, snapshot coalesces probes, memo still hits within TTL), red-verified in the original PR.

## Validation
| | Before | After |
|---|---|---|
| Credential lands mid-session | tool never appears until restart | appears within ~35s worst case (probe TTL + snapshot TTL), immediately on explicit invalidation |
| Stable environment | memo hits | memo hits (verdict tuple unchanged, key identical) |
| tests | — | 58 passed (`test_availability_cache_staleness.py`, `test_get_tool_definitions_cache_isolation.py`, `test_terminal_tool_requirements.py`, `test_mcp_reload_refreshes_cached_agents.py`, `test_tool_search.py`) |

## Infographic

![availability cache staleness fix](https://v3b.fal.media/files/b/0aa7cd94/Hqay1PTior4VyC5Zluc50_QcgzKkOE.png)
