### PR TITLE
fix(gateway): secondary profile whose first adapter connect fails now reconnects (salvage #92074, fixes #92064)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15794,9 +15794,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _await_running_then_schedule() -> None:
             if self._running:
-                self._schedule_secondary_profile_reconnect(
-                    profile_name, platform, adapter
-                )
+                try:
+                    self._schedule_secondary_profile_reconnect(
+                        profile_name, platform, adapter
+                    )
+                except Exception:
+                    # Same GC-time-exception hazard as the post-poll handoff
+                    # below; surface it in gateway.log instead.
+                    logger.exception(
+                        "secondary-startup-reconnect handoff failed "
+                        "(profile=%s platform=%s)",
+                        profile_name,
+                        platform.value,
+                    )
                 return
             # Modest poll interval: startup completion has no dedicated event,
             # and the reconnect runner's own backoff makes sub-100ms precision
@@ -15804,9 +15814,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             while not self._running and not self._shutdown_event.is_set():
                 await asyncio.sleep(0.1)
             if self._running and not self._shutdown_event.is_set():
-                self._schedule_secondary_profile_reconnect(
-                    profile_name, platform, adapter
-                )
+                try:
+                    self._schedule_secondary_profile_reconnect(
+                        profile_name, platform, adapter
+                    )
+                except Exception:
+                    # The handoff touches live registries; if it raises, the
+                    # parked task would otherwise die as an unretrieved-task
+                    # exception logged only at GC time. Surface it where
+                    # operators look.
+                    logger.exception(
+                        "secondary-startup-reconnect handoff failed "
+                        "(profile=%s platform=%s)",
+                        profile_name,
+                        platform.value,
+                    )
 
         task = asyncio.create_task(
             _await_running_then_schedule(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15618,9 +15618,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
                     await self._safe_adapter_disconnect(adapter, platform)
+                    self._schedule_secondary_profile_startup_reconnect(
+                        profile_name, platform, adapter
+                    )
             except Exception as e:
                 logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
                 await self._safe_adapter_disconnect(adapter, platform)
+                self._schedule_secondary_profile_startup_reconnect(
+                    profile_name, platform, adapter
+                )
         return connected
 
     def _configure_profile_adapter(
@@ -15765,6 +15771,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         profile_pending.pop(platform, None)
                         if not profile_pending:
                             pending.pop(profile_name, None)
+
+    def _schedule_secondary_profile_startup_reconnect(
+        self, profile_name: str, platform: Platform, adapter: BasePlatformAdapter
+    ) -> None:
+        """Queue a cold-start reconnect for a secondary adapter.
+
+        Startup failure branches run BEFORE ``self._running`` flips True
+        (``_start_secondary_profile_adapters()`` is called mid-``start()``,
+        while ``self._running`` is still False), so the regular scheduler's
+        ``not self._running`` guard would silently drop the request and the
+        runner's ``while self._running`` loop would exit immediately. This
+        bridge parks a background task across the remainder of startup and
+        hands off to the regular scheduler once the gateway is live (the
+        scheduler's own ``_profile_failed_platforms`` slot dedupes at
+        handoff); if shutdown begins first, the request is released.
+        Non-retryable failures are dropped here exactly as the regular
+        scheduler would.
+        """
+        if not getattr(adapter, "fatal_error_retryable", True):
+            return
+
+        async def _await_running_then_schedule() -> None:
+            if self._running:
+                self._schedule_secondary_profile_reconnect(
+                    profile_name, platform, adapter
+                )
+                return
+            # Modest poll interval: startup completion has no dedicated event,
+            # and the reconnect runner's own backoff makes sub-100ms precision
+            # irrelevant. Bounded so a wedged startup cannot spin the loop.
+            while not self._running and not self._shutdown_event.is_set():
+                await asyncio.sleep(0.1)
+            if self._running and not self._shutdown_event.is_set():
+                self._schedule_secondary_profile_reconnect(
+                    profile_name, platform, adapter
+                )
+
+        task = asyncio.create_task(
+            _await_running_then_schedule(),
+            name=f"secondary-startup-reconnect:{profile_name}:{platform.value}",
+        )
+        background_tasks = getattr(self, "_background_tasks", None)
+        if not isinstance(background_tasks, set):
+            background_tasks = set()
+            self._background_tasks = background_tasks
+        background_tasks.add(task)
+        task.add_done_callback(background_tasks.discard)
 
     def _schedule_secondary_profile_reconnect(
         self, profile_name: str, platform: Platform, adapter: BasePlatformAdapter

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -274,6 +274,153 @@ class TestSecondaryProfileFatalRecovery:
         assert runner._profile_failed_platforms == {}
 
 
+class TestSecondaryStartupFailureRecovery:
+    """Cold-start connect failures must reach the same reconnect slot as
+    mid-run fatals — one unlucky connect window must not kill the platform
+    for the life of the process."""
+
+    @pytest.mark.asyncio
+    async def test_retryable_initial_failure_schedules_reconnect(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        failed = _SecondaryRecoveryAdapter()
+        replacement = _SecondaryRecoveryAdapter()
+        scoped_homes: list[Path] = []
+        _install_secondary_reconnect_context(
+            monkeypatch, runner, replacement, scoped_homes
+        )
+
+        # Startup creates `failed`; the reconnect runner creates `replacement`.
+        created = [failed, replacement]
+        monkeypatch.setattr(
+            runner, "_create_adapter", lambda platform, config: created.pop(0)
+        )
+
+        async def fail_initial_connect(adapter, platform):
+            return False
+
+        monkeypatch.setattr(
+            runner, "_connect_initial_adapter_with_timeout", fail_initial_connect
+        )
+
+        async def reconnect_ok(adapter, platform, *, is_reconnect=False):
+            assert is_reconnect is True
+            assert adapter is replacement
+            return True
+
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", reconnect_ok)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/reviewer", {}
+        )
+
+        assert connected == 0
+        assert failed.disconnected is True
+        assert Platform.DISCORD not in runner._profile_adapters.get(
+            "reviewer", {}
+        )
+        bridge = list(runner._background_tasks)
+        assert len(bridge) == 1
+        # Drive the bridge to completion; it hands off (immediately when the
+        # gateway is already running) to the regular reconnect task, which
+        # publishes the replacement and clears its own slot.
+        await asyncio.wait_for(bridge[0], timeout=0.5)
+        for _ in range(20):
+            if (
+                runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
+                is replacement
+            ):
+                break
+            await asyncio.sleep(0)
+        assert (
+            runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+        )
+        assert Platform.DISCORD not in runner._profile_failed_platforms.get(
+            "reviewer", {}
+        )
+        # Reconnect must have re-entered the profile's own runtime scope.
+        assert Path("/profiles/reviewer") in scoped_homes
+        assert all(
+            path in (Path("/tmp/reviewer"), Path("/profiles/reviewer"))
+            for path in scoped_homes
+        )
+
+    @pytest.mark.asyncio
+    async def test_raising_initial_connect_schedules_reconnect(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        failed = _SecondaryRecoveryAdapter()
+        replacement = _SecondaryRecoveryAdapter()
+        _install_secondary_reconnect_context(monkeypatch, runner, replacement)
+
+        created = [failed, replacement]
+        monkeypatch.setattr(
+            runner, "_create_adapter", lambda platform, config: created.pop(0)
+        )
+
+        async def explode(adapter, platform):
+            raise TimeoutError("initial connect budget exhausted")
+
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", explode)
+
+        async def reconnect_ok(adapter, platform, *, is_reconnect=False):
+            return True
+
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", reconnect_ok)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/reviewer", {}
+        )
+
+        assert connected == 0
+        assert failed.disconnected is True
+        bridge = list(runner._background_tasks)
+        assert len(bridge) == 1
+        await asyncio.wait_for(bridge[0], timeout=0.5)
+        for _ in range(20):
+            if (
+                runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
+                is replacement
+            ):
+                break
+            await asyncio.sleep(0)
+        assert (
+            runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+        )
+        assert Platform.DISCORD not in runner._profile_failed_platforms.get(
+            "reviewer", {}
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_initial_failure_does_not_schedule(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        failed = _SecondaryRecoveryAdapter(retryable=False)
+        _install_secondary_reconnect_context(
+            monkeypatch, runner, _SecondaryRecoveryAdapter()
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+
+        async def fail_initial_connect(adapter, platform):
+            return False
+
+        monkeypatch.setattr(
+            runner, "_connect_initial_adapter_with_timeout", fail_initial_connect
+        )
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/reviewer", {}
+        )
+
+        assert connected == 0
+        assert failed.disconnected is True
+        assert runner._background_tasks == set()
+        assert runner._profile_failed_platforms == {}
+
+
 class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -420,6 +420,53 @@ class TestSecondaryStartupFailureRecovery:
         assert runner._background_tasks == set()
         assert runner._profile_failed_platforms == {}
 
+    @pytest.mark.asyncio
+    async def test_handoff_failure_is_logged_not_raised(self, monkeypatch, caplog):
+        """If the scheduler raises at bridge handoff, the parked task must not
+        die as an unretrieved-task exception — the failure surfaces in the log."""
+        runner = _secondary_recovery_runner()
+        failed = _SecondaryRecoveryAdapter()
+        _install_secondary_reconnect_context(
+            monkeypatch, runner, _SecondaryRecoveryAdapter()
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+
+        async def fail_initial_connect(adapter, platform):
+            return False
+
+        monkeypatch.setattr(
+            runner, "_connect_initial_adapter_with_timeout", fail_initial_connect
+        )
+
+        def explode_at_handoff(profile_name, platform, adapter):
+            raise RuntimeError("scheduler exploded during handoff")
+
+        monkeypatch.setattr(
+            runner, "_schedule_secondary_profile_reconnect", explode_at_handoff
+        )
+
+        with caplog.at_level(logging.ERROR, logger="gateway.run"):
+            connected = await runner._start_one_profile_adapters(
+                "reviewer", "/tmp/reviewer", {}
+            )
+            bridge = list(runner._background_tasks)
+            assert len(bridge) == 1
+            # Awaiting completes cleanly: the guard swallows the handoff
+            # failure instead of letting it escape as an unretrieved-task
+            # exception at GC time.
+            await asyncio.wait_for(bridge[0], timeout=0.5)
+
+        assert connected == 0
+        assert failed.disconnected is True
+        assert any(
+            record.levelno == logging.ERROR
+            and "secondary-startup-reconnect handoff failed" in record.getMessage()
+            for record in caplog.records
+        )
+        # Nothing was scheduled and no slot leaked behind the failed handoff.
+        assert Platform.DISCORD not in runner._profile_adapters.get("reviewer", {})
+        assert runner._profile_failed_platforms == {}
+
 
 class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""


### PR DESCRIPTION
## Summary
A secondary profile whose adapter fails its very first connect at gateway startup now reconnects instead of staying dead until restart: the startup failure path arms the same reconnect machinery the mid-run fatal path already uses, and handoff failures are logged instead of silently dropped.

Class-3 python-side salvage from tracker #94724. Fixes #92064.

## Salvaged contributor work
- #92074 @ruangraung — _schedule_secondary_profile_startup_reconnect in gateway/run.py + follow-up logging commit. Both premises were independently verified in the PR thread and re-verified against current main (~line 15618 startup failure path only logged + disconnected).

## Validation
A/B: tests at origin/main's gateway/run.py → 3 failed (test_raising_initial_connect_schedules_reconnect, test_handoff_failure_is_logged_not_raised, +1) / 19 passed; at head → 22/22.

**Live repro:** gateway startup with a failing secondary adapter is exercised through the real gateway/run.py reconnect scheduling path in the A/B suite; live multiplex-gateway run available on request.

Targeted pytest under memory cap: 22/22. Attribution audit green.

## Infographic

![Startup Reconnect](https://v3b.fal.media/files/b/0aa7ceeb/SUdXoeZb0Pew9vhXjaq9i_shz0E1Ta.png)
