### PR TITLE
fix(checkpoints): unreadable files no longer disable checkpointing

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -113,6 +113,37 @@ class TestStoreInit:
         # Idempotent.
         assert _init_store(store, str(work_dir)) is None
 
+    def test_default_excludes_engine_cache_dirs(self):
+        from tools.checkpoint_manager import DEFAULT_EXCLUDES
+
+        # Machine-generated VM/engine caches: never project content, and
+        # commonly root-owned 0600 on shared/container filesystems, which
+        # fails plain `git add -A` outright (#78888).
+        for pattern in ("node-compile-cache/", "__pycache__/"):
+            assert pattern in DEFAULT_EXCLUDES
+
+    def test_init_store_refreshes_stale_excludes(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """A store initialized by an older Hermes gets current excludes."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        store = _store_path(checkpoint_base)
+
+        # Simulate an older-version store: init, then strip the new patterns.
+        assert _init_store(store, str(work_dir)) is None
+        exclude_path = store / "info" / "exclude"
+        stale = "\n".join(
+            line for line in exclude_path.read_text().splitlines()
+            if "node-compile-cache" not in line and "__pycache__" not in line
+        ) + "\n"
+        exclude_path.write_text(stale, encoding="utf-8")
+
+        # Re-init on the existing store must refresh the excludes.
+        assert _init_store(store, str(work_dir)) is None
+        refreshed = exclude_path.read_text()
+        assert "node-compile-cache/" in refreshed
+        assert "__pycache__/" in refreshed
+
     def test_legacy_migration_archives_prev2_repos(
         self, checkpoint_base, work_dir,
     ):
@@ -268,6 +299,60 @@ class TestRealPruning:
         names = set(files.splitlines())
         assert "small.py" in names
         assert "weights.bin" not in names  # filtered by size cap
+
+
+# =========================================================================
+# Unreadable files must not disable checkpointing (#78888)
+# =========================================================================
+
+class TestUnreadableFiles:
+    @pytest.mark.skipif(
+        os.name == "nt" or not hasattr(os, "geteuid") or os.geteuid() == 0,
+        reason="permission bits are not enforceable on Windows or as root",
+    )
+    def test_unreadable_file_does_not_kill_checkpointing(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """A single unreadable file must not zero out the whole snapshot.
+
+        Regression for #78888: one root-owned 0600 cache file inside the
+        working dir made ``git add -A`` fail fatally (rc=128, empty index),
+        so every checkpoint silently returned False forever.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "main.py").write_text("print('hello')\n")
+        locked = wd / "locked.bin"
+        locked.write_bytes(b"secret")
+        locked.chmod(0o000)
+        cache = wd / "node-compile-cache"
+        cache.mkdir()
+        (cache / "junk").write_bytes(b"x")
+
+        m = CheckpointManager(enabled=True, max_snapshots=5)
+        try:
+            assert m.ensure_checkpoint(str(wd), "initial") is True
+
+            store = _store_path(checkpoint_base)
+            ok, files, _ = _run_git(
+                ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(wd)))],
+                store, str(wd),
+            )
+            assert ok
+            names = set(files.splitlines())
+            assert "main.py" in names                      # readable content staged
+            assert "node-compile-cache/junk" not in names  # excluded by pattern
+            assert "locked.bin" not in names               # unreadable, skipped
+
+            # And checkpointing keeps working on later turns.
+            m.new_turn()
+            (wd / "main.py").write_text("print('changed')\n")
+            assert m.ensure_checkpoint(str(wd), "second turn") is True
+            cps = m.list_checkpoints(str(wd))
+            assert len(cps) >= 2
+        finally:
+            locked.chmod(0o644)
 
 
 # =========================================================================

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -141,6 +141,16 @@ DEFAULT_EXCLUDES = [
     # OS junk
     ".DS_Store",
     "Thumbs.db",
+    # Engine/VM bytecode caches. These are machine-generated, never
+    # project content, and are commonly created by *other* users (e.g.
+    # a root-owned V8 compile cache baked into a container image) with
+    # 0600 permissions the hermes user cannot read — one unreadable file
+    # used to fail the whole ``git add -A`` and zero out checkpointing
+    # for that working directory (#78888).
+    "node-compile-cache/",
+    "__pycache__/",
+    ".mypy_cache/",
+    ".ruff_cache/",
     # Logs
     "*.log",
 ]
@@ -490,6 +500,10 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
+        # Existing store: make sure its exclude file tracks the current
+        # DEFAULT_EXCLUDES (stores initialized by older versions keep stale
+        # excludes forever otherwise — see _refresh_store_excludes).
+        _refresh_store_excludes(store)
         return None
 
     store.mkdir(parents=True, exist_ok=True)
@@ -539,6 +553,30 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
 
     logger.debug("Initialised checkpoint store at %s", store)
     return None
