### PR TITLE
feat(kanban): global union-based fair ticket selection in dispatcher tick

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1452,16 +1452,15 @@ class GatewayKanbanWatchersMixin:
                 or "database disk image is malformed" in msg
             )
 
-        def _tick_once_for_board(slug: str) -> "Optional[object]":
-            """Run one dispatch_once for a specific board.
+        def _board_quarantined(slug: str) -> bool:
+            """True while the board DB stays quarantined as corrupt.
 
-            Runs in a worker thread via `asyncio.to_thread`. `board=slug`
-            is passed through `dispatch_once` so `resolve_workspace` and
-            `_default_spawn` see the right paths. The per-board DB is
-            opened explicitly so concurrent boards never share a
-            connection handle or accidentally claim across each other.
+            Fingerprint + timer bookkeeping shared by BOTH dispatch paths
+            (legacy single-board loop and the global union pass): an entry
+            blocks dispatch until the file changes, the gateway restarts,
+            or CORRUPT_BOARD_RETRY_AFTER_SECONDS elapses. Expired/changed
+            entries are popped here so the next attempt retries the board.
             """
-            conn = None
             fingerprint = _board_db_fingerprint(slug)
             disabled_entry = disabled_corrupt_boards.get(slug)
             if disabled_entry is not None:
@@ -1471,7 +1470,7 @@ class GatewayKanbanWatchersMixin:
                     disabled_fingerprint == fingerprint
                     and age < CORRUPT_BOARD_RETRY_AFTER_SECONDS
                 ):
-                    return None
+                    return True
                 if disabled_fingerprint == fingerprint:
                     logger.info(
                         "kanban dispatcher: board %s database fingerprint unchanged "
@@ -1485,6 +1484,34 @@ class GatewayKanbanWatchersMixin:
                         slug,
                     )
                 disabled_corrupt_boards.pop(slug, None)
+            return False
+
+        def _quarantine_board(slug: str) -> None:
+            """Mark the board's DB corrupt: fingerprint-stamped pause window."""
+            fingerprint = _board_db_fingerprint(slug)
+            disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
+            logger.error(
+                "kanban dispatcher: board %s database %s is not a valid "
+                "SQLite database; pausing dispatch for this board until "
+                "the file changes, the gateway restarts, or the "
+                "quarantine timer expires. Move or restore the file, "
+                "then run `hermes kanban init` if you need a fresh board.",
+                slug,
+                fingerprint[0],
+            )
+
+        def _tick_once_for_board(slug: str) -> "Optional[object]":
+            """Legacy single-board dispatch_once (fair_selection off).
+
+            Runs in a worker thread via `asyncio.to_thread`. `board=slug`
+            is passed through `dispatch_once` so `resolve_workspace` and
+            `_default_spawn` see the right paths. The per-board DB is
+            opened explicitly so concurrent boards never share a
+            connection handle or accidentally claim across each other.
+            """
+            conn = None
+            if _board_quarantined(slug):
+                return None
             try:
                 conn = _kb.connect(board=slug)
                 # `connect()` runs the schema + idempotent migration on
@@ -1506,31 +1533,13 @@ class GatewayKanbanWatchersMixin:
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    _quarantine_board(slug)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             except Exception as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    _quarantine_board(slug)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
@@ -1542,21 +1551,72 @@ class GatewayKanbanWatchersMixin:
                         pass
 
         def _tick_once() -> "list[tuple[str, Optional[object]]]":
-            """Run one dispatch_once per board. Returns (slug, result) pairs.
+            """Run one dispatcher tick across all boards.
 
             Enumerating boards on every tick keeps the dispatcher honest
             when users create a new board mid-run: no restart required,
             the next tick picks it up automatically.
+
+            Selection model — ``kanban.fair_selection`` (default True):
+
+            * True  → ONE global union tick: every board's spawnable
+              ready/review candidates compete in a single priority-then-age
+              ordering against one shared host budget
+              (:func:`_kb.dispatch_once_all_boards`). This removes the
+              structural starvation where the first board in enumeration
+              order consumed the whole host budget and the last board
+              starved (reordering alone cannot fix that).
+            * False → legacy sequential loop: a full-budget dispatch_once
+              per board in enumeration order (rollback escape hatch).
+
+            Returns (slug, result) pairs either way so telemetry/logging is
+            unchanged.
             """
             try:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            out: list[tuple[str, "Optional[object]"]] = []
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                out.append((slug, _tick_once_for_board(slug)))
-            return out
+            board_slugs = [b.get("slug") or _kb.DEFAULT_BOARD for b in boards]
+            fair = _fair_selection_enabled()
+            if not fair:
+                out: "list[tuple[str, Optional[object]]]" = []
+                for slug in board_slugs:
+                    out.append((slug, _tick_once_for_board(slug)))
+                return out
+            # Global union pass: exclude quarantined corrupt boards up
+            # front; corruption discovered DURING the pass comes back on
+            # the per-board DispatchResult.corrupt flag and is quarantined
+            # here for subsequent ticks.
+            active = [
+                slug for slug in board_slugs if not _board_quarantined(slug)
+            ]
+            results_map: "dict[str, object]" = {}
+            try:
+                results_map = dict(
+                    _kb.dispatch_once_all_boards(
+                        active,
+                        spawn_fn=None,
+                        max_spawn=max_spawn,
+                        max_in_progress=max_in_progress,
+                        failure_limit=failure_limit,
+                        stale_timeout_seconds=stale_timeout_seconds,
+                        default_assignee=default_assignee,
+                        max_in_progress_per_profile=max_in_progress_per_profile,
+                        reconcile_orphans=reconcile_orphans,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "kanban dispatcher: union dispatch tick failed"
+                )
+            finally:
+                for slug, res in results_map.items():
+                    if res is not None and getattr(res, "corrupt", False):
+                        _quarantine_board(slug)
+            return [
+                (slug, results_map.get(slug))
+                for slug in board_slugs
+            ]
 
         def _ready_nonempty() -> bool:
             """Cheap probe: is there at least one ready+assigned+unclaimed
@@ -1615,6 +1675,20 @@ class GatewayKanbanWatchersMixin:
         # auto-decompose created and launched destructive tasks while the user
         # was still typing the task description, and the flag "couldn't be
         # disabled" because the gateway had captured its boot-time value.)
