### PR TITLE
fix(cli): detect dashboards launched from a named profile

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -25,6 +25,60 @@ def _m():
     return main
 
 
+_SUBCOMMANDS = ("dashboard", "serve")
+
+
+def _is_hermes_entrypoint(token: str) -> bool:
+    """True when *token* is the hermes entrypoint of a command line.
+
+    Covers every shape the launcher takes: the console script
+    (``/usr/local/bin/hermes``, quoted ``"C:\\...\\hermes.exe"``), the module
+    form (``-m hermes_cli.main``) and a direct script path
+    (``.../hermes_cli/main.py``).  Comparing the final path segment rather than
+    a suffix keeps an unrelated ``/opt/nothermes`` from matching.
+    """
+    cleaned = token.strip("\"'").replace("\\", "/")
+    if cleaned.lower().endswith(".exe"):
+        cleaned = cleaned[: -len(".exe")]
+    return (
+        cleaned.rsplit("/", 1)[-1] == "hermes"
+        or cleaned == "hermes_cli.main"
+        or cleaned.endswith("hermes_cli/main.py")
+    )
+
+
+def _cmdline_runs_subcommand(command: str, subcommands: tuple[str, ...]) -> bool:
+    """True when *command* invokes hermes with one of *subcommands*.
+
+    The literal ``patterns`` list below only matches when the subcommand sits
+    directly after the entrypoint (``hermes_cli.main dashboard``).  A profile
+    launch puts a global flag in between — ``hermes_cli.main -p carmelo
+    dashboard`` — so the scan silently misses every profile-started server,
+    which is the normal way these run.  ``--status`` then reports nothing while
+    a backend is bound to the port, and ``--stop`` leaves it running.
+
+    Matching on the bare word instead would re-introduce the false positive the
+    ps-over-pgrep comment warns about: ``hermes chat --query "fix the
+    dashboard"`` also contains the token.  A real subcommand always appears
+    before the first long option, while prose only ever reaches the cmdline as
+    the value of one (``--query ...``), so cutting the token list at the first
+    ``--`` separates the two without a regex.
+    """
+    tokens = command.split()
+    entry = next(
+        (i for i, tok in enumerate(tokens) if _is_hermes_entrypoint(tok)),
+        None,
+    )
+    if entry is None:
+        return False
+    for tok in tokens[entry + 1 :]:
+        if tok.startswith("--"):
+            break
+        if tok in subcommands:
+            return True
+    return False
+
+
 def _scan_dashboard_processes(
     *,
     exclude_pids: set[int] | None = None,
@@ -101,7 +155,10 @@ def _scan_dashboard_processes(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        (
+                            any(p in current_cmd for p in patterns)
+                            or _cmdline_runs_subcommand(current_cmd, _SUBCOMMANDS)
+                        )
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -134,7 +191,10 @@ def _scan_dashboard_processes(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        or _cmdline_runs_subcommand(command, _SUBCOMMANDS)
+                    ) and pid != self_pid:
                         dashboard_processes.append((pid, command))
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -47,6 +47,27 @@ def _is_hermes_entrypoint(token: str) -> bool:
     )
 
 
+# ``-p``/``--profile`` never reaches ``build_top_level_parser()``: it is
+# pre-parsed by hand in ``main._apply_profile_override`` before argparse runs.
+_EXTRA_VALUE_FLAGS = frozenset({"-p", "--profile"})
+
+
+def _top_level_value_flags() -> tuple[frozenset[str], frozenset[str]]:
+    """(required-value, optional-value) top-level flags, from the real parser.
+
+    Imported lazily so this module keeps its one-way, import-time-cheap
+    relationship with the CLI; the callee caches per process.  A broken import
+    degrades to the profile flag alone rather than taking the scan down.
+    """
+    try:
+        from hermes_cli._parser import top_level_value_flag_sets
+
+        required, optional = top_level_value_flag_sets()
+        return frozenset(required) | _EXTRA_VALUE_FLAGS, frozenset(optional)
+    except Exception:
+        return _EXTRA_VALUE_FLAGS, frozenset()
+
+
 def _cmdline_runs_subcommand(command: str, subcommands: tuple[str, ...]) -> bool:
     """True when *command* invokes hermes with one of *subcommands*.
 
@@ -63,6 +84,17 @@ def _cmdline_runs_subcommand(command: str, subcommands: tuple[str, ...]) -> bool
     before the first long option, while prose only ever reaches the cmdline as
     the value of one (``--query ...``), so cutting the token list at the first
     ``--`` separates the two without a regex.
+
+    Short flags take values too, and they live in exactly the region scanned
+    here — before any ``--``.  ``hermes -p dashboard chat`` (a profile named
+    "dashboard") would otherwise read its own ``-p`` value as the subcommand
+    and report a chat process as a server, so ``--stop`` would kill it.  Flag
+    values are skipped using the same parser-derived sets ``main.py`` uses for
+    its own argv scans, which is what keeps this from drifting off the argparse
+    surface — the drift behind #93530, where ``hermes --reasoning high chat``
+    misread ``high`` as the subcommand.  ``-p``/``--profile`` is added on top
+    because it is pre-parsed by hand in ``_apply_profile_override`` and so
+    never reaches the parser those sets are built from.
     """
     tokens = command.split()
     entry = next(
@@ -71,11 +103,25 @@ def _cmdline_runs_subcommand(command: str, subcommands: tuple[str, ...]) -> bool
     )
     if entry is None:
         return False
-    for tok in tokens[entry + 1 :]:
+    value_flags, optional_value_flags = _top_level_value_flags()
+    i = entry + 1
+    while i < len(tokens):
+        tok = tokens[i]
         if tok.startswith("--"):
             break
+        if tok in value_flags and i + 1 < len(tokens):
+            i += 2
+            continue
+        if (
+            tok in optional_value_flags
+            and i + 1 < len(tokens)
+            and not tokens[i + 1].startswith("-")
+        ):
+            i += 2
+            continue
         if tok in subcommands:
             return True
+        i += 1
     return False
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8310,7 +8310,13 @@ def _find_stale_dashboard_pids(
 
 def _parse_dashboard_runtime(command: str) -> tuple[str, str, int] | None:
     """Best-effort parse of a dashboard/server cmdline into mode, host, and port."""
+    from hermes_cli.dashboard_procs import _cmdline_runs_subcommand
+
     mode = None
+    # The literal patterns only match when the subcommand follows the
+    # entrypoint directly; a profile launch (`hermes_cli.main -p carmelo
+    # dashboard`) puts a global flag in between. _cmdline_runs_subcommand
+    # covers that shape without matching prose in a chat cmdline.
     if any(
         pattern in command
         for pattern in (
@@ -8318,7 +8324,7 @@ def _parse_dashboard_runtime(command: str) -> tuple[str, str, int] | None:
             "hermes_cli.main dashboard",
             "hermes_cli/main.py dashboard",
         )
-    ):
+    ) or _cmdline_runs_subcommand(command, ("dashboard",)):
         mode = "dashboard"
     elif any(
         pattern in command
@@ -8327,7 +8333,7 @@ def _parse_dashboard_runtime(command: str) -> tuple[str, str, int] | None:
             "hermes_cli.main serve",
             "hermes_cli/main.py serve",
         )
-    ):
+    ) or _cmdline_runs_subcommand(command, ("serve",)):
         mode = "serve"
     if mode is None:
         return None

