### PR TITLE
fix(install): tier-0 locked sync no longer trips over UV_NO_CONFIG

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1709,7 +1709,22 @@ install_deps() {
         #                  This respects the curation in pyproject.toml.
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
-        if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+        #
+        # Strip UV_NO_CONFIG for this one invocation. The global export at
+        # script start (the #21269 sudo -u hygiene guard) also hides the
+        # project's own [tool.uv] policy — exclude-newer and its package
+        # exemptions — from uv. The resolver then runs under a different
+        # policy than the one uv.lock was resolved under, and --locked
+        # turns that mismatch fatal:
+        #   error: The lockfile at `uv.lock` needs to be updated, but
+        #   `--locked` was provided.
+        # Every fresh install then falls through to the non-hash-verified
+        # PyPI fallback tiers, defeating the point of Tier 0. Runtime code
+        # already strips UV_NO_CONFIG before its own locked syncs for the
+        # same reason (hermes_cli/managed_uv.py, "Locked sync must see
+        # project [tool.uv] exclude-newer"). The export stays in effect for
+        # every other uv call in this script.
+        if env -u UV_NO_CONFIG UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0


### PR DESCRIPTION
## Summary

`scripts/install.sh` exports `UV_NO_CONFIG=1` at script start (sudo -u config-hygiene guard, #21269). That global export also hides the **project's own** `[tool.uv]` policy — `exclude-newer = "14 days"` plus its package exemptions — from uv. The resolver then runs under a different policy than the one `uv.lock` was resolved under, and `--locked` turns that mismatch fatal:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
hint: To update the lockfile, run `uv lock`.
```

The installer's tier-0 hash-verified install (`uv sync --extra all --locked`, line ~1712) hits this on **every fresh install**, then logs ``uv.lock sync failed … falling back to PyPI resolve`` — so installs still complete, but silently through the non-hash-verified fallback tiers, defeating the point of Tier 0 (the "worm-poisoned transitive" protection the script itself documents).

Reproduced on two hosts (uv 0.11.21 and uv 0.11.32 — not version-specific):

| Scenario | Result |
|---|---|
| tier-0 line with `UV_NO_CONFIG=1` inherited (current behavior) | `Resolving despite existing lockfile due to removal of global exclude newer` → `error: The lockfile at uv.lock needs to be updated, but --locked was provided` (rc=1) |
| tier-0 line with `env -u UV_NO_CONFIG` (patched) | resolves 253 packages cleanly, installs (rc=0) |

## Fix

Strip `UV_NO_CONFIG` for this single invocation — `env -u UV_NO_CONFIG UV_PROJECT_ENVIRONMENT=… uv sync --extra all --locked` — leaving the export in effect for every other uv call in the script. This mirrors what the runtime already does for itself: `hermes_cli/managed_uv.py` pops `UV_NO_CONFIG` before its own locked syncs, with the comment ``Locked sync must see project [tool.uv] exclude-newer; --no-config / UV_NO_CONFIG drops it and uv refuses --locked``.

The other `UV_NO_CONFIG=1` site (line ~2591, Browser Use `uv tool install`) is not a project `--locked` sync and is intentionally left as-is.

## Test plan

- [x] A/B reproduces the failure and the fix on a fresh venv with `UV_NO_CONFIG` exported (output above)
- [x] `bash -n scripts/install.sh` syntax-checks clean
- [ ] CI