### PR TITLE
feat(desktop): open a Browser tab in the default browser from its context menu

### DIFF
--- a/apps/desktop/src/app/chat/pane-mirror.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.ts
@@ -10,6 +10,7 @@ import type { ReadableAtom } from 'nanostores'
 import type { ReactElement, ReactNode, PointerEvent as ReactPointerEvent } from 'react'
 
 import { registerPaneCloser, removeTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
+import type { MenuKit } from '@/components/ui/actions-menu'
 import { registry } from '@/contrib/registry'
 import type { WorkspaceMode } from '@/contrib/types'
 import type { TileDock } from '@/store/session-states'
@@ -52,6 +53,8 @@ export interface PaneMirror<T> {
    *  Per tile so a mirror can offer it for some of its tabs and not others. */
   newTab?: (key: string) => (() => void) | undefined
   render: (key: string) => ReactNode
+  /** Extra rows at the top of the zone tab menu (see PaneChrome.tabMenuPrefix). */
+  tabMenuPrefix?: (key: string) => ((kit: MenuKit) => ReactNode) | undefined
   /** Wrap the tile's TAB (domain context menu — session verbs). */
   tabWrap?: (key: string, tab: ReactElement) => ReactNode
   /** Override the tile's TAB drag (session drop language: stack/split/link).
@@ -113,6 +116,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
           tabDrag: cfg.tabDrag
             ? (event: ReactPointerEvent<HTMLElement>, onTap: () => void) => cfg.tabDrag!(key, event, onTap)
             : undefined, // returns boolean (handled) — see PaneChrome.tabDrag
+          tabMenuPrefix: cfg.tabMenuPrefix?.(key),
           tabWrap: cfg.tabWrap ? (tab: ReactElement) => cfg.tabWrap!(key, tab) : undefined
         },
         render: () => cfg.render(key),

--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -10,9 +10,9 @@ vi.mock('./right-rail/preview-console-store', () => ({
 
 import { contributesToWorkspace } from '@/components/pane-shell/workspace-scope'
 import { registry } from '@/contrib/registry'
-import { closeRightRail, openPreview } from '@/store/preview'
+import { $previewTabs, closeRightRail, noteBrowserPage, openPreview } from '@/store/preview'
 
-import { browserTabLabel, watchPreviewTiles } from './preview-tile'
+import { browserTabExternalUrl, browserTabLabel, watchPreviewTiles } from './preview-tile'
 
 beforeAll(() => {
   watchPreviewTiles()
@@ -69,6 +69,36 @@ describe('browserTabLabel', () => {
   // there is to name it by.
   it('names an unreported tab from its target', () => {
     expect(browserTabLabel({ ...target, url: 'https://github.com/nous' })).toBe('github.com')
+  })
+})
+
+describe('browserTabExternalUrl', () => {
+  const openBrowser = (url: string) => {
+    openPreview({ kind: 'url', label: 'Browser', source: url, url }, 'explicit-link')
+
+    return $previewTabs.get().find(tab => tab.target.kind === 'url')!.id
+  }
+
+  it('hands the live page to the OS browser, not the address the tab was opened with', () => {
+    const tabId = openBrowser('https://example.com')
+
+    noteBrowserPage(tabId, { title: 'Hacker News', url: 'https://news.ycombinator.com/' })
+
+    expect(browserTabExternalUrl(tabId)).toBe('https://news.ycombinator.com/')
+  })
+
+  it('falls back to the target when the tab has not reported a page yet', () => {
+    expect(browserTabExternalUrl(openBrowser('https://github.com/nous'))).toBe('https://github.com/nous')
+  })
+
+  it('refuses about:blank and other non-pages', () => {
+    expect(browserTabExternalUrl(openBrowser('about:blank'))).toBeNull()
+  })
+
+  it('is null for a file peek', () => {
+    openPreview(fileTarget('/tmp/a.ts'), 'file-browser')
+
+    expect(browserTabExternalUrl('file:/tmp/a.ts')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -14,8 +14,11 @@ import { useStore } from '@nanostores/react'
 
 import { findGroup } from '@/components/pane-shell/tree/model'
 import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
+import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
+import { translateNow } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
 import {
   $browserPages,
@@ -34,6 +37,40 @@ import { forgetPreviewConsole } from './right-rail/preview-console-store'
 /** The target behind a tile id, or null once its tab is gone. */
 function targetFor(tabId: string): PreviewTarget | null {
   return $previewTabs.get().find(tab => tab.id === tabId)?.target ?? null
+}
+
+/** Schemes that are not a page the user's default browser can usefully open
+ *  (blank vessel, Chromium internals, injected documents). */
+const NON_EXTERNAL_URL = /^(about|blob|chrome|data|devtools|javascript):/i
+
+/** The URL a Browser tab should hand to the OS browser — the page it is
+ *  showing now, else the address it was opened with. Null when there isn't
+ *  one (`about:blank`, a half-typed address, a file/artifact tab). */
+export function browserTabExternalUrl(tabId: string): null | string {
+  const target = targetFor(tabId)
+
+  if (target?.kind !== 'url') {
+    return null
+  }
+
+  const url = $browserPages.get()[tabId]?.url || target.url
+
+  return url && !NON_EXTERNAL_URL.test(url) ? url : null
+}
+
+function browserTabMenuPrefix(tabId: string) {
+  if (targetFor(tabId)?.kind !== 'url') {
+    return undefined
+  }
+
+  return (kit: MenuKit) =>
+    renderActionItem(kit, {
+      disabled: !browserTabExternalUrl(tabId),
+      icon: 'link-external',
+      key: 'open-external',
+      label: translateNow('preview.openInExternal'),
+      onSelect: () => openExternalLink(browserTabExternalUrl(tabId) ?? '')
+    })
 }
 
 /** Tab title. A URL tab is titled by the CONTRIBUTION as the surface — see
@@ -207,6 +244,7 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   // A Browser is a vessel, so there can be more of it — a file peek is one of
   // a kind and leaves the strip's "+" to whatever else the zone holds.
   newTab: tabId => (targetFor(tabId)?.kind === 'url' ? newBrowserTab : undefined),
+  tabMenuPrefix: browserTabMenuPrefix,
   render: tabId => <PreviewTilePane tabId={tabId} />,
   close: tabId => {
     forgetBrowserPage(tabId)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -9,6 +9,7 @@
 
 import type * as React from 'react'
 
+import type { MenuKit } from '@/components/ui/actions-menu'
 import type { Contribution } from '@/contrib/types'
 
 import type { GroupNode, LayoutNode } from '../model'
@@ -75,6 +76,10 @@ interface PaneChrome extends PaneSizing {
    *  pin/branch/rename/archive/delete). The wrapper must render `tab` as its
    *  interactive child; the zone's own strip menu still owns non-tab space. */
   tabWrap?: (tab: React.ReactElement) => React.ReactNode
+  /** Extra rows at the top of the zone tab menu. Called when the menu opens
+   *  against the right-clicked pane — a Browser tab's Open-in-external, without
+   *  replacing Reload / Close / the strip. */
+  tabMenuPrefix?: (kit: MenuKit) => React.ReactNode
   /** Override this pane's TAB drag (a session tab drags like a sidebar row —
    *  stack / split / composer-link — not the generic pane move). Given the
    *  tab's tap (activate) so that gesture survives. Returns whether it took the

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -97,6 +97,7 @@ function ZoneMenu({
   minimized,
   nodeId,
   stripVisible,
+  tabMenuPrefix,
   targetPane
 }: {
   children: ReactNode
@@ -111,6 +112,8 @@ function ZoneMenu({
   /** Whether the strip is on screen — the Hide/Show row toggles against what
    *  the user can see, not against the stored mode (a zone on auto has none). */
   stripVisible?: boolean
+  /** Domain verbs for the right-clicked pane, resolved when the menu opens. */
+  tabMenuPrefix?: (kit: MenuKit) => ReactNode
   /** The right-clicked chip (else the active pane) — what the close-others /
    *  to-the-right / all verbs measure from. Called when the menu RENDERS, not
    *  on every zone re-render: resolving the siblings reads the layout tree,
@@ -131,8 +134,12 @@ function ZoneMenu({
     const paneId = closable?.()
     const targetId = targetPane()
 
+    const prefix = tabMenuPrefix?.(kit)
+
     return (
       <>
+        {prefix}
+        {prefix ? <kit.Separator /> : null}
         {renderActionItem(kit, {
           icon: 'refresh',
           label: t.zones.reload,
@@ -394,6 +401,7 @@ export function TreeGroup({
     minimized: node.minimized,
     nodeId: node.id,
     stripVisible,
+    tabMenuPrefix: (kit: MenuKit) => paneChrome(paneFor(targetPane())).tabMenuPrefix?.(kit),
     targetPane
   }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2327,6 +2327,7 @@ export const ar = defineLocale({
     hide: 'إخفاء',
     openPreview: 'فتح المعاينة',
     openInBrowser: 'فتح في المتصفح',
+    openInExternal: 'فتح في الخارج',
     linkHint: '⌘/Ctrl-نقر لجزء المعاينة',
     sourceLineTitle: 'انقر للتحديد · shift-نقر للتوسيع · اسحب إلى المُنشئ',
     source: 'المصدر',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2970,6 +2970,7 @@ export const en: Translations = {
     hide: 'Hide',
     openPreview: 'Open preview',
     openInBrowser: 'Open in browser',
+    openInExternal: 'Open in external',
     linkHint: '⌘/Ctrl-click for preview pane',
     sourceLineTitle: 'Click to select · shift-click to extend · drag to composer',
     source: 'SOURCE',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2624,6 +2624,7 @@ export const ja = defineLocale({
     hide: '非表示',
     openPreview: 'プレビューを開く',
     openInBrowser: 'ブラウザで開く',
+    openInExternal: '外部で開く',
     linkHint: '⌘/Ctrl+クリックでプレビューペイン',
     sourceLineTitle: 'クリックして選択 · Shift クリックで拡張 · コンポーザーにドラッグ',
     source: 'ソース',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2535,6 +2535,7 @@ export interface Translations {
     hide: string
     openPreview: string
     openInBrowser: string
+    openInExternal: string
     linkHint: string
     sourceLineTitle: string
     source: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2535,6 +2535,7 @@ export const zhHant = defineLocale({
     hide: '隱藏',
     openPreview: '開啟預覽',
     openInBrowser: '在瀏覽器中開啟',
+    openInExternal: '在外部開啟',
     linkHint: '⌘/Ctrl+點擊在預覽窗格開啟',
     sourceLineTitle: '點擊選取 · shift 點擊擴展 · 拖曳至輸入框',
     source: '原始碼',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3134,6 +3134,7 @@ export const zh: Translations = {
     hide: '隐藏',
     openPreview: '打开预览',
     openInBrowser: '在浏览器中打开',
+    openInExternal: '在外部打开',
     linkHint: '⌘/Ctrl+点击在预览面板打开',
     sourceLineTitle: '点击选择 · shift 点击扩展 · 拖到输入框',
     source: '源码',


### PR DESCRIPTION
## Summary

Right-click a Browser tab to open its current page in the user's default browser. `about:blank` keeps the row but disables it so the verb stays discoverable.

## Test plan

- [ ] Open a URL in the in-app browser, right-click the tab chip, choose **Open in external**
- [ ] Confirm the default OS browser opens the page you are looking at (after navigating away from the tab's original address)
- [ ] On `about:blank`, the row is present and disabled
- [ ] A file preview tab does not get the extra row