### PR TITLE
fix(providers): make live Desktop chats fail over on Codex quota

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1176,6 +1176,23 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
+        if (
+            usage_limit_reached
+            and current_provider == "openai-codex"
+            and len(pool.entries()) > 1
+            and getattr(agent, "_fallback_index", 0)
+            < len(getattr(agent, "_fallback_chain", []) or [])
+            and not _ra()._pool_may_recover_from_rate_limit(
+                pool,
+                provider=current_provider,
+                error_context=error_context,
+            )
+        ):
+            _ra().logger.info(
+                "Codex usage-limit quota is shared by the available pool entries — "
+                "deferring directly to the fallback chain"
+            )
+            return False, True
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5474,6 +5474,8 @@ def run_conversation(
                         False if _is_upstream
                         else _ra()._pool_may_recover_from_rate_limit(
                             agent._credential_pool,
+                            provider=getattr(agent, "provider", "") or "",
+                            error_context=classified.error_context,
                         )
                     )
                     if not pool_may_recover:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9914,31 +9914,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         replace the chain so mid-uptime ``fallback_providers`` edits take
         effect without requiring a gateway restart (#60955).
         """
-        if agent is None:
-            return
-        new_chain = list(chain or [])
-        rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
-        if (
-            getattr(agent, "_fallback_activated", False)
-            and rate_limited_until > time.monotonic()
-        ):
-            return
-        old_chain = list(getattr(agent, "_fallback_chain", []) or [])
-        agent._fallback_chain = new_chain
-        agent._fallback_model = new_chain[0] if new_chain else None
-        if not getattr(agent, "_fallback_activated", False):
-            agent._fallback_index = 0
-        # A config edit signals the user changed something — drop the
-        # session-scoped unavailability memo so re-configured entries
-        # (e.g. credentials added mid-uptime for a previously-failing
-        # provider) get retried instead of staying suppressed for the
-        # cached agent's lifetime.  Only on actual content change, so
-        # the per-message no-op refresh keeps the memo's rate-limiting
-        # benefit (#60955).
-        if new_chain != old_chain:
-            unavailable = getattr(agent, "_unavailable_fallback_keys", None)
-            if unavailable:
-                unavailable.clear()
+        from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+        apply_fallback_chain_to_agent(agent, chain)
 
     def _snapshot_running_agents(self) -> Dict[str, Any]:
         return {

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 
@@ -99,3 +100,25 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def apply_fallback_chain_to_agent(agent: Any, chain: list[dict[str, Any]] | None) -> None:
+    """Align a reused agent with the current configured fallback chain."""
+    if agent is None:
+        return
+    new_chain = list(chain or [])
+    rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
+    if (
+        getattr(agent, "_fallback_activated", False)
+        and rate_limited_until > time.monotonic()
+    ):
+        return
+    old_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    agent._fallback_chain = new_chain
+    agent._fallback_model = new_chain[0] if new_chain else None
+    if not getattr(agent, "_fallback_activated", False):
+        agent._fallback_index = 0
+    if new_chain != old_chain:
+        unavailable = getattr(agent, "_unavailable_fallback_keys", None)
+        if unavailable:
+            unavailable.clear()

--- a/run_agent.py
+++ b/run_agent.py
@@ -316,7 +316,12 @@ def _routermint_headers() -> dict:
     }
 
 
-def _pool_may_recover_from_rate_limit(pool) -> bool:
+def _pool_may_recover_from_rate_limit(
+    pool,
+    *,
+    provider: str = "",
+    error_context: dict | None = None,
+) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
     The existing pool-rotation path requires the pool to (1) exist and (2) have
@@ -338,7 +343,41 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
         return False
     if not pool.has_available():
         return False
-    return len(pool.entries()) > 1
+    entries = pool.entries()
+    if len(entries) <= 1:
+        return False
+
+    context_reason = str((error_context or {}).get("reason") or "").lower()
+    context_message = str((error_context or {}).get("message") or "").lower()
+    usage_limit_reached = (
+        "usage_limit_reached" in context_reason
+        or "gousagelimit" in context_reason
+        or "usage limit reached" in context_message
+        or "usage limit has been reached" in context_message
+    )
+    pool_provider = str(getattr(pool, "provider", "") or "").strip().lower()
+    current_provider = str(provider or pool_provider).strip().lower()
+    if current_provider == "openai-codex" and usage_limit_reached:
+        from hermes_cli.auth import _decode_jwt_claims
+
+        account_ids: list[str] = []
+        for entry in entries:
+            token = str(getattr(entry, "runtime_api_key", "") or "")
+            claims = _decode_jwt_claims(token)
+            auth_claim = claims.get("https://api.openai.com/auth")
+            account_id = (
+                auth_claim.get("chatgpt_account_id")
+                if isinstance(auth_claim, dict)
+                else None
+            )
+            # Unknown identity must preserve ordinary pool rotation. Only
+            # collapse entries when the JWTs prove they share one quota scope.
+            if not isinstance(account_id, str) or not account_id:
+                return True
+            account_ids.append(account_id)
+        return len(set(account_ids)) > 1
+
+    return True
 
 
 def _qwen_portal_headers() -> dict:

--- a/tests/run_agent/test_codex_quota_fallback.py
+++ b/tests/run_agent/test_codex_quota_fallback.py
@@ -1,0 +1,142 @@
+"""Codex account-quota failures must not rotate duplicate OAuth entries."""
+
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.credential_pool import PooledCredential
+from agent.error_classifier import FailoverReason
+from run_agent import AIAgent, _pool_may_recover_from_rate_limit
+
+
+def _jwt_for_account(account_id: str) -> str:
+    payload = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id}
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def _entry(index: int, account_id: str) -> PooledCredential:
+    return PooledCredential(
+        provider="openai-codex",
+        id=f"cred-{index}",
+        label=f"Credential {index}",
+        auth_type="device_code",
+        priority=index,
+        source="oauth",
+        access_token=_jwt_for_account(account_id),
+    )
+
+
+def _pool(entries: list[PooledCredential]):
+    pool = MagicMock()
+    pool.provider = "openai-codex"
+    pool.entries.return_value = entries
+    pool.has_available.return_value = True
+    pool.current.return_value = entries[0]
+    pool.entry_id_for_api_key.return_value = entries[0].id
+    return pool
+
+
+def _agent(pool, entries, fallback_chain):
+    return SimpleNamespace(
+        _credential_pool=pool,
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=entries[0].access_token,
+        _credential_pool_entry_id=entries[0].id,
+        _swap_credential=MagicMock(),
+        _fallback_chain=fallback_chain,
+        _fallback_index=0,
+    )
+
+
+def test_same_codex_account_entries_cannot_recover_account_quota():
+    pool = _pool([_entry(0, "acct-shared"), _entry(1, "acct-shared")])
+
+    assert _pool_may_recover_from_rate_limit(
+        pool,
+        provider="openai-codex",
+        error_context={"reason": "usage_limit_reached"},
+    ) is False
+
+
+def test_distinct_codex_accounts_can_recover_account_quota():
+    pool = _pool([_entry(0, "acct-a"), _entry(1, "acct-b")])
+
+    assert _pool_may_recover_from_rate_limit(
+        pool,
+        provider="openai-codex",
+        error_context={"reason": "usage_limit_reached"},
+    ) is True
+
+
+def test_recovery_defers_duplicate_account_quota_to_fallback_chain():
+    entries = [_entry(0, "acct-shared"), _entry(1, "acct-shared")]
+    pool = _pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = entries[1]
+    agent = _agent(
+        pool,
+        entries,
+        [{"provider": "xai-oauth", "model": "grok-4.6"}],
+    )
+
+    recovered, retried = AIAgent._recover_with_credential_pool(
+        agent,
+        status_code=429,
+        has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached.",
+            "resets_in_seconds": 14400,
+        },
+    )
+
+    assert recovered is False
+    assert retried is True
+    pool.mark_exhausted_and_rotate.assert_not_called()
+    agent._swap_credential.assert_not_called()
+
+
+def test_duplicate_account_quota_still_rotates_without_a_fallback():
+    entries = [_entry(0, "acct-shared"), _entry(1, "acct-shared")]
+    pool = _pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = entries[1]
+    agent = _agent(pool, entries, [])
+
+    recovered, retried = AIAgent._recover_with_credential_pool(
+        agent,
+        status_code=429,
+        has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+        error_context={"reason": "usage_limit_reached"},
+    )
+
+    assert recovered is True
+    assert retried is False
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    agent._swap_credential.assert_called_once_with(entries[1])
+
+
+def test_single_codex_entry_is_still_marked_exhausted():
+    entries = [_entry(0, "acct-only")]
+    pool = _pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = None
+    agent = _agent(pool, entries, [])
+
+    recovered, retried = AIAgent._recover_with_credential_pool(
+        agent,
+        status_code=429,
+        has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+        error_context={"reason": "usage_limit_reached"},
+    )
+
+    assert recovered is False
+    assert retried is True
+    pool.mark_exhausted_and_rotate.assert_called_once()

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -152,6 +152,39 @@ def test_concluded_turn_clears_marker(emits, turn_env, marker_home):
     assert read_turn_marker(marker_home, "session-key") is None
 
 
+def test_live_turn_refreshes_fallback_chain_from_current_config(
+    emits, turn_env, marker_home, monkeypatch
+):
+    configured = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    seen_chain: list[list[dict]] = []
+
+    def _run(message, **kwargs):
+        seen_chain.append(list(agent._fallback_chain))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=_run,
+        clear_interrupt=lambda: None,
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys={("old", "entry")},
+    )
+    monkeypatch.setattr(server, "_load_fallback_model", lambda: configured)
+
+    server._run_prompt_submit(
+        "rid", "sid", _session(agent=agent, running=True), "do the thing"
+    )
+
+    assert seen_chain == [configured]
+    assert agent._fallback_model == configured[0]
+    assert agent._fallback_index == 0
+    assert agent._unavailable_fallback_keys == set()
+
+
 def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
     """An exception is a CONCLUDED turn (terminal frame + retained snapshot own
     recovery) — only a process death may leave the marker behind."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11472,6 +11472,13 @@ def _run_prompt_submit(
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+            # A Desktop/TUI agent can outlive config edits for hours. Refresh
+            # the chain inside the per-profile turn scope so an already-open or
+            # remounted session adopts fallback_providers without an agent
+            # rebuild, matching the messaging gateway's cached-agent path.
+            from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+            apply_fallback_chain_to_agent(agent, _load_fallback_model())
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty


### PR DESCRIPTION
## What does this PR do?

Live Desktop chats now adopt fallback provider edits before each turn, so a chat opened before `fallback_providers` was configured can fail over without being recreated. Codex `usage_limit_reached` responses also stop rotating duplicate OAuth entries that resolve to the same ChatGPT account when a fallback is available; distinct-account pools keep their existing recovery behavior.

### Symptom

An already-open Desktop chat could keep an empty in-memory fallback chain after `hermes fallback add`. When Codex returned HTTP 429 with `usage_limit_reached`, two OAuth entries for the same ChatGPT account made the credential pool appear recoverable, so the turn retried Codex instead of activating the configured fallback.

### Impact

Affected Desktop turns end in a provider error even though the user configured a healthy fallback. Creating a new chat or pinning another model works around the failure, but the existing chat remains stale.

### Bug Cause

**Trigger:** `tui_gateway/server.py:_run_prompt_submit` and `run_agent.py:_pool_may_recover_from_rate_limit`

**Causal chain:**
1. A Desktop agent is created before `fallback_providers` is added, so its `_fallback_chain` is empty.
2. Later turns reuse that agent without re-reading the active profile's fallback config. Separately, the pool recovery hinge counts credential rows rather than Codex quota scopes.
3. A Codex account-quota 429 sees no live fallback chain or treats duplicate tokens for one ChatGPT account as independent recovery options, and the user receives a provider error.

**Why it is wrong:** fallback configuration is operator-owned live config, while Codex usage quota is scoped by the JWT's `chatgpt_account_id`, not by the number of stored OAuth rows.

**Working sibling / contrast:** the messaging gateway already refreshes cached agents from current fallback config before each message, and distinct Codex account IDs remain valid credential-pool recovery candidates.

**Ruled out:** generic 429 classification is not the missing link. Current classification already recognizes `usage_limit_reached`; the failure is the stale Desktop chain plus the pool recovery decision made after classification.

### Fix

- Extract the cached-agent chain application logic into `hermes_cli.fallback_config` and reuse it from both messaging and Desktop/TUI paths.
- Refresh the Desktop/TUI agent's chain inside the active profile scope before every model turn.
- Compare Codex OAuth JWT `chatgpt_account_id` values for account-quota failures. Duplicate rows for one account defer directly to an available fallback, while distinct accounts, unknown token identities, single credentials, and pools without a fallback retain credential rotation.

## Related Issue


N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/fallback_config.py` - share safe live-agent fallback chain synchronization.
- `tui_gateway/server.py` - refresh the current profile's fallback chain before each live turn.
- `run_agent.py` and `agent/agent_runtime_helpers.py` - distinguish Codex account quota scopes before suppressing provider fallback.
- `agent/conversation_loop.py` - pass structured provider error context into the pool recovery hinge.
- `tests/` - cover live Desktop refresh, duplicate and distinct Codex accounts, and no-fallback/single-entry preservation.

## How to Test

1. Configure a Codex primary and an xAI fallback, open a Desktop chat, then edit `fallback_providers`; the next turn should use the refreshed chain without recreating the chat.
2. Return `usage_limit_reached` for two Codex OAuth entries with the same `chatgpt_account_id`; an available fallback should activate without rotating the duplicate entry.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_codex_quota_fallback.py -q
scripts/run_tests.sh tests/tui_gateway/test_auto_continue.py tests/agent/test_gemini_fast_fallback.py tests/gateway/test_fallback_chain_reload.py tests/hermes_cli/test_fallback_config.py -q
```

Result: 32 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and regression tests document the change
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow contract changed
- [x] I've considered cross-platform impact; the implementation uses existing Python config and JWT helpers
- [x] Tool description/schema updates are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - automated regression tests cover the backend behavior.
