### PR TITLE
fix(discord): make thread rename and slash sync durable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16685,6 +16685,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "title":
             return await self._handle_title_command(event)
 
+        if canonical == "rename":
+            return await self._handle_rename_command(event)
+
         if canonical == "resume":
             return await self._handle_resume_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4603,6 +4603,92 @@ class GatewaySlashCommandsMixin:
             else:
                 return t("gateway.title.current_no_title", session_id=session_id)
 
+    def _derive_discord_rename_title_from_history(self, session_id: str) -> str:
+        """Best-effort deterministic title from recent stored user messages."""
+        try:
+            history = self.session_store.load_transcript(session_id) or []
+        except Exception:
+            history = []
+        for msg in reversed(history):
+            if not isinstance(msg, dict) or msg.get("role") != "user":
+                continue
+            content = msg.get("content") or ""
+            if isinstance(content, list):
+                content = " ".join(
+                    str(item.get("text") or item.get("content") or "")
+                    if isinstance(item, dict) else str(item)
+                    for item in content
+                )
+            raw = re.sub(r"\[[^\]]+\]", " ", str(content))
+            raw = re.sub(r"^\s*[^:\n]{1,80}:\s*", "", raw)
+            raw = re.sub(r"https?://\S+", "", raw)
+            raw = re.sub(r"[`*_~>#|]", "", raw)
+            raw = re.sub(r"\s+", " ", raw).strip(" -:.,\n\t")
+            if not raw or raw.startswith("/"):
+                continue
+            words = raw.split()
+            return " ".join(words[:10]) or "Hermes Thread"
+        return "Hermes Thread"
+
+    async def _handle_rename_command(self, event: MessageEvent) -> str:
+        """Rename the visible Discord thread and persist the session title."""
+        source = event.source
+        if source.platform != Platform.DISCORD:
+            return "/rename is only available in Discord threads. Use /title for the Hermes session."
+        if not source.thread_id:
+            return "/rename must be used inside a Discord thread."
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
+
+        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_id = session_entry.session_id
+        existing_title = await self._session_db.get_session_title(session_id)
+        if existing_title is None:
+            try:
+                await self._session_db.create_session(
+                    session_id=session_id,
+                    source=source.platform.value,
+                    user_id=source.user_id,
+                    chat_id=source.chat_id,
+                    chat_type=source.chat_type,
+                    thread_id=source.thread_id,
+                )
+            except Exception:
+                pass
+
+        raw_title = event.get_command_args().strip() or existing_title or ""
+        if not raw_title:
+            raw_title = self._derive_discord_rename_title_from_history(session_id)
+
+        from hermes_state import SessionDB
+        try:
+            title = SessionDB.sanitize_title(raw_title)
+        except ValueError as exc:
+            return t("gateway.shared.warn_passthrough", error=exc)
+        if not title:
+            return "No usable title could be derived. Try `/rename <name>`."
+
+        try:
+            await self._session_db.set_session_title(session_id, title)
+        except ValueError as exc:
+            return t("gateway.shared.warn_passthrough", error=exc)
+        except Exception:
+            logger.debug("Failed to store session title from /rename", exc_info=True)
+
+        adapter = self.adapters.get(source.platform)
+        rename = getattr(adapter, "rename_thread", None) if adapter else None
+        if not callable(rename):
+            return f"Session title set to **{title}**, but this Discord adapter cannot rename threads."
+        try:
+            changed = await rename(str(source.thread_id), title)
+        except Exception as exc:
+            logger.warning("Discord /rename failed for thread %s: %s", source.thread_id, exc, exc_info=True)
+            return f"Session title set to **{title}**, but Discord thread rename failed: {exc}"
+        if changed:
+            return f"Renamed this Discord thread to **{title}**."
+        return f"Session title set to **{title}**, but Discord did not change the visible thread name."
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — list or switch to a previous session."""
         if not self._session_db:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -123,6 +123,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[N]"),
     CommandDef("title", "Set a title for the current session", "Session",
                args_hint="[name]"),
+    CommandDef("rename", "Rename the current Discord thread from session title or context", "Session",
+               gateway_only=True, args_hint="[name]"),
     CommandDef("handoff", "Hand off this session to a messaging platform (Telegram, Discord, etc.)", "Session",
                args_hint="<platform>", cli_only=True),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7242,12 +7242,20 @@ class DiscordAdapter(BasePlatformAdapter):
         name: str,
         *,
         only_if_current_name: Optional[str] = None,
+        prefer_connector_created: bool = False,
+        parent_chat_id: Optional[str] = None,
     ) -> bool:
         """Best-effort Discord thread rename.
 
         ``only_if_current_name`` prevents overwriting human-renamed or
         pre-existing threads.  This is intentionally a no-op on mismatch.
