### PR TITLE
fix(desktop/bots): stop treating retained terminal turn errors as live work

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7275,6 +7275,40 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
   }
 }
 
+/** A retained `inflight` object is not necessarily live. The gateway keeps a
+ * compact status=error snapshot after `running` flips false so reconnecting
+ * clients can replay the failure. Every other inflight shape is conservative
+ * live work, including a non-streaming gap between tool/provider operations. */
+function groupSessionTurnActive(state) {
+  if (state?.running) {
+    return true
+  }
+
+  const inflight = state?.inflight
+  if (!inflight) {
+    return false
+  }
+
+  if (typeof inflight !== 'object') {
+    return Boolean(inflight)
+  }
+
+  return inflight.streaming === true || inflight.status !== 'error'
+}
+
+function groupSessionTerminalError(state) {
+  const inflight = state?.inflight
+  if (!inflight || typeof inflight !== 'object') {
+    return null
+  }
+
+  if (inflight.status !== 'error' && !inflight.error) {
+    return null
+  }
+
+  return String(inflight.error || 'turn failed')
+}
+
 async function runGroupChatMemberTurnLeased(group, member, prompt, thread, images) {
   const { runtime, stored } = await ensureGroupChatSession(group, member)
 
@@ -7369,12 +7403,18 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
     }
 
     const messages = Array.isArray(state?.messages) ? state.messages : []
-    const busy = Boolean(state?.inflight || state?.running)
+    const terminalError = groupSessionTerminalError(state)
+    const busy = groupSessionTurnActive(state)
     // A clarify blocking inside the member's session is a question for the
     // HUMAN (#90694) — mirror it into the room store so a card renders, and
     // hold the turn open: the member isn't stalling, it's waiting on us.
     const awaitingUser = syncGroupClarify(group, member, state)
     const done = !busy && !awaitingUser
