### PR TITLE
fix(tui): reattach the live session on reconnect instead of forging a sibling

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1026,6 +1026,55 @@ describe('createGatewayEventHandler', () => {
     expect(getUiState().status).toBe('recovering session…')
   })
 
+  // #94935: after a transport drop (WS close / silent-drop heartbeat), the
+  // gateway fires `gateway.ready` again on reconnect while THIS client still
+  // holds its live session record. Reattach to that session — never forge an
+  // empty sibling via newSession(), which orphans a turn the gateway completed
+  // and persisted while the client was away (the reporter's lost reply).
+  it('on gateway.ready after a transport drop with a live session, reattaches instead of forging', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+
+    const onEvent = createGatewayEventHandler(ctx)
+
+    // The client was mid-conversation when the socket dropped: live sid and
+    // durable persisted id are both still in ui state.
+    patchUiState({ durableSessionId: '20260825_105702_a1b2c3', sid: 'f3a1b2c4' })
+    onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalled())
+    // The DURABLE id wins: the ephemeral sid may already be dead to
+    // ws_orphan_reap, while the persisted row is always reopenable.
+    expect(resumeById).toHaveBeenCalledWith('20260825_105702_a1b2c3')
+    expect(newSession).not.toHaveBeenCalled()
+  })
+
+  it('on gateway.ready after a drop before first prompt, reattaches by the live sid', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+
+    const onEvent = createGatewayEventHandler(ctx)
+
+    // A never-messaged chat has no persisted row yet — only the live sid.
+    patchUiState({ durableSessionId: '', sid: 'f3a1b2c4' })
+    onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('f3a1b2c4'))
+    expect(newSession).not.toHaveBeenCalled()
+  })
+
   it('on gateway.ready with auto_resume on and a recent session, resumes it', async () => {
     const appended: Msg[] = []
     const newSession = vi.fn()

--- a/ui-tui/src/__tests__/gatewayRecovery.test.ts
+++ b/ui-tui/src/__tests__/gatewayRecovery.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { GATEWAY_RECOVERY_LIMIT, GATEWAY_RECOVERY_WINDOW_MS, planGatewayRecovery } from '../app/gatewayRecovery.js'
+import {
+  GATEWAY_RECOVERY_LIMIT,
+  GATEWAY_RECOVERY_WINDOW_MS,
+  pickRecoverySessionId,
+  planGatewayRecovery
+} from '../app/gatewayRecovery.js'
 
 describe('planGatewayRecovery', () => {
   it('recovers the live session and records the attempt', () => {
@@ -43,5 +48,22 @@ describe('planGatewayRecovery', () => {
 
     expect(plan.attempts).toEqual([GATEWAY_RECOVERY_WINDOW_MS + 100])
     expect(plan.recover).toBe(true)
+  })
+})
+
+// #94935: the recovery target must survive a server-side ws_orphan_reap. The
+// ephemeral 8-hex live sid is minted per gateway process; the durable
+// state.db row key is what session.resume can still reopen after the reap.
+describe('pickRecoverySessionId', () => {
+  it('prefers the durable persisted id over the ephemeral live sid', () => {
+    expect(pickRecoverySessionId('20260825_105702_a1b2c3', 'f3a1b2c4')).toBe('20260825_105702_a1b2c3')
+  })
+
+  it('falls back to the live sid when nothing was persisted yet (fresh chat)', () => {
+    expect(pickRecoverySessionId('', 'f3a1b2c4')).toBe('f3a1b2c4')
+  })
+
+  it('returns null when there is neither a durable id nor a live session', () => {
+    expect(pickRecoverySessionId('', null)).toBeNull()
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -703,6 +703,24 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       return
     }
 
+    // Transport-drop reattach (#94935): unlike a process death, a dropped WS /
+    // silent socket keeps THIS client's session record alive in ui state while
+    // `gateway.ready` fires again on reconnect. Falling through to newSession()
+    // here forges an empty sibling conversation and orphans whatever the
+    // gateway was doing for the real one — including a turn that completed and
+    // persisted while the client was away (the reporter's lost reply; its
+    // session row then died to ws_orphan_reap before any reattach). Rebind to
+    // the session the UI still owns instead — by its durable persisted id when
+    // we have one (survives an orphan reap), else the live sid (fast-path
+    // reuse cancels a pending reap). resumeById carries its own setup gate.
+    const liveSid = getUiState().sid
+
+    if (liveSid && !STARTUP_RESUME_ID) {
+      resumeById(getUiState().durableSessionId || liveSid)
+
+      return
+    }
+
     if (STARTUP_RESUME_ID) {
       patchUiState({ status: 'resuming…' })
       resumeById(STARTUP_RESUME_ID)

--- a/ui-tui/src/app/gatewayRecovery.ts
+++ b/ui-tui/src/app/gatewayRecovery.ts
@@ -33,3 +33,14 @@ export function planGatewayRecovery(
 
   return { attempts: recover ? [...recent, now] : recent, recover, sid }
 }
+
+// Pick the id to carry into the next gateway.ready recovery (#94935). The
+// durable persisted id (state.db row key) wins whenever we have one: the live
+// 8-hex sid is minted per gateway process and dies with its in-memory record,
+// so a ws_orphan_reap during the very outage being recovered from makes a
+// resume-by-live-sid fail with 4007 ("session not found") and strands whatever
+// the gateway persisted for that conversation. Falls back to the live sid for
+// sessions with nothing persisted yet (fresh/lazy chats).
+export function pickRecoverySessionId(durableId: string, liveSid: null | string): null | string {
+  return durableId || liveSid || null
+}

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -341,6 +341,10 @@ export interface UiState {
   showReasoning: boolean
   indicatorStyle: IndicatorStyle
   sid: null | string
+  // Durable persisted session id (state.db row key) for the live `sid`, kept
+  // fresh on create/resume so a transport drop followed by a server-side
+  // ws_orphan_reap can still reattach the conversation by a valid id (#94935).
+  durableSessionId: string
   status: string
   statusBar: StatusBarMode
   streaming: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -30,6 +30,7 @@ const buildUiState = (): UiState => ({
   sessionTitle: '',
   showReasoning: false,
   sid: null,
+  durableSessionId: '',
   status: 'summoning hermes…',
   statusBar: 'top',
   streaming: true,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -48,7 +48,7 @@ import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
-import { planGatewayRecovery } from './gatewayRecovery.js'
+import { pickRecoverySessionId, planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type StateSetter, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
@@ -908,7 +908,15 @@ export function useMainApp(gw: GatewayClient) {
       patchUiState({ busy: false, sid: null, status: 'gateway exited' })
 
       if (plan.recover && plan.sid) {
-        recoverSidRef.current = plan.sid
+        // Prefer the DURABLE persisted id when we have one (#94935): the live
+        // 8-hex sid is minted per gateway process and dies with its in-memory
+        // record — a ws_orphan_reap during this very outage makes
+        // `session.resume` by live sid fail with 4007 ("session not found"),
+        // stranding a turn the gateway had already persisted and delivered.
+        // The durable state.db key reopens that same row instead of forging a
+        // sibling session; pickRecoverySessionId falls back to the live sid
+        // when nothing was persisted yet.
+        recoverSidRef.current = pickRecoverySessionId(getUiState().durableSessionId, plan.sid)
         turnController.pushActivity('gateway exited · recovering session…', 'warn')
         sys('gateway exited — recovering your session (any in-flight reply was lost)')
         gw.start()

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -148,7 +148,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
-    patchUiState({ bgTasks: new Set(), info: null, sid: null, usage: ZERO })
+    patchUiState({ bgTasks: new Set(), durableSessionId: '', info: null, sid: null, usage: ZERO })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')
@@ -215,7 +215,14 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       setSessionStartedAt(Date.now())
 
       writeActiveSessionFile(r.session_id)
+      // Remember the DURABLE persisted id (`stored_session_id`, the state.db row
+      // key) alongside the ephemeral live sid. The live sid dies with its
+      // gateway session record — a ws_orphan_reap during a transport drop makes
+      // any later resume-by-live-sid fail with 4007 and strands the completed
+      // turn in the persisted transcript (#94935). The durable key keeps the
+      // conversation reattachable from any future gateway.ready.
       patchUiState({
+        durableSessionId: r.stored_session_id || '',
         info,
         sid: r.session_id,
         status: info?.version ? 'ready' : 'starting agent…',
@@ -361,8 +368,13 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
             setHistoryItems(info ? [introMsg(info), ...resumed] : resumed)
             writeActiveSessionFile(r.resumed ?? r.session_id)
+            // `resumed`/`session_key` is the durable persisted id this live
+            // record now carries — keep it fresh so a later drop can reattach
+            // by it even if this resume was reached through a title or a
+            // stale live sid (#94935).
             patchUiState({
               busy: running,
+              durableSessionId: r.resumed || r.session_key || '',
               info,
               sid: r.session_id,
               status: statusFromLiveSession(r.status, running),

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -179,6 +179,9 @@ export interface SystemBatteryResponse {
 export interface SessionCreateResponse {
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
+  // Durable state.db row key (timestamped) — survives the ephemeral live sid,
+  // which a ws_orphan_reap can invalidate while the client is disconnected.
+  stored_session_id?: string
 }
 
 export interface SessionResumeResponse {
@@ -188,6 +191,9 @@ export interface SessionResumeResponse {
   messages: GatewayTranscriptMessage[]
   resumed?: string
   running?: boolean
+  // Durable persisted id the live record carries (same value as `resumed` on
+  // cold resumes; present on live-reuse resumes too).
+  session_key?: string
   session_id: string
   started_at?: number
   status?: LiveSessionStatus


### PR DESCRIPTION
## Summary

- A transport drop (WS close, silent-drop heartbeat) followed by a reconnect fires `gateway.ready` again while **this client still holds its live session record**. `handleReady` fell through to `newSession()` in that state: it forged an empty sibling conversation and left the real one unattached.
- Everything the gateway did for the original session after the drop was stranded — including a turn that **completed and persisted** (`finish_reason=stop` in `state.db`) while the client was away. Its row then died to the `ws_orphan_reap` grace timer (20s) before any reattach could cancel it. That is exactly the #94935 timeline: idle 76 min → socket closes mid-turn at 10:57:02 → reap fires at 10:57:22 → client reconnects at 10:57:25.9 → reply persisted but never rendered.
- Track the **durable persisted id** (`stored_session_id` from `session.create`, refreshed from `resumed`/`session_key` on every resume) alongside the ephemeral 8-hex live sid. The live sid is minted per gateway process; once its record is reaped, `session.resume` by that sid fails with 4007. The state.db row key reopens the same conversation even after the reap (`reopen_session` clears `ws_orphan_reap` by design — the code itself calls it a "mistaken TUI reaper").
- On `gateway.ready` with a live session in ui state (and no explicit `STARTUP_RESUME_ID`), `resumeById(durable || liveSid)` instead of forging new. Crash recovery via `recoverSidRef` keeps priority, and now also carries the durable id so a respawn during the same outage resumes the persisted row rather than the doomed ephemeral one.

The desktop surface is unaffected: its lossless replay (#94399) already covers missed events across reconnects. The TUI consumes no event replay today — which is exactly why the reattach must go through `session.resume`.

## Tests

- `pickRecoverySessionId` contract: durable wins over the ephemeral sid; live-sid fallback for never-persisted chats; null when neither exists.
- Two handler-contract tests proving `gateway.ready` after a drop reattaches — by durable id when present, by live sid otherwise — and never calls `newSession` while a live session exists.
- All five new assertions fail on pristine main and pass with this diff (RED→GREEN proven).
- Full ui-tui suite: 159 files / 1718 tests green. `tsc --noEmit` clean; eslint clean (one pre-existing exhaustive-deps warning in useSessionLifecycle, untouched).

Fixes #94935