### PR TITLE
fix(slack): deduplicate cross-scope message events

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
@@ -44,51 +45,56 @@ class MessageDeduplicator:
         self._seen: Dict[str, float] = {}
         self._max_size = max_size
         self._ttl = ttl_seconds
+        self._lock = threading.Lock()
 
     def is_duplicate(self, msg_id: str) -> bool:
         """Return True if *msg_id* was already seen within the TTL window."""
         if not msg_id:
             return False
-        now = time.time()
-        if msg_id in self._seen:
-            if now - self._seen[msg_id] < self._ttl:
-                return True
-            # Entry has expired — remove it and treat as new
-            del self._seen[msg_id]
-        self._seen[msg_id] = now
-        if len(self._seen) > self._max_size:
-            cutoff = now - self._ttl
-            self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+        with self._lock:
+            now = time.time()
+            seen_at = self._seen.get(msg_id)
+            if seen_at is not None:
+                if now - seen_at < self._ttl:
+                    return True
+                del self._seen[msg_id]
+            self._seen[msg_id] = now
             if len(self._seen) > self._max_size:
-                # TTL pruning alone does not cap the cache when every entry is
-                # still fresh. Keep the newest entries so the helper's
-                # max_size bound is enforced under sustained traffic.
-                newest = sorted(
-                    self._seen.items(),
-                    key=lambda item: item[1],
-                )[-self._max_size:]
-                self._seen = dict(newest)
-        return False
+                cutoff = now - self._ttl
+                self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+                if len(self._seen) > self._max_size:
+                    # TTL pruning alone does not cap the cache when every entry is
+                    # still fresh. Keep the newest entries so the helper's
+                    # max_size bound is enforced under sustained traffic.
+                    newest = sorted(
+                        self._seen.items(),
+                        key=lambda item: item[1],
+                    )[-self._max_size:]
+                    self._seen = dict(newest)
+            return False
 
     def contains(self, msg_id: str) -> bool:
         """Return whether *msg_id* is live in the cache without inserting it."""
         if not msg_id:
             return False
-        seen_at = self._seen.get(msg_id)
-        if seen_at is None:
+        with self._lock:
+            seen_at = self._seen.get(msg_id)
+            if seen_at is None:
+                return False
+            if time.time() - seen_at < self._ttl:
+                return True
+            del self._seen[msg_id]
             return False
-        if time.time() - seen_at < self._ttl:
-            return True
-        del self._seen[msg_id]
-        return False
 
     def discard(self, msg_id: str) -> None:
         """Release a claimed message ID after cancelled/failed handoff."""
-        self._seen.pop(msg_id, None)
+        with self._lock:
+            self._seen.pop(msg_id, None)
 
     def clear(self):
         """Clear all tracked messages."""
-        self._seen.clear()
+        with self._lock:
+            self._seen.clear()
 
 
 # ─── Text Batch Aggregation ──────────────────────────────────────────────────

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -74,7 +74,7 @@ class MessageDeduplicator:
             return False
 
     def contains(self, msg_id: str) -> bool:
-        """Return whether *msg_id* is live in the cache without inserting it."""
+        """Return whether *msg_id* is live, evicting it when it has expired."""
         if not msg_id:
             return False
         with self._lock:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5136,6 +5136,70 @@ class SlackAdapter(BasePlatformAdapter):
                 return str(authorization["team_id"])
         return ""
 
