### PR TITLE
fix(terminal): pin the local run-env TERMINAL_CWD to the per-command cwd

### DIFF
--- a/tests/tools/test_local_env_terminal_cwd_pin.py
+++ b/tests/tools/test_local_env_terminal_cwd_pin.py
@@ -1,0 +1,70 @@
+"""Regression tests for the local run-env TERMINAL_CWD pin (#95078).
+
+``_make_run_env`` merges the host process environment, so a long-lived
+backend that carries a process-global ``TERMINAL_CWD`` (gateway/cron bridge,
+a session ``cd``, a worktree retarget) leaks that stale value into every
+local subprocess. A nested ``hermes`` process inherits the correct OS cwd
+from the spawn but prefers the inherited variable when resolving its agent
+cwd (``agent/runtime_cwd.py``), landing in the wrong project. The fix pins
+the run-env copy to the per-command effective cwd at the ``_run_bash`` spawn
+point, so the child's carrier and its OS cwd always agree.
+"""
+
+from tools.environments.local import LocalEnvironment
+
+
+def test_per_command_cwd_pins_terminal_cwd_env(tmp_path, monkeypatch):
+    stale = tmp_path / "stale-home"
+    project = tmp_path / "project"
+    stale.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+
+    env = LocalEnvironment(cwd=str(stale), timeout=10)
+    try:
+        result = env.execute("printenv TERMINAL_CWD", cwd=str(project), timeout=10)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0, result
+    assert result["output"].strip() == str(project), (
+        "a subprocess spawned with an explicit per-command cwd must not see "
+        "the stale process-global TERMINAL_CWD (#95078)"
+    )
+
+
+def test_session_cwd_pins_over_stale_process_global(tmp_path, monkeypatch):
+    # No per-command cwd: the pin falls back to the backend session cwd,
+    # which is still more current than a stale process-global value.
+    stale = tmp_path / "stale-home"
+    session = tmp_path / "session-dir"
+    stale.mkdir()
+    session.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+
+    env = LocalEnvironment(cwd=str(session), timeout=10)
+    try:
+        result = env.execute("printenv TERMINAL_CWD", timeout=10)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0, result
+    assert result["output"].strip() == str(session)
+
+
+def test_backend_env_not_polluted_after_execute(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    env = LocalEnvironment(cwd=str(project), timeout=10)
+    try:
+        assert "TERMINAL_CWD" not in env.env, (
+            "fixture assumption: the backend env dict starts without the carrier"
+        )
+        env.execute("true", cwd=str(project), timeout=10)
+        assert "TERMINAL_CWD" not in env.env, (
+            "the per-command pin must live only in the spawned run env, "
+            "never mutate the backend's own environment dict"
+        )
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -929,7 +929,14 @@ class BaseEnvironment(ABC):
         # Values stay in environment memory and never enter the shell command
         # string, so secrets are not exposed through process arguments/logs.
         saved_names: list[tuple[str, str, str]] = []
-        for name in passthrough_names:
+        # TERMINAL_CWD rides the same save/restore path: the local backend's
+        # run env carries a per-command pin (see LocalEnvironment._run_bash),
+        # and restoring it after the snapshot source keeps a stale
+        # process-global value — frozen into the shared snapshot by an
+        # earlier command — from overriding the pin in nested subprocesses
+        # (#95078). Backends that never set it simply restore unset.
+        restore_names = list(passthrough_names) + ["TERMINAL_CWD"]
+        for name in restore_names:
             marker = f"_HERMES_RUNTIME_PASSTHROUGH_{name}"
             present = f"{marker}_PRESENT"
             value = f"{marker}_VALUE"
@@ -1482,6 +1489,12 @@ class BaseEnvironment(ABC):
             exec_command = _rewrite_compound_background(exec_command)
         effective_timeout = timeout or self.timeout
         effective_cwd = cwd or self.cwd
+        # Surface the per-command cwd to backend _run_bash implementations
+        # so they can pin the spawned process's cwd-carrier env to it (the
+        # local backend rewrites its run-env TERMINAL_CWD; without this a
+        # stale process-global value leaks into nested Hermes subprocesses,
+        # #95078).
+        self._command_env_cwd = effective_cwd
 
         # Merge sudo stdin with caller stdin
         if sudo_stdin is not None and stdin_data is not None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1824,6 +1824,15 @@ class LocalEnvironment(BaseEnvironment):
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
+        # Pin the cwd-carrier env to the per-command cwd (set by the base
+        # execute) so a nested Hermes subprocess cannot inherit a stale
+        # process-global TERMINAL_CWD from a long-lived backend and resolve
+        # its agent cwd to the wrong project (#95078). The command's shell
+        # already `cd`s here via _wrap_command, so the OS cwd and the carrier
+        # agree for the child.
+        _pinned_cwd = getattr(self, "_command_env_cwd", "")
+        if _pinned_cwd:
+            run_env["TERMINAL_CWD"] = _pinned_cwd
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir


### PR DESCRIPTION
## What does this PR do?

A nested Hermes process launched through the terminal tool with an explicit `workdir` receives the correct OS cwd but retains a stale process-global `TERMINAL_CWD` inherited from the long-lived parent backend (`_make_run_env` merges the host `os.environ`). `resolve_agent_cwd()` prefers the inherited variable over `os.getcwd()`, so the nested agent's system prompt, session metadata, and terminal/file default cwd all point at the wrong project — the report documents a nested role implementing against a disposable clone instead of the intended checkout because its system prompt said the wrong directory (#95078).

The fix pins the cwd carrier at three cooperating points:

1. The base `execute()` surfaces the per-command effective cwd (`self._command_env_cwd`) — one attribute assignment, no signature changes to any `_run_bash` implementation.
2. The local `_run_bash` writes that value into the spawned run env (`run_env["TERMINAL_CWD"]`), so the child's carrier and its OS cwd always agree.
3. `_wrap_command` rides `TERMINAL_CWD` through the existing snapshot save/restore path (the same mechanism used for passthrough names): the run-env value is saved before the snapshot `source` and restored after, so a shared snapshot frozen with an older value cannot override the pin — and the post-command re-dump persists the pinned value, converging the snapshot too.

Container backends are unaffected: their `TERMINAL_CWD` handling is separately sanity-checked against host paths, and the local pin only rewrites the local run env.

## Related Issue

Fixes #95078

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base.py` — `execute()` records the per-command effective cwd on the instance for backend `_run_bash` implementations; `_wrap_command()` includes `TERMINAL_CWD` in the snapshot save/restore set.
- `tools/environments/local.py` — `_run_bash()` pins `TERMINAL_CWD` in the spawned run env to the per-command cwd.
- `tests/tools/test_local_env_terminal_cwd_pin.py` — three regression tests: an explicit per-command cwd overrides a stale process-global value in the child env; the session cwd pins over the stale value when no per-command cwd is given; the backend's own env dict is never mutated by the pin.

## How to Test

1. `.venv/bin/python -m pytest tests/tools -k terminal_cwd_pin -v` — should pass (3 passed).
2. Adjacent suites stay green: `.venv/bin/python -m pytest tests/tools/test_local_env_relative_cwd.py tests/tools/test_local_cwd_permission_fallback.py tests/tools/test_interrupted_command_cwd.py tests/tools/test_local_tempdir.py tests/tools/test_base_environment.py tests/tools/test_local_background_child_hang.py -q` — should pass (52 passed).
3. Fail-on-main control: `git checkout HEAD~1 -- tools/environments/base.py tools/environments/local.py` and rerun the new file — should fail (2 failed: both pin tests; the no-pollution test passes on both sides by design), then restore. Observed result: `2 failed` pre-fix, `3 passed` post-fix.
4. Live check from the report's minimal reproduction: `mkdir -p /tmp/hermes-nested-cwd-repro && cd /tmp/hermes-nested-cwd-repro && TERMINAL_CWD="$HOME" hermes --oneshot 'Report the Current working directory supplied in your system context, then run pwd with the terminal tool.'` — model-visible cwd and `pwd` should both report the repro dir, not `$HOME`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the open TERMINAL_CWD PRs are warning-suppression and precedence-annotation fixes in the CLI layer — none touch the subprocess env propagation this fixes)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the pin flows through existing Windows path-normalization layers (`_msys_to_windows_path` consumers untouched); value is a plain directory string in a dict assignment
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
