### PR TITLE
macOS permission grants survive every update — hermes desktop --setup-tcc-identity now works on modern macOS (salvage #77189)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7793,6 +7793,27 @@ def _desktop_macos_relaunchable_fixup(
     return False
 
 
+def _macos_codesigning_identity_valid(security: str, identity: str) -> bool:
+    """True when `identity` appears among VALID code-signing identities.
+
+    ``security find-identity -p codesigning`` (without ``-v``) also lists
+    certificates macOS will refuse to sign with — e.g. a self-signed cert that
+    was imported but never trusted for the codeSign policy. Only the ``-v``
+    listing proves codesign can actually use it, so this is both the
+    idempotency probe and the success postcondition for
+    ``--setup-tcc-identity``. Never raises.
+    """
+    try:
+        result = subprocess.run(
+            [security, "find-identity", "-v", "-p", "codesigning"],
+            capture_output=True, text=True, check=False,
+        )
+    except Exception:
+        return False
+
+    return f'"{identity}"' in (result.stdout or "")
+
+
 def _desktop_macos_setup_tcc_identity(identity: str = "Hermes Local Signing") -> bool:
     """Create/import a self-signed code-signing cert and configure Hermes to use it.
 
@@ -7829,11 +7850,11 @@ def _desktop_macos_setup_tcc_identity(identity: str = "Hermes Local Signing") ->
         return False
 
     keychain = str(Path.home() / "Library" / "Keychains" / "login.keychain-db")
-    existing = subprocess.run(
-        [security, "find-identity", "-p", "codesigning"],
-        capture_output=True, text=True, check=False,
-    )
-    already_imported = identity in f"{existing.stdout}\n{existing.stderr}"
+    # A certificate that merely EXISTS in the keychain is not enough — macOS
+    # only treats it as a code-signing identity once it is trusted for the
+    # codeSign policy. Probe with `-v` (valid identities only) so a previously
+    # imported-but-untrusted cert is repaired rather than reported as done.
+    already_imported = _macos_codesigning_identity_valid(security, identity)
 
     if not already_imported:
         # Create a self-signed code-signing cert (valid 10 years) and import it
@@ -7856,33 +7877,82 @@ def _desktop_macos_setup_tcc_identity(identity: str = "Hermes Local Signing") ->
                 ],
                 capture_output=True, check=True,
             )
-            subprocess.run(
-                [
-                    openssl, "pkcs12", "-export",
-                    "-inkey", str(key), "-in", str(crt),
-                    "-out", str(p12), "-passout", "pass:hermeslocal",
-                ],
-                capture_output=True, check=True,
-            )
-            imported = subprocess.run(
-                [
-                    security, "import", str(p12), "-k", keychain,
-                    "-P", "hermeslocal",
-                    "-T", codesign, "-T", "/usr/bin/codesign_allocate",
-                ],
-                capture_output=True, text=True, check=False,
-            )
+            # OpenSSL 3 defaults to AES/SHA-2 PKCS#12 encryption that macOS
+            # `security import` rejects with "MAC verification failed during
+            # PKCS12 import (wrong password?)". The `-legacy` flag restores the
+            # RC2/SHA-1 format the importer accepts, but only exists on
+            # OpenSSL 3 — so try the plain export first and fall back to
+            # `-legacy` when the IMPORT fails with that signature. (Verified
+            # E2E on macOS 26.3.1 / OpenSSL 3.6.3 by @ctaylor86 on PR #77189.)
+            def _export_p12(extra_args: list) -> None:
+                subprocess.run(
+                    [
+                        openssl, "pkcs12", "-export", *extra_args,
+                        "-inkey", str(key), "-in", str(crt),
+                        "-out", str(p12), "-passout", "pass:hermeslocal",
+                    ],
+                    capture_output=True, check=True,
+                )
+
+            def _import_p12():
+                return subprocess.run(
+                    [
+                        security, "import", str(p12), "-k", keychain,
+                        "-P", "hermeslocal",
+                        "-T", codesign, "-T", "/usr/bin/codesign_allocate",
+                    ],
+                    capture_output=True, text=True, check=False,
+                )
+
+            _export_p12([])
+            imported = _import_p12()
+            if imported.returncode != 0 and "MAC verification failed" in (imported.stderr or ""):
+                try:
+                    _export_p12(["-legacy"])
+                    imported = _import_p12()
+                except subprocess.CalledProcessError:
+                    # Older OpenSSL without -legacy: keep the original failure.
+                    pass
             if imported.returncode != 0:
                 print(f"  (could not import signing identity into keychain: {imported.stderr.strip()})")
                 return False
-            print(f"  → created and imported self-signed identity: {identity!r}")
+
+            # Importing is still not enough: without explicit trust for the
+            # codeSign policy, `security find-identity -v -p codesigning`
+            # reports 0 valid identities and codesign refuses the cert. Trust
+            # the self-signed root for code signing. This writes to the user's
+            # trust settings, so macOS may prompt for the login password ONCE
+            # here — that is the one-time setup cost this command exists to
+            # front-load.
+            trusted = subprocess.run(
+                [security, "add-trusted-cert", "-r", "trustRoot", "-p", "codeSign", "-k", keychain, str(crt)],
+                capture_output=True, text=True, check=False,
+            )
+            if trusted.returncode != 0:
+                print(
+                    "  (could not trust the certificate for code signing: "
+                    f"{(trusted.stderr or trusted.stdout).strip()})"
+                )
+                return False
+            print(f"  → created, imported, and trusted self-signed identity: {identity!r}")
         except Exception as exc:
             print(f"  (certificate creation failed: {exc})")
             return False
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
     else:
-        print(f"  → identity {identity!r} already in keychain")
+        print(f"  → identity {identity!r} already valid in keychain")
+
+    # Postcondition gate: only report success once macOS actually agrees the
+    # identity is usable for code signing. Name-in-output checks pass for
+    # invalid identities; this is the check that failed silently before.
+    if not _macos_codesigning_identity_valid(security, identity):
+        print(
+            f"  (identity {identity!r} was imported but is not a VALID code-signing identity; "
+            "run `security find-identity -v -p codesigning` to inspect, and see the manual "
+            "Keychain Access steps in the desktop docs)"
+        )
+        return False
 
     # Point Hermes at the identity (config.yaml, not .env — it's not a secret).
     try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -433,6 +433,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -7792,6 +7793,127 @@ def _desktop_macos_relaunchable_fixup(
     return False
 
 
+def _desktop_macos_setup_tcc_identity(identity: str = "Hermes Local Signing") -> bool:
+    """Create/import a self-signed code-signing cert and configure Hermes to use it.
+
+    One-shot setup for ``hermes desktop --setup-tcc-identity``. Creates a
+    self-signed "Code Signing" certificate in the login keychain (the same
+    artifact the docs describe creating manually via Keychain Access), grants
+    ``codesign`` access to it, writes ``desktop.macos_signing_identity`` to
+    config.yaml, and re-signs the already-packaged app so the next launch uses
+    the certificate-anchored identity.
+
+    Why this matters: macOS TCC grants (Full Disk Access, Accessibility,
+    Automation, Files and Folders, microphone) persist against the app's
+    code-signing identity, not its path. A plain ad-hoc signature gets a
+    cdhash-only Designated Requirement, so every rebuild looks like a new app
+    and the user must re-grant everything. A certificate-anchored identity is
+    stable across rebuilds — the same mechanism yabai/skhd users rely on.
+
+    Idempotent: re-running after an update finds the existing certificate and
+    only re-points the config + re-signs. Returns True on success (or when
+    already configured), False on failure. Never raises.
+    """
+    if sys.platform != "darwin":
+        print("  (--setup-tcc-identity is macOS-only; skipping)")
+        return False
+
+    openssl = shutil.which("openssl")
+    security = shutil.which("security")
+    codesign = shutil.which("codesign")
+    if not (openssl and security and codesign):
+        print(
+            "  (--setup-tcc-identity requires openssl, security, and codesign; "
+            f"found openssl={bool(openssl)} security={bool(security)} codesign={bool(codesign)})"
+        )
+        return False
+
+    keychain = str(Path.home() / "Library" / "Keychains" / "login.keychain-db")
+    existing = subprocess.run(
+        [security, "find-identity", "-p", "codesigning"],
+        capture_output=True, text=True, check=False,
+    )
+    already_imported = identity in f"{existing.stdout}\n{existing.stderr}"
+
+    if not already_imported:
+        # Create a self-signed code-signing cert (valid 10 years) and import it
+        # into the login keychain with codesign access so signing works without
+        # an interactive unlock prompt.
+        tmp_dir = Path(tempfile.mkdtemp(prefix="hermes-tcc-"))
+        try:
+            key = tmp_dir / "sign.key"
+            crt = tmp_dir / "sign.crt"
+            p12 = tmp_dir / "sign.p12"
+            subprocess.run(
+                [
+                    openssl, "req", "-x509", "-newkey", "rsa:2048",
+                    "-keyout", str(key), "-out", str(crt),
+                    "-days", "3650", "-nodes",
+                    "-subj", f"/CN={identity}",
+                    "-addext", "basicConstraints=critical,CA:TRUE",
+                    "-addext", "keyUsage=critical,digitalSignature,keyCertSign",
+                    "-addext", "extendedKeyUsage=codeSigning",
+                ],
+                capture_output=True, check=True,
+            )
+            subprocess.run(
+                [
+                    openssl, "pkcs12", "-export",
+                    "-inkey", str(key), "-in", str(crt),
+                    "-out", str(p12), "-passout", "pass:hermeslocal",
+                ],
+                capture_output=True, check=True,
+            )
+            imported = subprocess.run(
+                [
+                    security, "import", str(p12), "-k", keychain,
+                    "-P", "hermeslocal",
+                    "-T", codesign, "-T", "/usr/bin/codesign_allocate",
+                ],
+                capture_output=True, text=True, check=False,
+            )
+            if imported.returncode != 0:
+                print(f"  (could not import signing identity into keychain: {imported.stderr.strip()})")
+                return False
+            print(f"  → created and imported self-signed identity: {identity!r}")
+        except Exception as exc:
+            print(f"  (certificate creation failed: {exc})")
+            return False
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+    else:
+        print(f"  → identity {identity!r} already in keychain")
+
+    # Point Hermes at the identity (config.yaml, not .env — it's not a secret).
+    try:
+        from hermes_cli.config import set_config_value
+
+        set_config_value("desktop.macos_signing_identity", identity)
+        print(f"  → set desktop.macos_signing_identity = {identity!r}")
+    except Exception as exc:
+        print(f"  (could not write desktop.macos_signing_identity: {exc})")
+        return False
+
+    # Re-sign the packaged app so the current build already uses the identity.
+    desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+    if _desktop_packaged_executable(desktop_dir) is not None:
+        try:
+            if _desktop_macos_relaunchable_fixup(desktop_dir):
+                print(
+                    "  → packaged app re-signed with certificate-anchored identity; "
+                    "TCC grants persist across rebuilds"
+                )
+        except Exception as exc:
+            print(f"  (could not re-sign packaged app: {exc})")
+
+    print(
+        "\n  Note: macOS will re-prompt for permissions ONE final time (the identity "
+        "changed). Grant them and they persist from then on. If a permission gets "
+        "stuck, reset it with:  tccutil reset All com.nousresearch.hermes"
+    )
+    return True
+
+
 def _force_adhoc_macos_signing(env: dict, *, source_mode: bool) -> bool:
     """Stop electron-builder grabbing a random keychain identity on self-update.
 
@@ -8079,6 +8201,13 @@ def cmd_gui(args: argparse.Namespace):
     source_mode = getattr(args, "source", False)
     skip_build = getattr(args, "skip_build", False)
     force_build = getattr(args, "force_build", False)
+
+    # macOS-only one-shot: create a self-signed code-signing identity so TCC
+    # grants survive rebuilds, then exit without building/launching.
+    if getattr(args, "setup_tcc_identity", False):
+        identity = getattr(args, "identity", None) or "Hermes Local Signing"
+        ok = _desktop_macos_setup_tcc_identity(identity)
+        sys.exit(0 if ok else 1)
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -60,4 +60,21 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         action="store_true",
         help="Force a full rebuild even if the content stamp matches",
     )
