### PR TITLE
feat(cron): escalate unacked incident alerts

### DIFF
--- a/cron/incidents.py
+++ b/cron/incidents.py
@@ -2,15 +2,17 @@
 
 The executions ledger (``cron.executions``) records every attempt; this module
 groups the *failures* into durable incidents keyed by ``(job_id, error
-signature)`` so the same job failing with the same error does not re-ping the
-operator every run once they have acknowledged it.
+signature)``. An open incident alerts immediately, then after four hours, then
+daily; acknowledgment closes that signature and silences it entirely.
 
 Lifecycle: ``detected`` → ``alerted`` → ``closed``. Closing
 (acking) an incident is per-signature: the same job + same normalized error
 keeps resolving to the SAME incident id, so a closed incident stays closed (no
 re-alert) until the error text changes, which mints a brand-new incident.
 ``detected`` means the failure was recorded; ``alerted`` means at least one
-failure ping for the signature actually reached the operator. Richer states
+failure ping for the signature actually reached the operator. The
+``last_alerted_at`` confirmation makes due reminders retry after delivery
+failure without moving reminder bookkeeping into the scheduler. Richer states
 (e.g. a dv9.6 ``reviewed``) are deliberately NOT reserved here — state
 validity lives in ``INCIDENT_STATES`` (Python), not a SQLite CHECK, exactly
 so a future slice can add states without a table rebuild.
@@ -27,6 +29,7 @@ import re
 import sqlite3
 import threading
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
@@ -48,6 +51,8 @@ _FAILURE_TYPE_ORDER = (
 )
 MAX_ERROR_CHARS = 500
 _MAX_SIGNATURE_ERROR_CHARS = 200
+_FIRST_REMINDER_SECONDS = 4 * 60 * 60
+_DAILY_REMINDER_SECONDS = 24 * 60 * 60
 
 _lock = threading.RLock()
 
@@ -94,6 +99,7 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              failure_type  TEXT NOT NULL DEFAULT 'unknown',
              first_seen_at TEXT NOT NULL,
              last_seen_at  TEXT NOT NULL,
+             last_alerted_at TEXT,
              acked_at      TEXT,
              closed_at     TEXT,
              error         TEXT NOT NULL,
@@ -108,6 +114,13 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_cron_incidents_state "
         "ON cron_incidents(state)"
     )
+    columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(cron_incidents)")
+    }
+    if "last_alerted_at" not in columns:
+        conn.execute(
+            "ALTER TABLE cron_incidents ADD COLUMN last_alerted_at TEXT"
+        )
 
 
 @contextmanager
@@ -147,8 +160,16 @@ def _redact_error(error: str) -> str:
 
 
 def _error_signature(job_id: str, error: str) -> str:
-    """Dedup key: stable for same job + same normalized error prefix."""
+    """Dedup key for a job's raw error, independent of delivered message text.
+
+    Dynamic hexadecimal ids and decimal numbers normalize before signing so
+    request ids, ports, retry counters, and the streak count in a separately
+    composed ``_failure_streak_nudge`` cannot fragment one incident. Callers
+    must pass the error itself, never the summarized/nudged delivery message.
+    """
     normalized = _normalize_error(error)[:_MAX_SIGNATURE_ERROR_CHARS]
+    normalized = re.sub(r"\b[0-9a-f]{8,}\b", "<id>", normalized)
+    normalized = re.sub(r"\d+", "<n>", normalized)
     digest = hashlib.sha256(job_id.encode() + normalized.encode()).hexdigest()
     return digest[:12]
 
@@ -172,6 +193,79 @@ def _classify_failure_type(error: str) -> str:
     return "unknown"
 
 
