### PR TITLE
chore(contributors): map jefferson@jeffersonnunn.com → MindDragonLabs

### DIFF
--- a/contributors/emails/jefferson@jeffersonnunn.com
+++ b/contributors/emails/jefferson@jeffersonnunn.com
@@ -1,0 +1,1 @@
+MindDragonLabs


### PR DESCRIPTION
## Summary

Adds the one-file mapping `contributors/emails/jefferson@jeffersonnunn.com` → `MindDragonLabs` via `scripts/add_contributor.py`, so commits authored with this address pass the Contributor Attribution Check instead of failing CI.

This is the same contributor already mapped in the frozen legacy `AUTHOR_MAP` (release.py:951 `jefferson@heimdallstrategy.com` → Mind-Dragon; :962 `mind-dragon@nous.research`; :1893 the Mind-Dragon GitHub noreply) — this just covers the one email variant that had no entry in either the map or `contributors/emails/`.

## Test plan

- [x] Created with `python3 scripts/add_contributor.py jefferson@jeffersonnunn.com MindDragonLabs` (the blessed path; it refused nothing, exit 0)
- [x] File format matches `contributors/README.md`: filename = exact email, content = login on first non-comment line
- [x] Follows the "no new AUTHOR_MAP entries" rule (directory wins on duplicates, dict is frozen)
- [ ] CI