--- a/tests/hermes_cli/test_dashboard_scan_profile_launch.py
+++ b/tests/hermes_cli/test_dashboard_scan_profile_launch.py
@@ -1,0 +1,176 @@
+"""Detection of dashboards started from a named profile.
+
+``hermes -p <profile> dashboard`` re-execs into
+``python -m hermes_cli.main -p <profile> dashboard ...``.  The literal pattern
+list only matches when the subcommand follows the entrypoint directly, so the
+global ``-p`` flag in between made every profile-started server invisible to
+``--status``, ``--stop`` and the post-update cleanup.
+
+These tests pin both the positive shape and the false positive the
+ps-over-pgrep choice exists to avoid: a chat cmdline that merely mentions the
+word "dashboard".
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.dashboard_procs import (
+    _SUBCOMMANDS,
+    _cmdline_runs_subcommand,
+    _is_hermes_entrypoint,
+    _scan_dashboard_processes,
+)
+from hermes_cli.main import _parse_dashboard_runtime, cmd_dashboard
+
+PROFILE_DASHBOARD = (
+    "/opt/hermes/venv/bin/python3 -m hermes_cli.main -p carmelo dashboard "
+    "--isolated --port 9119 --host 127.0.0.1 --no-open --skip-build"
+)
+UNIFIED_DASHBOARD = (
+    "/opt/hermes/venv/bin/python3 -m hermes_cli.main -p default dashboard "
+    "--port 9119 --host 127.0.0.1 --open-profile carmelo --no-open"
+)
+
+
+def _ns(**kw):
+    defaults = dict(
+        port=9119, host="127.0.0.1", no_open=False, insecure=False,
+        stop=False, status=False,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+class TestCmdlineRunsSubcommand:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            PROFILE_DASHBOARD,
+            UNIFIED_DASHBOARD,
+            "/usr/local/bin/hermes dashboard",
+            "/usr/local/bin/hermes -p carmelo dashboard",
+            "python3 /opt/hermes/hermes_cli/main.py -p carmelo dashboard --port 9120",
+            "/opt/hermes/venv/bin/python3 -m hermes_cli.main -p carmelo serve --port 0",
+        ],
+    )
+    def test_matches_real_launches(self, command):
+        assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Prose only reaches a cmdline as the value of a long option.
+            '/usr/local/bin/hermes -p carmelo chat --query fix the dashboard',
+            '/usr/local/bin/hermes chat --query please serve the report',
+            "/usr/local/bin/hermes chat",
+            # Unrelated program that happens to take a "dashboard" argument.
+            "/usr/bin/python3 /home/u/report.py dashboard",
+        ],
+    )
+    def test_ignores_non_launches(self, command):
+        assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is False
+
+
+class TestParseDashboardRuntime:
+    def test_profile_launch_is_parsed(self):
+        assert _parse_dashboard_runtime(PROFILE_DASHBOARD) == (
+            "dashboard",
+            "127.0.0.1",
+            9119,
+        )
+
+    def test_unified_relaunch_is_parsed(self):
+        assert _parse_dashboard_runtime(UNIFIED_DASHBOARD) == (
+            "dashboard",
+            "127.0.0.1",
+            9119,
+        )
+
+    def test_profile_serve_is_parsed(self):
+        command = (
+            "/opt/hermes/venv/bin/python3 -m hermes_cli.main -p carmelo serve "
+            "--host 0.0.0.0 --port 9200"
+        )
+        assert _parse_dashboard_runtime(command) == ("serve", "0.0.0.0", 9200)
+
+    def test_chat_mentioning_dashboard_is_not_a_runtime(self):
+        command = "/usr/local/bin/hermes -p carmelo chat --query fix the dashboard"
+        assert _parse_dashboard_runtime(command) is None
+
+
+class TestScanFindsProfileLaunch:
+    def _ps_output(self):
+        return (
+            "  1234 /opt/hermes/venv/bin/python3 -m hermes_cli.main -p carmelo "
+            "dashboard --isolated --port 9119 --host 127.0.0.1\n"
+            "  5678 /usr/local/bin/hermes -p carmelo chat --query fix the dashboard\n"
+        )
+
+    def test_scan_returns_profile_launch_only(self):
+        completed = subprocess.CompletedProcess(
+            args=["ps"], returncode=0, stdout=self._ps_output(), stderr=""
+        )
+        with patch("sys.platform", "linux"), \
+             patch("hermes_cli.dashboard_procs.subprocess.run", return_value=completed):
+            found = _scan_dashboard_processes()
+        assert [pid for pid, _cmd in found] == [1234]
+
+
+class TestStatusReportsProfileLaunch:
+    def test_status_lists_profile_started_dashboard(self, capsys):
+        processes = [(1234, PROFILE_DASHBOARD)]
+        with patch("hermes_cli.main._scan_dashboard_processes", return_value=processes), \
+             patch("gateway.status._pid_exists", return_value=True), \
+             patch("hermes_cli.main._dashboard_listening", return_value=True), \
+             pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns(status=True))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "1 hermes dashboard process(es) running" in out
+        assert "PID 1234" in out
+
+
+class TestIsHermesEntrypoint:
+    """The entrypoint shapes the launcher produces on each platform."""
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "/usr/local/bin/hermes",
+            "/home/u/.local/bin/hermes",
+            'C:\\Users\\u\\AppData\\Local\\hermes\\hermes.exe',
+            '"C:\\Users\\u\\AppData\\Local\\hermes\\hermes.exe"',
+            "hermes_cli.main",
+            "/opt/hermes/hermes_cli/main.py",
+            "C:\\hermes\\hermes_cli\\main.py",
+        ],
+    )
+    def test_recognises_entrypoints(self, token):
+        assert _is_hermes_entrypoint(token) is True
+
+    @pytest.mark.parametrize(
+        "token",
+        ["/usr/bin/python3", "/opt/nothermes", "-m", "--port", "dashboard"],
+    )
+    def test_rejects_everything_else(self, token):
+        assert _is_hermes_entrypoint(token) is False
+
+
+class TestWindowsCmdlineShape:
+    """Regression for the Windows .exe entry-point cmdline (issue #86911)."""
+
+    def test_quoted_exe_launch_is_detected(self):
+        command = '"C:\\Users\\u\\AppData\\Local\\hermes\\hermes.exe" dashboard --no-open'
+        assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is True
+
+    def test_quoted_exe_launch_is_parsed(self):
+        command = (
+            '"C:\\Users\\u\\AppData\\Local\\hermes\\hermes.exe" dashboard '
+            "--host 127.0.0.1 --port 9119"
+        )
+        assert _parse_dashboard_runtime(command) == ("dashboard", "127.0.0.1", 9119)

--- a/tests/hermes_cli/test_dashboard_scan_profile_launch.py
+++ b/tests/hermes_cli/test_dashboard_scan_profile_launch.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_cli import dashboard_procs
 from hermes_cli.dashboard_procs import (
     _SUBCOMMANDS,
     _cmdline_runs_subcommand,
@@ -74,6 +75,71 @@ class TestCmdlineRunsSubcommand:
     )
     def test_ignores_non_launches(self, command):
         assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is False
+
+
+class TestValueFlagsAreNotSubcommands:
+    """A short flag's value must not be read as the subcommand.
+
+    Short flags take values and sit in exactly the region this scan walks —
+    before any ``--``. A profile, toolset or skill named "dashboard" would
+    otherwise make an ordinary chat process look like a running server, and
+    ``--stop`` would kill it.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Profile named after a subcommand (-p is pre-parsed by hand).
+            "/usr/local/bin/hermes -p dashboard chat",
+            "/usr/local/bin/hermes -p serve chat",
+            # Parser-derived flags: -t/--toolsets, -s/--skills, -m/--model.
+            "/usr/local/bin/hermes -t dashboard chat",
+            "/usr/local/bin/hermes -s serve chat",
+            "/usr/local/bin/hermes -m dashboard chat",
+            "/opt/hermes/venv/bin/python3 -m hermes_cli.main -p dashboard chat",
+        ],
+    )
+    def test_flag_value_is_not_a_launch(self, command):
+        assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # The same flags must not hide a launch that follows them.
+            "/usr/local/bin/hermes -m gpt-4 dashboard",
+            "/usr/local/bin/hermes -p carmelo -t coding dashboard --port 9119",
+        ],
+    )
+    def test_launch_after_a_flag_value_still_matches(self, command):
+        assert _cmdline_runs_subcommand(command, _SUBCOMMANDS) is True
+
+    def test_optional_value_flag_consumes_a_bare_word(self):
+        """``-c``/``--continue`` takes an optional value, so ``hermes -c serve``
+        resumes a session named "serve" rather than starting a server — the
+        same reading ``main._apply_profile_override`` gives it."""
+        assert _cmdline_runs_subcommand(
+            "/usr/local/bin/hermes -c serve", _SUBCOMMANDS
+        ) is False
+
+    def test_falls_back_to_the_profile_flag_when_the_parser_is_unavailable(self, monkeypatch):
+        """A broken parser import must not take the whole scan down."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "hermes_cli._parser":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", boom)
+        assert dashboard_procs._top_level_value_flags() == (
+            frozenset({"-p", "--profile"}),
+            frozenset(),
+        )
+        assert _cmdline_runs_subcommand(
+            "/usr/local/bin/hermes -p dashboard chat", _SUBCOMMANDS
+        ) is False
 
 
 class TestParseDashboardRuntime:


