### PR TITLE
feat(desktop): pop the in-app Browser into its own window

### DIFF
--- a/apps/desktop/electron/browser-windows.test.ts
+++ b/apps/desktop/electron/browser-windows.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { buildBrowserWindowUrl } from './browser-windows'
+
+test('buildBrowserWindowUrl puts win=browser before the hash (dev server)', () => {
+  const url = buildBrowserWindowUrl('url:browser-1', { devServer: 'http://localhost:5173' })
+
+  assert.equal(url, 'http://localhost:5173/?win=browser&tab=url%3Abrowser-1#/')
+  assert.ok(url.indexOf('?win=browser') < url.indexOf('#'))
+})
+
+test('buildBrowserWindowUrl encodes the tab id', () => {
+  const url = buildBrowserWindowUrl('url:browser a/b', { devServer: 'http://localhost:5173' })
+
+  assert.equal(url, 'http://localhost:5173/?win=browser&tab=url%3Abrowser%20a%2Fb#/')
+})
+
+test('buildBrowserWindowUrl avoids a double slash when the dev server has a trailing slash', () => {
+  const url = buildBrowserWindowUrl('t', { devServer: 'http://localhost:5173/' })
+
+  assert.equal(url, 'http://localhost:5173/?win=browser&tab=t#/')
+})
+
+test('buildBrowserWindowUrl omits a blank tab', () => {
+  assert.equal(buildBrowserWindowUrl('  ', { devServer: 'http://localhost:5173' }), 'http://localhost:5173/?win=browser#/')
+  assert.equal(buildBrowserWindowUrl(null, { devServer: 'http://localhost:5173' }), 'http://localhost:5173/?win=browser#/')
+})
+
+test('buildBrowserWindowUrl builds a packaged file URL with the flag before the hash', () => {
+  const url = buildBrowserWindowUrl('abc', { rendererIndexPath: '/opt/app/index.html' })
+
+  assert.match(url, /^file:\/\/.*index\.html\?win=browser&tab=abc#\/$/)
+})

--- a/apps/desktop/electron/browser-windows.ts
+++ b/apps/desktop/electron/browser-windows.ts
@@ -1,0 +1,31 @@
+// Popped-out in-app Browser windows. Same query-before-hash contract as
+// session-windows / hud-url: `?win=browser` MUST sit in the search string
+// before the '#', or HashRouter swallows it as part of the route.
+
+import { pathToFileURL } from 'node:url'
+
+export const BROWSER_WINDOW_WIDTH = 960
+export const BROWSER_WINDOW_HEIGHT = 720
+export const BROWSER_WINDOW_MIN_WIDTH = 480
+export const BROWSER_WINDOW_MIN_HEIGHT = 400
+
+/**
+ * Renderer URL for a popped-out Browser. `tab` is the `$previewTabs` id the
+ * window should show — the tab stays in storage so closing the window can
+ * dock it again. Absent/blank tab is still a valid Browser window (blank page).
+ */
+export function buildBrowserWindowUrl(
+  tabId: null | string | undefined,
+  { devServer, rendererIndexPath }: { devServer?: null | string; rendererIndexPath?: string } = {}
+): string {
+  const tab = typeof tabId === 'string' ? tabId.trim() : ''
+  const query = `?win=browser${tab ? `&tab=${encodeURIComponent(tab)}` : ''}`
+
+  if (devServer) {
+    const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
+
+    return `${base}/${query}#/`
+  }
+
+  return `${pathToFileURL(rendererIndexPath!).toString()}${query}#/`
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -283,6 +283,13 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
 import {
+  BROWSER_WINDOW_HEIGHT,
+  BROWSER_WINDOW_MIN_HEIGHT,
+  BROWSER_WINDOW_MIN_WIDTH,
+  BROWSER_WINDOW_WIDTH,
+  buildBrowserWindowUrl
+} from './browser-windows'
+import {
   classifyStoredSecret,
   readSecretStoragePolicy,
   SECRET_STORAGE_POLICY_FILE,
@@ -11598,6 +11605,87 @@ function createSessionWindow(sessionId, { watch = false } = {}) {
   return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
 }
 
+// Popped-out in-app Browser: same webview + address bar as a docked Browser
+// tab, in its own OS window. One window per tab id (re-open focuses); closing
+// it tells the other renderers so they can dock the tab again.
+const browserWindows = createSessionWindowRegistry()
+
+function notifyBrowserPopoutClosed(tabId) {
+  if (typeof tabId !== 'string' || !tabId) {
+    return
+  }
+
+  for (const other of BrowserWindow.getAllWindows()) {
+    if (!other.isDestroyed()) {
+      other.webContents.send('hermes:browser-popout:closed', tabId)
+    }
+  }
+}
+
+function spawnBrowserWindow(tabId) {
+  const icon = getAppIconPath()
+
+  const win = new BrowserWindow({
+    width: BROWSER_WINDOW_WIDTH,
+    height: BROWSER_WINDOW_HEIGHT,
+    minWidth: BROWSER_WINDOW_MIN_WIDTH,
+    minHeight: BROWSER_WINDOW_MIN_HEIGHT,
+    title: 'Hermes',
+    titleBarStyle: 'hidden',
+    titleBarOverlay: getTitleBarOverlayOptions(),
+    trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
+    ...chatWindowSurfaceOptions(),
+    icon,
+    show: false,
+    webPreferences: chatWindowWebPreferences(PRELOAD_PATH)
+  })
+
+  translucencyBackedWindows.add(win)
+
+  if (IS_MAC) {
+    win.setWindowButtonPosition?.(WINDOW_BUTTON_POSITION)
+  }
+
+  wireWindowReveal(win)
+
+  win.on('enter-full-screen', () => sendWindowStateChanged(true))
+  win.on('leave-full-screen', () => sendWindowStateChanged(false))
+
+  streamThrottle.register(win)
+  wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
+  attachRendererConsoleCapture(win, 'browser-window', rememberLog)
+
+  installWindowRendererLifecycle(win, {
+    kind: 'browser',
+    callbacks: {
+      log: rememberLog,
+      reload: () => {
+        win.webContents.reload()
+      }
+    },
+    reloadWindowMs: RENDERER_RELOAD_WINDOW_MS,
+    reloadMax: RENDERER_RELOAD_MAX,
+    recentReloadTimesRef: rendererReloadTimesRef
+  })
+
+  win.on('closed', () => notifyBrowserPopoutClosed(tabId))
+
+  loadWindowUrl(
+    win,
+    buildBrowserWindowUrl(tabId, {
+      devServer: DEV_SERVER,
+      rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
+    }),
+    'Browser window'
+  )
+
+  return win
+}
+
+function createBrowserWindow(tabId) {
+  return browserWindows.openOrFocus(tabId, () => spawnBrowserWindow(tabId))
+}
+
 // Additional full "instance" windows — peers of the primary that render the
 // COMPLETE app (sidebar, routing, its own draft) against the shared backend, so
 // a user can run multiple GUI windows at once (⌘⇧N / the "New Window" palette
@@ -12878,6 +12966,15 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
 })
 ipcMain.handle('hermes:window:openInstance', async () => {
   createInstanceWindow()
+
+  return { ok: true }
+})
+ipcMain.handle('hermes:window:openBrowser', async (_event, tabId) => {
+  if (typeof tabId !== 'string' || !tabId.trim()) {
+    return { ok: false, error: 'invalid-tab-id' }
+  }
+
+  createBrowserWindow(tabId.trim())
 
   return { ok: true }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -76,6 +76,13 @@ import {
 } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
+import {
+  BROWSER_WINDOW_HEIGHT,
+  BROWSER_WINDOW_MIN_HEIGHT,
+  BROWSER_WINDOW_MIN_WIDTH,
+  BROWSER_WINDOW_WIDTH,
+  buildBrowserWindowUrl
+} from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
 import { applyConnectionChange } from './connection-apply'
 import {
@@ -282,13 +289,6 @@ import {
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
-import {
-  BROWSER_WINDOW_HEIGHT,
-  BROWSER_WINDOW_MIN_HEIGHT,
-  BROWSER_WINDOW_MIN_WIDTH,
-  BROWSER_WINDOW_WIDTH,
-  buildBrowserWindowUrl
-} from './browser-windows'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -29,6 +29,13 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openSessionInTerminal: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openInTerminal', sessionId, opts),
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),
+  openBrowserWindow: tabId => ipcRenderer.invoke('hermes:window:openBrowser', tabId),
+  onBrowserPopoutClosed: callback => {
+    const listener = (_event, tabId) => callback(tabId)
+    ipcRenderer.on('hermes:browser-popout:closed', listener)
+
+    return () => ipcRenderer.removeListener('hermes:browser-popout:closed', listener)
+  },
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
   wakeIndicator: {
     getState: () => ipcRenderer.invoke('hermes:wake-indicator:get'),

--- a/apps/desktop/src/app/chat/browser-popout-shell.tsx
+++ b/apps/desktop/src/app/chat/browser-popout-shell.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from 'react'
+
+import { PanelEmpty } from '@/app/overlays/panel'
+import { TITLEBAR_HEIGHT } from '@/app/shell/titlebar'
+import { useI18n } from '@/i18n'
+import { windowBrowserTabId } from '@/store/windows'
+
+import { PreviewTilePane } from './right-rail/preview'
+
+/**
+ * Dedicated shell for `?win=browser`: the in-app Browser, full-window, no
+ * session sidebar or layout tree. Same webview + address bar the docked tab
+ * uses — just in its own OS window.
+ */
+export function BrowserPopoutShell() {
+  const { t } = useI18n()
+  const tabId = windowBrowserTabId()
+
+  return (
+    <div
+      className="flex h-screen min-h-0 w-screen flex-col bg-(--ui-bg-chrome) text-(--ui-text-primary)"
+      data-contrib-shell=""
+      style={{ '--titlebar-height': `${TITLEBAR_HEIGHT}px` } as CSSProperties}
+    >
+      <div
+        aria-hidden="true"
+        className="relative shrink-0 bg-(--ui-bg-chrome)"
+        style={{ height: TITLEBAR_HEIGHT }}
+      >
+        {/* Same traffic-light / native-overlay carve-out as the main titlebar:
+            a full-bar drag region would eat the window buttons. */}
+        <div
+          className="pointer-events-none absolute inset-y-0 left-0 w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]"
+        />
+        <div
+          className="pointer-events-none absolute inset-y-0 left-[calc(var(--titlebar-controls-left,14px)+(var(--titlebar-control-size,24px)*2)+0.75rem)] right-[calc(var(--titlebar-tools-right,0.75rem)+0.75rem)] [-webkit-app-region:drag]"
+        />
+      </div>
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+        {tabId ? (
+          <PreviewTilePane tabId={tabId} />
+        ) : (
+          <div className="grid h-full place-items-center">
+            <PanelEmpty description={t.preview.web.blankPageBody} icon="globe" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -22,13 +22,18 @@ import { openExternalLink } from '@/lib/external-link'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
 import {
   $browserPages,
+  $dockedPreviewTabs,
   $previewTabs,
+  adoptPersistedBrowserTab,
   type BrowserPage,
   closeRightRailTab,
   forgetBrowserPage,
+  markBrowserTabPopped,
   newBrowserTab,
+  popOutBrowserTab,
   type PreviewTarget
 } from '@/store/preview'
+import { canOpenBrowserWindow } from '@/store/windows'
 
 import { paneMirror } from './pane-mirror'
 import { PreviewTilePane } from './right-rail/preview'
@@ -63,14 +68,25 @@ function browserTabMenuPrefix(tabId: string) {
     return undefined
   }
 
-  return (kit: MenuKit) =>
-    renderActionItem(kit, {
-      disabled: !browserTabExternalUrl(tabId),
-      icon: 'link-external',
-      key: 'open-external',
-      label: translateNow('preview.openInExternal'),
-      onSelect: () => openExternalLink(browserTabExternalUrl(tabId) ?? '')
-    })
+  return (kit: MenuKit) => (
+    <>
+      {canOpenBrowserWindow()
+        ? renderActionItem(kit, {
+            icon: 'empty-window',
+            key: 'pop-out',
+            label: translateNow('preview.popOut'),
+            onSelect: () => popOutBrowserTab(tabId)
+          })
+        : null}
+      {renderActionItem(kit, {
+        disabled: !browserTabExternalUrl(tabId),
+        icon: 'link-external',
+        key: 'open-external',
+        label: translateNow('preview.openInExternal'),
+        onSelect: () => openExternalLink(browserTabExternalUrl(tabId) ?? '')
+      })}
+    </>
+  )
 }
 
 /** Tab title. A URL tab is titled by the CONTRIBUTION as the surface — see
@@ -169,7 +185,7 @@ function existingPreviewAnchor(tabId: string): string | undefined {
     return inTree
   }
 
-  const other = $previewTabs.get().find(tab => tab.id !== tabId)
+  const other = $dockedPreviewTabs.get().find(tab => tab.id !== tabId)
 
   return other ? previewPaneId(other.id) : undefined
 }
@@ -179,6 +195,11 @@ function existingPreviewAnchor(tabId: string): string | undefined {
  *  selected. Call once from the root. */
 export function watchPreviewTiles(): void {
   watchPreviewTileMirror()
+
+  window.hermesDesktop?.onBrowserPopoutClosed?.(tabId => {
+    adoptPersistedBrowserTab(tabId)
+    markBrowserTabPopped(tabId, false)
+  })
 
   // The reveal analog of session tiles (session-states calls revealTreePane on
   // open): `openPreview` selects the tab, and the TREE must front its pane —
@@ -223,7 +244,7 @@ export function watchPreviewTiles(): void {
 }
 
 const watchPreviewTileMirror = paneMirror<{ id: string }>({
-  source: $previewTabs,
+  source: $dockedPreviewTabs,
   // Unscoped on purpose. `$previewTabs` is one global Browser/file surface —
   // clicking a link in a bot chat must open the same pane Sessions already
   // shows. Scoping this to `sessions` filtered the pane out of Bot Mode, so

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
@@ -12,7 +12,7 @@ const baseProps = {
   onBack: vi.fn(),
   onForward: vi.fn(),
   onNavigate: vi.fn(),
-  onOpenExternal: vi.fn(),
+  onPopOut: vi.fn(),
   onReload: vi.fn(),
   onToggleConsole: vi.fn(),
   onToggleDevTools: vi.fn(),
@@ -86,7 +86,7 @@ describe('PreviewBrowserBar', () => {
     expect(rendered.getByRole('button', { name: 'Forward' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Reload page' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Copy URL' })).toBeTruthy()
-    expect(rendered.getByRole('button', { name: 'Open in browser' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Pop out' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Show preview console' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Open preview DevTools' })).toBeTruthy()
     expect(address(rendered)).toBeTruthy()
@@ -110,7 +110,7 @@ describe('PreviewBrowserBar', () => {
     ['Back', 'onBack'],
     ['Forward', 'onForward'],
     ['Reload page', 'onReload'],
-    ['Open in browser', 'onOpenExternal']
+    ['Pop out', 'onPopOut']
   ] as const)('fires %s', (label, handler) => {
     const spy = vi.fn()
     const rendered = render(<PreviewBrowserBar {...baseProps} canGoBack canGoForward {...{ [handler]: spy }} />)
@@ -316,5 +316,39 @@ describe('PreviewBrowserBar', () => {
     // code-block copy icon (inline appearance, overlay on the field's edge).
     expect(copyButton.parentElement?.contains(address)).toBe(true)
     expect(copyButton.className).toContain('absolute')
+  })
+
+  it('shows Open in browser when only the external handler is provided', () => {
+    const onOpenExternal = vi.fn()
+    const rendered = render(
+      <PreviewBrowserBar {...baseProps} onOpenExternal={onOpenExternal} onPopOut={undefined} />
+    )
+
+    expect(rendered.getByRole('button', { name: 'Open in browser' })).toBeTruthy()
+    expect(rendered.queryByRole('button', { name: 'Pop out' })).toBeNull()
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Open in browser' }))
+
+    expect(onOpenExternal).toHaveBeenCalledOnce()
+  })
+
+  it('prefers pop-out over open-in-browser when both handlers are provided', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} onOpenExternal={vi.fn()} />)
+
+    expect(rendered.getByRole('button', { name: 'Pop out' })).toBeTruthy()
+    expect(rendered.queryByRole('button', { name: 'Open in browser' })).toBeNull()
+  })
+
+  it('shows Pop in when the window is already popped out', () => {
+    const onPopIn = vi.fn()
+    const rendered = render(<PreviewBrowserBar {...baseProps} onPopIn={onPopIn} onPopOut={undefined} />)
+
+    expect(rendered.getByRole('button', { name: 'Pop in' })).toBeTruthy()
+    expect(rendered.queryByRole('button', { name: 'Pop out' })).toBeNull()
+    expect(rendered.queryByRole('button', { name: 'Open in browser' })).toBeNull()
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Pop in' }))
+
+    expect(onPopIn).toHaveBeenCalledOnce()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -1,6 +1,6 @@
 /**
- * BROWSER BAR: back / forward / reload / address / open-in-browser for a URL
- * preview.
+ * BROWSER BAR: back / forward / reload / address / pop-out (or pop-in) for a
+ * URL preview.
  *
  * The Browser tab had no way to move: no history, and the only address on
  * screen was a read-only label. Every other embedded browser (VS Code's Simple
@@ -32,7 +32,9 @@ interface PreviewBrowserBarProps {
   onBack: () => void
   onForward: () => void
   onNavigate: (url: string) => void
-  onOpenExternal: () => void
+  onOpenExternal?: () => void
+  onPopIn?: () => void
+  onPopOut?: () => void
   onReload: () => void
   onToggleConsole: () => void
   onToggleDevTools: () => void
@@ -96,6 +98,8 @@ export function PreviewBrowserBar({
   onForward,
   onNavigate,
   onOpenExternal,
+  onPopIn,
+  onPopOut,
   onReload,
   onToggleConsole,
   onToggleDevTools,
@@ -202,11 +206,25 @@ export function PreviewBrowserBar({
           text={url}
         />
       </div>
-      <PaneStripGlyph
-        icon={<Codicon name="link-external" size="0.8125rem" />}
-        label={t.preview.openInBrowser}
-        onSelect={onOpenExternal}
-      />
+      {onPopIn ? (
+        <PaneStripGlyph
+          icon={<Codicon name="screen-normal" size="0.8125rem" />}
+          label={t.preview.popIn}
+          onSelect={onPopIn}
+        />
+      ) : onPopOut ? (
+        <PaneStripGlyph
+          icon={<Codicon name="empty-window" size="0.8125rem" />}
+          label={t.preview.popOut}
+          onSelect={onPopOut}
+        />
+      ) : onOpenExternal ? (
+        <PaneStripGlyph
+          icon={<Codicon name="link-external" size="0.8125rem" />}
+          label={t.preview.openInBrowser}
+          onSelect={onOpenExternal}
+        />
+      ) : null}
       <PaneStripGlyph
         active={consoleOpen}
         icon={<Codicon name="terminal" size="0.8125rem" />}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -18,7 +18,16 @@ import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $previewServerRestart, failPreviewServerRestart, noteBrowserPage, type PreviewTarget } from '@/store/preview'
+import {
+  $browserPages,
+  $previewServerRestart,
+  commitBrowserTabLocation,
+  failPreviewServerRestart,
+  noteBrowserPage,
+  popOutBrowserTab,
+  type PreviewTarget
+} from '@/store/preview'
+import { canOpenBrowserWindow, isBrowserWindow } from '@/store/windows'
 
 import { ArtifactPreview } from './preview-artifact'
 import { PreviewBrowserBar } from './preview-browser-bar'
@@ -59,6 +68,20 @@ type PreviewWebview = HTMLElement & {
   replaceMisspelling?: (word: string) => void
   selectAll?: () => void
   sendInputEvent?: (event: PreviewInputEvent) => void
+}
+
+/** Electron throws if getURL/getTitle run before attach + dom-ready, or after
+ *  the guest has been removed. Optional chaining does not help — the method
+ *  exists, it just refuses. */
+function guestPage(webview: PreviewWebview | null | undefined, fallbackUrl = ''): { title: string; url: string } {
+  try {
+    return {
+      title: webview?.getTitle?.() ?? '',
+      url: webview?.getURL?.() || fallbackUrl
+    }
+  } catch {
+    return { title: '', url: fallbackUrl }
+  }
 }
 
 /** The raw Chromium params riding the webview tag's `context-menu` event. */
@@ -213,6 +236,8 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
   const [currentUrl, setCurrentUrl] = useState(target.url)
+  const liveUrlRef = useRef(currentUrl)
+  liveUrlRef.current = currentUrl
   const [devtoolsOpen, setDevtoolsOpen] = useState(false)
   const [history, setHistory] = useState({ back: false, forward: false })
   const [loading, setLoading] = useState(true)
@@ -227,6 +252,27 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
   const isRemoteHtmlTarget =
     target.kind === 'file' && target.previewKind === 'html' && Boolean(target.dataUrl || target.transient)
+
+  // Hand the live address to storage when this guest is about to go away
+  // (pop-out, dock-back, tab close). The other renderer builds from
+  // `target.url`; without this it would reopen the tab's original page.
+  useEffect(() => {
+    if (target.kind !== 'url' || !tabId) {
+      return
+    }
+
+    const persist = () => {
+      const page = $browserPages.get()[tabId]
+      commitBrowserTabLocation(tabId, page?.url || liveUrlRef.current, page?.title)
+    }
+
+    window.addEventListener('pagehide', persist)
+
+    return () => {
+      window.removeEventListener('pagehide', persist)
+      persist()
+    }
+  }, [tabId, target.kind])
 
   const isRemoteHtml = isRemoteHtmlTarget && target.renderMode !== 'source' && Boolean(target.dataUrl)
 
@@ -459,8 +505,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
       return {
         text: typeof text === 'string' ? text : '',
-        title: webview.getTitle?.() ?? '',
-        url: webview.getURL?.() ?? ''
+        ...guestPage(webview)
       }
     })
   }, [isWebPreview, tabId])
@@ -741,14 +786,19 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       if ((detail.level ?? 0) >= 3 && isModuleMimeError(message)) {
         setLoadError({
           description: copy.moduleMimeDescription,
-          url: webview.getURL?.() || target.url
+          url: guestPage(webview, target.url).url
         })
         setLoading(false)
       }
     }
 
-    const syncHistory = () =>
-      setHistory({ back: webview.canGoBack?.() ?? false, forward: webview.canGoForward?.() ?? false })
+    const syncHistory = () => {
+      try {
+        setHistory({ back: webview.canGoBack?.() ?? false, forward: webview.canGoForward?.() ?? false })
+      } catch {
+        // Same attach / dom-ready rule as getURL.
+      }
+    }
 
     // Tell the strip what this Browser is showing, so its tab renames itself
     // like a tab anywhere else. Deliberately NOT written back into the tab's
@@ -759,7 +809,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
         return
       }
 
-      noteBrowserPage(tabId, { title: webview.getTitle?.() ?? '', url: webview.getURL?.() || target.url })
+      noteBrowserPage(tabId, guestPage(webview, target.url))
     }
 
     const onNavigate = (event: Event) => {
@@ -799,7 +849,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       setLoadError({
         code: errorCode,
         description: detail.errorDescription || copy.unreachableDescription,
-        url: detail.validatedURL || webview.getURL?.() || target.url
+        url: detail.validatedURL || guestPage(webview, target.url).url
       })
       setLoading(false)
     }
@@ -981,7 +1031,15 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             onBack={goBack}
             onForward={goForward}
             onNavigate={navigateTo}
-            onOpenExternal={() => void window.hermesDesktop?.openExternal(currentUrl)}
+            onOpenExternal={
+              !isBrowserWindow() && !canOpenBrowserWindow()
+                ? () => void window.hermesDesktop?.openExternal(currentUrl)
+                : undefined
+            }
+            onPopIn={isBrowserWindow() ? () => window.close() : undefined}
+            onPopOut={
+              isBrowserWindow() || !tabId || !canOpenBrowserWindow() ? undefined : () => popOutBrowserTab(tabId)
+            }
             onReload={reloadPreview}
             onToggleConsole={() => consoleState.setOpen(open => !open)}
             onToggleDevTools={toggleDevTools}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -105,6 +105,7 @@ vi.mock('@/store/session-states', () => ({
 vi.mock('@/store/windows', () => ({
   canOpenSessionInTerminal: () => false,
   canOpenSessionWindow: () => false,
+  isBrowserWindow: () => false,
   isSecondaryWindow: () => false,
   openSessionInNewWindow: vi.fn(),
   openSessionInTerminal: vi.fn()

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -72,8 +72,9 @@ import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionM
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
-import { isHudWindow } from '@/store/windows'
+import { isBrowserWindow, isHudWindow } from '@/store/windows'
 
+import { BrowserPopoutShell } from '../chat/browser-popout-shell'
 import type { SessionDragPayload } from '../chat/composer/inline-refs'
 import { watchPreviewTiles } from '../chat/preview-tile'
 import { watchRouteTiles } from '../chat/route-tile'
@@ -451,10 +452,14 @@ discoverBundledPlugins()
 watchContributedPanes()
 
 // Session + route (page) tiles: persisted splits register panes docked beside
-// main.
-watchSessionTiles()
-watchRouteTiles()
-watchPreviewTiles()
+// main. A popped-out Browser has no layout tree — registering tiles there
+// would still run, and preview-tile watching would try to dock into a tree
+// this window never renders.
+if (!isBrowserWindow()) {
+  watchSessionTiles()
+  watchRouteTiles()
+  watchPreviewTiles()
+}
 
 // Composer pop-out state is keyed by layout zone, so drop entries for zones the
 // user has since closed or merged away — otherwise a long-lived install keeps a
@@ -817,6 +822,14 @@ export function ContribController() {
     return (
       <ContribWiring>
         <HudShell />
+      </ContribWiring>
+    )
+  }
+
+  if (isBrowserWindow()) {
+    return (
+      <ContribWiring>
+        <BrowserPopoutShell />
       </ContribWiring>
     )
   }

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -25,7 +25,7 @@ import {
 } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
-import { isHudWindow, isSecondaryWindow } from '@/store/windows'
+import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
@@ -97,7 +97,7 @@ export function useDesktopIntegrations({
   // This ref is a one-time lifecycle latch, not a mirror of reactive atom state.
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    if (!profileReady || isHudWindow()) {
+    if (!profileReady || isHudWindow() || isBrowserWindow()) {
       return
     }
 
@@ -332,7 +332,7 @@ export function useDesktopIntegrations({
 
   // Another window mutated the shared session list -> re-pull the sidebar.
   useEffect(() => {
-    if (isSecondaryWindow()) {
+    if (isSecondaryWindow() || isBrowserWindow()) {
       return
     }
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -83,7 +83,7 @@ import { requestForSessionProfile, type SessionOwnerScope } from '@/store/sessio
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
-import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
+import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { closeWorkspaceTab } from '../chat/close-tab'
@@ -1175,10 +1175,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           } as CSSProperties
         }
       >
-        {/* HUD mode has no titlebar to hang these off — the clusters are
-            `fixed`, so without this they'd float over the chat as orphaned
-            buttons. Exits are the ⌘⇧H toggle and ⌘W. */}
-        {!isHudWindow() && (
+        {/* HUD and the popped-out Browser have no titlebar to hang these off —
+            the clusters are `fixed`, so without this they'd float over the
+            surface as orphaned buttons. */}
+        {!isHudWindow() && !isBrowserWindow() && (
           <TitlebarControls
             leftTools={leftTitlebarTools}
             onOpenSettings={() => navigate(SETTINGS_ROUTE)}
@@ -1298,11 +1298,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       {/* Petdex floating mascot — renders nothing unless installed + enabled.
           Never in the HUD: that window is the chat bar and nothing else. */}
-      {!isHudWindow() && <FloatingPet />}
+      {!isHudWindow() && !isBrowserWindow() && <FloatingPet />}
 
       {/* Single persistent xterm host chasing the terminal pane's slot rect.
           The HUD has no terminal pane, so it has nothing to chase. */}
-      {!isHudWindow() && <PersistentTerminal onAddSelectionToChat={composer.addTerminalSelectionAttachment} />}
+      {!isHudWindow() && !isBrowserWindow() && <PersistentTerminal onAddSelectionToChat={composer.addTerminalSelectionAttachment} />}
     </ContribWiringContext.Provider>
   )
 }

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -13,7 +13,7 @@ import { translateNow } from '@/i18n'
 import { readJson, readKey, writeJson, writeKey } from '@/lib/storage'
 import { notify } from '@/store/notifications'
 import { clearAllPaneSizeOverrides } from '@/store/panes'
-import { isSecondaryWindow } from '@/store/windows'
+import { isBrowserWindow, isSecondaryWindow } from '@/store/windows'
 
 import {
   allPaneIds,
@@ -65,7 +65,8 @@ function loadPersisted(): LayoutNode | null {
 function persist(tree: LayoutNode | null) {
   // A secondary window (single-chat pop-out) shares the origin's localStorage;
   // writing its stripped-down DEFAULT tree back would wipe the primary's layout.
-  if (isSecondaryWindow()) {
+  // A popped-out Browser is the same class of window.
+  if (isSecondaryWindow() || isBrowserWindow()) {
     return
   }
 
@@ -75,7 +76,9 @@ function persist(tree: LayoutNode | null) {
 /** The live tree (null until a default is declared). A secondary window ignores
  *  the persisted (primary) layout and boots to the default — nothing but its
  *  own routed session. */
-export const $layoutTree = atom<LayoutNode | null>(isSecondaryWindow() ? null : loadPersisted())
+export const $layoutTree = atom<LayoutNode | null>(
+  isSecondaryWindow() || isBrowserWindow() ? null : loadPersisted()
+)
 
 /**
  * Which layout preset the current tree came from; `'custom'` after the user

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -63,6 +63,11 @@ declare global {
       // renders the complete app against the shared backend, so the user can run
       // multiple GUI windows at once.
       openWindow: () => Promise<{ ok: boolean; error?: string }>
+      // Pop the in-app Browser (webview + address bar) into its own OS window.
+      // `tabId` is the `$previewTabs` id; closing the window fires
+      // `onBrowserPopoutClosed` so the caller can dock the tab again.
+      openBrowserWindow: (tabId: string) => Promise<{ ok: boolean; error?: string }>
+      onBrowserPopoutClosed: (callback: (tabId: string) => void) => () => void
       // Claim a one-shot cross-window ambient cue (turn-end sound / spoken
       // reply). Resolves true for the first window to claim a key, false for
       // peers — so N open windows don't all fire the same cue.

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2328,6 +2328,8 @@ export const ar = defineLocale({
     openPreview: 'فتح المعاينة',
     openInBrowser: 'فتح في المتصفح',
     openInExternal: 'فتح في الخارج',
+    popIn: 'إدخال',
+    popOut: 'إخراج',
     linkHint: '⌘/Ctrl-نقر لجزء المعاينة',
     sourceLineTitle: 'انقر للتحديد · shift-نقر للتوسيع · اسحب إلى المُنشئ',
     source: 'المصدر',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2971,6 +2971,8 @@ export const en: Translations = {
     openPreview: 'Open preview',
     openInBrowser: 'Open in browser',
     openInExternal: 'Open in external',
+    popIn: 'Pop in',
+    popOut: 'Pop out',
     linkHint: '⌘/Ctrl-click for preview pane',
     sourceLineTitle: 'Click to select · shift-click to extend · drag to composer',
     source: 'SOURCE',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2625,6 +2625,8 @@ export const ja = defineLocale({
     openPreview: 'プレビューを開く',
     openInBrowser: 'ブラウザで開く',
     openInExternal: '外部で開く',
+    popIn: 'ポップイン',
+    popOut: 'ポップアウト',
     linkHint: '⌘/Ctrl+クリックでプレビューペイン',
     sourceLineTitle: 'クリックして選択 · Shift クリックで拡張 · コンポーザーにドラッグ',
     source: 'ソース',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2536,6 +2536,8 @@ export interface Translations {
     openPreview: string
     openInBrowser: string
     openInExternal: string
+    popIn: string
+    popOut: string
     linkHint: string
     sourceLineTitle: string
     source: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2536,6 +2536,8 @@ export const zhHant = defineLocale({
     openPreview: '開啟預覽',
     openInBrowser: '在瀏覽器中開啟',
     openInExternal: '在外部開啟',
+    popIn: '彈回',
+    popOut: '彈出',
     linkHint: '⌘/Ctrl+點擊在預覽窗格開啟',
     sourceLineTitle: '點擊選取 · shift 點擊擴展 · 拖曳至輸入框',
     source: '原始碼',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3135,6 +3135,8 @@ export const zh: Translations = {
     openPreview: '打开预览',
     openInBrowser: '在浏览器中打开',
     openInExternal: '在外部打开',
+    popIn: '弹回',
+    popOut: '弹出',
     linkHint: '⌘/Ctrl+点击在预览面板打开',
     sourceLineTitle: '点击选择 · shift 点击扩展 · 拖到输入框',
     source: '源码',

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -6,7 +6,6 @@ import {
   $previewServerRestartStatus,
   $previewTabs,
   $previewTarget,
-  adoptPersistedBrowserTab,
   beginPreviewServerRestart,
   closePreviewForSource,
   closePreviewMatching,

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -6,11 +6,13 @@ import {
   $previewServerRestartStatus,
   $previewTabs,
   $previewTarget,
+  adoptPersistedBrowserTab,
   beginPreviewServerRestart,
   closePreviewForSource,
   closePreviewMatching,
   closeRightRail,
   closeRightRailTab,
+  commitBrowserTabLocation,
   newBrowserTab,
   openPreview,
   previewTabId,
@@ -82,6 +84,18 @@ describe('preview store', () => {
     expect(urlTabs).toHaveLength(1)
     expect(urlTabs[0].target.url).toBe('https://www.reddit.com')
     expect($rightRailActiveTabId.get()).toBe(urlTabs[0].id)
+  })
+
+  it('commits the live page onto a Browser tab without changing its id', () => {
+    openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
+    const id = $previewTabs.get()[0].id
+
+    commitBrowserTabLocation(id, 'https://news.ycombinator.com/item?id=1', 'Item')
+
+    expect($previewTabs.get()).toHaveLength(1)
+    expect($previewTabs.get()[0].id).toBe(id)
+    expect($previewTabs.get()[0].target.url).toBe('https://news.ycombinator.com/item?id=1')
+    expect($previewTabs.get()[0].target.label).toBe('Item')
   })
 
   it('opens more than one Browser on request, each holding its own page', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -1,9 +1,11 @@
 import { atom, computed } from 'nanostores'
 
 import { persistentAtom } from '@/lib/persisted'
+import { readKey } from '@/lib/storage'
 import { normalize } from '@/lib/text'
 
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from './layout'
+import { canOpenBrowserWindow, openBrowserInNewWindow } from './windows'
 
 /**
  * PREVIEW RAIL — one list of tabs, one way in.
@@ -205,6 +207,124 @@ export function forgetBrowserPage(tabId: string) {
     $browserPages.set(rest)
   }
 }
+
+/** Write the page a Browser is showing back onto its persisted tab. The
+ *  webview is built from `target.url`, so this is for hand-off (pop-out /
+ *  dock-back), not for every in-page hop — that would tear the guest down. */
+export function commitBrowserTabLocation(tabId: string, url: string, title?: string) {
+  const nextUrl = url.trim()
+
+  if (!tabId || !nextUrl) {
+    return
+  }
+
+  const tabs = $previewTabs.get()
+  const index = tabs.findIndex(tab => tab.id === tabId)
+
+  if (index === -1) {
+    return
+  }
+
+  const tab = tabs[index]
+  const nextTitle = title?.trim()
+
+  if (tab.target.kind !== 'url' || (tab.target.url === nextUrl && (!nextTitle || tab.target.label === nextTitle))) {
+    return
+  }
+
+  $previewTabs.set(
+    tabs.map((item, i) =>
+      i === index
+        ? {
+            ...item,
+            target: {
+              ...item.target,
+              ...(nextTitle ? { label: nextTitle } : {}),
+              url: nextUrl
+            }
+          }
+        : item
+    )
+  )
+}
+
+/** Pull one tab from storage into this renderer's atom. A sibling window
+ *  (the pop-out) may have committed a newer URL that we never saw. */
+export function adoptPersistedBrowserTab(tabId: string) {
+  if (!tabId) {
+    return
+  }
+
+  try {
+    const raw = readKey(TABS_STORAGE_KEY)
+
+    if (!raw) {
+      return
+    }
+
+    const persisted = decodePreviewTabs(raw).find(tab => tab.id === tabId)
+
+    if (!persisted || persisted.target.kind !== 'url') {
+      return
+    }
+
+    commitBrowserTabLocation(tabId, persisted.target.url, persisted.target.label)
+  } catch {
+    // Storage can throw; the in-memory tab stays as it was.
+  }
+}
+
+/** Pop the in-app Browser into its own OS window. Shared by the address-bar
+ *  glyph and the tab context menu so they cannot drift. */
+export function popOutBrowserTab(tabId: string) {
+  if (!tabId || !canOpenBrowserWindow()) {
+    return
+  }
+
+  const tab = $previewTabs.get().find(item => item.id === tabId)
+
+  if (!tab || tab.target.kind !== 'url') {
+    return
+  }
+
+  const page = $browserPages.get()[tabId]
+
+  markBrowserTabPopped(tabId, true)
+  commitBrowserTabLocation(tabId, page?.url || tab.target.url, page?.title)
+  void openBrowserInNewWindow(tabId).then(ok => {
+    if (!ok) {
+      markBrowserTabPopped(tabId, false)
+    }
+  })
+}
+
+/** Tabs currently shown in a popped-out Browser window. The docked tree
+ *  hides them so the page isn't in two places; closing the window docks
+ *  them again. Memory-only — a relaunch with no pop-out window restores. */
+export const $poppedBrowserTabIds = atom<ReadonlySet<string>>(new Set())
+
+export function markBrowserTabPopped(tabId: string, popped: boolean) {
+  const current = $poppedBrowserTabIds.get()
+
+  if (current.has(tabId) === popped) {
+    return
+  }
+
+  const next = new Set(current)
+
+  if (popped) {
+    next.add(tabId)
+  } else {
+    next.delete(tabId)
+  }
+
+  $poppedBrowserTabIds.set(next)
+}
+
+/** Preview tabs that still belong in the layout tree (not popped out). */
+export const $dockedPreviewTabs = computed([$previewTabs, $poppedBrowserTabIds], (tabs, popped) =>
+  popped.size === 0 ? tabs : tabs.filter(tab => !popped.has(tab.id))
+)
 
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -51,7 +51,7 @@ import {
 } from './session'
 import { requestForSessionProfile, type SessionOwnerScope, type SessionProfileRoute } from './session-request-router'
 import { ackStoredSessionId, markSessionUnreadFinished } from './session-unread'
-import { isSecondaryWindow } from './windows'
+import { isBrowserWindow, isSecondaryWindow } from './windows'
 
 // ---------------------------------------------------------------------------
 // Reactive per-runtime session state (view mirror of the wiring cache).
@@ -687,13 +687,15 @@ const profileKey = () => normalizeProfileKey($activeGatewayProfile.get())
 // A secondary window (single-chat pop-out) shows ONLY its routed session — no
 // tiles, and no repopulation on a profile switch.
 export const $sessionTiles = atom<SessionTile[]>(
-  isSecondaryWindow() ? [] : [...(tilesByProfile[profileKey()] ?? []), ...(tilesByProfile[BOTS_TILE_BUCKET] ?? [])]
+  isSecondaryWindow() || isBrowserWindow()
+    ? []
+    : [...(tilesByProfile[profileKey()] ?? []), ...(tilesByProfile[BOTS_TILE_BUCKET] ?? [])]
 )
 
 function persistTiles() {
-  // Shares the origin's storage; a secondary window holds no tiles, so a write
-  // back would only wipe the primary's set.
-  if (isSecondaryWindow()) {
+  // Shares the origin's storage; a secondary / browser pop-out holds no tiles,
+  // so a write back would only wipe the primary's set.
+  if (isSecondaryWindow() || isBrowserWindow()) {
     return
   }
 
@@ -725,7 +727,7 @@ function saveTiles(tiles: SessionTile[]) {
 // they re-resume against the now-current gateway. (Fires immediately on
 // subscribe; harmless — the init value already matches.) A secondary window
 // never carries tiles, so it stays out of this entirely.
-if (!isSecondaryWindow()) {
+if (!isSecondaryWindow() && !isBrowserWindow()) {
   $activeGatewayProfile.subscribe(() => {
     $sessionTiles.set([...(tilesByProfile[profileKey()] ?? []), ...(tilesByProfile[BOTS_TILE_BUCKET] ?? [])])
   })

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -13,7 +13,7 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from './session'
-import { isSecondaryWindow } from './windows'
+import { isBrowserWindow, isSecondaryWindow } from './windows'
 
 /**
  * PERSISTED UNREAD ("finished — unread" green dot) — the durable layer under
@@ -554,7 +554,7 @@ function onListChange(): void {
 // (single-chat pop-out, watch window) sees a sliver of the session lists, and
 // letting it seed/ack against that partial view would clobber the primary's
 // whole-record writes — same isolation rule as the persisted session tiles.
-if (!isSecondaryWindow()) {
+if (!isSecondaryWindow() && !isBrowserWindow()) {
   $sessions.listen(onListChange)
   $cronSessions.listen(onListChange)
   $messagingSessions.listen(onListChange)

--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -151,7 +151,7 @@ export function setTranslucencyScope(scope: GlassScope): void {
 // secondary session windows). The HUD, pet overlay, quick entry and wake
 // indicator are transparent special-purpose windows that manage their own
 // backgrounds — a page-surface rewrite there would fight them.
-const CHAT_WINDOW_KINDS = new Set([null, 'secondary'])
+const CHAT_WINDOW_KINDS = new Set([null, 'secondary', 'browser'])
 
 export const isChatWindow = (search = typeof window === 'undefined' ? '' : window.location.search): boolean => {
   try {

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  canOpenBrowserWindow,
   canOpenNewWindow,
   canOpenSessionWindow,
   isPeerInstanceWindow,
+  openBrowserInNewWindow,
   openNewWindow,
   openSessionInNewWindow
 } from './windows'
@@ -19,11 +21,13 @@ vi.mock('./notifications', () => ({
 
 function installBridge(
   openSessionWindow?: Window['hermesDesktop']['openSessionWindow'],
-  openWindow?: Window['hermesDesktop']['openWindow']
+  openWindow?: Window['hermesDesktop']['openWindow'],
+  openBrowserWindow?: Window['hermesDesktop']['openBrowserWindow']
 ) {
   desktopWindow.hermesDesktop = {
     ...(openSessionWindow ? { openSessionWindow } : {}),
-    ...(openWindow ? { openWindow } : {})
+    ...(openWindow ? { openWindow } : {}),
+    ...(openBrowserWindow ? { openBrowserWindow } : {})
   } as unknown as Window['hermesDesktop']
 }
 
@@ -170,6 +174,64 @@ describe('openNewWindow', () => {
 
     await openNewWindow()
 
+    expect(notifyError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('canOpenBrowserWindow', () => {
+  it('is false when the desktop bridge is absent', () => {
+    delete desktopWindow.hermesDesktop
+    expect(canOpenBrowserWindow()).toBe(false)
+  })
+
+  it('is false when the bridge lacks openBrowserWindow', () => {
+    installBridge(vi.fn().mockResolvedValue({ ok: true }))
+    expect(canOpenBrowserWindow()).toBe(false)
+  })
+
+  it('is true when the bridge exposes openBrowserWindow', () => {
+    installBridge(undefined, undefined, vi.fn().mockResolvedValue({ ok: true }))
+    expect(canOpenBrowserWindow()).toBe(true)
+  })
+})
+
+describe('openBrowserInNewWindow', () => {
+  it('returns false without a tab id', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(undefined, undefined, open)
+
+    expect(await openBrowserInNewWindow('')).toBe(false)
+    expect(open).not.toHaveBeenCalled()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the bridge is absent', async () => {
+    delete desktopWindow.hermesDesktop
+
+    expect(await openBrowserInNewWindow('tab-1')).toBe(false)
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('invokes the bridge with the tab id', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(undefined, undefined, open)
+
+    expect(await openBrowserInNewWindow('tab-1')).toBe(true)
+    expect(open).toHaveBeenCalledWith('tab-1')
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('returns false and notifies on an ok:false result', async () => {
+    installBridge(undefined, undefined, vi.fn().mockResolvedValue({ ok: false, error: 'invalid-tab-id' }))
+
+    expect(await openBrowserInNewWindow('tab-1')).toBe(false)
+    expect(notifyError).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false and notifies when the bridge throws', async () => {
+    installBridge(undefined, undefined, vi.fn().mockRejectedValue(new Error('boom')))
+
+    expect(await openBrowserInNewWindow('tab-1')).toBe(false)
     expect(notifyError).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -76,12 +76,42 @@ export function isWatchWindow(): boolean {
   return result
 }
 
+// A "browser" window is a popped-out in-app Browser: the same webview +
+// address bar as the docked tab, in its own OS window. The tab id rides
+// `?tab=` next to `win=browser` (before the hash, same contract as secondary).
+let browserWindowCache: boolean | null = null
+
+export function isBrowserWindow(): boolean {
+  if (browserWindowCache !== null) {
+    return browserWindowCache
+  }
+
+  let result = false
+
+  try {
+    result = new URLSearchParams(window.location.search).get('win') === 'browser'
+  } catch {
+    result = false
+  }
+
+  browserWindowCache = result
+
+  return result
+}
+
+export function windowBrowserTabId(): null | string {
+  try {
+    return new URLSearchParams(window.location.search).get('tab')?.trim() || null
+  } catch {
+    return null
+  }
+}
+
 // True for any window that is NOT the primary app instance — a secondary
-// session window or the HUD. Single-claim channels (the quick-entry capture
-// bridge, the pet overlay control bridge) and the install/onboarding overlays
-// belong to the primary alone: two windows answering one channel turns one
-// keystroke into N prompts, and a HUD is the last place to paint onboarding.
-export const isAuxiliaryWindow = (): boolean => isSecondaryWindow() || isHudWindow()
+// session window, the HUD, or a popped-out Browser. Single-claim channels
+// (the quick-entry capture bridge, the pet overlay control bridge) and the
+// install/onboarding overlays belong to the primary alone.
+export const isAuxiliaryWindow = (): boolean => isSecondaryWindow() || isHudWindow() || isBrowserWindow()
 
 // A full peer window renders the ordinary app shell against the backend that
 // Electron already has running. It is not an auxiliary/specialized renderer,
@@ -122,6 +152,11 @@ export function canOpenNewWindow(): boolean {
   return typeof window !== 'undefined' && typeof window.hermesDesktop?.openWindow === 'function'
 }
 
+// True when the shell can pop the in-app Browser into its own OS window.
+export function canOpenBrowserWindow(): boolean {
+  return typeof window !== 'undefined' && typeof window.hermesDesktop?.openBrowserWindow === 'function'
+}
+
 // True when the shell can hand a session to the user's own terminal emulator.
 // Desktop-only, and a REMOTE connection is excluded by the caller: the terminal
 // we'd open is on this machine, but the session lives on the remote host.
@@ -133,15 +168,21 @@ type WindowOpenResult = { ok: boolean; error?: string } | undefined
 
 // Run a window-open bridge call, surfacing any failure as a toast. Shared by the
 // session pop-out and the new-window opener.
-async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage: string): Promise<void> {
+async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage: string): Promise<boolean> {
   try {
     const result = await call()
 
     if (!result?.ok) {
       notifyError(new Error(result?.error || 'unknown error'), failMessage)
+
+      return false
     }
+
+    return true
   } catch (err) {
     notifyError(err, failMessage)
+
+    return false
   }
 }
 
@@ -167,6 +208,16 @@ export async function openNewWindow(): Promise<void> {
   }
 
   await runWindowOpen(() => window.hermesDesktop.openWindow(), 'Could not open a new window')
+}
+
+/** Pop the in-app Browser into its own OS window. Returns whether the
+ *  window opened so the caller can dock the tab again on failure. */
+export async function openBrowserInNewWindow(tabId: string): Promise<boolean> {
+  if (!tabId || !canOpenBrowserWindow()) {
+    return false
+  }
+
+  return runWindowOpen(() => window.hermesDesktop.openBrowserWindow(tabId), 'Could not pop out browser')
 }
 
 // Resume a session in the user's own terminal emulator, running the TUI there.


### PR DESCRIPTION
## Summary

The in-app Browser (webview + address bar) can leave the layout tree and live in its own Electron window. The docked tab hides while it is out; closing the window or choosing Pop in docks it back on the page it was showing, not the URL the tab was first opened with. The tab menu still has Open in external for the OS browser.

## Test plan

- [ ] Pop out from the address-bar glyph and from the Browser tab context menu
- [ ] Navigate away from the tab's original URL, then pop out — the new window shows the current page
- [ ] Pop in / close the window — the tab returns on that same page
- [ ] While popped, the docked tab is gone from the tree
- [ ] Primary window layout, session tiles, and unread stay as they were
- [ ] Tab-menu Open in external still opens the live page in the OS browser