### PR TITLE
fix(agent): recover llama.cpp combined context budgets

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5287,6 +5287,34 @@ def run_conversation(
                 # compress history and retry, not abort immediately.
                 status_code = getattr(api_error, "status_code", None)
 
+                # Keep the exact output reservation that was sent on the wire.
+                # Current llama.cpp reports prompt + reserved output as one
+                # combined request total, so the error text alone cannot tell
+                # an oversized prompt from an oversized max_tokens setting.
+                # Middleware may rewrite the request, therefore read the final
+                # payload rather than agent.max_tokens.
+                _request_output_tokens = None
+                if isinstance(api_kwargs, dict):
+                    for _output_key in (
+                        "max_output_tokens",
+                        "max_completion_tokens",
+                        "max_tokens",
+                    ):
+                        _output_value = api_kwargs.get(_output_key)
+                        if (
+                            isinstance(_output_value, int)
+                            and not isinstance(_output_value, bool)
+                            and _output_value > 0
+                        ):
+                            _request_output_tokens = _output_value
+                            break
+                _parsed_output_cap_budget = (
+                    parse_available_output_tokens_from_error(
+                        error_msg,
+                        requested_output_tokens=_request_output_tokens,
+                    )
+                )
+
                 # ── Respect disabled auto-compaction on overflow ──────
                 # Ported from anomalyco/opencode#30749.  When the user has
                 # turned auto-compaction off (``compression.enabled: false``),
@@ -5314,8 +5342,11 @@ def run_conversation(
                     FailoverReason.context_overflow,
                 }
                 _is_output_cap_error = (
-                    is_output_cap_error(error_msg)
-                    or parse_available_output_tokens_from_error(error_msg) is not None
+                    is_output_cap_error(
+                        error_msg,
+                        requested_output_tokens=_request_output_tokens,
+                    )
+                    or _parsed_output_cap_budget is not None
                 )
                 if (
                     classified.reason in _overflow_reasons
@@ -5436,7 +5467,7 @@ def run_conversation(
                 # widened is_context_length_error entry, and is reused as
                 # available_out inside the handler.
                 _wrapped_output_cap_budget = (
-                    parse_available_output_tokens_from_error(error_msg)
+                    _parsed_output_cap_budget
                     if classified.reason == FailoverReason.rate_limit
                     else None
                 )
@@ -5771,7 +5802,7 @@ def run_conversation(
                     #
                     # Note: max_tokens = output token cap (one response).
                     #       context_length = total window (input + output combined).
-                    available_out = parse_available_output_tokens_from_error(error_msg)
+                    available_out = _parsed_output_cap_budget
                     if available_out is not None:
                         # This is an output-cap error, not input overflow.
                         # The provider's available_tokens is the authoritative
@@ -5867,7 +5898,10 @@ def run_conversation(
                     # re-sends the same max_tokens, gets the identical 400, and
                     # death-loops until "cannot compress further" (#55546).
                     # Fail fast with an actionable message instead of looping.
-                    if is_output_cap_error(error_msg):
+                    if is_output_cap_error(
+                        error_msg,
+                        requested_output_tokens=_request_output_tokens,
+                    ):
                         agent._flush_status_buffer()
                         agent._vprint(
                             f"{agent.log_prefix}❌ The provider rejected the request because "

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1707,7 +1707,11 @@ def get_context_length_from_provider_error(
     return None
 
 
-def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
+def parse_available_output_tokens_from_error(
+    error_msg: str,
+    *,
+    requested_output_tokens: Optional[int] = None,
+) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
     Background — two distinct context errors exist:
@@ -1725,6 +1729,43 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     the error does not look like a max_tokens-too-large error.
     """
     error_lower = error_msg.lower()
+
+    # Current llama.cpp chat-completions servers report the TOTAL request
+    # reservation (measured prompt + requested max_tokens) without naming the
+    # two components:
+    #
+    #   request (67585 tokens) exceeds the available context size
+    #   (65536 tokens), try increasing it
+    #
+    # On its own that wording is ambiguous: it could describe an input that
+    # already exceeds the window.  The exact wire request removes the
+    # ambiguity because Hermes knows the output reservation it sent.  Infer
+    # the measured input as ``total - requested_output`` and only classify the
+    # failure as output-cap-shaped when that input fits by itself.  If it does
+    # not fit, return None and let the ordinary compression path handle the
+    # genuine prompt overflow.
+    _llama_combined_budget: Optional[int] = None
+    _m_llama_combined = re.search(
+        r'request\s*\(\s*(\d+)\s*tokens?\s*\)\s*exceeds\s*the\s*'
+        r'available\s*context\s*size\s*\(\s*(\d+)\s*tokens?\s*\)',
+        error_lower,
+    )
+    if (
+        _m_llama_combined
+        and isinstance(requested_output_tokens, int)
+        and not isinstance(requested_output_tokens, bool)
+        and requested_output_tokens > 0
+    ):
+        _request_total = int(_m_llama_combined.group(1))
+        _context_size = int(_m_llama_combined.group(2))
+        _inferred_input = _request_total - requested_output_tokens
+        _available = _context_size - _inferred_input
+        if (
+            _request_total > _context_size
+            and 0 <= _inferred_input < _context_size
+            and 1 <= _available < requested_output_tokens
+        ):
+            _llama_combined_budget = _available
 
     # Must look like an output-cap error, not a prompt-length error.
     is_output_cap_error = (
@@ -1759,9 +1800,12 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
-    )
+    ) or _llama_combined_budget is not None
     if not is_output_cap_error:
         return None
+
+    if _llama_combined_budget is not None:
+        return _llama_combined_budget
 
     # Generic model-output-cap form:
     #   "max_tokens (98304) exceeds model's maximum output tokens (65536)"
@@ -1865,7 +1909,11 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     return None
 
 
-def is_output_cap_error(error_msg: str) -> bool:
+def is_output_cap_error(
+    error_msg: str,
+    *,
+    requested_output_tokens: Optional[int] = None,
+) -> bool:
     """Return True if a 400 is about the OUTPUT cap (max_tokens) being too large.
 
     This is the broader sibling of :func:`parse_available_output_tokens_from_error`:
@@ -1889,6 +1937,18 @@ def is_output_cap_error(error_msg: str) -> bool:
     path (a real input overflow can also mention max_tokens).
     """
     error_lower = error_msg.lower()
+
+    # The current llama.cpp combined-budget wording does not mention
+    # max_tokens.  It is only safe to call it output-cap-shaped when the wire
+    # reservation lets the parser prove that the input fits independently.
+    if requested_output_tokens is not None and (
+        parse_available_output_tokens_from_error(
+            error_msg,
+            requested_output_tokens=requested_output_tokens,
+        )
+        is not None
+    ):
+        return True
 
     mentions_output_param = (
         "max_tokens" in error_lower

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4922,6 +4922,55 @@ class TestRunConversation:
         # context_length was NOT mutated by an output-cap error.
         assert agent.context_compressor.context_length == 200_000
 
+    def test_llama_cpp_combined_budget_retries_with_smaller_output_cap(self, agent):
+        """Current llama.cpp reports prompt + reserved output as one total.
+
+        The exact live failure was misrouted into input compression.  When the
+        protected transcript could not shrink, Hermes returned ``Cannot
+        compress further`` without retrying even though the prompt itself fit
+        and lowering the 32K output reservation was sufficient.
+        """
+        self._setup_agent(agent)
+        agent.api_mode = "chat_completions"
+        agent.provider = "custom"
+        agent.base_url = "http://127.0.0.1:8091/v1"
+        agent.model = "qwen3.6-27b-uncensored"
+        agent.max_tokens = 32_768
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 65_536
+        agent.context_compressor.should_compress = MagicMock(return_value=True)
+
+        error_msg = (
+            "request (67585 tokens) exceeds the available context size "
+            "(65536 tokens), try increasing it"
+        )
+        exc = Exception(error_msg)
+        exc.status_code = 400
+        exc.code = 400
+
+        ok_resp = _mock_response(content="continued", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [exc, ok_resp]
+
+        def _no_progress(messages, system_message, **kwargs):
+            return messages, system_message
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent.context_compressor, "update_model"),
+            patch.object(agent, "_compress_context", side_effect=_no_progress),
+        ):
+            result = agent.run_conversation("continue the project")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "continued"
+        assert not result.get("compression_exhausted")
+        assert agent.client.chat.completions.create.call_count == 2
+        second_call = agent.client.chat.completions.create.call_args_list[1].kwargs
+        assert 1 <= second_call["max_tokens"] < 32_768
+        assert agent.context_compressor.context_length == 65_536
+
     def test_output_cap_retry_compression_no_progress_terminates_bounded(self, agent):
         """Regression: when the compressor cannot reduce the request (zero
         progress AND no images to strip), the output-cap retry must terminate

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,51 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+class TestParseLlamaCppCombinedRequestBudget:
+    """llama.cpp reports input + reserved output as one request total.
+
+    Unlike its older error format, the current server response does not name
+    ``max_tokens`` or split input from output.  The wire request still gives
+    Hermes the missing output reservation, so the parser can recover the
+    available output budget without compacting an input that already fits.
+    """
+
+    _MSG = (
+        "request (67585 tokens) exceeds the available context size "
+        "(65536 tokens), try increasing it"
+    )
+
+    def test_combined_request_budget_uses_wire_output_reservation(self):
+        # inferred input = 67,585 - 32,768 = 34,817
+        # available output = 65,536 - 34,817 = 30,719
+        assert parse_available_output_tokens_from_error(
+            self._MSG,
+            requested_output_tokens=32_768,
+        ) == 30_719
+
+    def test_combined_request_budget_is_output_cap_error(self):
+        assert is_output_cap_error(
+            self._MSG,
+            requested_output_tokens=32_768,
+        ) is True
+
+    def test_combined_request_without_wire_cap_stays_ambiguous(self):
+        # The same wording could describe a genuinely oversized input when
+        # the caller does not know what output reservation was sent.
+        assert parse_available_output_tokens_from_error(self._MSG) is None
+        assert is_output_cap_error(self._MSG) is False
+
+    def test_input_alone_over_window_stays_context_overflow(self):
+        msg = (
+            "request (100000 tokens) exceeds the available context size "
+            "(65536 tokens), try increasing it"
+        )
+        assert parse_available_output_tokens_from_error(
+            msg,
+            requested_output_tokens=8_192,
+        ) is None
+        assert is_output_cap_error(
+            msg,
+            requested_output_tokens=8_192,
+        ) is False


### PR DESCRIPTION
## What does this PR do?

Handles the current llama.cpp context error when its reported `request` total includes both the prompt and the requested output reservation:

```text
request (67585 tokens) exceeds the available context size (65536 tokens), try increasing it
```

In the reproduced case, Hermes sent `max_tokens=32768`. That means the input itself was about 34,817 tokens and fit inside the 65,536-token runtime window; only the combined input-plus-output reservation was too large. Hermes previously treated this as oversized input, attempted compression, and terminated with `Context length exceeded ... Cannot compress further` when the protected transcript could not shrink.

This change reads the exact output cap from the final request kwargs, proves whether the input fits by itself, and then reuses the existing output-cap retry with a smaller cap. The parser deliberately returns no output budget when the wire cap is unavailable, and a genuinely oversized input remains on the context-compression path.

## Related Issue

Related to #89504, but complementary: #89504 handles a resolved context window that is larger than llama.cpp's actual runtime window. This PR handles a correct runtime window where llama.cpp rejects the combined prompt-plus-output reservation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: safely parse llama.cpp's combined request/context totals when the exact requested output cap is known.
- `agent/conversation_loop.py`: capture the output reservation from the final wire kwargs and reuse the parsed budget across context and output-cap recovery.
- `tests/test_output_cap_parsing.py`: cover the exact error arithmetic, ambiguous no-cap input, and genuine input overflow.
- `tests/run_agent/test_run_agent.py`: reproduce the terminal no-progress path and prove that Hermes retries with a smaller output cap instead.

## How to Test

1. Run `scripts/run_tests.sh tests/test_output_cap_parsing.py tests/test_ctx_halving_fix.py tests/agent/test_protected_tail_pressure_61932.py -q`.
2. Run `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestRunConversation::test_llama_cpp_combined_budget_retries_with_smaller_output_cap -q`.
3. Configure a llama.cpp endpoint with a 65,536-token context and request 32,768 output tokens after the prompt grows beyond 32,768 tokens. Hermes should reduce the output reservation and retry rather than terminating when compression makes no progress.

Current rebased result: 38/38 affected and adjacent tests passed on Windows 11; Ruff passed on all four changed files.

The all-repository runner was also attempted on this Windows checkout. It was not a clean gate because unrelated baseline files require the optional ACP package or POSIX/symlink behavior and some LSP tests timed out under the parallel runner, so the full-suite checkbox below is intentionally left unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented in code/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure provider-error parsing and request-budget handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:

```text
Provider error
Context length exceeded (35,815 tokens). Cannot compress further.
```

After parsing the reproduced wire values:

```text
available output: 30719
output-cap error: true
ambiguous without exact wire cap: none
```
