### PR TITLE
fix(verify): do not invent uvicorn entrypoint when FastAPI has no main/app.py

### DIFF
--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -297,13 +297,11 @@ def _detect_python_recipe(root: Path) -> Recipe | None:
             ),
         )
 
-    if is_fastapi:
+    if is_fastapi and ((root / "main.py").exists() or (root / "app.py").exists()):
         if (root / "main.py").exists():
             app_module = "main:app"
-        elif (root / "app.py").exists():
-            app_module = "app:app"
         else:
-            app_module = "main:app"
+            app_module = "app:app"
         return Recipe(
             name="FastAPI app",
             kind="fastapi",

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -125,6 +125,18 @@ class TestPythonDetection:
         assert recipe.start.startswith("uvicorn main:app")
         assert recipe.port == 8000
 
+    def test_fastapi_dependency_without_root_entrypoint_falls_back_to_python(self, tmp_path):
+        """Regression: FastAPI/Uvicorn listed in deps but no main.py or app.py at root
+        must not be reported as a runnable FastAPI app. A dependency is not an
+        entrypoint — the detector must not invent one."""
+        (tmp_path / "requirements.txt").write_text(
+            "fastapi>=0.115\nuvicorn>=0.30\n", encoding="utf-8"
+        )
+        recipe = detect_recipe(tmp_path)
+        assert recipe.kind == "python"
+        assert not recipe.start
+        assert recipe.port is None
+
     def test_flask(self, tmp_path):
         (tmp_path / "requirements.txt").write_text("flask\n", encoding="utf-8")
         (tmp_path / "app.py").touch()


### PR DESCRIPTION
## Summary

Gate the FastAPI recipe on the presence of a root entrypoint (`main.py` or `app.py`). When a project lists `fastapi`/`uvicorn` as a dependency but exposes neither file at the root — the typical Render-deploy case where build-time deps live in `requirements.txt` but the entrypoint lives under a subpackage — `hermes verify` fabricated `uvicorn main:app` and the readiness phase failed with `Could not import module "main"`. With this fix, a missing root entrypoint falls through to the generic Python project branch (no `start`, no `port`, no invented module).

## Files (2)

- `agent/verify/recipes.py` — gate the FastAPI branch on entrypoint existence
- `tests/verify/test_recipes.py` — new regression test

Diff: +14 / -4

## Verification

- `pytest -q tests/verify/test_recipes.py` → **36 passed** (35 pre-existing + 1 new regression)
- Reproduced the symptom on current `main` (`62b2d78025`) before the fix: `assert recipe.kind == 'python'` fails with `'fastapi' == 'python'`
- After the fix: passes; the existing `test_fastapi_uvicorn` (with `main.py`) is preserved, confirming the fix does not break real FastAPI projects

## Notes

- The Flask branch (line 315) has the same shape of bug (invents `app.py` when absent) and is intentionally left out of this PR — separate fix in a separate concern.
- Co-authored attribution preserved.