### PR TITLE
fix(verify): do not invent flask entrypoint when Flask has no app.py/main.py

### DIFF
--- a/agent/verify/recipes.py
+++ b/agent/verify/recipes.py
@@ -314,13 +314,11 @@ def _detect_python_recipe(root: Path) -> Recipe | None:
             evidence=["Detected Python project", "Detected FastAPI/Uvicorn dependency"],
         )
 
-    if is_flask:
+    if is_flask and ((root / "app.py").exists() or (root / "main.py").exists()):
         if (root / "app.py").exists():
             app_module = "app.py"
-        elif (root / "main.py").exists():
-            app_module = "main.py"
         else:
-            app_module = "app.py"
+            app_module = "main.py"
         return Recipe(
             name="Flask app",
             kind="flask",

--- a/tests/verify/test_recipes.py
+++ b/tests/verify/test_recipes.py
@@ -132,6 +132,16 @@ class TestPythonDetection:
         assert recipe.kind == "flask"
         assert recipe.port == 5000
 
+    def test_flask_dependency_without_root_entrypoint_falls_back_to_python(self, tmp_path):
+        """Regression: Flask listed as dependency but no app.py or main.py at root
+        must not be reported as a runnable Flask app. A dependency is not an
+        entrypoint — the detector must not invent one."""
+        (tmp_path / "requirements.txt").write_text("flask>=3\n", encoding="utf-8")
+        recipe = detect_recipe(tmp_path)
+        assert recipe.kind == "python"
+        assert not recipe.start
+        assert recipe.port is None
+
     def test_generic_python_uv(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
         (tmp_path / "uv.lock").touch()


### PR DESCRIPTION
## Summary

Same shape of bug as the FastAPI recipe detector (PR #95110): when a project lists `flask` as a dependency but exposes neither `app.py` nor `main.py` at the root, `hermes verify` fabricated `flask --app app.py run` and the readiness phase would fail with `Could not locate a Flask application`. Gate the Flask recipe on root-entrypoint existence; a missing entrypoint falls through to the generic Python project branch.

## Files (2)

- `agent/verify/recipes.py` — gate the Flask branch on entrypoint existence
- `tests/verify/test_recipes.py` — new regression test

Diff: +14 / -6

## Verification

- `pytest -q tests/verify/test_recipes.py` → **36 passed** (35 pre-existing + 1 new regression)
- The new regression reproduces the bug on current `main` (kind='flask' instead of 'python') and passes after the fix
- The existing `test_flask` (with app.py) is preserved

## Notes

- Follows the same fix pattern as #95110 for FastAPI
- Co-authored attribution preserved