### PR TITLE
fix(desktop): stop packaged preview opens from succeeding invisibly

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -8,13 +8,17 @@ vi.mock('./right-rail/preview-console-store', () => ({
   forgetPreviewConsole: () => undefined
 }))
 
+import { group } from '@/components/pane-shell/tree/model'
+import { $layoutTree, watchContributedPanes } from '@/components/pane-shell/tree/store'
 import { contributesToWorkspace } from '@/components/pane-shell/workspace-scope'
 import { registry } from '@/contrib/registry'
 import { $previewTabs, closeRightRail, noteBrowserPage, openPreview } from '@/store/preview'
 
-import { browserTabExternalUrl, browserTabLabel, watchPreviewTiles } from './preview-tile'
+import { browserTabExternalUrl, browserTabLabel, isPreviewTileVisible, watchPreviewTiles } from './preview-tile'
 
 beforeAll(() => {
+  $layoutTree.set(group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+  watchContributedPanes()
   watchPreviewTiles()
 })
 
@@ -29,6 +33,15 @@ function browserPane() {
 }
 
 describe('preview tiles in Bot Mode', () => {
+  it('reports visible only after the real layout-tree pane is fronted', () => {
+    const tabId = openPreview(
+      { kind: 'url', label: 'example.com', source: 'https://example.com', url: 'https://example.com' },
+      'tool-result'
+    )
+
+    expect(isPreviewTileVisible(tabId)).toBe(true)
+  })
+
   it('registers the in-app Browser as a global pane so Bot Mode can show it', () => {
     openPreview(
       { kind: 'url', label: 'example.com', source: 'https://example.com', url: 'https://example.com' },

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -13,7 +13,13 @@
 import { useStore } from '@nanostores/react'
 
 import { findGroup } from '@/components/pane-shell/tree/model'
-import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
+import {
+  $activeTreeGroup,
+  $layoutTree,
+  isPaneVisible,
+  revealTreePane,
+  treePanesWithPrefix
+} from '@/components/pane-shell/tree/store'
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
@@ -172,6 +178,9 @@ function PreviewTabLead({ tabId }: { tabId: string }) {
 const PREVIEW_TILE_PREFIX = 'preview-tile'
 
 const previewPaneId = (tabId: string) => `${PREVIEW_TILE_PREFIX}:${tabId}`
+
+/** True only when the tab's real layout-tree pane is the visible stack slot. */
+export const isPreviewTileVisible = (tabId: string): boolean => isPaneVisible(previewPaneId(tabId))
 
 /** The pane a NEW preview tile should stack into: another preview tile already
  *  in the tree, else another open tab adopted earlier in the same pass (a

--- a/apps/desktop/src/app/session/hooks/preview-open.test.tsx
+++ b/apps/desktop/src/app/session/hooks/preview-open.test.tsx
@@ -2,6 +2,14 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { isPreviewTileVisible } = vi.hoisted(() => ({
+  isPreviewTileVisible: vi.fn(() => true)
+}))
+
+vi.mock('@/app/chat/preview-tile', () => ({
+  isPreviewTileVisible
+}))
+
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
 import { $previewTabs, $previewTarget, closeRightRail, type PreviewTarget } from '@/store/preview'
 import { $activeSessionId, $currentCwd, $messages, $selectedStoredSessionId } from '@/store/session'
@@ -10,6 +18,13 @@ import type { RpcEvent } from '@/types/hermes'
 import { usePreviewRouting } from './use-preview-routing'
 
 const RUNTIME_SESSION_ID = '20260727_140707_edec2d'
+const requestGatewayMock = vi.fn()
+
+async function requestGateway<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+  requestGatewayMock(method, params)
+
+  return {} as T
+}
 
 function assistantMessage(id: string, text: string): ChatMessage {
   return { id, parts: [assistantTextPart(text)], role: 'assistant' }
@@ -25,7 +40,7 @@ function Harness() {
   const routing = usePreviewRouting({
     baseHandleGatewayEvent: vi.fn(),
     currentCwd: '/work',
-    requestGateway: vi.fn()
+    requestGateway
   })
 
   useEffect(() => {
@@ -39,6 +54,16 @@ async function emitPreviewOpen(url = '/tmp/artifact-test.html', sessionId = RUNT
   await act(async () => {
     handleEvent({
       payload: { label: 'hi bestie', url },
+      session_id: sessionId,
+      type: 'preview.open'
+    } as unknown as RpcEvent)
+  })
+}
+
+async function emitPreviewOpenRequest(url = '/tmp/artifact-test.html', sessionId = RUNTIME_SESSION_ID) {
+  await act(async () => {
+    handleEvent({
+      payload: { label: 'hi bestie', request_id: 'open-1', url },
       session_id: sessionId,
       type: 'preview.open'
     } as unknown as RpcEvent)
@@ -63,6 +88,8 @@ describe('preview routing', () => {
     $messages.set([])
     closeRightRail()
     window.localStorage.clear()
+    requestGatewayMock.mockClear()
+    isPreviewTileVisible.mockReturnValue(true)
 
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,
@@ -93,6 +120,33 @@ describe('preview routing', () => {
 
       await waitFor(() => expect($previewTarget.get()?.path).toBe('/tmp/artifact-test.html'))
       expect($previewTabs.get()).toHaveLength(1)
+    })
+
+    it('acknowledges only after the requested preview tab becomes visible', async () => {
+      render(<Harness />)
+
+      await emitPreviewOpenRequest()
+
+      await waitFor(() =>
+        expect(requestGatewayMock).toHaveBeenCalledWith('preview.open.respond', {
+          request_id: 'open-1',
+          text: expect.stringContaining('"success":true') as string
+        })
+      )
+    })
+
+    it('rejects the request when the tab exists but its layout pane is not visible', async () => {
+      isPreviewTileVisible.mockReturnValue(false)
+      render(<Harness />)
+
+      await emitPreviewOpenRequest()
+
+      await waitFor(() =>
+        expect(requestGatewayMock).toHaveBeenCalledWith('preview.open.respond', {
+          request_id: 'open-1',
+          text: expect.stringContaining('"success":false') as string
+        })
+      )
     })
 
     it('keeps the tab when the stored session id arrives afterwards', async () => {

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { isPreviewTileVisible } from '@/app/chat/preview-tile'
 import { gatewayEventCompletedFileDiff } from '@/lib/gateway-events'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
@@ -83,27 +84,63 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         // session that is NOT visible anywhere still can't yank the pane
         // open (offer, don't hijack). Routes through the same normalizer as
         // the file browser so URLs, localhost, and file paths all resolve.
-        const { url, label } = asRecord(event.payload)
+        const { url, label, request_id: requestIdValue } = asRecord(event.payload)
         const target = typeof url === 'string' ? url.trim() : ''
+        const requestId = typeof requestIdValue === 'string' ? requestIdValue : ''
 
-        if (target && (!event.session_id || sessionIsOnScreen(event.session_id))) {
-          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(
-            async resolved => {
-              if (!resolved) {
-                return
-              }
-
-              const trimmedLabel = typeof label === 'string' ? label.trim() : ''
-              // The agent's loopback is the GATEWAY's loopback. Give the pane a
-              // URL this machine can load, keeping the original as the label so
-              // the user still sees the address the agent named.
-              const url = resolved.kind === 'url' ? await reachablePreviewUrl(resolved.url) : resolved.url
-              const reached = url === resolved.url ? resolved : { ...resolved, label: resolved.label || target, url }
-
-              openPreview(trimmedLabel ? { ...reached, label: trimmedLabel } : reached, 'tool-result')
-            }
-          )
+        const answer = (result: Record<string, unknown>) => {
+          if (requestId) {
+            void requestGateway('preview.open.respond', {
+              request_id: requestId,
+              text: JSON.stringify(result)
+            }).catch(() => undefined)
+          }
         }
+
+        if (!target) {
+          answer({ error: 'The preview target was empty.', success: false })
+
+          return
+        }
+
+        if (event.session_id && !sessionIsOnScreen(event.session_id)) {
+          answer({ error: 'The requesting session is not visible in this window.', success: false })
+
+          return
+        }
+        void (async () => {
+          try {
+            const resolved = await normalizeOrLocalPreviewTarget(
+              target,
+              $currentCwd.get() || currentCwd || undefined
+            )
+
+            if (!resolved) {
+              answer({ error: 'The preview target could not be resolved.', success: false })
+
+              return
+            }
+
+            const trimmedLabel = typeof label === 'string' ? label.trim() : ''
+            // The agent's loopback is the GATEWAY's loopback. Give the pane a
+            // URL this machine can load, keeping the original as the label so
+            // the user still sees the address the agent named.
+            const url = resolved.kind === 'url' ? await reachablePreviewUrl(resolved.url) : resolved.url
+            const reached = url === resolved.url ? resolved : { ...resolved, label: resolved.label || target, url }
+            const tabId = openPreview(trimmedLabel ? { ...reached, label: trimmedLabel } : reached, 'tool-result')
+
+            answer(
+              isPreviewTileVisible(tabId)
+                ? { success: true, tab_id: tabId, url }
+                : { error: 'The preview tab opened, but its pane did not become visible.', success: false }
+            )
+          } catch (error) {
+            answer({
+              error: error instanceof Error ? error.message : String(error),
+              success: false
+            })
+          }
+        })()
 
         return
       }
@@ -173,7 +210,7 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         requestPreviewReload()
       }
     },
-    [baseHandleGatewayEvent, currentCwd]
+    [baseHandleGatewayEvent, currentCwd, requestGateway]
   )
 
   return { handleDesktopGatewayEvent, restartPreviewServer }

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -391,6 +391,8 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
 
   $previewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
   selectRightRailTab(id)
+
+  return id
 }
 
 const blankPage = (): PreviewTarget => ({ kind: 'url', label: 'Browser', source: 'about:blank', url: 'about:blank' })

--- a/tests/tools/test_desktop_ui.py
+++ b/tests/tools/test_desktop_ui.py
@@ -8,13 +8,16 @@ from tools import desktop_ui
 @pytest.fixture(autouse=True)
 def _reset_emitter():
     desktop_ui.set_emitter(None)
+    desktop_ui.set_requester(None)
     yield
     desktop_ui.set_emitter(None)
+    desktop_ui.set_requester(None)
 
 
 def test_unavailable_without_emitter():
     assert desktop_ui.available() is False
     assert desktop_ui.emit("preview.open", {"url": "x"}) is False
+    assert desktop_ui.request("preview.open", {"url": "x"}, timeout=10) is None
 
 
 def test_routes_event_to_owning_window(monkeypatch):
@@ -28,3 +31,17 @@ def test_routes_event_to_owning_window(monkeypatch):
     assert desktop_ui.available() is True
     assert desktop_ui.emit("pane.reveal", {"pane": "terminal"}) is True
     assert seen == [("win-7", "pane.reveal", {"pane": "terminal"})]
+
+
+def test_routes_request_to_owning_window(monkeypatch):
+    monkeypatch.setattr(
+        desktop_ui, "get_session_env",
+        lambda name, default="": "win-9" if name == "HERMES_UI_SESSION_ID" else default,
+    )
+    seen = []
+    desktop_ui.set_requester(
+        lambda sid, event, payload, timeout: seen.append((sid, event, payload, timeout)) or "answer"
+    )
+
+    assert desktop_ui.request("preview.open", {"url": "x"}, timeout=10) == "answer"
+    assert seen == [("win-9", "preview.open", {"url": "x"}, 10)]

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -10,10 +10,12 @@ from tools.registry import registry
 
 @pytest.fixture(autouse=True)
 def _reset_emitter():
-    """Each test controls the emitter; never leak one across tests."""
+    """Each test controls the bridge; never leak one across tests."""
     desktop_ui.set_emitter(None)
+    desktop_ui.set_requester(None)
     yield
     desktop_ui.set_emitter(None)
+    desktop_ui.set_requester(None)
 
 
 def test_lives_in_the_gui_surface_toolset(monkeypatch):
@@ -31,5 +33,49 @@ def test_emitter_failure_is_reported():
     def _boom(*_a):
         raise RuntimeError("no window")
 
-    desktop_ui.set_emitter(_boom)
+    desktop_ui.set_requester(_boom)
     assert "no window" in json.loads(op.open_preview_tool("https://x.example"))["error"]
+
+
+def test_waits_for_the_renderer_to_confirm_the_pane_is_visible():
+    calls = []
+
+    def request(sid, event, payload, timeout):
+        calls.append((sid, event, payload, timeout))
+        return json.dumps({"success": True, "tab_id": "url:browser", "url": payload["url"]})
+
+    desktop_ui.set_requester(request)
+
+    out = json.loads(op.open_preview_tool("www.example.com", "Example"))
+
+    assert out == {
+        "success": True,
+        "tab_id": "url:browser",
+        "url": "https://www.example.com",
+    }
+    assert calls == [
+        (
+            "",
+            "preview.open",
+            {"url": "https://www.example.com", "label": "Example"},
+            10,
+        )
+    ]
+
+
+def test_unanswered_renderer_reports_a_stale_or_missing_desktop_pane():
+    desktop_ui.set_requester(lambda *_args: "")
+
+    out = json.loads(op.open_preview_tool("https://x.example"))
+
+    assert "Update the Hermes Desktop app" in out["error"]
+
+
+def test_renderer_rejection_is_returned_instead_of_false_success():
+    desktop_ui.set_requester(
+        lambda *_args: json.dumps({"success": False, "error": "Preview pane did not become visible."})
+    )
+
+    out = json.loads(op.open_preview_tool("https://x.example"))
+
+    assert out == {"error": "Preview pane did not become visible."}

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -337,10 +337,11 @@ def test_sensitive_prompt_timeout_emits_expiry(capture, event):
         ("sudo.respond", "password"),
         ("clarify.respond", "answer"),
         ("terminal.read.respond", "text"),
+        ("preview.open.respond", "text"),
     ],
 )
 def test_late_prompt_response_is_idempotent(server, method, value_key):
-    """All four blocking bridges tolerate a late reply after their request has
+    """Blocking bridges tolerate a late reply after their request has
     expired — the `*.respond` returns a graceful `{"status": "expired"}` instead
     of the raw 4009 protocol error a client would otherwise surface verbatim."""
     response = server.handle_request(

--- a/tools/desktop_ui.py
+++ b/tools/desktop_ui.py
@@ -16,12 +16,20 @@ from gateway.session_context import get_session_env
 
 # (sid, event, payload) sink, installed by the desktop gateway.
 _emit: Optional[Callable[[str, str, dict], None]] = None
+# Blocking renderer round-trip, installed alongside the event sink.
+_request: Optional[Callable[[str, str, dict, float], str]] = None
 
 
 def set_emitter(fn: Optional[Callable[[str, str, dict], None]]) -> None:
     """Install (or clear) the renderer-event sink. Called by the desktop gateway."""
     global _emit
     _emit = fn
+
+
+def set_requester(fn: Optional[Callable[[str, str, dict, float], str]]) -> None:
+    """Install (or clear) the blocking renderer request bridge."""
+    global _request
+    _request = fn
 
 
 def available() -> bool:
@@ -38,3 +46,15 @@ def emit(event: str, payload: dict) -> bool:
         return False
     fn(get_session_env("HERMES_UI_SESSION_ID", ""), event, payload)
     return True
+
+
+def request(event: str, payload: dict, *, timeout: float) -> Optional[str]:
+    """Route an event and wait for the owning renderer's response.
+
+    Returns ``None`` when no desktop gateway installed the blocking bridge;
+    an empty string means a wired renderer did not answer before ``timeout``.
+    """
+    fn = _request
+    if fn is None:
+        return None
+    return fn(get_session_env("HERMES_UI_SESSION_ID", ""), event, payload, timeout)

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -34,7 +34,7 @@ def _normalize_target(raw: str) -> str:
 
 
 def open_preview_tool(url: str, label: str = "") -> str:
-    """Ask the desktop GUI to show ``url`` in the preview pane beside the chat."""
+    """Ask the desktop GUI to show ``url`` and confirm the pane became visible."""
     target = _normalize_target(url or "")
     if not target:
         return tool_error(
@@ -44,13 +44,33 @@ def open_preview_tool(url: str, label: str = "") -> str:
 
     label = (label or "").strip()
     try:
-        ok = desktop_ui.emit("preview.open", {"url": target, "label": label})
+        raw = desktop_ui.request(
+            "preview.open",
+            {"url": target, "label": label},
+            timeout=10,
+        )
     except Exception as exc:
         return tool_error(f"Failed to open the preview pane: {exc}")
-    if not ok:
+    if raw is None:
         return tool_error("The preview pane is only available in the Hermes desktop app.")
+    if not raw:
+        return tool_error(
+            "No Hermes Desktop window confirmed that the preview pane became visible. "
+            "The desktop renderer updates separately from the backend. Update the Hermes "
+            "Desktop app and start a new session."
+        )
 
-    return json.dumps({"success": True, "url": target, "label": label}, ensure_ascii=False)
+    try:
+        result = json.loads(raw)
+    except (TypeError, ValueError):
+        return tool_error("The Hermes Desktop window returned an invalid preview response.")
+
+    if not isinstance(result, dict):
+        return tool_error("The Hermes Desktop window returned an invalid preview response.")
+    if result.get("success") is not True:
+        return tool_error(str(result.get("error") or "The preview pane did not become visible."))
+
+    return json.dumps(result, ensure_ascii=False)
 
 
 OPEN_PREVIEW_SCHEMA = {

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1538,6 +1538,14 @@ def _(rid, params: dict) -> dict:
     return _respond(rid, params, "text", allow_expired=True)
 
 
+@method("preview.open.respond")
+def _(rid, params: dict) -> dict:
+    # `text` confirms that the renderer normalized the target, registered its
+    # layout-tree pane, and made that pane visible. Older renderer bundles do
+    # not answer, so open_preview reports bundle skew instead of false success.
+    return _respond(rid, params, "text", allow_expired=True)
+
+
 @method("preview.act.respond")
 def _(rid, params: dict) -> dict:
     # `text` is a JSON string with the interaction's outcome (drive_preview

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4096,6 +4096,7 @@ def _block(
         "sudo.request",
         "clarify.request",
         "terminal.read.request",
+        "preview.open",
         "preview.read.request",
         "preview.act.request",
         "window.read.request",
@@ -11144,6 +11145,14 @@ def _wire_desktop_ui() -> None:
         return
 
     desktop_ui.set_emitter(lambda sid, event, payload: _emit(event, sid, payload))
+    desktop_ui.set_requester(
+        lambda sid, event, payload, timeout: _block(
+            event,
+            sid,
+            dict(payload),
+            timeout=timeout,
+        )
+    )
     _desktop_ui_wired = True
 
 


### PR DESCRIPTION
## What does this PR do?

Packaged Desktop users can currently get a successful `open_preview` result even when no preview pane is visible, leaving every subsequent `read_preview` or `drive_preview` call to time out. This change makes opening a preview a renderer-confirmed operation: success is returned only after the target is normalized, its layout-tree tab is registered, and that pane is actually visible. A stale or missing Desktop renderer now gets a clear update instruction instead of false success.

### Symptom

`open_preview` returns `success: true`, but no preview pane appears. The hidden preview tab can still be closed, while `read_preview` reports `No preview tab is open, or the read timed out` and `drive_preview` times out waiting for a GUI response.

### Impact

The in-app preview workflow is unusable for affected packaged Desktop installations. Both remote URLs and local HTML files can enter a phantom-open state, and the agent cannot distinguish that state from a working pane.

### Bug Cause

**Trigger:** `tools/open_preview_tool.py:open_preview_tool` calls `desktop_ui.emit("preview.open", ...)` while the packaged Desktop renderer is stale, missing, or unable to make the dynamic preview pane visible.

**Causal chain:**
1. The backend exposes `open_preview` for a Desktop-sourced session and emits `preview.open` to the owning window.
2. `tools/desktop_ui.py` reports success as soon as an event sink exists; it never waits for the renderer to normalize the target, register the preview contribution, or reveal the layout-tree pane.
3. The tool returns `success: true` even when the renderer never handled the event or retained only tab state without a visible pane. Later read and drive requests then time out.

**Why it is wrong:** emitter availability proves only that a Desktop gateway is connected. It does not prove that the separately updated packaged renderer implements the event or that the requested pane reached a visible layout slot.

**Working sibling / contrast:** `read_preview` and `drive_preview` already use the gateway's blocking request/response bridge, so they only return renderer-owned results. `open_preview` was the fire-and-forget exception.

**Ruled out:** URL normalization is not the root cause because the reported failure affects both remote URLs and local HTML files, while the ability to close the hidden tab proves that target state was created before visibility diverged.

### Fix

- Add a blocking request path to the shared Desktop UI bridge and route `open_preview` through it with a bounded compatibility probe.
- Have the renderer answer `preview.open.respond` only after `openPreview` completes and `isPaneVisible` confirms the corresponding layout-tree pane is active and visible.
- Return explicit renderer errors for invalid targets, background sessions, normalization failures, and phantom tabs.
- Tell users to update Hermes Desktop when an older packaged renderer does not implement the acknowledgement.
- Add Python protocol/tool tests and Desktop routing/layout visibility tests for successful acknowledgement, renderer rejection, timeout, and late-response behavior.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/desktop_ui.py`, `tools/open_preview_tool.py` - add the renderer-confirmed open request and clear stale-renderer failure.
- `tui_gateway/server.py`, `tui_gateway/methods_prompt.py` - bridge and resolve `preview.open.respond` with bounded timeout semantics.
- `apps/desktop/src/app/session/hooks/use-preview-routing.ts` - acknowledge only a resolved and visible preview pane.
- `apps/desktop/src/app/chat/preview-tile.tsx`, `apps/desktop/src/store/preview.ts` - expose the opened tab identity and verify its real layout-tree visibility.
- Related Python and Desktop tests - cover the complete request, acknowledgement, visibility, timeout, and protocol paths.

## How to Test

1. From a Desktop session, call `open_preview` for a remote URL and a local HTML file. Confirm each call returns success only after the pane is visible.
2. Run the targeted Desktop tests:

```bash
cd apps/desktop
npx vitest run src/app/session/hooks/preview-open.test.tsx src/app/chat/preview-tile.test.ts src/store/preview.test.ts src/app/chat/right-rail/preview-reader.test.ts src/app/chat/right-rail/preview-act.test.ts
npm run check:lint
```

3. Run the targeted Python tests:

```bash
scripts/run_tests.sh tests/tools/test_desktop_ui.py tests/tools/test_open_preview_tool.py tests/tui_gateway/test_protocol.py -q
scripts/run_tests.sh tests/tools/test_close_preview_tool.py tests/tools/test_read_preview_tool.py tests/tools/test_drive_preview_tool.py tests/tui_gateway/test_gui_surface_toolsets.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Relevant Python and Desktop tests pass
- [x] I've added tests for the bug fix
- [x] I've tested the automated behavior on Windows 11

### Documentation & Housekeeping

- [x] Documentation changes are N/A; user-facing failure guidance is in the tool result
- [x] Config example changes are N/A
- [x] Architecture guide changes are N/A
- [x] Cross-platform impact was considered; the bridge and renderer logic are platform-independent
- [x] The `open_preview` behavior and error reporting were updated

## Screenshots / Logs

N/A - Phase B will verify the packaged Windows Desktop interaction against the real renderer.
