### PR TITLE
test(doctor): stop os.geteuid aborting collection on Windows

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -142,7 +142,12 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        # POSIX-only, and skipif conditions run at collection time — see the
+        # note on test_unreadable_file_is_reported_as_permission_denied.
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -278,9 +283,18 @@ class TestLiveConnectionSafety:
 
 class TestUnreadableReason:
     def test_missing_file_keeps_the_os_error_text(self, tmp_path):
-        reason = doctor._unreadable_reason(tmp_path / "gone.db")
+        missing = tmp_path / "gone.db"
+        # The OS wording differs by platform ("No such file or directory" on
+        # POSIX, "The system cannot find the file specified" on Windows). Take
+        # it from the same call doctor makes instead of pinning one platform.
+        with pytest.raises(OSError) as excinfo:
+            missing.stat()
+        expected = excinfo.value.strerror
+        assert expected, "a blank strerror would make the check below vacuous"
 
-        assert "No such file or directory" in reason
+        reason = doctor._unreadable_reason(missing)
+
+        assert expected in reason
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
     @pytest.mark.skipif(
@@ -363,7 +377,10 @@ class TestReportDatabaseJournalModes:
         assert "state.db is in WAL mode" in out
         assert "projects.db: rollback journal mode" in out
         assert "kanban.db: rollback journal mode" in out
-        assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
+        # doctor renders the relative path with the platform's own separator,
+        # so build the expected label the same way rather than assuming POSIX.
+        board_label = os.path.join("kanban", "boards", "myboard", "kanban.db")
+        assert f"{board_label} is in WAL mode" in out
 
     def test_missing_databases_are_skipped(self, tmp_path, capsys):
         doctor._report_database_journal_modes(tmp_path, VULNERABLE)
@@ -387,7 +404,12 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        # POSIX-only, and skipif conditions run at collection time — see the
+        # note on test_unreadable_file_is_reported_as_permission_denied.
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores file permissions",
+    )
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)


### PR DESCRIPTION
`skipif` conditions are evaluated at **collection time**, so the two bare `os.geteuid()` calls in `tests/hermes_cli/test_doctor_journal_modes.py` raise `AttributeError` on Windows before any test runs. That takes the whole module down rather than just the two tests they guard, and it fails collection for anything sweeping the directory — `pytest tests/hermes_cli/` errors out instead of running.

### This repo already has a rule for it

`scripts/check-windows-footguns.py` carries the rule **"bare os.getuid / os.geteuid / os.getgid"**, whose stated fix is *"gate with `hasattr(os, 'getuid')`"*. Pointed at this file it flags both lines:

```
tests/hermes_cli/test_doctor_journal_modes.py:145: [bare os.getuid / os.geteuid / os.getgid]
tests/hermes_cli/test_doctor_journal_modes.py:390: [bare os.getuid / os.geteuid / os.getgid]
```

The rule has existed since `cc38282b0` (2026-05-08), predating this code. A third site in this same module was fixed in `1aea75843` (2026-08-16) with exactly that guard plus a comment explaining the collection-time hazard — these two were missed.

### Two follow-on POSIX assumptions

Fixing the abort surfaces two more failures in the module. Both are test-side only; `doctor` itself behaves correctly on Windows:

- **`_unreadable_reason`** returns the OS error text — `"No such file or directory"` on POSIX, `"The system cannot find the file specified"` on Windows. The expected wording now comes from the same `stat()` call doctor makes rather than pinning one platform, with a guard so a blank `strerror` cannot make the assertion vacuous.
- **`_report_database_journal_modes`** renders each relative path with the platform separator, so the expected label is built with `os.path.join` instead of a hardcoded forward slash. I checked the production path directly: doctor **does** find and list the board database — only the assertion was wrong.

Neither is selected by the `windows_only` lane in `tests-os.yml`, so they are correctness-on-Windows rather than CI-visible today. They're included because fixing the collection abort alone just trades one error for two red tests.

### Verification

On Windows 10 / CPython 3.11.15:

| | before | after |
|---|---|---|
| `test_doctor_journal_modes.py` | collection error, **0 tests run** | **33 passed, 3 skipped** |
| `check-windows-footguns.py --all` | flags 2 | clean (1001 files scanned) |

No production code is changed — the diff is one test file.
