### PR TITLE
feat(kanban): add to-be-worked shelf status

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -398,7 +398,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           default="running",
                           help="Initial card status. Use 'blocked' for cards "
                                "that require immediate human ops (R3 gate) "
-                               "to skip the brief running-to-blocked transition.")
+                               "to skip the brief running-to-blocked transition; "
+                               "use 'to_be_worked' for the non-dispatchable shelf.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---
@@ -654,6 +655,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
     )
     p_unblock.add_argument("task_ids", nargs="+")
+
+    p_shelf = sub.add_parser(
+        "shelf",
+        help="Move a blocked/ready task to the non-dispatchable to-be-worked shelf",
+    )
+    p_shelf.add_argument("task_id")
+    p_shelf.add_argument("--reason", default=None)
+
+    p_unshelf = sub.add_parser(
+        "unshelf",
+        help="Move a to-be-worked task to triage or the parent-gated ready path",
+    )
+    p_unshelf.add_argument("task_id")
+    p_unshelf.add_argument("--dest", required=True, choices=("triage", "ready"))
+    p_unshelf.add_argument("--reason", default=None)
 
     p_request_review = sub.add_parser(
         "request-review",
@@ -1130,6 +1146,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
+            "shelf":    _cmd_shelf,
+            "unshelf":  _cmd_unshelf,
             "request-review": _cmd_request_review,
             "request-changes": _cmd_request_changes,
             "reopen-review":  _cmd_reopen_review,
@@ -1198,6 +1216,8 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "block",
     "schedule",
     "unblock",
+    "shelf",
+    "unshelf",
     "promote",
     "archive",
     "dispatch",
@@ -2415,6 +2435,45 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     return 0 if not failed else 1
 
 
+def _cmd_shelf(args: argparse.Namespace) -> int:
+    reason = getattr(args, "reason", None)
+    reason = (reason.strip() or None) if reason is not None else None
+    actor = _profile_author()
+    with kb.connect_closing() as conn:
+        ok, error = kb.shelf_task(
+            conn, args.task_id, actor=actor, reason=reason,
+        )
+    if not ok:
+        print(f"cannot shelf {args.task_id}: {error}", file=sys.stderr)
+        return 1
+    print(f"Shelved {args.task_id}" + (f": {reason}" if reason else ""))
+    return 0
+
+
+def _cmd_unshelf(args: argparse.Namespace) -> int:
+    reason = getattr(args, "reason", None)
+    reason = (reason.strip() or None) if reason is not None else None
+    actor = _profile_author()
+    with kb.connect_closing() as conn:
+        ok, error = kb.unshelf_task(
+            conn,
+            args.task_id,
+            actor=actor,
+            dest=args.dest,
+            reason=reason,
+        )
+        landed = kb.get_task(conn, args.task_id) if ok else None
+    if not ok:
+        print(f"cannot unshelf {args.task_id}: {error}", file=sys.stderr)
+        return 1
+    landed_status = landed.status if landed is not None else args.dest
+    print(
+        f"Unshelved {args.task_id} -> {landed_status}"
+        + (f": {reason}" if reason else "")
+    )
+    return 0
+
+
 def _cmd_request_review(args: argparse.Namespace) -> int:
     tid = args.task_id
     summary = getattr(args, "summary", None)
@@ -2924,7 +2983,10 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for k in (
+        "triage", "todo", "scheduled", "ready", "running", "blocked",
+        "to_be_worked", "review", "done",
+    ):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,8 +99,11 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
-VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_STATUSES = {
+    "triage", "todo", "scheduled", "ready", "running", "blocked",
+    "to_be_worked", "review", "done", "archived",
+}
+VALID_INITIAL_STATUSES = {"running", "blocked", "to_be_worked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -3192,6 +3195,10 @@ def create_task(
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
+    ``initial_status="to_be_worked"`` lands directly on the operator-owned
+    shelf in the INSERT. It is never created as ``ready`` first, and parent
+    state does not move it to ``todo``.
+
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
     creating a duplicate. Useful for retried webhooks / automation that
@@ -3234,6 +3241,10 @@ def create_task(
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
+        )
+    if initial_status == "to_be_worked" and triage:
+        raise ValueError(
+            "triage and initial_status='to_be_worked' are conflicting landings"
         )
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
@@ -3441,7 +3452,13 @@ def create_task(
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
-                if initial_status == "blocked":
+                if initial_status == "to_be_worked":
+                    task_status = "to_be_worked"
+                    if parents:
+                        missing = _find_missing_parents(conn, parents)
+                        if missing:
+                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                elif initial_status == "blocked":
                     task_status = "blocked"
                     if parents:
                         missing = _find_missing_parents(conn, parents)
@@ -6838,6 +6855,104 @@ def promote_task(
     return True, None
 
 
+def shelf_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    reason: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+    """Move a ``blocked`` or ``ready`` task onto the operator-owned shelf.
+
+    This is deliberately distinct from :func:`block_task` and
+    :func:`unblock_task`: the card is neither stuck nor dispatchable. Failure
+    counters are preserved because shelving is a planning decision, not a
+    successful retry.
+    """
+    actor = str(actor or "").strip()
+    if not actor:
+        raise ValueError("actor is required to shelf a task")
+    reason = str(reason).strip() if reason is not None else None
+    reason = reason or None
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
+        from_status = row["status"]
+        if from_status not in {"blocked", "ready"}:
+            return False, (
+                f"task {task_id} is {from_status!r}; shelf only applies to "
+                "'blocked' or 'ready'"
+            )
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'to_be_worked' "
+            "WHERE id = ? AND status = ?",
+            (task_id, from_status),
+        )
+        if cur.rowcount != 1:
+            return False, f"task {task_id} status changed while shelving"
+        _append_event(
+            conn,
+            task_id,
+            "shelved",
+            {"actor": actor, "from_status": from_status, "reason": reason},
+        )
+    return True, None
+
+
+def unshelf_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    dest: str,
+    reason: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+    """Move a shelf task to ``triage`` or the parent-gated ready path."""
+    actor = str(actor or "").strip()
+    if not actor:
+        raise ValueError("actor is required to unshelf a task")
+    dest = str(dest or "").strip()
+    if dest not in {"triage", "ready"}:
+        return False, "unshelf destination must be 'triage' or 'ready'"
+    reason = str(reason).strip() if reason is not None else None
+    reason = reason or None
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
+        if row["status"] != "to_be_worked":
+            return False, (
+                f"task {task_id} is {row['status']!r}; unshelf only applies "
+                "to 'to_be_worked'"
+            )
+        landing = (
+            _landing_status_after_parents(conn, task_id)
+            if dest == "ready"
+            else "triage"
+        )
+        cur = conn.execute(
+            "UPDATE tasks SET status = ? "
+            "WHERE id = ? AND status = 'to_be_worked'",
+            (landing, task_id),
+        )
+        if cur.rowcount != 1:
+            return False, f"task {task_id} status changed while unshelving"
+        _append_event(
+            conn,
+            task_id,
+            "unshelved",
+            {"actor": actor, "dest": landing, "reason": reason},
+        )
+    return True, None
+
+
 def _reclaim_dangling_run(
     conn: sqlite3.Connection, task_id: str, *, statuses, now: int, note: str,
 ) -> None:
@@ -7515,7 +7630,7 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status != 'archived'",
+            "WHERE id = ? AND status NOT IN ('archived', 'to_be_worked')",
             (task_id,),
         )
         if cur.rowcount != 1:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -87,16 +87,18 @@
   }
 
   // Board column display order; any backend status not listed here renders after these.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "review", "done"];
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "to_be_worked", "review", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
+    to_be_worked: "to be worked",
     review: "Review",
     done: "Done",
     archived: "Archived",
@@ -104,9 +106,11 @@
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Waiting on time; dispatcher will not claim",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    to_be_worked: "Shelf. Marcin decides. Dispatcher will not claim.",
     review: "Implementation complete — awaiting review",
     done: "Completed",
     archived: "Archived",
@@ -169,12 +173,24 @@
     return tx(t, key, FALLBACK_DIAGNOSTIC_EVENT_LABELS[kind]);
   }
 
