### PR TITLE
fix(desktop): auth envelopes and backend processes stay bound to their connection (multi-gateway classes 5+6, tracker #94724)

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection } from './connection-apply'
+import {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  teardownSshState
+} from './connection-apply'
 
 function deferred() {
   let resolve!: () => void
@@ -83,6 +88,39 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('teardownSshState', () => {
+  it('terminates the owned remote backend before closing its tunnel and SSH transport', async () => {
+    const events: string[] = []
+
+    const ssh = {
+      cancelForward: async () => events.push('forward'),
+      close: async () => events.push('ssh')
+    }
+
+    await teardownSshState(
+      { ssh, ownershipId: 'owner', localPort: 1234, remotePort: 5678 },
+      { cleanupRemote: async () => events.push('remote') }
+    )
+
+    expect(events).toEqual(['remote', 'forward', 'ssh'])
+  })
+
+  it('still closes the SSH transport when remote cleanup fails', async () => {
+    const close = vi.fn(async () => undefined)
+
+    await teardownSshState(
+      { ssh: { cancelForward: vi.fn(async () => undefined), close }, ownershipId: 'owner' },
+      {
+        cleanupRemote: async () => {
+          throw new Error('remote unavailable')
+        }
+      }
+    )
+
+    expect(close).toHaveBeenCalledOnce()
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -61,4 +61,35 @@ async function resolveTerminalConnectionForSender(webContentsId, getTarget, ensu
   )
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, resolveTerminalConnectionForSender }
+async function teardownSshState(state, { cleanupRemote }) {
+  // Remote process first, while the SSH channel can still exec kill.
+  // Then drop the local forward and close the transport. Each step is
+  // best-effort so a failed remote cleanup cannot trap Cmd+Q (#91668).
+  try {
+    await cleanupRemote(state.ssh, state.ownershipId)
+  } catch {
+    // Remote teardown is best-effort; always release the local tunnel and SSH transport.
+  }
+
+  try {
+    if (state.localPort && state.remotePort) {
+      await state.ssh.cancelForward(state.localPort, state.remotePort)
+    }
+  } catch {
+    // Best effort; closing the transport below drops any remaining forwards.
+  }
+
+  try {
+    await state.ssh.close()
+  } catch {
+    // The app must still be able to quit when SSH teardown fails.
+  }
+}
+
+export {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  resolveTerminalConnectionForSender,
+  teardownSshState
+}

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -60,6 +60,42 @@ test('labelSlug kebab-cases and never returns empty for non-empty input', () => 
   assert.equal(labelSlug('!!!'), 'connection')
 })
 
+test('registry SSH fingerprint failures name the connection and ssh -G step', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  const cause = new Error('spawn ssh ENOENT')
+
+  source.label = 'Build box'
+
+  await assert.rejects(
+    reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => {
+        throw cause
+      },
+      ensurePrimary: async () => ({ mode: 'remote', remoteKind: 'ssh' }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    error => {
+      assert.equal(
+        (error as Error).message,
+        `Could not resolve effective SSH config for connection "Build box" (${source.id}) via ssh -G: spawn ssh ENOENT`
+      )
+      assert.equal((error as Error).cause, cause)
+
+      return true
+    }
+  )
+})
+
 test('matching primary/default SSH route reuses the existing descriptor once', async () => {
   const registry = migrateV1ToRegistry({
     mode: 'ssh',

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -32,6 +32,7 @@ import {
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
   setPrimaryConnection,
@@ -57,6 +58,148 @@ test('labelSlug kebab-cases and never returns empty for non-empty input', () => 
   assert.equal(labelSlug('Work Laptop'), 'work-laptop')
   assert.equal(labelSlug('Spark Box #2'), 'spark-box-2')
   assert.equal(labelSlug('!!!'), 'connection')
+})
+
+test('matching primary/default SSH route reuses the existing descriptor once', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)
+
+  const descriptor = {
+    mode: 'remote' as const,
+    remoteKind: 'ssh' as const,
+    ssh: {
+      effectiveConfigFingerprint: 'same-effective-config',
+      host: 'build-host',
+      keyPath: '~/.ssh/id_ed25519',
+      remoteProfile: 'default',
+      user: 'alice'
+    }
+  }
+
+  let ensureCalls = 0
+  let fingerprintCalls = 0
+
+  assert.equal(source?.kind, 'ssh')
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => {
+        fingerprintCalls += 1
+
+        return 'same-effective-config'
+      },
+      ensurePrimary: async () => {
+        ensureCalls += 1
+
+        return descriptor
+      },
+      profile: 'default',
+      registry,
+      source: source!
+    }),
+    descriptor
+  )
+  assert.equal(ensureCalls, 1)
+  assert.equal(fingerprintCalls, 1)
+})
+
+test('non-default or non-primary SSH routes do not resolve the primary backend', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+  let ensureCalls = 0
+
+  const opts = {
+    effectiveFingerprint: async () => 'same',
+    ensurePrimary: async () => {
+      ensureCalls += 1
+
+      return { mode: 'remote' as const, remoteKind: 'ssh' as const }
+    },
+    registry,
+    source
+  }
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({ ...opts, connectionId: registry.primary, profile: 'researcher' }),
+    null
+  )
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({ ...opts, connectionId: LOCAL_CONNECTION_ID, profile: 'default' }),
+    null
+  )
+  assert.equal(ensureCalls, 0)
+})
+
+test('primary SSH reuse rejects a descriptor with different effective dialing config', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => 'registry-config',
+      ensurePrimary: async () => ({
+        mode: 'remote',
+        remoteKind: 'ssh',
+        ssh: {
+          effectiveConfigFingerprint: 'active-config',
+          host: 'other-host',
+          remoteProfile: ''
+        }
+      }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    null
+  )
+})
+
+test('primary SSH reuse rejects a descriptor with a different remote Hermes path', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', remoteHermesPath: '/srv/hermes', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => 'same-effective-config',
+      ensurePrimary: async () => ({
+        mode: 'remote',
+        remoteKind: 'ssh',
+        ssh: {
+          effectiveConfigFingerprint: 'same-effective-config',
+          host: 'build-host',
+          remoteHermesPath: '/opt/hermes',
+          remoteProfile: '',
+          user: 'alice'
+        }
+      }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    null
+  )
 })
 
 test('resolvedConnectionId identifies local and migrated remote descriptors', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -185,6 +185,7 @@ export interface RegistryLocalRoute {
 }
 
 export interface ResolvedConnectionSshDescriptor {
+  effectiveConfigFingerprint?: string
   host?: string
   keyPath?: string
   port?: number
@@ -331,6 +332,53 @@ export function resolvedConnectionId(
   }
 
   return matchingConnectionId(registry, route, 'unique') ?? null
+}
+
+export interface ReuseMatchingPrimarySshBackendOptions {
+  connectionId: null | string | undefined
+  effectiveFingerprint: (source: RegistryConnection) => Promise<string>
+  ensurePrimary: () => Promise<ResolvedConnectionDescriptor>
+  profile: null | string | undefined
+  registry: ConnectionRegistry
+  source: RegistryConnection
+}
+
+/**
+ * Reuse the already-booted v1 window SSH backend only when its actual dialing
+ * identity matches the registry primary. Guards run before either async
+ * dependency so secondary profiles and sources never bootstrap the primary.
+ */
+export async function reuseMatchingPrimarySshBackend({
+  connectionId,
+  effectiveFingerprint,
+  ensurePrimary,
+  profile,
+  registry,
+  source
+}: ReuseMatchingPrimarySshBackendOptions): Promise<null | ResolvedConnectionDescriptor> {
+  const id = String(connectionId ?? '').trim()
+  const profileKey = String(profile ?? '').trim() || 'default'
+
+  if (profileKey !== 'default' || !id || id !== registry.primary || source.id !== id || source.kind !== 'ssh') {
+    return null
+  }
+
+  const sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  const descriptor = await ensurePrimary()
+  const activeSsh = descriptor.mode === 'remote' && descriptor.remoteKind === 'ssh' ? descriptor.ssh : null
+  const rootProfile = (value: unknown) => String(value || '').trim() || 'default'
+
+  if (
+    !sourceFingerprint ||
+    !activeSsh ||
+    sourceFingerprint !== String(activeSsh.effectiveConfigFingerprint || '').trim() ||
+    String(source.remoteHermesPath || '').trim() !== String(activeSsh.remoteHermesPath || '').trim() ||
+    rootProfile(source.remoteProfile) !== rootProfile(activeSsh.remoteProfile)
+  ) {
+    return null
+  }
+
+  return descriptor
 }
 
 function normalizedSshTarget(route: { host?: unknown; port?: unknown; user?: unknown }): null | string {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -344,9 +344,13 @@ export interface ReuseMatchingPrimarySshBackendOptions {
 }
 
 /**
- * Reuse the already-booted v1 window SSH backend only when its actual dialing
- * identity matches the registry primary. Guards run before either async
- * dependency so secondary profiles and sources never bootstrap the primary.
+ * Reuse the v1 window SSH backend only when its actual dialing identity matches
+ * the registry primary. Resolving that descriptor may boot the primary; a
+ * mismatch returns null without reusing it so the caller continues with its
+ * separately scoped registry backend. A matching descriptor is returned
+ * unchanged and the caller may re-stamp routing fields such as profile and
+ * connectionId. Guards run before either async dependency so secondary
+ * profiles and sources never bootstrap the primary.
  */
 export async function reuseMatchingPrimarySshBackend({
   connectionId,
@@ -363,7 +367,19 @@ export async function reuseMatchingPrimarySshBackend({
     return null
   }
 
-  const sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  let sourceFingerprint
+
+  try {
+    sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause)
+
+    throw new Error(
+      `Could not resolve effective SSH config for connection "${source.label}" (${source.id}) via ssh -G: ${detail}`,
+      { cause }
+    )
+  }
+
   const descriptor = await ensurePrimary()
   const activeSsh = descriptor.mode === 'remote' && descriptor.remoteKind === 'ssh' ? descriptor.ssh : null
   const rootProfile = (value: unknown) => String(value || '').trim() || 'default'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9537,7 +9537,17 @@ async function teardownSshConnection(profile) {
       ownershipId: state.ownershipId || sshOwnershipKey(profile)
     },
     {
-      cleanupRemote: state.remotePlatform === 'Windows' ? async () => {} : remoteLifecycle.disconnect
+      cleanupRemote:
+        state.remotePlatform === 'Windows'
+          ? async () => {
+              // connectWindowsRemote does not share POSIX lock/kill. Stay
+              // silent on the kill path, but leave a log so quit is not a
+              // mysterious no-op on Windows remotes.
+              sshRememberLog(
+                '[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply'
+              )
+            }
+          : remoteLifecycle.disconnect
     }
   )
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -85,7 +85,7 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange } from './connection-apply'
+import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -9526,19 +9526,20 @@ async function teardownSshConnection(profile) {
 
   terminalIpc.disposeTerminalSessionsForSshScope(scope)
 
-  try {
-    if (state.localPort && state.remotePort) {
-      await state.ssh.cancelForward(state.localPort, state.remotePort)
+  // Kill the owned remote serve --isolated *before* closing the SSH
+  // transport. Spawn detaches with setsid/nohup, so closing the tunnel
+  // alone leaves the backend at pid 1 holding state.db (#91668).
+  // Windows remotes use a different lifecycle (connectWindowsRemote) and
+  // are left to a follow-up; POSIX is the leak that OOM'd gateways.
+  await teardownSshState(
+    {
+      ...state,
+      ownershipId: state.ownershipId || sshOwnershipKey(profile)
+    },
+    {
+      cleanupRemote: state.remotePlatform === 'Windows' ? async () => {} : remoteLifecycle.disconnect
     }
-  } catch {
-    // best effort
-  }
-
-  try {
-    await state.ssh.close()
-  } catch {
-    // best effort
-  }
+  )
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -9811,6 +9812,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   sshConnections.set(scope, {
     ssh,
     fingerprint,
+    ownershipId: result.ownershipId || sshOwnershipKey(profile),
     localPort: result.localPort,
     remotePort: result.remotePort,
     pid: result.pid,
@@ -16217,6 +16219,12 @@ app.on('before-quit', event => {
     return
   }
 
+  // A prevented first quit leaves the renderer alive while teardown runs.
+  // Seal the SSH coordinator before touching connections so reconnect
+  // callbacks cannot recreate a backend for a registration whose app is
+  // already quitting (#91668).
+  sshBootstrapCoordinator.shutdown()
+
   if (!backendQuitTeardownDone) {
     event.preventDefault()
     void backendShutdown.run().finally(() => {
@@ -16227,7 +16235,6 @@ app.on('before-quit', event => {
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()
-    sshBootstrapCoordinator.cancelAll()
     const scopes = [...sshConnections.keys()]
 
     const pending = Promise.allSettled([
@@ -16235,7 +16242,10 @@ app.on('before-quit', event => {
       ...sshBootstrapCoordinator.promises()
     ])
 
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
+    // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
+    // The previous 4s race could close SSH first and leave serve --isolated
+    // reparented to pid 1.
+    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 6_000))]).then(async () => {
       await sshBootstrapCoordinator.forceCleanupAll()
       sshQuitTeardownDone = true
       app.quit()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -226,6 +226,7 @@ import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
+  oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
@@ -9427,7 +9428,7 @@ async function buildRemoteConnection(
 
       throw gatewayTicketFailure(
         error,
-        'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.',
+        oauthTicketFailureAuthMessage(hasNativeSession(baseUrl)),
         'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.'
       )
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -249,7 +249,6 @@ import {
   buildRegistryProfileRoutes,
   isLocalEnumerationFailure,
   localRouteFallbackProfiles,
-  registryGatewayWsUrl,
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -137,6 +137,7 @@ import {
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
   setPrimaryConnection,
@@ -9669,7 +9670,7 @@ async function reachablePreviewUrl(webContentsId: number, rawUrl: string): Promi
   }
 }
 
-function effectiveSshConfigFingerprint(sshConfig) {
+async function effectiveSshConfigFingerprint(sshConfig) {
   const ssh =
     process.platform === 'win32'
       ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
@@ -9686,14 +9687,14 @@ function effectiveSshConfigFingerprint(sshConfig) {
   }
 
   args.push('--', sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host)
-  const output = execFileSync(ssh, args, { encoding: 'utf8', timeout: 10_000, windowsHide: true })
+  const output = await execText(ssh, args, { timeout: 10_000 })
 
   return crypto.createHash('sha256').update(output).digest('hex')
 }
 
-async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
+async function bootstrapSshConnection(profile, sshConfig, reuseToken, source, resolvedEffectiveFingerprint?) {
   const scope = sshScopeKey(profile)
-  const effectiveConfigFingerprint = effectiveSshConfigFingerprint(sshConfig)
+  const effectiveConfigFingerprint = resolvedEffectiveFingerprint || (await effectiveSshConfigFingerprint(sshConfig))
   const resolvedConfig = { ...sshConfig, effectiveConfigFingerprint }
   const fingerprint = sshConfigFingerprint(scope, resolvedConfig)
 
@@ -9835,7 +9836,19 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     result.ownershipId
   )
 
-  return { ...connection, remoteHermesVersion: result.hermesVersion || '' }
+  return {
+    ...connection,
+    remoteHermesVersion: result.hermesVersion || '',
+    ssh: {
+      effectiveConfigFingerprint: sshConfig.effectiveConfigFingerprint,
+      host: sshConfig.host,
+      keyPath: sshConfig.keyPath,
+      port: sshConfig.port,
+      remoteHermesPath: sshConfig.remoteHermesPath,
+      remoteProfile: sshConfig.remoteProfile,
+      user: sshConfig.user
+    }
+  }
 }
 
 function persistSshConnectionToken(profile, source, token) {
@@ -10492,6 +10505,64 @@ async function ensureRegistryBackend(connectionId, profile) {
     throw new Error(`No connection with id "${id}".`)
   }
 
+  const profileKey = String(profile ?? '').trim() || 'default'
+  let resolvedRegistrySshConfig
+  let registryEffectiveFingerprintPromise: null | Promise<string> = null
+
+  const resolveRegistrySshConfig = () => {
+    if (source.kind !== 'ssh') {
+      return null
+    }
+
+    if (!resolvedRegistrySshConfig) {
+      resolvedRegistrySshConfig = normalizeSshConfig({
+        mode: 'ssh',
+        host: source.host,
+        user: source.user,
+        port: source.port,
+        keyPath: source.keyPath,
+        remoteHermesPath: source.remoteHermesPath,
+        remoteProfile: source.remoteProfile || (profileKey === 'default' ? '' : profileKey)
+      })
+    }
+
+    return resolvedRegistrySshConfig
+  }
+
+  const resolveRegistryEffectiveFingerprint = () => {
+    if (!registryEffectiveFingerprintPromise) {
+      const sshConfig = resolveRegistrySshConfig()
+
+      registryEffectiveFingerprintPromise = sshConfig
+        ? effectiveSshConfigFingerprint(sshConfig)
+        : Promise.reject(new Error(`SSH connection "${source.label}" has no host configured.`))
+    }
+
+    return registryEffectiveFingerprintPromise
+  }
+
+  // The v2 registry is migrated from (but intentionally coexists with) the
+  // v1 primary connection config. Reuse the already-booted primary descriptor
+  // when both identities match; otherwise a default-profile registry request
+  // opens a second SSH dashboard under a different scope and the competing
+  // lifecycle probes repeatedly tear down each other's tunnel.
+  const primary = await reuseMatchingPrimarySshBackend({
+    connectionId: id,
+    effectiveFingerprint: resolveRegistryEffectiveFingerprint,
+    ensurePrimary: () => ensureBackend(profile),
+    profile,
+    registry,
+    source
+  })
+
+  if (primary) {
+    return {
+      ...primary,
+      profile: profileKey,
+      connectionId: id
+    }
+  }
+
   if (source.kind === 'local') {
     // The registry's 'local' entry means THIS machine's runtime — always.
     // ensureBackend() follows the v1 routing table, which resolves to a
@@ -10502,8 +10573,6 @@ async function ensureRegistryBackend(connectionId, profile) {
     // the v1 route is genuinely local; otherwise spawn/reuse a forced-local
     // child pooled under the composite 'conn:local::<profile>' key so it
     // can't collide with the v1 remote descriptor cached at the bare key.
-    const profileKey = String(profile ?? '').trim() || 'default'
-
     profileDeletionGate.assertCanStart(profileKey)
 
     const localRoute = resolveRegistryLocalRoute(profileKey, {
@@ -10613,7 +10682,14 @@ async function ensureRegistryBackend(connectionId, profile) {
     remoteBaseUrl: null
   }
 
-  entry.connectionPromise = connectRegistryBackend(source, profile, key, entry).catch(error => {
+  entry.connectionPromise = connectRegistryBackend(
+    source,
+    profile,
+    key,
+    entry,
+    resolveRegistrySshConfig(),
+    source.kind === 'ssh' ? resolveRegistryEffectiveFingerprint() : null
+  ).catch(error => {
     if (backendPool.get(key) === entry) {
       backendPool.delete(key)
     }
@@ -10629,7 +10705,14 @@ async function ensureRegistryBackend(connectionId, profile) {
 // Dial a non-local registry connection for one profile. Never spawns a local
 // child (entry.process stays null — stopPoolBackend/evict already tolerate
 // that shape from remote per-profile overrides).
-async function connectRegistryBackend(source, profile, key, poolEntry) {
+async function connectRegistryBackend(
+  source,
+  profile,
+  key,
+  poolEntry,
+  resolvedSshConfig?,
+  resolvedEffectiveFingerprint?: null | Promise<string>
+) {
   const profileKey = String(profile ?? '').trim() || 'default'
 
   if (source.kind === 'ssh') {
@@ -10637,15 +10720,7 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
     // pair owns its own tunnel + remote dashboard; the profile that re-homes
     // the REMOTE process is the entry's remoteProfile or the requested one —
     // never the composite string.
-    const sshConfig = normalizeSshConfig({
-      mode: 'ssh',
-      host: source.host,
-      user: source.user,
-      port: source.port,
-      keyPath: source.keyPath,
-      remoteHermesPath: source.remoteHermesPath,
-      remoteProfile: source.remoteProfile || (profileKey === 'default' ? '' : profileKey)
-    })
+    const sshConfig = resolvedSshConfig
 
     if (!sshConfig) {
       throw new Error(`SSH connection "${source.label}" has no host configured.`)
@@ -10655,7 +10730,8 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
       key,
       sshConfig,
       decryptDesktopSecret(source.token),
-      `registry:${source.id}`
+      `registry:${source.id}`,
+      resolvedEffectiveFingerprint ? await resolvedEffectiveFingerprint : undefined
     )
 
     poolEntry.remoteBaseUrl = connection.baseUrl

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14058,14 +14058,17 @@ async function fetchJsonForBackend(
 
 ipcMain.handle('hermes:connection-config:probe', async (_event, rawUrl) => probeRemoteAuthMode(rawUrl))
 ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) => {
-  // Capability-gated login (RFC 8252). Probe the gateway's public /api/status:
-  //   - advertises "native_pkce" in auth_flows → run the system-browser +
-  //     loopback + PKCE flow. No embedded webview, tokens held by the app
-  //     (encrypted keychain), REST/WS authenticated by bearer — no cookies.
-  //   - older gateway without native_pkce → fall back to the legacy embedded
-  //     BrowserWindow cookie flow, preserving compatibility.
-  // This is the "observable ladder + compatibility fallback tied to an
-  // identified older runtime" the desktop guide requires.
+  // Capability-gated login (RFC 8252). Probe the gateway's public /api/status
+  // for supported auth_flows and /api/auth/providers for provider capabilities:
+  //   - all providers support password → always use the embedded login window
+  //     (password providers require the dashboard login form; native PKCE
+  //     can never complete for that provider shape)
+  //   - advertises "native_pkce" AND at least one non-password provider →
+  //     run the system-browser + loopback + PKCE flow
+  //   - older gateway with no provider metadata → fall back to the auth_flows
+  //     check (existing compatibility)
+  //   - a failed native login reports the error rather than auto-falling back
+  //     to the embedded flow — one sign-in action opens at most one window.
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
 
   let statusBody: any = null
@@ -14077,7 +14080,10 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
     // own error handling and works against any gated gateway.
   }
 
-  const strategy = resolveLoginStrategy(statusBody)
+  const authRequired = statusBody && authModeFromStatus(statusBody) === 'oauth'
+  const providers = authRequired ? await gatewayAuthProviders(baseUrl) : []
+
+  const strategy = resolveLoginStrategy(statusBody, { providers })
 
   if (strategy === 'native') {
     try {
@@ -14097,10 +14103,10 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
       rememberLog(
         `[native-oauth] native login failed (${
           error instanceof Error ? error.message : String(error)
-        }); falling back to embedded flow`
+        })`
       )
-      // Fall through to the embedded flow so a native-flow hiccup (blocked
-      // loopback, user closed the browser) still lets the user sign in.
+
+      return { ok: false, error: error instanceof Error ? error.message : String(error), connected: false }
     }
   }
 
@@ -14119,19 +14125,17 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
   return { ok: true, baseUrl, connected }
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
-  const baseUrl = rawUrl ? normalizeRemoteBaseUrl(rawUrl) : ''
-  await clearOauthSession(baseUrl || undefined)
+  const baseUrl = normalizeRemoteBaseUrl(rawUrl)
+  await clearOauthSession(baseUrl)
 
   // Also drop any native (RFC 8252) bearer tokens for this gateway so a
   // logout clears BOTH auth shapes.
-  if (baseUrl) {
-    _clearNativeTokens(baseUrl)
-  }
+  _clearNativeTokens(baseUrl)
 
   // Report against the SAME liveness notion the Settings indicator uses
   // (AT-or-RT cookie, or a native token) so a logout that left any session
   // behind is reflected as still-connected rather than silently signed-out.
-  const connected = baseUrl ? (await hasLiveOauthSession(baseUrl)) || hasNativeSession(baseUrl) : false
+  const connected = (await hasLiveOauthSession(baseUrl)) || hasNativeSession(baseUrl)
 
   return { ok: true, connected }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -292,6 +292,11 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import {
+  applyRemoteRequestHeaders,
+  createRegistryGatewayWsUrlHandler,
+  createRemoteWsHeaderStore
+} from './remote-ws-headers'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
 import {
@@ -1405,7 +1410,7 @@ let connectionConfigCacheMtime = null
 let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
-const remoteWsHeadersByUrl = new Map<string, Record<string, string>>()
+const remoteWsHeaderStore = createRemoteWsHeaderStore()
 const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
@@ -8686,25 +8691,11 @@ function encryptIncomingRemoteHeaders(raw, existing, options: { allowPlainText?:
 }
 
 function rememberRemoteWsHeaders(wsUrl, headers = {}) {
-  if (!wsUrl || Object.keys(headers).length === 0) {
-    return
-  }
-
-  remoteWsHeadersByUrl.set(String(wsUrl), headers as Record<string, string>)
-
-  while (remoteWsHeadersByUrl.size > 100) {
-    const oldest = remoteWsHeadersByUrl.keys().next().value
-
-    if (!oldest) {
-      break
-    }
-
-    remoteWsHeadersByUrl.delete(oldest)
-  }
+  remoteWsHeaderStore.remember(wsUrl, headers)
 }
 
 function headersForRemoteRequest(requestUrl) {
-  const exactWsHeaders = remoteWsHeadersByUrl.get(String(requestUrl))
+  const exactWsHeaders = remoteWsHeaderStore.headersFor(requestUrl)
 
   if (exactWsHeaders && Object.keys(exactWsHeaders).length > 0) {
     return exactWsHeaders
@@ -8730,15 +8721,7 @@ function installRemoteHeaderRules() {
 
   remoteHeaderRulesInstalled = true
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    const headers = headersForRemoteRequest(details.url)
-
-    if (Object.keys(headers).length === 0) {
-      callback({})
-
-      return
-    }
-
-    callback({ requestHeaders: { ...details.requestHeaders, ...headers } })
+    applyRemoteRequestHeaders(details, callback, headersForRemoteRequest)
   })
 }
 
@@ -13850,25 +13833,15 @@ ipcMain.handle('hermes:agents:roster', async () => {
 
 // Registry-scoped fresh WS URL: the (connectionId, profile) analogue of
 // hermes:gateway:ws-url. Same single-use-ticket discipline for OAuth sources.
+const registryGatewayWsUrlHandler = createRegistryGatewayWsUrlHandler({
+  ensureBackend: ensureRegistryBackend,
+  mintTicket: mintGatewayWsTicket,
+  buildTicketUrl: buildGatewayWsUrlWithTicket,
+  rememberHeaders: rememberRemoteWsHeaders
+})
+
 ipcMain.handle('hermes:gateway:ws-url-for', async (_event, payload) => {
-  const { connectionId, profile } = payload && typeof payload === 'object' ? (payload as any) : ({} as any)
-
-  return gatewayWsUrlIpcResult(async () => {
-    const connection: any = await ensureRegistryBackend(connectionId, profile)
-
-    if (connection.authMode === 'oauth') {
-      const ticket = await mintGatewayWsTicket(connection.baseUrl, connection.headers)
-      const wsUrl = buildGatewayWsUrlWithTicket(connection.baseUrl, ticket)
-
-      rememberRemoteWsHeaders(wsUrl, connection.headers)
-
-      return registryGatewayWsUrl(connection, wsUrl)
-    }
-
-    rememberRemoteWsHeaders(connection.wsUrl, connection.headers)
-
-    return registryGatewayWsUrl(connection, connection.wsUrl)
-  })
+  return gatewayWsUrlIpcResult(() => registryGatewayWsUrlHandler(payload))
 })
 
 // Fan out `hermes update` to every eligible registered connection at once.

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -11,8 +11,10 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  normalizeAdvertisedAuthProviders,
   oauthGuardMayHardFail,
   oauthSessionIsLive,
+  oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
@@ -130,6 +132,28 @@ test('oauthGuardMayHardFail keeps the strict guard when the list is unusable', (
   assert.equal(oauthGuardMayHardFail(undefined), true)
   assert.equal(oauthGuardMayHardFail('nonsense' as any), true)
   assert.equal(oauthGuardMayHardFail([{ supportsPassword: true }]), true)
+})
+
+
+test('oauthGuardMayHardFail treats status-shaped string basic as password-only', () => {
+  assert.equal(oauthGuardMayHardFail(['basic'] as any), false)
+  assert.equal(oauthGuardMayHardFail([' basic '] as any), false)
+})
+
+test('oauthGuardMayHardFail keeps the strict guard for string oauth providers', () => {
+  assert.equal(oauthGuardMayHardFail(['nous'] as any), true)
+  assert.equal(oauthGuardMayHardFail(['nous', 'basic'] as any), true)
+})
+
+test('normalizeAdvertisedAuthProviders maps snake_case supports_password', () => {
+  assert.deepEqual(normalizeAdvertisedAuthProviders([{ name: 'basic', supports_password: true }]), [
+    { name: 'basic', supportsPassword: true }
+  ])
+})
+
+test('oauthTicketFailureAuthMessage is expired only with a decryptable native session', () => {
+  assert.match(oauthTicketFailureAuthMessage(true), /session has expired/)
+  assert.match(oauthTicketFailureAuthMessage(false), /not signed in/)
 })
 
 // --- 6. gated download auth (guards the Files-panel 401 on cookieless native) ---

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -138,6 +138,73 @@ export interface AdvertisedAuthProvider {
   supportsPassword?: boolean
 }
 
+/** Dashboard `basic` auth is username/password; `/api/status` often lists it as a bare string. */
+const PASSWORD_PROVIDER_NAMES = new Set(['basic'])
+
+const OAUTH_NOT_SIGNED_IN_MESSAGE =
+  'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
+  'Open Settings → Gateway and click "Sign in", or switch back to Local.'
+
+const OAUTH_SESSION_EXPIRED_MESSAGE =
+  'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+
+/**
+ * Normalize `/api/auth/providers` objects *or* `/api/status` `auth_providers`
+ * string names into the shape `oauthGuardMayHardFail` understands.
+ */
+export function normalizeAdvertisedAuthProviders(providers: unknown): AdvertisedAuthProvider[] {
+  if (!Array.isArray(providers)) {
+    return []
+  }
+
+  const out: AdvertisedAuthProvider[] = []
+
+  for (const provider of providers) {
+    if (typeof provider === 'string') {
+      const name = provider.trim()
+
+      if (!name) {
+        continue
+      }
+
+      out.push({ name, supportsPassword: PASSWORD_PROVIDER_NAMES.has(name) })
+      continue
+    }
+
+    if (!provider || typeof provider !== 'object') {
+      continue
+    }
+
+    const raw = provider as AdvertisedAuthProvider & { supports_password?: boolean }
+    const name = typeof raw.name === 'string' ? raw.name.trim() : ''
+
+    if (!name) {
+      continue
+    }
+
+    const supportsPassword =
+      typeof raw.supportsPassword === 'boolean'
+        ? raw.supportsPassword
+        : typeof raw.supports_password === 'boolean'
+          ? raw.supports_password
+          : PASSWORD_PROVIDER_NAMES.has(name)
+
+    out.push({ name, supportsPassword })
+  }
+
+  return out
+}
+
+/**
+ * A 401/403 on `POST /api/auth/ws-ticket` is "session expired" only when we
+ * actually had a decryptable native token set. Stale partition cookies plus
+ * an unreadable keychain otherwise look like a live oauth session and the
+ * ticket mint 401s — that must send the user to Sign in, not "expired".
+ */
+export function oauthTicketFailureAuthMessage(hasDecryptableNativeSession: boolean): string {
+  return hasDecryptableNativeSession ? OAUTH_SESSION_EXPIRED_MESSAGE : OAUTH_NOT_SIGNED_IN_MESSAGE
+}
+
 /**
  * Whether the oauth pre-flight guard may hard-fail a connection for "not
  * signed in".
@@ -156,12 +223,8 @@ export interface AdvertisedAuthProvider {
  * unknown or empty list keeps the strict guard, so backends that predate
  * `/api/auth/providers` are unaffected.
  */
-export function oauthGuardMayHardFail(providers: AdvertisedAuthProvider[] | null | undefined): boolean {
-  if (!Array.isArray(providers) || providers.length === 0) {
-    return true
-  }
-
-  const named = providers.filter(provider => provider && typeof provider === 'object' && provider.name)
+export function oauthGuardMayHardFail(providers: unknown): boolean {
+  const named = normalizeAdvertisedAuthProviders(providers)
 
   if (named.length === 0) {
     return true

--- a/apps/desktop/electron/native-oauth.test.ts
+++ b/apps/desktop/electron/native-oauth.test.ts
@@ -85,6 +85,58 @@ test('resolveLoginStrategy picks native only when advertised and not forced', ()
   assert.equal(resolveLoginStrategy(gated, { forceEmbedded: true }), 'embedded')
 })
 
+// --- provider-aware strategy ---
+
+test('resolveLoginStrategy returns embedded when every provider supports password', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+  const providers = [{ name: 'basic', supportsPassword: true }]
+
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'embedded')
+})
+
+test('resolveLoginStrategy returns embedded for all-password even without native_pkce in auth_flows', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie'] }
+  const providers = [{ name: 'basic', supportsPassword: true }]
+
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'embedded')
+})
+
+test('resolveLoginStrategy returns native for native_pkce gateway with non-password provider', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+  const providers = [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }]
+
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
+})
+
+test('resolveLoginStrategy returns native for a mixed provider deployment', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+
+  const providers = [
+    { name: 'basic', supportsPassword: true },
+    { name: 'nous', supportsPassword: false }
+  ]
+
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
+})
+
+test('resolveLoginStrategy preserves existing behavior when providers are empty or missing', () => {
+  const gated = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+  const legacy = { auth_required: true, auth_flows: ['cookie'] }
+
+  assert.equal(resolveLoginStrategy(gated, {}), 'native')
+  assert.equal(resolveLoginStrategy(gated, { providers: [] }), 'native')
+  assert.equal(resolveLoginStrategy(legacy, {}), 'embedded')
+  assert.equal(resolveLoginStrategy(legacy, { providers: [] }), 'embedded')
+})
+
+test('resolveLoginStrategy ignores providers with no name', () => {
+  const statusBody = { auth_required: true, auth_flows: ['cookie', 'native_pkce'] }
+  const providers = [{ supportsPassword: true }]
+
+  // The unnamed provider is filtered out — still falls through to auth_flows.
+  assert.equal(resolveLoginStrategy(statusBody, { providers }), 'native')
+})
+
 // --- URL building ---
 
 test('buildNativeAuthorizeUrl encodes params and honours a path prefix', () => {

--- a/apps/desktop/electron/native-oauth.ts
+++ b/apps/desktop/electron/native-oauth.ts
@@ -28,6 +28,8 @@
 
 import { createHash, randomBytes } from 'node:crypto'
 
+import { type AdvertisedAuthProvider, oauthGuardMayHardFail } from './native-auth-decisions'
+
 // The gateway status field that lists supported auth flows. See
 // hermes_cli/web_server.py status handler.
 const NATIVE_FLOW_ID = 'native_pkce'
@@ -78,16 +80,30 @@ export function statusSupportsNativeFlow(statusBody: any): boolean {
 }
 
 /**
- * Decide the login strategy for a gated gateway from its status body.
- * Returns 'native' when the gateway can do RFC 8252 AND we're not forced to
- * the legacy path; 'embedded' otherwise (older gateway ⇒ webview fallback).
+ * Decide the login strategy for a gated gateway from its status body and
+ * advertised provider capabilities.
+ *
+ * Returns 'native' when the gateway advertises native_pkce AND at least one
+ * non-password provider is available; 'embedded' when all providers are
+ * password-only, the gateway lacks native_pkce, or forceEmbedded is set.
+ *
+ * Provider metadata is discovered from /api/auth/providers (separate from
+ * /api/status). When absent (older gateway), the decision falls through to
+ * the auth_flows check — existing compatibility is preserved.
  *
  * `forceEmbedded` lets a user/setting or an env override pin the legacy flow
  * (e.g. a corporate proxy that blocks loopback). Precedence written down here,
  * in one place, as a pure function — per the desktop "observable ladder" rule.
  */
-export function resolveLoginStrategy(statusBody: any, opts: { forceEmbedded?: boolean } = {}): 'native' | 'embedded' {
+export function resolveLoginStrategy(
+  statusBody: any,
+  opts: { forceEmbedded?: boolean; providers?: AdvertisedAuthProvider[] } = {}
+): 'native' | 'embedded' {
   if (opts.forceEmbedded) {
+    return 'embedded'
+  }
+
+  if (!oauthGuardMayHardFail(opts.providers)) {
     return 'embedded'
   }
 

--- a/apps/desktop/electron/primary-backend-startup.test.ts
+++ b/apps/desktop/electron/primary-backend-startup.test.ts
@@ -70,6 +70,7 @@ test('primary remote descriptor preserves the effective SSH dialing identity', (
   )
 
   assert.equal(connection.ssh, ssh)
+  assert.equal(connection.ssh?.effectiveConfigFingerprint, 'effective-config')
 })
 
 test('primary remote descriptor keeps legacy unregistered routes unqualified', () => {

--- a/apps/desktop/electron/primary-backend-startup.test.ts
+++ b/apps/desktop/electron/primary-backend-startup.test.ts
@@ -48,6 +48,30 @@ test('primary remote descriptor preserves a resolved registry connection id', ()
   assert.equal(connection.isFullscreen, false)
 })
 
+test('primary remote descriptor preserves the effective SSH dialing identity', () => {
+  const ssh = {
+    effectiveConfigFingerprint: 'effective-config',
+    host: 'build-host',
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'default',
+    user: 'alice'
+  }
+
+  const connection = createPrimaryRemoteConnection(
+    {
+      baseUrl: 'http://127.0.0.1:49152',
+      remoteKind: 'ssh',
+      ssh,
+      token: 'secret',
+      wsUrl: 'ws://127.0.0.1:49152/api/ws'
+    },
+    [],
+    {}
+  )
+
+  assert.equal(connection.ssh, ssh)
+})
+
 test('primary remote descriptor keeps legacy unregistered routes unqualified', () => {
   const connection = createPrimaryRemoteConnection(
     {

--- a/apps/desktop/electron/primary-backend-startup.ts
+++ b/apps/desktop/electron/primary-backend-startup.ts
@@ -20,6 +20,15 @@ interface ResolvedPrimaryRemote {
   remoteHost?: string
   remoteKind?: 'cloud' | 'ssh' | 'url'
   source?: string
+  ssh?: {
+    effectiveConfigFingerprint?: string
+    host?: string
+    keyPath?: string
+    port?: number
+    remoteHermesPath?: string
+    remoteProfile?: string
+    user?: string
+  }
   token: unknown
   wsUrl: string
 }
@@ -43,6 +52,7 @@ export function createPrimaryRemoteConnection<State extends object>(
     remoteKind: remote.remoteKind,
     remoteHermesVersion: remote.remoteHermesVersion,
     ...(remote.connectionId ? { connectionId: remote.connectionId } : {}),
+    ...(remote.ssh ? { ssh: remote.ssh } : {}),
     token: remote.token,
     wsUrl: remote.wsUrl,
     logs,

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   buildSpawnCommand,
   cleanupStale,
   connect,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
@@ -469,6 +470,29 @@ test.skipIf(process.platform === 'win32')(
     }
   }
 )
+
+test('disconnect reaps the backend recorded for this desktop ownership', async () => {
+  const lock = ownedLock()
+
+  const ssh = fakeSsh([
+    [/cat .*backend\.lock\.json/, JSON.stringify(lock)],
+    [/kill -0 333/, 'ALIVE\n'],
+    [/print\("OWNED"/, 'OWNED\n']
+  ])
+
+  await disconnect(ssh, OWNERSHIP_ID)
+
+  assert.ok(ssh.calls.some(command => /kill 333\b/.test(command)))
+  assert.ok(ssh.calls.some(command => /rm -f .*backend\.lock\.json/.test(command)))
+})
+
+test('disconnect is a no-op when this desktop has no lockfile', async () => {
+  const ssh = fakeSsh([[/cat .*backend\.lock\.json/, '']])
+
+  await disconnect(ssh, OWNERSHIP_ID)
+
+  assert.ok(!ssh.calls.some(command => /\bkill\b/.test(command)))
+})
 
 test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', async () => {
   const notOurs = fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']])

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -518,6 +518,26 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   await removeLockfile(ssh, ownershipId)
 }
 
+// Normal disconnect (quit, connection switch): reuse cleanupStale so we
+// kill only a provably-owned serve --isolated and drop our lockfile.
+// Closing the SSH transport first is not enough — spawn detaches with
+// setsid/nohup, so the backend reparents to pid 1 and keeps state.db
+// open (#91668).
+async function disconnect(ssh, ownershipId) {
+  if (!ssh || !ownershipId) {
+    return
+  }
+
+  const lock = await readLockfile(ssh, ownershipId)
+
+  if (!lock) {
+    return
+  }
+
+  const pidAlive = await remotePidAlive(ssh, lock.pid)
+  await cleanupStale(ssh, ownershipId, lock, pidAlive)
+}
+
 // Detach so the backend survives the SSH channel closing: setsid (Linux)
 // starts a new session; macOS has no setsid, so fall back to nohup (HUP-immune;
 // fd-detachment is already handled by </dev/null + redirect + &).
@@ -960,6 +980,7 @@ export {
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,

--- a/apps/desktop/electron/remote-ws-headers.test.ts
+++ b/apps/desktop/electron/remote-ws-headers.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  applyRemoteRequestHeaders,
+  createRegistryGatewayWsUrlHandler,
+  createRemoteWsHeaderStore,
+  type RegistryGatewayWsConnection
+} from './remote-ws-headers'
+
+const accessHeaders = {
+  'CF-Access-Client-Id': 'client-id',
+  'CF-Access-Client-Secret': 'client-secret'
+}
+
+function createHarness(connection: RegistryGatewayWsConnection) {
+  const store = createRemoteWsHeaderStore()
+  const ensureBackend = vi.fn(async () => connection)
+  const mintTicket = vi.fn(async () => 'fresh-ticket')
+
+  const handler = createRegistryGatewayWsUrlHandler({
+    ensureBackend,
+    mintTicket,
+    buildTicketUrl: baseUrl => `${baseUrl.replace(/^https:/, 'wss:')}/api/ws?region=us&ticket=fresh-ticket&profile=old`,
+    rememberHeaders: store.remember
+  })
+
+  return { ensureBackend, handler, mintTicket, store }
+}
+
+function expectRequestHeaders(
+  store: ReturnType<typeof createRemoteWsHeaderStore>,
+  url: string,
+  expected: Record<string, string> | undefined
+) {
+  const callback = vi.fn()
+
+  applyRemoteRequestHeaders({ url, requestHeaders: { Origin: 'app://hermes' } }, callback, store.headersFor)
+
+  expect(callback).toHaveBeenCalledOnce()
+  expect(callback).toHaveBeenCalledWith(expected ? { requestHeaders: { Origin: 'app://hermes', ...expected } } : {})
+}
+
+function expectNoHeadersForNearbyUrls(store: ReturnType<typeof createRemoteWsHeaderStore>, exactUrl: string) {
+  const exact = new URL(exactUrl)
+  const unscoped = new URL(exact)
+  unscoped.searchParams.delete('profile')
+  const sibling = new URL(exact)
+  sibling.pathname = '/api/ws/sibling'
+  const otherProfile = new URL(exact)
+  otherProfile.searchParams.set('profile', 'analysis')
+  const otherCredential = new URL(exact)
+
+  if (otherCredential.searchParams.has('ticket')) {
+    otherCredential.searchParams.set('ticket', 'other-ticket')
+  } else {
+    otherCredential.searchParams.set('token', 'other-token')
+  }
+
+  const reordered = new URL(exact)
+  const entries = [...reordered.searchParams.entries()].reverse()
+  reordered.search = ''
+
+  for (const [name, value] of entries) {
+    reordered.searchParams.append(name, value)
+  }
+
+  for (const url of [unscoped, sibling, otherProfile, otherCredential, reordered]) {
+    expect(store.headersFor(url.toString())).toEqual({})
+    expectRequestHeaders(store, url.toString(), undefined)
+  }
+}
+
+describe('registry gateway WebSocket headers', () => {
+  it('token path binds headers to the exact profile scoped URL', async () => {
+    const { ensureBackend, handler, mintTicket, store } = createHarness({
+      authMode: 'token',
+      baseUrl: 'https://gateway.example',
+      wsUrl: 'wss://gateway.example/api/ws?token=secret&trace=one&profile=old',
+      headers: accessHeaders,
+      profile: 'research',
+      sharedRemote: true
+    })
+
+    const result = await handler({ connectionId: 'remote-one', profile: 'research' })
+    const expectedUrl = 'wss://gateway.example/api/ws?token=secret&trace=one&profile=research'
+
+    expect(result).toBe(expectedUrl)
+    expect(ensureBackend).toHaveBeenCalledWith('remote-one', 'research')
+    expect(mintTicket).not.toHaveBeenCalled()
+    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expectRequestHeaders(store, result, accessHeaders)
+    expectNoHeadersForNearbyUrls(store, result)
+  })
+
+  it('OAuth path binds headers to the exact fresh profile scoped URL', async () => {
+    const { handler, mintTicket, store } = createHarness({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example',
+      wsUrl: 'wss://gateway.example/api/ws?ticket=stale',
+      headers: accessHeaders,
+      profile: 'research',
+      sharedRemote: true
+    })
+
+    const result = await handler({ connectionId: 'cloud-one', profile: 'research' })
+    const expectedUrl = 'wss://gateway.example/api/ws?region=us&ticket=fresh-ticket&profile=research'
+
+    expect(result).toBe(expectedUrl)
+    expect(mintTicket).toHaveBeenCalledOnce()
+    expect(mintTicket).toHaveBeenCalledWith('https://gateway.example', accessHeaders)
+    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expectRequestHeaders(store, result, accessHeaders)
+    expectNoHeadersForNearbyUrls(store, result)
+  })
+
+  it('sharedRemote false preserves the original URL and exact header behavior', async () => {
+    const { handler, store } = createHarness({
+      authMode: 'token',
+      baseUrl: 'https://gateway.example',
+      wsUrl: 'wss://gateway.example/api/ws?trace=one&token=secret',
+      headers: accessHeaders,
+      profile: 'research',
+      sharedRemote: false
+    })
+
+    const result = await handler({ connectionId: 'remote-one', profile: 'research' })
+
+    expect(result).toBe('wss://gateway.example/api/ws?trace=one&token=secret')
+    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expectRequestHeaders(store, result, accessHeaders)
+    expect(store.headersFor('wss://gateway.example/api/ws?token=secret&trace=one')).toEqual({})
+  })
+})

--- a/apps/desktop/electron/remote-ws-headers.test.ts
+++ b/apps/desktop/electron/remote-ws-headers.test.ts
@@ -71,6 +71,40 @@ function expectNoHeadersForNearbyUrls(store: ReturnType<typeof createRemoteWsHea
 }
 
 describe('registry gateway WebSocket headers', () => {
+  it('evicts the least recently accessed exact URL', () => {
+    const store = createRemoteWsHeaderStore(2)
+    const firstUrl = 'wss://gateway.example/api/ws?token=first&profile=research'
+    const secondUrl = 'wss://gateway.example/api/ws?token=second&profile=research'
+    const thirdUrl = 'wss://gateway.example/api/ws?token=third&profile=research'
+
+    store.remember(firstUrl, accessHeaders)
+    store.remember(secondUrl, accessHeaders)
+    expect(store.headersFor('wss://gateway.example/api/ws?token=missing&profile=research')).toEqual({})
+    expect(store.headersFor(firstUrl)).toEqual(accessHeaders)
+
+    store.remember(thirdUrl, accessHeaders)
+
+    expect(store.headersFor(firstUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(secondUrl)).toEqual({})
+    expect(store.headersFor(thirdUrl)).toEqual(accessHeaders)
+  })
+
+  it('updates headers without changing insertion recency', () => {
+    const store = createRemoteWsHeaderStore(2)
+    const firstUrl = 'wss://gateway.example/api/ws?token=first'
+    const secondUrl = 'wss://gateway.example/api/ws?token=second'
+    const thirdUrl = 'wss://gateway.example/api/ws?token=third'
+
+    store.remember(firstUrl, { 'CF-Access-Client-Id': 'old-client-id' })
+    store.remember(secondUrl, accessHeaders)
+    store.remember(firstUrl, { 'CF-Access-Client-Id': 'updated-client-id' })
+    store.remember(thirdUrl, accessHeaders)
+
+    expect(store.headersFor(firstUrl)).toEqual({})
+    expect(store.headersFor(secondUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(thirdUrl)).toEqual(accessHeaders)
+  })
+
   it('token path binds headers to the exact profile scoped URL', async () => {
     const { ensureBackend, handler, mintTicket, store } = createHarness({
       authMode: 'token',

--- a/apps/desktop/electron/remote-ws-headers.ts
+++ b/apps/desktop/electron/remote-ws-headers.ts
@@ -44,7 +44,19 @@ export function createRemoteWsHeaderStore(limit = 100) {
     }
   }
 
-  const headersFor = (requestUrl: string): Record<string, string> => headersByUrl.get(String(requestUrl)) ?? {}
+  const headersFor = (requestUrl: string): Record<string, string> => {
+    const key = String(requestUrl)
+    const headers = headersByUrl.get(key)
+
+    if (!headers) {
+      return {}
+    }
+
+    headersByUrl.delete(key)
+    headersByUrl.set(key, headers)
+
+    return headers
+  }
 
   return { headersFor, remember }
 }

--- a/apps/desktop/electron/remote-ws-headers.ts
+++ b/apps/desktop/electron/remote-ws-headers.ts
@@ -1,0 +1,85 @@
+import { registryGatewayWsUrl } from './plugin-profile-routes'
+
+export interface RegistryGatewayWsConnection {
+  authMode: string
+  baseUrl: string
+  wsUrl: string
+  headers?: Record<string, string>
+  profile?: null | string
+  sharedRemote?: boolean
+}
+
+interface RegistryGatewayWsUrlDependencies {
+  ensureBackend: (connectionId: unknown, profile: unknown) => Promise<RegistryGatewayWsConnection>
+  mintTicket: (baseUrl: string, headers?: Record<string, string>) => Promise<string>
+  buildTicketUrl: (baseUrl: string, ticket: string) => string
+  rememberHeaders: (wsUrl: string, headers?: Record<string, string>) => void
+}
+
+interface RemoteRequestDetails {
+  url: string
+  requestHeaders?: Record<string, string>
+}
+
+type RemoteRequestCallback = (result: { requestHeaders?: Record<string, string> }) => void
+
+export function createRemoteWsHeaderStore(limit = 100) {
+  const headersByUrl = new Map<string, Record<string, string>>()
+
+  const remember = (wsUrl: string, headers: Record<string, string> = {}) => {
+    if (!wsUrl || Object.keys(headers).length === 0) {
+      return
+    }
+
+    headersByUrl.set(String(wsUrl), headers)
+
+    while (headersByUrl.size > limit) {
+      const oldest = headersByUrl.keys().next().value
+
+      if (!oldest) {
+        break
+      }
+
+      headersByUrl.delete(oldest)
+    }
+  }
+
+  const headersFor = (requestUrl: string): Record<string, string> => headersByUrl.get(String(requestUrl)) ?? {}
+
+  return { headersFor, remember }
+}
+
+export function applyRemoteRequestHeaders(
+  details: RemoteRequestDetails,
+  callback: RemoteRequestCallback,
+  headersForRequest: (requestUrl: string) => Record<string, string>
+) {
+  const headers = headersForRequest(details.url)
+
+  if (Object.keys(headers).length === 0) {
+    callback({})
+
+    return
+  }
+
+  callback({ requestHeaders: { ...details.requestHeaders, ...headers } })
+}
+
+export function createRegistryGatewayWsUrlHandler(dependencies: RegistryGatewayWsUrlDependencies) {
+  return async (payload: unknown): Promise<string> => {
+    const { connectionId, profile } = payload && typeof payload === 'object' ? (payload as any) : ({} as any)
+    const connection = await dependencies.ensureBackend(connectionId, profile)
+    let wsUrl = connection.wsUrl
+
+    if (connection.authMode === 'oauth') {
+      const ticket = await dependencies.mintTicket(connection.baseUrl, connection.headers)
+      wsUrl = dependencies.buildTicketUrl(connection.baseUrl, ticket)
+    }
+
+    const finalWsUrl = registryGatewayWsUrl(connection, wsUrl)
+
+    dependencies.rememberHeaders(finalWsUrl, connection.headers)
+
+    return finalWsUrl
+  }
+}

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -111,6 +111,29 @@ test('forceCleanupAll runs registered pending resource cleanup', async () => {
   await promise
 })
 
+test('shutdown cancels active bootstraps and permanently rejects respawn attempts', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const gate = deferred()
+
+  const active = coordinator.start('primary', 'old', async lease => {
+    await gate.promise
+    lease.assertCurrent()
+  })
+
+  coordinator.shutdown()
+  gate.resolve()
+
+  await assert.rejects(active, (error: any) => error.kind === 'superseded')
+  let started = 0
+  await assert.rejects(
+    coordinator.start('primary', 'new', async () => {
+      started += 1
+    }),
+    (error: any) => error.kind === 'superseded'
+  )
+  assert.equal(started, 0)
+})
+
 test('cancelAll invalidates every pending scope and exposes promises for quit', async () => {
   const coordinator = createBootstrapCoordinator()
   const gates = [deferred(), deferred()]

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -23,8 +23,16 @@ function createBootstrapCoordinator() {
   const pending = new Map<string, any>()
   const generations = new Map<string, number>()
   const drains = new Map<string, Promise<void>>()
+  let shutdownRequested = false
 
   function start(scope, fingerprint, run) {
+    if (shutdownRequested) {
+      const error: any = new Error('SSH bootstrap was cancelled because Desktop is quitting.')
+      error.kind = 'superseded'
+
+      return Promise.reject(error)
+    }
+
     const current = pending.get(scope)
 
     if (current?.fingerprint === fingerprint) {
@@ -121,6 +129,13 @@ function createBootstrapCoordinator() {
     }
   }
 
+  function shutdown() {
+    // Terminal: reconnect callbacks during a prevented first quit must not
+    // spawn a replacement serve --isolated for an app that is already leaving.
+    shutdownRequested = true
+    cancelAll()
+  }
+
   async function forceCleanupAll() {
     const cleanups = [...active].flatMap(entry => [...entry.forceCleanups])
     await Promise.allSettled(cleanups.map(cleanup => cleanup()))
@@ -130,7 +145,7 @@ function createBootstrapCoordinator() {
     return [...active].map(entry => entry.promise)
   }
 
-  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, start }
+  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, shutdown, start }
 }
 
 export { createBootstrapCoordinator, sshConfigFingerprint }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -18,6 +18,7 @@ import {
 } from '@/store/boot'
 import {
   $gateway,
+  activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
@@ -31,6 +32,7 @@ import {
   reportPrimaryGatewayState,
   setPrimaryGateway,
   setPrimaryGatewayConnection,
+  setPrimaryGatewayConnectionId,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
@@ -185,6 +187,7 @@ export function useGatewayBoot({
             }
           : null
       )
+      setPrimaryGatewayConnectionId(next?.connectionId)
     }
 
     if (!desktop) {
@@ -737,9 +740,17 @@ export function useGatewayBoot({
 
     const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
 
-    const offEvent = gateway.onEvent(event =>
-      callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
-    )
+    const offEvent = gateway.onEvent(event => {
+      const connectionId = activeGatewayConnectionId()
+      const scopedEvent = {
+        ...event,
+        profile: sourceProfile,
+        ...(connectionId ? { connectionId } : {})
+      }
+
+      recordSessionEventScope(scopedEvent)
+      callbacksRef.current.handleGatewayEvent(scopedEvent)
+    })
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.

--- a/apps/desktop/src/app/settings/gateway-settings.test.ts
+++ b/apps/desktop/src/app/settings/gateway-settings.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from 'vitest'
 
-import { savedCloudConnectionUrl } from './gateway-settings'
+import { normalizeGatewaySettingsState, savedCloudConnectionUrl } from './gateway-settings'
+
+describe('normalizeGatewaySettingsState', () => {
+  it('fills missing and undefined persisted fields with canonical defaults', () => {
+    const normalized = normalizeGatewaySettingsState({
+      mode: 'remote',
+      remoteAuthMode: undefined,
+      remoteUrl: 'https://gateway.example'
+    })
+
+    expect(normalized.mode).toBe('remote')
+    expect(normalized.remoteAuthMode).toBe('token')
+    expect(normalized.remoteUrl).toBe('https://gateway.example')
+    expect(normalized.sshHost).toBe('')
+    expect(normalized.sshPort).toBeNull()
+    expect(normalized.secureTokenStorage).toBe(true)
+  })
+
+  it('returns an independent default state for invalid persisted data', () => {
+    const first = normalizeGatewaySettingsState(null)
+    const second = normalizeGatewaySettingsState(undefined)
+
+    expect(first).toEqual(second)
+    expect(first).not.toBe(second)
+  })
+})
 
 describe('savedCloudConnectionUrl', () => {
   it('normalizes the URL of a persisted cloud connection', () => {

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -37,7 +37,7 @@ type ProbeStatus = 'idle' | 'probing' | 'done' | 'error'
 // Hermes Cloud discovery lifecycle for the cloud-mode panel.
 type CloudDiscoverStatus = 'idle' | 'loading' | 'done' | 'error'
 
-interface GatewaySettingsState {
+export interface GatewaySettingsState {
   envOverride: boolean
   mode: Mode
   remoteAuthMode: AuthMode
@@ -79,6 +79,18 @@ const EMPTY_STATE: GatewaySettingsState = {
   sshKeyPath: '',
   sshRemoteHermesPath: '',
   sshRemoteProfile: ''
+}
+
+export function normalizeGatewaySettingsState(
+  config: Partial<GatewaySettingsState> | null | undefined
+): GatewaySettingsState {
+  if (!config || typeof config !== 'object') {
+    return { ...EMPTY_STATE }
+  }
+
+  const defined = Object.fromEntries(Object.entries(config).filter(([, value]) => value != null))
+
+  return { ...EMPTY_STATE, ...defined }
 }
 
 export function savedCloudConnectionUrl(config: Pick<GatewaySettingsState, 'mode' | 'remoteUrl'>): string {
@@ -199,8 +211,10 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   }
 
   const acceptSavedConfig = (config: GatewaySettingsState) => {
-    setState(config)
-    setConnectedCloudUrl(savedCloudConnectionUrl(config))
+    const normalized = normalizeGatewaySettingsState(config)
+
+    setState(normalized)
+    setConnectedCloudUrl(savedCloudConnectionUrl(normalized))
   }
 
   // When set, the plain-text opt-in dialog is open; `apply` remembers whether
@@ -622,11 +636,15 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   }
 
   const signOut = async () => {
+    if (!trimmedUrl) {
+      return
+    }
+
     const seq = ++signingSeq.current
     setSigningIn(true)
 
     try {
-      await window.hermesDesktop.oauthLogoutConnectionConfig(trimmedUrl || undefined)
+      await window.hermesDesktop.oauthLogoutConnectionConfig(trimmedUrl)
       const refreshed = await window.hermesDesktop.getConnectionConfig(null)
 
       if (seq !== signingSeq.current) {

--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -25,11 +25,11 @@ function failBoot() {
   })
 }
 
-function stubDesktop(config: Record<string, unknown>) {
+function stubDesktop(config: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
   const original = window.hermesDesktop
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getRecentLogs: async () => ({ lines: [] }), getConnectionConfig: async () => config }
+    value: { getRecentLogs: async () => ({ lines: [] }), getConnectionConfig: async () => config, ...overrides }
   })
 
   return () => Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
@@ -94,6 +94,53 @@ describe('BootFailureOverlay', () => {
       await waitFor(() => expect(screen.queryByRole('button', { name: /repair/i })).toBeNull())
       expect(screen.getByRole('button', { name: /gateway settings/i })).toBeTruthy()
       expect(screen.getByRole('button', { name: /use local gateway/i })).toBeTruthy()
+    } finally {
+      restore()
+    }
+  })
+
+  it('opens gateway settings with a partial persisted remote config', async () => {
+    const restore = stubDesktop({ mode: 'remote', remoteAuthMode: undefined, remoteUrl: undefined })
+
+    try {
+      render(<BootFailureOverlay />)
+      fireEvent.click(screen.getByRole('button', { name: /gateway settings/i }))
+
+      expect(await screen.findByRole('button', { name: /back/i })).toBeTruthy()
+      expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+    } finally {
+      restore()
+    }
+  })
+
+  it('clears and signs in only the failed gateway once', async () => {
+    const gatewayUrl = 'http://100.116.104.53:9191'
+    const logout = vi.fn().mockResolvedValue({ ok: true, connected: false })
+    const login = vi.fn().mockResolvedValue({ ok: true, connected: false })
+
+    const restore = stubDesktop(
+      {
+        ...remoteToken,
+        remoteAuthMode: 'oauth',
+        remoteOauthConnected: false,
+        remoteTokenSet: false,
+        remoteUrl: gatewayUrl
+      },
+      {
+        oauthLoginConnectionConfig: login,
+        oauthLogoutConnectionConfig: logout,
+        probeConnectionConfig: vi.fn().mockResolvedValue({ providers: [{ id: 'basic', type: 'password' }] })
+      }
+    )
+
+    try {
+      render(<BootFailureOverlay />)
+      fireEvent.click(await screen.findByRole('button', { name: /sign out & sign in/i }))
+
+      await waitFor(() => expect(login).toHaveBeenCalledWith(gatewayUrl))
+      expect(logout).toHaveBeenCalledTimes(1)
+      expect(logout).toHaveBeenCalledWith(gatewayUrl)
+      expect(login).toHaveBeenCalledTimes(1)
     } finally {
       restore()
     }

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -163,12 +163,10 @@ export function BootFailureOverlay() {
     setBusy(null)
   }
 
-  // Clear the OAuth partition first, then open the gateway's login window
-  // (username/password form or OAuth redirect — the desktop drives both). A
-  // partition-wide sign-out drops stale gateway AND identity-provider cookies so
-  // an expired session can't silently bounce us back into the same state. On a
+  // Clear this gateway's stale auth first, then open its login window
+  // (username/password form or OAuth redirect — the desktop drives both). On a
   // successful sign-in the cookie is re-established; reload so boot mints a fresh
-  // ticket against a live session.
+  // ticket against a live session without disturbing other saved gateways.
   const signInRemote = async () => {
     if (!remoteReauth) {
       return
@@ -177,7 +175,7 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
-      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
+      await window.hermesDesktop?.oauthLogoutConnectionConfig?.(remoteReauth.url)
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
 
       if (result?.connected) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -186,7 +186,7 @@ declare global {
       sshResolveHost: (host: string) => Promise<DesktopSshResolveResult>
       probeConnectionConfig: (remoteUrl: string) => Promise<DesktopConnectionProbeResult>
       oauthLoginConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLoginResult>
-      oauthLogoutConnectionConfig: (remoteUrl?: string) => Promise<DesktopOauthLogoutResult>
+      oauthLogoutConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLogoutResult>
       // Hermes Cloud: one portal login powers discovery + silent per-agent
       // sign-in (cloud-auto-discovery Phase 3).
       cloud: {

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -40,14 +40,17 @@ vi.mock('@/store/session', () => ({
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
+  activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
   openGatewayForAgent,
   pruneSecondaryGateways,
-  setPrimaryGateway
+  setPrimaryGateway,
+  setPrimaryGatewayConnectionId
 } = await import('./gateway')
+const { setApiRequestConnection } = await import('@/hermes')
 
 function installDesktop(): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -83,6 +86,25 @@ afterEach(() => {
   closeSecondaryGateways()
   vi.clearAllMocks()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('primary gateway registry scope', () => {
+  it('publishes a registered primary connection id for ambient API/WebSocket helpers', () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+    setPrimaryGatewayConnectionId(' homelab-ssh ')
+
+    expect(activeGatewayConnectionId()).toBe('homelab-ssh')
+    expect(setApiRequestConnection).toHaveBeenLastCalledWith('homelab-ssh')
+  })
+
+  it('clears primary connection scope when the primary becomes legacy/local again', () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+    setPrimaryGatewayConnectionId('homelab-ssh')
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    expect(activeGatewayConnectionId()).toBeNull()
+    expect(setApiRequestConnection).toHaveBeenLastCalledWith(null)
+  })
 })
 
 describe('pruneSecondaryGateways with registry-scoped entries', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -226,11 +226,23 @@ export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'defa
 
   g.primaryGateway = gateway
   g.primaryProfile = next
+
+  if (g.activeKey === g.primaryProfile) {
+    setApiRequestConnection(g.primaryConnectionId)
+  }
+}
+
+export function setPrimaryGatewayConnectionId(connectionId: null | string | undefined): void {
+  g.primaryConnectionId = (connectionId ?? '').trim() || null
+
+  if (g.activeKey === g.primaryProfile) {
+    setApiRequestConnection(g.primaryConnectionId)
+  }
 }
 
 /** Publish the registry source owned by the window primary socket. */
 export function setPrimaryGatewayConnection(connection: Pick<HermesConnection, 'connectionId'> | null): void {
-  g.primaryConnectionId = connection?.connectionId?.trim() || null
+  setPrimaryGatewayConnectionId(connection?.connectionId)
 }
 
 function isPrimaryRegistryRoute(connectionId: null | string, profile: string): boolean {
@@ -276,7 +288,7 @@ export function activeGateway(): HermesGateway | null {
  */
 export function activeGatewayConnectionId(): null | string {
   if (g.activeKey === g.primaryProfile) {
-    return null
+    return g.primaryConnectionId
   }
 
   return g.secondaries.get(g.activeKey)?.connectionId ?? null

--- a/contributors/emails/Fernstaedtmarco@gmail.com
+++ b/contributors/emails/Fernstaedtmarco@gmail.com
@@ -1,0 +1,1 @@
+MarcoFernstaedt

--- a/contributors/emails/RaviTharuma@users.noreply.github.com
+++ b/contributors/emails/RaviTharuma@users.noreply.github.com
@@ -1,0 +1,1 @@
+RaviTharuma

--- a/contributors/emails/jaimemarques93@icloud.com
+++ b/contributors/emails/jaimemarques93@icloud.com
@@ -1,0 +1,1 @@
+MrTheSoulz

--- a/contributors/emails/victornogu80@gmail.com
+++ b/contributors/emails/victornogu80@gmail.com
@@ -1,0 +1,1 @@
+victorftrdba


### PR DESCRIPTION
## Summary
Per-connection auth envelopes and backend process ownership now hold under multi-gateway: CF-Access-style proxy headers ride the FINAL scoped WebSocket URL instead of being dropped by the pre-scope cache key, a ws-ticket 401 with unreadable native tokens reads "sign in" instead of lying "session expired", the registered SSH primary publishes its connectionId so it stops falling back to legacy/local scope, a registry-scoped request reuses the migrated v1 primary SSH backend instead of opening a duplicate, quitting Desktop kills the owned detached remote `hermes serve --isolated` (pid-ownership-checked), and a remote dashboard restart no longer forces password-only gateways into a PKCE flow that can't complete.

Consolidated class-5/6 salvage from tracker #94724. Fixes #88494, half of #90323, the #94119 shape, the #93189-reported duplicate-SSH-backend path, the #91668 serve-leak half, and half of #94246.

## Salvaged contributor work
- #88544 @MarcoFernstaedt — headers bound to final scoped URL + remote-ws-headers.ts extraction + LRU
- #90685 @RaviTharuma — ticket-401 routed through native-auth-decisions.ts
- #94207 @Ahmett101 — primaryConnectionId into renderer registry state (commit re-authored to their noreply id: PR carried an invalid redacted email)
- #93189 @MrTheSoulz — effective-identity reuse of the migrated primary SSH backend
- #94628 @686f6c61 — teardownSshConnection kills owned remote serve (unrelated jsdom-flake files excluded; not needed for green)
- #94403 @victorftrdba — restart recovery: no forced PKCE, persisted-state normalization (broad i18n/component churn trimmed; core fix stands alone)

Merge-train note: semantic overlap with class-1's #94824 (both establish the primary's registry owner) — disjoint files, no textual conflict expected; reconcile semantics when both land.

## Validation
A/B: 11 salvaged source files reverted under salvaged tests → 20 failures across 10 files, each mapping 1:1 to a fix; restored → 247/247 across 12 suites, re-run green post-rebase.

**Live repro:** SSH-remote/CF-Access surfaces unreachable on this box — A/B matrix is the evidence per gate, stated per live-repro-confirm-gate; live SSH two-gateway pass available on request.

Attribution audit green (4 new mapping files).

## Infographic

![Auth & Process Patrol](https://v3b.fal.media/files/b/0aa7ced1/TCANIatA2tgukCmLNsjNW_KIezgnQ0.png)