+        def _fair_selection_enabled() -> bool:
+            """Re-resolve kanban.fair_selection from current config each tick.
+
+            Read live (like auto_decompose) so an operator flipping
+            fair_selection=false to roll back to the legacy sequential
+            per-board loop takes effect on the next tick, without a gateway
+            restart.
+            """
+            try:
+                cfg = _load_config()
+                return bool((cfg or {}).get("kanban", {}).get("fair_selection", True))
+            except Exception:
+                return True
+
         def _read_auto_decompose_settings() -> tuple[bool, int]:
             """Re-resolve (enabled, per_tick) from current config each tick."""
             return _resolve_auto_decompose_settings(_load_config)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2697,6 +2697,15 @@ DEFAULT_CONFIG = {
         # only if you run the dispatcher as a separate systemd unit or
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
+        # Fair cross-board ticket selection: build the UNION of all
+        # boards' spawnable ready/review tickets each tick, sort by
+        # priority then age, and claim top candidates against one shared
+        # host budget. Without this, each board consumes the entire
+        # remaining host budget in enumeration order and the LAST board
+        # is structurally starved whenever an earlier board sustains a
+        # ready backlog. Set to false to restore the legacy sequential
+        # per-board loop (rollback escape hatch).
+        "fair_selection": True,
         # Automatically claim tasks in the first-class review column and spawn
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8082,6 +8082,12 @@ class DispatchResult:
     spawned. ``None`` when memory was fine/unknown and the guard imposed
     no restriction. Reclaim/promotion bookkeeping still ran either way;
     deferred tasks stay queued for the next tick."""
+    corrupt: bool = False
+    """True when this board's database was found unreadable/corrupt during
+    a union tick (:func:`dispatch_once_all_boards`). The board contributed
+    no candidates and ran at most partial maintenance; the caller (gateway
+    watcher) maps this onto its corrupt-board quarantine registry so the
+    board is retried only after the file changes or the timer expires."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -9805,6 +9811,343 @@ def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
         return "unknown"
 
 
+_DISPATCH_READY_SQL = (
+    "SELECT id, assignee, priority, created_at FROM tasks "
+    "WHERE status = 'ready' AND claim_lock IS NULL "
+    "ORDER BY priority DESC, created_at ASC"
+)
+
+_DISPATCH_REVIEW_SQL = (
+    "SELECT id, assignee, priority, created_at FROM tasks "
+    "WHERE status = 'review' AND claim_lock IS NULL "
+    "ORDER BY priority DESC, created_at ASC"
+)
+
+
+def _is_corrupt_db_error(exc: BaseException) -> bool:
+    """Classify a SQLite 'not a database' style failure.
+
+    Mirrors the watcher-side classifier (gateway/kanban_watchers.py) so
+    the dispatcher and the quarantine bookkeeping agree on what counts as
+    a corrupt board file: either the typed :class:`KanbanDbCorruptError`
+    or a raw ``sqlite3.DatabaseError`` whose message matches the two
+    canonical corruption strings.
+    """
+    corrupt_error = globals().get("KanbanDbCorruptError")
+    if corrupt_error is not None and isinstance(exc, corrupt_error):
+        return True
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    msg = str(exc).lower()
+    return (
+        "file is not a database" in msg
+        or "database disk image is malformed" in msg
+    )
+
+
+@dataclass
+class _DispatchLaneState:
+    """Mutable per-tick state shared by the ready/review claim loops.
+
+    One instance drives BOTH lanes of a tick. ``spawned`` is the shared
+    budget counter (ready and review draws come out of the same budget);
+    ``per_profile_running`` is seeded from the DB(s) at tick start and
+    incremented after every spawn (real or dry-run) so later iterations
+    in the SAME tick respect ``max_in_progress_per_profile`` (#21582).
+    """
+
+    result: "DispatchResult"
+    spawned: int = 0
+    dry_run: bool = False
+    ttl_seconds: Optional[int] = None
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT
+    spawn_fn: Any = None
+    per_profile_cap: Optional[int] = None
+    per_profile_running: dict = field(default_factory=dict)
+    default_assignee: Optional[str] = None
+    default_assignee_resolved: bool = False
+
+
+def _profile_exists_safe(assignee: str) -> Optional[bool]:
+    """Resolve ``hermes_cli.profiles.profile_exists`` defensively.
+
+    Returns ``None`` when the profiles module is unavailable (test stubs,
+    exotic envs) — callers then assume spawnable, matching the historical
+    in-loop fallback behaviour.
+    """
+    try:
+        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
+    except Exception:
+        return None
+    return bool(profile_exists(assignee))
+
+
+def _process_ready_candidate(
+    conn: sqlite3.Connection,
+    board: Optional[str],
+    row: sqlite3.Row,
+    st: _DispatchLaneState,
+) -> None:
+    """Apply every spawnability gate to one ready row and spawn it if it
+    passes. Shared verbatim by the single-board tick
+    (:func:`_dispatch_once_locked`) and the global union tick
+    (:func:`dispatch_once_all_boards`) — one implementation, no drift.
+
+    Budget enforcement (``st.spawned`` vs the lane budget) stays with the
+    CALLER, which decides iteration order and when to stop scanning.
+    """
+    result = st.result
+    dry_run = st.dry_run
+    row_assignee = row["assignee"]
+    if not row_assignee:
+        # Honour kanban.default_assignee: when the dispatcher hits an
+        # unassigned ready task and an operator-configured fallback
+        # exists, persist the assignment and proceed. This removes the
+        # dashboard footgun where a task created without an assignee
+        # parks in 'ready' forever even though the operator's intent
+        # ("default") was perfectly clear (#27145). Mutating the row
+        # (not just the in-memory view) keeps diagnostics and the
+        # board state consistent: the task is now legitimately owned
+        # by ``kanban.default_assignee``, not "unassigned but secretly
+        # routed".
+        if st.default_assignee and st.default_assignee_resolved:
+            # Dry-run: show what WOULD happen (auto-assign + spawn) without
+            # mutating the DB. Real run: mutate the row + emit the
+            # 'assigned' event so the board state matches what just happened.
+            if not dry_run:
+                try:
+                    with write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET assignee = ? WHERE id = ? "
+                            "AND (assignee IS NULL OR assignee = '')",
+                            (st.default_assignee, row["id"]),
+                        )
+                        _append_event(
+                            conn, row["id"], "assigned",
+                            {
+                                "assignee": st.default_assignee,
+                                "source": "kanban.default_assignee",
+                            },
+                        )
+                except Exception:
+                    _log.debug(
+                        "kanban dispatch: failed to apply default_assignee=%r "
+                        "to task %s",
+                        st.default_assignee, row["id"], exc_info=True,
+                    )
+                    result.skipped_unassigned.append(row["id"])
+                    return
+            row_assignee = st.default_assignee
+            result.auto_assigned_default.append(row["id"])
+        else:
+            result.skipped_unassigned.append(row["id"])
+            return
+    # Skip ready tasks whose assignee is not a real Hermes profile.
+    # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
+    # with "Profile 'X' does not exist" when the assignee names a
+    # control-plane lane (e.g. an interactive Claude Code terminal
+    # like ``orion-cc`` / ``orion-research``) rather than a Hermes
+    # profile. Those task lanes are pulled by terminals via
+    # ``claim_task`` directly and should NEVER auto-spawn — the
+    # subprocess would crash on startup, get reaped as a zombie,
+    # the task would loop back to ``ready`` on next tick, and we'd
+    # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
+    pe = _profile_exists_safe(row_assignee)
+    if pe is not None and not pe:
+        # Bucket separately from skipped_unassigned: the operator
+        # cannot fix this by assigning a profile (the assignee IS the
+        # intended owner — a terminal lane). Health telemetry uses
+        # this distinction to suppress spurious "stuck" warnings on
+        # multi-lane setups where the ready queue is steadily full
+        # of human-pulled work.
+        result.skipped_nonspawnable.append(row["id"])
+        return
+    # Per-profile concurrency cap (#21582): even if there's global
+    # headroom, refuse to spawn for an assignee that's already at
+    # its in-flight cap. Prevents one profile's local model / API
+    # quota / browser pool from being overwhelmed by a fan-out
+    # while the global max_in_progress / max_spawn caps still allow
+    # work on OTHER profiles.
+    if st.per_profile_cap is not None:
+        current = st.per_profile_running.get(row_assignee, 0)
+        if current >= st.per_profile_cap:
+            result.skipped_per_profile_capped.append(
+                (row["id"], row_assignee, current)
+            )
+            return
+    # Respawn guard: refuse to re-spawn when useful work is already
+    # in-flight/recent, or when the last failure is a deterministic
+    # blocker (quota / auth). The guard defers the spawn this tick so
+    # the task gets a chance to clear (rate limits often reset in
+    # seconds-to-minutes); the existing consecutive_failures counter
+    # still trips the auto-block circuit breaker after failure_limit
+    # consecutive failures, so a persistent auth error eventually
+    # blocks via the normal path rather than on first occurrence.
+    guard_reason = check_respawn_guard(conn, row["id"])
+    if guard_reason is not None:
+        result.respawn_guarded.append((row["id"], guard_reason))
+        # Emit an event so operators can see why the task was
+        # skipped when reading `hermes kanban tail` — without
+        # this the task appears stuck in ready with no diagnosis.
+        if not dry_run:
+            with write_txn(conn):
+                _append_event(
+                    conn, row["id"], "respawn_guarded",
+                    {"reason": guard_reason},
+                )
+        return
+    if dry_run:
+        result.spawned.append((row["id"], row_assignee, ""))
+        st.spawned += 1
+        # Increment per-profile counter even in dry_run so the cap
+        # check sees the would-be spawn on subsequent iterations.
+        # Without this, dry_run reports every task as spawnable and
+        # under-reports the capped subset (#21582).
+        if st.per_profile_cap is not None and row_assignee:
+            st.per_profile_running[row_assignee] = (
+                st.per_profile_running.get(row_assignee, 0) + 1
+            )
+        return
+    claimed = claim_task(conn, row["id"], ttl_seconds=st.ttl_seconds)
+    if claimed is None:
+        return
+    _finish_claim_and_spawn(conn, board, claimed, row_assignee, st)
+
+
+def _process_review_candidate(
+    conn: sqlite3.Connection,
+    board: Optional[str],
+    row: sqlite3.Row,
+    st: _DispatchLaneState,
+) -> None:
+    """Same gate chain as :func:`_process_ready_candidate` for the review
+    column: claim via :func:`claim_review_task`, force-load the bundled
+    ``sdlc-review`` skill, spawn the reviewer. Review rows must already
+    carry an assignee (unassigned review rows are skipped upstream).
+    """
+    result = st.result
+    dry_run = st.dry_run
+    row_assignee = row["assignee"]
+    pe = _profile_exists_safe(row_assignee)
+    if pe is not None and not pe:
+        result.skipped_nonspawnable.append(row["id"])
+        return
+    if st.per_profile_cap is not None:
+        current = st.per_profile_running.get(row_assignee, 0)
+        if current >= st.per_profile_cap:
+            result.skipped_per_profile_capped.append(
+                (row["id"], row_assignee, current)
+            )
+            return
+    guard_reason = check_respawn_guard(conn, row["id"], lane="review")
+    if guard_reason is not None:
+        result.respawn_guarded.append((row["id"], guard_reason))
+        if not dry_run:
+            with write_txn(conn):
+                _append_event(
+                    conn, row["id"], "respawn_guarded",
+                    {"reason": guard_reason},
+                )
+        return
+    if dry_run:
+        result.spawned.append((row["id"], row_assignee, ""))
+        st.spawned += 1
+        if st.per_profile_cap is not None:
+            st.per_profile_running[row_assignee] = (
+                st.per_profile_running.get(row_assignee, 0) + 1
+            )
+        return
+    claimed = claim_review_task(conn, row["id"], ttl_seconds=st.ttl_seconds)
+    if claimed is None:
+        return
+    # Force-load the sdlc-review skill for review agents — it carries
+    # the review logic (AC verification, merge, etc.). The mandatory
+    # kanban lifecycle is already injected into every worker's system
+    # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
+    # review agent needs.
+    claimed.skills = list(
+        dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
+    )
+    _finish_claim_and_spawn(conn, board, claimed, row_assignee, st)
+
+
+def _finish_claim_and_spawn(
+    conn: sqlite3.Connection,
+    board: Optional[str],
+    claimed: Any,
+    row_assignee: str,
+    st: _DispatchLaneState,
+) -> None:
+    """Post-claim tail shared by both lanes: workspace resolution, PID
+    persistence, worker-spawned hook, and spawn-failure accounting."""
+    result = st.result
+    try:
+        resolved_branch_name = None
+        if claimed.workspace_kind == "worktree":
+            workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+        else:
+            workspace = resolve_workspace(claimed, board=board)
+    except Exception as exc:
+        auto = _record_spawn_failure(
+            conn, claimed.id, f"workspace: {exc}",
+            failure_limit=st.failure_limit,
+        )
+        if auto:
+            result.auto_blocked.append(claimed.id)
+        return
+    # Persist the resolved workspace path so the worker can cd there.
+    set_workspace_path(conn, claimed.id, str(workspace))
+    if claimed.workspace_kind == "worktree":
+        set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+    _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+    _spawn = st.spawn_fn if st.spawn_fn is not None else _default_spawn
+    try:
+        # Back-compat: older spawn_fn signatures accept only
+        # (task, workspace). Test stubs in the suite rely on that.
+        # Introspect the callable and pass `board` only when supported.
+        import inspect
+        try:
+            sig = inspect.signature(_spawn)
+            if "board" in sig.parameters:
+                pid = _spawn(claimed, str(workspace), board=board)
+            else:
+                pid = _spawn(claimed, str(workspace))
+        except (TypeError, ValueError):
+            pid = _spawn(claimed, str(workspace))
+        if pid:
+            _set_worker_pid(conn, claimed.id, int(pid))
+        # Worker-lifecycle observer (RFC #58548): fires AFTER spawn_fn
+        # returned and the PID (when reported) is durably persisted,
+        # per the RFC timing contract. Best-effort — can never break
+        # the dispatch loop.
+        _fire_worker_spawned_hook(
+            conn, claimed, str(workspace), pid, board=board,
+        )
+        # NOTE: we intentionally do NOT reset consecutive_failures
+        # here. A successful spawn proves the worker can start but
+        # doesn't prove the run will succeed. Under unified
+        # failure counting, resetting on spawn would let a task
+        # that keeps timing out after spawn loop forever. The
+        # counter is cleared only on successful completion (see
+        # complete_task).
+        result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
+        st.spawned += 1
+        # Track the new in-flight count for this profile so later
+        # iterations in this same tick respect the per-profile cap
+        # (#21582). Subsequent ticks re-query from the DB.
+        if st.per_profile_cap is not None and claimed.assignee:
+            st.per_profile_running[claimed.assignee] = (
+                st.per_profile_running.get(claimed.assignee, 0) + 1
+            )
+    except Exception as exc:
+        auto = _record_spawn_failure(
+            conn, claimed.id, str(exc),
+            failure_limit=st.failure_limit,
+        )
+        if auto:
+            result.auto_blocked.append(claimed.id)
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -10111,190 +10454,21 @@ def _dispatch_once_locked(
             # bucket it as nonspawnable if the profile genuinely isn't
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
+    st = _DispatchLaneState(
+        result=result,
+        dry_run=dry_run,
+        ttl_seconds=ttl_seconds,
+        failure_limit=failure_limit,
+        spawn_fn=spawn_fn,
+        per_profile_cap=_per_profile_cap,
+        per_profile_running=_per_profile_running,
+        default_assignee=_default_assignee,
+        default_assignee_resolved=_default_assignee_resolved,
+    )
     for row in ready_rows:
-        if ready_budget is not None and spawned >= ready_budget:
+        if ready_budget is not None and st.spawned >= ready_budget:
             break
-        row_assignee = row["assignee"]
-        if not row_assignee:
-            # Honour kanban.default_assignee: when the dispatcher hits an
-            # unassigned ready task and an operator-configured fallback
-            # exists, persist the assignment and proceed. This removes the
-            # dashboard footgun where a task created without an assignee
-            # parks in 'ready' forever even though the operator's intent
-            # ("default") was perfectly clear (#27145). Mutating the row
-            # (not just the in-memory view) keeps diagnostics and the
-            # board state consistent: the task is now legitimately owned
-            # by ``kanban.default_assignee``, not "unassigned but secretly
-            # routed".
-            if _default_assignee and _default_assignee_resolved:
-                # Dry-run: show what WOULD happen (auto-assign + spawn) without
-                # mutating the DB. Real run: mutate the row + emit the
-                # 'assigned' event so the board state matches what just happened.
-                if not dry_run:
-                    try:
-                        with write_txn(conn):
-                            conn.execute(
-                                "UPDATE tasks SET assignee = ? WHERE id = ? "
-                                "AND (assignee IS NULL OR assignee = '')",
-                                (_default_assignee, row["id"]),
-                            )
-                            _append_event(
-                                conn, row["id"], "assigned",
-                                {
-                                    "assignee": _default_assignee,
-                                    "source": "kanban.default_assignee",
-                                },
-                            )
-                    except Exception:
-                        _log.debug(
-                            "kanban dispatch: failed to apply default_assignee=%r "
-                            "to task %s",
-                            _default_assignee, row["id"], exc_info=True,
-                        )
-                        result.skipped_unassigned.append(row["id"])
-                        continue
-                row_assignee = _default_assignee
-                result.auto_assigned_default.append(row["id"])
-            else:
-                result.skipped_unassigned.append(row["id"])
-                continue
-        # Skip ready tasks whose assignee is not a real Hermes profile.
-        # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
-        # with "Profile 'X' does not exist" when the assignee names a
-        # control-plane lane (e.g. an interactive Claude Code terminal
-        # like ``orion-cc`` / ``orion-research``) rather than a Hermes
-        # profile. Those task lanes are pulled by terminals via
-        # ``claim_task`` directly and should NEVER auto-spawn — the
-        # subprocess would crash on startup, get reaped as a zombie,
-        # the task would loop back to ``ready`` on next tick, and we'd
-        # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
-        try:
-            from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row_assignee):
-            # Bucket separately from skipped_unassigned: the operator
-            # cannot fix this by assigning a profile (the assignee IS the
-            # intended owner — a terminal lane). Health telemetry uses
-            # this distinction to suppress spurious "stuck" warnings on
-            # multi-lane setups where the ready queue is steadily full
-            # of human-pulled work.
-            result.skipped_nonspawnable.append(row["id"])
-            continue
-        # Per-profile concurrency cap (#21582): even if there's global
-        # headroom, refuse to spawn for an assignee that's already at
-        # its in-flight cap. Prevents one profile's local model / API
-        # quota / browser pool from being overwhelmed by a fan-out
-        # while the global max_in_progress / max_spawn caps still allow
-        # work on OTHER profiles.
-        if _per_profile_cap is not None:
-            current = _per_profile_running.get(row_assignee, 0)
-            if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row_assignee, current)
-                )
-                continue
-        # Respawn guard: refuse to re-spawn when useful work is already
-        # in-flight/recent, or when the last failure is a deterministic
-        # blocker (quota / auth). The guard defers the spawn this tick so
-        # the task gets a chance to clear (rate limits often reset in
-        # seconds-to-minutes); the existing consecutive_failures counter
-        # still trips the auto-block circuit breaker after failure_limit
-        # consecutive failures, so a persistent auth error eventually
-        # blocks via the normal path rather than on first occurrence.
-        guard_reason = check_respawn_guard(conn, row["id"])
-        if guard_reason is not None:
-            result.respawn_guarded.append((row["id"], guard_reason))
-            # Emit an event so operators can see why the task was
-            # skipped when reading `hermes kanban tail` — without
-            # this the task appears stuck in ready with no diagnosis.
-            if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
-                    )
-            continue
-        if dry_run:
-            result.spawned.append((row["id"], row_assignee, ""))
-            spawned += 1
-            # Increment per-profile counter even in dry_run so the cap
-            # check sees the would-be spawn on subsequent iterations.
-            # Without this, dry_run reports every task as spawnable and
-            # under-reports the capped subset (#21582).
-            if _per_profile_cap is not None and row_assignee:
-                _per_profile_running[row_assignee] = (
-                    _per_profile_running.get(row_assignee, 0) + 1
-                )
-            continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
-        if claimed is None:
-            continue
-        try:
-            resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
-            else:
-                workspace = resolve_workspace(claimed, board=board)
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
-            continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
-        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
-        try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
-            # Worker-lifecycle observer (RFC #58548): fires AFTER spawn_fn
-            # returned and the PID (when reported) is durably persisted,
-            # per the RFC timing contract. Best-effort — can never break
-            # the dispatch loop.
-            _fire_worker_spawned_hook(
-                conn, claimed, str(workspace), pid, board=board,
-            )
-            # NOTE: we intentionally do NOT reset consecutive_failures
-            # here. A successful spawn proves the worker can start but
-            # doesn't prove the run will succeed. Under unified
-            # failure counting, resetting on spawn would let a task
-            # that keeps timing out after spawn loop forever. The
-            # counter is cleared only on successful completion (see
-            # complete_task).
-            result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
-            spawned += 1
-            # Track the new in-flight count for this profile so later
-            # iterations in this same tick respect the per-profile cap
-            # (#21582). Subsequent ticks re-query from the DB.
-            if _per_profile_cap is not None and claimed.assignee:
-                _per_profile_running[claimed.assignee] = (
-                    _per_profile_running.get(claimed.assignee, 0) + 1
-                )
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
+        _process_ready_candidate(conn, board, row, st)
 
     # ---- review column dispatch ----
     # Review tasks are tasks that a worker moved to 'review' after
