### PR TITLE
fix(kanban): clear stale repeated crash streaks

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -40,6 +40,18 @@ import time
 # critical first so operators see the worst fires at the top.
 SEVERITY_ORDER = ("warning", "error", "critical")
 
+# A run that produced a deliberate board transition proves the worker spawned
+# and ran. Only infrastructure-level non-outcomes such as ``timed_out``,
+# ``spawn_failed``, and ``gave_up`` may be skipped without breaking a crash
+# streak. ``reclaimed`` is the equivalent explicit operator reset.
+_WORKER_RAN_OUTCOMES = frozenset({
+    "completed",
+    "reclaimed",
+    "blocked",
+    "review_requested",
+    "changes_requested",
+})
+
 
 def severity_at_or_above(severity: Optional[str], threshold: Optional[str]) -> bool:
     """Return True when ``severity`` meets or exceeds ``threshold``."""
@@ -698,13 +710,14 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
             consecutive += 1
             if last_err is None:
                 last_err = _task_field(r, "error")
-        elif outcome in {"completed", "reclaimed"}:
-            # A success (or manual reclaim) breaks the streak.
+        elif outcome in _WORKER_RAN_OUTCOMES:
+            # A deliberate lifecycle transition or reclaim proves this is no
+            # longer the same uninterrupted infrastructure crash streak.
             break
         else:
-            # Other outcomes (timed_out, blocked, spawn_failed, gave_up)
-            # aren't crash signals — don't count them, but they also
-            # don't break the crash streak.
+            # Infrastructure-level non-outcomes (timed_out, spawn_failed,
+            # gave_up) aren't crash signals, but they also don't prove the
+            # worker ran successfully enough to clear the crash streak.
             continue
     if consecutive < threshold:
         return []

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -101,6 +101,52 @@ def test_stuck_in_blocked_fires_past_threshold():
 
 
 
+def _repeated_crash_diagnostics(outcomes):
+    runs = [_run(outcome=outcome, run_id=index) for index, outcome in enumerate(outcomes, 1)]
+    return [
+        diagnostic
+        for diagnostic in kd.compute_task_diagnostics(_task(status="ready"), [], runs)
+        if diagnostic.kind == "repeated_crashes"
+    ]
+
+
+def test_repeated_crashes_clear_after_deliberate_worker_transitions():
+    outcomes = [
+        "crashed",
+        "blocked",
+        "crashed",
+        "crashed",
+        "changes_requested",
+        "review_requested",
+        "blocked",
+        "blocked",
+    ]
+
+    assert _repeated_crash_diagnostics(outcomes) == []
+
+
+def test_repeated_crashes_clear_after_review_handoff():
+    assert _repeated_crash_diagnostics(["crashed", "crashed", "review_requested"]) == []
+
+
+def test_repeated_crashes_clear_after_blocking_for_input():
+    assert _repeated_crash_diagnostics(["crashed", "crashed", "blocked"]) == []
+
+
+def test_repeated_crashes_skip_timeout_without_clearing_streak():
+    diagnostics = _repeated_crash_diagnostics(["crashed", "timed_out", "crashed"])
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].count == 2
+
+
+def test_repeated_crashes_still_fire_without_later_worker_transition():
+    diagnostics = _repeated_crash_diagnostics(["crashed", "crashed"])
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].count == 2
+
+
 def test_repeated_crashes_truncates_huge_tracebacks():
     """Full Python tracebacks can be tens of KB. The title stays one
     line (≤160 chars); the detail caps at 500 chars + ellipsis so the


### PR DESCRIPTION
## Summary
- break repeated-crash streaks when a worker deliberately blocks, requests review, or requests changes
- keep infrastructure non-outcomes such as timeouts neutral so real crash loops remain detectable
- add regressions for the live sequence and preserved crash-loop behavior

## Test plan
- `python -m pytest tests/hermes_cli/test_kanban_diagnostics.py -q`
- `python -m ruff check hermes_cli/kanban_diagnostics.py tests/hermes_cli/test_kanban_diagnostics.py`
- `git diff --check`