### PR TITLE
feat(evals): add explanation-policy eval harness

### DIFF
--- a/evals/explanation_policy/README.md
+++ b/evals/explanation_policy/README.md
@@ -30,10 +30,15 @@ change.
 
 ## Usage
 
-Every arm — explainer, reader and judge — runs on `EVAL_MODEL`
-(`anthropic/claude-opus-5`), pinned in `policies.py`. Holding the model fixed
-across policies is what makes a scorecard difference attributable to the
-policy, so change it only to re-run the whole matrix, never one arm.
+By default every arm — explainer, reader and judge — goes through your
+configured auxiliary route, the way the other `evals/` harnesses call
+`call_llm`. Pass `--model` to force one; `EVAL_MODEL` in `policies.py`
+(`anthropic/claude-opus-5`) is the **reference** model that published
+scorecards should use, not a pin the runner enforces.
+
+Either way the model is held constant across policies within a run, which is
+what makes a scorecard difference attributable to the policy — and whatever
+answered is recorded per row, so a scorecard always names its own model.
 
 ```bash
 # from repo root, venv active, provider configured

--- a/evals/explanation_policy/README.md
+++ b/evals/explanation_policy/README.md
@@ -1,0 +1,117 @@
+# Explanation Policy Eval Harness
+
+Measures whether choosing *how* to explain something changes what a reader
+can actually do with it — comprehension, transfer, and confidence
+calibration — against a fixed-Markdown control.
+
+This is the policy/evaluation layer discussed in #93382, cut down to the part
+that needs no response envelope. Everything renders as ordinary Markdown, so
+the harness has no dependency on #7191, #61095, or #74334 and adds no core
+surface: no model tool, no CLI command, no config key, no system-prompt
+change.
+
+## What it does
+
+1. Builds `Signals` for a task — intent, structure, declared prior knowledge,
+   risk. These are the bounded, observable inputs from #93382; nothing is
+   inferred into a durable profile, and nothing persists between runs.
+2. Applies each policy in the matrix to those signals to pick a **modality**
+   (`policies.py`). `fixed_markdown` is the control arm: always one concise
+   answer, no selection.
+3. Asks the model to explain the concept under that modality's render
+   instruction. Markdown out, always.
+4. Hands the explanation — and nothing else — to a fresh reader model, which
+   answers the comprehension items, the transfer item, and states a
+   confidence for each.
+5. Judges those answers against gold in a separate call that sees gold. The
+   reader never does.
+6. Emits a scorecard: comprehension, transfer, calibration error, explanation
+   length, and wall time per policy.
+
+## Usage
+
+Every arm — explainer, reader and judge — runs on `EVAL_MODEL`
+(`anthropic/claude-opus-5`), pinned in `policies.py`. Holding the model fixed
+across policies is what makes a scorecard difference attributable to the
+policy, so change it only to re-run the whole matrix, never one arm.
+
+```bash
+# from repo root, venv active, provider configured
+python evals/explanation_policy/runner.py \
+    --task value_vs_reference \
+    --policies fixed_markdown,smallest_useful,prediction_first \
+    --intent learn --structure comparison \
+    --repeats 3 \
+    --out evals/explanation_policy/results/run1
+python evals/explanation_policy/report.py evals/explanation_policy/results/run1
+```
+
+Before spending a real run, smoke the whole chain against your provider for a
+few hundred tokens:
+
+```bash
+python evals/explanation_policy/runner.py \
+    --task synthetic --policies fixed_markdown --repeats 1 \
+    --out evals/explanation_policy/results/smoke
+python evals/explanation_policy/report.py evals/explanation_policy/results/smoke
+```
+
+The synthetic task's gold is mechanically checkable ("ALPHA is red"), so a
+correct pipeline scores 100% on it. Anything less means the plumbing is
+broken, not the policy — and you find that out in one cheap call instead of
+twenty-seven expensive ones.
+
+`--knowledge practitioner` exercises the expertise-reversal guard: a reader
+who declares prior knowledge gets a retrieval check instead of a worked
+example. Each run costs three LLM calls per policy per repeat, so start with
+`--repeats 1` while you are changing the matrix.
+
+`--timeout` defaults to 180s. These task names are in nobody's `auxiliary.*`
+config, so without it the 30s aux default applies and a slow route makes a
+long modality look like a provider failure.
+
+`--repeats` averages within a run. A real comparison needs enough repeats to
+separate a policy effect from model variance; three is a smoke number, not an
+evidentiary one.
+
+## Scope — what this is and is not
+
+**The reader is a proxy, not a human subject.** This harness measures what
+survives an explanation. That is a prerequisite for the human study #93382
+describes, not a substitute for it: a win here does not license a claim about
+human learning, and the issue's own caveat about dialogue benchmarks applies
+to this harness too.
+
+**It is measurement, not an extension point.** There is no hook, callback, or
+interface here for anything else to depend on — it is a runner you invoke by
+hand, in `evals/`, like `compaction` and `readtool`. Nothing ships to users.
+
+**The stated consumer** is the Flow State vertical described in #93382's
+thread; the policy exists to be measured before any of it is built, not
+after.
+
+## Promotion gate
+
+Per #93382's own acceptance criteria, a policy earns its way out of `evals/`
+only by improving at least one declared primary outcome with no material
+regression in the others. Concretely, for anything in this matrix:
+
+- transfer or comprehension up against `fixed_markdown`, and
+- calibration error not worse, and
+- explanation length and latency cost reported, not hidden.
+
+A policy that wins on comprehension while inflating length 3x and worsening
+calibration has not won.
+
+Individual runs under `results/` are gitignored. Publishing a finding means
+committing a dated `results/SCORECARD-<date>.md`, the way `evals/compaction`
+does — and a null or negative result is as publishable as a positive one.
+
+## Files
+
+| file | what it holds |
+| --- | --- |
+| `policies.py` | intent/structure/modality enums, the policy matrix, render instructions |
+| `fixtures.py` | the concept-comparison task, its gold discriminators and transfer item; `synthetic_task()` for smoke tests |
+| `runner.py` | explain → read → judge pipeline, writes `runs.json` + `scorecard.json` |
+| `report.py` | scorecard table, deltas against the control, `scorecard.md` |

--- a/evals/explanation_policy/fixtures.py
+++ b/evals/explanation_policy/fixtures.py
@@ -1,0 +1,103 @@
+"""Concept-comparison tasks for the explanation-policy eval.
+
+The first slice is deliberately one task family: two concepts a reader
+routinely conflates, the discriminators a correct explanation has to carry,
+comprehension items answerable from a good explanation, and one transfer item
+that a reader cannot answer by restating the explanation back.
+
+`synthetic_task()` returns a task whose scoring is mechanically checkable, so
+a smoke test can exercise the whole pipeline without spending an LLM call.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass(frozen=True)
+class Task:
+    key: str
+    question: str
+    concepts: Tuple[str, str]
+    discriminators: List[str]
+    comprehension: List[str]
+    transfer: str
+    transfer_gold: str
+
+    @property
+    def gold(self) -> str:
+        return "\n".join(f"- {d}" for d in self.discriminators)
+
+
+TASKS: List[Task] = [
+    Task(
+        key="value_vs_reference",
+        question=(
+            "What is the difference between passing a payload by value and "
+            "passing it by reference in a response protocol?"
+        ),
+        concepts=("by value", "by reference"),
+        discriminators=[
+            "by value embeds the payload inside the response; by reference "
+            "sends an identifier the client has to resolve separately",
+            "by reference introduces a lifetime question the protocol must "
+            "answer: how long the referenced artifact stays resolvable",
+            "by value makes a response self-contained, so replaying stored "
+            "history reproduces exactly what the user originally saw",
+            "by reference keeps responses small and lets one artifact be "
+            "shared across responses or updated after it was sent",
+        ],
+        comprehension=[
+            "Which of the two makes a response self-contained, and why?",
+            "What new question does passing by reference force the protocol "
+            "to answer that passing by value does not?",
+        ],
+        transfer=(
+            "A client replays a six-month-old conversation from its own log to "
+            "re-render it. Which of the two approaches is more likely to render "
+            "incorrectly, and what exactly fails?"
+        ),
+        transfer_gold=(
+            "By reference. The identifier may no longer resolve -- the artifact "
+            "can have expired, been deleted, or been mutated since it was sent -- "
+            "so the replay either fails to render or renders content that "
+            "differs from what the user originally saw. By value is unaffected, "
+            "because the payload travels inside the stored response."
+        ),
+    ),
+]
+
+
+def get_task(key: str) -> Task:
+    """Look up a task by key. `synthetic` is always available.
+
+    Exposing the synthetic task through the same lookup is what makes
+    `--task synthetic` a real end-to-end smoke run: the whole
+    explain -> read -> judge -> scorecard chain against a live provider, for
+    a few hundred tokens instead of a few thousand.
+    """
+    if key == "synthetic":
+        return synthetic_task()
+    for t in TASKS:
+        if t.key == key:
+            return t
+    known = [t.key for t in TASKS] + ["synthetic"]
+    raise KeyError(f"unknown task: {key!r} (have: {known})")
+
+
+def synthetic_task() -> Task:
+    """Deterministic task with literal, greppable gold for smoke tests.
+
+    Every gold string appears verbatim in the discriminators, so a smoke test
+    can assert the scoring plumbing end to end with a stub answerer instead of
+    a live model.
+    """
+    return Task(
+        key="synthetic",
+        question="What is the difference between ALPHA and BETA?",
+        concepts=("ALPHA", "BETA"),
+        discriminators=["ALPHA is red", "BETA is blue"],
+        comprehension=["What colour is ALPHA?", "What colour is BETA?"],
+        transfer="Something is blue. Is it ALPHA or BETA?",
+        transfer_gold="BETA, because BETA is blue.",
+    )

--- a/evals/explanation_policy/policies.py
+++ b/evals/explanation_policy/policies.py
@@ -16,9 +16,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Dict
 
-# Model used for every arm -- explainer, reader and judge alike. Holding the
-# model fixed across policies is a requirement of the evaluation contract
-# (#93382: "the same model and source content"), not a tuning knob.
+# Reference model for PUBLISHED scorecards. The runner does not pin this: by
+# default it lets the configured auxiliary route answer, like the other evals/
+# harnesses, and records whatever replied on each scorecard row. What the
+# evaluation contract actually requires is that the model be held constant
+# across policies within a run -- "the same model and source content" -- which
+# holds either way. Pass --model to force this one.
 EVAL_MODEL = "anthropic/claude-opus-5"
 
 

--- a/evals/explanation_policy/policies.py
+++ b/evals/explanation_policy/policies.py
@@ -1,0 +1,151 @@
+"""Explanation-policy matrix for the adaptive-explanation eval (#93382).
+
+Each policy is a name -> spec mapping. A spec has:
+  select: (Signals) -> Modality, the policy under test
+  label:  human-readable description, used by report.py
+
+`fixed_markdown` is the control arm from #93382's evaluation contract: one
+concise answer, no modality selection. Every other policy picks a modality
+from the catalog and renders it as Markdown too, so the arms differ only in
+*what* gets explained -- never in transport. Nothing here touches the
+response envelope, so the harness has no dependency on #7191/#61095/#74334.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict
+
+# Model used for every arm -- explainer, reader and judge alike. Holding the
+# model fixed across policies is a requirement of the evaluation contract
+# (#93382: "the same model and source content"), not a tuning knob.
+EVAL_MODEL = "anthropic/claude-opus-5"
+
+
+# Only the signal values some policy actually branches on are defined. #93382
+# lists a wider vocabulary; adding a member no policy reads would be surface
+# with no consumer, and the scorecard could not say anything about it.
+class Intent(str, Enum):
+    ANSWER = "answer"
+    DECIDE = "decide"
+    LEARN = "learn"
+    PRACTICE = "practice"
+    OPERATE = "operate"
+
+
+class Structure(str, Enum):
+    COMPARISON = "comparison"
+    CAUSAL = "causal"
+
+
+class Modality(str, Enum):
+    CONCISE = "concise"
+    COMPARISON_TABLE = "comparison_table"
+    CAUSAL_CHAIN = "causal_chain"
+    WORKED_EXAMPLE = "worked_example"
+    PREDICTION_FIRST = "prediction_first"
+    RETRIEVAL_CHECK = "retrieval_check"
+
+
+@dataclass(frozen=True)
+class Signals:
+    """The bounded, observable inputs a policy may read (#93382).
+
+    `knowledge` is user-declared or evidenced in the current task, never
+    inferred into a durable profile: it is re-supplied per run, stored never.
+    """
+
+    intent: Intent
+    structure: Structure
+    risk: str = "low"
+    knowledge: str = "unknown"  # unknown | novice | practitioner
+
+
+def _always_concise(_: Signals) -> Modality:
+    return Modality.CONCISE
+
+
+def _smallest_useful(s: Signals) -> Modality:
+    """Smallest modality that fits intent + structure.
+
+    A lookup rather than a model call on purpose: the policy under test has to
+    be reproducible across runs, or a scorecard difference cannot be
+    attributed to it. The `practitioner` branch is the expertise-reversal
+    guard -- a reader who declares prior knowledge never gets a worked example.
+    """
+    if s.intent in (Intent.ANSWER, Intent.OPERATE):
+        return Modality.CONCISE
+    if s.intent is Intent.DECIDE:
+        if s.structure is Structure.COMPARISON:
+            return Modality.COMPARISON_TABLE
+        return Modality.CAUSAL_CHAIN
+    if s.intent in (Intent.LEARN, Intent.PRACTICE):
+        if s.knowledge == "practitioner":
+            return Modality.RETRIEVAL_CHECK
+        if s.structure is Structure.COMPARISON:
+            return Modality.COMPARISON_TABLE
+        return Modality.WORKED_EXAMPLE
+    return Modality.CONCISE
+
+
+def _prediction_first(s: Signals) -> Modality:
+    """Retrieval-practice arm: ask before revealing, else smallest useful.
+
+    Deliberately does NOT consult `knowledge`. Expertise reversal is a result
+    about redundant *guidance* -- a worked example a knowledgeable reader has
+    to wade through -- not about retrieval, so `_smallest_useful`'s guard does
+    not apply here. Practitioners losing on this arm would be a finding, not a
+    bug to patch away.
+    """
+    if s.intent in (Intent.LEARN, Intent.PRACTICE):
+        return Modality.PREDICTION_FIRST
+    return _smallest_useful(s)
+
+
+POLICIES: Dict[str, Dict[str, object]] = {
+    "fixed_markdown": {
+        "select": _always_concise,
+        "label": "control: one concise Markdown answer",
+    },
+    "smallest_useful": {
+        "select": _smallest_useful,
+        "label": "smallest modality that fits intent + structure",
+    },
+    "prediction_first": {
+        "select": _prediction_first,
+        "label": "retrieval practice before reveal, then smallest useful",
+    },
+}
+
+# How each modality is rendered. Markdown only: no artifact envelope, no
+# renderer, no client-side component. An unsupported modality falls back to
+# CONCISE, which is the degradation path #93382 asks for.
+RENDER_INSTRUCTIONS: Dict[Modality, str] = {
+    Modality.CONCISE:
+        "At most 120 words of plain prose. No headings, no table, no exercise.",
+    Modality.COMPARISON_TABLE:
+        "A short Markdown table on the axes that actually discriminate the "
+        "concepts, then one sentence naming the axis that matters most.",
+    Modality.CAUSAL_CHAIN:
+        "A cause -> effect chain of at most 5 links, then one sentence on "
+        "which link is load-bearing.",
+    Modality.WORKED_EXAMPLE:
+        "One fully worked concrete example showing the distinction in action, "
+        "then one sentence generalizing from it.",
+    Modality.PREDICTION_FIRST:
+        "Pose ONE short prediction question and stop. Then, after a '---' "
+        "separator, reveal the answer with corrective feedback aimed at the "
+        "likely wrong prediction.",
+    Modality.RETRIEVAL_CHECK:
+        "At most 80 words, then one short retrieval question the reader can "
+        "use to self-check.",
+}
+
+
+def select(policy: str, signals: Signals) -> Modality:
+    """Apply a named policy, failing closed to CONCISE on an unknown name."""
+    spec = POLICIES.get(policy)
+    if spec is None:
+        return Modality.CONCISE
+    fn: Callable[[Signals], Modality] = spec["select"]  # type: ignore[assignment]
+    return fn(signals)

--- a/evals/explanation_policy/report.py
+++ b/evals/explanation_policy/report.py
@@ -1,0 +1,70 @@
+"""Render an explanation-policy scorecard as a terminal table + markdown.
+
+Usage: python evals/explanation_policy/report.py <results_dir>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HEADERS = ("policy", "modality", "n", "comprehension", "transfer", "calib err", "chars", "sec")
+
+
+def main():
+    out_dir = Path(sys.argv[1])
+    card = json.loads((out_dir / "scorecard.json").read_text(encoding="utf-8"))
+    # Transfer first: it is the outcome the policy is supposed to move.
+    card.sort(key=lambda s: (-s["transfer_pct"], -s["comprehension_pct"]))
+
+    models = {s.get("model") for s in card if s.get("model")}
+    if models:
+        print(f"model: {', '.join(sorted(models))}   task: {card[0].get('task', '?')}")
+        if len(models) > 1:
+            print("WARNING: rows come from different models — not comparable.")
+        print()
+
+    rows = [
+        (
+            s["policy"],
+            s["modality"],
+            str(s["n"]),
+            f"{s['comprehension_pct']}%",
+            f"{s['transfer_pct']}%",
+            f"{s['calibration_error']:.3f}",
+            f"{s['explanation_chars']:,}",
+            str(s["seconds"]),
+        )
+        for s in card
+    ]
+
+    widths = [max(len(HEADERS[i]), *(len(r[i]) for r in rows)) for i in range(len(HEADERS))]
+    line = "  ".join(h.ljust(widths[i]) for i, h in enumerate(HEADERS))
+    print(line)
+    print("-" * len(line))
+    for r in rows:
+        print("  ".join(r[i].ljust(widths[i]) for i in range(len(HEADERS))))
+
+    control = next((s for s in card if s["policy"] == "fixed_markdown"), None)
+    if control:
+        print()
+        for s in card:
+            if s["policy"] == control["policy"]:
+                continue
+            d_t = s["transfer_pct"] - control["transfer_pct"]
+            d_c = s["comprehension_pct"] - control["comprehension_pct"]
+            print(
+                f"{s['policy']} vs control: transfer {d_t:+d}pp, "
+                f"comprehension {d_c:+d}pp, "
+                f"{s['explanation_chars'] / max(control['explanation_chars'], 1):.2f}x length"
+            )
+
+    md = ["| " + " | ".join(HEADERS) + " |", "|" + "|".join("---" for _ in HEADERS) + "|"]
+    for r in rows:
+        md.append("| " + " | ".join(r) + " |")
+    (out_dir / "scorecard.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+    print(f"\nmarkdown -> {out_dir}/scorecard.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/explanation_policy/results/.gitignore
+++ b/evals/explanation_policy/results/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!SCORECARD-*.md

--- a/evals/explanation_policy/results/SCORECARD-2026-08-25.md
+++ b/evals/explanation_policy/results/SCORECARD-2026-08-25.md
@@ -1,0 +1,80 @@
+# Explanation policy — first run (2026-08-25): null result, ceiling effect
+
+One concept-comparison task (`value_vs_reference`), three policies, `n=1` each,
+reader and judge on the same model as the explainer.
+
+**Model:** `Qwen3.8-27B` (whatever the configured auxiliary route served — not
+`EVAL_MODEL`; see caveats). **Signals:** `intent=learn`, `structure=comparison`,
+`knowledge=unknown`.
+
+## Results
+
+| policy | modality | comprehension | transfer | calib err | chars | sec |
+|---|---|---|---|---|---|---|
+| fixed_markdown | concise | 100% | 100% | 0.007 | 530 | 183.9 |
+| smallest_useful | comparison_table | 100% | 100% | 0.000 | 770 | 199.4 |
+| prediction_first | prediction_first | 100% | 100% | 0.007 | 670 | 95.6 |
+
+Against the `fixed_markdown` control:
+
+- `smallest_useful`: transfer **+0pp**, comprehension **+0pp**, **1.45x** length
+- `prediction_first`: transfer **+0pp**, comprehension **+0pp**, **1.26x** length
+
+## Reading
+
+**The instrument has no resolution on this task.** Every arm saturates. The
+adaptive policies cost 26–45% more output and buy nothing measurable, which
+under the promotion gate in the README is a clear "not promoted" — a policy that
+inflates length without moving a primary outcome has not won.
+
+This is a ceiling effect, not a lenient judge. The reader's answers were
+substantive and independently correct in all three arms; the transfer item was
+answered with the right mechanism (the identifier may no longer resolve after
+six months, so the replay cannot reproduce what the user saw), not by restating
+the explanation. The judge scored 3/3 items in each arm on answers that deserved
+it.
+
+The modality renderers do work and do differ: `concise` produced plain prose,
+`comparison_table` produced an actual Markdown table on discriminating axes, and
+`prediction_first` produced a prediction question, a `---` separator, and
+corrective feedback aimed at the likely wrong prediction. The policies are
+behaving as specified. The *task* is the problem.
+
+## What this says about the evaluation contract
+
+A four-discriminator concept comparison is too easy for a proxy reader. If the
+control already conveys everything needed for both comprehension and transfer,
+no modality can beat it, and the comparison is uninformative regardless of how
+many repeats you run.
+
+For #93382's evaluation contract this is a real constraint, and it lands before
+any transport work: task families have to be hard enough that the concise
+control genuinely loses information, or the whole comparison measures nothing.
+Concretely, candidates for the next task generation are more discriminators than
+a short answer can carry, transfer items requiring composition of two
+discriminators rather than one, and distractor concepts that a surface reading
+would conflate.
+
+## Caveats — do not over-read this
+
+- **`n=1` per policy.** This is a smoke number. It is enough to establish that
+  all three arms sit at the ceiling, not enough to size any effect.
+- **The reader is a proxy, not a human subject.** A ceiling for a model reader
+  does not imply a ceiling for a person; the failure mode may be specific to a
+  reader that already knows the material from pretraining. This is the sharpest
+  limitation of the harness and it is why the README refuses to call this a
+  result about human learning.
+- **Not `EVAL_MODEL`.** The published reference model is
+  `anthropic/claude-opus-5`; this run served `Qwen3.8-27B`, because that is what
+  the configured auxiliary route returned. Numbers from different models are not
+  comparable, which is why the model is recorded on every scorecard row.
+- **Latency here is route noise**, not a property of the policies. The same
+  route timed out repeatedly at 180s during earlier attempts.
+
+## Reproduce
+
+```bash
+python evals/explanation_policy/runner.py --repeats 1 --timeout 900 \
+    --out evals/explanation_policy/results/run1
+python evals/explanation_policy/report.py evals/explanation_policy/results/run1
+```

--- a/evals/explanation_policy/runner.py
+++ b/evals/explanation_policy/runner.py
@@ -158,6 +158,17 @@ def run_policy(policy: str, task: Task, signals: Signals, model: str | None,
     )
     scored = _extract_json(judged)["scores"]
 
+    # The judge has to return one score per answer, in the order asked. Without
+    # this check a short judge response silently slides a comprehension score
+    # into the transfer slot, or empties transfer entirely and reports it as 0%
+    # -- a wrong number that looks like a real result. Raise instead; main()
+    # records the failed repeat and keeps every other one.
+    if not (len(scored) == len(answers) == len(questions)):
+        raise ValueError(
+            f"cannot align scores to items: {len(questions)} questions, "
+            f"{len(answers)} answers, {len(scored)} scores"
+        )
+
     n_comp = len(task.comprehension)
     comp = scored[:n_comp]
     transfer = scored[n_comp:]
@@ -182,7 +193,12 @@ def run_policy(policy: str, task: Task, signals: Signals, model: str | None,
 
 
 def summarize(policy: str, rs: list) -> dict:
-    """Average one policy's repeats into a scorecard row."""
+    """Average one policy's repeats into a scorecard row.
+
+    The model label is this policy's own, not a union across the whole run: if
+    a route changes mid-run, a global union would make every row claim every
+    model and none of them would be true.
+    """
     def avg(key: str, digits: int = 0):
         value = sum(r[key] for r in rs) / len(rs)
         return round(value, digits) if digits else round(value)
@@ -192,12 +208,30 @@ def summarize(policy: str, rs: list) -> dict:
         "label": rs[0]["label"],
         "modality": rs[0]["modality"],
         "n": len(rs),
+        "model": ", ".join(sorted({m for r in rs for m in r["models"]})),
         "comprehension_pct": avg("comprehension_pct"),
         "transfer_pct": avg("transfer_pct"),
         "calibration_error": avg("calibration_error", 3),
         "explanation_chars": avg("explanation_chars"),
         "seconds": avg("seconds", 1),
     }
+
+
+def write_results(out_dir: Path, runs: list, failures: list, task_key: str) -> None:
+    """Persist everything gathered so far.
+
+    Called after every repeat, not once at the end: a malformed model response
+    on the last policy must not discard the completed, already-paid-for repeats
+    of every earlier one.
+    """
+    (out_dir / "runs.json").write_text(json.dumps(runs, indent=2), encoding="utf-8")
+    if failures:
+        (out_dir / "failures.json").write_text(
+            json.dumps(failures, indent=2), encoding="utf-8")
+    card = [dict(summarize(policy, [r for r in runs if r["policy"] == policy]),
+                 task=task_key)
+            for policy in dict.fromkeys(r["policy"] for r in runs)]
+    (out_dir / "scorecard.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
 
 
 def main():
@@ -234,7 +268,8 @@ def main():
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    runs = []
+    runs: list = []
+    failures: list = []
     for policy in args.policies.split(","):
         policy = policy.strip()
         if policy not in POLICIES:
@@ -242,18 +277,20 @@ def main():
             continue
         for i in range(args.repeats):
             print(f"[{policy}] run {i + 1}/{args.repeats} ...", flush=True)
-            runs.append(run_policy(policy, task, signals, args.model, args.timeout))
+            try:
+                runs.append(
+                    run_policy(policy, task, signals, args.model, args.timeout))
+            except Exception as exc:  # noqa: BLE001 - one bad call must not void the run
+                print(f"  FAILED: {type(exc).__name__}: {exc}", flush=True)
+                failures.append({"policy": policy, "repeat": i + 1,
+                                 "error": f"{type(exc).__name__}: {exc}"})
+            write_results(out_dir, runs, failures, task.key)
 
-    (out_dir / "runs.json").write_text(json.dumps(runs, indent=2), encoding="utf-8")
-
-    # The model goes on every row: a scorecard that does not say which model
-    # produced it cannot be compared to any other scorecard.
-    models = sorted({m for r in runs for m in r["models"]})
-    card = [dict(summarize(policy, [r for r in runs if r["policy"] == policy]),
-                 model=", ".join(models), task=task.key)
-            for policy in dict.fromkeys(r["policy"] for r in runs)]
-    (out_dir / "scorecard.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
-    print(f"\nwrote {out_dir}/scorecard.json  ({len(runs)} runs)")
+    if not runs:
+        print("\nno successful runs; see failures.json")
+        return
+    print(f"\nwrote {out_dir}/scorecard.json  ({len(runs)} runs"
+          + (f", {len(failures)} failed)" if failures else ")"))
     print(f"render it with: python evals/explanation_policy/report.py {out_dir}")
 
 

--- a/evals/explanation_policy/runner.py
+++ b/evals/explanation_policy/runner.py
@@ -1,0 +1,261 @@
+"""Explanation-policy eval runner (#93382, Markdown-only slice).
+
+Pipeline per policy, on one concept-comparison task:
+  1. Apply the policy to the task's signals -> a modality.
+  2. Explain the concept under that modality's render instruction. Markdown
+     out, always -- no artifact envelope.
+  3. Hand that explanation, and nothing else, to a fresh reader model, which
+     answers the comprehension and transfer items with a confidence each.
+  4. Judge those answers with a separate call that sees gold; the reader
+     never does.
+  5. Emit scorecard.json for report.py.
+
+The reader is a PROXY, not a human subject: this measures what survives an
+explanation, which is a prerequisite for the human study #93382 describes,
+not a substitute for it.
+
+Run from the repo root, venv active, provider configured:
+
+    python evals/explanation_policy/runner.py --out evals/explanation_policy/results/run1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from evals.explanation_policy.fixtures import Task, get_task  # noqa: E402
+from evals.explanation_policy.policies import (  # noqa: E402
+    EVAL_MODEL,
+    POLICIES,
+    RENDER_INSTRUCTIONS,
+    Intent,
+    Signals,
+    Structure,
+    select,
+)
+
+EXPLAIN_PROMPT = """You are answering a user's question. Follow the format instruction exactly.
+
+Question: {question}
+
+Format instruction: {instruction}
+
+Cover these points; do not add unrelated material:
+{gold}
+"""
+
+READ_PROMPT = """Read the explanation below, then answer the questions using ONLY what it taught you.
+
+--- explanation ---
+{explanation}
+--- end explanation ---
+
+Answer each question, and rate your confidence that your answer is correct
+from 0 to 100. Reply with JSON only:
+
+{{"answers": [{{"q": "<question>", "a": "<your answer>", "confidence": <0-100>}}]}}
+
+Questions:
+{questions}
+"""
+
+JUDGE_PROMPT = """Score a reader's answers against the reference. Be strict: an answer
+scores 1 only if it is substantively correct, 0 otherwise. Restating the
+question, or a vague gesture at the right area, scores 0.
+
+Reference:
+{gold}
+
+Reader's answers:
+{answers}
+
+Reply with JSON only: {{"scores": [0 or 1, ...]}} in the same order.
+"""
+
+
+def _call(prompt: str, task: str, model: str | None, timeout: float,
+          max_tokens: int = 1500):
+    """Return (text, model_the_provider_reported).
+
+    With no `model` the configured auxiliary route decides, which is how the
+    other harnesses in `evals/` call this. We record what came back rather
+    than what we asked for: a scorecard has to name the model that actually
+    produced it, and a route can answer with something else entirely.
+
+    `timeout` is passed explicitly on purpose. These task names are not in
+    anyone's `auxiliary.*` config, so they fall back to _DEFAULT_AUX_TIMEOUT
+    (30s) -- far too short for a model composing a worked example, and the
+    failure looks like a provider problem rather than a config default.
+    """
+    from agent.auxiliary_client import call_llm
+
+    kwargs = {"messages": [{"role": "user", "content": prompt}],
+              "task": task, "max_tokens": max_tokens, "timeout": timeout}
+    if model:
+        kwargs["model"] = model
+    resp = call_llm(**kwargs)
+    reported = getattr(resp, "model", None) or model or "unknown"
+    if hasattr(resp, "choices"):
+        return resp.choices[0].message.content or "", reported
+    return str(resp), reported
+
+
+def _extract_json(text: str):
+    m = re.search(r"```(?:json)?\s*(.*?)```", text, re.S)
+    if m:
+        text = m.group(1)
+    start = min([i for i in (text.find("["), text.find("{")) if i >= 0], default=0)
+    return json.loads(text[start:])
+
+
+def run_policy(policy: str, task: Task, signals: Signals, model: str | None,
+               timeout: float) -> dict:
+    started = time.time()
+    modality = select(policy, signals)
+
+    explanation, m1 = _call(
+        EXPLAIN_PROMPT.format(
+            question=task.question,
+            instruction=RENDER_INSTRUCTIONS[modality],
+            gold=task.gold,
+        ),
+        task="explanation_policy_explain",
+        model=model,
+        timeout=timeout,
+    )
+
+    questions = list(task.comprehension) + [task.transfer]
+    raw, m2 = _call(
+        READ_PROMPT.format(
+            explanation=explanation,
+            questions="\n".join(f"{i + 1}. {q}" for i, q in enumerate(questions)),
+        ),
+        task="explanation_policy_read",
+        model=model,
+        timeout=timeout,
+    )
+    answers = _extract_json(raw)["answers"]
+
+    gold = task.gold + f"\n\nTransfer item -- correct answer:\n{task.transfer_gold}"
+    judged, m3 = _call(
+        JUDGE_PROMPT.format(
+            gold=gold,
+            answers=json.dumps(
+                [{"q": a.get("q"), "a": a.get("a")} for a in answers], indent=2
+            ),
+        ),
+        task="explanation_policy_judge",
+        model=model,
+        timeout=timeout,
+        max_tokens=400,
+    )
+    scored = _extract_json(judged)["scores"]
+
+    n_comp = len(task.comprehension)
+    comp = scored[:n_comp]
+    transfer = scored[n_comp:]
+    confidences = [float(a.get("confidence", 0)) / 100 for a in answers]
+    accuracy = sum(scored) / len(scored) if scored else 0.0
+    mean_conf = sum(confidences) / len(confidences) if confidences else 0.0
+
+    return {
+        "policy": policy,
+        "label": POLICIES[policy]["label"],
+        "modality": modality.value,
+        "models": sorted({m1, m2, m3}),
+        "comprehension_pct": round(100 * sum(comp) / len(comp)) if comp else 0,
+        "transfer_pct": round(100 * sum(transfer) / len(transfer)) if transfer else 0,
+        "calibration_error": round(abs(mean_conf - accuracy), 3),
+        "explanation_chars": len(explanation),
+        "seconds": round(time.time() - started, 1),
+        "explanation": explanation,
+        "answers": answers,
+        "scores": scored,
+    }
+
+
+def summarize(policy: str, rs: list) -> dict:
+    """Average one policy's repeats into a scorecard row."""
+    def avg(key: str, digits: int = 0):
+        value = sum(r[key] for r in rs) / len(rs)
+        return round(value, digits) if digits else round(value)
+
+    return {
+        "policy": policy,
+        "label": rs[0]["label"],
+        "modality": rs[0]["modality"],
+        "n": len(rs),
+        "comprehension_pct": avg("comprehension_pct"),
+        "transfer_pct": avg("transfer_pct"),
+        "calibration_error": avg("calibration_error", 3),
+        "explanation_chars": avg("explanation_chars"),
+        "seconds": avg("seconds", 1),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task", default="value_vs_reference")
+    ap.add_argument("--policies", default=",".join(POLICIES))
+    ap.add_argument("--intent", default="learn", choices=[i.value for i in Intent])
+    ap.add_argument("--structure", default="comparison", choices=[s.value for s in Structure])
+    ap.add_argument("--knowledge", default="unknown", choices=["unknown", "novice", "practitioner"])
+    ap.add_argument("--repeats", type=int, default=1, help="runs per policy; report averages")
+    ap.add_argument(
+        "--model",
+        default=None,
+        help=(f"force a model for every arm. Default: let the configured auxiliary "
+              f"route decide, as the other evals/ harnesses do. Published reference "
+              f"scorecards use {EVAL_MODEL}; whatever runs, the model the provider "
+              f"reports is recorded on every scorecard row."),
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=180.0,
+        help=("per-call timeout in seconds. These task names are in nobody's "
+              "auxiliary config, so without this the 30s aux default applies "
+              "and a slow explanation looks like a provider failure."),
+    )
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    task = get_task(args.task)
+    signals = Signals(
+        intent=Intent(args.intent),
+        structure=Structure(args.structure),
+        knowledge=args.knowledge,
+    )
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = []
+    for policy in args.policies.split(","):
+        policy = policy.strip()
+        if policy not in POLICIES:
+            print(f"skipping unknown policy: {policy}")
+            continue
+        for i in range(args.repeats):
+            print(f"[{policy}] run {i + 1}/{args.repeats} ...", flush=True)
+            runs.append(run_policy(policy, task, signals, args.model, args.timeout))
+
+    (out_dir / "runs.json").write_text(json.dumps(runs, indent=2), encoding="utf-8")
+
+    # The model goes on every row: a scorecard that does not say which model
+    # produced it cannot be compared to any other scorecard.
+    models = sorted({m for r in runs for m in r["models"]})
+    card = [dict(summarize(policy, [r for r in runs if r["policy"] == policy]),
+                 model=", ".join(models), task=task.key)
+            for policy in dict.fromkeys(r["policy"] for r in runs)]
+    (out_dir / "scorecard.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
+    print(f"\nwrote {out_dir}/scorecard.json  ({len(runs)} runs)")
+    print(f"render it with: python evals/explanation_policy/report.py {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

Adds `evals/explanation_policy/`, a harness that measures whether choosing *how*
to explain something changes what a reader can do with it — comprehension,
transfer, and confidence calibration — against a fixed-Markdown control.

This is the policy/evaluation layer from #93382, cut down to the part that needs
no response envelope. Every arm renders as ordinary Markdown, so the harness has
**no dependency on #7191, #61095 or #74334** and adds **no core surface**: no
model tool, no CLI command, no config key, no system-prompt change, nothing on
the Footprint Ladder. It is measurement, not an extension point — there is no
hook or interface here for anything to depend on, just a runner you invoke by
hand, like `evals/compaction` and `evals/readtool`.

Answering the question raised on #93382 — whether to wait for an envelope
decision — this is the "useful first PR" side of it: the evaluator is the only
piece of that proposal with zero dependencies, and it is what tells us whether
the modality selection is worth building transport for at all.

## Related Issue

Refs #93382, now consolidated into #93319.

#93382 was closed and folded into the #93319 research index shortly after this
PR was opened, and that index asks that no PRs land from it while subtopics
carry `needs-decision`. This PR answers a direct question asked on that thread
before the consolidation — whether a Markdown-only policy/evaluator would be a
useful first PR.

The distinction I would draw: this is an eval harness under `evals/`, not an
implementation of the adaptive-explanation feature. No core surface, nothing
shipped to users, and its purpose is to produce evidence *for* a
`needs-decision` item rather than to pre-empt the decision — the first published
result argues against the feature as specified. If a maintainer reads it as code
landing from the index, say so and I will close it.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

New directory, nothing else touched:

- `evals/explanation_policy/policies.py` — intent/structure/modality enums, the
  policy matrix (`fixed_markdown` control + two arms), and the Markdown render
  instruction per modality. `select()` fails closed to `CONCISE` on an unknown
  policy name.
- `evals/explanation_policy/fixtures.py` — one concept-comparison task with its
  gold discriminators, comprehension items and a transfer item; plus a synthetic
  task with mechanically checkable gold, reachable as `--task synthetic`, so the
  whole chain can be smoked against a live provider in three cheap calls.
- `evals/explanation_policy/runner.py` — explain → read → judge pipeline. The
  reader sees only the explanation; the judge sees gold and the reader never
  does. Writes `runs.json` + `scorecard.json`.
- `evals/explanation_policy/report.py` — scorecard table, deltas against the
  control, `scorecard.md`.
- `evals/explanation_policy/README.md` — what it measures, how to run it, the
  promotion gate, and an explicit statement of what it is *not*.
- `evals/explanation_policy/results/.gitignore` — runs ignored, dated
  `SCORECARD-*.md` publishable, following `evals/readtool`.

Only signal values a policy actually branches on are defined. `Intent` and
`Structure` are narrower than the vocabulary #93382 lists, because an enum member
no policy reads is surface with no consumer and the scorecard could say nothing
about it.

### Three things found by running it, now documented in the code

1. Passing an explicit `model=` to `call_llm` breaks the configured auxiliary
   route. `evals/compaction` does not pass one; neither do we by default.
2. The model that answers is not necessarily the one requested, so the harness
   records `resp.model` — what the provider reported — on every scorecard row.
   A scorecard that does not name its model cannot be compared to another one.
3. These task names are in nobody's `auxiliary.*` config, so they fall back to
   `_DEFAULT_AUX_TIMEOUT` (30s) — far too short for a model composing a worked
   example, and the failure surfaces as `APITimeoutError`, which reads like a
   provider fault rather than a config default. Hence the explicit `--timeout`.

### First run is a null result, and it is published as one

`results/SCORECARD-2026-08-25.md`, `n=1` per policy on `Qwen3.8-27B`:

| policy | modality | comprehension | transfer | calib err | chars |
|---|---|---|---|---|---|
| fixed_markdown | concise | 100% | 100% | 0.007 | 530 |
| smallest_useful | comparison_table | 100% | 100% | 0.000 | 770 |
| prediction_first | prediction_first | 100% | 100% | 0.007 | 670 |

Every arm saturates. The adaptive policies cost 26–45% more output and buy
**+0pp** on both primary outcomes — under the README's promotion gate, a clear
"not promoted".

This is a ceiling in the *task*, not a lenient judge. The renderers do differ as
specified (prose / a real Markdown table / a prediction question, `---`, then
corrective feedback), and the reader answered the transfer item with the right
mechanism rather than restating the explanation. The task is simply easy enough
that the concise control already carries everything needed.

That is the useful part for #93382, and it lands before any transport work: a
four-discriminator concept comparison is too easy for a proxy reader, so no
modality can beat the control and the comparison is uninformative no matter how
many repeats you run. Task families have to be hard enough that the concise
control genuinely loses information.

Caveats are in the scorecard and I would rather they were read: `n=1` is a smoke
number, the reader is a proxy and not a human subject, and this ran on
`Qwen3.8-27B` rather than `EVAL_MODEL` because that is what my configured
auxiliary route served. If a maintainer wants this against a specific model, say
which and I will re-run the matrix.

## How to Test

```bash
# pure logic, no LLM calls — policy matrix, fail-closed, render coverage
python -c "
import sys; sys.path.insert(0,'.')
from evals.explanation_policy.policies import *
s = Signals(Intent.LEARN, Structure.COMPARISON)
print({p: select(p, s).value for p in POLICIES})
print('practitioner:', select('smallest_useful', Signals(Intent.LEARN, Structure.COMPARISON, knowledge='practitioner')).value)
print('unknown policy fails closed to:', select('nope', s).value)
"