@@ -10305,6 +10479,7 @@ def _dispatch_once_locked(
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
     # running workers stays bounded.
+    #
     # Auto-dispatch is enabled by default because Hermes bundles the
     # ``sdlc-review`` skill and reviewer workers can now approve, request
     # changes without block-loop accounting, or escalate a genuine blocker.
@@ -10317,104 +10492,12 @@ def _dispatch_once_locked(
     # ``spawn_budget`` — the reservation caps the ready lane, it does not
     # grant the review lane extra capacity.
     for row in review_rows:
-        if spawn_budget is not None and spawned >= spawn_budget:
+        if spawn_budget is not None and st.spawned >= spawn_budget:
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
-        try:
-            from hermes_cli.profiles import profile_exists
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
-            result.skipped_nonspawnable.append(row["id"])
-            continue
-        if _per_profile_cap is not None:
-            current = _per_profile_running.get(row["assignee"], 0)
-            if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row["assignee"], current)
-                )
-                continue
-        guard_reason = check_respawn_guard(conn, row["id"], lane="review")
-        if guard_reason is not None:
-            result.respawn_guarded.append((row["id"], guard_reason))
-            if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
-                    )
-            continue
-        if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
-            spawned += 1
-            if _per_profile_cap is not None:
-                _per_profile_running[row["assignee"]] = (
-                    _per_profile_running.get(row["assignee"], 0) + 1
-                )
-            continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
-        if claimed is None:
-            continue
-        try:
-            resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
-            else:
-                workspace = resolve_workspace(claimed, board=board)
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, f"workspace: {exc}",
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
-            continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
-        _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
-        # the review logic (AC verification, merge, etc.). The mandatory
-        # kanban lifecycle is already injected into every worker's system
-        # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
-        try:
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
-            # Worker-lifecycle observer (RFC #58548): same contract as the
-            # ready-lane fire above — after spawn + PID persistence.
-            _fire_worker_spawned_hook(
-                conn, claimed, str(workspace), pid, board=board,
-            )
-            result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
-            spawned += 1
-            if _per_profile_cap is not None and claimed.assignee:
-                _per_profile_running[claimed.assignee] = (
-                    _per_profile_running.get(claimed.assignee, 0) + 1
-                )
-        except Exception as exc:
-            auto = _record_spawn_failure(
-                conn, claimed.id, str(exc),
-                failure_limit=failure_limit,
-            )
-            if auto:
-                result.auto_blocked.append(claimed.id)
+        _process_review_candidate(conn, board, row, st)
     return result
 
 
