### PR TITLE
fix(config): recognize agent.reasoning_effort as a known config key

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -350,6 +350,12 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
 
+        # Global reasoning effort applied to every model unless a per-model
+        # override in ``reasoning_overrides`` (below) matches.  Valid levels:
+        # none|minimal|low|medium|high|xhigh|max|ultra (empty = provider
+        # default).  Read by hermes_constants.resolve_reasoning_config().
+        "reasoning_effort": "",
+
         # Per-model reasoning effort overrides (spelling-tolerant).
         # Dict mapping model names (any reasonable spelling) to effort levels.
         # Takes precedence over agent.reasoning_effort when the current model

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_reasoning_effort_is_recognized(self, _isolated_hermes_home, capsys):
+        """agent.reasoning_effort is runtime config and must not warn (#85741)."""
+        set_config_value("agent.reasoning_effort", "medium")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "reasoning_effort: medium" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)
@@ -544,6 +551,7 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "agent.reasoning_effort",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -515,6 +515,18 @@ class TestReasoningOverridesDefaultConfig:
         assert "reasoning_overrides" in DEFAULT_CONFIG["agent"]
         assert DEFAULT_CONFIG["agent"]["reasoning_overrides"] == {}
 
+    def test_default_config_has_reasoning_effort_key(self):
+        """DEFAULT_CONFIG['agent'] contains the global 'reasoning_effort' key.
+
+        The runtime reads ``agent.reasoning_effort`` via
+        ``hermes_constants.resolve_reasoning_config()``, but the schema in
+        ``DEFAULT_CONFIG`` omitted it — so ``hermes config set
+        agent.reasoning_effort ...`` emitted a false "not a recognized config
+        key" warning (#85741)."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "reasoning_effort" in DEFAULT_CONFIG["agent"]
+        assert DEFAULT_CONFIG["agent"]["reasoning_effort"] == ""
+
 
     def test_spelling_tolerant_lookup_works_with_user_config(self):
         """resolve_per_model_reasoning_effort works with user-added overrides."""


### PR DESCRIPTION
## What does this PR do?

`agent.reasoning_effort` is a documented, runtime-consumed config key (read by
`hermes_constants.resolve_reasoning_config()` — the single chokepoint shared by
the CLI, gateway, Desktop/TUI, cron, and `/model`), but it was omitted from
`DEFAULT_CONFIG["agent"]`. `_validate_config_key()` derives its known-key set by
walking `DEFAULT_CONFIG`, so `hermes config set agent.reasoning_effort high`
always emitted a false warning:

```
⚠ 'agent.reasoning_effort' is not a recognized config key — it was saved anyway, but Hermes may not read it.
  Did you mean: agent.reasoning_overrides
```

The value was saved and read fine — only the warning was wrong. This PR adds the
key to the schema so the warning disappears, in the same way `reasoning_overrides`
and `reasoning_echo` are already declared in that block.

## Related Issue

Fixes #85741

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_defaults.py` — add `"reasoning_effort": ""` to the `agent` block (empty = provider default, matching every other `reasoning_effort` leaf in `DEFAULT_CONFIG`).
- `tests/test_hermes_constants.py` — assert `DEFAULT_CONFIG["agent"]` contains `reasoning_effort` as an empty-string default.
- `tests/hermes_cli/test_set_config_value.py` — add `agent.reasoning_effort` to the validator's known-key cases, plus a round-trip test proving `set_config_value` emits no warning and persists the value.

## How to Test

1. `hermes config set agent.reasoning_effort high` — no unrecognized-key warning.
2. `hermes config get agent.reasoning_effort` — returns `high`.
3. `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/test_hermes_constants.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run targeted tests on the affected areas (see Verification); the full `pytest tests/ -q` suite (~17k tests) was not run locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (arm64), Python 3.11.16

### Documentation & Housekeeping

- [x] Documentation — N/A (bug fix, no doc surface changed)
- [x] `cli-config.yaml.example` — N/A (key already documented/supported at runtime)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure config-schema change)
- [x] Tool descriptions/schemas — N/A

## Verification

- `ruff check` clean on all three changed files.
- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/test_hermes_constants.py` → **152 passed, 0 failed**.
- `scripts/run_tests.sh tests/cron/test_cron_reasoning_effort.py tests/cron/test_reasoning_config_per_model.py tests/agent/test_moa_reasoning_effort.py tests/gateway/test_reasoning_config_per_model.py tests/hermes_cli/test_config.py tests/hermes_cli/test_setup_noninteractive.py` → **123 passed, 0 failed**.
- Regression tests were proven to fail on the pre-fix code (the new tests reproduce the exact false warning and the missing `DEFAULT_CONFIG` key when the fix is reverted).

## Duplicate / related work

Supersedes the earlier closed PRs #85757, #85931, #87544, and #89565 (all closed
unmerged). The open community PR #85752 carries the same core fix; this PR adds
the `DEFAULT_CONFIG` schema assertion from #89565 plus a validator known-key case
and a `set_config_value` round-trip regression test, closing the "only the positive
path is covered" gap raised in review there.