+    def _canonical_event_team_id(
+        self, event: dict, body: Optional[dict] = None
+    ) -> str:
+        """Resolve Slack's workspace team even when an event carries an org id.
+
+        Enterprise Grid can deliver the same message through ``message`` and
+        ``app_mention`` with one inner event scoped to the enterprise and the
+        other scoped to the workspace.  The authenticated bot-client map is the
+        authoritative set of workspace ids for this adapter.
+        """
+        candidates: list[str] = []
+        for payload in (body or {}, event):
+            if not isinstance(payload, dict):
+                continue
+            team = payload.get("team_id") or payload.get("team")
+            if isinstance(team, str) and team:
+                candidates.append(team)
+            elif isinstance(team, dict) and team.get("id"):
+                candidates.append(str(team["id"]))
+        authorizations = (body or {}).get("authorizations") if isinstance(body, dict) else None
+        for authorization in authorizations or []:
+            if isinstance(authorization, dict) and authorization.get("team_id"):
+                candidates.append(str(authorization["team_id"]))
+
+        known_teams = getattr(self, "_team_clients", {})
+        for candidate in candidates:
+            if candidate in known_teams:
+                return candidate
+        channel_id = str(event.get("channel") or event.get("channel_id") or "")
+        mapped_team = getattr(self, "_channel_team", {}).get(channel_id)
+        if mapped_team and mapped_team in known_teams:
+            return str(mapped_team)
+        if len(known_teams) == 1:
+            return next(iter(known_teams))
+        return candidates[0] if candidates else ""
+
+    def _message_dedup_id(
+        self, event: dict, body: Optional[dict] = None
+    ) -> str:
+        """Return one canonical workspace/channel/message identity.
+
+        Slack's message timestamp is stable across ``message``/``app_mention``
+        fan-out and reconnect replay.  Workspace normalization absorbs an
+        Enterprise Grid org-id variant without making ``client_msg_id`` global
+        across tenants.  Edits use their changed-event timestamp, so adding a
+        mention by edit can still wake once.
+        """
+        changed_event_ts = str(event.get("_slack_changed_event_ts") or "")
+        event_ts = changed_event_ts or str(event.get("ts") or "")
+        if not event_ts:
+            return ""
+        team_id = self._canonical_event_team_id(event, body) or "unknown-workspace"
+        channel_id = str(event.get("channel") or "unknown-channel")
+        return f"slack:channel-message:{team_id}:{channel_id}:{event_ts}"
+
+    def _processed_message_key(
+        self, event: dict, body: Optional[dict], message_ts: str
+    ) -> str:
+        if not message_ts:
+            return ""
+        team_id = self._canonical_event_team_id(event, body) or "unknown-workspace"
+        channel_id = str(event.get("channel") or "unknown-channel")
+        return f"{team_id}:{channel_id}:{message_ts}"
+
     @staticmethod
     def _context_channel_id(context: Any) -> str:
         """Extract the actively viewed channel from either Slack context shape."""
@@ -5783,7 +5847,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_id or not file_id:
             return
 