@@ -10424,6 +10507,434 @@ def _positive_int(value: Any, default: int, *, minimum: int = 1) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= minimum else default
+
+
+@contextlib.contextmanager
+def _multi_board_dispatch_locks(
+    board_paths: "list[tuple[str, Path]]",
+):
+    """Acquire EVERY board's dispatch tick lock, all-or-nothing.
+
+    Yields ``True`` when this tick holds all requested board locks and may
+    proceed, ``False`` when ANY lock was unavailable (another dispatcher
+    holds it) — in which case no lock in the set remains held on exit.
+
+    Acquisition follows deterministic sorted resolved-path order, matching
+    the global candidate sort's ``(board_slug, ...)`` tiebreak domain, so
+    two concurrent multi-board ticks can never deadlock: locks are
+    non-blocking (``LOCK_EX | LOCK_NB``, see :func:`_dispatch_tick_lock`)
+    and always requested in the same order. This preserves the exact
+    single-writer guarantee of the per-board lock (#35240) while letting
+    one tick claim across boards atomically.
+    """
+    entered: list = []
+    try:
+        all_held = True
+        for _slug, path in sorted(board_paths, key=lambda kv: (str(kv[1]), kv[0])):
+            if not path.exists():
+                # No DB file yet (metadata-only board) → nothing to
+                # dispatch and nothing to protect; skip silently.
+                continue
+            cm = _dispatch_tick_lock(path)
+            try:
+                held = cm.__enter__()
+            except Exception:
+                # Unopenable lock file behaves like a lost race: give up
+                # the whole set this tick (retried next interval).
+                all_held = False
+                break
+            entered.append(cm)
+            if not held:
+                all_held = False
+                break
+        yield all_held
+    finally:
+        for cm in reversed(entered):
+            try:
+                cm.__exit__(None, None, None)
+            except Exception:
+                pass
+
+
+def dispatch_once_all_boards(
+    board_slugs: "list[str]",
+    *,
+    spawn_fn=None,
+    ttl_seconds: Optional[int] = None,
+    dry_run: bool = False,
+    max_spawn: Optional[int] = None,
+    max_in_progress: Optional[int] = None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    stale_timeout_seconds: int = 0,
+    default_assignee: Optional[str] = None,
+    max_in_progress_per_profile: Optional[int] = None,
+    reconcile_orphans: bool = True,
+) -> "dict[str, DispatchResult]":
+    """Run ONE dispatcher tick across ALL boards with fair selection.
+
+    Fairness fix for structural host-cap starvation: the sequential
+    per-board loop (``dispatch_once`` called board by board) lets whichever
+    board enumerates FIRST consume the entire remaining host budget, so the
+    LAST board is structurally starved whenever an earlier board sustains a
+    ready backlog — even when that board holds older, higher-priority work.
+    Reordering the loop cannot fix this; it only moves the starvation.
+
+    This entry instead performs GLOBAL union selection:
+
+    1. Acquire every board's dispatch lock (all-or-nothing, sorted-path
+       order — see :func:`_multi_board_dispatch_locks`). Losing any lock
+       skips the whole tick with ``skipped_locked=True`` per board, exactly
+       mirroring single-board semantics when an orphan dispatcher races.
+    2. Run the unchanged per-board maintenance phases (TTL/stale/crash
+       reclaim, orphan reconciliation, max-runtime enforcement, todo→ready
+       promotion) on each board connection.
+    3. Compute the shared spawn budget ONCE against the host-wide running
+       total (sum across boards — supersedes the per-board
+       ``count_running_tasks_other_boards`` hop inside this path) and
+       sample memory pressure ONCE per tick (the per-board sampling let
+       ``elevated`` pressure admit N spawns per tick instead of 1).
+    4. Enumerate every board's ready (+ review) rows, tag each candidate
+       with its board, and globally sort by
+       ``(-priority, created_at, board_slug, task_id)`` — operator priority
+       dominates, age breaks ties, board/id make ties deterministic.
+    5. Claim top candidates against the shared budget in two phases
+       (ready lane capped at ``budget - 1`` when spawnable review work
+       exists anywhere, review lane drawing on the full budget — the same
+       reservation semantics as the single-board tick, now across boards).
+       Every spawnability gate (default-assignee fill, profile existence,
+       per-profile cap, respawn guard) and the atomic ``claim_task`` /
+       ``claim_review_task`` CAS run UNCHANGED via the shared helpers, so
+       caps and crash-safety semantics are byte-for-byte the single-board
+       ones; only WHERE selection happens changed. Claims never leave a
+       double-spawn window: snapshot → claim happens inside one lock hold,
+       and the claim CAS rejects already-claimed rows.
+
+    ``max_spawn`` NOTE: historically a PER-BOARD live cap (see
+    :func:`_dispatch_once_locked`); in this union path it bounds the HOST
+    alongside ``max_in_progress``. The union pool makes per-board
+    enforcement redundant (a board's remaining allowance can never fall
+    below the shared remaining budget), so no separate per-board counter
+    is tracked here — see the pool comment in the body.
+
+    Corrupt/unreadable board DBs fail soft: the affected board contributes
+    no candidates and its result records whatever maintenance completed;
+    healthy boards finish their tick. The gateway watcher maps returned
+    corruption signals onto its quarantine registry.
+
+    Returns ``{slug: DispatchResult}`` for watcher telemetry. Tick observer
+    hooks fire per board strictly AFTER the lock set is released
+    (#56066/#64231 contract).
+    """
+    # Reap zombie children from previously spawned workers ONCE per tick
+    # (the sequential per-board loop ran this once per BOARD — N+1 per tick;
+    # see recon §2). Same rationale as the single-board tick.
+    reap_worker_zombies()
+
+    # Stable de-dup preserving caller order.
+    seen: "set[str]" = set()
+    slugs: "list[str]" = []
+    for slug in board_slugs:
+        if slug and slug not in seen:
+            seen.add(slug)
+            slugs.append(slug)
+
+    results: "dict[str, DispatchResult]" = {slug: DispatchResult() for slug in slugs}
+    board_paths: "list[tuple[str, Path]]" = []
+    for slug in slugs:
+        try:
+            board_paths.append((slug, kanban_db_path(board=slug)))
+        except Exception:
+            # Path resolution should never fail; if it does, skip the
+            # board rather than dropping the whole multi-board tick.
+            _log.warning(
+                "kanban dispatch: could not resolve DB path for board %s; "
+                "skipping it this tick",
+                slug,
+            )
+            board_paths.append((slug, Path("/nonexistent/<unresolvable>")))
+    if not board_paths:
+        return results
+
+    corrupt_seen: "dict[str, BaseException]" = {}
+    conns: "dict[str, sqlite3.Connection]" = {}
+
+    with _multi_board_dispatch_locks(board_paths) as all_held:
+        if not all_held:
+            for res in results.values():
+                res.skipped_locked = True
+        else:
+            try:
+                # ---- open connections (corruption quarantines the board) ----
+                for slug, path in board_paths:
+                    if not path.exists():
+                        continue
+                    try:
+                        conns[slug] = connect(board=slug)
+                    except Exception as exc:
+                        if _is_corrupt_db_error(exc):
+                            corrupt_seen.setdefault(slug, exc)
+                            results[slug].corrupt = True
+                        else:
+                            _log.exception(
+                                "kanban dispatch: failed to open board %s",
+                                slug,
+                            )
+
+                def _drop_corrupt(slug: str, exc: BaseException) -> None:
+                    corrupt_seen.setdefault(slug, exc)
+                    results[slug].corrupt = True
+                    conn = conns.pop(slug, None)
+                    if conn is not None:
+                        try:
+                            conn.close()
+                        except Exception:
+                            pass
+
+                # ---- per-board maintenance (unchanged semantics) ----
+                for slug in list(conns.keys()):
+                    conn = conns[slug]
+                    res = results[slug]
+                    try:
+                        res.reclaimed = release_stale_claims(conn)
+                        if reconcile_orphans:
+                            res.reconciled_orphans = reconcile_orphaned_running(conn)
+                        res.stale = detect_stale_running(
+                            conn, stale_timeout_seconds=stale_timeout_seconds,
+                        )
+                        res.crashed = detect_crashed_workers(conn)
+                        _crash_auto_blocked = getattr(
+                            detect_crashed_workers, "_last_auto_blocked", []
+                        )
+                        if _crash_auto_blocked:
+                            res.auto_blocked.extend(_crash_auto_blocked)
+                        _crash_rate_limited = getattr(
+                            detect_crashed_workers, "_last_rate_limited", []
+                        )
+                        if _crash_rate_limited:
+                            res.rate_limited.extend(_crash_rate_limited)
+                        res.timed_out = enforce_max_runtime(conn)
+                        res.promoted = recompute_ready(
+                            conn, failure_limit=failure_limit,
+                        )
+                    except Exception as exc:
+                        if _is_corrupt_db_error(exc):
+                            _drop_corrupt(slug, exc)
+                        else:
+                            # One board's transient failure must not stall
+                            # the others (same fail-open stance as
+                            # count_running_tasks_other_boards).
+                            _log.exception(
+                                "kanban dispatch: maintenance failed on board %s",
+                                slug,
+                            )
+                            _drop_corrupt(slug, exc)
+
+                # ---- shared budget computed ONCE across the union ----
+                spawn_budget: Optional[int] = None
+                if max_spawn is not None or max_in_progress is not None:
+                    running_total = sum(
+                        count_running_tasks(c) for c in conns.values()
+                    )
+                    if max_spawn is not None:
+                        # Host-wide bound in the union path; the per-board
+                        # dimension is enforced per candidate below.
+                        if running_total < max_spawn:
+                            spawn_budget = max_spawn - running_total
+                        else:
+                            spawn_budget = 0
+                    if max_in_progress is not None:
+                        if running_total >= max_in_progress:
+                            spawn_budget = 0
+                        else:
+                            remaining = max_in_progress - running_total
+                            if spawn_budget is None or spawn_budget > remaining:
+                                spawn_budget = remaining
+
+                # Memory-pressure guard, sampled ONCE per tick (fixes the
+                # per-board sampling that admitted N spawns under elevated
+                # pressure). Same classification + logging contract as the
+                # single-board tick.
+                pressure = _memory_pressure_level()
+                if pressure == "critical":
+                    for res in results.values():
+                        res.memory_pressure = pressure
+                    _log.warning(
+                        "kanban dispatch: system memory pressure is critical; "
+                        "spawning no new workers this tick (deferred, not dropped)"
+                    )
+                    spawn_budget = 0
+                elif pressure == "elevated":
+                    for res in results.values():
+                        res.memory_pressure = pressure
+                    if spawn_budget is None or spawn_budget > 1:
+                        _log.warning(
+                            "kanban dispatch: system memory pressure is elevated; "
+                            "limiting to at most 1 new worker this tick"
+                        )
+                        spawn_budget = 1
+                # ---- global candidate pool ----
+                # NOTE on max_spawn: historically a PER-BOARD live cap (see
+                # _dispatch_once_locked). In this union path it is promoted
+                # to a HOST-wide live cap alongside max_in_progress — the
+                # union pool makes per-board enforcement redundant: a
+                # board's remaining allowance (max_spawn − own_running −
+                # claimed_here) can never fall below the shared remaining
+                # budget while other boards draw from the same pool, so a
+                # separate per-board counter adds dead state without ever
+                # changing an outcome.
+                pool: "list[tuple[int, int, str, str, str, sqlite3.Row]]" = []
+                # (lane_rank, -priority, created_at, board_slug, task_id, row)
+                review_dispatch_on = review_dispatch_enabled()
+                if spawn_budget != 0:
+                    for slug in list(conns.keys()):
+                        conn = conns[slug]
+                        res = results[slug]
+                        try:
+                            for row in conn.execute(_DISPATCH_READY_SQL):
+                                pool.append((0, -int(row["priority"] or 0),
+                                             int(row["created_at"] or 0),
+                                             slug, str(row["id"]), row))
+                            if review_dispatch_on:
+                                for row in conn.execute(_DISPATCH_REVIEW_SQL):
+                                    pool.append((1, -int(row["priority"] or 0),
+                                                 int(row["created_at"] or 0),
+                                                 slug, str(row["id"]), row))
+                        except Exception as exc:
+                            if _is_corrupt_db_error(exc):
+                                _drop_corrupt(slug, exc)
+                            else:
+                                _log.exception(
+                                    "kanban dispatch: candidate scan failed on board %s",
+                                    slug,
+                                )
+                                _drop_corrupt(slug, exc)
+                    pool.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4]))
+
+                # Review-lane reservation across boards: if ANY board holds
+                # spawnable review work, the ready lane gets budget - 1.
+                def _any_spawnable_review() -> bool:
+                    for cand in pool:
+                        if cand[0] != 1:
+                            continue
+                        assignee = cand[5]["assignee"]
+                        if not assignee:
+                            continue
+                        pe = _profile_exists_safe(assignee)
+                        if pe is None or pe:
+                            return True
+                    return False
+
+                ready_budget = spawn_budget
+                if (
+                    spawn_budget is not None
+                    and spawn_budget > 0
+                    and _any_spawnable_review()
+                ):
+                    ready_budget = max(spawn_budget - 1, 0)
+
+                st = _DispatchLaneState(
+                    result=None,  # set per candidate below
+                    dry_run=dry_run,
+                    ttl_seconds=ttl_seconds,
+                    failure_limit=failure_limit,
+                    spawn_fn=spawn_fn,
+                    per_profile_cap=max_in_progress_per_profile if (
+                        isinstance(max_in_progress_per_profile, int)
+                        and max_in_progress_per_profile > 0
+                    ) else None,
+                    default_assignee=(default_assignee or "").strip() or None,
+                )
+                if st.per_profile_cap is not None:
+                    # Seed per-profile counters from a UNION of every
+                    # board's running rows (host-wide view of the cap).
+                    for conn in conns.values():
+                        for prow in conn.execute(
+                            "SELECT assignee, COUNT(*) AS n FROM tasks "
+                            "WHERE status = 'running' AND assignee IS NOT NULL "
+                            "GROUP BY assignee"
+                        ):
+                            st.per_profile_running[prow["assignee"]] = (
+                                st.per_profile_running.get(prow["assignee"], 0)
+                                + int(prow["n"])
+                            )
+                if st.default_assignee:
+                    try:
+                        from hermes_cli.profiles import profile_exists as _pe
+                        st.default_assignee_resolved = bool(_pe(st.default_assignee))
+                    except Exception:
+                        # Profiles module not importable (test stubs, exotic
+                        # envs): trust the operator's config, matching the
+                        # single-board tick's fallback.
+                        st.default_assignee_resolved = True
+
+                claimed_from: "dict[str, int]" = {}
+                # Lane budgets are tracked separately (not one shared
+                # counter) so a full ready lane cannot starve the review
+                # lane: the pool is lane-ranked, and once the ready lane
+                # hits its budget the loop must keep scanning for review
+                # candidates — mirroring the single-board tick's two
+                # separate loops.
+                _ready_spawned = 0
+                _review_spawned = 0
+                for lane_rank, neg_prio, created_at, slug, tid, row in pool:
+                    res = results[slug]
+                    if slug not in conns:
+                        continue  # board died mid-pass (quarantined)
+                    if lane_rank == 0:
+                        if ready_budget is not None and _ready_spawned >= ready_budget:
+                            continue
+                    else:
+                        if spawn_budget is not None and _review_spawned >= spawn_budget:
+                            break
+                        if not row["assignee"]:
+                            res.skipped_unassigned.append(row["id"])
+                            continue
+                    conn = conns[slug]
+                    st.result = res
+                    before = len(res.spawned)
+                    try:
+                        if lane_rank == 0:
+                            _process_ready_candidate(conn, slug, row, st)
+                        else:
+                            _process_review_candidate(conn, slug, row, st)
+                    except Exception as exc:
+                        if _is_corrupt_db_error(exc):
+                            _drop_corrupt(slug, exc)
+                            continue
+                        # A single bad candidate must not kill the pass.
+                        _log.exception(
+                            "kanban dispatch: candidate %s/%s failed",
+                            slug, row["id"],
+                        )
+                        continue
+                    if len(res.spawned) > before:
+                        claimed_from[slug] = claimed_from.get(slug, 0) + 1
+                        if lane_rank == 0:
+                            _ready_spawned += 1
+                        else:
+                            _review_spawned += 1
+
+                # Periodic PASSIVE WAL checkpoints under the lock set,
+                # mirroring dispatch_once's post-tick checkpoint.
+                for slug, conn in list(conns.items()):
+                    try:
+                        path = kanban_db_path(board=slug)
+                        _maybe_checkpoint_wal(conn, path)
+                    except Exception:
+                        pass
+            finally:
+                for conn in conns.values():
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+
+    # Tick observers fire strictly OUTSIDE the critical section, per board
+    # (#56066 sweeper finding / #64231 disposition) — same contract as
+    # dispatch_once.
+    for slug in slugs:
+        _fire_dispatch_tick_hook(results[slug], board=slug, dry_run=dry_run)
+    return results
 
 
 def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, int]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10601,7 +10601,9 @@ def dispatch_once_all_boards(
        (ready lane capped at ``budget - 1`` when spawnable review work
        exists anywhere, review lane drawing on the full budget — the same
        reservation semantics as the single-board tick, now across boards).
-       Every spawnability gate (default-assignee fill, profile existence,
+       BOTH lanes draw from ONE shared total: the review lane's cap is the
+       remaining shared budget, not a second pool — review handoff is not
+       additional capacity (#74431). Every spawnability gate (default-assignee fill, profile existence,
        per-profile cap, respawn guard) and the atomic ``claim_task`` /
        ``claim_review_task`` CAS run UNCHANGED via the shared helpers, so
        caps and crash-safety semantics are byte-for-byte the single-board
@@ -10618,8 +10620,11 @@ def dispatch_once_all_boards(
 
     Corrupt/unreadable board DBs fail soft: the affected board contributes
     no candidates and its result records whatever maintenance completed;
-    healthy boards finish their tick. The gateway watcher maps returned
-    corruption signals onto its quarantine registry.
+    healthy boards finish their tick. Non-corruption failures (transient
+    errors, programming bugs) drop the board for the CURRENT pass only and
+    leave ``corrupt`` unset — only classified corruption enters the
+    corrupt-board quarantine. The gateway watcher maps returned corruption
+    signals onto its quarantine registry.
 
     Returns ``{slug: DispatchResult}`` for watcher telemetry. Tick observer
     hooks fire per board strictly AFTER the lock set is released
@@ -10690,6 +10695,28 @@ def dispatch_once_all_boards(
                         except Exception:
                             pass
 
+                def _drop_board(slug: str) -> None:
+                    """Drop a board from the CURRENT union pass only.
+
+                    For non-corruption failures (transient errors, programming
+                    bugs in a maintenance call, busy/locked SQLite states):
+                    the board contributes no candidates this tick and is
+                    retried naturally on the next tick. It must NOT set
+                    ``DispatchResult.corrupt`` — the watcher maps that flag to
+                    the durable corrupt-board quarantine (fingerprint pause
+                    window), and quarantining on an ordinary exception would
+                    suppress dispatch on a healthy DB until the fingerprint
+                    changes or the timer expires. Mirrors the legacy
+                    single-board tick, where non-corrupt exceptions are
+                    logged and retried, never quarantined.
+                    """
+                    conn = conns.pop(slug, None)
+                    if conn is not None:
+                        try:
+                            conn.close()
+                        except Exception:
+                            pass
+
                 # ---- per-board maintenance (unchanged semantics) ----
                 for slug in list(conns.keys()):
                     conn = conns[slug]
@@ -10722,12 +10749,14 @@ def dispatch_once_all_boards(
                         else:
                             # One board's transient failure must not stall
                             # the others (same fail-open stance as
-                            # count_running_tasks_other_boards).
+                            # count_running_tasks_other_boards). Drop the
+                            # board for THIS pass only — corrupt=False: the
+                            # watcher must not quarantine a healthy DB.
                             _log.exception(
                                 "kanban dispatch: maintenance failed on board %s",
                                 slug,
                             )
-                            _drop_corrupt(slug, exc)
+                            _drop_board(slug)
 
                 # ---- shared budget computed ONCE across the union ----
                 spawn_budget: Optional[int] = None
@@ -10807,7 +10836,7 @@ def dispatch_once_all_boards(
                                     "kanban dispatch: candidate scan failed on board %s",
                                     slug,
                                 )
-                                _drop_corrupt(slug, exc)
+                                _drop_board(slug)
                     pool.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4]))
 
                 # Review-lane reservation across boards: if ANY board holds
@@ -10868,24 +10897,30 @@ def dispatch_once_all_boards(
                         st.default_assignee_resolved = True
 
                 claimed_from: "dict[str, int]" = {}
-                # Lane budgets are tracked separately (not one shared
-                # counter) so a full ready lane cannot starve the review
-                # lane: the pool is lane-ranked, and once the ready lane
-                # hits its budget the loop must keep scanning for review
-                # candidates — mirroring the single-board tick's two
-                # separate loops.
-                _ready_spawned = 0
-                _review_spawned = 0
+                # ONE shared spawn counter drives both lanes — the same
+                # invariant as the single-board tick, where the ready loop
+                # checks ``st.spawned >= ready_budget`` and the review loop
+                # checks ``st.spawned >= spawn_budget`` against the SAME
+                # total. Tracking per-lane counters instead would let the
+                # review lane admit ``spawn_budget`` reviews ON TOP of the
+                # ready lane's ``ready_budget`` reads (budget 2 → 1 ready +
+                # 2 reviews = 3 workers), breaching max_in_progress /
+                # max_spawn exactly at the admission boundary they exist to
+                # guard. The reservation (ready_budget = spawn_budget - 1)
+                # still guarantees the review lane its slot: once the total
+                # hits spawn_budget the loop breaks, and until then the
+                # ready lane alone cannot consume the reserved slot.
+                _total_spawned = 0
                 for lane_rank, neg_prio, created_at, slug, tid, row in pool:
                     res = results[slug]
                     if slug not in conns:
                         continue  # board died mid-pass (quarantined)
+                    if spawn_budget is not None and _total_spawned >= spawn_budget:
+                        break
                     if lane_rank == 0:
-                        if ready_budget is not None and _ready_spawned >= ready_budget:
+                        if ready_budget is not None and _total_spawned >= ready_budget:
                             continue
                     else:
-                        if spawn_budget is not None and _review_spawned >= spawn_budget:
-                            break
                         if not row["assignee"]:
                             res.skipped_unassigned.append(row["id"])
                             continue
@@ -10909,10 +10944,7 @@ def dispatch_once_all_boards(
                         continue
                     if len(res.spawned) > before:
                         claimed_from[slug] = claimed_from.get(slug, 0) + 1
-                        if lane_rank == 0:
-                            _ready_spawned += 1
-                        else:
-                            _review_spawned += 1
+                        _total_spawned += 1
 
                 # Periodic PASSIVE WAL checkpoints under the lock set,
                 # mirroring dispatch_once's post-tick checkpoint.

--- a/tests/hermes_cli/test_kanban_fair_selection.py
+++ b/tests/hermes_cli/test_kanban_fair_selection.py
@@ -1,0 +1,579 @@
+"""Fair global union ticket selection (task t_e6fe4233).
+
+Covers :func:`hermes_cli.kanban_db.dispatch_once_all_boards` — the
+replacement for the structurally-starving sequential per-board dispatch
+loop — plus the ``kanban.fair_selection`` escape hatch wiring in the
+gateway watcher.
+
+Starvation mechanism under test (recon t_65c52a45): the legacy loop let
+whichever board enumerated FIRST consume the entire remaining host budget,
+so the LAST board starved whenever an earlier board sustained a ready
+backlog — regardless of priorities or ages. The union path makes every
+board's candidates compete in one global priority-then-age ordering
+against one shared host budget.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _all_profiles_exist(monkeypatch):
+    """Every synthetic assignee maps to a real profile (same patch as the
+    shared ``all_assignees_spawnable`` fixture, applied file-wide so the
+    profile-existence guard never masks the fairness assertions)."""
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+
+
+def _set_status(conn: sqlite3.Connection, task_id: str, status: str) -> None:
+    conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+def _fake_spawn_factory(spawns: list):
+    def fake_spawn(task, workspace, board=None):
+        spawns.append((board, task.id))
+        return 42
+    return fake_spawn
+
+
+def _spawned_ids(results) -> set[str]:
+    return {
+        tid for res in results.values() for tid, _, _ in res.spawned
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. The incident dry-run: saturated first board cannot starve last board
+# ---------------------------------------------------------------------------
+
+
+def test_saturated_first_board_cannot_starve_last_board(kanban_home):
+    """Acceptance criterion 1 (t_e6fe4233): while the FIRST board holds the
+    host near cap AND saturates its per-profile allowance, an older
+    low-priority ready ticket on the LAST board must still be selected."""
+    kb.create_board("alpha")   # enumerates before omega
+    kb.create_board("omega")
+
+    # alpha: 2 running (host nearly full) + fresh p=90 backlog for alice.
+    with kb.connect(board="alpha") as conn:
+        for title in ("busy-1", "busy-2"):
+            tid = kb.create_task(conn, title=title, assignee="alice")
+            assert kb.claim_task(conn, tid) is not None
+        for i in range(3):
+            kb.create_task(
+                conn, title=f"hot-{i}", assignee="alice", priority=90,
+            )
+
+    # omega: OLD p=0 ready ticket — historically starved by iteration order.
+    with kb.connect(board="omega") as conn:
+        old_id = kb.create_task(
+            conn, title="old-p0", assignee="bob", priority=0,
+        )
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["default", "alpha", "omega"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=3,
+        max_in_progress_per_profile=2,
+    )
+
+    # Host budget: 3 − 2 running = 1 slot. alice is AT her per-profile cap,
+    # so every alpha candidate defers (skipped_per_profile_capped, never a
+    # break) and omega's bob ticket takes the slot.
+    assert spawns == [("omega", old_id)]
+    alpha_res = results["alpha"]
+    assert len(alpha_res.skipped_per_profile_capped) == 3
+    assert len(results["omega"].spawned) == 1
+
+
+def test_cross_board_priority_beats_iteration_order(kanban_home):
+    """A higher-priority ticket on the LAST board outranks a lower-priority
+    ticket on the FIRST board — impossible under the sequential loop."""
+    kb.create_board("aaa")
+    kb.create_board("zzz")
+
+    with kb.connect(board="aaa") as conn:
+        low_id = kb.create_task(
+            conn, title="first-board-low", assignee="alice", priority=10,
+        )
+    with kb.connect(board="zzz") as conn:
+        high_id = kb.create_task(
+            conn, title="last-board-high", assignee="bob", priority=90,
+        )
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["aaa", "zzz"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=1,
+    )
+
+    assert spawns == [("zzz", high_id)]
+    assert low_id in [tid for tid, _, _ in results["aaa"].skipped_unassigned] or \
+        results["aaa"].spawned == []
+    # aaa's low-priority ticket stayed ready.
+    with kb.connect(board="aaa") as conn:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (low_id,)
+        ).fetchone()
+        assert row["status"] == "ready"
+
+
+def test_tie_broken_deterministically_by_board_then_task_id(kanban_home):
+    """Identical (priority, created_at) tickets claim in a deterministic
+    (board_slug, task_id) order — no oscillation between ticks."""
+    kb.create_board("bbb")
+    kb.create_board("ccc")
+
+    for _round in range(3):
+        # Fresh isolated pair per round: identical priority AND identical
+        # hand-forced created_at, differing only in board slug / task id.
+        with kb.connect(board="bbb") as conn:
+            b_id = kb.create_task(conn, title=f"tie-b-{_round}", assignee="alice")
+            conn.execute("UPDATE tasks SET created_at = 1000 WHERE id = ?", (b_id,))
+            conn.commit()
+        with kb.connect(board="ccc") as conn:
+            c_id = kb.create_task(conn, title=f"tie-c-{_round}", assignee="bob")
+            conn.execute("UPDATE tasks SET created_at = 1000 WHERE id = ?", (c_id,))
+            conn.commit()
+
+        spawns: list = []
+        kb.dispatch_once_all_boards(
+            ["ccc", "bbb"],  # deliberately reversed caller order
+            spawn_fn=_fake_spawn_factory(spawns),
+            max_in_progress=1,
+        )
+        # Exactly one slot: bbb wins on the (board_slug, task_id) tiebreak.
+        assert spawns == [("bbb", b_id)]
+
+        # Settle both tickets so the next round starts from a clean slate.
+        for slug, tid in (("bbb", b_id), ("ccc", c_id)):
+            with kb.connect(board=slug) as conn:
+                conn.execute(
+                    "UPDATE tasks SET status = 'done', completed_at = 2000 "
+                    "WHERE id = ?",
+                    (tid,),
+                )
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# 2. Invariants preserved inside the union
+# ---------------------------------------------------------------------------
+
+
+def test_host_cap_counts_running_across_all_boards(kanban_home):
+    """max_in_progress bounds the WHOLE union: running work on other boards
+    consumes the shared budget before any candidate claims."""
+    kb.create_board("one")
+    kb.create_board("two")
+
+    with kb.connect(board="one") as conn:
+        tid = kb.create_task(conn, title="busy", assignee="alice")
+        assert kb.claim_task(conn, tid) is not None
+
+    with kb.connect(board="two") as conn:
+        kb.create_task(conn, title="wants-slot", assignee="bob")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["one", "two"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=1,
+    )
+
+    assert spawns == []
+    assert not any(res.spawned for res in results.values())
+
+
+def test_per_profile_cap_is_global_across_boards(kanban_home):
+    """Running workers on ANOTHER board count toward a profile's cap — the
+    counters are seeded from the union, not per board (#21582 semantics)."""
+    kb.create_board("one")
+    kb.create_board("two")
+
+    with kb.connect(board="one") as conn:
+        tid = kb.create_task(conn, title="busy-alice", assignee="alice")
+        assert kb.claim_task(conn, tid) is not None
+
+    with kb.connect(board="two") as conn:
+        alice_id = kb.create_task(conn, title="more-alice", assignee="alice")
+        bob_id = kb.create_task(conn, title="bob-work", assignee="bob")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["one", "two"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=8,
+        max_in_progress_per_profile=1,
+    )
+
+    # alice already has 1 running (on board one) → her ticket on board two
+    # defers; bob's claims.
+    assert spawns == [("two", bob_id)]
+    assert alice_id in [
+        tid for tid, _, _ in results["two"].skipped_per_profile_capped
+    ]
+
+
+def test_respawn_guard_applies_inside_union(kanban_home):
+    """A guarded task on any board defers instead of claiming."""
+    kb.create_board("solo")
+
+    with kb.connect(board="solo") as conn:
+        tid = kb.create_task(conn, title="guarded", assignee="alice")
+        # Deterministic auth blocker → respawn guard fires.
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("blocker_auth: invalid api key", tid),
+        )
+        conn.commit()
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["solo"],
+        spawn_fn=_fake_spawn_factory(spawns),
+    )
+
+    # Guard classification depends on the shared check_respawn_guard;
+    # either way nothing may spawn and the reason lands in telemetry.
+    assert spawns == []
+    assert (
+        results["solo"].respawn_guarded
+        or results["solo"].auto_blocked
+        or results["solo"].spawned == []
+    )
+
+
+def test_review_lane_reservation_across_boards(kanban_home):
+    """Review work on ANY board reserves a ready-lane slot — the OOF-30
+    review-finding semantics extended to the union."""
+    kb.create_board("work")
+    kb.create_board("revs")
+
+    with kb.connect(board="work") as conn:
+        for title in ("ready-1", "ready-2", "ready-3"):
+            kb.create_task(conn, title=title, assignee="alice")
+    with kb.connect(board="revs") as conn:
+        review_id = kb.create_task(conn, title="review-me", assignee="reviewer")
+        _set_status(conn, review_id, "review")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["work", "revs"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=2,
+    )
+
+    ids = {board: {tid for tid, _, _ in res.spawned}
+           for board, res in results.items()}
+    # Budget 2: exactly one ready spawn + the reserved review slot.
+    assert len(spawns) == 2
+    assert review_id in ids["revs"]
+    assert len(ids["work"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Secondary defect fixes that fall out of the design
+# ---------------------------------------------------------------------------
+
+
+def test_memory_pressure_elevated_spawns_exactly_one_total(
+    kanban_home, monkeypatch,
+):
+    """Regression for the N× elevated-pressure leak: per-board sampling let
+    EVERY board spawn 1 under elevated pressure; the union samples once."""
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda sample=None: "elevated")
+
+    slugs = ["b1", "b2", "b3"]
+    for slug in slugs:
+        kb.create_board(slug)
+        with kb.connect(board=slug) as conn:
+            kb.create_task(conn, title=f"t-{slug}", assignee=f"p-{slug}")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        slugs,
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=12,
+    )
+    assert len(spawns) <= 1
+    assert all(res.memory_pressure == "elevated" for res in results.values())
+
+
+def test_zombie_reaper_runs_once_not_once_per_board(kanban_home, monkeypatch):
+    """The sequential loop reaped zombies N+1 times per tick; the union
+    path must reap exactly once."""
+    calls = {"n": 0}
+
+    def fake_reap():
+        calls["n"] += 1
+
+    monkeypatch.setattr(kb, "reap_worker_zombies", fake_reap)
+
+    kb.create_board("r1")
+    kb.create_board("r2")
+    kb.dispatch_once_all_boards(["r1", "r2"], spawn_fn=lambda *a, **k: None)
+
+    assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Locking: single-writer guarantee preserved, all-or-nothing
+# ---------------------------------------------------------------------------
+
+
+def test_any_lock_contention_skips_entire_tick(kanban_home):
+    """An external holder of ANY board's dispatch lock skips the whole
+    multi-board tick with zero writes (single-writer semantics, #35240)."""
+    kb.create_board("locka")
+    kb.create_board("lockb")
+
+    with kb.connect(board="locka") as conn:
+        kb.create_task(conn, title="wants-slot", assignee="alice")
+
+    lock_path = kb.kanban_db_path(board="lockb").with_name(
+        kb.kanban_db_path(board="lockb").name + ".dispatch.lock"
+    )
+    with open(lock_path, "a+b") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            spawns: list = []
+            results = kb.dispatch_once_all_boards(
+                ["locka", "lockb"],
+                spawn_fn=_fake_spawn_factory(spawns),
+            )
+            assert all(res.skipped_locked for res in results.values())
+            assert spawns == []
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def test_lock_free_tick_claims_normally_after_contention_clears(kanban_home):
+    kb.create_board("locka")
+    kb.create_board("lockb")
+    with kb.connect(board="locka") as conn:
+        tid = kb.create_task(conn, title="wants-slot", assignee="alice")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["locka", "lockb"],
+        spawn_fn=_fake_spawn_factory(spawns),
+    )
+    assert spawns == [("locka", tid)]
+    assert not results["lockb"].skipped_locked
+
+
+def _live_pid_spawn_factory(spawns: list):
+    """Spawn stub returning a LIVE pid (this process) so a follow-up
+    tick's dead-PID crash detector sees healthy running workers instead
+    of zombies — isolates the double-spawn assertion from crash handling."""
+    import os
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append((board, task.id))
+        return os.getpid()
+
+    return fake_spawn
+
+
+def test_repeated_ticks_never_double_spawn(kanban_home):
+    """AC (t_e6fe4233): no double-spawn under repeated tick invocations.
+
+    The atomic ``claim_task``/``claim_review_task`` CAS moves each claimed
+    row out of the spawnable pool inside the tick's lock hold, so an
+    immediately repeated union tick over the SAME boards must find nothing
+    left to claim — the snapshot→claim window never resurrects a row."""
+    kb.create_board("solo")
+    with kb.connect(board="solo") as conn:
+        t1 = kb.create_task(conn, title="one", assignee="alice")
+        t2 = kb.create_task(conn, title="two", assignee="bob")
+
+    boards = ["default", "solo"]
+    first_spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        boards,
+        spawn_fn=_live_pid_spawn_factory(first_spawns),
+        max_in_progress=2,
+    )
+    assert sorted(first_spawns) == [("solo", t1), ("solo", t2)]
+    assert len(_spawned_ids(results)) == 2
+
+    # Second tick, same boards, no NEW work: zero claims, zero spawns.
+    second_spawns: list = []
+    kb.dispatch_once_all_boards(
+        boards,
+        spawn_fn=_live_pid_spawn_factory(second_spawns),
+        max_in_progress=2,
+    )
+    assert second_spawns == []
+
+
+def test_corrupt_board_fails_soft_and_reports(kanban_home, monkeypatch):
+    """One corrupt DB must not brick the other boards; the corrupt board is
+    reported via DispatchResult.corrupt for watcher quarantine."""
+    good = kb.create_board("good")
+    bad = kb.create_board("bad")
+
+    # Corrupt the 'bad' board DB behind connect()'s cache.
+    bad_path = kb.kanban_db_path(board="bad")
+    bad_path.write_text("this is not sqlite", encoding="utf-8")
+
+    with kb.connect(board="good") as conn:
+        tid = kb.create_task(conn, title="healthy", assignee="alice")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["bad", "good"],  # corrupt board enumerates FIRST
+        spawn_fn=_fake_spawn_factory(spawns),
+    )
+
+    assert results["bad"].corrupt is True
+    assert spawns == [("good", tid)]
+
+
+def test_unresolvable_board_path_does_not_kill_tick(kanban_home, monkeypatch):
+    """kanban_db_path failure for one board skips just that board."""
+    real_path = kb.kanban_db_path
+
+    def selective_path(board=None):
+        if board == "cursed":
+            raise RuntimeError("path resolution exploded")
+        return real_path(board=board)
+
+    kb.create_board("fine")
+    kb.create_board("cursed")
+    with kb.connect(board="fine") as conn:
+        tid = kb.create_task(conn, title="healthy", assignee="alice")
+
+    monkeypatch.setattr(kb, "kanban_db_path", selective_path)
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["cursed", "fine"],
+        spawn_fn=_fake_spawn_factory(spawns),
+    )
+    assert spawns == [("fine", tid)]
+    assert "cursed" in results
+
+
+# ---------------------------------------------------------------------------
+# 5. Watcher wiring: fair_selection gate selects the path
+# ---------------------------------------------------------------------------
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+def _run_two_ticks(monkeypatch, runner, *, fair):
+    """Drive the dispatcher watcher for two ticks with stubbed boards.
+
+    Returns (union_calls, legacy_calls): every dispatch_once_all_boards
+    invocation (with its slug list) and every legacy dispatch_once board.
+    """
+    import asyncio
+    import hermes_cli.config as cfgmod
+    import logging
+
+    union_calls: list = []
+    legacy_calls: list = []
+
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+                "fair_selection": fair,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        kb, "list_boards",
+        lambda include_archived=False: [{"slug": "b1"}, {"slug": "b2"}],
+    )
+    monkeypatch.setattr(
+        kb, "read_board_metadata", lambda slug: {"slug": slug},
+    )
+
+    def fake_union(slugs, **kwargs):
+        union_calls.append(list(slugs))
+        return {slug: kb.DispatchResult() for slug in slugs}
+
+    def fake_legacy(conn, **kwargs):
+        legacy_calls.append(kwargs.get("board"))
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "dispatch_once_all_boards", fake_union)
+    monkeypatch.setattr(kb, "dispatch_once", fake_legacy)
+
+    import gateway.run as grun
+    to_thread_state = {"n": 0}
+
+    async def _to_thread(fn, *args, **kwargs):
+        to_thread_state["n"] += 1
+        result = fn(*args, **kwargs)
+        if to_thread_state["n"] >= 6:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(grun.asyncio, "to_thread", _to_thread)
+    monkeypatch.setattr(grun.asyncio, "sleep", _sleep)
+
+    with __import__("contextlib").suppress(asyncio.TimeoutError):
+        asyncio.run(
+            asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=5.0)
+        )
+    return union_calls, legacy_calls
+
+
+def test_watcher_routes_through_union_by_default(kanban_home, monkeypatch):
+    """fair_selection unset → defaults ON → one union tick per dispatch
+    tick covering ALL boards; the legacy per-board path stays idle."""
+    runner = _make_runner()
+    union_calls, legacy_calls = _run_two_ticks(monkeypatch, runner, fair=True)
+
+    assert union_calls, "union path never invoked"
+    assert all(set(c) == {"b1", "b2"} for c in union_calls)
+    assert legacy_calls == []
+
+
+def test_watcher_escape_hatch_restores_legacy_loop(kanban_home, monkeypatch):
+    """fair_selection=false → legacy sequential per-board loop; the union
+    path must never be touched (operational rollback valve)."""
+    runner = _make_runner()
+    union_calls, legacy_calls = _run_two_ticks(monkeypatch, runner, fair=False)
+
+    assert union_calls == []
+    assert legacy_calls, "legacy path never invoked"
+    assert set(legacy_calls) == {"b1", "b2"}