+def _alert_window(first_seen_at: str, value_at: str) -> int:
+    """Return the escalation window containing ``value_at``.
+
+    Window 0 starts at detection, window 1 starts four hours later, and each
+    later window starts after another day. Comparing the last confirmed alert
+    window with the current one produces immediate → 4h → daily reminders.
+    """
+    try:
+        age = (
+            datetime.fromisoformat(value_at) - datetime.fromisoformat(first_seen_at)
+        ).total_seconds()
+    except (TypeError, ValueError):
+        return 0
+    if age < _FIRST_REMINDER_SECONDS:
+        return 0
+    return 1 + int((age - _FIRST_REMINDER_SECONDS) // _DAILY_REMINDER_SECONDS)
+
+
+def _should_alert(row: sqlite3.Row, now: str) -> bool:
+    state = row["state"]
+    if state == "closed":
+        return False
+    if state == "detected":
+        # Retry the first ping until delivery confirms it by moving the row to
+        # alerted and stamping last_alerted_at.
+        return True
+    last_alerted_at = row["last_alerted_at"] or row["first_seen_at"]
+    return _alert_window(row["first_seen_at"], now) > _alert_window(
+        row["first_seen_at"], last_alerted_at
+    )
+
+
+def _upsert_incident(
+    job_id: str,
+    error: str,
+    *,
+    job_name: Optional[str] = None,
+    failure_type: Optional[str] = None,
+    output_file: Optional[str] = None,
+    decide_alert: bool = False,
+) -> tuple[str, bool, bool]:
+    job_id = str(job_id or "")
+    sig = _error_signature(job_id, error)
+    stored_error = _redact_error(error)
+    incident_id = _incident_id(job_id, sig)
+    now = _hermes_now().isoformat()
+    failure_type = failure_type or _classify_failure_type(error)
+    output_file = str(output_file) if output_file is not None else None
+
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM cron_incidents WHERE id=?", (incident_id,)
+        ).fetchone()
+        if row is not None:
+            should_alert = _should_alert(row, now) if decide_alert else False
+            conn.execute(
+                """UPDATE cron_incidents
+                   SET last_seen_at=?, error=?, output_file=?
+                   WHERE id=?""",
+                (now, stored_error, output_file, incident_id),
+            )
+            return incident_id, False, should_alert
+        conn.execute(
+            """INSERT INTO cron_incidents
+               (id, job_id, error_sig, state, failure_type,
+                first_seen_at, last_seen_at, error, output_file)
+               VALUES (?, ?, ?, 'detected', ?, ?, ?, ?, ?)""",
+            (incident_id, job_id, sig, failure_type, now, now,
+             stored_error, output_file),
+        )
+        return incident_id, True, True
+
+
 def upsert_incident(
     job_id: str,
     error: str,
@@ -187,35 +281,53 @@ def upsert_incident(
     current state — a ``closed`` (acked) incident stays closed for the same
     signature. A changed error text mints a new incident automatically.
     """
-    job_id = str(job_id or "")
-    sig = _error_signature(job_id, error)
-    stored_error = _redact_error(error)
-    incident_id = _incident_id(job_id, sig)
-    now = _hermes_now().isoformat()
-    failure_type = failure_type or _classify_failure_type(error)
-    output_file = str(output_file) if output_file is not None else None
+    incident_id, is_new, _ = _upsert_incident(
+        job_id,
+        error,
+        job_name=job_name,
+        failure_type=failure_type,
+        output_file=output_file,
+    )
+    return incident_id, is_new
 
+
+def upsert_incident_for_alert(
+    job_id: str,
+    error: str,
+    *,
+    job_name: Optional[str] = None,
+    failure_type: Optional[str] = None,
+    output_file: Optional[str] = None,
+) -> tuple[str, bool]:
+    """Record a failure and atomically apply the incident alert policy.
+
+    Returns ``(incident_id, should_alert)``. New and not-yet-delivered
+    incidents alert immediately. Confirmed alerts then back off to a reminder
+    after four hours and daily reminders thereafter. Closed incidents never
+    alert. ``last_seen_at`` is refreshed regardless of the decision.
+    """
+    incident_id, _, should_alert = _upsert_incident(
+        job_id,
+        error,
+        job_name=job_name,
+        failure_type=failure_type,
+        output_file=output_file,
+        decide_alert=True,
+    )
+    return incident_id, should_alert
+
+
+def mark_incident_alerted(incident_id: str) -> bool:
+    """Confirm a delivered alert and advance the incident's reminder clock."""
+    now = _hermes_now().isoformat()
     with _transaction() as conn:
-        row = conn.execute(
-            "SELECT id FROM cron_incidents WHERE id=?", (incident_id,)
-        ).fetchone()
-        if row is not None:
-            conn.execute(
-                """UPDATE cron_incidents
-                   SET last_seen_at=?, error=?, output_file=?
-                   WHERE id=?""",
-                (now, stored_error, output_file, incident_id),
-            )
-            return incident_id, False
-        conn.execute(
-            """INSERT INTO cron_incidents
-               (id, job_id, error_sig, state, failure_type,
-                first_seen_at, last_seen_at, error, output_file)
-               VALUES (?, ?, ?, 'detected', ?, ?, ?, ?, ?)""",
-            (incident_id, job_id, sig, failure_type, now, now,
-             stored_error, output_file),
+        cursor = conn.execute(
+            """UPDATE cron_incidents
+               SET state='alerted', last_alerted_at=?
+               WHERE id=? AND state != 'closed'""",
+            (now, incident_id),
         )
-        return incident_id, True
+        return cursor.rowcount > 0
 
 
 def set_incident_state(incident_id: str, state: str) -> bool:

--- a/cron/incidents.py
+++ b/cron/incidents.py
@@ -2,8 +2,9 @@
 
 The executions ledger (``cron.executions``) records every attempt; this module
 groups the *failures* into durable incidents keyed by ``(job_id, error
-signature)``. An open incident alerts immediately, then after four hours, then
-daily; acknowledgment closes that signature and silences it entirely.
+signature)``. An open incident alerts immediately, then on subsequent failing
+runs after four hours, then daily; acknowledgment closes that signature and
+silences it entirely.
 
 Lifecycle: ``detected`` → ``alerted`` → ``closed``. Closing
 (acking) an incident is per-signature: the same job + same normalized error
@@ -51,6 +52,7 @@ _FAILURE_TYPE_ORDER = (
 )
 MAX_ERROR_CHARS = 500
 _MAX_SIGNATURE_ERROR_CHARS = 200
+_SIGNATURE_VERSION = 2
 _FIRST_REMINDER_SECONDS = 4 * 60 * 60
 _DAILY_REMINDER_SECONDS = 24 * 60 * 60
 
@@ -103,7 +105,16 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              acked_at      TEXT,
              closed_at     TEXT,
              error         TEXT NOT NULL,
-             output_file   TEXT
+             output_file   TEXT,
+             signature_version INTEGER NOT NULL DEFAULT 2
+           )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS cron_incident_signature_aliases (
+             job_id      TEXT NOT NULL,
+             error_sig   TEXT NOT NULL,
+             incident_id TEXT NOT NULL,
+             PRIMARY KEY (job_id, error_sig)
            )"""
     )
     conn.execute(
@@ -121,6 +132,12 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE cron_incidents ADD COLUMN last_alerted_at TEXT"
         )
+    if "signature_version" not in columns:
+        conn.execute(
+            "ALTER TABLE cron_incidents "
+            "ADD COLUMN signature_version INTEGER NOT NULL DEFAULT 1"
+        )
+    _migrate_error_signatures(conn)
 
 
 @contextmanager
@@ -162,20 +179,122 @@ def _redact_error(error: str) -> str:
 def _error_signature(job_id: str, error: str) -> str:
     """Dedup key for a job's raw error, independent of delivered message text.
 
-    Dynamic hexadecimal ids and decimal numbers normalize before signing so
-    request ids, ports, retry counters, and the streak count in a separately
-    composed ``_failure_streak_nudge`` cannot fragment one incident. Callers
-    must pass the error itself, never the summarized/nudged delivery message.
+    Dynamic hexadecimal ids and long decimal values normalize before signing
+    so request ids and timestamps cannot fragment one incident. Short values
+    remain significant because status and exit codes identify the error class.
+    Callers must pass the error itself, never the summarized/nudged delivery
+    message.
     """
     normalized = _normalize_error(error)[:_MAX_SIGNATURE_ERROR_CHARS]
     normalized = re.sub(r"\b[0-9a-f]{8,}\b", "<id>", normalized)
-    normalized = re.sub(r"\d+", "<n>", normalized)
+    normalized = re.sub(r"\b\d{4,}\b", "<n>", normalized)
+    digest = hashlib.sha256(job_id.encode() + normalized.encode()).hexdigest()
+    return digest[:12]
+
+
+def _legacy_error_signature(job_id: str, error: str) -> str:
+    """Return the pre-v2 signature used before dynamic-value normalization."""
+    normalized = _normalize_error(error)[:_MAX_SIGNATURE_ERROR_CHARS]
     digest = hashlib.sha256(job_id.encode() + normalized.encode()).hexdigest()
     return digest[:12]
 
 
 def _incident_id(job_id: str, error_sig: str) -> str:
     return f"{job_id[:6]}_{error_sig}"
+
+
+def _latest_timestamp(*values: Optional[str]) -> Optional[str]:
+    present = [value for value in values if value]
+    return max(present) if present else None
+
+
+def _rekey_incident(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    new_sig: str,
+    new_id: str,
+) -> str:
+    """Move one incident to ``new_id``, merging a normalized collision."""
+    old_id = row["id"]
+    target = conn.execute(
+        "SELECT * FROM cron_incidents WHERE id=? AND id != ?",
+        (new_id, old_id),
+    ).fetchone()
+    if target is None:
+        conn.execute(
+            """UPDATE cron_incidents
+               SET id=?, error_sig=?, signature_version=?
+               WHERE id=?""",
+            (new_id, new_sig, _SIGNATURE_VERSION, old_id),
+        )
+    else:
+        rows = (row, target)
+        state_rank = {"detected": 0, "alerted": 1, "closed": 2}
+        latest = max(rows, key=lambda item: item["last_seen_at"])
+        state = max(rows, key=lambda item: state_rank[item["state"]])["state"]
+        output_file = latest["output_file"] or next(
+            (item["output_file"] for item in rows if item["output_file"]), None
+        )
+        conn.execute("DELETE FROM cron_incidents WHERE id=?", (old_id,))
+        conn.execute(
+            """UPDATE cron_incidents
+               SET error_sig=?, state=?, failure_type=?, first_seen_at=?,
+                   last_seen_at=?, last_alerted_at=?, acked_at=?, closed_at=?,
+                   error=?, output_file=?, signature_version=?
+               WHERE id=?""",
+            (
+                new_sig,
+                state,
+                latest["failure_type"],
+                min(item["first_seen_at"] for item in rows),
+                max(item["last_seen_at"] for item in rows),
+                _latest_timestamp(*(item["last_alerted_at"] for item in rows)),
+                _latest_timestamp(*(item["acked_at"] for item in rows)),
+                _latest_timestamp(*(item["closed_at"] for item in rows)),
+                latest["error"],
+                output_file,
+                _SIGNATURE_VERSION,
+                new_id,
+            ),
+        )
+    conn.execute(
+        """UPDATE cron_incident_signature_aliases
+           SET incident_id=? WHERE incident_id=?""",
+        (new_id, old_id),
+    )
+    return new_id
+
+
+def _migrate_error_signatures(conn: sqlite3.Connection) -> None:
+    """Re-key incidents created before numeric signature normalization.
+
+    The migration covers open and closed incidents so an acknowledged legacy
+    failure remains acknowledged after upgrade. If normalization makes legacy
+    rows converge, the strongest lifecycle state wins (closed over alerted
+    over detected) and their observation windows are combined.
+    """
+    legacy_rows = conn.execute(
+        "SELECT * FROM cron_incidents WHERE signature_version < ?",
+        (_SIGNATURE_VERSION,),
+    ).fetchall()
+    for snapshot in legacy_rows:
+        old_id = snapshot["id"]
+        row = conn.execute(
+            "SELECT * FROM cron_incidents "
+            "WHERE id=? AND signature_version < ?",
+            (old_id, _SIGNATURE_VERSION),
+        ).fetchone()
+        if row is None:
+            continue
+
+        conn.execute(
+            """INSERT OR IGNORE INTO cron_incident_signature_aliases
+               (job_id, error_sig, incident_id) VALUES (?, ?, ?)""",
+            (row["job_id"], row["error_sig"], old_id),
+        )
+        new_sig = _error_signature(row["job_id"], row["error"])
+        new_id = _incident_id(row["job_id"], new_sig)
+        _rekey_incident(conn, row, new_sig, new_id)
 
 
 def _classify_failure_type(error: str) -> str:
@@ -246,6 +365,26 @@ def _upsert_incident(
         row = conn.execute(
             "SELECT * FROM cron_incidents WHERE id=?", (incident_id,)
         ).fetchone()
+        if row is None:
+            legacy_sig = _legacy_error_signature(job_id, error)
+            alias = conn.execute(
+                """SELECT incident_id FROM cron_incident_signature_aliases
+                   WHERE job_id=? AND error_sig=?""",
+                (job_id, legacy_sig),
+            ).fetchone()
+            if alias is not None:
+                legacy_row = conn.execute(
+                    "SELECT * FROM cron_incidents WHERE id=?",
+                    (alias["incident_id"],),
+                ).fetchone()
+                if legacy_row is not None:
+                    incident_id = _rekey_incident(
+                        conn, legacy_row, sig, incident_id
+                    )
+                    row = conn.execute(
+                        "SELECT * FROM cron_incidents WHERE id=?",
+                        (incident_id,),
+                    ).fetchone()
         if row is not None:
             should_alert = _should_alert(row, now) if decide_alert else False
             conn.execute(
@@ -258,10 +397,11 @@ def _upsert_incident(
         conn.execute(
             """INSERT INTO cron_incidents
                (id, job_id, error_sig, state, failure_type,
-                first_seen_at, last_seen_at, error, output_file)
-               VALUES (?, ?, ?, 'detected', ?, ?, ?, ?, ?)""",
+                first_seen_at, last_seen_at, error, output_file,
+                signature_version)
+               VALUES (?, ?, ?, 'detected', ?, ?, ?, ?, ?, ?)""",
             (incident_id, job_id, sig, failure_type, now, now,
-             stored_error, output_file),
+             stored_error, output_file, _SIGNATURE_VERSION),
         )
         return incident_id, True, True
 
