### PR TITLE
fix: map Cmd/Super key sequences so they don't leak as literal text

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -357,6 +357,25 @@ def install_modify_other_keys_aliases() -> int:
     _install_paired(7, ctrl_alt_map)
     _install_paired(8, ctrl_alt_map)  # Ctrl+Alt+Shift — same normalization
 
+    # -- Cmd/Super (9) and Cmd+Shift (10) letters & digits → plain chars ----
+    # macOS terminals normally intercept Cmd+key themselves (paste, window
+    # management, etc.), but when one passes a Cmd+letter through under
+    # modifyOtherKeys=2 / kitty (e.g. Cmd+V = ESC[27;9;118~) the sequence is
+    # otherwise unmapped and leaks as literal "[27;9;118~" text into the
+    # prompt.  We can't access the clipboard at the key-decode layer, so the
+    # least-surprising normalization is the plain character — the same way
+    # Ctrl+Shift / Ctrl+Alt combos above collapse onto their primary key.
+    # Digits included: Cmd+1..9 switches tabs in most terminals, but a
+    # passthrough should still type the digit rather than leak CSI noise.
+    super_map: dict[int, str] = {}
+    for ch in range(ord('a'), ord('z') + 1):
+        for cp in (ch, ch - 32):  # unshifted + shifted codepoints
+            super_map[cp] = chr(cp)
+    for d in range(10):
+        super_map[ord('0') + d] = str(d)
+    _install_paired(9, super_map)
+    _install_paired(10, super_map)
+
     # -- The Esc KEY under Kitty disambiguate mode: ESC[27u (+ modifiers) --
     # Disambiguate mode reports the Esc key as CSI-u so it is
     # distinguishable from the ESC byte that starts escape sequences

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -435,6 +435,31 @@ def test_cmd_backspace_alias_not_clobbered():
     assert _parse("\x1b[127;9u") == [Keys.ControlU]
 
 
+def test_super_letter_sequences_map_to_plain_char():
+    """Cmd/Super + letter must decode to the plain character, never leak.
+
+    Cmd+V under modifyOtherKeys=2 arrives as ESC[27;9;118~ — previously
+    unmapped, it leaked as literal "[27;9;118~" into the prompt.
+    """
+    install_modify_other_keys_aliases()
+    # modifyOtherKeys tilde form, Super (9) and Super+Shift (10)
+    assert _parse("\x1b[27;9;118~") == ["v"]
+    assert _parse("\x1b[27;10;118~") == ["v"]
+    # kitty CSI-u form, including lock-bit twins (9+64, 9+128)
+    assert _parse("\x1b[118;9u") == ["v"]
+    assert _parse("\x1b[118;73u") == ["v"]
+    assert _parse("\x1b[118;137u") == ["v"]
+    # shifted codepoint maps to the uppercase character
+    assert _parse("\x1b[27;9;86~") == ["V"]
+
+
+def test_super_digit_sequences_map_to_plain_char():
+    """Cmd/Super + digit must decode to the digit, never leak."""
+    install_modify_other_keys_aliases()
+    assert _parse("\x1b[27;9;49~") == ["1"]
+    assert _parse("\x1b[49;9u") == ["1"]
+
+
 # ---------------------------------------------------------------------------
 # Lock-bit variants (#89651): kitty/ghostty OR the CapsLock (64) / NumLock
 # (128) state into the CSI-u modifier parameter, so with a lock enabled


### PR DESCRIPTION
## Symptom

On macOS, pressing Cmd+V (paste) in the Hermes CLI in a terminal that passes the key through under modifyOtherKeys=2 inserts the literal text `[27;9;118~` into the input line. Cmd+letter combos generally leak this way; Shift/Ctrl/Alt combos do not.

## Root cause

Hermes pushes modifyOtherKeys=2 / kitty keyboard protocol (for Shift+Enter etc.). `hermes_cli/pt_input_extras.py` maps modifiers 2–8 for letters and digits, and `install_cmd_backspace_alias` maps the Super bit (9/10) for Backspace — but no mapping exists for Super + letter/digit. The raw sequence (e.g. `ESC[27;9;118~` = Cmd+V) falls through the VT100 parser to literal insertion.

## Fix

Extend `install_modify_other_keys_aliases` with Super (9) and Super+Shift (10) mappings for letters and digits, normalized to the plain character — the same normalization the existing Ctrl+Shift / Ctrl+Alt entries already apply. Both the modifyOtherKeys tilde form and kitty CSI-u form are registered, lock-bit variants (CapsLock 64 / NumLock 128) included, per the module's existing conventions.

Note: the key-decode layer can't access the clipboard, so Cmd+V types `v` rather than pasting — but it no longer leaks CSI noise. (Most macOS terminals intercept Cmd+V as paste themselves and never send the sequence; this covers passthrough configurations.)

## Testing

- 2 new regression tests in `tests/cli/test_modify_other_keys_aliases.py` covering the exact reported sequence, both protocol forms, lock twins, and shifted codepoints.
- Full targeted keybinding suites pass: 235 passed (`test_modify_other_keys_aliases`, `test_cli_cmd_backspace`, `test_cli_shift_enter_newline`, `test_cli_terminal_shortcuts`).