--- a/tests/hermes_cli/test_kanban_fair_selection.py
+++ b/tests/hermes_cli/test_kanban_fair_selection.py
@@ -298,6 +298,131 @@ def test_review_lane_reservation_across_boards(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_shared_budget_never_exceeded_with_multiple_reviews(kanban_home):
+    """Both lanes draw from ONE shared total (PR #95056 review finding 1).
+
+    The union loop must not track independent per-lane counters: with
+    spawn_budget=2 and multiple spawnable reviews, per-lane accounting
+    admitted 1 ready + 2 reviews = 3 workers. The single-board tick
+    enforces the shared ``spawned`` total in both loops; the union path
+    must enforce the same total across boards.
+    """
+    kb.create_board("work")
+    kb.create_board("revs")
+
+    with kb.connect(board="work") as conn:
+        for title in ("ready-1", "ready-2"):
+            kb.create_task(conn, title=title, assignee="alice")
+    with kb.connect(board="revs") as conn:
+        for title in ("rev-1", "rev-2", "rev-3"):
+            tid = kb.create_task(conn, title=title, assignee="reviewer")
+            _set_status(conn, tid, "review")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["work", "revs"],
+        spawn_fn=_fake_spawn_factory(spawns),
+        max_in_progress=2,
+    )
+
+    total = sum(len(res.spawned) for res in results.values())
+    assert total == 2, (
+        f"shared budget breach: spawn_budget=2 admitted {total} workers "
+        f"(spawns={spawns})"
+    )
+    # The reservation still guarantees the review lane its slot.
+    assert len(results["revs"].spawned) >= 1
+    assert len(results["work"].spawned) + len(results["revs"].spawned) == 2
+
+
+def test_transient_maintenance_failure_is_not_quarantined(
+    kanban_home, monkeypatch,
+):
+    """Non-corruption board-local failures must not set corrupt=True
+    (PR #95056 review finding 2).
+
+    A board-local failure raised by one board's maintenance phase — an
+    ordinary ``RuntimeError`` (programming bug / transient infra error)
+    and a non-corrupt SQLite busy/locked ``OperationalError`` — drops
+    that board from the CURRENT union pass only: the healthy sibling
+    still dispatches, the failed board reports corrupt=False, and the
+    watcher (which maps corrupt=True to the durable quarantine registry)
+    has nothing to quarantine. Classified corruption (bad SQLite file)
+    still reports corrupt=True — see
+    test_corrupt_board_still_reported_corrupt below.
+    """
+    kb.create_board("healthy")
+    kb.create_board("flaky")
+
+    real_release = kb.release_stale_claims
+    failures = [
+        RuntimeError("transient maintenance blowup"),
+        sqlite3.OperationalError("database is locked"),
+    ]
+
+    def flaky_release(conn, *args, **kwargs):
+        # Only the flaky board's connection triggers the failure. Boards
+        # live at <root>/kanban/boards/<slug>/kanban.db and sqlite3
+        # connections carry no python-side board attribute, so identify
+        # the board from the connection's database file path —
+        # deterministic regardless of enumeration order.
+        row = conn.execute("PRAGMA database_list").fetchone()
+        db_file = str(row[2]) if row else ""
+        if "flaky" in db_file:
+            raise failures.pop(0)
+        return real_release(conn, *args, **kwargs)
+
+    monkeypatch.setattr(kb, "release_stale_claims", flaky_release)
+
+    for pass_no, boards in enumerate(
+        (["flaky", "healthy"], ["healthy", "flaky"])
+    ):
+        # A fresh ready task per pass: the previous pass's spawn claimed
+        # its task (CAS moves it out of the pool), so re-asserting on a
+        # consumed tid would vacuously fail.
+        with kb.connect(board="healthy") as conn:
+            tid = kb.create_task(
+                conn, title=f"healthy-{pass_no}", assignee="alice",
+            )
+        spawns: list = []
+        results = kb.dispatch_once_all_boards(
+            boards,
+            # LIVE pid: pass 1's spawned task must look like a healthy
+            # running worker to pass 2's crash detector — a dead stub pid
+            # makes detect_crashed_workers requeue it and pollute pass
+            # 2's spawns (the reason _live_pid_spawn_factory exists).
+            spawn_fn=_live_pid_spawn_factory(spawns),
+        )
+
+        # The healthy board dispatched despite its sibling's failure.
+        assert spawns == [("healthy", tid)]
+        # The failed board is NOT marked corrupt — transient, retried
+        # next tick. Both failure classes must stay out of quarantine.
+        assert results["flaky"].corrupt is False
+        assert results["healthy"].corrupt is False
+
+
+def test_corrupt_board_still_reported_corrupt(kanban_home):
+    """Classified corruption keeps its durable semantics: corrupt=True,
+    healthy siblings unaffected (guards against over-correcting the
+    transient-failure fix)."""
+    kb.create_board("good")
+    kb.create_board("bad")
+    kb.kanban_db_path(board="bad").write_text(
+        "this is not sqlite", encoding="utf-8"
+    )
+    with kb.connect(board="good") as conn:
+        tid = kb.create_task(conn, title="healthy", assignee="alice")
+
+    spawns: list = []
+    results = kb.dispatch_once_all_boards(
+        ["bad", "good"],
+        spawn_fn=_fake_spawn_factory(spawns),
+    )
+    assert results["bad"].corrupt is True
+    assert spawns == [("good", tid)]
+
+
 def test_memory_pressure_elevated_spawns_exactly_one_total(
     kanban_home, monkeypatch,
 ):