# end-to-end smoke against your provider — 3 calls, a few hundred tokens
python evals/explanation_policy/runner.py \
    --task synthetic --policies fixed_markdown --repeats 1 \
    --out evals/explanation_policy/results/smoke
python evals/explanation_policy/report.py evals/explanation_policy/results/smoke

# full run
python evals/explanation_policy/runner.py --repeats 3 --timeout 900 \
    --out evals/explanation_policy/results/run1
python evals/explanation_policy/report.py evals/explanation_policy/results/run1
```

The synthetic task's gold is mechanically checkable ("ALPHA is red"), so a
working pipeline scores 100% on it. Anything less means the plumbing is broken
rather than the policy — one cheap call instead of twenty-seven expensive ones.

Expected from the logic check: `smallest_useful` picks `comparison_table` for a
learner on a comparison, `retrieval_check` for a declared practitioner (the
expertise-reversal guard), and any unknown policy name falls closed to
`concise`.

**Platform tested:** Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes — the `--task synthetic` smoke run
      exercises the full chain against a live provider and its gold is
      mechanically checkable; plus the pure-logic check above
- [x] I've tested on my platform: Windows 11

**On `pytest tests/`:** I could not run the full suite locally — the project venv
is not set up on this machine and collection fails on missing declared
dependencies. What I can state precisely instead: `testpaths = ["tests"]`, so
pytest never collects `evals/`, and `rg -l 'from evals|import evals'` outside
`evals/` returns nothing. This change is structurally incapable of affecting the
suite. Happy to run it if a maintainer would rather see it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `README.md` in the new directory
- [x] `cli-config.yaml.example` — N/A, no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — file I/O uses explicit `encoding="utf-8"`
      throughout, per the `PLW1514` rule in `pyproject.toml`
- [x] Tool descriptions/schemas — N/A, no tool behavior changed