+  function isAllowedShelfMove(fromStatus, toStatus) {
+    if (toStatus === "to_be_worked") {
+      return fromStatus === "blocked" || fromStatus === "ready";
+    }
+    if (fromStatus === "to_be_worked") {
+      return toStatus === "triage" || toStatus === "ready";
+    }
+    return true;
+  }
+
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    to_be_worked: "hermes-kanban-dot-to-be-worked",
     review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
@@ -941,6 +957,17 @@
     // Single-task card move. Drives confirmation + completion summary
     // dialogs via the hook, then dispatches via performMoveTask.
     const moveTask = useCallback(function (taskId, newStatus) {
+      let sourceStatus = null;
+      for (const col of (boardData && boardData.columns) || []) {
+        if ((col.tasks || []).some(function (task) { return task.id === taskId; })) {
+          sourceStatus = col.name;
+          break;
+        }
+      }
+      if (!isAllowedShelfMove(sourceStatus, newStatus)) {
+        setError("The to-be-worked shelf only accepts ready/blocked cards and only exits to triage/ready.");
+        return;
+      }
       requestMoveConfirm(newStatus, 1)
         .then(function (r1) {
           if (!r1.confirmed) return null;
@@ -954,7 +981,7 @@
           });
         })
         .catch(function () { /* dialog cancelled */ });