@@ -302,9 +442,9 @@ def upsert_incident_for_alert(
     """Record a failure and atomically apply the incident alert policy.
 
     Returns ``(incident_id, should_alert)``. New and not-yet-delivered
-    incidents alert immediately. Confirmed alerts then back off to a reminder
-    after four hours and daily reminders thereafter. Closed incidents never
-    alert. ``last_seen_at`` is refreshed regardless of the decision.
+    incidents alert immediately. Subsequent failing runs send a reminder after
+    four hours and daily reminders thereafter. Closed incidents never alert.
+    ``last_seen_at`` is refreshed regardless of the decision.
     """
     incident_id, _, should_alert = _upsert_incident(
         job_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -344,40 +344,42 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
 
 def _upsert_incident_for_failure(
     job: dict, error: str, *, output_file: Optional[Any] = None
-) -> tuple[bool, Optional[str]]:
+) -> tuple[bool, bool, Optional[str]]:
     """Record a durable failure incident for this run.
 
-    The incident store groups "same job + same error signature" across runs so
-    an operator-acked failure stops re-pinging every run. Returns
-    ``(acked, incident_id)``: ``acked`` is True when the incident for this
-    exact signature is already ``closed`` (acked) — the per-run failure ping
-    should be suppressed. ``incident_id`` lets the caller mark the incident
-    ``alerted`` after the ping actually goes out. The streak nudge and
-    ``_summarize_cron_failure_for_delivery`` text stay intact for un-acked
-    failures.
+    The incident store groups "same job + same raw error signature" across
+    runs and owns the escalating alert policy. Returns ``(should_alert,
+    closed, incident_id)``. Open incidents alert immediately, then after four
+    hours, then daily; closed (acked) incidents stay silent. The raw ``error``
+    is signed before the separately composed failure summary and streak nudge,
+    so the nudge's changing run count cannot fragment the incident.
 
     Best-effort: an incident-store error must never break the cron run or the
     delivery path — failures are logged at debug and the caller delivers as if
     no incident existed.
     """
     try:
-        from cron.incidents import get_incident, upsert_incident
+        from cron.incidents import get_incident, upsert_incident_for_alert
 
-        incident_id, _is_new = upsert_incident(
+        incident_id, should_alert = upsert_incident_for_alert(
             job["id"],
             str(error or ""),
             job_name=job.get("name"),
             output_file=output_file,
         )
         incident = get_incident(incident_id)
-        acked = bool(incident and incident.get("state") == "closed")
-        return acked, incident_id
+        closed = bool(incident and incident.get("state") == "closed")
+        if closed:
+            # Ack may race the upsert/decision transaction. Never deliver when
+            # the follow-up state read already proves the incident is closed.
+            should_alert = False
+        return should_alert, closed, incident_id
     except Exception as exc:
         logger.debug(
             "Incident store unavailable for job %s (delivery unaffected): %s",
             job["id"], exc,
         )
-        return False, None
+        return True, False, None
 
 
 def _mark_incident_alerted(incident_id: Optional[str]) -> None:
@@ -390,9 +392,9 @@ def _mark_incident_alerted(incident_id: Optional[str]) -> None:
     if not incident_id:
         return
     try:
-        from cron.incidents import set_incident_state
+        from cron.incidents import mark_incident_alerted
 
-        set_incident_state(incident_id, "alerted")
+        mark_incident_alerted(incident_id)
     except Exception as exc:
         logger.debug("Failed marking incident %s alerted: %s", incident_id, exc)
 
@@ -6826,7 +6828,8 @@ def _run_one_job_body(
     # Durable failure-incident bookkeeping for this run (see cron.incidents):
     # set on the failure paths below; consumed by the delivery_outcome
     # computation and the post-delivery "alerted" transition.
-    incident_acked = False
+    incident_should_alert = True
+    incident_closed = False
     failure_incident_id = None
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
@@ -7006,16 +7009,19 @@ def _run_one_job_body(
                 if success:
                     deliver_content = final_response
                 else:
-                    # Durable failure incident: record this job+error
-                    # signature once and, when the operator already acked it,
-                    # suppress the per-run failure ping (the streak nudge and
-                    # the failure summarizer stay intact for un-acked
-                    # failures). Best-effort — an incident-store error never
-                    # breaks the delivery path (see _upsert_incident_for_failure).
-                    incident_acked, failure_incident_id = _upsert_incident_for_failure(
+                    # Durable failure incident: the store decides whether this
+                    # raw-error signature is due for its immediate / four-hour
+                    # / daily alert. Summary + streak nudge are composed only
+                    # after that decision, so their changing text never affects
+                    # dedup. Best-effort — a store error fails open.
+                    (
+                        incident_should_alert,
+                        incident_closed,
+                        failure_incident_id,
+                    ) = _upsert_incident_for_failure(
                         job, error or "", output_file=output_file
                     )
-                    if incident_acked and not drift_skip:
+                    if not incident_should_alert and not drift_skip:
                         deliver_content = ""
                     else:
                         deliver_content = (
@@ -7172,17 +7178,17 @@ def _run_one_job_body(
             delivery_outcome = "not_configured"
         elif should_deliver and normalized_deliver != "local":
             delivery_outcome = "delivered"
-        elif incident_acked and not success:
+        elif incident_closed and not success:
             # Distinct from plain "suppressed" (silence marker / local jobs):
             # the failure ping was withheld because the operator acked this
             # exact signature via `hermes cron incidents ack`.
             delivery_outcome = "suppressed_acked"
         else:
             delivery_outcome = "suppressed"
-        if delivery_outcome in ("delivered", "not_configured") and not success:
-            # The failure ping left the process (or was composed for a
-            # configured target) — record it on the incident so the CLI
-            # distinguishes "failure seen" from "operator was pinged".
+        if delivery_outcome == "delivered" and not success:
+            # Confirm only an alert that reached a configured delivery target.
+            # An unresolved origin remains due so configuring it later retries
+            # immediately instead of waiting for the next escalation window.
             _mark_incident_alerted(failure_incident_id)
         finish_execution(
             execution_id,
@@ -7220,14 +7226,19 @@ def _run_one_job_body(
                 job.get("deliver", "local")
             )
             unresolved_origin = False
-            # Durable failure incident: same ack gate as the normal failure
-            # delivery above — an acked signature stays silent on this path
-            # too, so the retry-path alert cannot re-ping after acknowledgment.
-            incident_acked, failure_incident_id = _upsert_incident_for_failure(
-                job, _err_text
-            )
-            if incident_acked:
-                delivery_outcome = "suppressed_acked"
+            # Apply the same store-owned escalation policy as the normal
+            # failure path. When a reminder is due, the escaped-run streak
+            # nudge below remains part of the delivered alert (#88655).
+            (
+                incident_should_alert,
+                incident_closed,
+                failure_incident_id,
+            ) = _upsert_incident_for_failure(job, _err_text)
+            if not incident_should_alert:
+                if incident_closed:
+                    delivery_outcome = "suppressed_acked"
+                else:
+                    delivery_outcome = "suppressed"
             else:
                 try:
                     delivery_attempted = True
@@ -7257,7 +7268,7 @@ def _run_one_job_body(
                     delivery_outcome = "not_configured"
                 elif normalized_deliver != "local":
                     delivery_outcome = "delivered"
-                if delivery_outcome in ("delivered", "not_configured"):
+                if delivery_outcome == "delivered":
                     _mark_incident_alerted(failure_incident_id)
         try:
             if not _consume_interrupted_flag(job["id"], execution_token):

--- a/tests/cron/test_cron_incidents.py
+++ b/tests/cron/test_cron_incidents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import sqlite3
 import sys
 from datetime import datetime, timedelta, timezone
@@ -108,11 +109,24 @@ def test_same_signature_dedups_same_incident(monkeypatch, tmp_path):
     assert inc.get_incident(id1)["state"] == "detected"
 
 
-def test_signature_normalizes_dynamic_numbers():
+def test_signature_normalizes_long_dynamic_numbers():
     assert incidents._error_signature(
-        "job-1", "request 123 failed after 45 seconds"
+        "job-1", "request 123456 failed at 1720000000"
     ) == incidents._error_signature(
-        "job-1", "request 987 failed after 60 seconds"
+        "job-1", "request 987654 failed at 1730000000"
+    )
+
+
+def test_signature_preserves_status_and_exit_codes():
+    assert incidents._error_signature(
+        "job-1", "request failed with status 404"
+    ) != incidents._error_signature(
+        "job-1", "request failed with status 500"
+    )
+    assert incidents._error_signature(
+        "job-1", "script exited with code 1"
+    ) != incidents._error_signature(
+        "job-1", "script exited with code 137"
     )
 
 
@@ -123,26 +137,26 @@ def test_unacked_incident_alerts_immediately_then_after_four_hours_and_daily(
     started = datetime(2026, 8, 26, tzinfo=timezone.utc)
 
     monkeypatch.setattr(inc, "_hermes_now", lambda: started)
-    inc_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 123")
+    inc_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 12345")
     assert should_alert is True
     assert inc.mark_incident_alerted(inc_id) is True
 
     monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=1))
-    same_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 456")
+    same_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 45678")
     assert same_id == inc_id
     assert should_alert is False
 
     monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=4))
-    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 789")
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 78901")
     assert should_alert is True
     assert inc.mark_incident_alerted(inc_id) is True
 
     monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=5))
-    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 999")
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 99999")
     assert should_alert is False
 
     monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=28))
-    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 111")
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 11111")
     assert should_alert is True
 
 
@@ -312,6 +326,162 @@ def test_existing_incident_schema_gains_alert_confirmation_column(
     row = inc.get_incident(inc_id)
     assert row is not None
     assert row["last_alerted_at"] is not None
+
+
+def test_existing_incidents_migrate_to_normalized_signatures(monkeypatch, tmp_path):
+    db_path = tmp_path / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    legacy_rows = [
+        ("job-1", "request abcdef123456 failed", "alerted"),
+        ("job-2", "worker failed at 1720000000", "closed"),
+    ]
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE cron_incidents (
+                 id TEXT PRIMARY KEY,
+                 job_id TEXT NOT NULL,
+                 error_sig TEXT NOT NULL,
+                 state TEXT NOT NULL,
+                 failure_type TEXT NOT NULL DEFAULT 'unknown',
+                 first_seen_at TEXT NOT NULL,
+                 last_seen_at TEXT NOT NULL,
+                 last_alerted_at TEXT,
+                 acked_at TEXT,
+                 closed_at TEXT,
+                 error TEXT NOT NULL,
+                 output_file TEXT
+               )"""
+        )
+        for job_id, error, state in legacy_rows:
+            normalized = incidents._normalize_error(error)[:200]
+            legacy_sig = hashlib.sha256(
+                job_id.encode() + normalized.encode()
+            ).hexdigest()[:12]
+            legacy_id = incidents._incident_id(job_id, legacy_sig)
+            conn.execute(
+                """INSERT INTO cron_incidents
+                   (id, job_id, error_sig, state, failure_type,
+                    first_seen_at, last_seen_at, last_alerted_at,
+                    acked_at, closed_at, error, output_file)
+                   VALUES (?, ?, ?, ?, 'unknown', ?, ?, ?, ?, ?, ?, NULL)""",
+                (
+                    legacy_id,
+                    job_id,
+                    legacy_sig,
+                    state,
+                    "2026-08-25T00:00:00+00:00",
+                    "2026-08-26T00:00:00+00:00",
+                    "2026-08-25T00:00:00+00:00" if state == "alerted" else None,
+                    "2026-08-26T00:00:00+00:00" if state == "closed" else None,
+                    "2026-08-26T00:00:00+00:00" if state == "closed" else None,
+                    error,
+                ),
+            )
+
+    inc = _point_db(monkeypatch, tmp_path)
+    rows = {row["job_id"]: row for row in inc.list_incidents()}
+
+    assert set(rows) == {"job-1", "job-2"}
+    for job_id, error, state in legacy_rows:
+        expected_sig = inc._error_signature(job_id, error)
+        assert rows[job_id]["id"] == inc._incident_id(job_id, expected_sig)
+        assert rows[job_id]["error_sig"] == expected_sig
+        assert rows[job_id]["state"] == state
+
+
+def test_signature_migration_merges_collisions_and_preserves_ack(monkeypatch, tmp_path):
+    db_path = tmp_path / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    errors = (
+        ("worker failed at 1720000000", "alerted"),
+        ("worker failed at 1730000000", "closed"),
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE cron_incidents (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL,
+                 error_sig TEXT NOT NULL, state TEXT NOT NULL,
+                 failure_type TEXT NOT NULL DEFAULT 'unknown',
+                 first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL,
+                 last_alerted_at TEXT, acked_at TEXT, closed_at TEXT,
+                 error TEXT NOT NULL, output_file TEXT
+               )"""
+        )
+        for index, (error, state) in enumerate(errors):
+            normalized = incidents._normalize_error(error)[:200]
+            legacy_sig = hashlib.sha256(
+                b"job-1" + normalized.encode()
+            ).hexdigest()[:12]
+            conn.execute(
+                """INSERT INTO cron_incidents
+                   VALUES (?, 'job-1', ?, ?, 'unknown', ?, ?, NULL, ?, ?, ?, NULL)""",
+                (
+                    incidents._incident_id("job-1", legacy_sig),
+                    legacy_sig,
+                    state,
+                    f"2026-08-2{index + 4}T00:00:00+00:00",
+                    f"2026-08-2{index + 5}T00:00:00+00:00",
+                    "2026-08-26T00:00:00+00:00" if state == "closed" else None,
+                    "2026-08-26T00:00:00+00:00" if state == "closed" else None,
+                    error,
+                ),
+            )
+
+    inc = _point_db(monkeypatch, tmp_path)
+    rows = inc.list_incidents()
+
+    assert len(rows) == 1
+    assert rows[0]["state"] == "closed"
+    expected_sig = inc._error_signature("job-1", errors[0][0])
+    assert rows[0]["id"] == inc._incident_id("job-1", expected_sig)
+    assert inc.upsert_incident_for_alert("job-1", errors[1][0])[1] is False
+
+
+def test_signature_migration_matches_legacy_raw_error_after_redaction(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    raw_error = "provider rejected api_key=sk-secret-value"
+    stored_error = "provider rejected api_key=***REDACTED***"
+    legacy_sig = hashlib.sha256(
+        b"job-1" + incidents._normalize_error(raw_error)[:200].encode()
+    ).hexdigest()[:12]
+    legacy_id = incidents._incident_id("job-1", legacy_sig)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE cron_incidents (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL,
+                 error_sig TEXT NOT NULL, state TEXT NOT NULL,
+                 failure_type TEXT NOT NULL DEFAULT 'unknown',
+                 first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL,
+                 last_alerted_at TEXT, acked_at TEXT, closed_at TEXT,
+                 error TEXT NOT NULL, output_file TEXT
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO cron_incidents
+               VALUES (?, 'job-1', ?, 'closed', 'auth', ?, ?, NULL, ?, ?, ?, NULL)""",
+            (
+                legacy_id,
+                legacy_sig,
+                "2026-08-25T00:00:00+00:00",
+                "2026-08-26T00:00:00+00:00",
+                "2026-08-26T00:00:00+00:00",
+                "2026-08-26T00:00:00+00:00",
+                stored_error,
+            ),
+        )
+
+    inc = _point_db(monkeypatch, tmp_path)
+    inc.list_incidents()  # Run the eager migration from persisted data.
+    incident_id, should_alert = inc.upsert_incident_for_alert("job-1", raw_error)
+
+    assert should_alert is False
+    assert inc.count_incidents() == 1
+    row = inc.get_incident(incident_id)
+    assert row is not None
+    assert row["state"] == "closed"
 
 
 # ── Scheduler gating ───────────────────────────────────────────────────────

--- a/tests/cron/test_cron_incidents.py
+++ b/tests/cron/test_cron_incidents.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -104,6 +106,75 @@ def test_same_signature_dedups_same_incident(monkeypatch, tmp_path):
     assert inc.count_incidents() == 1
     # Refresh updates last_seen but never resets an open state.
     assert inc.get_incident(id1)["state"] == "detected"
+
+
+def test_signature_normalizes_dynamic_numbers():
+    assert incidents._error_signature(
+        "job-1", "request 123 failed after 45 seconds"
+    ) == incidents._error_signature(
+        "job-1", "request 987 failed after 60 seconds"
+    )
+
+
+def test_unacked_incident_alerts_immediately_then_after_four_hours_and_daily(
+    monkeypatch, tmp_path
+):
+    inc = _point_db(monkeypatch, tmp_path)
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started)
+    inc_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 123")
+    assert should_alert is True
+    assert inc.mark_incident_alerted(inc_id) is True
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=1))
+    same_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom 456")
+    assert same_id == inc_id
+    assert should_alert is False
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=4))
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 789")
+    assert should_alert is True
+    assert inc.mark_incident_alerted(inc_id) is True
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=5))
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 999")
+    assert should_alert is False
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=28))
+    _, should_alert = inc.upsert_incident_for_alert("job-1", "boom 111")
+    assert should_alert is True
+
+
+def test_due_reminder_retries_until_delivery_is_confirmed(monkeypatch, tmp_path):
+    inc = _point_db(monkeypatch, tmp_path)
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started)
+    inc_id, _ = inc.upsert_incident_for_alert("job-1", "boom")
+    inc.mark_incident_alerted(inc_id)
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(hours=4))
+    assert inc.upsert_incident_for_alert("job-1", "boom")[1] is True
+
+    monkeypatch.setattr(
+        inc, "_hermes_now", lambda: started + timedelta(hours=4, minutes=5)
+    )
+    assert inc.upsert_incident_for_alert("job-1", "boom")[1] is True
+
+    inc.mark_incident_alerted(inc_id)
+    assert inc.upsert_incident_for_alert("job-1", "boom")[1] is False
+
+
+def test_closed_incident_never_escalates(monkeypatch, tmp_path):
+    inc = _point_db(monkeypatch, tmp_path)
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started)
+    inc_id, _ = inc.upsert_incident_for_alert("job-1", "boom")
+    inc.mark_incident_alerted(inc_id)
+    inc.ack_incident(inc_id)
+
+    monkeypatch.setattr(inc, "_hermes_now", lambda: started + timedelta(days=3))
+    assert inc.upsert_incident_for_alert("job-1", "boom")[1] is False
 
 
 def test_error_change_mints_new_incident(monkeypatch, tmp_path):
@@ -211,22 +282,76 @@ def test_missing_db_no_crash(monkeypatch, tmp_path):
     assert inc.get_incident("nope") is None
 
 
+def test_existing_incident_schema_gains_alert_confirmation_column(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE cron_incidents (
+                 id TEXT PRIMARY KEY,
+                 job_id TEXT NOT NULL,
+                 error_sig TEXT NOT NULL,
+                 state TEXT NOT NULL,
+                 failure_type TEXT NOT NULL DEFAULT 'unknown',
+                 first_seen_at TEXT NOT NULL,
+                 last_seen_at TEXT NOT NULL,
+                 acked_at TEXT,
+                 closed_at TEXT,
+                 error TEXT NOT NULL,
+                 output_file TEXT
+               )"""
+        )
+    inc = _point_db(monkeypatch, tmp_path)
+
+    inc_id, should_alert = inc.upsert_incident_for_alert("job-1", "boom")
+
+    assert should_alert is True
+    assert inc.mark_incident_alerted(inc_id) is True
+    row = inc.get_incident(inc_id)
+    assert row is not None
+    assert row["last_alerted_at"] is not None
+
+
 # ── Scheduler gating ───────────────────────────────────────────────────────
 
 
-def test_unacked_failure_still_alerts(monkeypatch, tmp_path):
+def test_unacked_failure_alerts_immediately_then_escalates_with_nudge(
+    monkeypatch, tmp_path
+):
     inc = _point_db(monkeypatch, tmp_path)
     deliveries = []
     job = _job()
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
     with cron_jobs.use_cron_store(tmp_path):
         cron_jobs.save_jobs([job])
+        monkeypatch.setattr(inc, "_hermes_now", lambda: started)
         _tick_failing(job, tmp_path, deliveries, error="unacked boom")
+        incident_id = inc.list_incidents()[0]["id"]
+        assert inc.mark_incident_alerted(incident_id) is True
+
+        monkeypatch.setattr(
+            inc, "_hermes_now", lambda: started + timedelta(hours=1)
+        )
         _tick_failing(job, tmp_path, deliveries, error="unacked boom")
 
-    assert len(deliveries) == 2, "unacked failures must keep alerting per run"
+        monkeypatch.setattr(
+            inc, "_hermes_now", lambda: started + timedelta(hours=4)
+        )
+        _tick_failing(
+            {**job, "failure_streak": 2},
+            tmp_path,
+            deliveries,
+            error="unacked boom",
+        )
+
+    assert len(deliveries) == 2
+    assert "failed 3 runs in a row" in deliveries[-1]
     rows = inc.list_incidents()
     assert len(rows) == 1
-    assert rows[0]["state"] == "detected"
+    assert rows[0]["state"] == "alerted"
+    assert rows[0]["last_alerted_at"] == started.isoformat()
 
 
 def test_ack_suppresses_alert_until_signature_changes(monkeypatch, tmp_path):
@@ -274,12 +399,27 @@ def test_mark_incident_alerted_sets_state_never_resurrects(monkeypatch, tmp_path
     sched._mark_incident_alerted("nonexistent")
 
 
-def test_best_effort_incident_store_failure_returns_false(monkeypatch, tmp_path):
+def test_best_effort_incident_store_failure_fails_open(monkeypatch, tmp_path):
     """An incident-store error must never break the cron delivery path."""
     _point_db(monkeypatch, tmp_path)
-    with patch("cron.incidents.upsert_incident",
+    with patch("cron.incidents.upsert_incident_for_alert",
                side_effect=RuntimeError("db locked")):
-        assert sched._upsert_incident_for_failure(_job(), "boom") == (False, None)
+        assert sched._upsert_incident_for_failure(_job(), "boom") == (
+            True, False, None
+        )
+
+
+def test_ack_between_alert_decision_and_state_read_wins():
+    with patch(
+        "cron.incidents.upsert_incident_for_alert",
+        return_value=("incident-1", True),
+    ), patch(
+        "cron.incidents.get_incident",
+        return_value={"id": "incident-1", "state": "closed"},
+    ):
+        assert sched._upsert_incident_for_failure(_job(), "boom") == (
+            False, True, "incident-1"
+        )
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,8 +10,11 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
+import cron.incidents as incidents
 import cron.scheduler as s
 
 
@@ -235,6 +238,83 @@ def test_escaped_failure_delivery_stays_quiet_below_the_threshold(monkeypatch):
 
     assert ok is False
     assert delivered == ["⚠️ Cron 'scout' failed: provider failed"]
+
+
+def test_escaped_failure_uses_incident_escalation_and_keeps_due_nudge(
+    monkeypatch, tmp_path
+):
+    delivered = []
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        incidents, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    monkeypatch.setattr(incidents, "_hermes_now", lambda: started)
+    _patch_escaped_failure(
+        monkeypatch, delivered, exec_id="exec-escalation", err="provider failed 123"
+    )
+    job = {
+        "id": "escaped-escalation",
+        "name": "scout",
+        "deliver": "telegram",
+        "schedule": {"kind": "interval"},
+        "failure_streak": 0,
+    }
+
+    assert s.run_one_job(job) is False
+
+    monkeypatch.setattr(
+        incidents, "_hermes_now", lambda: started + timedelta(hours=1)
+    )
+    assert s.run_one_job({**job, "failure_streak": 1}) is False
+
+    monkeypatch.setattr(
+        incidents, "_hermes_now", lambda: started + timedelta(hours=4)
+    )
+    assert s.run_one_job({**job, "failure_streak": 2}) is False
+
+    assert len(delivered) == 2
+    assert "failed 3 runs in a row" in delivered[-1]
+
+
+def test_unresolved_origin_does_not_confirm_alert_delivery(
+    monkeypatch, tmp_path
+):
+    delivered = []
+    started = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        incidents, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    monkeypatch.setattr(incidents, "_hermes_now", lambda: started)
+    _patch_escaped_failure(
+        monkeypatch, delivered, exec_id="exec-origin", err="provider failed"
+    )
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda _job: [])
+    job = {
+        "id": "origin-retry",
+        "name": "scout",
+        "deliver": "origin",
+        "schedule": {"kind": "interval"},
+    }
+
+    assert s.run_one_job(job) is False
+    incident_id = incidents.list_incidents()[0]["id"]
+    row = incidents.get_incident(incident_id)
+    assert row is not None
+    assert row["state"] == "detected"
+    assert row["last_alerted_at"] is None
+
+    monkeypatch.setattr(
+        incidents, "_hermes_now", lambda: started + timedelta(hours=1)
+    )
+    monkeypatch.setattr(
+        s, "_resolve_delivery_targets", lambda _job: ["telegram:test"]
+    )
+    assert s.run_one_job(job) is False
+
+    assert len(delivered) == 2
+    row = incidents.get_incident(incident_id)
+    assert row is not None
+    assert row["state"] == "alerted"
 
 
 def test_run_one_job_exception_after_delivery_does_not_redeliver(monkeypatch):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -351,10 +351,11 @@ cron:
 
 ### Failure incidents: acknowledge a known failure
 
-A recurring job that keeps failing with the *same* error pings you on every
-run. Each failure is also recorded as a durable **incident**, keyed by the
-job plus a normalized signature of the error text, in the same per-profile
-ledger database as the execution history.
+A recurring job that keeps failing with the *same* error creates a durable
+**incident**, keyed by the job plus a normalized signature of the raw error
+text, in the same per-profile ledger database as the execution history. The
+incident alerts immediately, then after four hours, then daily while it stays
+open. Failed alert deliveries remain due and retry on the next failed run.
 
 ```bash
 hermes cron incidents                 # list incidents (newest activity first)
@@ -362,9 +363,9 @@ hermes cron incidents --state alerted # filter: detected | alerted | closed
 hermes cron incidents ack <id>        # acknowledge — stop re-pinging
 ```
 
-Acknowledging an incident silences the per-run failure ping for that exact
-signature only. Nothing else changes: the run history still records every
-failure, the failure streak keeps counting, and the moment the job starts
+Acknowledging an incident silences future alerts for that exact signature
+only. Nothing else changes: the run history still records every failure, the
+failure streak keeps counting, and the moment the job starts
 failing with a *different* error a new incident is minted and alerts fire
 again. A successful run doesn't touch incidents — they are per-signature, not
 per-job.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -354,8 +354,10 @@ cron:
 A recurring job that keeps failing with the *same* error creates a durable
 **incident**, keyed by the job plus a normalized signature of the raw error
 text, in the same per-profile ledger database as the execution history. The
-incident alerts immediately, then after four hours, then daily while it stays
-open. Failed alert deliveries remain due and retry on the next failed run.
+incident alerts immediately, then on subsequent failing runs after four hours,
+then daily while it stays open. Disabled jobs and successful runs do not send
+incident reminders. Failed alert deliveries remain due and retry on the next
+failed run.
 
 ```bash
 hermes cron incidents                 # list incidents (newest activity first)


### PR DESCRIPTION
## Summary

- move repeated-failure alert throttling into the durable incident store
- alert an open signature immediately, after four hours, and daily thereafter
- retry unconfirmed deliveries while keeping acknowledged signatures closed
- preserve the repeated-failure review nudge on both scheduler failure paths
- normalize dynamic numeric error text before signing the raw error

## Design

The incident row remains the source of truth. `first_seen_at`, lifecycle state, and a delivery-confirmed `last_alerted_at` timestamp determine whether the current failure crosses an escalation window. The scheduler asks the store for a decision and only composes the summary and streak nudge after that decision, so changing nudge counters cannot affect deduplication.

Existing incident databases gain the nullable confirmation column lazily. Store failures fail open, delivery failures remain due, and closed incidents stay terminal for their signature.

This follows the incident-store direction proposed when #88493 was superseded by #95017.

## Validation

- `scripts/run_tests.sh tests/cron/` — 968 passed, 1 skipped
- `uvx ruff check cron/incidents.py cron/scheduler.py tests/cron/test_cron_incidents.py tests/cron/test_run_one_job.py`
- `git diff --check`
- regression test was sabotage-checked by disabling the escalation decision and observing the expected failure

## Scope

- no separate scheduler/job marker state
- no new configuration or environment variables
- no changes to the incident acknowledgment CLI
