### PR TITLE
fix(desktop): keep New Cronjob owner labels render-safe (salvage #93572)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5879,6 +5879,12 @@ async function openRosterBot(bot) {
 }
 
 function displayName(bot, meta) {
+  // Defensive: callers have historically passed {name: <object>} here (e.g.
+  // wrapping a roster owner object instead of its .name); a non-string name
+  // must degrade to '' rather than TypeError mid-render.
+  if (bot && typeof bot.name !== 'string') {
+    bot = { ...bot, name: typeof bot.name === 'object' && bot.name !== null ? String(bot.name?.name ?? '') : '' }
+  }
   // A configured alias route claiming this row overrides source-derived
   // identity: the friendly alias name must survive hosted-session
   // activation and Cloud-only rosters (#89131).
@@ -11207,7 +11213,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
               'Send results to',
               pickerSelect(target, setTarget, [
                 { id: 'history', label: 'Run history only' },
-                { id: 'bot-chat', label: `${displayName({ name: bot }, $botMeta.get()[bot])}\u2019s chat (bot responds)` }
+                { id: 'bot-chat', label: `${displayName(typeof bot === 'string' ? { name: bot } : bot, botRosterMeta(bot, $botMeta.get()))}\u2019s chat (bot responds)` }
               ])
             ),
             jsxs('label', {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5879,12 +5879,6 @@ async function openRosterBot(bot) {
 }
 
 function displayName(bot, meta) {
-  // Defensive: callers have historically passed {name: <object>} here (e.g.
-  // wrapping a roster owner object instead of its .name); a non-string name
-  // must degrade to '' rather than TypeError mid-render.
-  if (bot && typeof bot.name !== 'string') {
-    bot = { ...bot, name: typeof bot.name === 'object' && bot.name !== null ? String(bot.name?.name ?? '') : '' }
-  }
   // A configured alias route claiming this row overrides source-derived
   // identity: the friendly alias name must survive hosted-session
   // activation and Cloud-only rosters (#89131).
@@ -11097,6 +11091,12 @@ function defaultScheduleState() {
   return { freq: 'daily', time: '9:0', weekday: '1', monthday: '1', intervalN: '2', intervalUnit: 'h', onceN: '30', onceUnit: 'm', repeatN: '', raw: '' }
 }
 
+function routineDialogBotLabel(bot, metaByName) {
+  const owner = typeof bot === 'string' ? { name: bot } : bot
+
+  return displayName(owner, botRosterMeta(owner, metaByName))
+}
+
 function CreateRoutineDialog({ bot, open, onClose }) {
   const [name, setName] = useState('')
   const [instruction, setInstruction] = useState('')
@@ -11110,7 +11110,9 @@ function CreateRoutineDialog({ bot, open, onClose }) {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(null)
   const activeProfile = useValue(host.state.profile)
+  const allMeta = useValue($botMeta)
   const profile = typeof bot === 'string' ? bot : bot?.name
+  const botLabel = routineDialogBotLabel(bot, allMeta)
   const schedule = composeSchedule(sched)
 
   const reset = () => {
@@ -11183,7 +11185,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
           children: [
             jsx(DialogTitle, { children: 'New Cronjob' }),
             jsx(DialogDescription, {
-              children: `A recurring task ${displayName(typeof bot === 'string' ? { name: bot } : bot, botRosterMeta(bot, $botMeta.get()))} runs on a schedule. Runs land in its own chat history.`
+              children: `A recurring task ${botLabel} runs on a schedule. Runs land in its own chat history.`
             })
           ]
         }),
@@ -11213,7 +11215,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
               'Send results to',
               pickerSelect(target, setTarget, [
                 { id: 'history', label: 'Run history only' },
-                { id: 'bot-chat', label: `${displayName(typeof bot === 'string' ? { name: bot } : bot, botRosterMeta(bot, $botMeta.get()))}\u2019s chat (bot responds)` }
+                { id: 'bot-chat', label: `${botLabel}\u2019s chat (bot responds)` }
               ])
             ),
             jsxs('label', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-dialog-owner.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-dialog-owner.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #93572: RoutinesPane.openCreate() stores resolveRoutineOwner()'s result as
+// CreateRoutineDialog's bot prop. The dialog wrapped that owner again and
+// passed the resulting {name: <object>} shape to displayName(), which called
+// string methods on the object and crashed the whole pane. Keep one normalized
+// owner shape for both display and metadata lookup.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+      globalThis.__api = { routineDialogBotLabel };
+    `)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__api
+}
+
+test('regression #93572: a roster-owner object composes the label without throwing', () => {
+  const { routineDialogBotLabel } = load()
+  assert.equal(routineDialogBotLabel({ name: 'blog-writer' }, {}), 'Blog Writer')
+})
+
+test('string owners keep their configured title through the normalized metadata lookup', () => {
+  const { routineDialogBotLabel } = load()
+  const metaByName = { 'blog-writer': { title: 'The Blog Writer' } }
+  assert.equal(routineDialogBotLabel('blog-writer', metaByName), 'The Blog Writer')
+})
+
+test('roster-object owners keep their configured title through the same metadata lookup', () => {
+  const { routineDialogBotLabel } = load()
+  const metaByName = { 'blog-writer': { title: 'The Blog Writer' } }
+  assert.equal(routineDialogBotLabel({ name: 'blog-writer' }, metaByName), 'The Blog Writer')
+})
+
+test('a remote roster-object owner never throws when its route cannot resolve', () => {
+  const { routineDialogBotLabel } = load()
+  const owner = { name: 'worker', remoteSource: true, sourceScoped: true, connectionId: 'gone' }
+  const label = routineDialogBotLabel(owner, {})
+  assert.equal(typeof label, 'string')
+  assert.ok(label.length > 0)
+})


### PR DESCRIPTION
## What does this PR do?

Opening **New Cronjob** can crash the whole Cronjobs pane when the selected bot is represented by a roster-owner object. The dialog wrapped that object again as `{ name: <object> }`; `displayName()` then used string methods on the nested object during render.

This salvage preserves @zhangfei1231231-sketch's original fix commit from #93572 and adds the smallest follow-up required by review:

- normalize string and roster-object owners once in a dialog-local helper;
- use the same normalized owner for display and metadata lookup;
- reuse one reactive label for the dialog description and delivery option;
- leave the global roster `displayName()` path unchanged.

Configured titles remain intact for both owner shapes, and opening the dialog no longer takes down the pane.

## Related Issue

Related to #94471 and the Routines class tracked in #94726. This fixes a separate deterministic render path with the same error-boundary signature; it does not replace #94621's RPC-rejection handling.

Supersedes #93572 while preserving its original authored commit.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: scope owner normalization to `CreateRoutineDialog` and reuse the computed label at both render sites.
- `apps/desktop/src/plugins/hermes-bots/tests/routine-dialog-owner.test.mjs`: cover string owners, roster-object owners, configured titles, and an unreachable remote-owner fallback.

## How to Test

1. Open a Bot Chat and its Cronjobs pane.
2. Select **New Cronjob**.
3. Confirm the bot label appears in the description and delivery destination.
4. Enter a name and instruction, create the cronjob, and confirm the row appears without an error boundary.

## Validation

| Check | Result |
| --- | --- |
| Focused owner-label tests | 4/4 pass |
| Full Bot plugin suite | 560/560 pass |
| Desktop TypeScript checks | pass |
| Production Desktop build | pass |
| Live macOS `dev:mock` dialog + create flow | pass |
| `git diff --check` | pass |

The full Python suite was also executed. It reported 36,890 passing tests and 87 failures across 21 unrelated Python/platform files; the same failure files reproduce on pristine `main` under this local environment. This Desktop-only diff does not modify those paths.

## Checklist

### Code

- [x] I've read the contribution and Desktop engineering guides.
- [x] My commits use Conventional Commits.
- [x] I searched open issues and PRs; this is a credited continuation of #93572.
- [x] The PR contains only changes related to this crash.
- [ ] The complete Python suite passes locally. See the baseline-parity note above.
- [x] I added behavior coverage for the bug.
- [x] I tested on macOS.

### Documentation & Housekeeping

- [x] Documentation changes are not applicable.
- [x] Config changes are not applicable.
- [x] Architecture/workflow changes are not applicable.
- [x] Cross-platform impact is limited to renderer JavaScript with no platform branch.
- [x] Tool descriptions and schemas are unchanged.

## Screenshots / Logs

The screenshot below shows both corrected owner-label surfaces. It was captured from an isolated mock home and excludes local paths and production identities.

<img width="958" height="1168" alt="New Cronjob dialog with the bot chat destination" src="https://github.com/user-attachments/assets/ffd22ec0-7784-4462-a412-64ba321f4fb8" />

<!-- screenshot attached after draft creation -->