+
+    if (terminalError && !busy && !awaitingUser) {
+      syncGroupClarify(group, member, null)
+      throw new Error(terminalError)
+    }
 
     if (messages.length > before && done) {
       for (let i = messages.length - 1; i >= 0; i--) {
@@ -7452,8 +7492,22 @@ async function harvestStrandedGroupReply(group, member) {
     return // source unreachable — leave the marker for the next boundary
   }
 
-  if (state?.inflight || state?.running) {
+  if (groupSessionTurnActive(state)) {
     return // still grinding — keep waiting
+  }
+
+  const terminalError = groupSessionTerminalError(state)
+  if (terminalError) {
+    syncGroupClarify(group, member, null)
+    updateGroupChat(group, r => {
+      const next = { ...(r.stranded || {}) }
+      delete next[memberKey]
+      r.stranded = next
+      return r
+    })
+    recordGroupActivity(group, { kind: 'failed', member: member.name, thread: strandedThread })
+    noteBotAttention(memberKey, terminalError)
+    return
   }
 
   // A stranded member blocked on a clarify is not "grinding" — surface the

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, terminalErrorByProfile, conflictOnce = false, deferredTimers = false, timerAdvanceMs = 0 } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -30,6 +30,12 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   const sharedUiMeta = {}
   const uiMetaRevisions = {}
   let sessionSequence = 0
+  let fakeNow = 0
+  class TestDate extends Date {
+    static now() {
+      return timerAdvanceMs ? fakeNow : Date.now()
+    }
+  }
   // busyUntilResumeCall[profile] = N: this profile's session.resume reports
   // inflight/running for its first N calls, then flips to done — simulating
   // a turn that is genuinely still running when harvested, without an
@@ -44,7 +50,11 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   }
   const context = {
     atom,
-    setTimeout: fn => {
+    Date: TestDate,
+    setTimeout: (fn, delay = 0) => {
+      if (Number(delay) >= 2000) {
+        fakeNow += timerAdvanceMs
+      }
       if (deferredTimers) {
         setImmediate(fn)
         return 1
@@ -158,8 +168,8 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             session_key: session.stored,
             message_count: session.messages.length,
             messages: [...session.messages],
-            inflight: busy,
-            running: busy,
+            inflight: session.inflightSnapshot || session.terminalError || busy,
+            running: session.runningSnapshot ?? busy,
             ...(pendingClarify ? { pending_clarify: pendingClarify } : {}),
             ...(pendingApproval ? { pending_approval: pendingApproval } : {})
           }
@@ -177,6 +187,16 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             stored: session.stored,
             title: session.title
           })
+          const retainedError = terminalErrorByProfile && terminalErrorByProfile[session.profile]
+          if (retainedError) {
+            session.terminalError = {
+              status: 'error',
+              streaming: false,
+              error: retainedError,
+              user: params.text
+            }
+            return {}
+          }
           const reply = turnScript(session.profile, params.text, calls.length, session)
           session.messages.push({ role: 'assistant', content: reply })
           return {}
@@ -204,7 +224,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, currentGroupActivity, $botAttention, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -212,7 +232,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, resumeCallCounts, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -319,6 +339,48 @@ test('failed member turn is a pass, not a room error', async () => {
 
   const log = roomLog(gc, 'Flaky')
   assert.equal(log.length, 1) // just the user message; no error entries
+})
+
+test('retained terminal inflight error fails immediately instead of consuming the hard cap', async () => {
+  const gc = load(() => '(pass)', {
+    deferredTimers: true,
+    terminalErrorByProfile: { research: 'provider quota exhausted' },
+    timerAdvanceMs: 1000
+  })
+
+  gc.sendToGroupChat('Terminal Error', [{ name: 'research', title: '' }], 'run expensive task')
+  for (let i = 0; i < 100 && (gc.$groupChats.get()['Terminal Error'] || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const room = gc.$groupChats.get()['Terminal Error']
+  assert.equal(room.running, false)
+  assert.equal(Object.keys(room.stranded || {}).length, 0, 'terminal failure is not stranded as live work')
+  assert.ok(gc.resumeCallCounts.get('research') <= 2, 'preflight plus one terminal poll only')
+  assert.equal(gc.$botAttention.get().research?.reason, 'provider_quota_limit')
+  assert.equal(gc.$botAttention.get().research?.message, 'provider quota exhausted')
+  assert.equal(
+    gc.currentGroupActivity('Terminal Error').some(event => event.kind === 'failed' && event.member === 'research'),
+    true,
+    'the terminal error reaches the existing failed-turn activity path'
+  )
+})
+
+test('retained error snapshot does not abort while the gateway still reports the turn running', async () => {
+  const gc = load(() => '(pass)', {
+    busyUntilResumeCall: { research: 2 },
+    deferredTimers: true,
+    terminalErrorByProfile: { research: 'provider retry still settling' },
+    timerAdvanceMs: 1000
+  })
+
+  gc.sendToGroupChat('Live Error', [{ name: 'research', title: '' }], 'run task')
+  for (let i = 0; i < 100 && (gc.$groupChats.get()['Live Error'] || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.ok(gc.resumeCallCounts.get('research') >= 3, 'poll continues until running flips false')
+  assert.equal(Object.keys(gc.$groupChats.get()['Live Error'].stranded || {}).length, 0)
 })
 
 test('delta injection: a second user send only feeds members the NEW messages', async () => {
@@ -1525,6 +1587,92 @@ test('stranded harvest: a timed-out turn whose reply landed late posts into the 
   assert.equal(log[0].from.name, 'research')
   assert.match(log[0].text, /delivered late/)
   assert.equal(gc.$groupChats.get().Late.stranded.research, undefined, 'marker consumed')
+})
+
+test('stranded harvest consumes a retained terminal inflight error instead of waiting forever', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  gc.sessions.set('sid-terminal', {
+    stored: 'sid-terminal',
+    runtime: 'rt-terminal',
+    profile: 'research',
+    title: 'Group: Terminal Harvest',
+    messages: [{ role: 'user', content: 'expensive task' }],
+    terminalError: {
+      status: 'error',
+      streaming: false,
+      error: 'provider quota exhausted',
+      user: 'expensive task'
+    }
+  })
+  gc.updateGroupChat('Terminal Harvest', room => {
+    room.sessions = { research: 'sid-terminal' }
+    room.stranded = { research: { before: 1, thread: 'legacy' } }
+    return room
+  })
+
+  await gc.harvestStrandedGroupReply('Terminal Harvest', member)
+
+  assert.equal(gc.$groupChats.get()['Terminal Harvest'].stranded.research, undefined)
+  assert.equal(roomLog(gc, 'Terminal Harvest').filter(entry => entry.from.kind === 'member').length, 0)
+})
+
+test('stranded harvest keeps a non-error inflight snapshot even when it is temporarily non-streaming', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  gc.sessions.set('sid-tool-gap', {
+    stored: 'sid-tool-gap',
+    runtime: 'rt-tool-gap',
+    profile: 'research',
+    title: 'Group: Active Snapshot',
+    messages: [{ role: 'user', content: 'long tool task' }],
+    inflightSnapshot: { status: 'running', streaming: false, user: 'long tool task' }
+  })
+  gc.updateGroupChat('Active Snapshot', room => {
+    room.sessions = { research: 'sid-tool-gap' }
+    room.stranded = { research: { before: 1, thread: 'legacy' } }
+    return room
+  })
+
+  await gc.harvestStrandedGroupReply('Active Snapshot', member)
+
+  assert.ok(gc.$groupChats.get()['Active Snapshot'].stranded.research, 'non-error inflight work remains harvestable')
+})
+
+test('stranded harvest preserves every live compatibility shape', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  const cases = [
+    { name: 'Truthy Running', runningSnapshot: 1 },
+    { name: 'Streaming Error', inflightSnapshot: { status: 'error', streaming: true, error: 'partial retry' } },
+    { name: 'Nonterminal Error Field', inflightSnapshot: { status: 'running', streaming: false, error: 'retry note' } },
+    { name: 'Legacy Inflight', inflightSnapshot: 'legacy-busy' }
+  ]
+
+  for (const [index, fixture] of cases.entries()) {
+    const sessionId = `sid-live-${index}`
+    gc.sessions.set(sessionId, {
+      stored: sessionId,
+      runtime: `rt-live-${index}`,
+      profile: 'research',
+      title: `Group: ${fixture.name}`,
+      messages: [{ role: 'user', content: 'still running' }],
+      ...(fixture.runningSnapshot !== undefined ? { runningSnapshot: fixture.runningSnapshot } : {}),
+      ...(fixture.inflightSnapshot !== undefined ? { inflightSnapshot: fixture.inflightSnapshot } : {})
+    })
+    gc.updateGroupChat(fixture.name, room => {
+      room.sessions = { research: sessionId }
+      room.stranded = { research: { before: 1, thread: 'legacy' } }
+      return room
+    })
+
+    await gc.harvestStrandedGroupReply(fixture.name, member)
+
+    assert.ok(
+      gc.$groupChats.get()[fixture.name].stranded.research,
+      `${fixture.name} must remain active`
+    )
+  }
 })
 
 test('stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running', async () => {


### PR DESCRIPTION
## What does this PR do?

Bot Mode group rooms currently classify any truthy `session.resume.inflight` value as active. The gateway intentionally retains a replayable terminal snapshot after a failed turn, with this shape:

```text
running: false
inflight.status: "error"
inflight.streaming: false
```

Because the retained object is truthy, the room keeps extending the member deadline up to the hard cap, and a timed-out/stranded marker can remain harvestable forever even though the backend has already finished.

This PR adds one conservative turn-state classifier shared by the foreground poller and stranded harvester:

- `running: true` always remains active;
- primitive truthy `inflight` values remain active for older gateways;
- non-error inflight objects remain active, including a temporary `streaming: false` provider/tool gap;
- only a retained `status: "error"` snapshot with no live `running` signal is terminal.

A terminal snapshot now reaches the existing failed-turn path immediately. Stranded terminal markers are consumed, the room activity records the failure, and the bot attention state receives the backend error instead of polling forever.

## Related Issue

Related to #92760 (the issue tracks several independent Bot Mode latency and silent-stall classes, so this PR intentionally does not close it).

Complementary to #94160: that PR makes a member-turn exception visible in the room; this PR makes a retained gateway failure stop polling and reach that exception path promptly. It does not add or duplicate #94160's failure-message rendering.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - distinguish live inflight work from the gateway's retained terminal-error snapshot;
  - stop the foreground Group Chat poller immediately on a terminal snapshot;
  - consume terminal stranded markers instead of leaving them permanently busy;
  - preserve conservative handling for live retries and non-streaming tool/provider gaps.
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`
  - reproduce the retained terminal snapshot shape in the real plugin VM harness;
  - cover foreground settlement, live-running error snapshots, terminal stranded cleanup, and non-error non-streaming snapshots.

## How to Test

1. Run the focused regression tests:
   ```bash
   cd apps/desktop
   node --test --test-reporter=spec --test-name-pattern='retained terminal|retained error snapshot|stranded harvest consumes|stranded harvest keeps' src/plugins/hermes-bots/tests/group-chat.test.mjs
   ```
2. Run the entire Group Chat and Hermes Bots plugin suites:
   ```bash
   node --test --test-reporter=spec src/plugins/hermes-bots/tests/group-chat.test.mjs
   node --test --test-reporter=spec src/plugins/hermes-bots/tests/*.test.mjs
   ```
3. Run Desktop UI tests and type checks:
   ```bash
   npm run test:ui
   npm run typecheck
   ```

Observed locally:

- focused terminal-state regressions: 5/5 passed (the two bug reproductions fail on unmodified `main`);
- Group Chat suite: 94/94 passed;
- Hermes Bots plugin suite: 561/561 passed;
- Desktop UI: 596 files, 5,736 tests passed;
- all Desktop/UI/Electron/E2E TypeScript configs passed;
- ESLint, `node --check`, and `git diff --check` passed;
- independent fresh-context review and Claude Opus cross-model review both passed with zero blocking findings.

`scripts/run_tests.sh` was also attempted, but this checkout's available Python virtualenv does not contain `pytest`, so the wrapper exited before collecting tests. No Python files are changed by this PR; the Draft PR's CI remains the authoritative repo-wide Python gate.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs and kept this change separate from #92041, #93580, #93903, #94160, #94999, and #95007
- [x] My PR contains only changes related to this bug
- [x] I've added tests for the bug and observed the regression fail on unmodified `main`
- [x] I've tested on macOS 15.7.9 (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior fix only
- [x] `cli-config.yaml.example` update — N/A; no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow change
- [x] Cross-platform impact considered — pure JavaScript state classification, no OS APIs
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

The regression harness uses the same retained snapshot contract pinned by `tests/tui_gateway/test_failed_turn_retention.py`: after a failed turn, `session.running` is false while `_inflight_snapshot()` retains `status: "error"`, `streaming: false`, and the error text for reconnect replay.
