### PR TITLE
fix(desktop): preserve clarify cards across lifecycle gaps

### DIFF
--- a/.github/workflows/windows-desktop-artifact.yml
+++ b/.github/workflows/windows-desktop-artifact.yml
@@ -1,0 +1,55 @@
+name: Windows Desktop Artifact
+
+on:
+  push:
+    branches:
+      - fix/clarify-cards-current-20260825
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-desktop-artifact-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows-x64:
+    name: Build Windows x64 installer
+    runs-on: windows-2025
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install npm 12
+        shell: bash
+        run: npm install --global npm@12
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci
+
+      - name: Build desktop application
+        working-directory: apps/desktop
+        shell: bash
+        run: npm run build
+
+      - name: Package Windows x64 NSIS installer
+        working-directory: apps/desktop
+        shell: bash
+        run: npm run builder -- --win nsis --x64 --publish never
+
+      - name: Upload installable artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Hermes-clarify-fix-Windows-x64
+          path: |
+            apps/desktop/release/Hermes-*-win-x64.exe
+            apps/desktop/release/latest.yml
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -290,6 +290,26 @@ describe('clarify.request stream hydration', () => {
     ])
   })
 
+  it('keeps a repeated single clarify on its own identity when tool.start arrives first', () => {
+    mountStream()
+
+    const args = { choices: ['a'], question: 'Pick' }
+    clarifyRequest({ ...args, request_id: 'req-old' })
+    clearClarifyRequest('req-old', SID)
+
+    toolStart({ args, name: 'clarify', tool_id: 'call-new' })
+    clarifyRequest({ ...args, request_id: 'req-new', tool_id: 'call-new' })
+    clearClarifyRequest('req-new', SID)
+    toolComplete({ args, name: 'clarify', result: { answer: 'a', question: 'Pick' }, tool_id: 'call-new' })
+
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toMatchObject({ args: { request_id: 'req-old' }, toolCallId: 'req-old' })
+    expect(parts[0].type === 'tool-call' && parts[0].result).toBeUndefined()
+    expect(parts[1]).toMatchObject({ args: { request_id: 'req-new' }, toolCallId: 'call-new' })
+    expect(parts[1].type === 'tool-call' && parts[1].result).toBeDefined()
+  })
+
   it('merges a BATCH tool.start row with its clarify.request (no top-level question)', () => {
     mountStream()
 
@@ -350,5 +370,31 @@ describe('clarify.request stream hydration', () => {
       'req-batch-old',
       'req-batch-new'
     ])
+  })
+
+  it('keeps a repeated batch clarify on its own identity when clarify.request arrives first', () => {
+    mountStream()
+
+    const requestQuestions = [
+      { qid: 'q0', question: 'Drink?' },
+      { qid: 'q1', question: 'Productive when?' }
+    ]
+
+    const args = { questions: requestQuestions.map(({ question }) => ({ question })) }
+
+    clarifyRequest({ questions: requestQuestions, request_id: 'req-batch-old' })
+    clearClarifyRequest('req-batch-old', SID)
+
+    clarifyRequest({ questions: requestQuestions, request_id: 'req-batch-new', tool_id: 'call-batch-new' })
+    toolStart({ args, name: 'clarify', tool_id: 'call-batch-new' })
+    clearClarifyRequest('req-batch-new', SID)
+    toolComplete({ args, name: 'clarify', result: { responses: [] }, tool_id: 'call-batch-new' })
+
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toMatchObject({ args: { request_id: 'req-batch-old' }, toolCallId: 'req-batch-old' })
+    expect(parts[0].type === 'tool-call' && parts[0].result).toBeUndefined()
+    expect(parts[1]).toMatchObject({ args: { request_id: 'req-batch-new' }, toolCallId: 'call-batch-new' })
+    expect(parts[1].type === 'tool-call' && parts[1].result).toBeDefined()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -135,7 +135,9 @@ describe('clarify.request stream hydration', () => {
     toolStart({ args: { choices: ['a'], question: 'Pick' }, name: 'clarify', tool_id: 'call-abc' })
     clarifyRequest({ choices: ['a'], question: 'Pick', request_id: 'req-2' })
 
-    expect(clarifyParts()).toHaveLength(1)
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(1)
+    expect(parts[0].type === 'tool-call' && parts[0].args).toMatchObject({ request_id: 'req-2' })
   })
 
   it('does not duplicate when clarify.request arrives before the tool.start row', () => {
@@ -144,7 +146,9 @@ describe('clarify.request stream hydration', () => {
     clarifyRequest({ choices: ['a'], question: 'Pick', request_id: 'req-3' })
     toolStart({ args: { choices: ['a'], question: 'Pick' }, name: 'clarify', tool_id: 'call-xyz' })
 
-    expect(clarifyParts()).toHaveLength(1)
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(1)
+    expect(parts[0].type === 'tool-call' && parts[0].args).toMatchObject({ request_id: 'req-3' })
   })
 
   it('re-arms a hydrated Codex tool-only clarify in place instead of appending a second card', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -276,6 +276,20 @@ describe('clarify.request stream hydration', () => {
     expect(stream.state().needsInput).toBe(false)
   })
 
+  it('does not rebind an identical single-question card owned by a newer request identity', () => {
+    mountStream()
+
+    clarifyRequest({ choices: ['a'], question: 'Pick', request_id: 'req-old' })
+    clarifyRequest({ choices: ['a'], question: 'Pick', request_id: 'req-new' })
+
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(2)
+    expect(parts.map(part => (part.type === 'tool-call' ? part.args?.request_id : null))).toEqual([
+      'req-old',
+      'req-new'
+    ])
+  })
+
   it('merges a BATCH tool.start row with its clarify.request (no top-level question)', () => {
     mountStream()
 
@@ -317,5 +331,24 @@ describe('clarify.request stream hydration', () => {
 
     expect(clarifyParts()).toHaveLength(1)
     expect($clarifyRequests.get()[SID]?.questions).toHaveLength(2)
+  })
+
+  it('does not rebind an identical batch card owned by a newer request identity', () => {
+    mountStream()
+
+    const questions = [
+      { qid: 'q0', question: 'Drink?' },
+      { qid: 'q1', question: 'Productive when?' }
+    ]
+
+    clarifyRequest({ questions, request_id: 'req-batch-old' })
+    clarifyRequest({ questions, request_id: 'req-batch-new' })
+
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(2)
+    expect(parts.map(part => (part.type === 'tool-call' ? part.args?.request_id : null))).toEqual([
+      'req-batch-old',
+      'req-batch-new'
+    ])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -93,6 +93,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
           }
         })
 
+
         if (sessionId === activeSessionIdRef.current) {
           requestScrollToBottom()
         }
@@ -130,6 +131,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
             pendingClarifyToolPayload(request),
             occurredAt
           )
+
 
           return {
             ...state,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -67,7 +67,8 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         questions,
         receivedAt: Date.now() / 1000,
         requestId,
-        sessionId: sessionId ?? null
+        sessionId: sessionId ?? null,
+        toolCallId: typeof payload?.tool_id === 'string' && payload.tool_id ? payload.tool_id : undefined
       }
 
       setClarifyRequest(request)
@@ -94,6 +95,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
 
+
         if (sessionId === activeSessionIdRef.current) {
           requestScrollToBottom()
         }
@@ -116,7 +118,8 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         choices: choices.length > 0 ? choices : null,
         multiSelect,
         receivedAt: Date.now() / 1000,
-        sessionId: sessionId ?? null
+        sessionId: sessionId ?? null,
+        toolCallId: typeof payload?.tool_id === 'string' && payload.tool_id ? payload.tool_id : undefined
       }
 
       setClarifyRequest(request)
@@ -131,6 +134,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
             pendingClarifyToolPayload(request),
             occurredAt
           )
+
 
 
           return {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
@@ -1,4 +1,6 @@
+import type { GatewayEventPayload } from '@/lib/chat-messages'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
+import { $clarifyRequests, type ClarifyRequest } from '@/store/clarify'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { flashPetActivity, setPetActivity } from '@/store/pet'
 import { pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
@@ -11,6 +13,45 @@ import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/s
 import { SUBAGENT_EVENT_TYPES, toTodoPayload } from '../utils'
 
 import type { GatewayEventContext } from './types'
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+function clarifyToolMatchesRequest(args: Record<string, unknown>, request: ClarifyRequest): boolean {
+  if (request.questions) {
+    if (!Array.isArray(args.questions) || args.questions.length !== request.questions.length) {
+      return false
+    }
+
+    return args.questions.every((entry, index) => {
+      const row = entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : null
+
+      return row?.question === request.questions?.[index]?.question
+    })
+  }
+
+  return (
+    args.question === request.question &&
+    JSON.stringify(stringArray(args.choices)) === JSON.stringify(request.choices ?? []) &&
+    (args.multi_select === true) === request.multiSelect
+  )
+}
+
+function identifyActiveClarify(payload: GatewayEventPayload | undefined, sessionId: string): GatewayEventPayload | undefined {
+  if (payload?.name !== 'clarify' || !payload.args || typeof payload.args !== 'object' || Array.isArray(payload.args)) {
+    return payload
+  }
+
+  const request = $clarifyRequests.get()[sessionId]
+  const args = payload.args as Record<string, unknown>
+
+  if (!request || !clarifyToolMatchesRequest(args, request)) {
+    return payload
+  }
+
+  return { ...payload, args: { ...args, request_id: request.requestId } }
+}
 
 /** tool.generating / tool.start / tool.progress / tool.complete / subagent.*. */
 export function handleToolEvent(ctx: GatewayEventContext): boolean {
@@ -46,7 +87,8 @@ export function handleToolEvent(ctx: GatewayEventContext): boolean {
     }
 
     flushQueuedDeltas(sessionId)
-    upsertToolCall(sessionId, toTodoPayload(payload) ?? payload, 'running', event.type, occurredAt)
+    const toolPayload = toTodoPayload(payload) ?? payload
+    upsertToolCall(sessionId, identifyActiveClarify(toolPayload, sessionId), 'running', event.type, occurredAt)
 
     if (isActiveEvent) {
       setPetActivity({ reasoning: false, toolRunning: true })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -273,6 +273,7 @@ function restorePendingApproval(response: SessionResumeResponse, sessionId: stri
   return true
 }
 
+
 function normalizeNewChatWorkspaceTarget(target: NewChatWorkspaceTarget): NewChatWorkspaceTarget {
   return typeof target === 'string' ? target.trim() || null : target
 }
@@ -1094,6 +1095,7 @@ export function useSessionActions({
               const visibleActivatedMessages =
                 pendingClarifyProjection?.messages ?? clearedClarifyProjection?.messages ?? activatedMessages
 
+
               const activatedState = updateSessionState(
                 cachedRuntimeId,
                 state => ({
@@ -1420,10 +1422,12 @@ export function useSessionActions({
 
         // Prefetch-hit fast path: reuse the live array when neither runtime
         // changes nor in-flight recovery changed the reconciled transcript.
-        const messagesForView =
+        const reconciledMessagesForView =
           inFlightRecovery.messages === currentMessages
             ? currentMessages
             : preserveLocalAssistantErrors(inFlightRecovery.messages, currentMessages)
+
+        const messagesForView = reconciledMessagesForView
 
         // Fail-latch on the PRE-recovery transcript: an orphan journal tail
         // must not mask a lost transcript (a retry that reloads real history

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -273,7 +273,6 @@ function restorePendingApproval(response: SessionResumeResponse, sessionId: stri
   return true
 }
 
-
 function normalizeNewChatWorkspaceTarget(target: NewChatWorkspaceTarget): NewChatWorkspaceTarget {
   return typeof target === 'string' ? target.trim() || null : target
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
@@ -176,7 +176,8 @@ describe('pendingClarifyToolPayload', () => {
       })
     ).toEqual({
       args: {
-        questions: [{ choices: ['Yes', 'No'], question: 'Proceed?' }]
+        questions: [{ choices: ['Yes', 'No'], question: 'Proceed?' }],
+        request_id: 'rid'
       },
       tool_id: 'rid'
     })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
@@ -90,16 +90,18 @@ export function pendingClarifyToolPayload(request: ClarifyRequest): GatewayEvent
   return {
     args: request.questions?.length
       ? {
+          request_id: request.requestId,
           questions: request.questions.map(question => ({
             choices: question.choices ?? undefined,
-            multi_select: question.multiSelect || undefined,
+            ...(question.multiSelect ? { multi_select: true } : {}),
             question: question.question
           }))
         }
       : {
           choices: request.choices ?? [],
           ...(request.multiSelect ? { multi_select: true } : {}),
-          question: request.question
+          question: request.question,
+          request_id: request.requestId
         },
     tool_id: request.toolCallId ?? request.requestId
   }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
@@ -77,6 +77,7 @@ export function restorePendingClarifyFromSnapshot(
     receivedAt: Date.now() / 1000,
     requestId: pending.request_id,
     sessionId,
+    toolCallId: typeof pending.tool_id === 'string' && pending.tool_id ? pending.tool_id : undefined,
     ...(questions.length > 0 ? { questions } : {})
   }
 
@@ -100,6 +101,6 @@ export function pendingClarifyToolPayload(request: ClarifyRequest): GatewayEvent
           ...(request.multiSelect ? { multi_select: true } : {}),
           question: request.question
         },
-    tool_id: request.requestId
+    tool_id: request.toolCallId ?? request.requestId
   }
 }

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,7 +1,7 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
@@ -19,12 +19,21 @@ vi.mock('@assistant-ui/react', () => ({
   useAuiState: () => messageRunning
 }))
 
+beforeEach(() => {
+  // jsdom does not implement the Web Animations API used by fallback cards.
+  Object.defineProperty(HTMLElement.prototype, 'animate', {
+    configurable: true,
+    value: () => ({}) as Animation
+  })
+})
+
 afterEach(() => {
   cleanup()
   clearClarifyRequest()
   $activeSessionId.set(null)
   $gateway.set(null)
   messageRunning = true
+  Reflect.deleteProperty(HTMLElement.prototype, 'animate')
   vi.clearAllMocks()
 })
 
@@ -60,8 +69,11 @@ function settledClarifyProps(
   }
 }
 
-function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessagePartProps {
-  const args = { choices, question: 'Which deployment target?' }
+function liveClarifyProps(
+  choices = ['staging', 'production'],
+  requestId: string | undefined = 'request-1'
+): ToolCallMessagePartProps {
+  const args = { choices, question: 'Which deployment target?', ...(requestId ? { request_id: requestId } : {}) }
 
   return {
     addResult: vi.fn(),
@@ -158,7 +170,7 @@ describe('ClarifyTool live card stays mounted across settle', () => {
 
 describe('ClarifyTool choice selection', () => {
   it('keeps a pending gateway question interactive after message hydration settles', () => {
-    assistantUiState.messageRunning = false
+    messageRunning = false
 
     renderLiveClarify()
 
@@ -168,7 +180,7 @@ describe('ClarifyTool choice selection', () => {
   })
 
   it('does not revive an older question when another gateway request is pending', () => {
-    assistantUiState.messageRunning = false
+    messageRunning = false
     $activeSessionId.set('session-1')
     setClarifyRequest({
       choices: ['yes', 'no'],
@@ -182,6 +194,57 @@ describe('ClarifyTool choice selection', () => {
 
     expect(screen.queryByText('Which deployment target?')).toBeNull()
     expect(screen.queryByRole('button', { name: /staging/ })).toBeNull()
+  })
+
+  it('does not revive an older card when the newer request repeats the same question', () => {
+    messageRunning = false
+    $activeSessionId.set('session-1')
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-newer',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveClarifyProps(['staging', 'production'], 'request-older')} />)
+
+    expect(screen.queryByText('Which deployment target?')).toBeNull()
+    expect(screen.queryByRole('button', { name: /staging/ })).toBeNull()
+  })
+
+  it('does not revive a repeated older card while the newer request is running', () => {
+    messageRunning = true
+    $activeSessionId.set('session-1')
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-newer',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveClarifyProps(['staging', 'production'], 'request-older')} />)
+
+    expect(screen.queryByText('Which deployment target?')).toBeNull()
+    expect(screen.queryByRole('button', { name: /staging/ })).toBeNull()
+  })
+
+  it('keeps only the exact repeated request interactive after hydration settles', () => {
+    messageRunning = false
+    $activeSessionId.set('session-1')
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-newer',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveClarifyProps(['staging', 'production'], 'request-newer')} />)
+
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /staging/ })).toBeTruthy()
   })
 
   it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
@@ -546,14 +609,18 @@ describe('ClarifyTool pending marker', () => {
 
 // ─── Batch (multi-question) clarify ─────────────────────────────────────────
 
-function batchArgs(): { questions: { question: string; choices?: string[] }[] } {
+function batchArgs(requestId = 'request-batch'): {
+  questions: { question: string; choices?: string[] }[]
+  request_id: string
+} {
   return {
-    questions: [{ choices: ['red', 'blue'], question: 'Color?' }, { question: 'Name?' }]
+    questions: [{ choices: ['red', 'blue'], question: 'Color?' }, { question: 'Name?' }],
+    request_id: requestId
   }
 }
 
-function liveBatchProps(): ToolCallMessagePartProps {
-  const args = batchArgs()
+function liveBatchProps(requestId = 'request-batch'): ToolCallMessagePartProps {
+  const args = batchArgs(requestId)
 
   return {
     addResult: vi.fn(),
@@ -617,6 +684,27 @@ describe('readClarifyBatchResult', () => {
 })
 
 describe('ClarifyTool batch card', () => {
+  it('does not revive an older batch with identical questions', () => {
+    messageRunning = false
+    $activeSessionId.set('session-1')
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: ['red', 'blue'], multiSelect: false, qid: 'new-q0', question: 'Color?' },
+        { choices: null, multiSelect: false, qid: 'new-q1', question: 'Name?' }
+      ],
+      requestId: 'request-newer-batch',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveBatchProps('request-older-batch')} />)
+
+    expect(screen.queryByText('Color?')).toBeNull()
+    expect(screen.queryByText('Name?')).toBeNull()
+  })
+
   it('renders every question at once', () => {
     renderLiveBatch()
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -157,6 +157,33 @@ describe('ClarifyTool live card stays mounted across settle', () => {
 })
 
 describe('ClarifyTool choice selection', () => {
+  it('keeps a pending gateway question interactive after message hydration settles', () => {
+    assistantUiState.messageRunning = false
+
+    renderLiveClarify()
+
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /staging/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /production/ })).toBeTruthy()
+  })
+
+  it('does not revive an older question when another gateway request is pending', () => {
+    assistantUiState.messageRunning = false
+    $activeSessionId.set('session-1')
+    setClarifyRequest({
+      choices: ['yes', 'no'],
+      multiSelect: false,
+      question: 'Continue with the newer request?',
+      requestId: 'req-newer',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    expect(screen.queryByText('Which deployment target?')).toBeNull()
+    expect(screen.queryByRole('button', { name: /staging/ })).toBeNull()
+  })
+
   it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
     const { request } = renderLiveClarify({ multiSelect: true })
     const staging = screen.getByRole('button', { name: /staging/ })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -292,20 +292,19 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
 }
 
 function ClarifyToolLive(props: ToolCallMessagePartProps) {
-  const messageRunning = useAuiState(selectMessageRunning)
   const sessionId = useStore(useSessionView().$runtimeId)
   const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
   const request = useStore($request)
   const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
   const requestMatches = Boolean(request && fromArgs.requestId && fromArgs.requestId === request.requestId)
 
-  // A hydrated message may already be marked complete while the gateway still
-  // owns this exact live request. Whenever a request is present, require its
-  // exact identity even while the message is running: question text is not an
-  // identity and duplicate old cards must stay inert. The sole exception is
-  // the brief tool.start -> clarify.request race, where no request exists yet;
-  // the running card may mount its non-interactive spinner until it arrives.
-  if (!requestMatches && (request || !messageRunning)) {
+  // Whenever a request is present, require its exact identity even while the
+  // message is running: question text is not an identity and duplicate old
+  // cards must stay inert. With no request, leave the decision to
+  // ClarifyToolPending: it owns the submit latch that keeps an answered card
+  // mounted through the request-clear -> tool.complete gap, and demotes an
+  // unanswered stopped card itself.
+  if (request && !requestMatches) {
     return <ToolFallback {...props} />
   }
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -286,6 +286,40 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
     return <ClarifyToolSettled {...props} />
   }
 
+  return <ClarifyToolLive {...props} />
+}
+
+function ClarifyToolLive(props: ToolCallMessagePartProps) {
+  const messageRunning = useAuiState(selectMessageRunning)
+  const sessionId = useStore(useSessionView().$runtimeId)
+  const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
+  const request = useStore($request)
+  const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
+  const requestMatches = useMemo(() => {
+    if (!request) {
+      return false
+    }
+
+    if (fromArgs.questions?.length) {
+      return (
+        request.questions?.length === fromArgs.questions.length &&
+        fromArgs.questions.every((question, index) => question.question === request.questions?.[index]?.question)
+      )
+    }
+
+    if (request.questions?.length) {
+      return false
+    }
+
+    return !fromArgs.question || !request.question || fromArgs.question === request.question
+  }, [fromArgs.question, fromArgs.questions, request])
+
+  // A hydrated message may already be marked complete while the gateway still
+  // owns this exact live request. A newer request must not revive an older card.
+  if (!messageRunning && !requestMatches) {
+    return <ToolFallback {...props} />
+  }
+
   return <ClarifyToolPending {...props} />
 }
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -42,6 +42,7 @@ import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
 
 interface ClarifyArgs {
+  requestId?: string
   question?: string
   choices?: string[] | null
   multiSelect?: boolean
@@ -105,6 +106,7 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   }
 
   return {
+    requestId: stringField(row, 'request_id'),
     question,
     choices: choices.length > 0 ? choices : null,
     multiSelect: row.multi_select === true,
@@ -295,28 +297,15 @@ function ClarifyToolLive(props: ToolCallMessagePartProps) {
   const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
   const request = useStore($request)
   const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
-  const requestMatches = useMemo(() => {
-    if (!request) {
-      return false
-    }
-
-    if (fromArgs.questions?.length) {
-      return (
-        request.questions?.length === fromArgs.questions.length &&
-        fromArgs.questions.every((question, index) => question.question === request.questions?.[index]?.question)
-      )
-    }
-
-    if (request.questions?.length) {
-      return false
-    }
-
-    return !fromArgs.question || !request.question || fromArgs.question === request.question
-  }, [fromArgs.question, fromArgs.questions, request])
+  const requestMatches = Boolean(request && fromArgs.requestId && fromArgs.requestId === request.requestId)
 
   // A hydrated message may already be marked complete while the gateway still
-  // owns this exact live request. A newer request must not revive an older card.
-  if (!messageRunning && !requestMatches) {
+  // owns this exact live request. Whenever a request is present, require its
+  // exact identity even while the message is running: question text is not an
+  // identity and duplicate old cards must stay inert. The sole exception is
+  // the brief tool.start -> clarify.request race, where no request exists yet;
+  // the running card may mount its non-interactive spinner until it arrives.
+  if (!requestMatches && (request || !messageRunning)) {
     return <ToolFallback {...props} />
   }
 
@@ -960,7 +949,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
 
   // qids only exist on the gateway request — args are a hydration-race
   // fallback for display, never answerable (no ids to respond with).
-  const questions = request?.questions ?? []
+  const questions = useMemo(() => request?.questions ?? [], [request?.questions])
   const ready = Boolean(request?.requestId) && questions.length > 0
 
   const [staged, setStaged] = useState<Record<string, { choices: string[]; draft: string }>>({})
@@ -1008,8 +997,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
 
       return next
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by the replay map only
-  }, [request?.lockedAnswers])
+  }, [questions, request?.lockedAnswers])
 
   const stageFor = (qid: string) => staged[qid] ?? emptyStage
 

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -15,6 +15,7 @@ export {
 export type { UnspokenTurnSpeech } from './parts'
 export { branchGroupForUser, preserveLocalAssistantErrors } from './reconciliation'
 export {
+  bindPendingClarifyIdentity,
   restorePendingClarifyToolCall,
   sealOpenToolParts,
   settlePendingClarifyToolCall,

--- a/apps/desktop/src/lib/chat-messages/tool-parts.test.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { bindPendingClarifyIdentity } from './tool-parts'
+import type { ChatMessage } from './types'
+
+function clarifyMessage(id: string, requestId?: string, args?: Record<string, unknown>): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [
+      {
+        args: {
+          choices: ['staging', 'production'],
+          question: 'Which deployment target?',
+          ...(requestId ? { request_id: requestId } : {}),
+          ...args
+        },
+        result: undefined,
+        toolCallId: `call-${id}`,
+        toolName: 'clarify',
+        type: 'tool-call'
+      }
+    ]
+  }
+}
+
+describe('bindPendingClarifyIdentity', () => {
+  it('binds an unresolved batch by its ordered questions', () => {
+    const messages = [
+      clarifyMessage('batch', undefined, {
+        questions: [{ question: 'Color?' }, { question: 'Name?' }]
+      })
+    ]
+
+    const bound = bindPendingClarifyIdentity(messages, {
+      questions: ['Color?', 'Name?'],
+      requestId: 'request-batch'
+    })
+
+    expect(bound[0]?.parts[0]).toMatchObject({
+      args: { request_id: 'request-batch' }
+    })
+  })
+
+  it('binds only the newest matching unresolved card', () => {
+    const messages = [clarifyMessage('older'), clarifyMessage('newer')]
+
+    const bound = bindPendingClarifyIdentity(messages, {
+      choices: ['staging', 'production'],
+      question: 'Which deployment target?',
+      requestId: 'request-newer'
+    })
+
+    expect(bound[0].parts[0].type === 'tool-call' && bound[0].parts[0].args).not.toMatchObject({
+      request_id: 'request-newer'
+    })
+    expect(bound[1].parts[0].type === 'tool-call' && bound[1].parts[0].args).toMatchObject({
+      request_id: 'request-newer'
+    })
+  })
+
+  it('never falls back to an older card when the newest match has another request identity', () => {
+    const older = clarifyMessage('older')
+    const newer = clarifyMessage('newer', 'request-older')
+    const messages = [older, newer]
+
+    const bound = bindPendingClarifyIdentity(messages, {
+      choices: ['staging', 'production'],
+      question: 'Which deployment target?',
+      requestId: 'request-newer'
+    })
+
+    expect(bound).toBe(messages)
+    expect(bound[0].parts[0].type === 'tool-call' && bound[0].parts[0].args).not.toMatchObject({
+      request_id: 'request-newer'
+    })
+    expect(bound[1].parts[0].type === 'tool-call' && bound[1].parts[0].args).toMatchObject({
+      request_id: 'request-older'
+    })
+  })
+})

--- a/apps/desktop/src/lib/chat-messages/tool-parts.test.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.test.ts
@@ -34,7 +34,8 @@ describe('bindPendingClarifyIdentity', () => {
 
     const bound = bindPendingClarifyIdentity(messages, {
       questions: ['Color?', 'Name?'],
-      requestId: 'request-batch'
+      requestId: 'request-batch',
+      toolCallId: 'call-batch'
     })
 
     expect(bound[0]?.parts[0]).toMatchObject({
@@ -48,7 +49,8 @@ describe('bindPendingClarifyIdentity', () => {
     const bound = bindPendingClarifyIdentity(messages, {
       choices: ['staging', 'production'],
       question: 'Which deployment target?',
-      requestId: 'request-newer'
+      requestId: 'request-newer',
+      toolCallId: 'call-newer'
     })
 
     expect(bound[0].parts[0].type === 'tool-call' && bound[0].parts[0].args).not.toMatchObject({
@@ -59,7 +61,7 @@ describe('bindPendingClarifyIdentity', () => {
     })
   })
 
-  it('never falls back to an older card when the newest match has another request identity', () => {
+  it('never falls back to an older card when the exact tool identity is absent', () => {
     const older = clarifyMessage('older')
     const newer = clarifyMessage('newer', 'request-older')
     const messages = [older, newer]
@@ -67,7 +69,8 @@ describe('bindPendingClarifyIdentity', () => {
     const bound = bindPendingClarifyIdentity(messages, {
       choices: ['staging', 'production'],
       question: 'Which deployment target?',
-      requestId: 'request-newer'
+      requestId: 'request-newer',
+      toolCallId: 'call-missing'
     })
 
     expect(bound).toBe(messages)
@@ -77,5 +80,32 @@ describe('bindPendingClarifyIdentity', () => {
     expect(bound[1].parts[0].type === 'tool-call' && bound[1].parts[0].args).toMatchObject({
       request_id: 'request-older'
     })
+  })
+
+  it('binds cold resume by the exact tool call id instead of identical question text', () => {
+    const messages = [clarifyMessage('old'), clarifyMessage('current')]
+
+    const bound = bindPendingClarifyIdentity(messages, {
+      choices: ['staging', 'production'],
+      question: 'Which deployment target?',
+      requestId: 'request-current',
+      toolCallId: 'call-current'
+    })
+
+    expect(bound[0]?.parts[0]).not.toMatchObject({ args: { request_id: 'request-current' } })
+    expect(bound[1]?.parts[0]).toMatchObject({ args: { request_id: 'request-current' } })
+  })
+
+  it('does not revive an identical stale card when the exact resumed tool call is absent', () => {
+    const messages = [clarifyMessage('stale')]
+
+    const bound = bindPendingClarifyIdentity(messages, {
+      choices: ['staging', 'production'],
+      question: 'Which deployment target?',
+      requestId: 'request-current',
+      toolCallId: 'call-current'
+    })
+
+    expect(bound).toBe(messages)
   })
 })

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -185,6 +185,22 @@ function toolPayloadMatchValues(payload: GatewayEventPayload | undefined): strin
   return collectToolMatchValues(query, context, preview)
 }
 
+function toolPayloadRequestId(payload: GatewayEventPayload | undefined): string {
+  const requestId = liveToolArgs(payload).request_id
+
+  return typeof requestId === 'string' ? requestId : ''
+}
+
+function toolPartRequestId(part: ChatMessagePart): string {
+  if (part.type !== 'tool-call') {
+    return ''
+  }
+
+  const requestId = parseMaybeJsonObject(part.args).request_id
+
+  return typeof requestId === 'string' ? requestId : ''
+}
+
 /**
  * The batch-clarify counterpart of the `question` correlation key: a batch
  * payload has no top-level `question`, only `questions[]`, so without this
@@ -249,6 +265,7 @@ function findToolPartIndex(
   phase: 'running' | 'complete'
 ): number {
   const matchValues = toolPayloadMatchValues(payload)
+  const requestId = toolPayloadRequestId(payload)
   const overlaps = (index: number) => hasToolMatchOverlap(matchValues, toolPartMatchValues(parts[index]))
 
   if (stableId) {
@@ -268,7 +285,19 @@ function findToolPartIndex(
 
   const pendingIndices = parts
     .map((part, index) => ({ part, index }))
-    .filter(({ part }) => part.type === 'tool-call' && part.toolName === name && part.result === undefined)
+    .filter(({ part }) => {
+      if (part.type !== 'tool-call' || part.toolName !== name || part.result !== undefined) {
+        return false
+      }
+
+      const pendingRequestId = toolPartRequestId(part)
+
+      // A clarify.request carries the authoritative request identity. Never
+      // correlate it by question text with a card already owned by another
+      // request: identical prompts can legitimately recur. A tool.start has
+      // no request_id, so it can still merge with the synthetic request row.
+      return !requestId || !pendingRequestId || requestId === pendingRequestId
+    })
     .map(({ index }) => index)
 
   if (pendingIndices.length === 0) {

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -441,6 +441,7 @@ function findPendingClarifyLocation(
 ): PendingClarifyLocation | null {
   const stableId = toolId(payload)
   const matchValues = toolPayloadMatchValues(payload)
+  const requestId = toolPayloadRequestId(payload)
   let solePending: PendingClarifyLocation | null = null
   let pendingCount = 0
 
@@ -451,6 +452,15 @@ function findPendingClarifyLocation(
       const part = message.parts[partIndex]
 
       if (part.type !== 'tool-call' || part.toolName !== 'clarify' || part.result !== undefined) {
+        continue
+      }
+
+      const partRequestId = toolPartRequestId(part)
+
+      // An already-bound row belongs to that exact request. Identical question
+      // text can recur, so a newer clarify.request must create/re-arm its own
+      // row instead of stealing the older card.
+      if (requestId && partRequestId && requestId !== partRequestId) {
         continue
       }
 
@@ -592,13 +602,29 @@ export function restorePendingClarifyToolCall(
 
   if (location) {
     const message = messages[location.messageIndex]
+    const part = message.parts[location.partIndex]
+    const requestId = toolPayloadRequestId(clarifyPayload)
+    const currentRequestId = toolPartRequestId(part)
+    const mustBindRequest = Boolean(requestId && requestId !== currentRequestId && part.type === 'tool-call')
 
-    if (message.pending) {
+    if (message.pending && !mustBindRequest) {
       return { messages, streamId: message.id }
     }
 
+    const parts = mustBindRequest
+      ? message.parts.map((candidate, index) =>
+          index === location.partIndex && candidate.type === 'tool-call'
+            ? {
+                ...candidate,
+                args: { ...parseMaybeJsonObject(candidate.args), request_id: requestId },
+                argsText: JSON.stringify({ ...parseMaybeJsonObject(candidate.args), request_id: requestId })
+              }
+            : candidate
+        )
+      : message.parts
+
     const next = [...messages]
-    next[location.messageIndex] = { ...message, pending: true }
+    next[location.messageIndex] = { ...message, parts, pending: true }
 
     return { messages: next, streamId: message.id }
   }

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -4,6 +4,14 @@ import type { SessionMessage } from '@/types/hermes'
 
 import type { ChatMessage, ChatMessagePart, GatewayEventPayload } from './types'
 
+interface PendingClarifyIdentity {
+  choices?: string[]
+  multiSelect?: boolean
+  question?: string
+  questions?: string[]
+  requestId: string
+}
+
 function toolId(payload: GatewayEventPayload | undefined): string {
   return payload?.tool_id || payload?.tool_call_id || payload?.id || ''
 }
@@ -44,6 +52,85 @@ function parseMaybeJsonObject(value: unknown): Record<string, unknown> {
   } catch {
     return {}
   }
+}
+
+function stringChoices(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((choice): choice is string => typeof choice === 'string') : []
+}
+
+function choicesEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((choice, index) => choice === right[index])
+}
+
+function clarifyArgsMatch(row: Record<string, unknown>, pending: PendingClarifyIdentity): boolean {
+  if (pending.questions) {
+    if (!Array.isArray(row.questions)) {
+      return false
+    }
+
+    const questions = row.questions.map(value => {
+      const entry = recordFromUnknown(value)
+
+      return typeof entry?.question === 'string' ? entry.question : ''
+    })
+
+    return choicesEqual(questions, pending.questions)
+  }
+
+  return (
+    row.question === pending.question &&
+    choicesEqual(stringChoices(row.choices), pending.choices ?? []) &&
+    (row.multi_select === true) === Boolean(pending.multiSelect)
+  )
+}
+
+export function bindPendingClarifyIdentity(
+  messages: ChatMessage[],
+  pending: PendingClarifyIdentity
+): ChatMessage[] {
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messages[messageIndex]
+
+    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = message.parts[partIndex]
+
+      if (part.type !== 'tool-call' || part.toolName !== 'clarify' || part.result !== undefined) {
+        continue
+      }
+
+      const row = parseMaybeJsonObject(part.args)
+
+      if (row.request_id === pending.requestId) {
+        return messages
+      }
+
+      if (typeof row.request_id === 'string' && row.request_id) {
+        if (clarifyArgsMatch(row, pending)) {
+          return messages
+        }
+
+        continue
+      }
+
+      if (!clarifyArgsMatch(row, pending)) {
+        continue
+      }
+
+      const boundPart: ChatMessagePart = {
+        ...part,
+        args: { ...row, request_id: pending.requestId }
+      }
+
+      const boundMessage: ChatMessage = {
+        ...message,
+        parts: message.parts.map((candidate, index) => (index === partIndex ? boundPart : candidate))
+      }
+
+      return messages.map((candidate, index) => (index === messageIndex ? boundMessage : candidate))
+    }
+  }
+
+  return messages
 }
 
 function firstNonEmptyObject(...values: unknown[]): Record<string, unknown> {

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -10,6 +10,7 @@ interface PendingClarifyIdentity {
   question?: string
   questions?: string[]
   requestId: string
+  toolCallId?: string
 }
 
 function toolId(payload: GatewayEventPayload | undefined): string {
@@ -54,80 +55,39 @@ function parseMaybeJsonObject(value: unknown): Record<string, unknown> {
   }
 }
 
-function stringChoices(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((choice): choice is string => typeof choice === 'string') : []
-}
-
-function choicesEqual(left: string[], right: string[]): boolean {
-  return left.length === right.length && left.every((choice, index) => choice === right[index])
-}
-
-function clarifyArgsMatch(row: Record<string, unknown>, pending: PendingClarifyIdentity): boolean {
-  if (pending.questions) {
-    if (!Array.isArray(row.questions)) {
-      return false
-    }
-
-    const questions = row.questions.map(value => {
-      const entry = recordFromUnknown(value)
-
-      return typeof entry?.question === 'string' ? entry.question : ''
-    })
-
-    return choicesEqual(questions, pending.questions)
-  }
-
-  return (
-    row.question === pending.question &&
-    choicesEqual(stringChoices(row.choices), pending.choices ?? []) &&
-    (row.multi_select === true) === Boolean(pending.multiSelect)
-  )
-}
-
 export function bindPendingClarifyIdentity(
   messages: ChatMessage[],
   pending: PendingClarifyIdentity
 ): ChatMessage[] {
+  if (!pending.toolCallId) {
+    return messages
+  }
+
   for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
     const message = messages[messageIndex]
 
-    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
-      const part = message.parts[partIndex]
+    const partIndex = message.parts.findIndex(
+      part =>
+        part.type === 'tool-call' &&
+        part.toolName === 'clarify' &&
+        part.toolCallId === pending.toolCallId &&
+        part.result === undefined
+    )
 
-      if (part.type !== 'tool-call' || part.toolName !== 'clarify' || part.result !== undefined) {
-        continue
-      }
-
-      const row = parseMaybeJsonObject(part.args)
-
-      if (row.request_id === pending.requestId) {
-        return messages
-      }
-
-      if (typeof row.request_id === 'string' && row.request_id) {
-        if (clarifyArgsMatch(row, pending)) {
-          return messages
-        }
-
-        continue
-      }
-
-      if (!clarifyArgsMatch(row, pending)) {
-        continue
-      }
-
-      const boundPart: ChatMessagePart = {
-        ...part,
-        args: { ...row, request_id: pending.requestId }
-      }
-
-      const boundMessage: ChatMessage = {
-        ...message,
-        parts: message.parts.map((candidate, index) => (index === partIndex ? boundPart : candidate))
-      }
-
-      return messages.map((candidate, index) => (index === messageIndex ? boundMessage : candidate))
+    if (partIndex < 0) {
+      continue
     }
+
+    const part = message.parts[partIndex]
+    const row = parseMaybeJsonObject(part.type === 'tool-call' ? part.args : undefined)
+    const boundPart = { ...part, args: { ...row, request_id: pending.requestId } } as ChatMessagePart
+
+    const boundMessage = {
+      ...message,
+      parts: message.parts.map((candidate, index) => (index === partIndex ? boundPart : candidate))
+    }
+
+    return messages.map((candidate, index) => (index === messageIndex ? boundMessage : candidate))
   }
 
   return messages
@@ -292,10 +252,15 @@ function findToolPartIndex(
 
       const pendingRequestId = toolPartRequestId(part)
 
+      if (name === 'clarify' && !requestId && phase === 'running' && pendingRequestId) {
+        return false
+      }
+
       // A clarify.request carries the authoritative request identity. Never
       // correlate it by question text with a card already owned by another
-      // request: identical prompts can legitimately recur. A tool.start has
-      // no request_id, so it can still merge with the synthetic request row.
+      // request: identical prompts can legitimately recur. Request-less
+      // clarify starts may only merge with an unbound row; the event handler
+      // adds the active request id when clarify.request arrived first.
       return !requestId || !pendingRequestId || requestId === pendingRequestId
     })
     .map(({ index }) => index)
@@ -305,7 +270,8 @@ function findToolPartIndex(
   }
 
   if (matchValues.length) {
-    const contextualIndex = pendingIndices.find(overlaps)
+    const contextualIndex =
+      name === 'clarify' && phase === 'complete' ? pendingIndices.findLast(overlaps) : pendingIndices.find(overlaps)
 
     if (contextualIndex !== undefined) {
       return contextualIndex
@@ -421,9 +387,14 @@ export function upsertToolPart(
   const prevResult = prev && 'result' in prev ? prev.result : undefined
   const args = toolArgs(payload, prevArgs)
 
+  const prevId = prev && 'toolCallId' in prev && typeof prev.toolCallId === 'string' ? prev.toolCallId : ''
+  const prevRequestId = prev ? toolPartRequestId(prev) : ''
+  const incomingRequestId = toolPayloadRequestId(payload)
+  const syntheticClarifyRequest = name === 'clarify' && Boolean(stableId) && stableId === incomingRequestId
+
   const id =
-    stableId ||
-    (prev && 'toolCallId' in prev && typeof prev.toolCallId === 'string' ? prev.toolCallId : '') ||
+    (syntheticClarifyRequest && prevId && !prevRequestId ? prevId : stableId) ||
+    prevId ||
     nextLiveToolId(name)
 
   const base = {

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -19,6 +19,8 @@ export interface ClarifyRequest {
   /** Local receipt time (Unix seconds), used to reject stale resume cleanup. */
   receivedAt?: number
   sessionId: string | null
+  /** Provider tool-call identity used to correlate tool.start/tool.complete. */
+  toolCallId?: string
   /** Batch (multi-question) clarify: present instead of question/choices. */
   questions?: ClarifyQuestion[]
   /** Answers already locked server-side (reconnect replay): qid → answer. */

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -672,6 +672,7 @@ export interface SessionResumeResponse {
     question?: string
     questions?: unknown
     request_id?: string
+    tool_id?: string
   }
   info?: SessionRuntimeInfo
   message_count: number

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
+- POST /v1/runs/{run_id}/clarify  — resolve a pending run clarification
 - POST /v1/runs/{run_id}/steer      — inject guidance into a running agent
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
@@ -1564,6 +1565,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Pending clarify state for each run. This is also the
+        # authorization boundary for the response route: one run must never
+        # resolve another run's question, even when both share a session id.
+        self._run_clarify_requests: Dict[str, Dict[str, Any]] = {}
+        self._run_clarify_lock = threading.Lock()
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -2268,6 +2274,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+            ("POST", "/v1/runs/{run_id}/clarify", self._handle_run_clarify),
             ("POST", "/v1/runs/{run_id}/steer", self._handle_steer_run),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
         ]
@@ -2819,6 +2826,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        clarify_callback=None,
         gateway_session_key: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
@@ -3132,6 +3140,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
+            "clarify_callback": clarify_callback,
             "session_db": self._ensure_session_db(),
             "fallback_model": fallback_model,
             "reasoning_config": reasoning_config,
@@ -3346,12 +3355,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 "responses_streaming": True,
                 "run_submission": True,
                 "run_status": True,
+                "run_session_resume": True,
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_steer": True,
                 "run_approval_response": True,
+                "run_clarify_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "clarify_events": True,
                 "session_resources": True,
                 "model_options": True,
                 "session_chat": True,
@@ -3405,6 +3417,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "run_clarify": {"method": "POST", "path": "/v1/runs/{run_id}/clarify"},
                 "run_steer": {"method": "POST", "path": "/v1/runs/{run_id}/steer"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
@@ -4506,6 +4519,7 @@ class APIServerAdapter(BasePlatformAdapter):
         raw_limit = request.query.get("limit")
         raw_offset = request.query.get("offset", "0")
         order = request.query.get("order")
+        raw_before = request.query.get("before")
         if order not in (None, "oldest", "latest"):
             return web.json_response(
                 _openai_error(
@@ -4517,13 +4531,26 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             offset = int(raw_offset)
             requested_limit = None if raw_limit is None else int(raw_limit)
+            before_id = None
+            if raw_before is not None:
+                if not re.fullmatch(r"[1-9][0-9]{0,18}", raw_before):
+                    raise ValueError("invalid before cursor")
+                before_id = int(raw_before)
+                if before_id > 9_223_372_036_854_775_807:
+                    raise ValueError("before cursor exceeds SQLite row ID range")
         except (TypeError, ValueError):
             offset = -1
             requested_limit = -1
-        if offset < 0 or (requested_limit is not None and requested_limit < 0):
+            before_id = -1
+        if (
+            offset < 0
+            or (requested_limit is not None and requested_limit < 0)
+            or (before_id is not None and before_id <= 0)
+            or (before_id is not None and (order != "latest" or offset != 0))
+        ):
             return web.json_response(
                 _openai_error(
-                    "limit and offset must be non-negative integers",
+                    "invalid session message pagination",
                     code="invalid_pagination",
                 ),
                 status=400,
@@ -4532,17 +4559,36 @@ class APIServerAdapter(BasePlatformAdapter):
         default_page = requested_limit is None
         latest_page = order == "latest" or (order is None and default_page)
         limit = 500 if default_page else min(requested_limit, 500)
-        messages = await asyncio.to_thread(
-            db.get_messages,
-            resolved_id,
-            limit=limit,
-            offset=offset,
-            latest=latest_page,
-        )
+        if latest_page and limit:
+            messages = await asyncio.to_thread(
+                db.get_messages,
+                resolved_id,
+                limit=limit + 1,
+                offset=offset,
+                latest=True,
+                before_id=before_id,
+            )
+            has_more = len(messages) > limit
+            if has_more:
+                messages = messages[-limit:]
+            next_before = str(messages[0]["id"]) if has_more and messages else None
+        else:
+            messages = await asyncio.to_thread(
+                db.get_messages,
+                resolved_id,
+                limit=limit,
+                offset=offset,
+                latest=latest_page,
+            )
+            has_more = False
+            next_before = None
         return web.json_response({
             "object": "list",
+            "requested_session_id": session_id,
             "session_id": resolved_id,
             "data": [self._message_response(m) for m in messages],
+            "has_more": has_more,
+            "next_before": next_before,
             "pagination": {
                 "limit": limit,
                 "offset": offset,
@@ -7728,11 +7774,140 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     return
                 with self._profile_scope(request_profile):
+                    def _clarify_callback(
+                        question: str,
+                        choices,
+                        multi_select: bool = False,
+                        questions=None,
+                    ):
+                        from tools import clarify_gateway
+
+                        request_id = uuid.uuid4().hex
+                        if questions:
+                            wire = [
+                                {
+                                    "qid": str(entry["qid"]),
+                                    "question": str(entry["question"]),
+                                    "choices": list(entry["choices"]) if entry.get("choices") else None,
+                                    "multi_select": bool(entry.get("multi_select")),
+                                }
+                                for entry in questions
+                            ]
+                            done = threading.Event()
+                            state = {
+                                "answers": {},
+                                "done": done,
+                                "kind": "batch",
+                                "question_ids": [entry["qid"] for entry in wire],
+                                "question_modes": {
+                                    entry["qid"]: entry["multi_select"]
+                                    for entry in wire
+                                },
+                                "request_id": request_id,
+                            }
+                            event = {
+                                "event": "clarify.request",
+                                "run_id": run_id,
+                                "timestamp": time.time(),
+                                "request_id": request_id,
+                                "questions": wire,
+                            }
+                        else:
+                            clarify_gateway.register(
+                                clarify_id=request_id,
+                                session_key=run_id,
+                                question=question,
+                                choices=list(choices) if choices else None,
+                                multi_select=bool(multi_select),
+                            )
+                            state = {
+                                "kind": "single",
+                                "multi_select": bool(multi_select) and bool(choices),
+                                "request_id": request_id,
+                            }
+                            event = {
+                                "event": "clarify.request",
+                                "run_id": run_id,
+                                "timestamp": time.time(),
+                                "request_id": request_id,
+                                "question": question,
+                                "choices": list(choices) if choices else None,
+                                "multi_select": bool(multi_select) and bool(choices),
+                            }
+
+                        with self._run_clarify_lock:
+                            self._run_clarify_requests[run_id] = state
+                        self._set_run_status(
+                            run_id,
+                            "waiting_for_clarify",
+                            last_event="clarify.request",
+                        )
+                        try:
+                            loop.call_soon_threadsafe(_put_event_if_active, event)
+                            timeout = float(clarify_gateway.get_clarify_timeout())
+                            if state["kind"] == "single":
+                                response = clarify_gateway.wait_for_response(
+                                    request_id,
+                                    timeout=timeout,
+                                )
+                                return response or ""
+
+                            deadline = None if timeout <= 0 else time.monotonic() + timeout
+                            try:
+                                from tools.environments.base import touch_activity_if_due
+                            except Exception:
+                                touch_activity_if_due = None
+                            activity_state = {
+                                "last_touch": time.monotonic(),
+                                "start": time.monotonic(),
+                            }
+                            while True:
+                                remaining = None if deadline is None else deadline - time.monotonic()
+                                if remaining is not None and remaining <= 0:
+                                    break
+                                if state["done"].wait(timeout=1.0 if remaining is None else min(1.0, remaining)):
+                                    break
+                                if touch_activity_if_due is not None:
+                                    touch_activity_if_due(
+                                        activity_state,
+                                        "waiting for user clarify responses",
+                                    )
+                            with self._run_clarify_lock:
+                                answers = dict(state["answers"])
+                            result = {"answers": answers}
+                            if len(answers) < len(state["question_ids"]):
+                                result["timed_out"] = True
+                            return result
+                        finally:
+                            owned = False
+                            with self._run_clarify_lock:
+                                if self._run_clarify_requests.get(run_id) is state:
+                                    self._run_clarify_requests.pop(run_id, None)
+                                    owned = True
+                            if owned:
+                                def _mark_responded_if_unblocked() -> None:
+                                    with self._run_clarify_lock:
+                                        pending = self._run_clarify_requests.get(run_id)
+                                    status = self._run_statuses.get(run_id, {}).get("status")
+                                    if (
+                                        pending is None
+                                        and run_id not in self._stopping_run_ids
+                                        and status == "waiting_for_clarify"
+                                    ):
+                                        self._set_run_status(
+                                            run_id,
+                                            "running",
+                                            last_event="clarify.responded",
+                                        )
+
+                                loop.call_soon_threadsafe(_mark_responded_if_unblocked)
+
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
                         tool_progress_callback=event_cb,
+                        clarify_callback=_clarify_callback,
                         gateway_session_key=gateway_session_key,
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
@@ -7968,6 +8143,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     unregister_gateway_notify(approval_session_key)
                 except Exception:
                     pass
+                try:
+                    from tools.clarify_gateway import clear_session
+
+                    clear_session(run_id)
+                except Exception:
+                    pass
                 # Sentinel: signal SSE stream to close
                 try:
                     _put_event_if_active(None)
@@ -7976,6 +8157,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                with self._run_clarify_lock:
+                    self._run_clarify_requests.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()
@@ -8152,6 +8335,153 @@ class APIServerAdapter(BasePlatformAdapter):
             "resolved": resolved,
         })
 
+    async def _handle_run_clarify(self, request: "web.Request") -> "web.Response":
+        """POST /v1/runs/{run_id}/clarify — answer that run's pending question."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        if run_id not in self._run_statuses:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        request_id = str(body.get("request_id", "")).strip()
+        if not request_id:
+            return web.json_response(
+                _openai_error(
+                    "Missing clarify request_id",
+                    code="invalid_clarify_request",
+                ),
+                status=400,
+            )
+
+        with self._run_clarify_lock:
+            state = self._run_clarify_requests.get(run_id)
+            matches = state is not None and state.get("request_id") == request_id
+        if not matches:
+            return web.json_response(
+                _openai_error(
+                    f"Run has no matching pending clarify request: {run_id}",
+                    code="clarify_not_pending",
+                ),
+                status=409,
+            )
+        assert state is not None
+
+        run_status = self._run_statuses.get(run_id, {}).get("status")
+        if run_id in self._stopping_run_ids or run_status in {
+            "stopping", "completed", "failed", "cancelled",
+        }:
+            return web.json_response(
+                _openai_error(
+                    f"Run is not accepting clarify answers: {run_id}",
+                    code="clarify_not_pending",
+                ),
+                status=409,
+            )
+
+        question_id = None
+        if state["kind"] == "batch":
+            question_id = str(body.get("question_id", "")).strip()
+            if question_id not in state["question_ids"]:
+                return web.json_response(
+                    _openai_error(
+                        "Missing or unknown clarify question_id",
+                        code="invalid_clarify_question",
+                    ),
+                    status=400,
+                )
+            multi_select = bool(state["question_modes"].get(question_id))
+        else:
+            multi_select = bool(state.get("multi_select"))
+
+        answer = body.get("answer", "")
+        if isinstance(answer, list):
+            if not multi_select:
+                return web.json_response(
+                    _openai_error(
+                        "Clarify answer must be a string for this question",
+                        code="invalid_clarify_answer",
+                    ),
+                    status=400,
+                )
+            answer = json.dumps([str(item) for item in answer], ensure_ascii=False)
+        elif not isinstance(answer, str):
+            return web.json_response(
+                _openai_error(
+                    "Clarify answer must be a string or array",
+                    code="invalid_clarify_answer",
+                ),
+                status=400,
+            )
+
+        completed = True
+        if state["kind"] == "batch":
+            with self._run_clarify_lock:
+                if (
+                    self._run_clarify_requests.get(run_id) is not state
+                    or run_id in self._stopping_run_ids
+                    or self._run_statuses.get(run_id, {}).get("status") in {
+                        "stopping", "completed", "failed", "cancelled",
+                    }
+                ):
+                    return web.json_response(
+                        _openai_error(
+                            f"Run has no pending clarify request: {run_id}",
+                            code="clarify_not_pending",
+                        ),
+                        status=409,
+                    )
+                previous = state["answers"].get(question_id)
+                if previous is not None and previous != answer:
+                    return web.json_response(
+                        _openai_error(
+                            "Clarify answer is already locked",
+                            code="clarify_answer_locked",
+                        ),
+                        status=409,
+                    )
+                state["answers"][question_id] = answer
+                completed = len(state["answers"]) == len(state["question_ids"])
+                if completed:
+                    state["done"].set()
+        else:
+            from tools.clarify_gateway import resolve_gateway_clarify
+
+            if not resolve_gateway_clarify(request_id, answer):
+                return web.json_response(
+                    _openai_error(
+                        f"Run has no pending clarify request: {run_id}",
+                        code="clarify_not_pending",
+                    ),
+                    status=409,
+                )
+
+        q = self._run_streams.get(run_id)
+        if q is not None:
+            q.put_nowait({
+                "event": "clarify.responded",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "request_id": request_id,
+                "question_id": question_id,
+                "completed": completed,
+            })
+        return web.json_response({
+            "object": "hermes.run.clarify",
+            "run_id": run_id,
+            "request_id": request_id,
+            "accepted": True,
+        })
+
     async def _handle_steer_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/steer — inject guidance into a running agent."""
         auth_err = self._check_auth(request)
@@ -8228,6 +8558,17 @@ class APIServerAdapter(BasePlatformAdapter):
         self._set_run_status(run_id, "stopping", last_event="run.stopping")
         self._stopping_run_ids.add(run_id)
 
+        with self._run_clarify_lock:
+            clarify_state = self._run_clarify_requests.get(run_id)
+            if clarify_state is not None and clarify_state.get("kind") == "batch":
+                clarify_state["done"].set()
+        try:
+            from tools.clarify_gateway import clear_session
+
+            clear_session(run_id)
+        except Exception:
+            pass
+
         if agent is not None:
             try:
                 request_hard_interrupt(agent, "Stop requested via API")
@@ -8281,6 +8622,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                with self._run_clarify_lock:
+                    self._run_clarify_requests.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
 
         stale_statuses = [

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11393,6 +11393,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         offset: int = 0,
         latest: bool = False,
         after_id: Optional[int] = None,
+        before_id: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Load messages for a session in insertion order.
 
@@ -11424,11 +11425,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``after_id`` enables keyset pagination (``id > after_id``): O(1)
         page seeks on huge transcripts where OFFSET degrades to O(n) per
         page. Ascending order only (incompatible with ``latest``/``offset``).
+
+        ``before_id`` is the reverse keyset counterpart (``id < before_id``)
+        used for paging backward from the newest messages. It requires
+        ``latest=True`` and is incompatible with ``after_id``/``offset``;
+        results remain in chronological order.
         """
-        if after_id is not None and (latest or offset):
+        if after_id is not None and (latest or offset or before_id is not None):
             raise ValueError("after_id is incompatible with latest/offset paging")
-        if after_id is not None and include_compacted:
-            raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
+        if before_id is not None and (not latest or offset):
+            raise ValueError("before_id requires latest paging without offset")
+        if (after_id is not None or before_id is not None) and include_compacted:
+            raise ValueError("keyset paging is incompatible with include_compacted (deduped display reads use offset paging)")
         if include_inactive:
             # Audit / debug reads: every row, including soft-deleted.
             active_clause = ""
@@ -11439,7 +11447,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             active_clause = " AND (active = 1 OR compacted = 1)"
         else:
             active_clause = " AND active = 1"
-        keyset_clause = " AND id > ?" if after_id is not None else ""
+        keyset_clause = (
+            " AND id > ?" if after_id is not None
+            else (" AND id < ?" if before_id is not None else "")
+        )
         sql = (
             "SELECT * FROM messages WHERE session_id = ?"
             f"{active_clause}{keyset_clause} ORDER BY id {'DESC' if latest else 'ASC'}"
@@ -11447,6 +11458,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         params: list = [session_id]
         if after_id is not None:
             params.append(after_id)
+        elif before_id is not None:
+            params.append(before_id)
         if include_compacted:
             # Compaction epochs copy the protected tail into each new
             # generation, so the same logical message can exist as several

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -870,9 +870,15 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_clarify_response"] is True
+            assert data["features"]["clarify_events"] is True
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
+            assert data["endpoints"]["run_clarify"] == {
+                "method": "POST",
+                "path": "/v1/runs/{run_id}/clarify",
+            }
             assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1,15 +1,17 @@
-"""Tests for /v1/runs endpoints: start, status, events, steer, and stop.
+"""Tests for /v1/runs endpoints: start, status, events, prompts, steer, and stop.
 
 Covers:
 - POST /v1/runs — start a run (202)
 - GET /v1/runs/{run_id} — poll run status
 - GET /v1/runs/{run_id}/events — SSE event stream
+- POST /v1/runs/{run_id}/clarify — resolve a pending user question
 - POST /v1/runs/{run_id}/steer — inject guidance into a running agent
 - POST /v1/runs/{run_id}/stop — interrupt a running agent
 - Auth, error handling, and cleanup
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -76,6 +78,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/runs/{run_id}/clarify", adapter._handle_run_clarify)
     app.router.add_post("/v1/runs/{run_id}/steer", adapter._handle_steer_run)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
@@ -409,6 +412,454 @@ class TestRunEvents:
                     approval_mod._gateway_queues.pop(victim_run, None)
                 victim_interrupted.set()
                 attacker_interrupted.set()
+
+
+class TestRunClarify:
+    @pytest.mark.asyncio
+    async def test_clarify_event_blocks_until_run_scoped_answer(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        answer_seen = threading.Event()
+        fake_agent = MagicMock()
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        def _run_conversation(*_args, **_kwargs):
+            answer = fake_agent.clarify_callback(
+                "Which deployment target?",
+                ["staging", "production"],
+            )
+            answer_seen.set()
+            return {"final_response": f"selected:{answer}"}
+
+        fake_agent.run_conversation.side_effect = _run_conversation
+
+        def _create_agent(**kwargs):
+            fake_agent.clarify_callback = kwargs["clarify_callback"]
+            return fake_agent
+
+        headers = {"Authorization": "Bearer sk-secret"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_create_agent):
+                start = await cli.post(
+                    "/v1/runs",
+                    json={"input": "deploy", "session_id": "clarify-session"},
+                    headers=headers,
+                )
+                assert start.status == 202
+                run_id = (await start.json())["run_id"]
+
+                status = {}
+                for _ in range(60):
+                    status = auth_adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "waiting_for_clarify":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "waiting_for_clarify"
+                event = await asyncio.wait_for(
+                    auth_adapter._run_streams[run_id].get(),
+                    timeout=2.0,
+                )
+                assert event == {
+                    "event": "clarify.request",
+                    "run_id": run_id,
+                    "timestamp": event["timestamp"],
+                    "request_id": event["request_id"],
+                    "question": "Which deployment target?",
+                    "choices": ["staging", "production"],
+                    "multi_select": False,
+                }
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/clarify",
+                    json={
+                        "request_id": event["request_id"],
+                        "answer": "staging",
+                    },
+                    headers=headers,
+                )
+                assert response.status == 200
+                assert (await response.json()) == {
+                    "object": "hermes.run.clarify",
+                    "run_id": run_id,
+                    "request_id": event["request_id"],
+                    "accepted": True,
+                }
+
+                for _ in range(60):
+                    status = auth_adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert answer_seen.is_set()
+        assert status["status"] == "completed"
+        assert status["output"] == "selected:staging"
+
+    @pytest.mark.asyncio
+    async def test_batch_clarify_locks_each_answer_before_resuming(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        fake_agent = MagicMock()
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        def _run_conversation(*_args, **_kwargs):
+            result = fake_agent.clarify_callback(
+                "Deployment details",
+                None,
+                questions=[
+                    {
+                        "qid": "q0",
+                        "question": "Which target?",
+                        "choices": ["staging", "production"],
+                        "multi_select": False,
+                    },
+                    {
+                        "qid": "q1",
+                        "question": "Which checks?",
+                        "choices": ["smoke", "full"],
+                        "multi_select": True,
+                    },
+                ],
+            )
+            return {"final_response": json.dumps(result, sort_keys=True)}
+
+        fake_agent.run_conversation.side_effect = _run_conversation
+
+        def _create_agent(**kwargs):
+            fake_agent.clarify_callback = kwargs["clarify_callback"]
+            return fake_agent
+
+        headers = {"Authorization": "Bearer sk-secret"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_create_agent):
+                start = await cli.post(
+                    "/v1/runs",
+                    json={"input": "deploy", "session_id": "batch-session"},
+                    headers=headers,
+                )
+                run_id = (await start.json())["run_id"]
+
+                status = {}
+                for _ in range(60):
+                    status = auth_adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "waiting_for_clarify":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "waiting_for_clarify"
+                event = await asyncio.wait_for(
+                    auth_adapter._run_streams[run_id].get(),
+                    timeout=2.0,
+                )
+                assert event["event"] == "clarify.request"
+                assert event["questions"] == [
+                    {
+                        "qid": "q0",
+                        "question": "Which target?",
+                        "choices": ["staging", "production"],
+                        "multi_select": False,
+                    },
+                    {
+                        "qid": "q1",
+                        "question": "Which checks?",
+                        "choices": ["smoke", "full"],
+                        "multi_select": True,
+                    },
+                ]
+
+                first = await cli.post(
+                    f"/v1/runs/{run_id}/clarify",
+                    json={
+                        "request_id": event["request_id"],
+                        "question_id": "q0",
+                        "answer": "staging",
+                    },
+                    headers=headers,
+                )
+                assert first.status == 200
+                assert auth_adapter._run_statuses[run_id]["status"] == "waiting_for_clarify"
+
+                second = await cli.post(
+                    f"/v1/runs/{run_id}/clarify",
+                    json={
+                        "request_id": event["request_id"],
+                        "question_id": "q1",
+                        "answer": ["smoke", "full"],
+                    },
+                    headers=headers,
+                )
+                assert second.status == 200
+
+                for _ in range(60):
+                    status = auth_adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["status"] == "completed"
+        assert json.loads(status["output"]) == {
+            "answers": {"q0": "staging", "q1": '["smoke", "full"]'}
+        }
+
+    @pytest.mark.asyncio
+    async def test_stop_releases_batch_clarify_waiter(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        waiter_released = threading.Event()
+        fake_agent = MagicMock()
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+        fake_agent.interrupt.return_value = None
+
+        def _run_conversation(*_args, **_kwargs):
+            fake_agent.clarify_callback(
+                "Stop test",
+                None,
+                questions=[
+                    {
+                        "qid": "q0",
+                        "question": "Continue?",
+                        "choices": ["yes", "no"],
+                        "multi_select": False,
+                    }
+                ],
+            )
+            waiter_released.set()
+            return {"final_response": "released"}
+
+        fake_agent.run_conversation.side_effect = _run_conversation
+
+        def _create_agent(**kwargs):
+            fake_agent.clarify_callback = kwargs["clarify_callback"]
+            return fake_agent
+
+        headers = {"Authorization": "Bearer sk-secret"}
+        with patch("tools.clarify_gateway.get_clarify_timeout", return_value=5):
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(auth_adapter, "_create_agent", side_effect=_create_agent):
+                    start = await cli.post(
+                        "/v1/runs",
+                        json={"input": "deploy", "session_id": "stop-batch"},
+                        headers=headers,
+                    )
+                    run_id = (await start.json())["run_id"]
+
+                    for _ in range(60):
+                        if auth_adapter._run_statuses.get(run_id, {}).get("status") == "waiting_for_clarify":
+                            break
+                        await asyncio.sleep(0.05)
+
+                    stop = await cli.post(f"/v1/runs/{run_id}/stop", headers=headers)
+                    assert stop.status == 200
+                    assert waiter_released.wait(timeout=0.5)
+
+    @pytest.mark.asyncio
+    async def test_clarify_answer_cannot_cross_run_boundary(self, auth_adapter):
+        from tools import clarify_gateway
+
+        app = _create_runs_app(auth_adapter)
+        first = clarify_gateway.register("question-a", "run-a", "A?", ["yes", "no"])
+        second = clarify_gateway.register("question-b", "run-b", "B?", ["yes", "no"])
+        auth_adapter._set_run_status("run-a", "waiting_for_clarify")
+        auth_adapter._set_run_status("run-b", "waiting_for_clarify")
+        auth_adapter._run_clarify_requests.update({
+            "run-a": {"kind": "single", "request_id": "question-a"},
+            "run-b": {"kind": "single", "request_id": "question-b"},
+        })
+
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs/run-a/clarify",
+                    json={"request_id": "question-b", "answer": "yes"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                payload = await response.json()
+
+            assert response.status == 409
+            assert payload["error"]["code"] == "clarify_not_pending"
+            assert not first.event.is_set()
+            assert not second.event.is_set()
+        finally:
+            clarify_gateway.clear_session("run-a")
+            clarify_gateway.clear_session("run-b")
+
+    @pytest.mark.asyncio
+    async def test_clarify_answer_requires_authentication(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/v1/runs/run-any/clarify",
+                json={"request_id": "question", "answer": "yes"},
+            )
+
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_first_answer_cannot_reopen_running_over_next_clarify(self, auth_adapter):
+        from tools import clarify_gateway
+
+        app = _create_runs_app(auth_adapter)
+        fake_agent = MagicMock()
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        def _run_conversation(*_args, **_kwargs):
+            fake_agent.clarify_callback("First?", ["one", "two"])
+            second = fake_agent.clarify_callback("Second?", ["three", "four"])
+            return {"final_response": f"second:{second}"}
+
+        fake_agent.run_conversation.side_effect = _run_conversation
+
+        def _create_agent(**kwargs):
+            fake_agent.clarify_callback = kwargs["clarify_callback"]
+            return fake_agent
+
+        headers = {"Authorization": "Bearer sk-secret"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_create_agent):
+                start = await cli.post(
+                    "/v1/runs",
+                    json={"input": "ask twice", "session_id": "two-clarifies"},
+                    headers=headers,
+                )
+                run_id = (await start.json())["run_id"]
+
+                state = None
+                for _ in range(60):
+                    state = auth_adapter._run_clarify_requests.get(run_id)
+                    if state:
+                        break
+                    await asyncio.sleep(0.05)
+                assert state is not None
+                first_id = state["request_id"]
+
+                real_resolve = clarify_gateway.resolve_gateway_clarify
+
+                def _resolve_first(request_id, answer):
+                    resolved = real_resolve(request_id, answer)
+                    deadline = time.monotonic() + 2.0
+                    while time.monotonic() < deadline:
+                        current = auth_adapter._run_clarify_requests.get(run_id)
+                        if current and current.get("request_id") != first_id:
+                            break
+                        time.sleep(0.01)
+                    return resolved
+
+                try:
+                    with patch(
+                        "tools.clarify_gateway.resolve_gateway_clarify",
+                        side_effect=_resolve_first,
+                    ):
+                        first_response = await cli.post(
+                            f"/v1/runs/{run_id}/clarify",
+                            json={"request_id": first_id, "answer": "one"},
+                            headers=headers,
+                        )
+                    assert first_response.status == 200
+                    current = auth_adapter._run_clarify_requests[run_id]
+                    assert current["request_id"] != first_id
+                    assert auth_adapter._run_statuses[run_id]["status"] == "waiting_for_clarify"
+                finally:
+                    current = auth_adapter._run_clarify_requests.get(run_id)
+                    if current:
+                        await cli.post(
+                            f"/v1/runs/{run_id}/clarify",
+                            json={"request_id": current["request_id"], "answer": "three"},
+                            headers=headers,
+                        )
+
+    @pytest.mark.asyncio
+    async def test_single_select_rejects_array_answer(self, auth_adapter):
+        from tools import clarify_gateway
+
+        app = _create_runs_app(auth_adapter)
+        entry = clarify_gateway.register("single-array", "run-single", "Target?", ["one", "two"])
+        auth_adapter._set_run_status("run-single", "waiting_for_clarify")
+        auth_adapter._run_clarify_requests["run-single"] = {
+            "kind": "single",
+            "multi_select": False,
+            "request_id": "single-array",
+        }
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs/run-single/clarify",
+                    json={"request_id": "single-array", "answer": ["one"]},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                payload = await response.json()
+            assert response.status == 400
+            assert payload["error"]["code"] == "invalid_clarify_answer"
+            assert not entry.event.is_set()
+        finally:
+            clarify_gateway.clear_session("run-single")
+
+    @pytest.mark.asyncio
+    async def test_batch_single_select_rejects_array_answer(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        done = threading.Event()
+        auth_adapter._set_run_status("run-batch", "waiting_for_clarify")
+        auth_adapter._run_clarify_requests["run-batch"] = {
+            "answers": {},
+            "done": done,
+            "kind": "batch",
+            "question_ids": ["q0"],
+            "question_modes": {"q0": False},
+            "request_id": "batch-array",
+        }
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/v1/runs/run-batch/clarify",
+                json={
+                    "request_id": "batch-array",
+                    "question_id": "q0",
+                    "answer": ["one"],
+                },
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "invalid_clarify_answer"
+        assert not done.is_set()
+
+    @pytest.mark.asyncio
+    async def test_stopping_run_rejects_late_batch_answer(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        done = threading.Event()
+        state = {
+            "answers": {},
+            "done": done,
+            "kind": "batch",
+            "question_ids": ["q0"],
+            "question_modes": {"q0": False},
+            "request_id": "late-batch",
+        }
+        auth_adapter._set_run_status("run-stopping", "stopping")
+        auth_adapter._stopping_run_ids.add("run-stopping")
+        auth_adapter._run_clarify_requests["run-stopping"] = state
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/v1/runs/run-stopping/clarify",
+                json={
+                    "request_id": "late-batch",
+                    "question_id": "q0",
+                    "answer": "one",
+                },
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            payload = await response.json()
+
+        assert response.status == 409
+        assert payload["error"]["code"] == "clarify_not_pending"
+        assert state["answers"] == {}
+        assert not done.is_set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -628,6 +628,75 @@ def test_concurrent_clarify_calls_keep_execution_local_tool_ids_and_serialize(ca
     assert set(results.values()) == {"first", "second"}
 
 
+def test_interrupt_cancels_clarify_waiting_for_session_lock(capture):
+    """A serialized clarify must not open after its turn was interrupted."""
+    server, _buf = capture
+    session = {
+        "history": [],
+        "history_lock": threading.RLock(),
+        "_turn_cancel_requested": False,
+    }
+    server._sessions["s1"] = session
+    started = threading.Barrier(3)
+    results = {}
+
+    def run(call_id, question):
+        server._on_tool_start("s1", call_id, "clarify", {})
+        started.wait()
+        results[call_id] = server._clarify_block("s1", question, ["yes", "no"])
+
+    threads = [
+        threading.Thread(target=run, args=("call-a", "Question A?"), daemon=True),
+        threading.Thread(target=run, args=("call-b", "Question B?"), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    started.wait()
+
+    deadline = time.monotonic() + 2
+    active_request_id = None
+    while time.monotonic() < deadline:
+        with server._prompt_lock:
+            pending = [
+                rid
+                for rid, (event, _payload) in server._pending_prompt_payloads.items()
+                if event == "clarify.request"
+            ]
+        if pending:
+            active_request_id = pending[0]
+            break
+        time.sleep(0.01)
+    assert active_request_id is not None
+
+    with session["history_lock"]:
+        session["_turn_cancel_requested"] = True
+    server._clear_pending("s1")
+
+    for thread in threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    assert set(results.values()) == {""}
+    with server._prompt_lock:
+        assert not [
+            rid
+            for rid, (event, _payload) in server._pending_prompt_payloads.items()
+            if event == "clarify.request"
+        ]
+
+
+def test_popping_session_cancels_its_pending_prompts(server):
+    session = {"history": []}
+    event = threading.Event()
+    server._sessions["s1"] = session
+    server._pending["request-1"] = ("s1", event)
+
+    assert server._pop_session_by_id("s1") is session
+
+    assert event.is_set()
+    assert server._answers["request-1"] == ""
+
+
 def test_approval_pending_replays_unresolved_requests(server, monkeypatch):
     from tools import approval
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -521,6 +521,11 @@ def test_clarify_block_helper_builds_batch_payload(capture):
     multi_select) — the tool-side normalized entries carry extra keys the
     renderer must not see."""
     server, buf = capture
+    server._sessions["s1"] = {"history": []}
+    server._on_tool_start("s1", "call-batch", "clarify", {})
+    assert server._sessions["s1"]["clarify_tool_id"] == "call-batch"
+    buf.seek(0)
+    buf.truncate(0)
     normalized = [
         {
             "qid": "q0", "id": "approach", "question": "Which?",
@@ -553,9 +558,13 @@ def test_clarify_block_helper_builds_batch_payload(capture):
     messages = [json.loads(line) for line in buf.getvalue().splitlines()]
     request = messages[0]["params"]
     assert request["type"] == "clarify.request"
+    assert request["payload"]["tool_id"] == "call-batch"
     sent = request["payload"]["questions"][0]
     assert set(sent) == {"qid", "question", "choices", "multi_select"}
     assert "id" not in sent and "choices_offered" not in sent
+
+    server._on_tool_complete("s1", "call-batch", "clarify", {}, "{}")
+    assert "clarify_tool_id" not in server._sessions["s1"]
 
 
 def test_approval_pending_replays_unresolved_requests(server, monkeypatch):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -697,6 +697,69 @@ def test_popping_session_cancels_its_pending_prompts(server):
     assert server._answers["request-1"] == ""
 
 
+def test_popping_session_cancels_clarify_before_generation_capture(server, monkeypatch):
+    """Close must not let a pre-registration clarify capture its new generation."""
+    session = {"history": []}
+    server._sessions["s1"] = session
+    clarify_at_prompt_lock = threading.Event()
+    release_clarify = threading.Event()
+    pop_done = threading.Event()
+    result = {}
+
+    class ClarifyGateLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+
+        def __enter__(self):
+            if threading.current_thread().name == "clarify-before-generation":
+                clarify_at_prompt_lock.set()
+                assert release_clarify.wait(timeout=2)
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_exc):
+            self._lock.release()
+
+    monkeypatch.setattr(server, "_prompt_lock", ClarifyGateLock())
+
+    clarify_thread = threading.Thread(
+        target=lambda: result.setdefault(
+            "answer", server._clarify_block("s1", "Question?", ["yes", "no"])
+        ),
+        name="clarify-before-generation",
+        daemon=True,
+    )
+    clarify_thread.start()
+    assert clarify_at_prompt_lock.wait(timeout=2)
+
+    def pop_session():
+        result["popped"] = server._pop_session_by_id("s1")
+        pop_done.set()
+
+    pop_thread = threading.Thread(target=pop_session, daemon=True)
+    pop_thread.start()
+    pop_done.wait(timeout=0.2)
+    release_clarify.set()
+
+    pop_thread.join(timeout=2)
+    clarify_thread.join(timeout=2)
+    clarify_was_alive = clarify_thread.is_alive()
+    with server._prompt_lock:
+        pending_before_cleanup = [
+            rid
+            for rid, (event, _payload) in server._pending_prompt_payloads.items()
+            if event == "clarify.request"
+        ]
+    if clarify_was_alive:
+        server._clear_pending("s1")
+        clarify_thread.join(timeout=2)
+
+    assert result["popped"] is session
+    assert not clarify_was_alive
+    assert not pending_before_cleanup
+    assert result["answer"] == ""
+
+
 def test_approval_pending_replays_unresolved_requests(server, monkeypatch):
     from tools import approval
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -567,6 +567,67 @@ def test_clarify_block_helper_builds_batch_payload(capture):
     assert "clarify_tool_id" not in server._sessions["s1"]
 
 
+def test_concurrent_clarify_calls_keep_execution_local_tool_ids_and_serialize(capture):
+    """Parallel clarify workers must not share one session-wide physical ID.
+
+    Only one prompt is exposed at a time so reconnect's singular
+    ``pending_clarify`` snapshot remains complete.
+    """
+    server, buf = capture
+    server._sessions["s1"] = {"history": []}
+    started = threading.Barrier(3)
+    results = {}
+
+    def run(call_id, question):
+        server._on_tool_start("s1", call_id, "clarify", {})
+        started.wait()
+        results[call_id] = server._clarify_block("s1", question, ["yes", "no"])
+        server._on_tool_complete("s1", call_id, "clarify", {}, "{}")
+
+    threads = [
+        threading.Thread(target=run, args=("call-a", "Question A?"), daemon=True),
+        threading.Thread(target=run, args=("call-b", "Question B?"), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    started.wait()
+
+    observed = []
+    handled = set()
+    for answer in ("first", "second"):
+        deadline = time.monotonic() + 2
+        pending = []
+        while time.monotonic() < deadline:
+            with server._prompt_lock:
+                pending = [
+                    (rid, dict(payload))
+                    for rid, (event, payload) in server._pending_prompt_payloads.items()
+                    if event == "clarify.request" and rid not in handled
+                ]
+            if pending:
+                break
+            time.sleep(0.01)
+        assert len(pending) == 1
+        rid, payload = pending[0]
+        handled.add(rid)
+        observed.append((payload["question"], payload["tool_id"]))
+        server.handle_request({
+            "id": answer,
+            "method": "clarify.respond",
+            "params": {"request_id": rid, "answer": answer},
+        })
+
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert set(observed) == {
+        ("Question A?", "call-a"),
+        ("Question B?", "call-b"),
+    }
+    assert set(results.values()) == {"first", "second"}
+
+
 def test_approval_pending_replays_unresolved_requests(server, monkeypatch):
     from tools import approval
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4126,6 +4126,10 @@ def _clarify_timeout_seconds() -> float | None:
 def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     """Bridge the clarify tool callback onto _block.
 
+    Parallel tool calls execute on separate worker threads. Keep their physical
+    IDs execution-local, then serialize the blocking prompts because reconnect
+    currently exposes one ``pending_clarify`` snapshot per session.
+
     Single-question calls keep the exact historical payload shape (older
     renderers never see a new field). Batch calls emit one clarify.request
     carrying the question list — only wire fields (qid/question/choices/
@@ -4133,41 +4137,58 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     result-assembly keys (id, choices_offered) the renderer must not see.
     The tool decodes the JSON reply via its batch answer parser.
     """
-    session = _sessions.get(sid)
-    tool_id = str(session.get("clarify_tool_id") or "") if session else ""
+    with _sessions_lock:
+        session = _sessions.get(sid)
+        if session is None:
+            tool_id = ""
+            clarify_lock = None
+        else:
+            by_thread = session.setdefault("clarify_tool_ids_by_thread", {})
+            tool_id = str(
+                by_thread.get(threading.get_ident())
+                or session.get("clarify_tool_id")
+                or ""
+            )
+            clarify_lock = session.setdefault("clarify_lock", threading.Lock())
 
-    if questions:
-        wire = [
-            {
-                "qid": entry["qid"],
-                "question": entry["question"],
-                "choices": entry["choices"],
-                "multi_select": bool(entry["multi_select"]),
-            }
-            for entry in questions
-        ]
+    def request() -> str:
+        if questions:
+            wire = [
+                {
+                    "qid": entry["qid"],
+                    "question": entry["question"],
+                    "choices": entry["choices"],
+                    "multi_select": bool(entry["multi_select"]),
+                }
+                for entry in questions
+            ]
+            return _block(
+                "clarify.request",
+                sid,
+                {"questions": wire, **({"tool_id": tool_id} if tool_id else {})},
+                timeout=_clarify_timeout_seconds(),
+                batch_qids=[entry["qid"] for entry in questions],
+            )
+        # multi_select is a pass-through hint: renderers with checkbox
+        # support can honor it; older renderers ignore the extra field
+        # and stay single-select (a single answer still parses as a
+        # one-element list on the tool side). Only emitted when True so
+        # single-select payloads keep the exact pre-multi-select shape.
         return _block(
             "clarify.request",
             sid,
-            {"questions": wire, **({"tool_id": tool_id} if tool_id else {})},
+            (
+                {"question": q, "choices": c, "multi_select": True, **({"tool_id": tool_id} if tool_id else {})}
+                if multi_select
+                else {"question": q, "choices": c, **({"tool_id": tool_id} if tool_id else {})}
+            ),
             timeout=_clarify_timeout_seconds(),
-            batch_qids=[entry["qid"] for entry in questions],
         )
-    # multi_select is a pass-through hint: renderers with checkbox
-    # support can honor it; older renderers ignore the extra field
-    # and stay single-select (a single answer still parses as a
-    # one-element list on the tool side). Only emitted when True so
-    # single-select payloads keep the exact pre-multi-select shape.
-    return _block(
-        "clarify.request",
-        sid,
-        (
-            {"question": q, "choices": c, "multi_select": True, **({"tool_id": tool_id} if tool_id else {})}
-            if multi_select
-            else {"question": q, "choices": c, **({"tool_id": tool_id} if tool_id else {})}
-        ),
-        timeout=_clarify_timeout_seconds(),
-    )
+
+    if clarify_lock is None:
+        return request()
+    with clarify_lock:
+        return request()
 
 
 # A tour action is a DOM operation the renderer performs and answers straight
@@ -6597,6 +6618,9 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
         if name == "clarify":
             session["clarify_tool_id"] = tool_call_id
+            session.setdefault("clarify_tool_ids_by_thread", {})[
+                threading.get_ident()
+            ] = tool_call_id
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
         payload: dict[str, object] = {
             "tool_id": tool_call_id,
@@ -6627,8 +6651,15 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     if session is not None:
         snapshot = session.setdefault("edit_snapshots", {}).pop(tool_call_id, None)
         started_at = session.setdefault("tool_started_at", {}).pop(tool_call_id, None)
-        if name == "clarify" and session.get("clarify_tool_id") == tool_call_id:
-            session.pop("clarify_tool_id", None)
+        if name == "clarify":
+            by_thread = session.setdefault("clarify_tool_ids_by_thread", {})
+            thread_id = threading.get_ident()
+            if by_thread.get(thread_id) == tool_call_id:
+                by_thread.pop(thread_id, None)
+            if not by_thread:
+                session.pop("clarify_tool_ids_by_thread", None)
+            if session.get("clarify_tool_id") == tool_call_id:
+                session.pop("clarify_tool_id", None)
     duration_s = time.time() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -146,6 +146,10 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
+# Per-session cancellation generation.  A serialized clarify captures this before
+# waiting for its session lock; _block compares it atomically with registration so
+# interrupt/teardown cannot miss a waiter that was not pending yet.
+_prompt_cancel_generation: dict[str, int] = {}
 # Batch clarify accumulators: rid → {"qids": [...], "answers": {qid: answer}}.
 # Written by clarify.respond (per-question lock, update-in-place), read out by
 # _block on resolution/timeout so locked answers survive the deadline.
@@ -1014,6 +1018,10 @@ def _pop_session_by_id(sid: str) -> dict | None:
             _sessions.pop(sid, None)
     if session is None:
         return None
+    # Detach and cancel as one ownership operation.  In particular this wakes
+    # the active clarify and advances its generation so a sibling serialized on
+    # clarify_lock cannot publish a fresh card after close.
+    _clear_pending(sid)
     # The session is already out of _sessions here, so downstream teardown
     # (e.g. _finalize_session's per-session async-delegation interrupt) can't
     # recover its live id by scanning the dict — stamp it on the record.
@@ -4034,10 +4042,16 @@ def _block(
     payload: dict,
     timeout: float | None = 300,
     batch_qids: list[str] | None = None,
+    cancel_generation: int | None = None,
 ) -> str:
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
     with _prompt_lock:
+        if (
+            cancel_generation is not None
+            and _prompt_cancel_generation.get(sid, 0) != cancel_generation
+        ):
+            return ""
         _pending[rid] = (sid, ev)
         payload["request_id"] = rid
         _pending_prompt_payloads[rid] = (event, dict(payload))
@@ -4139,7 +4153,7 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     """
     with _sessions_lock:
         session = _sessions.get(sid)
-        if session is None:
+        if session is None or session.get("_turn_cancel_requested"):
             tool_id = ""
             clarify_lock = None
         else:
@@ -4150,6 +4164,11 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
                 or ""
             )
             clarify_lock = session.setdefault("clarify_lock", threading.Lock())
+    with _prompt_lock:
+        cancel_generation = _prompt_cancel_generation.get(sid, 0)
+
+    if session is None or session.get("_turn_cancel_requested"):
+        return ""
 
     def request() -> str:
         if questions:
@@ -4168,6 +4187,7 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
                 {"questions": wire, **({"tool_id": tool_id} if tool_id else {})},
                 timeout=_clarify_timeout_seconds(),
                 batch_qids=[entry["qid"] for entry in questions],
+                cancel_generation=cancel_generation,
             )
         # multi_select is a pass-through hint: renderers with checkbox
         # support can honor it; older renderers ignore the extra field
@@ -4183,6 +4203,7 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
                 else {"question": q, "choices": c, **({"tool_id": tool_id} if tool_id else {})}
             ),
             timeout=_clarify_timeout_seconds(),
+            cancel_generation=cancel_generation,
         )
 
     if clarify_lock is None:
@@ -4269,6 +4290,8 @@ def _clear_pending(sid: str | None = None) -> None:
     None, every pending prompt is released (used during shutdown).
     """
     with _prompt_lock:
+        if sid is not None:
+            _prompt_cancel_generation[sid] = _prompt_cancel_generation.get(sid, 0) + 1
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
                 _answers[rid] = ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4164,8 +4164,12 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
                 or ""
             )
             clarify_lock = session.setdefault("clarify_lock", threading.Lock())
-    with _prompt_lock:
-        cancel_generation = _prompt_cancel_generation.get(sid, 0)
+        # Capture session ownership and its cancellation generation atomically.
+        # A close must either remove the session before this lookup or advance
+        # the generation after this capture; it must never fit between them and
+        # let a stale caller adopt the new session generation.
+        with _prompt_lock:
+            cancel_generation = _prompt_cancel_generation.get(sid, 0)
 
     if session is None or session.get("_turn_cancel_requested"):
         return ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4133,6 +4133,9 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     result-assembly keys (id, choices_offered) the renderer must not see.
     The tool decodes the JSON reply via its batch answer parser.
     """
+    session = _sessions.get(sid)
+    tool_id = str(session.get("clarify_tool_id") or "") if session else ""
+
     if questions:
         wire = [
             {
@@ -4146,7 +4149,7 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
         return _block(
             "clarify.request",
             sid,
-            {"questions": wire},
+            {"questions": wire, **({"tool_id": tool_id} if tool_id else {})},
             timeout=_clarify_timeout_seconds(),
             batch_qids=[entry["qid"] for entry in questions],
         )
@@ -4159,9 +4162,9 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
         "clarify.request",
         sid,
         (
-            {"question": q, "choices": c, "multi_select": True}
+            {"question": q, "choices": c, "multi_select": True, **({"tool_id": tool_id} if tool_id else {})}
             if multi_select
-            else {"question": q, "choices": c}
+            else {"question": q, "choices": c, **({"tool_id": tool_id} if tool_id else {})}
         ),
         timeout=_clarify_timeout_seconds(),
     )
@@ -6592,6 +6595,8 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
         except Exception:
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+        if name == "clarify":
+            session["clarify_tool_id"] = tool_call_id
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
         payload: dict[str, object] = {
             "tool_id": tool_call_id,
@@ -6622,6 +6627,8 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     if session is not None:
         snapshot = session.setdefault("edit_snapshots", {}).pop(tool_call_id, None)
         started_at = session.setdefault("tool_started_at", {}).pop(tool_call_id, None)
+        if name == "clarify" and session.get("clarify_tool_id") == tool_call_id:
+            session.pop("clarify_tool_id", None)
     duration_s = time.time() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s


### PR DESCRIPTION
## Summary
- preserve clarify request identity across live events, reconnect snapshots and transcript hydration
- reject stale or cross-request responses and close run teardown races
- add regression coverage for repeated questions, reconnects and lifecycle gaps
- publish an unsigned Windows x64 NSIS installer as a CI artifact for this branch

## Verification
- `213 passed` — targeted gateway/TUI Python tests
- `135 passed` — targeted Desktop UI tests
- Desktop TypeScript typecheck passed
- Desktop ESLint passed (warnings only; no errors)
- independent read-only review: APPROVE, no blockers/security issues

## Windows install route
The branch push workflow `Windows Desktop Artifact` builds and uploads `Hermes-clarify-fix-Windows-x64` for direct installation/testing. The fork artifact is unsigned and may trigger Windows SmartScreen.