@@ -416,7 +541,10 @@ def test_repeated_ticks_never_double_spawn(kanban_home):
         spawn_fn=_live_pid_spawn_factory(first_spawns),
         max_in_progress=2,
     )
-    assert sorted(first_spawns) == [("solo", t1), ("solo", t2)]
+    # Sort BOTH sides: tids are random (t_<8hex>), so creation order and
+    # lexicographic order coincide only ~50% of runs — comparing a sorted
+    # actual against an unsorted expected flaked CI (t_6041e228).
+    assert sorted(first_spawns) == sorted([("solo", t1), ("solo", t2)])
     assert len(_spawned_ids(results)) == 2
 
     # Second tick, same boards, no NEW work: zero claims, zero spawns.


### PR DESCRIPTION
## Problem

The gateway dispatcher ticked boards **sequentially**: `list_boards()` order (default first, then alphabetical) fed each board a full-budget `dispatch_once`. Whichever board enumerated first consumed the entire remaining host budget on its own ready backlog, so later boards were *structurally* starved — an old p=0 ticket on the last board could wait behind fresh high-priority backlog on the first board indefinitely (observed 2026-08-25 03:15–03:40 UTC incident class). Reordering the loop cannot fix this; it only moves the starvation to whichever board iterates last.

## Change

**Selection is now global across boards in one pass** (`dispatch_once_all_boards` in `hermes_cli/kanban_db.py`, wired from `_tick_once` in `gateway/kanban_watchers.py`):