+
+        ``prefer_connector_created`` and ``parent_chat_id`` are relay routing
+        hints accepted for compatibility with the shared gateway adapter
+        contract. Native Discord resolves the thread directly and therefore
+        does not use them.
         """
+        _ = prefer_connector_created, parent_chat_id
         if not self._client or not DISCORD_AVAILABLE:
             return False
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5880,6 +5880,11 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_title(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/title {name}".strip())
 
+        @tree.command(name="rename", description="Rename the current Discord thread from session title or context")
+        @discord.app_commands.describe(name="Thread name. Leave empty to derive from session context.")
+        async def slash_rename(interaction: discord.Interaction, name: str = ""):
+            await self._run_simple_slash(interaction, f"/rename {name}".strip())
+
         @tree.command(name="resume", description="Resume a previously-named session")
         @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
         async def slash_resume(interaction: discord.Interaction, name: str = ""):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3290,6 +3290,16 @@ class DiscordAdapter(BasePlatformAdapter):
             current_existing_payload = self._existing_command_to_payload(current)
             current_payload = self._canonicalize_app_command_payload(current_existing_payload)
             desired_payload = self._canonicalize_app_command_payload(desired)
+            # discord.py serializes an unspecified install/context policy as
+            # null, while Discord may expand that omission in the fetched
+            # command (for example integration_types=[0, 1]).  Unspecified
+            # means "use the application's defaults", not "replace the live
+            # defaults on every startup".  Compare the fetched value when the
+            # desired tree left the field unspecified; explicit restrictions
+            # remain authoritative.
+            for defaulted_field in ("contexts", "integration_types"):
+                if desired.get(defaulted_field) is None:
+                    desired_payload[defaulted_field] = current_payload[defaulted_field]
             if current_payload == desired_payload:
                 unchanged += 1
                 continue
@@ -5806,7 +5816,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
         @tree.command(name="new", description="Start a new conversation")
         async def slash_new(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reset", "New conversation started~")
+            # Dispatch the canonical command directly.  `/reset` remains a
+            # compatibility alias, but routing `/new` through the alias made
+            # the two native picker entries needlessly depend on different
+            # registration and alias-resolution paths.
+            await self._run_simple_slash(interaction, "/new", "New conversation started~")
 
         @tree.command(name="reset", description="Reset your Hermes session")
         async def slash_reset(interaction: discord.Interaction):

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -601,6 +601,80 @@ async def test_safe_sync_reads_permission_attrs_from_existing_command():
     fake_http.upsert_global_command.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_safe_sync_accepts_discord_expanded_default_install_types():
+    """Discord expands an omitted integration_types policy server-side.
+
+    The local Command tree leaves the application default unspecified (None),
+    while fetched commands may contain [0, 1].  That is semantically unchanged
+    and must not trigger delete+recreate churn for every command on startup.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    desired = {
+        "name": "new",
+        "description": "Start a new conversation",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+        "contexts": None,
+        "integration_types": None,
+    }
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return dict(desired)
+
+    class _ExistingCommand:
+        id = 42
+        name = "new"
+        description = desired["description"]
+        type = SimpleNamespace(value=1)
+        nsfw = False
+        guild_only = False
+        default_member_permissions = None
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **desired,
+                "integration_types": [0, 1],
+            }
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand()],
+        fetch_commands=AsyncMock(return_value=[_ExistingCommand()]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary == {
+        "total": 1,
+        "unchanged": 1,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    fake_http.edit_global_command.assert_not_awaited()
+    fake_http.delete_global_command.assert_not_awaited()
+    fake_http.upsert_global_command.assert_not_awaited()
+
+
 # ============================================================================
 # #31049: unconfigured platform skips reconnection (non-retryable fatal error)
 # ============================================================================

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -142,6 +142,20 @@ async def test_registers_native_thread_slash_command(adapter):
 
 
 @pytest.mark.asyncio
+async def test_native_new_dispatches_canonical_new_command(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["new"]
+    interaction = SimpleNamespace()
+    await command(interaction)
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/new", "New conversation started~"
+    )
+
+
+@pytest.mark.asyncio
 async def test_registers_native_rename_slash_command(adapter):
     adapter._run_simple_slash = AsyncMock()
     adapter._register_slash_commands()

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -142,6 +142,20 @@ async def test_registers_native_thread_slash_command(adapter):
 
 
 @pytest.mark.asyncio
+async def test_registers_native_rename_slash_command(adapter):
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["rename"]
+    interaction = SimpleNamespace()
+    await command(interaction, name="Clean Thread Name")
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/rename Clean Thread Name"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter):
     class UnknownInteraction(Exception):
         status = 404

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -449,6 +449,36 @@ async def test_rename_thread_edits_only_when_current_name_matches(adapter):
     )
 
 
+@pytest.mark.asyncio
+async def test_rename_thread_accepts_shared_gateway_contract_kwargs(adapter):
+    """Native Discord must accept the same rename kwargs as relay adapters.
+
+    The gateway calls every adapter through one polymorphic contract.  Native
+    Discord ignores relay-only routing hints, but rejecting them prevents the
+    semantic rename from running at all.
+    """
+    thread = SimpleNamespace(
+        id=999,
+        name="raw user prompt",
+        edit=AsyncMock(),
+    )
+    adapter._client.get_channel = lambda _id: thread
+
+    result = await adapter.rename_thread(
+        "999",
+        "Semantic Session Title",
+        only_if_current_name="raw user prompt",
+        prefer_connector_created=False,
+        parent_chat_id=None,
+    )
+
+    assert result is True
+    thread.edit.assert_awaited_once_with(
+        name="Semantic Session Title",
+        reason="Hermes semantic session title",
+    )
+
+
 # ------------------------------------------------------------------
 # Auto-thread integration in _handle_message
 # ------------------------------------------------------------------

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -15,13 +15,16 @@ from gateway.session import SessionSource
 
 
 def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", thread_id=None,
+                chat_type="dm"):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
         user_name="testuser",