-        team_id = self._event_team_id(event, body)
+        team_id = self._canonical_event_team_id(event, body)
         try:
             client = self._team_clients.get(team_id) if team_id else None
             info_resp = await (client or self._get_client(channel_id)).files_info(
@@ -5829,9 +5893,10 @@ class SlackAdapter(BasePlatformAdapter):
         # If it does, _handle_slack_message records the same share ts and this
         # fallback skips instead of duplicating the user turn.
         await asyncio.sleep(0.75)
-        if ts and self._dedup.is_duplicate(
-            self._workspace_event_id(team_id, ts)
-        ):
+        fallback_dedup_id = self._message_dedup_id(
+            {"team": team_id, "channel": channel_id, "ts": ts}
+        )
+        if self._dedup.is_duplicate(fallback_dedup_id):
             return
 
         fallback_event = {
@@ -6061,9 +6126,12 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             original_message_ts = str(updated_message.get("ts") or "")
+            processed_message_key = self._processed_message_key(
+                event, payload, original_message_ts
+            )
             if (
-                original_message_ts
-                and original_message_ts in self._processed_message_ts
+                processed_message_key
+                and processed_message_key in self._processed_message_ts
             ):
                 return
             edited = updated_message.get("edited")
@@ -6089,15 +6157,12 @@ class SlackAdapter(BasePlatformAdapter):
                 normalized_event["_slack_changed_event_ts"] = changed_event_ts
             event = normalized_event
 
-        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
-        # Scope the dedup id by workspace: Slack event ts values are only
-        # unique within one workspace, so two teams' events with the same ts
-        # must not suppress each other.
-        event_ts = event.get("_slack_changed_event_ts") or event.get("ts", "")
-        dedup_team_id = self._event_team_id(event, payload)
-        if event_ts and self._dedup.is_duplicate(
-            self._workspace_event_id(dedup_team_id, event_ts)
-        ):
+        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777).
+        # Atomically claim the strongest stable transport identity before the
+        # first await below. This covers envelope retries, message/app_mention
+        # fan-out, and concurrent deliveries on separate Bolt worker threads.
+        dedup_id = self._message_dedup_id(event, payload)
+        if self._dedup.is_duplicate(dedup_id):
             return
 
         channel_id = event.get("channel", "")
@@ -6272,7 +6337,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         channel_id = event.get("channel", "")
         ts = event.get("ts", "")
-        outer_team_id = self._event_team_id(event, payload)
+        outer_team_id = self._canonical_event_team_id(event, payload)
         assistant_meta = self._lookup_assistant_thread_metadata(
             event,
             channel_id=channel_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5187,8 +5187,10 @@ class SlackAdapter(BasePlatformAdapter):
         event_ts = changed_event_ts or str(event.get("ts") or "")
         if not event_ts:
             return ""
-        team_id = self._canonical_event_team_id(event, body) or "unknown-workspace"
-        channel_id = str(event.get("channel") or "unknown-channel")
+        team_id = self._canonical_event_team_id(event, body)
+        channel_id = str(event.get("channel") or "")
+        if not team_id or not channel_id:
+            return ""
         return f"slack:channel-message:{team_id}:{channel_id}:{event_ts}"
 
     def _processed_message_key(
@@ -5196,8 +5198,10 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> str:
         if not message_ts:
             return ""
-        team_id = self._canonical_event_team_id(event, body) or "unknown-workspace"
-        channel_id = str(event.get("channel") or "unknown-channel")
+        team_id = self._canonical_event_team_id(event, body)
+        channel_id = str(event.get("channel") or "")
+        if not team_id or not channel_id:
+            return ""
         return f"{team_id}:{channel_id}:{message_ts}"
 
     @staticmethod
@@ -5847,7 +5851,10 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_id or not file_id:
             return
 
-        team_id = self._canonical_event_team_id(event, body)
+        # Canonical team normalization exists for dedup identity only. Client
+        # routing must preserve Slack's actual event scope and then use the
+        # channel map/primary-client fallback rather than guessing a tenant.
+        team_id = self._event_team_id(event, body)
         try:
             client = self._team_clients.get(team_id) if team_id else None
             info_resp = await (client or self._get_client(channel_id)).files_info(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5093,8 +5093,10 @@ class SlackAdapter(BasePlatformAdapter):
             "user_id": user_id,
         }
 
-    def _remember_processed_message_ts(self, ts: str) -> None:
-        """Mark a Slack message ts as claimed by this handler.
+    def _remember_processed_message_ts(
+        self, event: dict, body: Optional[dict], ts: str
+    ) -> None:
+        """Mark a workspace-scoped Slack message as claimed by this handler.
 
         Used by the ``message_changed`` guard to tell "we already took this
         message" from "this is new". Called on ENTRY (so an unfurl arriving
@@ -5104,9 +5106,10 @@ class SlackAdapter(BasePlatformAdapter):
         Bounded by ``_PROCESSED_MESSAGE_TS_MAX``: oldest entries are evicted
         first so a busy workspace cannot grow this map without limit.
         """
-        if not ts:
+        key = self._processed_message_key(event, body, ts)
+        if not key:
             return
-        self._processed_message_ts[ts] = time.time()
+        self._processed_message_ts[key] = time.time()
         if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
             newest_items = sorted(
                 self._processed_message_ts.items(),
@@ -6079,20 +6082,27 @@ class SlackAdapter(BasePlatformAdapter):
         started (the sequential-suppression case) is left untouched.
         """
         _ts = str((event or {}).get("ts") or "")
+        if (event or {}).get("subtype") == "message_changed":
+            _updated_message = (event or {}).get("message")
+            if isinstance(_updated_message, dict):
+                _ts = str(_updated_message.get("ts") or _ts)
+        _claim_key = self._processed_message_key(event or {}, payload, _ts)
         # getattr: bare test doubles (object.__new__) may lack the map.
         _claims = getattr(self, "_processed_message_ts", None)
-        _was_claimed = bool(_ts) and _claims is not None and _ts in _claims
+        _was_claimed = (
+            bool(_claim_key) and _claims is not None and _claim_key in _claims
+        )
         try:
             return await self._handle_slack_message_impl(event, payload)
         except BaseException:
             _claims = getattr(self, "_processed_message_ts", None)
             if (
-                _ts
+                _claim_key
                 and not _was_claimed
                 and _claims is not None
-                and _ts in _claims
+                and _claim_key in _claims
             ):
-                _claims.pop(_ts, None)
+                _claims.pop(_claim_key, None)
                 logger.warning(
                     "[%s] handler failed after claiming ts=%s; claim released "
                     "so a retry or edit can re-drive the turn",
@@ -6259,7 +6269,7 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks,
                 text,
                 bot_uid=self._team_bot_user_ids.get(
-                    dedup_team_id, self._bot_user_id
+                    self._event_team_id(event, payload), self._bot_user_id
                 )
                 or "",
             )
@@ -6624,7 +6634,7 @@ class SlackAdapter(BasePlatformAdapter):
         # enrichment awaits that open the race.
         _claim_ts = str(event.get("ts") or "")
         if _claim_ts:
-            self._remember_processed_message_ts(_claim_ts)
+            self._remember_processed_message_ts(event, payload, _claim_ts)
 
         if is_mentioned:
             # Strip the bot mention from the text
@@ -7220,7 +7230,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         if ts:
-            self._remember_processed_message_ts(ts)
+            self._remember_processed_message_ts(event, payload, ts)
 
         await self.handle_message(msg_event)
 

--- a/tests/gateway/test_slack_dedup_ttl.py
+++ b/tests/gateway/test_slack_dedup_ttl.py
@@ -14,7 +14,6 @@ import asyncio
 import os
 import sys
 import threading
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -193,28 +192,45 @@ def test_missing_all_stable_identity_does_not_collapse_messages():
     assert adapter._message_dedup_id(event) == ""
 
 
+def test_missing_workspace_identity_skips_cross_tenant_dedup():
+    """Unknown workspace scope must fail open rather than share a sentinel."""
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {}
+    event = {"channel": "C_ONE", "ts": "1787682677.049629"}
+
+    assert adapter._message_dedup_id(event) == ""
+    assert adapter._processed_message_key(event, {}, event["ts"]) == ""
+
+
+@pytest.mark.asyncio
+async def test_file_shared_client_routing_does_not_use_dedup_canonicalizer():
+    """A foreign event scope must fall back instead of guessing one workspace."""
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._app = MagicMock()
+    primary_client = MagicMock()
+    primary_client.files_info = AsyncMock(
+        return_value={"ok": True, "file": {"mimetype": "text/plain"}}
+    )
+    guessed_client = MagicMock()
+    guessed_client.files_info = AsyncMock()
+    adapter._app.client = primary_client
+    adapter._team_clients = {"T_HOME": guessed_client}
+
+    await adapter._handle_slack_file_shared(
+        {
+            "team": "E_PARTNER_ORG",
+            "channel_id": "C_SHARED",
+            "file_id": "F_SHARED",
+        }
+    )
+
+    primary_client.files_info.assert_awaited_once_with(file="F_SHARED")
+    guessed_client.files_info.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_concurrent_duplicate_event_runs_one_downstream_turn():
     """Concurrent scope variants must atomically claim one Slack message."""
-
-    class SlowLookupDict(dict):
-        """Widen the check-then-set race without changing lookup results."""
-
-        @staticmethod
-        def _pause_if_missing(present):
-            if not present:
-                time.sleep(0.05)
-
-        def __contains__(self, key):
-            present = super().__contains__(key)
-            self._pause_if_missing(present)
-            return present
-
-        def get(self, key, default=None):
-            value = super().get(key, default)
-            self._pause_if_missing(value is not default)
-            return value
-
     adapter = SlackAdapter(
         PlatformConfig(enabled=True, token="xoxb-test", extra={"require_mention": True})
     )
@@ -223,7 +239,6 @@ async def test_concurrent_duplicate_event_runs_one_downstream_turn():
     adapter._bot_user_id = "U_BOT"
     adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
     adapter._team_clients = {"T079QU5LX36": MagicMock()}
-    adapter._dedup._seen = SlowLookupDict()
 
     callback_count = 0
     callback_lock = threading.Lock()
@@ -261,14 +276,20 @@ async def test_concurrent_duplicate_event_runs_one_downstream_turn():
         "event": workspace_event,
     }
 
+    start_barrier = threading.Barrier(2)
+
+    async def start_together(event, payload):
+        start_barrier.wait(timeout=2)
+        await adapter._handle_slack_message(event, payload)
+
     await asyncio.gather(
         asyncio.to_thread(
             asyncio.run,
-            adapter._handle_slack_message(enterprise_event, enterprise_payload),
+            start_together(enterprise_event, enterprise_payload),
         ),
         asyncio.to_thread(
             asyncio.run,
-            adapter._handle_slack_message(workspace_event, workspace_payload),
+            start_together(workspace_event, workspace_payload),
         ),
     )
 

--- a/tests/gateway/test_slack_dedup_ttl.py
+++ b/tests/gateway/test_slack_dedup_ttl.py
@@ -10,10 +10,14 @@ replays >5 min later slipped through.
 Follows the slack-bolt mocking pattern from test_slack_mention.py.
 """
 
+import asyncio
 import os
 import sys
+import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _ensure_slack_mock():
@@ -47,7 +51,11 @@ import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.helpers import MessageDeduplicator  # noqa: E402
-from plugins.platforms.slack.adapter import _slack_dedup_ttl_seconds  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.slack.adapter import (  # noqa: E402
+    SlackAdapter,
+    _slack_dedup_ttl_seconds,
+)
 
 
 def test_default_ttl_outlasts_slack_reconnect_redelivery_window():
@@ -60,5 +68,210 @@ def test_default_ttl_outlasts_slack_reconnect_redelivery_window():
 def test_env_override_is_respected():
     with patch.dict(os.environ, {"SLACK_DEDUP_TTL_SECONDS": "120"}, clear=True):
         assert _slack_dedup_ttl_seconds() == 120.0
+
+
+def test_fallback_identity_preserves_distinct_workspaces_and_channels():
+    """ID-less fallback must not merge distinct workspace messages."""
+    first = {
+        "team": "T01KC2VC5U0",
+        "channel": "C0A3PUZPGN5",
+        "ts": "1787682677.049629",
+    }
+    same_message = dict(first)
+    other_workspace = {**first, "team": "T079QU5LX36"}
+    distinct_message = {**first, "channel": "C0DISTINCT01"}
+    dedup = MessageDeduplicator()
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {
+        "T01KC2VC5U0": MagicMock(),
+        "T079QU5LX36": MagicMock(),
+    }
+
+    assert dedup.is_duplicate(adapter._message_dedup_id(first)) is False
+    assert dedup.is_duplicate(adapter._message_dedup_id(same_message)) is True
+    assert dedup.is_duplicate(adapter._message_dedup_id(other_workspace)) is False
+    assert dedup.is_duplicate(adapter._message_dedup_id(distinct_message)) is False
+
+
+def test_client_message_id_is_not_process_global_across_workspaces():
+    event = {"channel": "C0A3PUZPGN5", "ts": "1787682677.049629"}
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {
+        "T01KC2VC5U0": MagicMock(),
+        "T079QU5LX36": MagicMock(),
+    }
+
+    assert adapter._message_dedup_id(
+        {**event, "team": "T01KC2VC5U0", "client_msg_id": "same-client-id"}
+    ) != adapter._message_dedup_id(
+        {**event, "team": "T079QU5LX36", "client_msg_id": "same-client-id"}
+    )
+
+
+def test_single_authenticated_workspace_normalizes_enterprise_scope():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {"T079QU5LX36": MagicMock()}
+    event = {
+        "team": "T01KC2VC5U0",
+        "channel": "C0A3PUZPGN5",
+        "ts": "1787682677.049629",
+    }
+    payload = {
+        "team_id": "T01KC2VC5U0",
+        "authorizations": [{"team_id": "T079QU5LX36"}],
+    }
+
+    assert adapter._canonical_event_team_id(event, payload) == "T079QU5LX36"
+    assert adapter._message_dedup_id(event, payload) == (
+        "slack:channel-message:T079QU5LX36:C0A3PUZPGN5:1787682677.049629"
+    )
+
+
+def test_known_channel_mapping_normalizes_enterprise_scope_with_multiple_workspaces():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {
+        "T_WORKSPACE_A": MagicMock(),
+        "T079QU5LX36": MagicMock(),
+    }
+    adapter._channel_team = {"C0A3PUZPGN5": "T079QU5LX36"}
+    event = {
+        "team": "E01ENTERPRISE",
+        "channel": "C0A3PUZPGN5",
+        "ts": "1787682677.049629",
+    }
+
+    assert adapter._canonical_event_team_id(event, {}) == "T079QU5LX36"
+
+
+def test_processed_edit_keys_are_workspace_and_channel_scoped():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {
+        "T_ONE": MagicMock(),
+        "T_TWO": MagicMock(),
+    }
+    first = {"team": "T_ONE", "channel": "C_ONE"}
+    second = {"team": "T_TWO", "channel": "C_TWO"}
+
+    assert adapter._processed_message_key(first, {}, "123.456") != (
+        adapter._processed_message_key(second, {}, "123.456")
+    )
+
+
+def test_scope_variants_with_different_envelopes_share_message_alias():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    adapter._team_clients = {"T079QU5LX36": MagicMock()}
+    dedup = MessageDeduplicator()
+    enterprise_event = {
+        "team": "T01KC2VC5U0",
+        "channel": "C0A3PUZPGN5",
+        "ts": "1787682677.049629",
+    }
+    workspace_event = {**enterprise_event, "team": "T079QU5LX36"}
+    enterprise_payload = {
+        "event_id": "EvEnterpriseDelivery",
+        "team_id": "T01KC2VC5U0",
+        "authorizations": [{"team_id": "T079QU5LX36"}],
+    }
+    workspace_payload = {
+        "event_id": "EvWorkspaceDelivery",
+        "team_id": "T079QU5LX36",
+    }
+
+    assert dedup.is_duplicate(
+        adapter._message_dedup_id(enterprise_event, enterprise_payload)
+    ) is False
+    assert dedup.is_duplicate(
+        adapter._message_dedup_id(workspace_event, workspace_payload)
+    ) is True
+
+
+def test_missing_all_stable_identity_does_not_collapse_messages():
+    """Without any stable ID or timestamp, let both messages reach routing."""
+    event = {"team": "T_TEAM", "channel": "C_ONE", "text": "same text"}
+
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-test"))
+    assert adapter._message_dedup_id(event) == ""
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_event_runs_one_downstream_turn():
+    """Concurrent scope variants must atomically claim one Slack message."""
+
+    class SlowLookupDict(dict):
+        """Widen the check-then-set race without changing lookup results."""
+
+        @staticmethod
+        def _pause_if_missing(present):
+            if not present:
+                time.sleep(0.05)
+
+        def __contains__(self, key):
+            present = super().__contains__(key)
+            self._pause_if_missing(present)
+            return present
+
+        def get(self, key, default=None):
+            value = super().get(key, default)
+            self._pause_if_missing(value is not default)
+            return value
+
+    adapter = SlackAdapter(
+        PlatformConfig(enabled=True, token="xoxb-test", extra={"require_mention": True})
+    )
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+    adapter._team_clients = {"T079QU5LX36": MagicMock()}
+    adapter._dedup._seen = SlowLookupDict()
+
+    callback_count = 0
+    callback_lock = threading.Lock()
+
+    async def downstream_turn(_event):
+        nonlocal callback_count
+        with callback_lock:
+            callback_count += 1
+
+    adapter.handle_message = downstream_turn
+    adapter._resolve_user_is_bot = AsyncMock(return_value=False)
+    adapter._resolve_user_name = AsyncMock(return_value="Test User")
+    adapter._resolve_channel_name = AsyncMock(return_value="test-channel")
+    adapter._humanize_user_mentions = AsyncMock(side_effect=lambda text, **_: text)
+
+    enterprise_event = {
+        "type": "message",
+        "team": "T01KC2VC5U0",
+        "channel": "C0A3PUZPGN5",
+        "channel_type": "channel",
+        "user": "U_USER",
+        "text": "<@U_BOT> run this once",
+        "ts": "1787682677.049629",
+        "client_msg_id": "11111111-2222-4333-8444-555555555555",
+    }
+    workspace_event = {**enterprise_event, "team": "T079QU5LX36"}
+    enterprise_payload = {
+        "event_id": "EvEnterpriseDelivery",
+        "team_id": "T01KC2VC5U0",
+        "event": enterprise_event,
+    }
+    workspace_payload = {
+        "event_id": "EvWorkspaceDelivery",
+        "team_id": "T079QU5LX36",
+        "event": workspace_event,
+    }
+
+    await asyncio.gather(
+        asyncio.to_thread(
+            asyncio.run,
+            adapter._handle_slack_message(enterprise_event, enterprise_payload),
+        ),
+        asyncio.to_thread(
+            asyncio.run,
+            adapter._handle_slack_message(workspace_event, workspace_payload),
+        ),
+    )
+
+    assert callback_count == 1
 
 

--- a/tests/gateway/test_slack_unfurl_duplicate_turn.py
+++ b/tests/gateway/test_slack_unfurl_duplicate_turn.py
@@ -27,7 +27,7 @@ import sys
 import time
 from importlib.machinery import PathFinder
 from types import ModuleType
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -224,21 +224,43 @@ class TestClaimHelperBounded:
         delivered = []
         adapter = _make_adapter(delivered)
         adapter._PROCESSED_MESSAGE_TS_MAX = 10
+        event = _original_event()
 
         for i in range(25):
-            adapter._remember_processed_message_ts(f"{i}.0")
+            adapter._remember_processed_message_ts(event, _body(), f"{i}.0")
             time.sleep(0.001)
 
         assert len(adapter._processed_message_ts) <= 10
         # newest survive, oldest evicted
-        assert "24.0" in adapter._processed_message_ts
-        assert "0.0" not in adapter._processed_message_ts
+        assert adapter._processed_message_key(event, _body(), "24.0") in (
+            adapter._processed_message_ts
+        )
+        assert adapter._processed_message_key(event, _body(), "0.0") not in (
+            adapter._processed_message_ts
+        )
 
     def test_empty_ts_is_ignored(self):
         delivered = []
         adapter = _make_adapter(delivered)
-        adapter._remember_processed_message_ts("")
+        adapter._remember_processed_message_ts(_original_event(), _body(), "")
         assert adapter._processed_message_ts == {}
+
+    def test_claims_are_workspace_and_channel_scoped(self):
+        delivered = []
+        adapter = _make_adapter(delivered)
+        other_team = "T_OTHER"
+        adapter._team_clients = {TEAM: MagicMock(), other_team: MagicMock()}
+        first = _original_event()
+        second = {**first, "team": other_team}
+        second_body = {"team_id": other_team, "event_id": "Ev-other"}
+
+        adapter._remember_processed_message_ts(first, _body(), ORIGINAL_TS)
+        adapter._remember_processed_message_ts(second, second_body, ORIGINAL_TS)
+
+        assert set(adapter._processed_message_ts) == {
+            adapter._processed_message_key(first, _body(), ORIGINAL_TS),
+            adapter._processed_message_key(second, second_body, ORIGINAL_TS),
+        }
 
 
 class TestClaimReleasedOnFailure:
@@ -272,7 +294,10 @@ class TestClaimReleasedOnFailure:
             with pytest.raises(RuntimeError):
                 await adapter._handle_slack_message(_original_event(), _body())
             # The failed invocation must not leave the ts claimed...
-            assert ORIGINAL_TS not in adapter._processed_message_ts
+            claim_key = adapter._processed_message_key(
+                _original_event(), _body(), ORIGINAL_TS
+            )
+            assert claim_key not in adapter._processed_message_ts
             # ...so a user edit of the unanswered message still summons the bot.
             await adapter._handle_slack_message(edit, _body())
 
@@ -287,7 +312,10 @@ class TestClaimReleasedOnFailure:
 
         async def scenario():
             await adapter._handle_slack_message(_original_event(), _body())
-            assert ORIGINAL_TS in adapter._processed_message_ts
+            claim_key = adapter._processed_message_key(
+                _original_event(), _body(), ORIGINAL_TS
+            )
+            assert claim_key in adapter._processed_message_ts
             # A later invocation for the same ts that fails must not strip
             # the claim the successful turn already holds.
             adapter._resolve_user_name = AsyncMock(
@@ -299,7 +327,7 @@ class TestClaimReleasedOnFailure:
                 await adapter._handle_slack_message(second, _body())
             except RuntimeError:
                 pass
-            assert ORIGINAL_TS in adapter._processed_message_ts
+            assert claim_key in adapter._processed_message_ts
 
         asyncio.run(scenario())
         assert len(delivered) == 1


### PR DESCRIPTION
## Summary

- Deduplicate Slack events by canonical authenticated workspace, channel, and message timestamp.
- Normalize enterprise/workspace delivery variants while preserving true multi-workspace isolation.
- Fail open when workspace or channel identity cannot be resolved instead of collapsing tenants onto a shared sentinel.
- Keep canonical dedup identity separate from `file_shared` client/token routing.

## Review follow-up

- Unresolved workspace/channel identity now skips deduplication.
- `MessageDeduplicator.contains()` documents that expired entries are evicted.
- The concurrency regression uses `threading.Barrier` rather than a timing sleep.
- `file_shared` uses raw event scope followed by the existing channel/primary-client fallback; a regression proves it does not guess the sole known workspace.

## Verification

- `pytest tests/gateway/test_slack.py tests/gateway/test_slack_dedup_ttl.py` → 177 passed
- Ruff on all changed files → passed
- `git diff --check origin/main...HEAD` → passed

## Risk / rollback

Scoped to Slack inbound deduplication, file-share client selection, and regression tests. Revert the two PR commits to restore prior behavior.