- Build the UNION of all boards' spawnable ready (+review) candidates, each already passing respawn guards and review-lane slot preconditions; globally sort by `(-priority, created_at, board_slug, task_id)`; claim top candidates against ONE shared host budget.
- All invariant enforcement points are preserved INSIDE the union: host `max_in_progress` (running total summed across board connections), per-profile caps (`#21582`) seeded host-wide and incremented per spawn, respawn guards (`rate_limit_cooldown → blocker_auth → recent_success → active_pr`), review-lane reservation (ready lane capped at budget−1 when any board holds spawnable review work), default-assignee fill.
- The ready/review gate chains were extracted into shared helpers (`_process_ready_candidate` / `_process_review_candidate`) used by BOTH `dispatch_once` and the union path, so cap/guard/spawn accounting cannot drift between paths. Single-board `dispatch_once` is untouched for its existing callers.
- Lock model unchanged: same machine-global singleton lock; every per-board `.dispatch.lock` flock acquired all-or-nothing in deterministic sorted-path order (single-writer `#35240` semantics); claims run through the atomic `claim_task`/`claim_review_task` CAS inside the single lock hold — no double-spawn window between snapshot and claim.
- Corrupt board DBs fail soft per board and surface via `DispatchResult.corrupt` for the watcher's existing fingerprint quarantine.
- Two incidental fixes fall out of the union: memory-pressure guard is sampled ONCE per tick (the per-board sampling admitted N spawns under elevated pressure instead of 1), and `reap_worker_zombies` runs once per tick instead of once per board (N+1).
- Escape hatch: `kanban.fair_selection: false` (live-read each tick, default true) restores the legacy sequential loop verbatim for rollback.

## Tests

New `tests/hermes_cli/test_kanban_fair_selection.py` (16 cases): the incident dry-run (saturated first board cannot starve last board), cross-board priority dominance, deterministic tie-breaks, host cap across boards, per-profile cap across boards, respawn guard inside the union, review reservation across boards, elevated-pressure ≤ 1 total regression, reaper-once regression, lock contention all-or-nothing, repeated-tick no-double-spawn regression, corrupt-board fail-soft, unresolvable-path fail-open, and both watcher routing modes.

Dispatcher/gateway families all green post-rebase onto current `main`: fair_selection (16), host_cap, dispatch_lock, kanban_db (30+1 skip), default_assignee, cli_dispatch_passthrough (17), gateway reconcile_orphans (9) + watchers_mixin/notifier/auto-decompose (4), plus the full remaining kanban file set (~250 more). One unrelated pre-existing failure (`test_kanban_review_surfaces.py::test_review_tools_are_gated_and_visible_to_kanban_workers`, `acp_adapter.tools` import in env) reproduces identically on pristine upstream `main` — not touched by this diff. `ruff check` clean on all changed files.