+
+
+def _refresh_store_excludes(store: Path) -> None:
+    """Keep an existing store's ``info/exclude`` current with the code.
+
+    ``info/exclude`` is written once at init, so stores created by older
+    Hermes versions keep their stale exclude list forever — including
+    missing patterns added later (e.g. engine cache dirs whose unreadable,
+    root-owned files fail every ``git add -A``, silently disabling
+    checkpointing for that working directory, #78888).
+
+    The file is manager-owned: whenever its content drifts from the shipped
+    ``DEFAULT_EXCLUDES`` it is rewritten verbatim.
+    """
+    exclude_path = store / "info" / "exclude"
+    desired = "\n".join(DEFAULT_EXCLUDES) + "\n"
+    try:
+        if exclude_path.read_text(encoding="utf-8") == desired:
+            return
+        exclude_path.parent.mkdir(exist_ok=True)
+        exclude_path.write_text(desired, encoding="utf-8")
+        logger.info("Refreshed checkpoint store excludes at %s", exclude_path)
+    except OSError as exc:
+        logger.debug("Could not refresh checkpoint excludes: %s", exc)
 
 
 def _volume_evidence(workdir: Path) -> Dict:
@@ -1284,8 +1322,32 @@ class CheckpointManager:
             timeout=_GIT_TIMEOUT * 2, index_file=index_file,
         )
         if not ok:
-            logger.debug("Checkpoint git-add failed: %s", err)
-            return False
+            # A single unreadable path (e.g. another user's 0600 cache file
+            # inside the workdir) fails plain ``git add -A`` outright with a
+            # fatal error and a stale/empty index, which used to silently
+            # disable checkpointing for the whole directory. Retry with
+            # ``--ignore-errors`` so every readable file still stages; that
+            # variant exits 1 when it had to skip paths — the snapshot just
+            # omits files we could not read (#78888).
+            logger.warning(
+                "Checkpoint git-add failed (%s); retrying with --ignore-errors",
+                (err or "").strip().splitlines()[-1] if err else "unknown error",
+            )
+            ok, _, err = _run_git(
+                ["add", "--ignore-errors", "-A"], store, working_dir,
+                timeout=_GIT_TIMEOUT * 2, index_file=index_file,
+                allowed_returncodes={1},  # rc=1 = skipped paths, not fatal
+            )
+            if not ok:
+                # ``_run_git`` reports strict rc==0, so a benign rc=1 lands
+                # here too. Decide by whether the index is actually usable.
+                index_ok, _, _ = _run_git(
+                    ["diff", "--cached", "--name-only"], store, working_dir,
+                    timeout=_GIT_TIMEOUT, index_file=index_file,
+                )
+                if not index_ok:
+                    logger.debug("Checkpoint git-add failed: %s", err)
+                    return False
 
         if self.max_file_size_mb > 0:
             self._drop_oversize_from_index(store, working_dir, index_file)


### PR DESCRIPTION
## What does this PR do?

One unreadable path inside the working directory makes plain `git add -A` fail fatally (rc=128), so checkpointing silently dies for that workdir from then on. Reproduced on a hosted install: any session with `workdir=/tmp` lost all checkpointing because `/tmp/node-compile-cache/` is root-owned 0600 (baked into the container image) — matching the scenario in #78888.

Three layers of fix:

1. **Exclude engine/VM cache dirs** (`node-compile-cache/`, `__pycache__/`, `.mypy_cache/`, `.ruff_cache/`) in `DEFAULT_EXCLUDES` — machine-generated, never project content, and commonly owned by another user on shared/container filesystems.
2. **Self-heal existing stores**: `info/exclude` was written once at init (`tools/checkpoint_manager.py::_init_store`), so stores created by older versions never picked up newly added patterns. `_init_store()` now refreshes the file whenever its content drifts from the shipped defaults.
3. **Class-level fallback**: if `git add -A` still fails fatally, retry once with `--ignore-errors` so every readable file still stages. That variant exits 1 when it had to skip paths, so success is decided by probing index usability rather than trusting the exit code — the snapshot omits only what could not be read instead of failing outright.

## Related Issue

Fixes #78888

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/checkpoint_manager.py`
  - Added engine/VM cache dirs to `DEFAULT_EXCLUDES`
  - New `_refresh_store_excludes()`; called from `_init_store()` for existing stores so stale excludes converge on the shipped defaults
  - In the checkpoint staging path: on fatal `git add -A`, retry with `--ignore-errors -A` and accept rc=1 (skipped paths) after verifying the index is usable
- `tests/tools/test_checkpoint_manager.py`
  - `test_default_excludes_engine_cache_dirs` — pins the new patterns
  - `test_init_store_refreshes_stale_excludes` — older-version store gets current excludes on re-init
  - `TestUnreadableFiles::test_unreadable_file_does_not_kill_checkpointing` — real rc=128 reproduction: a chmod-000 file plus a `node-compile-cache/` dir no longer zero out the snapshot; readable content stages, unreadable file is omitted, later turns keep checkpointing

## How to Test

1. Create a temp dir with a readable file, a `chmod 000` file, and a `node-compile-cache/` subdir
2. Call `ensure_checkpoint(dir, "initial")` — before this change it returns False forever; after, True with a snapshot containing only the readable file
3. Run `pytest tests/tools/test_checkpoint_manager.py -q` → 50 passed (47 pre-existing untouched, 3 new)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted suite: `tests/tools/test_checkpoint_manager.py` — 50 passed; full suite not runnable in the authoring container)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Docker container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(new test skips on Windows/root; permission semantics unchanged elsewhere)*
