### PR TITLE
feat(desktop): scroll a project's session preview past the third row

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -157,7 +157,7 @@ import {
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
-  PROJECT_PREVIEW_COUNT,
+  PROJECT_PREVIEW_LOADED,
   ProjectBackRow,
   ProjectMenu,
   projectTreeCwd,
@@ -1125,10 +1125,10 @@ export function ChatSidebar({
   // matching the flat Recents list. Keyed by project id for the rows.
   const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(
     () =>
-      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, {
+      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_LOADED, {
         removed: removedSessionIds,
-        // Rank before the trim, so "3 priciest in this project" isn't "3 most
-        // recent, priciest first".
+        // Rank before the trim, so "the priciest in this project" isn't "the
+        // most recent, priciest first".
         rankIds: sortOrderIds
       }),
     [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds]

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -3,6 +3,7 @@ export { EnteredProjectContent } from './entered-content'
 export {
   orderProjectsByIds,
   PROJECT_PREVIEW_COUNT,
+  PROJECT_PREVIEW_LOADED,
   projectTreeCwd,
   sortProjectsForOverview,
   useRepoWorktreeMap

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -3,7 +3,6 @@ export { EnteredProjectContent } from './entered-content'
 export {
   orderProjectsByIds,
   PROJECT_PREVIEW_COUNT,
-  PROJECT_PREVIEW_LOADED,
   projectTreeCwd,
   sortProjectsForOverview,
   useRepoWorktreeMap
@@ -16,6 +15,7 @@ export {
   liveSessionProjectId,
   overlayLiveLanes,
   overlayLivePreviews,
+  PROJECT_PREVIEW_LOADED,
   reconcileEnteredProjectSessions,
   sessionRecency,
   type SidebarProjectTree,

--- a/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { orderProjectsByIds, sortProjectsForOverview } from './model'
-import { NO_PROJECT_ID, type SidebarProjectTree } from './workspace-groups'
+import {
+  orderProjectsByIds,
+  previewWindowMaxHeight,
+  PROJECT_PREVIEW_COUNT,
+  sortProjectsForOverview,
+  usePreviewWindowHeight
+} from './model'
+import { NO_PROJECT_ID, PROJECT_PREVIEW_LOADED, type SidebarProjectTree } from './workspace-groups'
 
 function makeProject(id: string, sessionCount: number): SidebarProjectTree {
   return {
@@ -74,5 +82,81 @@ describe('sortProjectsForOverview', () => {
     const projects = [makeProject('scanned', 0), active, home()]
 
     expect(ids(sortProjectsForOverview(projects, 'active'))).toEqual([NO_PROJECT_ID, 'active', 'scanned'])
+  })
+})
+
+describe('preview window height', () => {
+  it('sizes the window in rows off the active density, gaps included', () => {
+    // compact 28 / comfortable 45 / detailed 63, plus a 1px gap per seam.
+    expect(previewWindowMaxHeight('compact')).toBe('86px')
+    expect(previewWindowMaxHeight('comfortable')).toBe('137px')
+    expect(previewWindowMaxHeight('detailed')).toBe('191px')
+  })
+
+  it('prefers a measured row height over the estimate', () => {
+    // The estimate is sized for the virtualizer, which only needs to be close.
+    // A hard max-height is stricter: a row that renders taller than its estimate
+    // would be cropped mid-glyph by an estimate-derived cap.
+    expect(previewWindowMaxHeight('compact', PROJECT_PREVIEW_COUNT, 40)).toBe('122px')
+  })
+
+  it('ignores a non-positive measurement (an unmounted or hidden row)', () => {
+    expect(previewWindowMaxHeight('compact', PROJECT_PREVIEW_COUNT, 0)).toBe('86px')
+    expect(previewWindowMaxHeight('compact', PROJECT_PREVIEW_COUNT, null)).toBe('86px')
+  })
+})
+
+describe('usePreviewWindowHeight', () => {
+  // jsdom reports every box as 0x0 and ships no ResizeObserver, so both are
+  // stubbed: the observer fires once on observe (its spec-guaranteed first
+  // delivery), and the row reports a height taller than compact's estimate.
+  class TestResizeObserver {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    disconnect() {}
+    observe(target: Element) {
+      this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
+    }
+    unobserve() {}
+  }
+
+  const ROW_PX = 40
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({ height: ROW_PX } as DOMRect)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function Harness({ rows }: { rows: number }): ReactNode {
+    const [ref, maxHeight] = usePreviewWindowHeight('compact', rows)
+
+    return createElement(
+      'div',
+      { 'data-testid': 'window', ref, style: { maxHeight } },
+      Array.from({ length: rows }, (_, i) => createElement('div', { key: i }, `row ${i}`))
+    )
+  }
+
+  it('sizes the window from the rendered row, not compact\u2019s estimate', () => {
+    const { getByTestId } = render(createElement(Harness, { rows: 8 }))
+
+    // 3 * 40 + 2 * 1 — the estimate would have said 86px and clipped the third.
+    expect(getByTestId('window').style.maxHeight).toBe('122px')
+  })
+
+  it('falls back to the estimate while there is no row to measure', () => {
+    const { getByTestId } = render(createElement(Harness, { rows: 0 }))
+
+    expect(getByTestId('window').style.maxHeight).toBe('86px')
+  })
+})
+
+describe('preview depth', () => {
+  it('holds more rows than it shows, so the window has something to scroll', () => {
+    expect(PROJECT_PREVIEW_LOADED).toBeGreaterThan(PROJECT_PREVIEW_COUNT)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -7,14 +7,34 @@ import { desktopGit } from '@/lib/desktop-git'
 import { mapPool } from '@/lib/pool'
 import { $sidebarWorkspaceNodeOpen, toggleWorkspaceNodeCollapsed } from '@/store/layout'
 import { $worktreeRefreshToken } from '@/store/projects'
+import type { SessionListDensity } from '@/store/session-list-density'
+
+import { sessionRowEstimate } from '../session-row-details'
 
 import { sessionRecency, type SidebarProjectTree } from './workspace-groups'
 
 // Page size when revealing more already-loaded rows within a workspace group.
 export const SIDEBAR_GROUP_PAGE = 5
 
-// Recent sessions previewed under each project in the overview.
+// Recent sessions VISIBLE under each project in the overview. The preview is a
+// glance, not a list — three rows is the height it gets.
 export const PROJECT_PREVIEW_COUNT = 3
+
+// How many rows the preview actually HOLDS. The window still shows
+// PROJECT_PREVIEW_COUNT of them; the rest are reachable by scrolling inside it,
+// so a project with a busy week doesn't force a drill-in to see chat number
+// four. Keep it in step with `PROJECT_TREE_PREVIEW_LIMIT` (store/projects.ts),
+// which is what the backend is asked to send.
+export const PROJECT_PREVIEW_LOADED = 10
+
+// Row heights are density-driven (session-row.tsx), and the preview window is
+// defined in ROWS, not pixels — so it has to be measured, not hardcoded, or
+// `comfortable`/`detailed` crop their third row mid-glyph.
+const PREVIEW_ROW_GAP_PX = 1
+
+export function previewWindowMaxHeight(density: SessionListDensity, rows = PROJECT_PREVIEW_COUNT): string {
+  return `${rows * sessionRowEstimate(density) + Math.max(0, rows - 1) * PREVIEW_ROW_GAP_PX}px`
+}
 
 // Max concurrent `git worktree list` probes when a project spans many repos.
 const WORKTREE_PROBE_CONCURRENCY = 4

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -1,8 +1,9 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useMemo, useState } from 'react'
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
+import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { desktopGit } from '@/lib/desktop-git'
 import { mapPool } from '@/lib/pool'
 import { $sidebarWorkspaceNodeOpen, toggleWorkspaceNodeCollapsed } from '@/store/layout'
@@ -17,23 +18,70 @@ import { sessionRecency, type SidebarProjectTree } from './workspace-groups'
 export const SIDEBAR_GROUP_PAGE = 5
 
 // Recent sessions VISIBLE under each project in the overview. The preview is a
-// glance, not a list — three rows is the height it gets.
+// glance, not a list — three rows is the height it gets. How many it HOLDS is
+// `PROJECT_PREVIEW_LOADED` (workspace-groups.ts), shared with the store so the
+// fetch depth and the render depth cannot drift.
 export const PROJECT_PREVIEW_COUNT = 3
-
-// How many rows the preview actually HOLDS. The window still shows
-// PROJECT_PREVIEW_COUNT of them; the rest are reachable by scrolling inside it,
-// so a project with a busy week doesn't force a drill-in to see chat number
-// four. Keep it in step with `PROJECT_TREE_PREVIEW_LIMIT` (store/projects.ts),
-// which is what the backend is asked to send.
-export const PROJECT_PREVIEW_LOADED = 10
 
 // Row heights are density-driven (session-row.tsx), and the preview window is
 // defined in ROWS, not pixels — so it has to be measured, not hardcoded, or
 // `comfortable`/`detailed` crop their third row mid-glyph.
 const PREVIEW_ROW_GAP_PX = 1
 
-export function previewWindowMaxHeight(density: SessionListDensity, rows = PROJECT_PREVIEW_COUNT): string {
-  return `${rows * sessionRowEstimate(density) + Math.max(0, rows - 1) * PREVIEW_ROW_GAP_PX}px`
+export function previewWindowMaxHeight(
+  density: SessionListDensity,
+  rows = PROJECT_PREVIEW_COUNT,
+  rowPx?: null | number
+): string {
+  const height = rowPx && rowPx > 0 ? rowPx : sessionRowEstimate(density)
+
+  return `${rows * height + Math.max(0, rows - 1) * PREVIEW_ROW_GAP_PX}px`
+}
+
+/**
+ * The preview window's height, in rows, measured off a real rendered row.
+ *
+ * `sessionRowEstimate` is what its name says — an estimate, sized for the
+ * virtualizer, which only needs to be close. A hard `max-height` is stricter:
+ * if a row ever renders TALLER than its estimate (OS font scaling, a label that
+ * wraps), the cap reintroduces exactly the mid-glyph crop the density-driven
+ * height exists to prevent. So measure the first row and size the window off
+ * it, and keep the estimate only for the frame before that measurement lands.
+ *
+ * The read rides `useResizeObserver` (shared observer, post-layout timing)
+ * rather than a synchronous layout effect — see that hook for why measuring
+ * from a dirty commit thrashes layout.
+ */
+export function usePreviewWindowHeight(
+  density: SessionListDensity,
+  rowCount: number
+): [RefObject<HTMLDivElement | null>, string] {
+  const ref = useRef<HTMLDivElement>(null)
+  // A measurement only describes the density and row set it was taken under.
+  // Keying it means a density switch falls back to that density's estimate for
+  // one frame instead of sizing the new rows with the old rows' height.
+  const key = `${density}:${rowCount}`
+  const [measured, setMeasured] = useState<{ key: string; rowPx: number } | null>(null)
+
+  const measure = useCallback(() => {
+    const first = ref.current?.firstElementChild
+
+    if (!first) {
+      return
+    }
+
+    const rowPx = Math.round(first.getBoundingClientRect().height)
+
+    setMeasured(prev => (rowPx > 0 && (prev?.key !== key || prev.rowPx !== rowPx) ? { key, rowPx } : prev))
+  }, [key])
+
+  useResizeObserver(measure, ref)
+
+  // Once the window is capped its own box stops changing, so row growth
+  // underneath never reaches the observer. Re-measure whenever the key moves.
+  useEffect(measure, [measure])
+
+  return [ref, previewWindowMaxHeight(density, PROJECT_PREVIEW_COUNT, measured?.key === key ? measured.rowPx : null)]
 }
 
 // Max concurrent `git worktree list` probes when a project spans many repos.

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
 
@@ -24,10 +24,14 @@ vi.mock('@/i18n', () => ({
   })
 }))
 
+const nodeOpen = vi.hoisted(() => ({ current: false }))
+
 vi.mock('./model', () => ({
   PROJECT_PREVIEW_COUNT: 3,
+  PROJECT_PREVIEW_LOADED: 10,
   latestProjectSessions: () => [],
-  useWorkspaceNodeOpen: () => [false, vi.fn()]
+  previewWindowMaxHeight: () => '86px',
+  useWorkspaceNodeOpen: () => [nodeOpen.current, vi.fn()]
 }))
 
 // ProjectMenu (the kebab) has its own dedicated test file — stub it here so
@@ -91,5 +95,57 @@ describe('ProjectOverviewRow', () => {
     const { container } = render(<ProjectOverviewRow project={project} />)
 
     expect(container.querySelector('[data-sessions-project="p1"]')).toBeTruthy()
+  })
+
+  describe('preview window', () => {
+    const sessions = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `s${i}` }) as unknown as SessionInfo)
+
+    // The nest is the only element that carries both rows and a maxHeight.
+    const nest = (container: HTMLElement) => container.querySelector<HTMLElement>('[style*="max-height"]')
+
+    beforeEach(() => {
+      nodeOpen.current = true
+    })
+
+    afterEach(() => {
+      nodeOpen.current = false
+    })
+
+    it('renders every loaded preview row, not just the three that fit', () => {
+      const renderRows = vi.fn((_rows: SessionInfo[]) => null)
+
+      render(<ProjectOverviewRow previewSessions={sessions(8)} project={project} renderRows={renderRows} />)
+
+      expect(renderRows.mock.calls.at(-1)?.[0]).toHaveLength(8)
+    })
+
+    it('caps the preview at a fixed window and scrolls it once past three rows', () => {
+      const { container } = render(
+        <ProjectOverviewRow previewSessions={sessions(8)} project={project} renderRows={() => null} />
+      )
+
+      const window = nest(container)
+      expect(window).toBeTruthy()
+      expect(window?.style.maxHeight).toBe('86px')
+      expect(window?.className).toContain('overflow-y-auto')
+    })
+
+    it('leaves a short preview unbounded — no window, no scroller', () => {
+      const { container } = render(
+        <ProjectOverviewRow previewSessions={sessions(3)} project={project} renderRows={() => null} />
+      )
+
+      expect(nest(container)).toBeNull()
+    })
+
+    it('never traps the wheel: the window must not contain its overscroll', () => {
+      // The nest sits INSIDE the sidebar's own scroller — containing overscroll
+      // here kills wheel chaining at the list's ends (#84964).
+      const { container } = render(
+        <ProjectOverviewRow previewSessions={sessions(8)} project={project} renderRows={() => null} />
+      )
+
+      expect(nest(container)?.className).not.toContain('overscroll-contain')
+    })
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -28,9 +28,8 @@ const nodeOpen = vi.hoisted(() => ({ current: false }))
 
 vi.mock('./model', () => ({
   PROJECT_PREVIEW_COUNT: 3,
-  PROJECT_PREVIEW_LOADED: 10,
   latestProjectSessions: () => [],
-  previewWindowMaxHeight: () => '86px',
+  usePreviewWindowHeight: () => [vi.fn(), '86px'],
   useWorkspaceNodeOpen: () => [nodeOpen.current, vi.fn()]
 }))
 

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useRef } from 'react'
 
@@ -5,6 +6,7 @@ import { Codicon } from '@/components/ui/codicon'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { $sessionListDensity } from '@/store/session-list-density'
 
 import {
   SIDEBAR_LEAD_ICON_SIZE,
@@ -19,7 +21,13 @@ import {
   SidebarRowShell
 } from '../chrome'
 
-import { latestProjectSessions, PROJECT_PREVIEW_COUNT, useWorkspaceNodeOpen } from './model'
+import {
+  latestProjectSessions,
+  previewWindowMaxHeight,
+  PROJECT_PREVIEW_COUNT,
+  PROJECT_PREVIEW_LOADED,
+  useWorkspaceNodeOpen
+} from './model'
 import { ProjectContextMenu, ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 import { WorkspaceAddButton } from './workspace-header'
@@ -89,13 +97,18 @@ export function ProjectOverviewRow({
 }: ProjectOverviewRowProps) {
   const { t } = useI18n()
   const s = t.sidebar
+  const density = useStore($sessionListDensity)
   const isActive = project.id === activeProjectId
   const [open, toggleOpen] = useWorkspaceNodeOpen(project.id)
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
   const rowRef = useRef<HTMLDivElement>(null)
-  const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_COUNT)
-  const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_COUNT)) : []
+  const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_LOADED)
+  const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_LOADED)) : []
+  // Past three rows the preview stops growing and starts scrolling: the glance
+  // keeps its height, and the rest of the project's recent chats are a wheel
+  // away instead of behind a drill-in.
+  const previewScrolls = preview.length > PROJECT_PREVIEW_COUNT
 
   const lead = reorderable ? (
     <SidebarRowGrab
@@ -172,7 +185,23 @@ export function ProjectOverviewRow({
           {shell}
         </ProjectContextMenu>
       )}
-      {open && preview.length > 0 && <SidebarRowNest>{renderRows?.(preview)}</SidebarRowNest>}
+      {open && preview.length > 0 && (
+        <SidebarRowNest
+          // The window is defined in ROWS, so its height is measured from the
+          // active density rather than hardcoded. Only scrolls once there is
+          // something past the third row — a two-chat project renders exactly
+          // as it always did, no scroller, no reserved gutter.
+          //
+          // NO `overscroll-contain` here: this scroller is nested inside the
+          // sidebar's own (index.tsx SCROLL_Y). Containing overscroll swallows
+          // the wheel at this list's ends instead of chaining it out to the
+          // sidebar — the same dead-zone the virtualized list hit in #84964.
+          className={cn(previewScrolls && 'scrollbar-fade overflow-y-auto overflow-x-hidden')}
+          style={previewScrolls ? { maxHeight: previewWindowMaxHeight(density) } : undefined}
+        >
+          {renderRows?.(preview)}
+        </SidebarRowNest>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -21,15 +21,9 @@ import {
   SidebarRowShell
 } from '../chrome'
 
-import {
-  latestProjectSessions,
-  previewWindowMaxHeight,
-  PROJECT_PREVIEW_COUNT,
-  PROJECT_PREVIEW_LOADED,
-  useWorkspaceNodeOpen
-} from './model'
+import { latestProjectSessions, PROJECT_PREVIEW_COUNT, usePreviewWindowHeight, useWorkspaceNodeOpen } from './model'
 import { ProjectContextMenu, ProjectMenu } from './project-menu'
-import type { SidebarProjectTree } from './workspace-groups'
+import { PROJECT_PREVIEW_LOADED, type SidebarProjectTree } from './workspace-groups'
 import { WorkspaceAddButton } from './workspace-header'
 
 // A bare color dot (no icon) or an icon glyph — tinted by `color` when set, else
@@ -109,6 +103,8 @@ export function ProjectOverviewRow({
   // keeps its height, and the rest of the project's recent chats are a wheel
   // away instead of behind a drill-in.
   const previewScrolls = preview.length > PROJECT_PREVIEW_COUNT
+  // Sized from the row that actually rendered, not from the estimate alone.
+  const [previewRef, previewMaxHeight] = usePreviewWindowHeight(density, preview.length)
 
   const lead = reorderable ? (
     <SidebarRowGrab
@@ -197,7 +193,8 @@ export function ProjectOverviewRow({
           // the wheel at this list's ends instead of chaining it out to the
           // sidebar — the same dead-zone the virtualized list hit in #84964.
           className={cn(previewScrolls && 'scrollbar-fade overflow-y-auto overflow-x-hidden')}
-          style={previewScrolls ? { maxHeight: previewWindowMaxHeight(density) } : undefined}
+          ref={previewRef}
+          style={previewScrolls ? { maxHeight: previewMaxHeight } : undefined}
         >
           {renderRows?.(preview)}
         </SidebarRowNest>

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -11,6 +11,19 @@ import { rankSessions } from '../order'
 // pure helpers and the VISUAL-ONLY worktree enhancer that injects empty lanes
 // from `git worktree list`. It never decides session membership.
 
+// How many recent sessions a project's overview preview HOLDS — one number for
+// both ends of the contract: the depth `projects.tree` is asked for
+// (`preview_limit`, store/projects.ts) and the depth the preview renders and
+// scrolls (overview-row.tsx). The sidebar SHOWS `PROJECT_PREVIEW_COUNT` of them
+// and scrolls the rest in place, so this is the little scroller's depth, not the
+// number of rows on screen.
+//
+// It lives here, next to `overlayLivePreviews` (the trim it bounds) and the
+// `previewSessions` payload it describes, because this module is the leaf both
+// the store and the sidebar already depend on. Defining it in either of those
+// would make the other import it back.
+export const PROJECT_PREVIEW_LOADED = 10
+
 export interface SidebarSessionGroup {
   id: string
   label: string

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -153,7 +153,13 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
-    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'coder' })
+    // The assertion under test is the PROFILE forwarding, not the preview
+    // depth — the sibling cases already match it loosely, so freezing the
+    // literal here just made a tuning change look like a regression.
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', {
+      preview_limit: expect.any(Number),
+      profile: 'coder'
+    })
     expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
       profile: 'coder',
       project_id: 'p_123'

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -1,7 +1,11 @@
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import {
+  NO_PROJECT_ID,
+  PROJECT_PREVIEW_LOADED,
+  type SidebarProjectTree
+} from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
@@ -153,11 +157,11 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
-    // The assertion under test is the PROFILE forwarding, not the preview
-    // depth — the sibling cases already match it loosely, so freezing the
-    // literal here just made a tuning change look like a regression.
+    // The preview depth is pinned to the SHARED constant, not to a literal:
+    // the fetch depth and the sidebar's render depth are one number now
+    // (workspace-groups.ts), and this is what keeps them that way.
     expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', {
-      preview_limit: expect.any(Number),
+      preview_limit: PROJECT_PREVIEW_LOADED,
       profile: 'coder'
     })
     expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -380,7 +380,11 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-const PROJECT_TREE_PREVIEW_LIMIT = 3
+// How many recent sessions each project carries in the overview payload. The
+// sidebar SHOWS three (PROJECT_PREVIEW_COUNT) and scrolls the rest inside the
+// preview window, so this is the depth of that little scroller — not the number
+// of rows on screen. Keep the two in step.
+const PROJECT_TREE_PREVIEW_LIMIT = 10
 // The all-profiles fan-out reads one database per profile, so it is allowed the
 // same headroom as the cross-profile session list rather than the interactive
 // default.

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import {
   liveSessionProjectId,
   NO_PROJECT_ID,
+  PROJECT_PREVIEW_LOADED,
   type SidebarProjectTree
 } from '@/app/chat/sidebar/projects/workspace-groups'
 import type { HermesGitBaseBranch, HermesGitBranch } from '@/global'
@@ -380,11 +381,6 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-// How many recent sessions each project carries in the overview payload. The
-// sidebar SHOWS three (PROJECT_PREVIEW_COUNT) and scrolls the rest inside the
-// preview window, so this is the depth of that little scroller — not the number
-// of rows on screen. Keep the two in step.
-const PROJECT_TREE_PREVIEW_LIMIT = 10
 // The all-profiles fan-out reads one database per profile, so it is allowed the
 // same headroom as the cross-profile session list rather than the interactive
 // default.
@@ -426,7 +422,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
       res = await gatewayRequestOn<ProjectTreePayload>(
         gateway,
         'projects.tree',
-        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+        projectParams({ preview_limit: PROJECT_PREVIEW_LOADED }, profile)
       )
     } catch (error) {
       // A remote source switch can leave the first read RPC on a newly-opened
@@ -440,7 +436,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
       res = await gatewayRequestOn<ProjectTreePayload>(
         gateway,
         'projects.tree',
-        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+        projectParams({ preview_limit: PROJECT_PREVIEW_LOADED }, profile)
       )
     }
 
@@ -488,7 +484,7 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 
   try {
     const res = await hermesApi<ProjectTreePayload>({
-      path: `/api/profiles/projects/tree?preview_limit=${PROJECT_TREE_PREVIEW_LIMIT}`,
+      path: `/api/profiles/projects/tree?preview_limit=${PROJECT_PREVIEW_LOADED}`,
       timeoutMs: PROJECT_TREE_REQUEST_TIMEOUT_MS
     })
 


### PR DESCRIPTION
## Summary

The project overview previews each project's recent sessions, hard-capped at three (`PROJECT_PREVIEW_COUNT`). A project with a busy week shows three rows and stops — the fourth-most-recent chat is only reachable by entering the project, even when the row for it would fit in space already on screen.

This keeps the three-row **height** and drops the three-row **limit**: the preview holds ten sessions and windows to three, scrolling in place.

## Why this shape

- `preview_limit` is already a `projects.tree` parameter, so the extra depth is a constant change — no new request, no backend change, nothing fetched that the overview wasn't fetching already.
- The window's height is measured in ROWS off the rendered row, not hardcoded. `comfortable` (45px) and `detailed` (63px) rows are much taller than `compact` (28px), so a fixed pixel cap would crop the third row in the denser modes.
- The scroller deliberately omits `overscroll-contain`. It nests inside the sidebar's own scroller, and containing overscroll there swallows the wheel at the list's ends instead of chaining out — the same dead-zone `virtual-session-list.tsx` documents and avoids.

A project with three or fewer previewed sessions is untouched: no scroller, no reserved gutter, identical markup to before.

## Review follow-ups (second commit)

Two structural points from review, both about seams the first commit left held together by comments rather than by code.

**The preview depth is one constant now.** `PROJECT_PREVIEW_LOADED` (what the preview renders and scrolls) and `PROJECT_TREE_PREVIEW_LIMIT` (what `projects.tree` is asked to send) were two `10`s coupled only by a comment: tune one and either rows are fetched and never rendered, or the scroller truncates earlier than intended.

They are the same exported constant, defined in `workspace-groups.ts`. That is the module both ends already import, and it is where the preview contract lives — the `previewSessions` payload shape and `overlayLivePreviews`, the trim this number bounds. Defining it in `store/projects.ts` or the sidebar's `model.ts` would have made the other import it back.

**The window measures a real row; the estimate is the fallback.** `sessionRowEstimate` is sized for the virtualizer, which only needs to be close. A hard `max-height` is stricter — a row that renders taller than its estimate (OS font scaling, a label that wraps) gets cropped mid-glyph by an estimate-derived cap, which is the failure the density-driven height existed to prevent.

`usePreviewWindowHeight` measures the first rendered row and sizes the window off the real height, falling back to the estimate only until that measurement lands. The read rides the existing shared `useResizeObserver` (post-layout timing, one observer for all callers) rather than a synchronous layout effect. Measurements are keyed by density and row count so a stale height never sizes a new density's rows — and since a capped element's own box stops changing, that key is also what re-measures when the content underneath grows.

No change for a third point raised: `overlayLivePreviews` already ranks before it trims (`rankSessions(pool, rankIds).slice(0, limit)`), and `workspace-groups.test.ts` already covers that ordering, so the looser trim rides the same path.

## Test plan

Ten cases across the two commits.

Four in `overview-row.test.tsx`: renders every loaded row, caps and scrolls past three, stays unbounded under four, never contains its overscroll.

Six in `model.test.ts`: window height per density, a measured height beating the estimate, a non-positive measurement ignored, the hook sizing off a rendered row under a stubbed `ResizeObserver`, its pre-measurement fallback, and the loaded-exceeds-shown invariant.

Regression-validated rather than assumed. Reverting `overview-row.tsx` to `main` fails 3 of the first four. Reverting the window to estimate-only and drifting the store's `preview_limit` back to a literal fails 3 of the rest; restoring passes.

```
npx vitest run --environment jsdom src/app/chat/sidebar/ src/store/projects.test.ts
# Test Files 26 passed | Tests 276 passed

npx tsc --noEmit -p tsconfig.json                        # 0 errors
npx eslint src/app/chat/sidebar/ src/store/projects.ts   # 0 errors
npx prettier --check src/app/chat/sidebar/               # clean
```

Rebased onto current `main` and re-verified there: the suite above is the merged-tree result, not a stale pre-rebase number.

## Note on one test change

`projects.test.ts` asserts `preview_limit` against the shared constant.

The first commit relaxed it to `expect.any(Number)`, because it was freezing `3` as a bare literal while its two sibling assertions in the same file already matched loosely — a snapshot of a tunable value in a test whose subject is profile forwarding. Now that the value is a single shared constant rather than two hand-synced copies, it is pinned again, to the imported symbol: asserting the request carries the depth the renderer was built for is a contract, and it is the drift guard that was otherwise missing.

## Scope

Deliberately limited to the preview window. Splitting Projects and Sessions into independent sidebar sections is already covered by #62547 and #67463; neither touches the preview limit or the preview's scrolling, so this is complementary to both and conflict-free.
