### PR TITLE
macOS setup-launched Desktop no longer silently loses the microphone (salvage #74862)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/Info.plist
+++ b/apps/bootstrap-installer/src-tauri/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>Hermes launches the desktop app, which uses audio capture for voice conversations.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Hermes launches the desktop app, which uses the microphone for voice input and voice conversations.</string>
+</dict>
+</plist>

--- a/apps/bootstrap-installer/src-tauri/entitlements.plist
+++ b/apps/bootstrap-installer/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -57,7 +57,8 @@
     },
     "macOS": {
       "minimumSystemVersion": "11.0",
-      "hardenedRuntime": true
+      "hardenedRuntime": true,
+      "entitlements": "entitlements.plist"
     }
   },
   "plugins": {

--- a/contributors/emails/ulysse.trin@hotmail.fr
+++ b/contributors/emails/ulysse.trin@hotmail.fr
@@ -1,0 +1,1 @@
+hermias1

--- a/tests-js/desktop-mac-entitlements.test.ts
+++ b/tests-js/desktop-mac-entitlements.test.ts
@@ -35,6 +35,10 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const ELECTRON_DIR = path.join(REPO_ROOT, 'apps', 'desktop', 'electron')
 const MAIN_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.plist')
 const INHERIT_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.inherit.plist')
+const BOOTSTRAP_TAURI_DIR = path.join(REPO_ROOT, 'apps', 'bootstrap-installer', 'src-tauri')
+const BOOTSTRAP_TAURI_CONFIG = path.join(BOOTSTRAP_TAURI_DIR, 'tauri.conf.json')
+const BOOTSTRAP_ENTITLEMENTS = path.join(BOOTSTRAP_TAURI_DIR, 'entitlements.plist')
+const BOOTSTRAP_INFO_PLIST = path.join(BOOTSTRAP_TAURI_DIR, 'Info.plist')
 
 const DEVICE_PREFIX = 'com.apple.security.device.'
 
@@ -89,3 +93,41 @@ for (const plist of [MAIN_PLIST, INHERIT_PLIST]) {
     )
   })
 }
+
+test('bootstrap installer carries microphone entitlement for launcher attribution', () => {
+  const config = JSON.parse(fs.readFileSync(BOOTSTRAP_TAURI_CONFIG, 'utf-8'))
+  assert.equal(
+    config.bundle?.macOS?.entitlements,
+    'entitlements.plist',
+    'the macOS bootstrap installer must sign with its entitlements.plist. ' +
+      'When /Applications/Hermes.app is the setup launcher, macOS TCC treats ' +
+      'com.nousresearch.hermes.setup as the responsible process for the desktop ' +
+      'app it opens; without audio-input on the setup app, microphone access is ' +
+      'denied before a permission prompt can appear.'
+  )
+
+  const entitlements = loadEntitlements(BOOTSTRAP_ENTITLEMENTS)
+  assert.equal(
+    entitlements['com.apple.security.device.audio-input'],
+    true,
+    'bootstrap installer entitlements must grant audio-input because it is the ' +
+      'TCC responsible process for the desktop app launched from the setup fast path'
+  )
+})
+
+test('bootstrap installer Info.plist explains microphone usage', () => {
+  const info = plist.parse(fs.readFileSync(BOOTSTRAP_INFO_PLIST, 'utf-8')) as Record<
+    string,
+    unknown
+  >
+  assert.equal(
+    typeof info.NSMicrophoneUsageDescription,
+    'string',
+    'macOS requires NSMicrophoneUsageDescription before it can prompt for microphone access'
+  )
+  assert.match(
+    info.NSMicrophoneUsageDescription as string,
+    /microphone/i,
+    'microphone usage description should be user-visible and specific'
+  )
+})


### PR DESCRIPTION
## Summary
The microphone now works when Hermes Desktop is launched from the macOS setup app — previously the mic was silently denied with no permission prompt at all, because the Tauri bootstrap installer signs with hardened runtime but carried no `com.apple.security.device.audio-input` entitlement and no `NSMicrophoneUsageDescription`. Salvage of #74862 by @hermias1 (commit cherry-picked, authorship preserved).

When the setup bundle is the TCC-responsible process for the relaunched desktop app, macOS attributes the mic request to the installer; hardened runtime without the entitlement means denial-without-prompt (the same failure class as the Electron-side #37718, fixed long ago — the installer bundle was the uncovered sibling).

## Changes
- `apps/bootstrap-installer/src-tauri/entitlements.plist` (new): audio-input + the JIT/library-validation entitlements the Electron app already declares
- `apps/bootstrap-installer/src-tauri/Info.plist` (new): `NSMicrophoneUsageDescription`
- `apps/bootstrap-installer/src-tauri/tauri.conf.json`: `bundle.macOS.entitlements` now points at the plist
- `tests-js/desktop-mac-entitlements.test.ts`: extended to pin the installer bundle's entitlements alongside the existing Electron main/inherit parity checks
- `contributors/emails/`: mapping for @hermias1

## Validation
| | Before | After |
|---|---|---|
| Installer bundle entitlements | none (hardened runtime only) | audio-input + usage description, wired in tauri.conf.json |
| tests-js/desktop-mac-entitlements | 4 checks (Electron only) | 6 passed incl. installer bundle |

- `npx vitest run desktop-mac-entitlements.test.ts`: 6/6 passed
- **Live repro:** file-level premise verified on current main (no entitlements.plist/Info.plist in src-tauri, no `entitlements` key in tauri.conf.json macOS block); the end-to-end mic prompt from a setup-launched app can only be confirmed on a real signed macOS build — flagged for maintainer verification.

Credit: @hermias1. Closes #74862.

## Infographic

![Mic works from the setup app](https://v3b.fal.media/files/b/0aa7d11b/SItOjT7xsfZp8qAaZjpYK_iwjrtNMI.png)