### PR DESCRIPTION
## What does this PR do?

`hermes dashboard --status` and `--stop` never detect a dashboard that was started from a named profile, even while it is actively listening on its port.

`hermes -p <profile> dashboard` re-execs into:

```
python -m hermes_cli.main -p carmelo dashboard --isolated --port 9119 --host 127.0.0.1
```

Both detection sites match with fixed substrings that assume the subcommand sits **directly** after the entrypoint:

```python
# hermes_cli/dashboard_procs.py::_scan_dashboard_processes
patterns = ["hermes dashboard", "hermes_cli.main dashboard", "hermes_cli/main.py dashboard", ...]
# hermes_cli/main.py::_parse_dashboard_runtime  — the same list, duplicated
```

The global `-p <profile>` lands between the two, so nothing matches and the server becomes invisible to its own lifecycle commands. This is the normal shape for anyone using profiles, including the unified relaunch the code itself produces (`-p default dashboard --open-profile <name>`).

Note this bites at **two** sites: fixing only `_scan_dashboard_processes` changes nothing, because `_report_dashboard_status()` then discards every process whose `_parse_dashboard_runtime()` returns `None`.

### Approach

A small `_cmdline_runs_subcommand()` helper, used **alongside** the existing patterns rather than replacing them, so no currently-detected shape can regress.

