### PR TITLE
fix(desktop): per-(connection, profile) state stops bleeding across gateways (multi-gateway classes 7+8, tracker #94724)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -544,6 +544,24 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(roster.length, 4)
 })
 
+test('roster: source profile metadata follows the connection-qualified row', () => {
+  const local = { id: 'local', kind: 'local' as const, label: 'This device' }
+  const vps = { id: 'vps', kind: 'remote' as const, label: 'VPS', url: 'http://vps:8642' }
+  const vpsMeta = {
+    display_name: 'Emma',
+    ui_meta: { 'hermes-bots': { title: 'Emma', shape: 'blobatar::sun', color: '#8b5cf6' } },
+    has_avatar: true
+  }
+
+  const roster = buildAgentRoster([
+    { connection: local, profiles: ['default'] },
+    { connection: vps, profiles: ['default'], profileMetadata: { default: vpsMeta } }
+  ])
+
+  assert.deepEqual(roster.find(agent => agent.connectionId === 'vps')?.profileMetadata, vpsMeta)
+  assert.equal(roster.find(agent => agent.connectionId === 'local')?.profileMetadata, undefined)
+})
+
 test('rememberSshEnumeration: live list wins, cache then seed default', () => {
   assert.deepEqual(rememberSshEnumeration({ profiles: ['bob', 'kai'] }, ['stale'], 'ssh'), {
     profiles: ['bob', 'kai']

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -413,6 +413,9 @@ export interface ConnectionAgents {
   /** Profile names enumerated from the connection, or null when unreachable /
    * connect-on-demand (ssh not yet dialed). */
   profiles: null | string[]
+  /** Credential-free profile metadata from the same connection. Kept separate
+   * from `profiles` so old enumerators can continue returning names only. */
+  profileMetadata?: Record<string, RosterProfileMetadata>
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
   /** Stable backend identity from the connection's /api/status (`install_id`).
@@ -433,6 +436,15 @@ export interface RosterAgent {
   /** Bare profile name, or `<profile>-<label-slug>` when the profile name
    * exists on more than one registered source (the @name-device rule). */
   handle: string
+  /** Rich metadata for this exact connection + profile, when enumerated. */
+  profileMetadata?: RosterProfileMetadata
+}
+
+export interface RosterProfileMetadata {
+  display_name?: string
+  title?: string
+  ui_meta?: Record<string, unknown>
+  has_avatar?: boolean
 }
 
 /**
@@ -529,18 +541,30 @@ export function buildAgentRoster(
   // counting names for @name-device disambiguation.
   const identities = new Map<
     string,
-    { connection: RegistryConnection; installId?: string; order: number; profile: string }
+    {
+      connection: RegistryConnection
+      installId?: string
+      order: number
+      profile: string
+      profileMetadata?: RosterProfileMetadata
+    }
   >()
 
   let order = 0
 
-  for (const { connection, installId, profiles } of enumerations) {
+  for (const { connection, installId, profiles, profileMetadata } of enumerations) {
     for (const profile of profiles || []) {
       const name = String(profile || '').trim() || 'default'
       const key = `${connection.id}\0${name}`
 
       if (!identities.has(key)) {
-        identities.set(key, { connection, installId, order, profile: name })
+        identities.set(key, {
+          connection,
+          installId,
+          order,
+          profile: name,
+          ...(profileMetadata?.[name] ? { profileMetadata: profileMetadata[name] } : {})
+        })
       }
     }
 
@@ -551,16 +575,19 @@ export function buildAgentRoster(
   // are the SAME physical install registered under two addresses, so their
   // (install, profile) rows are one bot, not two. Connections without an id
   // (older backends, undialed ssh) keep a per-connection key — no collapse.
-  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
+  const backends = new Map<
+    string,
+    { connection: RegistryConnection; order: number; profile: string; profileMetadata?: RosterProfileMetadata }[]
+  >()
 
-  for (const { connection, installId, order: rank, profile } of identities.values()) {
+  for (const { connection, installId, order: rank, profile, profileMetadata } of identities.values()) {
     const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
     const group = backends.get(key)
 
     if (group) {
-      group.push({ connection, order: rank, profile })
+      group.push({ connection, order: rank, profile, profileMetadata })
     } else {
-      backends.set(key, [{ connection, order: rank, profile }])
+      backends.set(key, [{ connection, order: rank, profile, profileMetadata }])
     }
   }
 
@@ -577,14 +604,15 @@ export function buildAgentRoster(
 
   const roster: RosterAgent[] = []
 
-  for (const { connection, profile } of rows) {
+  for (const { connection, profile, profileMetadata } of rows) {
     roster.push({
       connectionId: connection.id,
       connectionKind: connection.kind,
       connectionLabel: connection.label,
       profile,
       targetProfile: connection.remoteProfile || profile,
-      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
+      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1),
+      ...(profileMetadata ? { profileMetadata } : {})
     })
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14074,6 +14074,13 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+// Persistence-only sibling of hermes:profile:set: records the profile the
+// Desktop should boot into next launch WITHOUT tearing down the backend or
+// reloading the window — the rail's live workspace switch already re-homed
+// the gateway (#79886).
+ipcMain.handle('hermes:profile:remember', async (_event, name) => ({
+  profile: writeActiveDesktopProfile(name)
+}))
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -145,6 +145,7 @@ import {
   updateEligibility,
   upsertConnection
 } from './connection-registry'
+import type { RosterProfileMetadata } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
@@ -13675,7 +13676,13 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
   return Promise.all(
     registry.connections.map(async connection => {
-      let raw: { connection: typeof connection; error?: string; installId?: string; profiles: null | string[] }
+      let raw: {
+        connection: typeof connection
+        error?: string
+        installId?: string
+        profiles: null | string[]
+        profileMetadata?: Record<string, RosterProfileMetadata>
+      }
 
       try {
         // SSH roster listing must never spawn a dashboard. A stale
@@ -13720,13 +13727,52 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
             : []
 
+          const profileMetadata = Array.isArray(body?.profiles)
+            ? Object.fromEntries(
+                body.profiles
+                  .map(profile => {
+                    const name = String(profile?.name || '').trim()
+
+                    if (!name) {
+                      return null
+                    }
+
+                    const metadata: RosterProfileMetadata = {}
+
+                    if (typeof profile?.display_name === 'string' && profile.display_name.trim()) {
+                      metadata.display_name = profile.display_name.trim()
+                    }
+
+                    if (typeof profile?.title === 'string' && profile.title.trim()) {
+                      metadata.title = profile.title.trim()
+                    }
+
+                    if (profile?.ui_meta && typeof profile.ui_meta === 'object') {
+                      metadata.ui_meta = profile.ui_meta
+                    }
+
+                    if (typeof profile?.has_avatar === 'boolean') {
+                      metadata.has_avatar = profile.has_avatar
+                    }
+
+                    return [name, metadata] as const
+                  })
+                  .filter((entry): entry is readonly [string, RosterProfileMetadata] => Boolean(entry))
+              )
+            : undefined
+
           // The root HERMES_HOME is an agent too; enumerations that omit it
           // (older backends list only named profiles) still get a default row.
           if (!profiles.includes('default')) {
             profiles.unshift('default')
           }
 
-          raw = { connection, profiles, ...(installId ? { installId } : {}) }
+          raw = {
+            connection,
+            profiles,
+            ...(installId ? { installId } : {}),
+            ...(profileMetadata ? { profileMetadata } : {})
+          }
         }
       } catch (error: any) {
         raw = { connection, profiles: null, error: String(error?.message || error) }
@@ -13738,7 +13784,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
       const remembered = rememberSshEnumeration(raw, sshRosterCache.get(connection.id), connection.kind)
 
-      return { connection, ...remembered, ...(raw.installId ? { installId: raw.installId } : {}) }
+      return {
+        connection,
+        ...remembered,
+        ...(raw.installId ? { installId: raw.installId } : {}),
+        ...(raw.profileMetadata ? { profileMetadata: raw.profileMetadata } : {})
+      }
     })
   )
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -244,6 +244,7 @@ import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-pro
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
   buildRegistryProfileRoutes,
+  isLocalEnumerationFailure,
   localRouteFallbackProfiles,
   registryGatewayWsUrl,
   undialedSshRouteSeeds
@@ -13336,7 +13337,12 @@ ipcMain.handle('hermes:plugin-profile-routes', async (_event, rawProfileNames) =
     : undefined
 
   const localFallbackProfiles = localSource
-    ? localRouteFallbackProfiles(agents, localSource.id, fallbackProfileNames, Boolean(localEnumeration?.error))
+    ? localRouteFallbackProfiles(
+        agents,
+        localSource.id,
+        fallbackProfileNames,
+        isLocalEnumerationFailure(localEnumeration?.error)
+      )
     : []
 
   if (localSource && localFallbackProfiles.length > 0) {

--- a/apps/desktop/electron/plugin-profile-routes.test.ts
+++ b/apps/desktop/electron/plugin-profile-routes.test.ts
@@ -278,6 +278,18 @@ describe('localRouteFallbackProfiles', () => {
   it('does not synthesize local routes after a successful local enumeration', () => {
     expect(localRouteFallbackProfiles([], 'local', ['default'], false)).toEqual([])
   })
+
+  it('does not synthesize local routes for a deferred connect-on-demand enumeration', () => {
+    expect(
+      localRouteFallbackProfiles([], 'local', ['default'], isLocalEnumerationFailure('connect-on-demand'))
+    ).toEqual([])
+  })
+
+  it('synthesizes local routes for a genuine local enumeration error', () => {
+    expect(
+      localRouteFallbackProfiles([], 'local', ['default'], isLocalEnumerationFailure('ECONNREFUSED'))
+    ).toEqual(['default'])
+  })
 })
 
 describe('undialedSshRouteSeeds', () => {

--- a/apps/desktop/electron/plugin-profile-routes.test.ts
+++ b/apps/desktop/electron/plugin-profile-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildOpaqueProfileRoutes,
   buildRegistryProfileRoutes,
+  isLocalEnumerationFailure,
   localRouteFallbackProfiles,
   type ProfileRouteConfig,
   registryGatewayWsUrl,
@@ -250,6 +251,20 @@ describe('buildRegistryProfileRoutes', () => {
     expect(registryGatewayWsUrl({ profile: 'research' }, 'ws://127.0.0.1:5151/api/ws?token=local')).toBe(
       'ws://127.0.0.1:5151/api/ws?token=local'
     )
+  })
+})
+
+describe('isLocalEnumerationFailure', () => {
+  it('does not treat an intentionally deferred local enumeration as a failure', () => {
+    expect(isLocalEnumerationFailure('connect-on-demand')).toBe(false)
+  })
+
+  it('treats any other enumeration error as a failure', () => {
+    expect(isLocalEnumerationFailure('ECONNREFUSED')).toBe(true)
+  })
+
+  it('treats a missing error as no failure', () => {
+    expect(isLocalEnumerationFailure(undefined)).toBe(false)
   })
 })
 

--- a/apps/desktop/electron/plugin-profile-routes.ts
+++ b/apps/desktop/electron/plugin-profile-routes.ts
@@ -53,7 +53,10 @@ interface BuildOpaqueProfileRoutesOptions {
 
 /** A 'connect-on-demand' local enumeration was intentionally deferred, not
  * failed — it must not be treated as a failure or Bot Mode will synthesize
- * cached local rows on remote-only workspaces where local was never dialed. */
+ * cached local rows on remote-only workspaces where local was never dialed.
+ * The sentinel is set by `enumerateRegistryAgentSources` in main.ts when
+ * `shouldDeferLocalEnumeration` (connection-registry.ts) defers the local
+ * source. */
 export function isLocalEnumerationFailure(error?: string): boolean {
   return Boolean(error) && error !== 'connect-on-demand'
 }

--- a/apps/desktop/electron/plugin-profile-routes.ts
+++ b/apps/desktop/electron/plugin-profile-routes.ts
@@ -51,6 +51,13 @@ interface BuildOpaqueProfileRoutesOptions {
   resolveSsh: (config: ProfileRouteConfig) => Promise<EffectiveSshRoute>
 }
 
+/** A 'connect-on-demand' local enumeration was intentionally deferred, not
+ * failed — it must not be treated as a failure or Bot Mode will synthesize
+ * cached local rows on remote-only workspaces where local was never dialed. */
+export function isLocalEnumerationFailure(error?: string): boolean {
+  return Boolean(error) && error !== 'connect-on-demand'
+}
+
 /** Return cached local profile names only when the local roster read failed. */
 export function localRouteFallbackProfiles(
   agents: RegistryProfileRouteAgent[],

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -214,6 +214,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   profile: {
     get: () => ipcRenderer.invoke('hermes:profile:get'),
+    remember: name => ipcRenderer.invoke('hermes:profile:remember', name),
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
   api: request => ipcRenderer.invoke('hermes:api', request),

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -6,9 +6,9 @@ import { MAIN_COMPOSER_SCOPE } from './composer/scope'
 
 const requestGatewayMock = vi.hoisted(() => vi.fn())
 
-const { $activeSessionId } = await import('@/store/session')
+const { $activeSessionId, $sessions, setSessions } = await import('@/store/session')
 const { $sessionTiles, setSessionTileDelegate } = await import('@/store/session-states')
-const { useSessionTileActions } = await import('./session-tile-actions')
+const { listTileSessionRow, useSessionTileActions } = await import('./session-tile-actions')
 
 const RUNTIME_SESSION_ID = 'rt-tile-current'
 const STORED_SESSION_ID = 'stored-tile-db'
@@ -25,6 +25,36 @@ function renderTileActions() {
   )
 }
 
+describe('session tile optimistic owner metadata', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+
+  it('keeps the tile source on its first optimistic sidebar row', () => {
+    const storedSessionId = 'stored-tile-owner-metadata'
+    const ownerRoute = { connectionId: 'source-a', profile: 'default' }
+    $sessionTiles.set([{ ownerRoute, storedSessionId }])
+
+    expect(
+      listTileSessionRow({
+        cwd: '/remote/worktree',
+        model: 'model-a',
+        preview: 'hello from the tile',
+        runtimeId: 'rt-tile-owner-metadata',
+        sessions: [],
+        storedSessionId
+      })
+    ).toBe(true)
+
+    expect($sessions.get()[0]).toMatchObject({
+      connection_id: 'source-a',
+      id: storedSessionId,
+      profile: 'default'
+    })
+  })
+})
+
 // A tile's cancelRun/steerPrompt/reloadFromMessage each build their own
 // requestGateway call directly instead of going through the shared
 // submitPromptText pipeline (which already wraps its call in
@@ -34,6 +64,7 @@ function renderTileActions() {
 describe('useSessionTileActions sleep/wake session recovery', () => {
   beforeEach(() => {
     $activeSessionId.set('foreground-runtime')
+    setSessions([])
     $sessionTiles.set([{ runtimeId: RUNTIME_SESSION_ID, storedSessionId: STORED_SESSION_ID }])
     setSessionTileDelegate({
       archiveSession: vi.fn(async () => undefined),
@@ -59,6 +90,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
 
   afterEach(() => {
     $activeSessionId.set(null)
+    setSessions([])
     $sessionTiles.set([])
     requestGatewayMock.mockReset()
     vi.restoreAllMocks()

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,7 +22,7 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $connection, $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
+import { $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
 import {
   requestForSessionProfile,
   type SessionOwnerScope,

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,8 +22,19 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $sessions, sessionMatchesStoredId } from '@/store/session'
-import { $sessionStates, isSessionRemote, patchSessionTile, sessionTileDelegate } from '@/store/session-states'
+import { $connection, $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
+import {
+  requestForSessionProfile,
+  type SessionOwnerScope,
+  type SessionProfileRoute
+} from '@/store/session-request-router'
+import {
+  $sessionStates,
+  isSessionRemote,
+  patchSessionTile,
+  sessionTileDelegate,
+  sessionTileOwnerRoute
+} from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
@@ -85,11 +96,19 @@ export function listTileSessionRow(deps: {
     return false
   }
 
+  const knownOwner =
+    sessionTileOwnerRoute(deps.storedSessionId) ?? knownSessionOwner(deps.sessions, deps.storedSessionId)
+  const ownerRoute: SessionProfileRoute | undefined =
+    knownOwner && typeof knownOwner === 'object' ? knownOwner : undefined
+
   upsertOptimisticSession(
     { info: { cwd: deps.cwd, model: deps.model }, session_id: deps.runtimeId, stored_session_id: deps.storedSessionId },
     deps.storedSessionId,
     null,
-    preview
+    preview,
+    null,
+    undefined,
+    ownerRoute
   )
   broadcastSessionsChanged()
 
@@ -153,6 +172,22 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   const readState = useCallback(() => $sessionStates.get()[runtimeIdRef.current], [])
   const readMessages = useCallback(() => readState()?.messages ?? [], [readState])
 
+  // Tile session RPCs must follow the tile's composite owner even when the
+  // active gateway has moved to a same-named profile on another source.
+  const requestSessionGateway = useCallback(
+    <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+      const knownOwner: SessionOwnerScope =
+        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner($sessions.get(), storedIdRef.current)
+      // A bare profile is the legacy/unknown tile shape. Preserve its ambient
+      // behavior; only a composite route is strong enough to retarget a tile
+      // across same-named sources.
+      const owner: SessionOwnerScope = knownOwner && typeof knownOwner === 'object' ? knownOwner : undefined
+
+      return requestForSessionProfile<T>(owner, requestGateway, method, params ?? {}, timeoutMs, signal)
+    },
+    [requestGateway]
+  )
+
   // A ⌘T tab's session is unlisted until its first turn persists — seed the
   // row from the user's first message so the tab and sidebar name it right
   // away (see listTileSessionRow).
@@ -200,7 +235,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
           const next = await uploadComposerAttachment(attachment, {
             backendCwd: readState()?.cwd,
             remote,
-            requestGateway,
+            requestGateway: requestSessionGateway,
             sessionId: liveSessionId,
             storedSessionId: storedIdRef.current,
             onSessionRecovered
@@ -233,7 +268,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
 
       return { attachments: synced, sessionId: liveSessionId }
     },
-    [bindRecoveredRuntime, readState, requestGateway, scope.attachments]
+    [bindRecoveredRuntime, readState, requestSessionGateway, scope.attachments]
   )
 
   // The REAL submit pipeline with tile seams: session always exists, and the
@@ -249,7 +284,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
     // token is a stable constant (the guard never trips for a tile).
     getRouteToken: () => runtimeId,
     onRuntimeRecovered: bindRecoveredRuntime,
-    requestGateway,
+    requestGateway: requestSessionGateway,
     runtimeIdByStoredSessionIdRef,
     // Tile ids are always bound before this hook mounts, so routed recovery is
     // unreachable here; keep the shared submit contract explicit.
@@ -315,16 +350,16 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       await withSessionNotFoundResume(
         sessionId,
         storedIdRef.current,
-        liveId => requestGateway('session.interrupt', { session_id: liveId }),
+        liveId => requestSessionGateway('session.interrupt', { session_id: liveId }),
         {
-          requestGateway,
+          requestGateway: requestSessionGateway,
           onRecovered: bindRecoveredRuntime
         }
       )
     } catch (err) {
       notifyError(err, copy.stopFailed)
     }
-  }, [bindRecoveredRuntime, copy.stopFailed, requestGateway, update])
+  }, [bindRecoveredRuntime, copy.stopFailed, requestSessionGateway, update])
 
   const steerPrompt = useCallback(
     async (rawText: string): Promise<boolean> => {
@@ -374,9 +409,9 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         const { result } = await withSessionNotFoundResume(
           sessionId,
           storedIdRef.current,
-          liveId => requestGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          liveId => requestSessionGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
           {
-            requestGateway,
+            requestGateway: requestSessionGateway,
             onRecovered: bindRecoveredRuntime
           }
         )
@@ -404,7 +439,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
 
       return false
     },
-    [bindRecoveredRuntime, requestGateway]
+    [bindRecoveredRuntime, requestSessionGateway]
   )
 
   // Rewind primitive (interrupt-first for live turns, busy-retry) — shared with
@@ -420,7 +455,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       rebindRowIds?: readonly number[]
     ) =>
       runRewindSubmit(
-        requestGateway,
+        requestSessionGateway,
         runtimeIdRef.current,
         text,
         truncateOrdinal,
@@ -434,7 +469,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         sourceText,
         rebindRowIds
       ),
-    [bindRecoveredRuntime, requestGateway]
+    [bindRecoveredRuntime, requestSessionGateway]
   )
 
   // After a durable rewind the surviving bubbles' cached rowIds are stale (the

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -130,14 +130,20 @@ describe('resolvePinnedSessions', () => {
     ]
     const index = buildSessionByAnyId(sessions, [], [])
 
-    expect(resolvePinnedSessions(['foreign', 'local'], index, sessions).map(s => s.id)).toEqual(['foreign', 'local'])
+    expect(resolvePinnedSessions(['foreign', 'local'], index, sessions, settled).map(s => s.id)).toEqual([
+      'foreign',
+      'local'
+    ])
 
     const clicked = [
       row('foreign', { last_active: 99, pinned: true, profile: 'k9' }),
       row('local', { last_active: 50, pinned: true, profile: 'default' })
     ]
 
-    expect(resolvePinnedSessions(['foreign', 'local'], index, clicked).map(s => s.id)).toEqual(['foreign', 'local'])
+    expect(resolvePinnedSessions(['foreign', 'local'], index, clicked, settled).map(s => s.id)).toEqual([
+      'foreign',
+      'local'
+    ])
   })
 
   it('ignores rows from a backend that predates the pinned flag', () => {

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -119,6 +119,27 @@ describe('resolvePinnedSessions', () => {
     expect(resolvePinnedSessions([], index, sessions, new Set(['other'])).map(s => s.id)).toEqual(['foreign'])
   })
 
+  it('does not reshuffle Show-all pins that already live in the local set', () => {
+    // Foreign-profile rows used to miss the per-profile local copy and fall
+    // through the recency-ordered fallback, so a click (last_active bump)
+    // reshuffled the whole Pinned section. A connection-wide local set keeps
+    // the hand-picked order even when recency changes.
+    const sessions = [
+      row('foreign', { last_active: 1, pinned: true, profile: 'k9' }),
+      row('local', { last_active: 50, pinned: true, profile: 'default' })
+    ]
+    const index = buildSessionByAnyId(sessions, [], [])
+
+    expect(resolvePinnedSessions(['foreign', 'local'], index, sessions).map(s => s.id)).toEqual(['foreign', 'local'])
+
+    const clicked = [
+      row('foreign', { last_active: 99, pinned: true, profile: 'k9' }),
+      row('local', { last_active: 50, pinned: true, profile: 'default' })
+    ]
+
+    expect(resolvePinnedSessions(['foreign', 'local'], index, clicked).map(s => s.id)).toEqual(['foreign', 'local'])
+  })
+
   it('ignores rows from a backend that predates the pinned flag', () => {
     // `pinned` undefined means "no opinion", never "pinned".
     const sessions = [row('a')]

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -132,6 +132,25 @@ describe('useSessionTileDelegate resumeTile', () => {
     expect(requestGateway).not.toHaveBeenCalled()
   })
 
+  it('carries a session row connection owner into a same-named tile resume', async () => {
+    setSessions([row({ connection_id: 'source-b', id: 'stored-shared', profile: 'default' })])
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({ session_id: 'runtime-shared' } as never)
+
+    renderTile(ambientRequest)
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-shared')
+
+    expect(runtimeId).toBe('runtime-shared')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-b', 'default', 'session.resume', {
+      session_id: 'stored-shared',
+      cols: 96,
+      omit_messages: true,
+      profile: 'default'
+    })
+    expect(ambientRequest).not.toHaveBeenCalled()
+  })
+
   it('routes a Bot tile prefetch and resume through its exact connection owner', async () => {
     const route = {
       connectionId: 'barry',

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { getSessionOwnerHint } from '@/store/session'
+import { $sessions, knownSessionOwner } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
@@ -76,8 +76,8 @@ export function useSessionTileDelegate({
 
     const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
       const owner =
-        getSessionOwnerHint(storedSessionId) ??
         sessionTileOwnerRoute(storedSessionId) ??
+        knownSessionOwner($sessions.get(), storedSessionId) ??
         (await resolveSessionProfile(storedSessionId))
 
       return owner

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -320,7 +320,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // profile's own local gateway — never to whatever is "active" (active is
   // presentation only). Resolve the owner from, in order: the tile's persisted
   // route (bot chats carry an exact connectionId+profile), the known session
-  // profile (row or open-time hint), then a cross-profile REST probe that
+  // owner (row or open-time hint), then a cross-profile REST probe that
   // stamps ownership for a hidden/unlisted session. Only a request with NO
   // session at all (a fresh draft, global chrome) falls to the ambient socket.
   // The probe result is cached as an owner hint so the next call is sync.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -560,14 +560,17 @@ export function useGatewayBoot({
         // re-pulls /api/profiles deterministically post-switch — leaving the
         // rail stale or (if a stale in-flight response landed) collapsed
         // (#85731). Best-effort like the rest: a failure keeps the cached
-        // list rather than blanking the rail.
+        // list rather than blanking the rail. NOT awaited: refreshProfiles
+        // now carries a bounded retry chain (#70679), and switch completion
+        // must not wait out backoff timers against an unhealthy backend.
         if (!(await adoptPrimaryProfile(ownsSwitch)) || !ownsSwitch()) {
           return
         }
 
+        void refreshActiveProfile().catch(() => undefined)
+
         await Promise.all([
           seedDefaultCwd(ownsSwitch),
-          refreshActiveProfile().catch(() => undefined),
           callbacksRef.current.refreshHermesConfig(false, ownsSwitch).catch(() => undefined),
           callbacksRef.current.refreshSessions(ownsSwitch).catch(() => undefined)
         ])

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -1,24 +1,230 @@
+import type { GatewayWsUrlResult } from '@hermes/shared'
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const gatewayMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    connect: ReturnType<typeof vi.fn>
+    connectionState: string
+    request: ReturnType<typeof vi.fn>
+    wsUrl: string
+  }>
+}))
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof HermesModule>()
+
+  class FakeHermesGateway {
+    connectionState = 'closed'
+    wsUrl = ''
+    request = vi.fn()
+    connect = vi.fn(async (wsUrl: string) => {
+      this.wsUrl = wsUrl
+      this.connectionState = 'open'
+
+      for (const handler of this.stateHandlers) {
+        handler('open')
+      }
+    })
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+
+      for (const handler of this.stateHandlers) {
+        handler('closed')
+      }
+    })
+    onEvent = vi.fn(() => () => undefined)
+    onState = vi.fn((handler: (state: string) => void) => {
+      this.stateHandlers.add(handler)
+      handler(this.connectionState)
+
+      return () => this.stateHandlers.delete(handler)
+    })
+    private stateHandlers = new Set<(state: string) => void>()
+
+    constructor() {
+      gatewayMocks.instances.push(this)
+    }
+  }
+
+  return { ...actual, HermesGateway: FakeHermesGateway }
+})
+
+import type * as HermesModule from '@/hermes'
 import type { HermesGateway } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import {
+  $gateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForAgent,
+  setPrimaryGateway
+} from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState } from '@/store/session'
 
 import { useGatewayRequest } from './use-gateway-request'
 
+interface TestGateway {
+  connect: ReturnType<typeof vi.fn>
+  connectionState: string
+  request: ReturnType<typeof vi.fn>
+  wsUrl?: string
+}
+
 const fakeGateway = { connectionState: 'open' } as unknown as HermesGateway
 
-afterEach(() => {
+const remoteConnection = {
+  authMode: 'oauth' as const,
+  baseUrl: 'https://ssh.example.test',
+  connectionId: 'ssh-source',
+  mode: 'remote' as const,
+  profile: 'research',
+  remoteIdentity: 'ssh.example.test',
+  remoteKind: 'ssh' as const,
+  token: 'remote-token',
+  wsUrl: 'wss://ssh.example.test/api/ws?ticket=stale'
+}
+
+function installRemoteDesktop() {
+  let mintCount = 0
+  const getConnection = vi.fn(async (profile?: null | string) => ({
+    authMode: 'token' as const,
+    baseUrl: 'http://127.0.0.1:5151',
+    mode: 'local' as const,
+    profile: profile ?? 'default',
+    token: 'local-token',
+    wsUrl: 'ws://127.0.0.1:5151/api/ws?token=local'
+  }))
+  const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+    ...remoteConnection,
+    connectionId,
+    profile
+  }))
+  const getGatewayWsUrl = vi.fn(async () => ({
+    ok: true as const,
+    wsUrl: 'ws://127.0.0.1:5151/api/ws?token=fresh-local'
+  }))
+  const getGatewayWsUrlFor = vi.fn(
+    async ({ connectionId, profile }: { connectionId: string; profile: string }): Promise<GatewayWsUrlResult> => {
+      mintCount += 1
+
+      return {
+        ok: true as const,
+        wsUrl: `wss://${connectionId}.example.test/api/ws?profile=${profile}&ticket=fresh-${mintCount}`
+      }
+    }
+  )
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+  })
+
+  return { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+}
+
+function installPrimaryDesktop(authMode: 'oauth' | 'token') {
+  const getConnection = vi.fn(async (profile?: null | string) => ({
+    authMode,
+    baseUrl: authMode === 'oauth' ? 'https://gateway.example.test' : 'http://127.0.0.1:5151',
+    mode: authMode === 'oauth' ? ('remote' as const) : ('local' as const),
+    profile: profile ?? 'default',
+    token: 'primary-token',
+    wsUrl: authMode === 'oauth' ? 'wss://gateway.example.test/api/ws?ticket=stale' : 'ws://127.0.0.1:5151/api/ws'
+  }))
+  const getGatewayWsUrl = vi.fn(async (profile?: null | string) => ({
+    ok: true as const,
+    wsUrl:
+      authMode === 'oauth'
+        ? `wss://gateway.example.test/api/ws?profile=${profile ?? 'default'}&ticket=fresh`
+        : 'ws://127.0.0.1:5151/api/ws?token=fresh'
+  }))
+  const getConnectionFor = vi.fn()
+  const getGatewayWsUrlFor = vi.fn()
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+  })
+
+  return { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+}
+
+function makePrimaryGateway(): TestGateway {
+  return {
+    connect: vi.fn(async () => undefined),
+    connectionState: 'open',
+    request: vi.fn()
+  }
+}
+
+async function activateRemoteGateway() {
+  const desktop = installRemoteDesktop()
+  const primary = makePrimaryGateway()
+
+  setPrimaryGateway(primary as unknown as HermesGateway, 'default')
+  $gateway.set(primary as unknown as HermesGateway)
+  await ensureGatewayForAgent('ssh-source', 'research')
+
+  const gateway = $gateway.get() as unknown as TestGateway
+
+  expect(gateway).not.toBe(primary)
+  expect($activeGatewayProfile.get()).toBe('research')
+
+  return { desktop, gateway }
+}
+
+async function expectSecondaryRecoveryFailure(
+  gateway: TestGateway,
+  request: ReturnType<typeof useGatewayRequest>['requestGateway']
+) {
+  const transportError = new Error('connection closed')
+  gateway.request.mockRejectedValueOnce(transportError)
+  gateway.connectionState = 'closed'
+
+  vi.useFakeTimers()
+  const retry = request('session.resume').then(
+    () => undefined,
+    error => error
+  )
+
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(8_000)
+  })
+
+  await expect(retry).resolves.toBe(transportError)
+  expect(gateway.request).toHaveBeenCalledTimes(1)
+  expect(gateway.connect).toHaveBeenCalledTimes(1)
+}
+
+beforeEach(() => {
+  gatewayMocks.instances.length = 0
+  closeSecondaryGateways()
+  setPrimaryGateway(null)
   $gateway.set(null)
+  $connection.set(null)
+  $gatewayState.set('idle')
+  $activeGatewayProfile.set('default')
+  configureGatewayRegistry({
+    onActiveRouteChanged: profile => $activeGatewayProfile.set(profile),
+    onEvent: vi.fn()
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  closeSecondaryGateways()
+  setPrimaryGateway(null)
+  $gateway.set(null)
+  $connection.set(null)
+  $gatewayState.set('idle')
+  $activeGatewayProfile.set('default')
+  Reflect.deleteProperty(window, 'hermesDesktop')
 })
 
 describe('useGatewayRequest', () => {
-  // The composer's `/` completions only exist when ChatBar receives a non-null
-  // gateway PROP. `gatewayRef` is populated by a subscription effect, so it is
-  // still null on the first render — a surface that read the ref while
-  // rendering (session tiles / ⌘T tabs) shipped `gateway={null}` and silently
-  // lost slash completions. The returned `gateway` value must be live
-  // immediately so that never happens again.
   it('exposes the live gateway on the first render, before effects run', () => {
     $gateway.set(fakeGateway)
 
@@ -35,5 +241,114 @@ describe('useGatewayRequest', () => {
     act(() => $gateway.set(fakeGateway))
 
     expect(result.current.gateway).toBe(fakeGateway)
+  })
+
+  it.each([
+    { error: new Error('connection closed'), label: 'closed message' },
+    { error: new Error('ECONNRESET'), label: 'reset message' },
+    { error: Object.assign(new Error('socket failed'), { code: 'ECONNRESET' }), label: 'error code' },
+    { error: Object.assign(new Error('socket failed'), { cause: { code: 'ECONNRESET' } }), label: 'cause code' }
+  ])('recovers the registered remote source after a $label failure', async ({ error }) => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    gateway.request.mockResolvedValueOnce({ turn: 1 }).mockRejectedValueOnce(error).mockResolvedValueOnce({ turn: 2 })
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await act(async () => {
+      await expect(result.current.requestGateway('prompt.submit', { text: 'first' })).resolves.toEqual({ turn: 1 })
+    })
+    gateway.connectionState = 'closed'
+    await act(async () => {
+      await expect(result.current.requestGateway('prompt.submit', { text: 'second' })).resolves.toEqual({ turn: 2 })
+    })
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledTimes(2)
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledTimes(2)
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+    expect(gateway.connect).toHaveBeenLastCalledWith(expect.stringContaining('ticket=fresh-2'))
+  })
+
+  it('does not reconnect for a non-transport request failure', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    const failure = Object.assign(new Error('request rejected'), { code: 'EVALIDATION' })
+    gateway.request.mockRejectedValueOnce(failure)
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expect(result.current.requestGateway('session.resume')).rejects.toBe(failure)
+    expect(desktop.getConnectionFor).toHaveBeenCalledTimes(1)
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledTimes(1)
+    expect(gateway.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a real secondary OAuth reauth rejection as the original transport failure', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    desktop.getGatewayWsUrlFor.mockImplementation(async () => ({
+      error: '401 cookie expired',
+      needsOauthLogin: true,
+      ok: false as const
+    }))
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalled()
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed secondary OAuth ticket mint without using the stale ticket or local bridges', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    desktop.getGatewayWsUrlFor.mockRejectedValue(new Error('ticket mint failed'))
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a missing optional scoped mint bridge without falling back to a stale ticket or local lookup', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    Reflect.deleteProperty(window.hermesDesktop, 'getGatewayWsUrlFor')
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { authMode: 'oauth' as const, label: 'primary OAuth' },
+    { authMode: 'token' as const, label: 'local primary' }
+  ])('preserves $label recovery', async ({ authMode }) => {
+    const desktop = installPrimaryDesktop(authMode)
+    const primary = makePrimaryGateway()
+    primary.request.mockRejectedValueOnce(new Error('connection closed')).mockResolvedValueOnce({ recovered: true })
+
+    setPrimaryGateway(primary as unknown as HermesGateway, 'default')
+    $gateway.set(primary as unknown as HermesGateway)
+    $gatewayState.set('closed')
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await act(async () => {
+      await expect(result.current.requestGateway('session.resume')).resolves.toEqual({ recovered: true })
+    })
+
+    expect(desktop.getConnection).toHaveBeenCalledWith('default')
+    expect(desktop.getGatewayWsUrl).toHaveBeenCalledWith('default')
+    expect(desktop.getConnectionFor).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrlFor).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -114,15 +114,14 @@ export function useGatewayRequest() {
       try {
         return await gateway.request<T>(method, params, timeoutMs, signal)
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-
-        if (!/not connected|connection closed/i.test(message)) {
+        if (!isGatewayTransportError(error)) {
           throw error
         }
 
         // Primary keeps the OAuth-aware reconnect (remote gateways re-mint a
-        // single-use ticket); background profiles are always local pool
-        // backends, so the registry handles their reconnect with no reauth.
+        // single-use ticket). Background profiles stay on the registry's
+        // connection-owned reconnect path, including composite remote/SSH
+        // sources.
         const recovered = isActivePrimary() ? await ensureGatewayOpen() : await ensureActiveGatewayOpen()
 
         if (!recovered) {
@@ -145,4 +144,43 @@ export function useGatewayRequest() {
   )
 
   return { connectionRef, gateway, gatewayRef, requestGateway }
+}
+
+const GATEWAY_TRANSPORT_ERROR_CODES = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'ERR_NETWORK',
+  'ERR_SOCKET_CLOSED'
+])
+
+function errorCode(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+
+  const code = (value as { code?: unknown }).code
+
+  return typeof code === 'string' ? code.toUpperCase() : null
+}
+
+function isGatewayTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (/not connected|connection closed|connection reset|ECONNRESET/i.test(message)) {
+    return true
+  }
+
+  const cause = typeof error === 'object' && error !== null ? (error as { cause?: unknown }).cause : undefined
+
+  return [error, cause].some(value => {
+    const code = errorCode(value)
+
+    return code !== null && GATEWAY_TRANSPORT_ERROR_CODES.has(code)
+  })
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -27,6 +27,7 @@ import {
   setCurrentServiceTier,
   setCurrentUsage,
   setMessagingSessions,
+  setSessionOwnerHint,
   setSessions,
   setWorkspaceCwdOwner,
   setYoloActive
@@ -1246,13 +1247,16 @@ export function upsertOptimisticSession(
   title: string | null = null,
   preview: string | null = null,
   parentSessionId: string | null = null,
-  lastActive?: number
+  lastActive?: number,
+  ownerRoute?: SessionProfileRoute
 ) {
   const now = lastActive ?? Date.now() / 1000
-  // Stamp the profile the session was just created on (= the live gateway's
-  // profile) so the scoped sidebar shows the new row immediately instead of
-  // filtering it out as "default" until the aggregator re-fetches.
-  const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  // Stamp the profile/source the session was just created on so the scoped
+  // sidebar shows the new row immediately instead of filtering it out as
+  // "default" until the aggregator re-fetches. The active gateway is only a
+  // presentation detail: a concurrent source switch can move it before this
+  // optimistic row is inserted.
+  const profileKey = normalizeProfileKey(ownerRoute?.profile ?? $activeGatewayProfile.get())
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
@@ -1274,7 +1278,12 @@ export function upsertOptimisticSession(
     source: 'tui',
     started_at: now,
     title,
-    tool_call_count: 0
+    tool_call_count: 0,
+    ...(ownerRoute?.connectionId.trim() ? { connection_id: ownerRoute.connectionId.trim() } : {})
+  }
+
+  if (ownerRoute) {
+    setSessionOwnerHint(id, ownerRoute)
   }
 
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -198,6 +198,9 @@ declare global {
       }
       profile: {
         get: () => Promise<DesktopActiveProfile>
+        // Persists the profile used on the next Desktop launch without
+        // interrupting the live gateway workspace switch.
+        remember: (name: string | null) => Promise<DesktopActiveProfile>
         // Persists the desktop's profile choice and relaunches the local
         // backend under the new HERMES_HOME (reloads the window). Pass null to
         // clear the preference.

--- a/apps/desktop/src/lib/connection-scoped.test.ts
+++ b/apps/desktop/src/lib/connection-scoped.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { connectionScopeSuffix } from './connection-scoped'
+
+const remote = (profile: string, baseUrl = 'https://gw.example:8443') => ({
+  baseUrl,
+  mode: 'remote' as const,
+  profile
+})
+
+describe('connectionScopeSuffix', () => {
+  it('is empty for a local connection', () => {
+    expect(connectionScopeSuffix({ baseUrl: 'http://127.0.0.1:8000', mode: 'local', profile: 'default' })).toBe('')
+  })
+
+  it('includes the profile by default so profile-local lists stay apart', () => {
+    expect(connectionScopeSuffix(remote('default'))).toBe(
+      `.remote.${encodeURIComponent('https://gw.example:8443')}.default`
+    )
+    expect(connectionScopeSuffix(remote('k9'))).not.toBe(connectionScopeSuffix(remote('default')))
+  })
+
+  it('is stable across profile switch when includeProfile is false', () => {
+    const a = connectionScopeSuffix(remote('default'), false)
+    const b = connectionScopeSuffix(remote('k9'), false)
+
+    expect(a).toBe(`.remote.${encodeURIComponent('https://gw.example:8443')}`)
+    expect(a).toBe(b)
+  })
+
+  it('still isolates different gateways when includeProfile is false', () => {
+    expect(connectionScopeSuffix(remote('default', 'https://gw-a.example'), false)).not.toBe(
+      connectionScopeSuffix(remote('default', 'https://gw-b.example'), false)
+    )
+  })
+})

--- a/apps/desktop/src/lib/connection-scoped.ts
+++ b/apps/desktop/src/lib/connection-scoped.ts
@@ -17,8 +17,10 @@ import { readKey, writeKey } from './storage'
 // but its storage key follows the active connection. The local connection
 // keeps the BARE key — byte-identical behavior for single-backend users, the
 // same contract as `backendScopeKey` in @hermes/shared — while a remote
-// connection gets `<key>.remote.<encoded baseUrl>.<encoded profile>`, the
-// shape `workspaceCwdKey` already established.
+// connection gets `<key>.remote.<encoded baseUrl>.<encoded profile>` by
+// default (the shape `workspaceCwdKey` already established). Gateway-wide
+// mirrors (pins) pass `{ includeProfile: false }` so a profile switch cannot
+// fragment the cache and re-assert a stale copy.
 //
 // Legacy globally-keyed values are deliberately NOT migrated into remote
 // scopes: those keys accumulated writes from every window, so ownership of
@@ -34,14 +36,32 @@ export interface ConnectionScopeDescriptor {
   profile?: null | string
 }
 
+export interface ConnectionScopeOptions {
+  /**
+   * When false, a remote suffix is `.remote.<baseUrl>` only. Use this for
+   * gateway-wide mirrors (pins) so a profile switch cannot reload a stale
+   * per-profile copy. Defaults to true — session order and other
+   * profile-local lists stay isolated.
+   */
+  includeProfile?: boolean
+}
+
 /** The storage-key suffix for a connection. Local (and unknown) connections
  *  map to the bare key; remote connections get their own namespace. */
-export function connectionScopeSuffix(connection: ConnectionScopeDescriptor | null | undefined): string {
+export function connectionScopeSuffix(
+  connection: ConnectionScopeDescriptor | null | undefined,
+  includeProfile = true
+): string {
   if (connection?.mode !== 'remote') {
     return ''
   }
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
+
+  if (!includeProfile) {
+    return `.remote.${base}`
+  }
+
   const profile = encodeURIComponent(connection.profile || 'default')
 
   return `.remote.${base}.${profile}`
@@ -51,24 +71,34 @@ interface ScopedEntry<T> {
   $value: WritableAtom<T>
   codec: Codec<T>
   fallback: T
+  includeProfile: boolean
   key: string
+  /** Last suffix this entry loaded or persisted under. */
+  suffix: string
   /** True while a rescope is applying a loaded value — the persistence
    *  subscriber must not echo that read back into storage. */
   applying: boolean
 }
 
+let activeConnection: ConnectionScopeDescriptor | null | undefined
 let activeSuffix = ''
+let activeGatewaySuffix = ''
 
 const registry: ScopedEntry<any>[] = []
 const scopeListeners = new Set<() => void>()
+
+function suffixFor(entry: Pick<ScopedEntry<unknown>, 'includeProfile'>): string {
+  return connectionScopeSuffix(activeConnection, entry.includeProfile)
+}
 
 /** The suffix for the connection the window is currently on. */
 export function activeConnectionScopeSuffix(): string {
   return activeSuffix
 }
 
-/** Observe scope changes (fires BEFORE the scoped atoms repaint, so
- *  per-connection bookkeeping can reset ahead of the reload). */
+/** Observe gateway-identity changes (fires BEFORE scoped atoms that
+ *  follow the connection reload, so pin-sync bookkeeping can reset).
+ *  Profile-only switches do not fire: pin state is gateway-wide. */
 export function onConnectionScopeChange(listener: () => void): () => void {
   scopeListeners.add(listener)
 
@@ -76,7 +106,7 @@ export function onConnectionScopeChange(listener: () => void): () => void {
 }
 
 function loadEntry<T>(entry: ScopedEntry<T>): T {
-  const raw = readKey(entry.key + activeSuffix)
+  const raw = readKey(entry.key + suffixFor(entry))
 
   if (raw === null) {
     return entry.fallback
@@ -94,8 +124,22 @@ function loadEntry<T>(entry: ScopedEntry<T>): T {
  * Reads seed from the current scope's key; writes land under it. When the
  * window's connection changes, every scoped atom reloads from the new scope.
  */
-export function connectionScopedAtom<T>(key: string, fallback: T, codec: Codec<T> = Codecs.json<T>()): WritableAtom<T> {
-  const entry: ScopedEntry<T> = { $value: atom<T>(fallback), applying: false, codec, fallback, key }
+export function connectionScopedAtom<T>(
+  key: string,
+  fallback: T,
+  codec: Codec<T> = Codecs.json<T>(),
+  options?: ConnectionScopeOptions
+): WritableAtom<T> {
+  const includeProfile = options?.includeProfile !== false
+  const entry: ScopedEntry<T> = {
+    $value: atom<T>(fallback),
+    applying: false,
+    codec,
+    fallback,
+    includeProfile,
+    key,
+    suffix: connectionScopeSuffix(activeConnection, includeProfile)
+  }
   entry.$value.set(loadEntry(entry))
   registry.push(entry)
 
@@ -115,7 +159,7 @@ export function connectionScopedAtom<T>(key: string, fallback: T, codec: Codec<T
       return
     }
 
-    writeKey(entry.key + activeSuffix, entry.codec.encode(value))
+    writeKey(entry.key + suffixFor(entry), entry.codec.encode(value))
   })
 
   return entry.$value
@@ -135,21 +179,35 @@ export function rescopeConnectionScopedStores(connection: ConnectionScopeDescrip
   }
 
   const next = connectionScopeSuffix(connection)
+  const nextGateway = connectionScopeSuffix(connection, false)
 
   if (next === activeSuffix) {
     return
   }
 
+  activeConnection = connection
   activeSuffix = next
 
-  // Bookkeeping listeners first: pin-sync's mirrored/pending sets describe
-  // the PREVIOUS backend and must be gone before the reload below triggers
-  // their reconcile against the new scope's lists.
-  for (const listener of scopeListeners) {
-    listener()
+  // Pin-sync's mirrored/pending sets describe the PREVIOUS gateway. Fire
+  // only when the connection (not the profile) changes — pins are
+  // gateway-wide, so a profile switch must not reset bookkeeping and then
+  // re-PATCH a leftover per-profile copy.
+  if (nextGateway !== activeGatewaySuffix) {
+    activeGatewaySuffix = nextGateway
+
+    for (const listener of scopeListeners) {
+      listener()
+    }
   }
 
   for (const entry of registry) {
+    const entrySuffix = suffixFor(entry)
+
+    if (entrySuffix === entry.suffix) {
+      continue
+    }
+
+    entry.suffix = entrySuffix
     entry.applying = true
 
     try {

--- a/apps/desktop/src/store/layout-connection-scope.test.ts
+++ b/apps/desktop/src/store/layout-connection-scope.test.ts
@@ -87,10 +87,9 @@ describe('connection-scoped sidebar lists (#77318)', () => {
     // The bare key still belongs to the local connection.
     expect(readKey('hermes.desktop.pinnedSessions')).toBe(JSON.stringify(['local-1']))
 
-    // The remote pin landed under its own scope, not the shared key.
-    const scoped = readKey(
-      `hermes.desktop.pinnedSessions.remote.${encodeURIComponent('https://vps-a.example:8443')}.default`
-    )
+    // The remote pin landed under its own gateway scope, not the shared key
+    // and not a per-profile fragment.
+    const scoped = readKey(`hermes.desktop.pinnedSessions.remote.${encodeURIComponent('https://vps-a.example:8443')}`)
 
     expect(scoped).toBe(JSON.stringify(['a-1']))
   })
@@ -115,6 +114,19 @@ describe('connection-scoped sidebar lists (#77318)', () => {
     // the remote window must not repaint the local scope's lists.
     setConnection(null)
     expect($pinnedSessionIds.get()).toEqual(['a-1'])
+  })
+
+  it('keeps pins across a profile switch on the same gateway, but not session order', () => {
+    setConnection(remoteA)
+    pinSession('a-1')
+    $sidebarSessionOrderIds.set(['s1'])
+    $sidebarSessionOrderManual.set(true)
+
+    setConnection({ ...remoteA, profile: 'k9' } as unknown as HermesConnection)
+
+    expect($pinnedSessionIds.get()).toEqual(['a-1'])
+    expect($sidebarSessionOrderIds.get()).toEqual([])
+    expect($sidebarSessionOrderManual.get()).toBe(false)
   })
 
   it('scopes the manual session order and its flag per connection', () => {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -97,7 +97,13 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
 // one localStorage area. A global key here is how one gateway's pins bleed
 // into another window's sidebar (#77318). The local connection keeps the
 // bare legacy key; remote connections get their own namespaced keys.
-export const $pinnedSessionIds = connectionScopedAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
+//
+// Pins omit the profile from that key: `sessions.pinned` is gateway-wide,
+// and a per-profile localStorage copy is how an unpin in profile A comes
+// back when the window rescopes to B (stale ids flush as pinned=true).
+export const $pinnedSessionIds = connectionScopedAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray, {
+  includeProfile: false
+})
 export const $sidebarSessionOrderIds = connectionScopedAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
   [] as string[],

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -91,3 +91,52 @@ describe('newSessionInProfile', () => {
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
 })
+
+describe('selectProfile startup preference (#79886)', () => {
+  const rememberProfile = vi.fn(async (name: null | string) => ({ profile: name }))
+
+  beforeEach(() => {
+    rememberProfile.mockClear()
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: { profile: { remember: rememberProfile } }
+    }
+  })
+
+  it('remembers the selected workspace for the next Desktop launch', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly')
+  })
+
+  it('waits for gateway activation before replacing the startup preference', async () => {
+    let resolveGateway!: () => void
+
+    activeGatewayConnectionId.mockReturnValue(null)
+    ensureGatewayForProfile.mockImplementationOnce(
+      () =>
+        new Promise<undefined>(resolve => {
+          resolveGateway = () => resolve(undefined)
+        })
+    )
+
+    selectProfile('tilly')
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+
+    resolveGateway()
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+  })
+
+  it('does not replace the startup preference for a registry-source pick', async () => {
+    activeGatewayConnectionId.mockReturnValue('mini')
+
+    selectProfile('researcher')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'researcher'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -161,6 +161,16 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
 })
 
 describe('refreshProfiles shared rail list (#49289)', () => {
+  beforeEach(() => {
+    vi.mocked(getProfiles).mockReset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
   it('removes a deleted profile from the shared $profiles cache after Manage Profiles refreshes', async () => {
     $profiles.set([profile('default', true), profile('test1')])
     vi.mocked(getProfiles).mockResolvedValueOnce({ profiles: [profile('default', true)] })
@@ -170,12 +180,54 @@ describe('refreshProfiles shared rail list (#49289)', () => {
     expect($profiles.get().map(profile => profile.name)).toEqual(['default'])
   })
 
-  it('leaves the shared $profiles cache intact when the refresh fails', async () => {
+  it('recovers from transient failures and writes the returned profile list (#70679)', async () => {
+    // Global remote mode: the refresh fires while the remote HTTP proxy is still
+    // routing, so the first attempts fail and a later one succeeds. The retry
+    // backoff is 500ms then 1000ms (refreshProfiles retries twice on failure).
+    $profiles.set([])
+    vi.mocked(getProfiles)
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('healthops')] })
+
+    const refresh = refreshProfiles()
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(refresh).resolves.toHaveLength(2)
+
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
+  })
+
+  it('shares one retry chain across concurrent callers (single-flight)', async () => {
+    // Gateway open fires both useBackgroundSync and the activeGatewayProfile
+    // effect at once; both callers must ride the same chain, not double it.
+    $profiles.set([])
+    vi.mocked(getProfiles)
+      .mockRejectedValueOnce(new Error('backend unavailable'))
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('healthops')] })
+
+    const first = refreshProfiles()
+    const second = refreshProfiles()
+    await vi.advanceTimersByTimeAsync(500)
+    await expect(first).resolves.toHaveLength(2)
+    await expect(second).resolves.toHaveLength(2)
+
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(2)
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
+  })
+
+  it('leaves the shared $profiles cache intact when every retry fails', async () => {
     $profiles.set([profile('default', true), profile('test1')])
-    vi.mocked(getProfiles).mockRejectedValueOnce(new Error('backend unavailable'))
+    vi.mocked(getProfiles).mockRejectedValue(new Error('backend unavailable'))
 
-    await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
+    const refresh = refreshProfiles()
+    const rejection = expect(refresh).rejects.toThrow('backend unavailable')
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await rejection
 
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -72,17 +72,64 @@ let profileListEpoch = 0
 
 export function invalidateProfileListFetches(): void {
   profileListEpoch += 1
+  // Detach the single-flight slot too: a caller arriving AFTER a backend
+  // switch must start a fresh fetch against the new backend, not ride the
+  // previous backend's in-flight retry chain.
+  refreshInFlight = null
 }
 
-export async function refreshProfiles(): Promise<ProfileInfo[]> {
-  const epoch = profileListEpoch
-  const { profiles } = await getProfiles()
+// Single-flight guard: on gateway open both useBackgroundSync and the
+// activeGatewayProfile-change effect call refreshActiveProfile() at once, and
+// the Manage Profiles panel can join mid-flight. Dedupe so concurrent callers
+// share one retry chain instead of stampeding /api/profiles (#70679).
+let refreshInFlight: Promise<ProfileInfo[]> | null = null
 
-  if (epoch === profileListEpoch) {
-    $profiles.set(profiles)
+export function refreshProfiles(): Promise<ProfileInfo[]> {
+  if (refreshInFlight) {
+    return refreshInFlight
   }
 
-  return profiles
+  const flight = (async () => {
+    const epoch = profileListEpoch
+    const MAX_RETRIES = 2
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const { profiles } = await getProfiles()
+
+        if (epoch === profileListEpoch) {
+          $profiles.set(profiles)
+        }
+
+        return profiles
+      } catch (error) {
+        if (attempt === MAX_RETRIES || epoch !== profileListEpoch) {
+          // Surface the failure so it's visible in the console — the prior
+          // silent catch in refreshActiveProfile() hid global-remote timing
+          // races (#70679). A stranded epoch stops retrying against the past.
+          console.error(`[profiles] refreshProfiles failed after ${attempt + 1} attempt(s):`, error)
+
+          throw error
+        }
+
+        // Back off before retrying: 500ms, then 1000ms. Gives the remote proxy
+        // a window to finish routing after WebSocket-ready but pre-HTTP-proxy
+        // states (global remote mode, #70679).
+        await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
+      }
+    }
+
+    // Unreachable — satisfies TypeScript.
+    return []
+  })().finally(() => {
+    if (refreshInFlight === flight) {
+      refreshInFlight = null
+    }
+  })
+
+  refreshInFlight = flight
+
+  return flight
 }
 
 // ── Rail order ─────────────────────────────────────────────────────────────

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -692,11 +692,28 @@ export function selectProfile(name: string): void {
   // #81094: any other failed switch must be visible too — the profile pill
   // stays on the previous profile and the user learns why the backend is
   // unreachable.
-  void activateOnCurrentSource(target).catch((error: unknown) => {
-    if (!notifyRemoteOverrideAuthFailure(target, error)) {
-      notifyError(error, `Failed to switch to profile "${target}"`)
-    }
-  })
+  //
+  // The profile rail is a live workspace switch, so it must not call
+  // profile.set() and reload the window. Once activation succeeds, remember
+  // the selection for the next Desktop launch through the persistence-only
+  // IPC instead (#79886). Registry-source picks name ANOTHER source's
+  // profiles, so only a primary-backend activation updates the startup
+  // preference.
+  const onPrimary = activeGatewayConnectionId() == null
+
+  void activateOnCurrentSource(target)
+    .then(() => {
+      if (onPrimary) {
+        return window.hermesDesktop?.profile?.remember(target)
+      }
+
+      return undefined
+    })
+    .catch((error: unknown) => {
+      if (!notifyRemoteOverrideAuthFailure(target, error)) {
+        notifyError(error, `Failed to switch to profile "${target}"`)
+      }
+    })
 }
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the

--- a/apps/desktop/src/store/session-pin-connection-scope.test.ts
+++ b/apps/desktop/src/store/session-pin-connection-scope.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+import { connectionScopeSuffix } from '@/lib/connection-scoped'
+import { readKey } from '@/lib/storage'
+import type { SessionInfo } from '@/types/hermes'
+
+const patch = vi.fn<(id: string, pinned: boolean, profile?: null | string) => Promise<{ ok: boolean }>>(() =>
+  Promise.resolve({ ok: true })
+)
+
+vi.mock('@/hermes', () => ({
+  setApiRequestProfile: () => {},
+  setSessionPinnedRemote: (id: string, pinned: boolean, profile?: null | string) => patch(id, pinned, profile)
+}))
+
+import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { $sessions, setConnection } from '@/store/session'
+
+import { resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
+
+const PIN_KEY = 'hermes.desktop.pinnedSessions'
+
+const remote = (profile: string, baseUrl = 'https://gw.example:8443'): HermesConnection =>
+  ({
+    baseUrl,
+    mode: 'remote',
+    profile,
+    token: 't',
+    wsUrl: 'ws://x'
+  }) as unknown as HermesConnection
+
+const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
+
+const flush = () => Promise.resolve()
+
+beforeAll(() => {
+  ;(globalThis as { window?: unknown }).window ??= {}
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {}
+  watchSessionPins()
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  setConnection(remote('default'))
+  $sessions.set([])
+  $pinnedSessionIds.set([])
+  resetSessionPinMirror()
+  patch.mockClear()
+})
+
+afterEach(() => {
+  $sessions.set([])
+  $pinnedSessionIds.set([])
+  resetSessionPinMirror()
+})
+
+describe('desktop pin list is connection-scoped, not profile-scoped', () => {
+  it('keeps the pin storage key stable across a profile switch', () => {
+    setConnection(remote('default'))
+    pinSession('s1')
+
+    const gatewayKey = `${PIN_KEY}${connectionScopeSuffix(remote('default'), false)}`
+
+    expect(readKey(gatewayKey)).toBe(JSON.stringify(['s1']))
+
+    setConnection(remote('k9'))
+    expect($pinnedSessionIds.get()).toEqual(['s1'])
+    expect(readKey(gatewayKey)).toBe(JSON.stringify(['s1']))
+    expect(readKey(`${PIN_KEY}${connectionScopeSuffix(remote('k9'))}`)).toBeNull()
+  })
+
+  it('still isolates pin sets between two different remote gateways', () => {
+    setConnection(remote('default', 'https://gw-a.example'))
+    pinSession('a-1')
+
+    setConnection(remote('default', 'https://gw-b.example'))
+    expect($pinnedSessionIds.get()).toEqual([])
+    pinSession('b-1')
+
+    setConnection(remote('k9', 'https://gw-a.example'))
+    expect($pinnedSessionIds.get()).toEqual(['a-1'])
+
+    setConnection(remote('default', 'https://gw-b.example'))
+    expect($pinnedSessionIds.get()).toEqual(['b-1'])
+  })
+
+  it('lets an unpin survive a profile rescope instead of flushing pin=true', async () => {
+    $sessions.set([row('s1', { pinned: false, profile: 'k9' })])
+
+    setConnection(remote('default'))
+    pinSession('s1')
+    await flush()
+
+    setConnection(remote('k9'))
+    expect($pinnedSessionIds.get()).toEqual(['s1'])
+
+    unpinSession('s1')
+    await flush()
+    patch.mockClear()
+
+    setConnection(remote('default'))
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('s1')
+    expect(patch).not.toHaveBeenCalledWith('s1', true, expect.anything())
+    expect(patch).not.toHaveBeenCalledWith('s1', true, 'k9')
+  })
+})

--- a/apps/desktop/src/store/session-pin-connection-scope.test.ts
+++ b/apps/desktop/src/store/session-pin-connection-scope.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 
 import type { HermesConnection } from '@/global'
 import { connectionScopeSuffix } from '@/lib/connection-scoped'
-import { readKey } from '@/lib/storage'
+import { readKey, storedStringArray, writeKey } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
 const patch = vi.fn<(id: string, pinned: boolean, profile?: null | string) => Promise<{ ok: boolean }>>(() =>
@@ -106,5 +106,58 @@ describe('desktop pin list is connection-scoped, not profile-scoped', () => {
     expect($pinnedSessionIds.get()).not.toContain('s1')
     expect(patch).not.toHaveBeenCalledWith('s1', true, expect.anything())
     expect(patch).not.toHaveBeenCalledWith('s1', true, 'k9')
+  })
+})
+
+describe('upgrade from per-profile pin keys is server-authoritative', () => {
+  const gateway = 'https://gw.example:8443'
+  const gatewayKey = () => `${PIN_KEY}${connectionScopeSuffix(remote('default', gateway), false)}`
+  const legacyKey = (profile: string) => `${PIN_KEY}${connectionScopeSuffix(remote(profile, gateway))}`
+
+  const seedStalePerProfilePins = () => {
+    // First launch after the gateway-wide key: old profile fragments still
+    // sit in localStorage, the new key is absent, and the in-memory set is
+    // empty. Those fragments caused #90021 — they must not be unioned in.
+    window.localStorage.clear()
+    writeKey(legacyKey('default'), JSON.stringify(['s1']))
+    writeKey(legacyKey('k9'), JSON.stringify(['s1']))
+    setConnection(remote('default', gateway))
+    $sessions.set([])
+    resetSessionPinMirror()
+    patch.mockClear()
+  }
+
+  it('does not resurrect a stale per-profile pin when the server says unpinned', async () => {
+    seedStalePerProfilePins()
+    expect(readKey(gatewayKey())).toBeNull()
+
+    $sessions.set([row('s1', { pinned: false, profile: 'k9' })])
+    await flush()
+
+    setConnection(remote('k9', gateway))
+    await flush()
+    setConnection(remote('default', gateway))
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('s1')
+    expect(storedStringArray(gatewayKey())).not.toContain('s1')
+    expect(patch).not.toHaveBeenCalledWith('s1', true, expect.anything())
+    expect(patch).not.toHaveBeenCalledWith('s1', true, 'k9')
+    expect(readKey(legacyKey('default'))).toBe(JSON.stringify(['s1']))
+    expect(readKey(legacyKey('k9'))).toBe(JSON.stringify(['s1']))
+  })
+
+  it('repopulates the gateway-wide cache from a durable server pin without echoing PATCH', async () => {
+    seedStalePerProfilePins()
+    expect(readKey(gatewayKey())).toBeNull()
+
+    $sessions.set([row('s1', { pinned: true, profile: 'k9' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('s1')
+    expect(storedStringArray(gatewayKey())).toContain('s1')
+    expect(patch).not.toHaveBeenCalledWith('s1', true, expect.anything())
+    expect(readKey(legacyKey('default'))).toBe(JSON.stringify(['s1']))
+    expect(readKey(legacyKey('k9'))).toBe(JSON.stringify(['s1']))
   })
 })

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -487,4 +487,18 @@ describe('requestForSessionProfile', () => {
 
     expect(ambient).toHaveBeenCalledOnce()
   })
+
+  it('preserves ambient request arity as optional controls are supplied', async () => {
+    const ambient = vi.fn(async () => ({ ambient: true }))
+    const params = { session_id: 'rt-3' }
+    const controller = new AbortController()
+
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params)
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params, 1_800_000)
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params, undefined, controller.signal)
+
+    expect(ambient.mock.calls.map(args => args.length)).toEqual([2, 3, 4])
+    expect(ambient).toHaveBeenNthCalledWith(2, 'session.usage', params, 1_800_000)
+    expect(ambient).toHaveBeenNthCalledWith(3, 'session.usage', params, undefined, controller.signal)
+  })
 })

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -154,9 +154,15 @@ export function requestForSessionProfile<T>(
     // changes the observed call shape for the many callers that never asked
     // for a deadline (the plugin host bridge in contrib/wiring is the only one
     // that does).
-    return timeoutMs === undefined && signal === undefined
-      ? ambientRequest<T>(method, params)
-      : ambientRequest<T>(method, params, timeoutMs, signal)
+    if (signal !== undefined) {
+      return ambientRequest<T>(method, params, timeoutMs, signal)
+    }
+
+    if (timeoutMs !== undefined) {
+      return ambientRequest<T>(method, params, timeoutMs)
+    }
+
+    return ambientRequest<T>(method, params)
   }
 
   const profile = normKey(ownerProfile)

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -610,6 +610,12 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
     expect(knownOwnerForSession('stored-2')).toBe('loki')
   })
 
+  it('keeps a session row connection owner when profiles share the same name', () => {
+    setSessions([{ connection_id: 'source-b', id: 'stored-shared', profile: 'default' } as never])
+
+    expect(knownOwnerForSession('stored-shared')).toEqual({ connectionId: 'source-b', profile: 'default' })
+  })
+
   it('returns undefined (ambient) when no owner is known, and for null ids', () => {
     expect(knownOwnerForSession('unknown-session')).toBeUndefined()
     expect(knownOwnerForSession(null)).toBeUndefined()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -43,7 +43,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
-  knownSessionProfile,
+  knownSessionOwner,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
@@ -745,7 +745,7 @@ export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRo
 /**
  * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
  * Tile route first (exact connectionId+profile, survives relaunch), then the
- * known session profile (row or open-time hint). Returns undefined when no
+ * known session owner (row or open-time hint). Returns undefined when no
  * owner is known — the caller falls back to ambient, never to "active".
  */
 export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
@@ -755,7 +755,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner($sessions.get(), storedSessionId)
 }
 
 /**

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1049,3 +1049,21 @@ describe('knownSessionProfile', () => {
     expect(knownSessionProfile([], null)).toBeUndefined()
   })
 })
+
+describe('knownSessionOwner', () => {
+  it('preserves a registry connection on a same-named session row', () => {
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'source-b', id: 'shared-session', profile: 'default' })],
+        'shared-session'
+      )
+    ).toEqual({ connectionId: 'source-b', profile: 'default' })
+  })
+
+  it('preserves a composite owner hint when the row is not listed', () => {
+    const owner = { connectionId: 'source-a', profile: 'default', targetProfile: 'backend-default' }
+    setSessionOwnerHint('hidden-session', owner)
+
+    expect(knownSessionOwner([], 'hidden-session')).toEqual(owner)
+  })
+})

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -169,35 +169,6 @@ export function knownSessionOwner(
 }
 
 /**
- * The exact owner a session-scoped RPC should use, preserving registry
- * connection identity when the session was discovered through a named remote
- * connection. Falling back to only the profile is safe solely when no exact
- * route hint exists.
- */
-export function knownSessionOwner(
-  sessions: readonly SessionInfo[],
-  sessionId: null | string
-): SessionProfileRoute | string | undefined {
-  if (!sessionId) {
-    return undefined
-  }
-
-  const session = sessions.find(candidate => sessionMatchesStoredId(candidate, sessionId))
-  const connectionId = session?.connection_id?.trim()
-
-  if (connectionId) {
-    return {
-      connectionId,
-      profile: session?.profile?.trim() || 'default'
-    }
-  }
-
-  const hint = getSessionOwnerHint(sessionId)
-
-  return hint ?? (session?.profile?.trim() || undefined)
-}
-
-/**
  * The profile a routed session belongs to, for keying the remembered id and
  * other PRESENTATION uses (which profile's sidebar/navigation this session sits
  * under). Falls back to the active gateway profile when the owner is unknown.

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -126,19 +126,46 @@ export function sessionBelongsToProfile(
  * often the only sync source.
  */
 export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId: null | string): string | undefined {
+  const owner = knownSessionOwner(sessions, sessionId)
+
+  return typeof owner === 'string' ? owner : (owner?.targetProfile ?? owner?.profile)?.trim() || undefined
+}
+
+/**
+ * The complete known owner of a session, including its registry connection
+ * when the row or an open-time hint carries one. Session-scoped RPC callers
+ * must use this instead of `knownSessionProfile`: two sources can expose the
+ * same profile name, so returning only that name silently collapses the route
+ * back to the local/profile-only path.
+ */
+export function knownSessionOwner(
+  sessions: readonly SessionInfo[],
+  sessionId: null | string
+): SessionProfileRoute | string | undefined {
   if (!sessionId) {
     return undefined
   }
 
-  const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
-
-  if (owner) {
-    return owner
-  }
-
+  const session = sessions.find(candidate => sessionMatchesStoredId(candidate, sessionId))
+  const profile = session?.profile?.trim()
+  const connectionId = session?.connection_id?.trim()
   const hint = getSessionOwnerHint(sessionId)
 
-  return (hint?.targetProfile ?? hint?.profile)?.trim() || undefined
+  if (connectionId) {
+    return { connectionId, profile: profile || 'default' }
+  }
+
+  const hintProfiles = new Set([hint?.profile.trim() || 'default', hint?.targetProfile?.trim() || 'default'])
+
+  if (hint && (!profile || hintProfiles.has(profile || 'default'))) {
+    return hint
+  }
+
+  if (profile) {
+    return profile
+  }
+
+  return hint
 }
 
 /**
@@ -177,7 +204,7 @@ export function knownSessionOwner(
  *
  * Do NOT use this to ROUTE a session-scoped RPC: the active-profile fallback is
  * exactly what sends a hidden/unlisted session's RPC to a backend that never
- * owned it. Routing must use `knownSessionProfile` + a cross-profile probe and
+ * owned it. Routing must use `knownSessionOwner` + a cross-profile probe and
  * surface an error instead of falling back. This remains for the navigation
  * keying it was written for.
  */

--- a/contributors/emails/tom@spoct.com
+++ b/contributors/emails/tom@spoct.com
@@ -1,0 +1,1 @@
+TomSpoct

--- a/contributors/emails/yl.tilly.everhome@gmail.com
+++ b/contributors/emails/yl.tilly.everhome@gmail.com
@@ -1,0 +1,1 @@
+Tilly-YL


### PR DESCRIPTION
## Summary
Per-(connection, profile) state stops bleeding across cells: unpins no longer resurrect on profile switch (pin identity is gateway-wide while session order stays profile-local), remote-primary desktops stop painting phantom local fallback rows from the connect-on-demand deferral sentinel, the profile rail refreshes when the gateway becomes ready in global remote mode (single-flight with retry) and remembers the selected profile across restarts, never-interacted remote bots get their roster metadata at enumeration time, and SSH/reconnect owner continuity plus transport-error (ECONNRESET-family) recovery hold through composite-source reconnects.

Consolidated class-7/8 salvage from tracker #94724. Fixes #90021, #94648, #70679, #79886, the #91365 enumeration half, and the #90477/#92352 SSH-continuity shapes.

## Salvaged contributor work
- #90290 @trippyogi — gateway-wide pin identity (+2 test-hardening commits)
- #94653 @chelsealong — deferral sentinel no longer treated as enumeration failure
- #74500 @DavidMetcalfe — single-flight refreshProfiles + gateway-ready recovery (reapplied atop main's #85731 epoch guard)
- #79888 @Tilly-YL — profile-rail selection persisted via writeActiveDesktopProfile IPC (semantic reapply over 3 weeks of drift)
- #92708 @TomSpoct — eager enumeration-time profileMetadata threading ONLY (plugin.js half superseded by landed #92731)
- #94192 @hxwvaa — unique work only: SSH/reconnect owner continuity, attachment routing, transport-error recovery (owner-hardening portions left to class-1/#94864 to avoid double-landing)

Dropped: #94147 (needs redesign of _bind_readiness_profile's process-global scope mutation — follow-up).

## Validation
Per-fix A/B: #90290 2 files fail → 32/32; #94653 5/20 fail → 20/20; #74500 errors → 16/16; #79888 2/6 fail → 22/22; #92708 1/76 fail → 76/76; #94192 4/16 fail → 153/153. Stale-base gate caught and stripped a foreign-stash contamination pre-push (consumed stash restored via git fsck).

**Live repro:** headless box — A/B regression evidence per gate; live two-gateway pass available on request.

Final: 16 suites 315/315; tsc --noEmit clean. Attribution audit green (5 new mapping files).

## Infographic

![Scoped & Synced](https://v3b.fal.media/files/b/0aa7ced1/LcTWuVNsJBcn5uwAD4Xd8_9FBn1057.png)