+        thread_id=thread_id,
+        chat_type=chat_type,
     )
     return MessageEvent(text=text, source=source)
 
@@ -47,6 +50,49 @@ def _make_runner(session_db=None):
     runner.session_store = mock_store
 
     return runner
+
+
+class TestHandleRenameCommand:
+    @pytest.mark.asyncio
+    async def test_rename_requires_discord_thread(self, tmp_path):
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        runner = _make_runner(session_db=db)
+
+        result = await runner._handle_rename_command(
+            _make_event(text="/rename New Name", platform=Platform.TELEGRAM)
+        )
+        assert "only available in Discord threads" in result
+
+        result = await runner._handle_rename_command(
+            _make_event(text="/rename New Name", platform=Platform.DISCORD)
+        )
+        assert "must be used inside a Discord thread" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_rename_sets_title_and_edits_visible_thread(self, tmp_path):
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+        runner = _make_runner(session_db=db)
+        adapter = MagicMock()
+        adapter.rename_thread = AsyncMock(return_value=True)
+        runner.adapters = {Platform.DISCORD: adapter}
+
+        event = _make_event(
+            text="/rename Clean Thread Name",
+            platform=Platform.DISCORD,
+            chat_id="999",
+            thread_id="999",
+            chat_type="thread",
+        )
+        result = await runner._handle_rename_command(event)
+
+        assert "Renamed this Discord thread" in result
+        assert db.get_session_title("test_session_123") == "Clean Thread Name"
+        adapter.rename_thread.assert_awaited_once_with("999", "Clean Thread Name")
+        db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- restore `/rename` as a central gateway command with native Discord registration and visible thread rename behavior
- align native `rename_thread` with the shared native/relay keyword contract so semantic auto-renames reach Discord
- route native `/new` through the canonical command instead of the `/reset` alias
- treat Discord-expanded default `integration_types`/`contexts` as semantically unchanged so safe sync no longer deletes and recreates every command on each gateway restart

## Root cause
Discord returns default install types as `[0, 1]` while discord.py serializes an unspecified local policy as `null`. Safe sync compared those literally, false-diffed every global command, and churned the command IDs until the rate-limit-bound reconciliation timed out. `/rename` and the full native rename adapter contract also lived only in carried local fixes and disappeared on update.

## Verification
- `python -m pytest tests/gateway/test_discord_connect.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_title_command.py tests/gateway/test_discord_free_response.py tests/gateway/relay/test_relay_threads.py -q -o addopts=` → 78 passed
- live payload comparison against the MiniMe Discord application: 64 shared commands, 0 semantic diffs after default-field normalization (before: 64 false diffs)
- duplicate guild-scoped MiniMe `/rename` removed; one global `/rename` remains
