### PR TITLE
feat(desktop): pin models to the top of the model menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import { $pinnedModels, pinnedModelKey, togglePinnedModel } from '@/store/model-pins'
 import {
   $modelVisibilityOpen,
   $visibleModels,
@@ -28,7 +29,9 @@ vi.mock('@/hermes', () => ({
 }))
 
 beforeEach(() => {
+  window.localStorage.clear()
   $visibleModels.set(null)
+  $pinnedModels.set([])
   setModelVisibilityOpen(false)
   getGlobalModelOptions.mockResolvedValue({
     providers: [{ models: ['gemini-3.1-pro', 'gemini-2.5-flash'], name: 'Google', slug: 'google' }]
@@ -104,5 +107,135 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit Models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+})
+
+// A pin lifts one provider/model pair above the provider groups. The point is
+// reach: the model you use every day is the first row, whatever its provider's
+// alphabetical position.
+describe('pinned models sit above the provider groups', () => {
+  const menuRows = () => screen.getAllByRole('menuitem').map(row => row.textContent ?? '')
+
+  it('renders a pinned model as the first row, ahead of the provider heading', async () => {
+    togglePinnedModel('google', 'gemini-2.5-flash')
+
+    renderMenu()
+    await screen.findByText('Pinned')
+
+    const rows = menuRows()
+    const pinnedIndex = rows.findIndex(text => /Gemini 2\.5 Flash/i.test(text))
+    const providerIndex = rows.findIndex(text => /^Google/.test(text))
+
+    expect(pinnedIndex).toBeGreaterThanOrEqual(0)
+    expect(pinnedIndex).toBeLessThan(providerIndex)
+  })
+
+  // Rendering it in both places would double the row's keyboard entry and show
+  // two check marks for one active model.
+  it('does not also list a pinned model under its provider', async () => {
+    togglePinnedModel('google', 'gemini-2.5-flash')
+
+    renderMenu()
+    await screen.findByText('Pinned')
+
+    expect(screen.getAllByText(/Gemini 2\.5 Flash/i)).toHaveLength(1)
+  })
+
+  it('shows pins in pin order, not catalog order', async () => {
+    // Flash is second in the provider's curated list; pinning it first must put
+    // it above Pro in the pinned section.
+    togglePinnedModel('google', 'gemini-2.5-flash')
+    togglePinnedModel('google', 'gemini-3.1-pro')
+
+    renderMenu()
+    await screen.findByText('Pinned')
+
+    const rows = menuRows()
+
+    expect(rows.findIndex(text => /Gemini 2\.5 Flash/i.test(text))).toBeLessThan(
+      rows.findIndex(text => /Gemini 3\.1 Pro/i.test(text))
+    )
+  })
+
+  // Curation and pinning are different questions: "which models do I usually
+  // want listed" vs "which one do I want first". A pin must win.
+  it('shows a pinned model the Edit Models shortlist hides', async () => {
+    setVisibleModels(new Set([modelVisibilityKey('google', 'gemini-3.1-pro')]))
+    togglePinnedModel('google', 'gemini-2.5-flash')
+
+    renderMenu()
+
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+  })
+
+  it('drops a pin whose model the catalog no longer offers, without hiding the rest', async () => {
+    $pinnedModels.set([pinnedModelKey('google', 'gemini-1.0-retired'), pinnedModelKey('google', 'gemini-2.5-flash')])
+
+    renderMenu()
+    await screen.findByText('Pinned')
+
+    expect(screen.queryByText(/Gemini 1\.0 Retired/i)).toBeNull()
+    expect(screen.getAllByText(/Gemini 2\.5 Flash/i)).toHaveLength(1)
+  })
+
+  it('filters the pinned section by search like any other row', async () => {
+    togglePinnedModel('google', 'gemini-2.5-flash')
+
+    renderMenu()
+    await screen.findByText('Pinned')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'gemini-3.1' } })
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Pinned')).toBeNull()
+    })
+
+    expect(screen.queryByText(/Gemini 3\.1 Pro/i)).not.toBeNull()
+  })
+})
+
+// The pin lives in the row's hover submenu, next to the other per-model
+// settings — pinning is a property of the model, not a separate mode. The row
+// names the ACTION, so it reads "Pin to top" unpinned and "Unpin" pinned.
+describe('pinning from the row submenu', () => {
+  it('pins the row it was opened from', async () => {
+    renderMenu()
+
+    const row = await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    fireEvent.pointerMove(row.closest('[role="menuitem"]')!, { pointerType: 'mouse' })
+
+    const pin = await screen.findByText('Pin to top')
+
+    fireEvent.click(pin)
+
+    expect($pinnedModels.get()).toEqual([pinnedModelKey('google', 'gemini-3.1-pro')])
+  })
+
+  it('offers Unpin once the model is pinned', async () => {
+    togglePinnedModel('google', 'gemini-3.1-pro')
+
+    renderMenu()
+
+    const row = await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    fireEvent.pointerMove(row.closest('[role="menuitem"]')!, { pointerType: 'mouse' })
+
+    await screen.findByText('Unpin')
+    expect(screen.queryByText('Pin to top')).toBeNull()
+  })
+
+  it('Unpin clears the pin', async () => {
+    togglePinnedModel('google', 'gemini-3.1-pro')
+
+    renderMenu()
+
+    const row = await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    fireEvent.pointerMove(row.closest('[role="menuitem"]')!, { pointerType: 'mouse' })
+
+    fireEvent.click(await screen.findByText('Unpin'))
+
+    expect($pinnedModels.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -25,6 +25,7 @@ import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
+import { $pinnedModels, pinnedModelKey, togglePinnedModel } from '@/store/model-pins'
 import {
   $visibleModels,
   collapseModelFamilies,
@@ -109,6 +110,12 @@ interface ProviderGroup {
   provider: ModelOptionProvider
 }
 
+/** A model family the user pinned to the top of the catalog. */
+interface PinnedRow {
+  family: ModelFamily
+  provider: ModelOptionProvider
+}
+
 /**
  * THE model catalog menu: searchable, provider-grouped, `-fast` families
  * collapsed to one row, per-row hover submenu for thinking/effort/fast, full
@@ -176,12 +183,54 @@ export function ModelCatalogMenu({
     [visibleModels, pickerProviders]
   )
 
+  const pinnedModels = useStore($pinnedModels)
+
+  const pinnedSet = useMemo(() => new Set(pinnedModels), [pinnedModels])
+
+  // Resolve pins against the fetched catalog in PIN ORDER (first pinned =
+  // first shown). Pins whose provider/model the catalog no longer carries are
+  // skipped — the stored preference survives re-auths and model list churn.
+  const pinnedRows = useMemo<PinnedRow[]>(() => {
+    const rows: PinnedRow[] = []
+
+    for (const key of pinnedModels) {
+      const [slug, model] = splitPinnedKey(key)
+
+      if (!slug || !model) {
+        continue
+      }
+
+      const provider = pickerProviders.find(entry => entry.slug === slug)
+
+      if (!provider) {
+        continue
+      }
+
+      const family = collapseModelFamilies(provider.models ?? []).find(
+        entry => entry.id === model || entry.fastId === model
+      )
+
+      if (family) {
+        rows.push({ family, provider })
+      }
+    }
+
+    return rows
+  }, [pinnedModels, pickerProviders])
+
   const groups = useMemo(
-    () => groupModels(pickerProviders, search, { model: current.model, provider: current.provider }, shownKeys),
-    [pickerProviders, search, current.model, current.provider, shownKeys]
+    () =>
+      groupModels(pickerProviders, search, { model: current.model, provider: current.provider }, shownKeys, pinnedSet),
+    [pickerProviders, search, current.model, current.provider, shownKeys, pinnedSet]
   )
 
   const q = normalize(search)
+
+  // Pins respect search like everything else; unfiltered they always show.
+  const shownPinnedRows = useMemo(
+    () => (q ? pinnedRows.filter(row => matchesFamily(row.provider, row.family, q)) : pinnedRows),
+    [pinnedRows, q]
+  )
 
   // Presets are searchable rows like everything else — an unfiltered preset
   // sitting under zero model matches would otherwise become the "first match"
@@ -231,6 +280,14 @@ export function ModelCatalogMenu({
 
   const kbRows = useMemo<KbRow[]>(
     () => [
+      ...shownPinnedRows.map(
+        ({ family, provider }): KbRow => ({
+          family,
+          key: `${provider.slug}:${family.id}`,
+          kind: 'family',
+          provider
+        })
+      ),
       ...groups.flatMap(group =>
         collapsedProviders.includes(group.provider.slug) && !search
           ? []
@@ -243,7 +300,7 @@ export function ModelCatalogMenu({
       ),
       ...shownMoaPresets.map((preset): KbRow => ({ key: `moa:${preset}`, kind: 'moa', preset }))
     ],
-    [groups, collapsedProviders, search, shownMoaPresets]
+    [shownPinnedRows, groups, collapsedProviders, search, shownMoaPresets]
   )
 
   const [kbOverride, setKbOverride] = useState<null | number>(null)
@@ -315,6 +372,98 @@ export function ModelCatalogMenu({
   // Rows are hover-selectable, so they go inert with the pointer.
   const quietRows = pointerQuiet && 'pointer-events-none'
 
+  // ONE row renderer for both the pinned section and the provider groups, so a
+  // pinned row is the same row — same label, same submenu, same keyboard key —
+  // just lifted to the top. Two copies of this markup is how the sections
+  // would drift apart.
+  const renderFamilyRow = (family: ModelFamily, provider: ModelOptionProvider) => {
+    // The active id may be the base or its -fast sibling; either
+    // way this one family row represents both.
+    const activeId =
+      isCurrentProvider(provider, current.provider) && (current.model === family.id || current.model === family.fastId)
+        ? current.model
+        : null
+
+    const isCurrent = activeId !== null
+    const name = modelDisplayParts(family.id).name
+    const caps = provider.capabilities?.[family.id]
+
+    // Effective settings for this row: the live choice when it's
+    // the active model, otherwise its remembered preset. Row
+    // label AND submenu read from these so they never disagree.
+    const preset = controller.presetFor(provider.slug, family.id)
+    const effEffort = isCurrent ? current.effort : (preset.effort ?? '')
+    const effFast = isCurrent ? current.fast : (preset.fast ?? false)
+
+    const fastControl: FastControl = resolveFastControl(
+      activeId ?? family.id,
+      provider.models ?? [],
+      caps?.fast ?? false,
+      effFast
+    )
+
+    const meta = [
+      fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
+      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
+    ]
+      .filter(Boolean)
+      .join(' ')
+
+    // Clicking the row commits the model and closes; the edit
+    // submenu (reasoning/fast) is reached by HOVER, so you can
+    // tweak those without the click dismissing everything.
+    const activate = () => {
+      if (!isCurrent) {
+        void selectFamily(family, provider)
+      }
+
+      closeMenu()
+    }
+
+    const rowKey = `${provider.slug}:${family.id}`
+
+    return (
+      <DropdownMenuSub key={rowKey}>
+        <DropdownMenuSubTrigger
+          hideChevron
+          onClick={activate}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              activate()
+            }
+          }}
+          {...kbRowProps(rowKey)}
+        >
+          <span className="min-w-0 flex-1 truncate">
+            <HighlightMatches query={search} text={name} />
+            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+          </span>
+          {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
+        </DropdownMenuSubTrigger>
+        <ModelEditSubmenu
+          canDisableReasoning={caps?.can_disable_reasoning}
+          defaultEffort={defaultEffort}
+          effort={effEffort}
+          fastControl={fastControl}
+          isActive={isCurrent}
+          isPinned={pinnedSet.has(pinnedModelKey(provider.slug, family.id))}
+          model={family.id}
+          onSelectModel={nextModel => controller.select(nextModel, provider.slug)}
+          onSetOptions={patch =>
+            controller.setOptions(patch, {
+              isActive: isCurrent,
+              model: family.id,
+              provider: provider.slug
+            })
+          }
+          onTogglePin={() => togglePinnedModel(provider.slug, family.id)}
+          provider={provider.slug}
+          reasoning={caps?.reasoning ?? true}
+        />
+      </DropdownMenuSub>
+    )
+  }
+
   return (
     <>
       <DropdownMenuSearch
@@ -359,12 +508,21 @@ export function ModelCatalogMenu({
         <DropdownMenuItem className={dropdownMenuRow} disabled>
           {error}
         </DropdownMenuItem>
-      ) : groups.length === 0 && moaPresets.length === 0 ? (
+      ) : groups.length === 0 && shownPinnedRows.length === 0 && moaPresets.length === 0 ? (
         <DropdownMenuItem className={dropdownMenuRow} disabled>
           {copy.noModels}
         </DropdownMenuItem>
       ) : (
         <div className={cn('max-h-[max(150px,30dvh)] overflow-y-auto py-0.5', quietRows)} ref={listRef}>
+          {shownPinnedRows.length > 0 ? (
+            <DropdownMenuGroup className="py-0.5">
+              <DropdownMenuLabel className="flex w-full items-center gap-1 px-2 pb-0.5 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary)">
+                <Codicon name="pinned" size="0.625rem" />
+                {copy.pinnedSection}
+              </DropdownMenuLabel>
+              {shownPinnedRows.map(({ family, provider }) => renderFamilyRow(family, provider))}
+            </DropdownMenuGroup>
+          ) : null}
           {groups.map(group => {
             const slug = group.provider.slug
 
@@ -391,93 +549,7 @@ export function ModelCatalogMenu({
                     size="0.625rem"
                   />
                 </DropdownMenuItem>
-                {!collapsed &&
-                  group.families.map(family => {
-                    // The active id may be the base or its -fast sibling; either
-                    // way this one family row represents both.
-                    const activeId =
-                      isCurrentProvider(group.provider, current.provider) &&
-                      (current.model === family.id || current.model === family.fastId)
-                        ? current.model
-                        : null
-
-                    const isCurrent = activeId !== null
-                    const name = modelDisplayParts(family.id).name
-                    const caps = group.provider.capabilities?.[family.id]
-
-                    // Effective settings for this row: the live choice when it's
-                    // the active model, otherwise its remembered preset. Row
-                    // label AND submenu read from these so they never disagree.
-                    const preset = controller.presetFor(group.provider.slug, family.id)
-                    const effEffort = isCurrent ? current.effort : (preset.effort ?? '')
-                    const effFast = isCurrent ? current.fast : (preset.fast ?? false)
-
-                    const fastControl: FastControl = resolveFastControl(
-                      activeId ?? family.id,
-                      group.provider.models ?? [],
-                      caps?.fast ?? false,
-                      effFast
-                    )
-
-                    const meta = [
-                      fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
-                    ]
-                      .filter(Boolean)
-                      .join(' ')
-
-                    // Clicking the row commits the model and closes; the edit
-                    // submenu (reasoning/fast) is reached by HOVER, so you can
-                    // tweak those without the click dismissing everything.
-                    const activate = () => {
-                      if (!isCurrent) {
-                        void selectFamily(family, group.provider)
-                      }
-
-                      closeMenu()
-                    }
-
-                    return (
-                      <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
-                        <DropdownMenuSubTrigger
-                          hideChevron
-                          onClick={activate}
-                          onKeyDown={event => {
-                            if (event.key === 'Enter' || event.key === ' ') {
-                              activate()
-                            }
-                          }}
-                          {...kbRowProps(`${group.provider.slug}:${family.id}`)}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches query={search} text={name} />
-                            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                          </span>
-                          {isCurrent ? (
-                            <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
-                          ) : null}
-                        </DropdownMenuSubTrigger>
-                        <ModelEditSubmenu
-                          canDisableReasoning={caps?.can_disable_reasoning}
-                          defaultEffort={defaultEffort}
-                          effort={effEffort}
-                          fastControl={fastControl}
-                          isActive={isCurrent}
-                          model={family.id}
-                          onSelectModel={nextModel => controller.select(nextModel, group.provider.slug)}
-                          onSetOptions={patch =>
-                            controller.setOptions(patch, {
-                              isActive: isCurrent,
-                              model: family.id,
-                              provider: group.provider.slug
-                            })
-                          }
-                          provider={group.provider.slug}
-                          reasoning={caps?.reasoning ?? true}
-                        />
-                      </DropdownMenuSub>
-                    )
-                  })}
+                {!collapsed && group.families.map(family => renderFamilyRow(family, group.provider))}
               </DropdownMenuGroup>
             )
           })}
@@ -532,6 +604,23 @@ export function ModelCatalogMenu({
 /** Re-exported so callers building a footer row match the catalog's rows. */
 export { dropdownMenuRow }
 
+/** Split a stored `provider::model` pin key. Returns empty strings for a
+ *  malformed entry so a corrupt localStorage value can't crash the menu. */
+function splitPinnedKey(key: string): [string, string] {
+  const index = key.indexOf('::')
+
+  return index === -1 ? ['', ''] : [key.slice(0, index), key.slice(index + 2)]
+}
+
+/** Whether a family matches the (already normalized) search query. Shared by
+ *  the pinned section and the provider groups so one query can never show a
+ *  model in one section and hide it in the other. */
+function matchesFamily(provider: ModelOptionProvider, family: ModelFamily, q: string): boolean {
+  return `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`
+    .toLowerCase()
+    .includes(q)
+}
+
 // Collapsed we show the user's chosen models (or the curated default); typing
 // spans every available model so anything is reachable past the cut. A search
 // is itself a narrowing action, so we do NOT cap per-provider matches.
@@ -539,7 +628,8 @@ function groupModels(
   providers: ModelOptionProvider[],
   search: string,
   current: { model: string; provider: string },
-  visible: Set<string> | null
+  visible: Set<string> | null,
+  pinned: Set<string>
 ): ProviderGroup[] {
   const q = normalize(search)
   const groups: ProviderGroup[] = []
@@ -551,10 +641,7 @@ function groupModels(
       continue
     }
 
-    const matches = (family: ModelFamily) =>
-      `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`
-        .toLowerCase()
-        .includes(q)
+    const matches = (family: ModelFamily) => matchesFamily(provider, family, q)
 
     let shown: Set<string>
 
@@ -578,7 +665,13 @@ function groupModels(
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 
-    const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
+    // A pinned model is rendered ONCE, in the pinned section — including when
+    // it is the active model. Leaving it in its provider group too would give
+    // the row two identical keyboard entries and two check marks.
+    const families = allFamilies.filter(
+      family =>
+        (shown.has(family.id) || family.id === activeId) && !pinned.has(pinnedModelKey(provider.slug, family.id))
+    )
 
     if (families.length > 0) {
       groups.push({ families, provider })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -1,3 +1,4 @@
+import { Codicon } from '@/components/ui/codicon'
 import {
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -73,6 +74,8 @@ interface ModelEditSubmenuProps {
   fastControl: FastControl
   /** Whether this row's model is the active one. */
   isActive: boolean
+  /** Whether this row's model is pinned to the top of the catalog. */
+  isPinned?: boolean
   /** This row's model id. */
   model: string
   /** Switch to a specific model id (used to swap base ⇄ -fast variant). */
@@ -82,6 +85,9 @@ interface ModelEditSubmenuProps {
    *  controller decides what an edit means. That's what lets the same submenu
    *  drive a live chat session and a detached per-task override. */
   onSetOptions: (patch: { effort?: string; fast?: boolean }) => void
+  /** Toggle the pin for this row. The submenu stays pure: it reports the
+   *  intent, the owning surface owns the store write. */
+  onTogglePin?: () => void
   /** This row's provider slug. */
   provider: string
   /** Whether this model supports reasoning effort. */
@@ -107,8 +113,10 @@ function ModelEditSubmenuBody({
   effort,
   fastControl,
   isActive,
+  isPinned = false,
   onSelectModel,
   onSetOptions,
+  onTogglePin,
   reasoning
 }: ModelEditSubmenuProps) {
   const { t } = useI18n()
@@ -139,12 +147,25 @@ function ModelEditSubmenuBody({
 
   const hasFast = fastControl.kind !== 'none'
   const fastOn = fastControl.kind === 'none' ? false : fastControl.on
+  const showPin = Boolean(onTogglePin)
 
-  return !hasFast && !reasoning ? (
+  return !showPin && !hasFast && !reasoning ? (
     <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
   ) : (
     <>
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
+      {showPin ? (
+        <DropdownMenuItem
+          className={dropdownMenuRow}
+          onSelect={event => {
+            event.preventDefault()
+            onTogglePin?.()
+          }}
+        >
+          {isPinned ? copy.unpinModel : copy.pinModel}
+          <Codicon className="ml-auto text-(--ui-text-tertiary)" name={isPinned ? 'pinned' : 'pin'} size="0.75rem" />
+        </DropdownMenuItem>
+      ) : null}
       {showThinkingToggle ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
           {copy.thinking}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2207,13 +2207,16 @@ export const ar = defineLocale({
       noModels: 'لا توجد نماذج',
       editModels: 'تحرير النماذج',
       refreshModels: 'تحديث النماذج',
-      fast: 'سريع'
+      fast: 'سريع',
+      pinnedSection: 'مثبَّت'
     },
     modelOptions: {
       noOptions: 'لا توجد خيارات لهذا النموذج',
       options: 'الخيارات',
       thinking: 'التفكير',
       fast: 'سريع',
+      pinModel: 'تثبيت في الأعلى',
+      unpinModel: 'إلغاء التثبيت',
       effort: 'الجهد',
       minimal: 'أدنى',
       low: 'منخفض',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2793,13 +2793,16 @@ export const en: Translations = {
       noModels: 'No models found',
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
-      fast: 'Fast'
+      fast: 'Fast',
+      pinnedSection: 'Pinned'
     },
     modelOptions: {
       noOptions: 'No options for this model',
       options: 'Options',
       thinking: 'Thinking',
       fast: 'Fast',
+      pinModel: 'Pin to top',
+      unpinModel: 'Unpin',
       effort: 'Effort',
       minimal: 'Minimal',
       low: 'Low',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2461,13 +2461,16 @@ export const ja = defineLocale({
       noModels: 'モデルが見つかりません',
       editModels: 'モデルを編集…',
       refreshModels: 'モデルを更新',
-      fast: '高速'
+      fast: '高速',
+      pinnedSection: 'ピン留め'
     },
     modelOptions: {
       noOptions: 'このモデルにはオプションがありません',
       options: 'オプション',
       thinking: '思考',
       fast: '高速',
+      pinModel: '先頭にピン留め',
+      unpinModel: 'ピン留めを解除',
       effort: '努力度',
       minimal: '最小',
       low: '低',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2359,12 +2359,15 @@ export interface Translations {
       editModels: string
       refreshModels: string
       fast: string
+      pinnedSection: string
     }
     modelOptions: {
       noOptions: string
       options: string
       thinking: string
       fast: string
+      pinModel: string
+      unpinModel: string
       effort: string
       minimal: string
       low: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2372,13 +2372,16 @@ export const zhHant = defineLocale({
       noModels: '找不到模型',
       editModels: '編輯模型…',
       refreshModels: '重新整理模型',
-      fast: '快速'
+      fast: '快速',
+      pinnedSection: '已釘選'
     },
     modelOptions: {
       noOptions: '此模型沒有可用選項',
       options: '選項',
       thinking: '思考',
       fast: '快速',
+      pinModel: '釘選到頂端',
+      unpinModel: '取消釘選',
       effort: '推理強度',
       minimal: '最小',
       low: '低',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2957,13 +2957,16 @@ export const zh: Translations = {
       noModels: '未找到模型',
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
-      fast: '快速'
+      fast: '快速',
+      pinnedSection: '已置顶'
     },
     modelOptions: {
       noOptions: '此模型没有可用选项',
       options: '选项',
       thinking: '思考',
       fast: '快速',
+      pinModel: '置顶',
+      unpinModel: '取消置顶',
       effort: '推理强度',
       minimal: '最小',
       low: '低',

--- a/apps/desktop/src/store/model-pins.test.ts
+++ b/apps/desktop/src/store/model-pins.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $pinnedModels, isModelPinned, pinnedModelKey, togglePinnedModel } from './model-pins'
+
+const STORAGE_KEY = 'hermes.desktop.pinned-models'
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $pinnedModels.set([])
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+// Pin order IS the display order — the catalog renders pins in this array's
+// order, so "most recently pinned wins the top slot" would be a behaviour
+// change, not a detail. Appending keeps a user's first pin where they put it.
+describe('pinned models keep their pin order', () => {
+  it('appends new pins after existing ones', () => {
+    togglePinnedModel('nous', 'opus-5')
+    togglePinnedModel('anthropic', 'claude-sonnet-5')
+
+    expect($pinnedModels.get()).toEqual([pinnedModelKey('nous', 'opus-5'), pinnedModelKey('anthropic', 'claude-sonnet-5')])
+  })
+
+  it('unpinning leaves the remaining order intact', () => {
+    togglePinnedModel('nous', 'opus-5')
+    togglePinnedModel('anthropic', 'claude-sonnet-5')
+    togglePinnedModel('google', 'gemini-3.1-pro')
+
+    togglePinnedModel('anthropic', 'claude-sonnet-5')
+
+    expect($pinnedModels.get()).toEqual([pinnedModelKey('nous', 'opus-5'), pinnedModelKey('google', 'gemini-3.1-pro')])
+  })
+
+  it('re-pinning an unpinned model puts it at the end, not back in its old slot', () => {
+    togglePinnedModel('nous', 'opus-5')
+    togglePinnedModel('google', 'gemini-3.1-pro')
+
+    togglePinnedModel('nous', 'opus-5')
+    togglePinnedModel('nous', 'opus-5')
+
+    expect($pinnedModels.get()).toEqual([pinnedModelKey('google', 'gemini-3.1-pro'), pinnedModelKey('nous', 'opus-5')])
+  })
+})
+
+// A pin is a durable preference: it has to survive the window closing, so the
+// store must reach localStorage rather than only the atom.
+describe('pins persist', () => {
+  it('writes the pin list to storage', () => {
+    togglePinnedModel('nous', 'opus-5')
+
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '[]')).toEqual([pinnedModelKey('nous', 'opus-5')])
+  })
+
+  it('clears the key once the last pin is removed', () => {
+    togglePinnedModel('nous', 'opus-5')
+    togglePinnedModel('nous', 'opus-5')
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})
+
+// Models from different providers can share an id (an aggregator and the lab
+// both serve `claude-opus-5`); pinning one must not pin the other.
+describe('pins are provider-scoped', () => {
+  it('does not report a same-named model on another provider as pinned', () => {
+    togglePinnedModel('nous', 'claude-opus-5')
+
+    expect(isModelPinned('nous', 'claude-opus-5')).toBe(true)
+    expect(isModelPinned('openrouter', 'claude-opus-5')).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/model-pins.ts
+++ b/apps/desktop/src/store/model-pins.ts
@@ -1,0 +1,36 @@
+import { atom } from 'nanostores'
+
+import { persistStringArray, storedStringArray } from '@/lib/storage'
+
+import { modelVisibilityKey } from './model-visibility'
+
+const STORAGE_KEY = 'hermes.desktop.pinned-models'
+
+/** Stable `provider::model` key for a pin. Reuses the visibility-store format
+ *  so every model identity in the app is written the same way. */
+export const pinnedModelKey = modelVisibilityKey
+
+/**
+ * Models the user pinned to the top of the model catalog menu, ordered by pin
+ * time (first pinned = first shown). A renderer-local presentation preference
+ * in the same family as the Edit Models shortlist and model presets: pins only
+ * reshape THIS dropdown's ordering, never the backend catalog or another
+ * surface's picker.
+ */
+export const $pinnedModels = atom<string[]>(storedStringArray(STORAGE_KEY))
+
+/** Whether a provider/model pair is currently pinned. */
+export function isModelPinned(provider: string, model: string): boolean {
+  return $pinnedModels.get().includes(pinnedModelKey(provider, model))
+}
+
+/** Pin a provider/model pair (appended to the order) or unpin it. */
+export function togglePinnedModel(provider: string, model: string): void {
+  const key = pinnedModelKey(provider, model)
+  const current = $pinnedModels.get()
+
+  const next = current.includes(key) ? current.filter(entry => entry !== key) : [...current, key]
+
+  $pinnedModels.set(next)
+  persistStringArray(STORAGE_KEY, next)
+}


### PR DESCRIPTION
## What does this PR do?

Lets you pin specific provider/model pairs to the top of the desktop model menu.

The menu groups models by provider in alphabetical order. With a dozen authenticated providers, the model you use every day sits wherever its provider's name happens to fall, so switching to it means scrolling or retyping the same search several times a day. #49777 asks for exactly this ("I'm constantly forced to either type their names manually or search through a large list").

Pinning lifts a provider/model pair into a Pinned section above the provider groups. The pin lives in the row's existing hover submenu next to Thinking and Fast, because it is another property of that model rather than a separate mode, and it is stored as one renderer-local preference in the same family as the Edit Models shortlist and the per-model presets.

Design decisions worth reviewing:

- Pins render in pin order, so the first model you pin keeps the top slot. Appending on pin means a later pin never displaces the one you put there first.
- A pinned model renders once. Its provider group drops the duplicate row, which would otherwise give the model two keyboard entries and two check marks when it is the active model.
- A pin outranks the Edit Models shortlist. Curation answers "which models do I usually want listed" and a pin answers "which one do I want first", so pinning a model you have hidden shows it.
- Search filters the pinned section like any other row. A query that does not match your pin hides the section instead of leaving it parked at the top of the results.
- Pins are provider-scoped. An aggregator and the lab both serve `claude-opus-5`, so pinning one leaves the other alone.
- A pin whose model the catalog stops carrying is skipped rather than deleted, so it survives a re-auth or a provider list refresh.

The pinned section and the provider groups share one row renderer (`renderFamilyRow`), so a pinned row is the same row with the same label, submenu, and keyboard key. Two copies of that markup is how the sections would drift apart.

Scope: desktop only. #23117 asks for the same idea across TUI and CLI backed by a `model.favorites` config key. That is a larger change and a different storage decision, so this PR does not attempt it.

## Related Issue

Fixes #49777

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/model-pins.ts` (new): the persisted ordered pin list, keyed `provider::model` to match the visibility store's format, with `togglePinnedModel` and `isModelPinned`.
- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: resolves pins against the fetched catalog, renders the Pinned section above the provider groups, extracts the shared `renderFamilyRow`, adds pinned rows to the keyboard row list so arrow keys reach them first, and filters pinned models out of their provider group.
- `apps/desktop/src/app/shell/model-edit-submenu.tsx`: adds the pin row. The submenu stays pure, taking `isPinned` and `onTogglePin` and reporting the intent rather than writing to any store, so the same submenu still drives both a live chat session and a detached per-task override.
- `apps/desktop/src/i18n/`: `pinnedSection`, `pinModel`, and `unpinModel` in types plus all five locales.
- Tests: `model-pins.test.ts` (new) covers pin order, persistence, and provider scoping. `model-catalog-menu.test.tsx` covers section placement, the no-duplicate-row rule, pin order over catalog order, pin beating the hidden shortlist, stale-pin skipping, search filtering, and the pin/unpin round trip.

## How to Test

1. Open the model menu from the composer pill.
2. Hover a model row to reveal its options submenu, then click "Pin to top".
3. Reopen the menu. The model appears under a Pinned heading above every provider group and no longer appears in its own provider's group.
4. Type a query that does not match the pinned model. The Pinned section disappears. Type one that does match and it comes back.
5. Hover the pinned row and click "Unpin". The section goes away and the model returns to its provider group.

Automated:

```
cd apps/desktop
npx tsc -p . --noEmit
TMPDIR=/tmp npx vitest run --project ui     # 597 files, 5747 tests passing
npx eslint src/store/model-pins.ts src/app/shell/model-catalog-menu.tsx src/app/shell/model-edit-submenu.tsx
```

I also drove the running desktop app over CDP against a live catalog of 135 models across 12 authenticated providers to confirm the behavior outside jsdom: the pin write reaches both the store and localStorage, the section renders first on reopen, search hides and restores it, the submenu label flips between "Pin to top" and "Unpin", and unpinning returns the model to its provider group.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the renderer gate (`tsc --noEmit`, `vitest run --project ui`, `eslint`) and all of it passes. This PR touches no Python, so `pytest tests/ -q` is not the relevant gate.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (renderer-local preference, no config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is renderer-only with no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