-    }, [requestMoveConfirm, requestCompletionSummary, performMoveTask]);
+    }, [boardData, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const clearSelected = useCallback(function () {
       setSelectedIds(new Set());
@@ -963,6 +990,14 @@
     }, []);
     const moveSelected = useCallback(function (newStatus) {
       if (selectedIds.size === 0) return;
+      for (const col of (boardData && boardData.columns) || []) {
+        for (const task of col.tasks || []) {
+          if (selectedIds.has(task.id) && !isAllowedShelfMove(col.name, newStatus)) {
+            setError("The to-be-worked shelf only accepts ready/blocked cards and only exits to triage/ready.");
+            return;
+          }
+        }
+      }
       const count = selectedIds.size;
       const taskId = Array.from(selectedIds)[0]; // representative id for performMoveTask's single-task branch
       requestMoveConfirm(newStatus, count)
@@ -978,7 +1013,7 @@
           });
         })
         .catch(function () { /* dialog cancelled */ });
-    }, [selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
+    }, [boardData, selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const createTask = useCallback(function (body) {
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
@@ -3192,6 +3227,9 @@
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
       };
+      if (props.columnName === "to_be_worked") {
+        body.initial_status = "to_be_worked";
+      }
       if (parent) body.parents = [parent];
       // Parse comma-separated skills into a clean list. Blank = no
       // extras (omit key so backend leaves it null). The dispatcher

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -172,9 +172,11 @@
 }
 .hermes-kanban-dot-triage   { background: #b47dd6; }  /* lilac — fresh/unspecified */
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
+.hermes-kanban-dot-scheduled { background: #7a8799; }  /* slate — waiting on time */
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
+.hermes-kanban-dot-to-be-worked { background: #8b7cc3; }  /* violet — operator shelf */
 .hermes-kanban-dot-review   { background: #48b0c4; }  /* cyan — awaiting review */
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -149,7 +149,8 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "running", "blocked",
+    "to_be_worked", "review", "done",
 ]
 
 
@@ -611,6 +612,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    initial_status: str = "running"
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -643,6 +645,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            initial_status=payload.initial_status,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
@@ -908,6 +911,13 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
+            elif s == "to_be_worked":
+                ok, _error = kanban_db.shelf_task(
+                    conn,
+                    task_id,
+                    actor="dashboard",
+                    reason=payload.block_reason,
+                )
             elif s == "review":
                 # Manual "request review" from the board. Routes through
                 # request_review so it is NOT a
@@ -928,7 +938,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # status set. "Changes requested" (review -> ready) goes through
                 # reopen_review_task via _reopen_if_review.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled"):
+                if current and current.status == "to_be_worked":
+                    ok, _error = kanban_db.unshelf_task(
+                        conn, task_id, actor="dashboard", dest="ready",
+                        reason=payload.block_reason,
+                    )
+                elif current and current.status in ("blocked", "scheduled"):
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     reopened = _reopen_if_review(conn, task_id, current)
@@ -944,9 +959,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             elif s in ("todo", "triage", "scheduled"):
                 # Only a review task moving to 'todo' needs the reopen
                 # transition; fetch lazily so triage/scheduled skip the query.
-                current = kanban_db.get_task(conn, task_id) if s == "todo" else None
-                reopened = _reopen_if_review(conn, task_id, current)
-                ok = reopened if reopened is not None else _set_status_direct(conn, task_id, s)
+                current = kanban_db.get_task(conn, task_id)
+                if current and current.status == "to_be_worked" and s == "triage":
+                    ok, _error = kanban_db.unshelf_task(
+                        conn, task_id, actor="dashboard", dest="triage",
+                        reason=payload.block_reason,
+                    )
+                else:
+                    reopened = _reopen_if_review(conn, task_id, current)
+                    ok = reopened if reopened is not None else _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
             if not ok:
@@ -1141,6 +1162,9 @@ def _set_status_direct(
             (task_id,),
         ).fetchone()
         if prev is None:
+            return False
+
+        if prev["status"] == "to_be_worked" or new_status == "to_be_worked":
             return False
 
         if prev["status"] == "running" and new_status == "ready":
@@ -1359,9 +1383,17 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             # Bulk dashboard action: explicit human override.
                             force=True,
                         )
+                    elif s == "to_be_worked":
+                        ok, _error = kanban_db.shelf_task(
+                            conn, tid, actor="dashboard",
+                        )
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status in ("blocked", "scheduled"):
+                        if cur and cur.status == "to_be_worked":
+                            ok, _error = kanban_db.unshelf_task(
+                                conn, tid, actor="dashboard", dest="ready",
+                            )
+                        elif cur and cur.status in ("blocked", "scheduled"):
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             reopened = _reopen_if_review(conn, tid, cur)
@@ -1380,9 +1412,14 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         ok = kanban_db.schedule_task(conn, tid)
                     elif s in {"todo", "triage"}:
                         # Fetch lazily: only review->todo needs reopen.
-                        cur = kanban_db.get_task(conn, tid) if s == "todo" else None
-                        reopened = _reopen_if_review(conn, tid, cur)
-                        ok = reopened if reopened is not None else _set_status_direct(conn, tid, s)
+                        cur = kanban_db.get_task(conn, tid)
+                        if cur and cur.status == "to_be_worked" and s == "triage":
+                            ok, _error = kanban_db.unshelf_task(
+                                conn, tid, actor="dashboard", dest="triage",
+                            )
+                        else:
+                            reopened = _reopen_if_review(conn, tid, cur)
+                            ok = reopened if reopened is not None else _set_status_direct(conn, tid, s)
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")
                         results.append(entry)

--- a/tests/hermes_cli/test_kanban_to_be_worked.py
+++ b/tests/hermes_cli/test_kanban_to_be_worked.py
@@ -1,0 +1,308 @@
+"""Behavior contract for the Marcin-owned ``to_be_worked`` shelf.
+
+The standing leftover index t_7f646b36 is deliberately out of scope: this
+suite creates isolated temporary cards and performs no migration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "unknown")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    kb.init_db()
+    connection = kb.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _event(conn, task_id: str, kind: str):
+    return [event for event in kb.list_events(conn, task_id) if event.kind == kind][-1]
+
+
+def _spawn_spy(calls: list[str]):
+    def spawn(task, _workspace, board=None):
+        calls.append(task.id)
+        return 4242
+
+    return spawn
+
+
+def test_e1_e2_create_into_shelf_is_direct_and_never_claimed(conn):
+    task_id = kb.create_task(
+        conn,
+        title="decide later",
+        assignee="default",
+        initial_status="to_be_worked",
+    )
+
+    task = kb.get_task(conn, task_id)
+    assert task is not None and task.status == "to_be_worked"
+    events = kb.list_events(conn, task_id)
+    assert [event.kind for event in events] == ["created"]
+    assert events[0].payload["status"] == "to_be_worked"
+
+    calls: list[str] = []
+    first = kb.dispatch_once(conn, spawn_fn=_spawn_spy(calls))
+    second = kb.dispatch_once(conn, spawn_fn=_spawn_spy(calls))
+    assert first.spawned == []
+    assert second.spawned == []
+    assert calls == []
+    assert kb.claim_task(conn, task_id) is None
+    assert kb.has_spawnable_ready(conn) is False
+    assert kb.has_spawnable_review(conn) is False
+    assert kb.get_task(conn, task_id).status == "to_be_worked"
+
+
+def test_create_shelf_rejects_conflicting_triage_landing(conn):
+    with pytest.raises(ValueError, match="triage"):
+        kb.create_task(
+            conn,
+            title="one landing only",
+            triage=True,
+            initial_status="to_be_worked",
+        )
+
+
+def test_e3_default_ready_path_still_dispatches(conn):
+    task_id = kb.create_task(conn, title="hot door", assignee="default")
+    calls: list[str] = []
+
+    result = kb.dispatch_once(conn, spawn_fn=_spawn_spy(calls))
+
+    assert [task_id] == calls
+    assert [entry[0] for entry in result.spawned] == [task_id]
+    assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_e4_blocked_remains_sticky_and_unblock_still_resumes(conn):
+    task_id = kb.create_task(conn, title="actually stuck", assignee="default")
+    assert kb.block_task(conn, task_id, reason="need input")
+    assert kb.get_task(conn, task_id).status == "blocked"
+    assert kb.recompute_ready(conn) == 0
+    assert kb.get_task(conn, task_id).status == "blocked"
+
+    assert kb.unblock_task(conn, task_id)
+    assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_e5_e6_blocked_to_shelf_is_not_unblock_or_promote(conn):
+    task_id = kb.create_task(conn, title="think about it", assignee="default")
+    assert kb.block_task(conn, task_id, reason="not a start")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 2 WHERE id = ?",
+            (task_id,),
+        )
+
+    ok, reason = kb.shelf_task(
+        conn, task_id, actor="marcin", reason="named for the shelf"
+    )
+    assert ok, reason
+    assert kb.get_task(conn, task_id).status == "to_be_worked"
+    shelved = _event(conn, task_id, "shelved")
+    assert shelved.payload == {
+        "actor": "marcin",
+        "from_status": "blocked",
+        "reason": "named for the shelf",
+    }
+
+    assert kb.unblock_task(conn, task_id) is False
+    promoted, promote_reason = kb.promote_task(conn, task_id, actor="marcin")
+    assert promoted is False
+    assert "todo" in promote_reason and "blocked" in promote_reason
+    after = kb.get_task(conn, task_id)
+    assert after.status == "to_be_worked"
+    assert after.consecutive_failures == 2
+
+    calls: list[str] = []
+    assert kb.dispatch_once(conn, spawn_fn=_spawn_spy(calls)).spawned == []
+    assert calls == []
+
+
+@pytest.mark.parametrize("source", ["todo", "scheduled", "running", "review", "done"])
+def test_shelf_task_refuses_unlocked_source_statuses(conn, source):
+    task_id = kb.create_task(conn, title=f"not from {source}")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (source, task_id))
+
+    ok, reason = kb.shelf_task(conn, task_id, actor="marcin")
+
+    assert ok is False
+    assert source in reason
+    assert kb.get_task(conn, task_id).status == source
+
+
+def test_e7_parent_completion_does_not_promote_shelf_child(conn):
+    parent = kb.create_task(conn, title="parent")
+    shelf_child = kb.create_task(
+        conn,
+        title="shelf child",
+        parents=[parent],
+        initial_status="to_be_worked",
+    )
+    control_child = kb.create_task(conn, title="normal child", parents=[parent])
+    assert kb.get_task(conn, shelf_child).status == "to_be_worked"
+    assert kb.get_task(conn, control_child).status == "todo"
+
+    assert kb.complete_task(conn, parent)
+    kb.recompute_ready(conn)
+
+    assert kb.get_task(conn, shelf_child).status == "to_be_worked"
+    assert kb.get_task(conn, control_child).status == "ready"
+    calls: list[str] = []
+    kb.dispatch_once(conn, spawn_fn=_spawn_spy(calls))
+    assert shelf_child not in calls
+
+
+def test_e8_unshelf_is_the_only_exit_and_parent_gates_ready(conn):
+    parent = kb.create_task(conn, title="parent")
+    gated = kb.create_task(
+        conn,
+        title="gated shelf",
+        parents=[parent],
+        initial_status="to_be_worked",
+    )
+
+    ok, reason = kb.unshelf_task(conn, gated, actor="marcin", dest="ready")
+    assert ok, reason
+    assert kb.get_task(conn, gated).status == "todo"
+    assert _event(conn, gated, "unshelved").payload == {
+        "actor": "marcin",
+        "dest": "todo",
+        "reason": None,
+    }
+
+    triage_task = kb.create_task(
+        conn, title="triage shelf", initial_status="to_be_worked"
+    )
+    ok, reason = kb.unshelf_task(
+        conn, triage_task, actor="marcin", dest="triage", reason="needs shaping"
+    )
+    assert ok, reason
+    assert kb.get_task(conn, triage_task).status == "triage"
+
+    refused = kb.create_task(
+        conn, title="cannot start", initial_status="to_be_worked"
+    )
+    ok, reason = kb.unshelf_task(conn, refused, actor="marcin", dest="running")
+    assert ok is False
+    assert "triage" in reason and "ready" in reason
+    assert kb.get_task(conn, refused).status == "to_be_worked"
+
+    assert kb.complete_task(conn, parent)
+    ready_task = kb.create_task(
+        conn,
+        title="parents done",
+        parents=[parent],
+        initial_status="to_be_worked",
+    )
+    ok, reason = kb.unshelf_task(conn, ready_task, actor="marcin", dest="ready")
+    assert ok, reason
+    assert kb.get_task(conn, ready_task).status == "ready"
+
+
+def test_e9_list_and_cli_surface_the_shelf(conn, monkeypatch, capsys):
+    task_id = kb.create_task(
+        conn,
+        title="visible shelf",
+        assignee="default",
+        initial_status="to_be_worked",
+    )
+    assert [task.id for task in kb.list_tasks(conn, status="to_be_worked")] == [task_id]
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    kanban_cli.build_parser(subparsers)
+    create_args = root.parse_args(
+        ["kanban", "create", "cli shelf", "--initial-status", "to_be_worked"]
+    )
+    assert create_args.initial_status == "to_be_worked"
+
+    stats_args = argparse.Namespace(json=False)
+    assert kanban_cli._cmd_stats(stats_args) == 0
+    assert "to_be_worked" in capsys.readouterr().out
+
+
+def test_cli_shelf_unshelf_and_unblock_refusal(conn, monkeypatch, capsys):
+    task_id = kb.create_task(conn, title="cli move")
+    assert kb.block_task(conn, task_id, reason="pause")
+    monkeypatch.setattr(kanban_cli, "_profile_author", lambda: "marcin")
+
+    shelf_args = argparse.Namespace(task_id=task_id, reason="think")
+    assert kanban_cli._cmd_shelf(shelf_args) == 0
+    assert kb.get_task(conn, task_id).status == "to_be_worked"
+
+    unblock_args = argparse.Namespace(task_ids=[task_id], reason=None)
+    assert kanban_cli._cmd_unblock(unblock_args) == 1
+    assert kb.get_task(conn, task_id).status == "to_be_worked"
+
+    unshelf_args = argparse.Namespace(
+        task_id=task_id, dest="triage", reason="shape it"
+    )
+    assert kanban_cli._cmd_unshelf(unshelf_args) == 0
+    assert kb.get_task(conn, task_id).status == "triage"
+    assert "cannot unblock" in capsys.readouterr().err
+
+
+def test_worker_schema_can_create_and_list_but_cannot_unshelf():
+    from tools import kanban_tools
+
+    create_statuses = set(
+        kanban_tools.KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+        ["initial_status"]["enum"]
+    )
+    list_statuses = set(
+        kanban_tools.KANBAN_LIST_SCHEMA["parameters"]["properties"]["status"]["enum"]
+    )
+    assert "to_be_worked" in create_statuses
+    assert {"scheduled", "review", "to_be_worked"} <= list_statuses
+    registered_names = {
+        schema["name"]
+        for schema in vars(kanban_tools).values()
+        if isinstance(schema, dict) and isinstance(schema.get("name"), str)
+    }
+    assert "kanban_unshelf" not in registered_names
+
+
+def test_e11_dispatch_selects_never_include_the_shelf_status(conn):
+    task_id = kb.create_task(
+        conn,
+        title="query inventory shelf",
+        assignee="default",
+        initial_status="to_be_worked",
+    )
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    try:
+        assert kb.claim_task(conn, task_id) is None
+        assert kb.has_spawnable_ready(conn) is False
+        assert kb.has_spawnable_review(conn) is False
+        assert kb.dispatch_once(
+            conn, spawn_fn=_spawn_spy([]),
+        ).spawned == []
+    finally:
+        conn.set_trace_callback(None)
+
+    selects = [
+        statement for statement in statements
+        if statement.lstrip().upper().startswith("SELECT")
+    ]
+    assert selects
+    assert all("to_be_worked" not in statement for statement in selects)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -73,7 +73,10 @@ def test_board_empty(client):
     # All canonical columns present (triage + the rest), each empty.
     names = [c["name"] for c in data["columns"]]
     assert set(names) == kb.VALID_STATUSES - {"archived"}
-    for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
+    for expected in (
+        "triage", "todo", "scheduled", "ready", "running", "blocked",
+        "to_be_worked", "review", "done",
+    ):
         assert expected in names, f"missing column {expected}: {names}"
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
@@ -114,6 +117,94 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_create_task_can_land_directly_on_to_be_worked_shelf(client):
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "decide later",
+            "assignee": "default",
+            "initial_status": "to_be_worked",
+        },
+    )
+    assert response.status_code == 200, response.text
+    task = response.json()["task"]
+    assert task["status"] == "to_be_worked"
+
+    board = client.get("/api/plugins/kanban/board").json()
+    columns = {column["name"]: column["tasks"] for column in board["columns"]}
+    assert [row["id"] for row in columns["to_be_worked"]] == [task["id"]]
+    assert all(
+        task["id"] not in {row["id"] for row in columns[name]}
+        for name in ("ready", "todo", "blocked")
+    )
+
+
+def test_dashboard_routes_shelf_moves_through_distinct_events(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "human shelf", "assignee": "default"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "to_be_worked", "block_reason": "pull off hot door"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == "to_be_worked"
+
+    # The shelf cannot be started, completed, or archived directly.
+    for forbidden in ("running", "done", "archived"):
+        refused = client.patch(
+            f"/api/plugins/kanban/tasks/{task['id']}",
+            json={"status": forbidden},
+        )
+        assert refused.status_code in {400, 409}, refused.text
+        current = client.get(
+            f"/api/plugins/kanban/tasks/{task['id']}"
+        ).json()["task"]
+        assert current["status"] == "to_be_worked"
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "triage"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == "triage"
+
+    with kb.connect() as conn:
+        kinds = [event.kind for event in kb.list_events(conn, task["id"])]
+    assert "shelved" in kinds
+    assert "unshelved" in kinds
+    assert "unblocked" not in kinds
+    assert "promoted_manual" not in kinds
+
+
+def test_dashboard_bulk_routes_shelf_and_unshelf(client):
+    tasks = [
+        client.post(
+            "/api/plugins/kanban/tasks", json={"title": f"bulk shelf {index}"},
+        ).json()["task"]
+        for index in range(2)
+    ]
+    ids = [task["id"] for task in tasks]
+
+    shelved = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": ids, "status": "to_be_worked"},
+    )
+    assert shelved.status_code == 200, shelved.text
+    assert all(row["ok"] for row in shelved.json()["results"])
+
+    unshelved = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": ids, "status": "ready"},
+    )
+    assert unshelved.status_code == 200, unshelved.text
+    assert all(row["ok"] for row in unshelved.json()["results"])
+    with kb.connect() as conn:
+        assert {kb.get_task(conn, task_id).status for task_id in ids} == {"ready"}
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1738,8 +1738,8 @@ KANBAN_LIST_SCHEMA = {
             "status": {
                 "type": "string",
                 "enum": [
-                    "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "triage", "todo", "scheduled", "ready", "running",
+                    "blocked", "to_be_worked", "review", "done", "archived",
                 ],
                 "description": "Optional task status filter.",
             },
@@ -2239,12 +2239,14 @@ KANBAN_CREATE_SCHEMA = {
             },
             "initial_status": {
                 "type": "string",
-                "enum": ["running", "blocked"],
+                "enum": ["running", "blocked", "to_be_worked"],
                 "description": (
                     "Initial card status. Use 'blocked' for tasks that "
                     "require immediate human ops (R3 gate) to skip the "
                     "brief running-to-blocked transition. Defaults to "
-                    "'running', which preserves the usual dispatch path."
+                    "'running', which preserves the usual dispatch path. "
+                    "Use 'to_be_worked' to land directly on Marcin's shelf; "
+                    "the dispatcher will not claim it."
                 ),
             },
             "skills": {


### PR DESCRIPTION
## Summary
- add the non-dispatchable `to_be_worked` board status with direct create landing
- add distinct shelf/unshelf transitions across DB, CLI, dashboard, and worker-visible schemas
- preserve ready/review dispatcher selectors and parent recomputation behavior

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_to_be_worked.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_cli_exit_status.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py` (153 passed, 2 skipped on macOS)
- `node --check plugins/kanban/dashboard/dist/index.js`
- ad-hoc E1 verifier: assigned shelf card stayed `to_be_worked`; dispatch spawned 0; `claim_task` returned null; both spawnability probes returned false

Board task: `t_2151860e`