+    gui_parser.add_argument(
+        "--setup-tcc-identity",
+        action="store_true",
+        help=(
+            "macOS only: create/import a self-signed code-signing certificate "
+            "in the login keychain and point desktop.macos_signing_identity at "
+            "it, then re-sign the packaged app. Makes macOS TCC grants (Full "
+            "Disk Access, Accessibility, Files and Folders, microphone) survive "
+            "rebuilds with a certificate-anchored identity. Idempotent — safe "
+            "to re-run after updates."
+        ),
+    )
+    gui_parser.add_argument(
+        "--identity",
+        default="Hermes Local Signing",
+        help="Certificate name to create/use for --setup-tcc-identity (default: Hermes Local Signing)",
+    )
     gui_parser.set_defaults(func=cmd_gui)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -57,6 +57,8 @@ def _ns(**kw):
         ignore_existing=False,
         hermes_root=None,
         cwd=None,
+        setup_tcc_identity=False,
+        identity=None,
     )
     defaults.update(kw)
     return argparse.Namespace(**defaults)
@@ -488,6 +490,109 @@ def test_relaunchable_fixup_falls_back_to_legacy_adhoc_on_failure(tmp_path, monk
     assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
     assert ["xattr", "-cr", str(app)] in calls
     assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
+
+
+# --- desktop --setup-tcc-identity ------------------------------------------
+
+
+def _fake_proc(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def test_setup_tcc_identity_creates_cert_imports_and_configures(tmp_path, monkeypatch, capsys):
+    """Fresh identity: openssl generates, security imports, config is written."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    identity = "Hermes Local Signing"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        # `security find-identity` on first run reports no matching identity.
+        if cmd[:3] == ["/usr/bin/security", "find-identity", "-p"]:
+            return _fake_proc(cmd, stdout="     0 identities found")
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_packaged_executable", lambda d: None)
+    monkeypatch.setattr(cli_main, "_desktop_macos_relaunchable_fixup", lambda d: True)
+    # Avoid writing the real user config.
+    monkeypatch.setattr("hermes_cli.config.set_config_value", lambda key, value: None)
+
+    assert cli_main._desktop_macos_setup_tcc_identity(identity) is True
+
+    out = capsys.readouterr().out
+    assert "created and imported self-signed identity" in out
+    assert "set desktop.macos_signing_identity" in out
+    # openssl cert generation + pkcs12 export + security import all ran.
+    assert any(c[0] == "/usr/bin/openssl" and "req" in c for c in calls)
+    assert any(c[0] == "/usr/bin/openssl" and "pkcs12" in c for c in calls)
+    assert any(c[0] == "/usr/bin/security" and c[1] == "import" for c in calls)
+    # Temp files cleaned up.
+    assert not list(tmp_path.glob("hermes-tcc-*"))
+
+
+def test_setup_tcc_identity_skips_generation_when_already_present(tmp_path, monkeypatch, capsys):
+    """Idempotent: an existing identity is reused, not regenerated."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["/usr/bin/security", "find-identity", "-p"]:
+            return _fake_proc(cmd, stdout='  "Hermes Local Signing" (CSSMERR_TP_NOT_TRUSTED)')
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_packaged_executable", lambda d: None)
+    monkeypatch.setattr(cli_main, "_desktop_macos_relaunchable_fixup", lambda d: True)
+    monkeypatch.setattr("hermes_cli.config.set_config_value", lambda key, value: None)
+
+    assert cli_main._desktop_macos_setup_tcc_identity("Hermes Local Signing") is True
+
+    out = capsys.readouterr().out
+    assert "already in keychain" in out
+    # No openssl generation, no security import — only find-identity + config.
+    assert not any(c[0] == "/usr/bin/openssl" for c in calls)
+    assert not any(c[0] == "/usr/bin/security" and c[1] == "import" for c in calls)
+
+
+def test_setup_tcc_identity_non_macos_skips(tmp_path, monkeypatch, capsys):
+    """On non-macOS the setup is a no-op failure (not a crash)."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    assert cli_main._desktop_macos_setup_tcc_identity() is False
+    assert "macOS-only" in capsys.readouterr().out
+
+
+def test_cmd_gui_setup_tcc_identity_exits_before_build(tmp_path, monkeypatch):
+    """`hermes desktop --setup-tcc-identity` calls the setup and exits 0/1
+    without building or launching the app."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+
+    with patch("hermes_cli.main._desktop_macos_setup_tcc_identity", return_value=True) as mock_setup, \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(setup_tcc_identity=True, identity="Hermes Local Signing"))
+
+    assert exc.value.code == 0
+    mock_setup.assert_called_once_with("Hermes Local Signing")
+    mock_install.assert_not_called()
 
 
 # --- desktop.* launch options (config.yaml) -------------------------------

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -499,8 +499,8 @@ def _fake_proc(cmd, returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
 
 
-def test_setup_tcc_identity_creates_cert_imports_and_configures(tmp_path, monkeypatch, capsys):
-    """Fresh identity: openssl generates, security imports, config is written."""
+def test_setup_tcc_identity_creates_cert_imports_trusts_and_configures(tmp_path, monkeypatch, capsys):
+    """Fresh identity: openssl generates, security imports + trusts, config is written."""
     monkeypatch.setattr(cli_main.sys, "platform", "darwin")
     monkeypatch.setattr(
         cli_main.shutil,
@@ -511,12 +511,20 @@ def test_setup_tcc_identity_creates_cert_imports_and_configures(tmp_path, monkey
 
     identity = "Hermes Local Signing"
     calls = []
+    state = {"trusted": False}
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
-        # `security find-identity` on first run reports no matching identity.
-        if cmd[:3] == ["/usr/bin/security", "find-identity", "-p"]:
-            return _fake_proc(cmd, stdout="     0 identities found")
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            # Valid only after import AND trust have both happened — mirrors
+            # real macOS, where an untrusted self-signed cert is invisible to
+            # the -v listing (the #77189 review finding).
+            if state["trusted"]:
+                return _fake_proc(cmd, stdout=f'  1) ABCD "{identity}"\n     1 valid identities found')
+            return _fake_proc(cmd, stdout="     0 valid identities found")
+        if cmd[0] == "/usr/bin/security" and cmd[1] == "add-trusted-cert":
+            state["trusted"] = True
+            return _fake_proc(cmd)
         return _fake_proc(cmd)
 
     monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
@@ -528,18 +536,119 @@ def test_setup_tcc_identity_creates_cert_imports_and_configures(tmp_path, monkey
     assert cli_main._desktop_macos_setup_tcc_identity(identity) is True
 
     out = capsys.readouterr().out
-    assert "created and imported self-signed identity" in out
+    assert "created, imported, and trusted self-signed identity" in out
     assert "set desktop.macos_signing_identity" in out
-    # openssl cert generation + pkcs12 export + security import all ran.
+    # openssl cert generation + pkcs12 export + security import + trust all ran.
     assert any(c[0] == "/usr/bin/openssl" and "req" in c for c in calls)
     assert any(c[0] == "/usr/bin/openssl" and "pkcs12" in c for c in calls)
     assert any(c[0] == "/usr/bin/security" and c[1] == "import" for c in calls)
+    assert any(c[0] == "/usr/bin/security" and c[1] == "add-trusted-cert" for c in calls)
+    # The trust step targets the codeSign policy specifically.
+    trust_call = next(c for c in calls if c[1:2] == ["add-trusted-cert"])
+    assert "codeSign" in trust_call and "trustRoot" in trust_call
     # Temp files cleaned up.
     assert not list(tmp_path.glob("hermes-tcc-*"))
 
 
-def test_setup_tcc_identity_skips_generation_when_already_present(tmp_path, monkeypatch, capsys):
-    """Idempotent: an existing identity is reused, not regenerated."""
+def test_setup_tcc_identity_retries_pkcs12_with_legacy_on_mac_verification_failure(tmp_path, monkeypatch, capsys):
+    """OpenSSL 3: first import fails with the MAC-verification signature, the
+    -legacy re-export imports cleanly (the exact failure @ctaylor86 hit live)."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    identity = "Hermes Local Signing"
+    calls = []
+    state = {"legacy_exported": False, "trusted": False}
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            if state["trusted"]:
+                return _fake_proc(cmd, stdout=f'  1) ABCD "{identity}"\n     1 valid identities found')
+            return _fake_proc(cmd, stdout="     0 valid identities found")
+        if cmd[0] == "/usr/bin/openssl" and "pkcs12" in cmd:
+            state["legacy_exported"] = "-legacy" in cmd
+            return _fake_proc(cmd)
+        if cmd[0] == "/usr/bin/security" and cmd[1] == "import":
+            if not state["legacy_exported"]:
+                return _fake_proc(
+                    cmd, returncode=1,
+                    stderr="security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)",
+                )
+            return _fake_proc(cmd)
+        if cmd[0] == "/usr/bin/security" and cmd[1] == "add-trusted-cert":
+            state["trusted"] = True
+            return _fake_proc(cmd)
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_packaged_executable", lambda d: None)
+    monkeypatch.setattr(cli_main, "_desktop_macos_relaunchable_fixup", lambda d: True)
+    monkeypatch.setattr("hermes_cli.config.set_config_value", lambda key, value: None)
+
+    assert cli_main._desktop_macos_setup_tcc_identity(identity) is True
+
+    # Two pkcs12 exports (plain then -legacy) and two import attempts.
+    pkcs12_calls = [c for c in calls if c[0] == "/usr/bin/openssl" and "pkcs12" in c]
+    assert len(pkcs12_calls) == 2
+    assert "-legacy" not in pkcs12_calls[0] and "-legacy" in pkcs12_calls[1]
+    assert len([c for c in calls if c[0] == "/usr/bin/security" and c[1] == "import"]) == 2
+
+
+def test_setup_tcc_identity_fails_when_trust_step_fails(tmp_path, monkeypatch, capsys):
+    """A cert that imports but cannot be trusted for codeSign is a failure,
+    not a silent success."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            return _fake_proc(cmd, stdout="     0 valid identities found")
+        if cmd[0] == "/usr/bin/security" and cmd[1] == "add-trusted-cert":
+            return _fake_proc(cmd, returncode=1, stderr="SecTrustSettingsSetTrustSettings: authorization denied")
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    assert cli_main._desktop_macos_setup_tcc_identity("Hermes Local Signing") is False
+    assert "could not trust the certificate" in capsys.readouterr().out
+
+
+def test_setup_tcc_identity_fails_when_identity_never_becomes_valid(tmp_path, monkeypatch, capsys):
+    """Postcondition gate: import + trust both 'succeed' but find-identity -v
+    still lists nothing → report failure with guidance (the silent-success bug
+    from the original PR)."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            return _fake_proc(cmd, stdout="     0 valid identities found")
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+
+    assert cli_main._desktop_macos_setup_tcc_identity("Hermes Local Signing") is False
+    assert "not a VALID code-signing identity" in capsys.readouterr().out
+
+
+def test_setup_tcc_identity_skips_generation_when_already_valid(tmp_path, monkeypatch, capsys):
+    """Idempotent: an existing VALID identity is reused, not regenerated."""
     monkeypatch.setattr(cli_main.sys, "platform", "darwin")
     monkeypatch.setattr(
         cli_main.shutil,
@@ -552,8 +661,8 @@ def test_setup_tcc_identity_skips_generation_when_already_present(tmp_path, monk
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
-        if cmd[:3] == ["/usr/bin/security", "find-identity", "-p"]:
-            return _fake_proc(cmd, stdout='  "Hermes Local Signing" (CSSMERR_TP_NOT_TRUSTED)')
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            return _fake_proc(cmd, stdout='  1) ABCD "Hermes Local Signing"\n     1 valid identities found')
         return _fake_proc(cmd)
 
     monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
@@ -564,10 +673,47 @@ def test_setup_tcc_identity_skips_generation_when_already_present(tmp_path, monk
     assert cli_main._desktop_macos_setup_tcc_identity("Hermes Local Signing") is True
 
     out = capsys.readouterr().out
-    assert "already in keychain" in out
+    assert "already valid in keychain" in out
     # No openssl generation, no security import — only find-identity + config.
     assert not any(c[0] == "/usr/bin/openssl" for c in calls)
     assert not any(c[0] == "/usr/bin/security" and c[1] == "import" for c in calls)
+
+
+def test_setup_tcc_identity_untrusted_existing_cert_is_repaired(tmp_path, monkeypatch, capsys):
+    """A cert that EXISTS but is not valid (CSSMERR_TP_NOT_TRUSTED) is repaired
+    — regenerated/trusted — instead of being reported as already done. The
+    original name-in-output probe treated this state as success."""
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        cli_main.shutil,
+        "which",
+        lambda name: {"openssl": "/usr/bin/openssl", "security": "/usr/bin/security", "codesign": "/usr/bin/codesign"}.get(name),
+    )
+    monkeypatch.setattr(cli_main.Path, "home", classmethod(lambda cls: tmp_path))
+
+    calls = []
+    state = {"trusted": False}
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:4] == ["/usr/bin/security", "find-identity", "-v", "-p"]:
+            # -v never lists the untrusted cert; it only appears once the
+            # repair path has run add-trusted-cert.
+            if state["trusted"]:
+                return _fake_proc(cmd, stdout='  1) ABCD "Hermes Local Signing"\n     1 valid identities found')
+            return _fake_proc(cmd, stdout="     0 valid identities found")
+        if cmd[0] == "/usr/bin/security" and cmd[1] == "add-trusted-cert":
+            state["trusted"] = True
+            return _fake_proc(cmd)
+        return _fake_proc(cmd)
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_packaged_executable", lambda d: None)
+    monkeypatch.setattr(cli_main, "_desktop_macos_relaunchable_fixup", lambda d: True)
+    monkeypatch.setattr("hermes_cli.config.set_config_value", lambda key, value: None)
+
+    assert cli_main._desktop_macos_setup_tcc_identity("Hermes Local Signing") is True
+    assert any(c[0] == "/usr/bin/security" and c[1] == "add-trusted-cert" for c in calls)
 
 
 def test_setup_tcc_identity_non_macos_skips(tmp_path, monkeypatch, capsys):
@@ -583,7 +729,7 @@ def test_cmd_gui_setup_tcc_identity_exits_before_build(tmp_path, monkeypatch):
     without building or launching the app."""
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
-    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    _make_packaged_executable(root, monkeypatch)
 
     with patch("hermes_cli.main._desktop_macos_setup_tcc_identity", return_value=True) as mock_setup, \
          patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -561,7 +561,11 @@ Or do it manually:
 1. Keychain Access → Certificate Assistant → **Create a Certificate…**
 2. Name: `Hermes Local Signing`, Identity Type: *Self-Signed Root*,
    Certificate Type: **Code Signing**.
-3. `hermes config set desktop.macos_signing_identity "Hermes Local Signing"`
+3. In Keychain Access, double-click the new certificate → **Trust** → set
+   **Code Signing** to *Always Trust* (an imported self-signed certificate is
+   not a valid signing identity until it is trusted for code signing —
+   `security find-identity -v -p codesigning` should list it afterwards).
+4. `hermes config set desktop.macos_signing_identity "Hermes Local Signing"`
 
 Use `--identity <name>` with the command to create/use a differently named
 certificate (default: `Hermes Local Signing`). The command is idempotent —

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -548,12 +548,24 @@ box.
 
 For the strongest guarantee — a certificate-anchored identity, the same
 mechanism yabai/skhd users rely on — create a self-signed code-signing
-certificate once and tell Hermes to use it:
+certificate once and tell Hermes to use it. The one-shot command does
+everything (creates the certificate in your login keychain, grants `codesign`
+access, writes the config, and re-signs the packaged app):
+
+```bash
+hermes desktop --setup-tcc-identity
+```
+
+Or do it manually:
 
 1. Keychain Access → Certificate Assistant → **Create a Certificate…**
 2. Name: `Hermes Local Signing`, Identity Type: *Self-Signed Root*,
    Certificate Type: **Code Signing**.
 3. `hermes config set desktop.macos_signing_identity "Hermes Local Signing"`
+
+Use `--identity <name>` with the command to create/use a differently named
+certificate (default: `Hermes Local Signing`). The command is idempotent —
+re-run it after updates to re-point the config and re-sign the rebuilt app.
 
 The next update re-signs the rebuilt app with that certificate; every TCC grant
 survives. No Apple Developer account is required. Notarized release builds are


### PR DESCRIPTION
## Summary
`hermes desktop --setup-tcc-identity` gives macOS users one command that makes permission grants (Full Disk Access, Desktop/Downloads/Documents, Accessibility, mic) stick permanently across updates — no more re-granting after every rebuild, and no manual Keychain Access certificate dance. Salvage of #77189 by @criptogus, plus fixes for the two live E2E blockers @ctaylor86 diagnosed in review.

macOS ties permission grants to the app's code-signing identity; a certificate-anchored identity (the yabai/skhd mechanism) is the strongest anchor, and creating one was previously a 3-step manual docs walkthrough.

## Changes
- `hermes_cli/main.py` (@criptogus, cherry-picked): `_desktop_macos_setup_tcc_identity()` — creates a self-signed code-signing cert (openssl, 10yr), imports it into the login keychain with codesign access, writes `desktop.macos_signing_identity`, re-signs the packaged app via the existing fixup. Idempotent.
- `hermes_cli/subcommands/gui.py` (@criptogus): `--setup-tcc-identity` + `--identity` flags.
- Fix-up commit (review findings from @ctaylor86, macOS 26.3.1 / OpenSSL 3.6.3):
  - **`-legacy` PKCS#12 retry** — OpenSSL 3's default export is rejected by `security import` ("MAC verification failed during PKCS12 import"); retry the export with `-legacy` on exactly that failure.
  - **Trust step** — `security add-trusted-cert -r trustRoot -p codeSign`; an imported-but-untrusted self-signed cert is invisible to `find-identity -v` and unusable by codesign. May prompt for the login password ONCE — the one-time cost this command front-loads.
  - **Postcondition gate** — success only when `security find-identity -v -p codesigning` actually lists the identity; the same `-v` probe drives idempotency, so an untrusted leftover cert gets repaired instead of falsely reported as done.
- Tests: stateful fakes (identity valid only after import+trust) covering the fresh path, `-legacy` retry, trust failure, postcondition gate, valid-identity idempotency, and untrusted-cert repair. Sabotage-verified: reverting to the old name-in-output probe fails 4 tests.
- Docs: `desktop.md` leads with the command; manual fallback now includes the required Trust step.

## Validation
| | Before (original PR) | After |
|---|---|---|
| OpenSSL 3 export | `security import` rejects, command fails | `-legacy` retry imports cleanly |
| Untrusted cert | reported success, 0 valid identities | trusted for codeSign + verified, or loud failure |
| Idempotency probe | name match (passes for invalid certs) | `find-identity -v` (valid only) |

- `tests/hermes_cli/test_gui_command.py`: 41 passed, 5 skipped (platform-gated)
- **Live repro:** the underlying failure pair (PKCS#12 MAC rejection; imported-cert-not-valid until `add-trusted-cert`) was reproduced and the fixed flow E2E-confirmed on real macOS 26.3.1 by @ctaylor86 in the PR #77189 review thread (DR became certificate-anchored, `codesign --verify --deep --strict` passed). No macOS runner here — mocked tests pin the exact subprocess sequence from that verified run.

Credits: @criptogus (feature, authorship preserved), @ctaylor86 (E2E diagnosis + fix recipe).
Closes #77189.

## Infographic

![One command, permissions that stick](https://v3b.fal.media/files/b/0aa7cf12/eOM1whED9-OT1lShYFaUx_rEvxAXaq.png)