Matching on the bare word would re-introduce exactly the false positive the ps-over-pgrep comment in `_scan_dashboard_processes` warns about — `hermes chat --query "fix the dashboard"` contains the token too. The observation that separates them without a regex: **a real subcommand always appears before the first long option, while prose only ever reaches a cmdline as the value of one.** So the token list is cut at the first `--`.

`_is_hermes_entrypoint()` also normalises quoting, `\` separators and the `.exe` suffix, which covers the Windows cmdline shape from #86911.

## Related Issue

Related: #86911 (same root cause — the substring match missing the real cmdline shape — reported for the Windows `.exe` entry point). This PR fixes the profile-launch shape on all platforms and includes regression tests for the quoted `.exe` shape, but I have no Windows machine to confirm #86911 end-to-end, so I've left it linked rather than closed.

Related: #75791.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_procs.py` — add `_is_hermes_entrypoint()`, `_cmdline_runs_subcommand()` and the shared `_SUBCOMMANDS` tuple; use them in both the POSIX and Windows branches of `_scan_dashboard_processes()`.
- `hermes_cli/main.py` — `_parse_dashboard_runtime()` uses the same helper, so a detected process also survives the runtime-parse filter.
- `tests/hermes_cli/test_dashboard_scan_profile_launch.py` — new, 30 cases: entrypoint shapes per platform, profile launches, the unified relaunch, the `ps`-level scan, the `--status` path, plus negative cases for chat cmdlines that merely mention "dashboard"/"serve" and for unrelated binaries such as `/opt/nothermes`.

## How to Test

Reproduce on `main`:

1. `hermes -p <profile> dashboard --no-open` (any named profile).
2. Confirm it's up: `ss -tlnp | grep 9119` shows a listening `hermes` process.
3. `hermes dashboard --status` → `No hermes dashboard processes running.`
4. `hermes dashboard --stop` → reports nothing and stops nothing.

With this branch, step 3 prints:

```
1 hermes dashboard process(es) running:
    PID 86225: /opt/hermes/venv/bin/python3 -m hermes_cli.main -p carmelo dashboard --isolated --port 9119 --host 127.0.0.1 --no-open --skip-build
```

and step 4 prints `✓ stopped PID <pid>`. Verified against a live server whose PID matched the one systemd reported as `MainPID`.

Unit tests: `pytest tests/hermes_cli/test_dashboard_scan_profile_launch.py -q` → 30 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open or closed PR covers this)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the related suites and they pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.11, Hermes v0.20.5

On the full-suite checkbox, to be precise rather than tick it blindly: I ran the dashboard-related suites (`test_dashboard_scan_profile_launch`, `test_dashboard_lifecycle_flags`, `test_update_stale_dashboard`, `test_orphan_desktop_serve_reap`, `test_lazy_command_exports`) — 86 passed, 2 skipped, with one pre-existing failure noted below. I did not run all of `tests/` locally because some suites need optional extras my environment lacks.

Two failures I checked are **pre-existing and unrelated** — both reproduce on a clean `upstream/main` checkout with my changes stashed:

- `tests/test_resource_limits.py::test_serve_startup_applies_limit_before_web_server` — `SystemExit: Web UI requires fastapi and uvicorn` (missing optional extras locally).
- `tests/hermes_cli/test_lazy_command_exports.py::test_lazy_reexports_resolve_to_real_objects` — fails only when run **after** `test_update_stale_dashboard.py` in the same session (cross-test state leak from patching `hermes_cli.main._scan_dashboard_processes`, which materialises the lazy re-export). Passes in isolation. Left alone to keep this PR scoped; happy to open a separate issue if useful.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new helpers explain the why) — no user-facing docs change needed
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the helper is used in both the `wmic` and `ps` branches, and `_is_hermes_entrypoint` handles quoted `.exe` and `\` paths, with tests for both
- [x] Tool descriptions/schemas — N/A
