### PR TITLE
hermes doctor now diagnoses broken macOS permission grants and prints the one-time fix (salvage #86391)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1072,6 +1072,11 @@ def check_macos_tcc_grants() -> None:
             "(could not read code-signing requirement of the desktop bundle)",
         )
         return
+    # The DR string is the only readable signal — TCC.db itself needs Full
+    # Disk Access. A cdhash anchor marks the pre-#73681 ad-hoc identity
+    # (rebuild ⇒ new cdhash ⇒ stale grants); its absence marks identifier-
+    # pinned. Treat the match as a proxy for the signing class, not a
+    # contract on DR wording.
     if "cdhash" in dr.lower():
         check_warn(
             "macOS TCC grants will reset after every update",
@@ -1087,8 +1092,9 @@ def check_macos_tcc_grants() -> None:
     )
     check_info(
         "If macOS still re-prompts for permissions (toggle shows ON): the stored "
-        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes`, "
-        "toggle it ON in System Settings, then fully quit & relaunch Hermes once."
+        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes` "
+        "(repeat per affected service), toggle it ON in System Settings, then "
+        "fully quit & relaunch Hermes once."
     )
 
 
@@ -1096,15 +1102,20 @@ def _desktop_app_bundle() -> Path | None:
     """Locate the locally-built desktop app bundle, if any.
 
     Mirrors the install layout the self-updater produces
-    (``apps/desktop/release/mac-<arch>/Hermes.app``).
+    (``apps/desktop/release/mac-<arch>/Hermes.app``) — the only layout whose
+    ad-hoc re-signed bundle can invalidate TCC grants. When multiple arch
+    trees coexist (stale cross-build), the newest wins, matching
+    ``_desktop_packaged_executable``'s selection. ``/Applications/Hermes.app``
+    is deliberately not probed: it is the separately-signed Hermes-Setup
+    launcher (``com.nousresearch.hermes.setup``, certificate-anchored), whose
+    grants are stable by construction and unaffected by rebuilds.
     """
     root = Path(__file__).resolve().parents[1]
     release_dir = root / "apps" / "desktop" / "release"
-    for arch in ("mac-arm64", "mac-x64"):
-        app = release_dir / arch / "Hermes.app"
-        if app.is_dir():
-            return app
-    return None
+    candidates = [p for p in release_dir.glob("mac*/Hermes.app") if p.is_dir()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
 def _macos_desktop_dr(app: Path) -> str | None:
@@ -1112,12 +1123,17 @@ def _macos_desktop_dr(app: Path) -> str | None:
     codesign = shutil.which("codesign")
     if not codesign:
         return None
-    proc = subprocess.run(
-        [codesign, "-d", "--requirements", "-", str(app)],
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
+    try:
+        proc = subprocess.run(
+            [codesign, "-d", "--requirements", "-", str(app)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Never let a hanging codesign abort the whole doctor run — the
+        # caller falls through to its "could not read" warning.
+        return None
     if proc.returncode != 0:
         return None
     return (proc.stdout or "") + (proc.stderr or "")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -616,9 +616,15 @@ def collect_relay_plugin_cutover_findings(
                 )
 
     effective_env = dict(env_map or {})
-    for name in (*LEGACY_RELAY_EXPORT_ENV_VARS, RELAY_PLUGINS_CONFIG_ENV):
-        if name not in effective_env and os.environ.get(name) is not None:
-            effective_env[name] = os.environ[name]
+    # Fall through to process-level env ONLY when no explicit env_map was
+    # given: run_doctor passes None and wants live-process vars included, but
+    # callers (and tests) that hand in an explicit map are describing a
+    # complete environment — merging os.environ on top breaks hermeticity on
+    # any box that exports legacy relay vars (10-vs-2 findings, Aug 2026).
+    if env_map is None:
+        for name in (*LEGACY_RELAY_EXPORT_ENV_VARS, RELAY_PLUGINS_CONFIG_ENV):
+            if name not in effective_env and os.environ.get(name) is not None:
+                effective_env[name] = os.environ[name]
     if not str(effective_env.get(RELAY_PLUGINS_CONFIG_ENV, "")).strip():
         for name in configured_legacy_relay_env_vars(effective_env):
             findings.append(
@@ -1086,10 +1092,19 @@ def check_macos_tcc_grants() -> None:
             "identity, then re-grant permissions once.",
         )
         return
-    check_ok(
-        "macOS TCC signing identity is stable",
-        "(identifier-pinned DR; grants survive rebuilds)",
-    )
+    if "certificate" in dr.lower():
+        # Certificate-anchored DR (hermes desktop --setup-tcc-identity, or a
+        # notarized release build): the strongest anchor TCC can key on.
+        check_ok(
+            "macOS TCC signing identity is stable",
+            "(certificate-anchored DR; grants survive rebuilds)",
+        )
+    else:
+        check_ok(
+            "macOS TCC signing identity is stable",
+            "(identifier-pinned DR; grants survive rebuilds — for the strongest "
+            "anchor, see `hermes desktop --setup-tcc-identity`)",
+        )
     check_info(
         "If macOS still re-prompts for permissions (toggle shows ON): the stored "
         "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes` "

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1043,6 +1043,86 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+def check_macos_tcc_grants() -> None:
+    """Check macOS TCC grant persistence for a locally-built desktop bundle.
+
+    TCC keys permission grants (Screen Recording, Full Disk Access,
+    Accessibility, ...) to the app's code-signing requirement. A bundle
+    signed with the pre-#73681 cdhash-pinned ad-hoc identity gets a new DR on
+    every rebuild, so all grants silently stop matching — and the stale row
+    keeps the System Settings toggle ON while macOS re-prompts on every
+    capture (issue #86385).
+
+    Post-#73681 builds pin ``designated => identifier "com.nousresearch.hermes"``
+    (no cdhash), so new grants survive rebuilds — but grants made to older
+    binaries remain stale until re-granted once. The stale state is not
+    directly readable (TCC.db needs Full Disk Access), so this check reports
+    the DR class and, when the DR is stable, prints the exact one-time repair.
+    Silent on non-macOS and when no desktop bundle is installed.
+    """
+    if sys.platform != "darwin":
+        return
+    app = _desktop_app_bundle()
+    if app is None:
+        return
+    dr = _macos_desktop_dr(app)
+    if dr is None:
+        check_warn(
+            "macOS TCC grant check",
+            "(could not read code-signing requirement of the desktop bundle)",
+        )
+        return
+    if "cdhash" in dr.lower():
+        check_warn(
+            "macOS TCC grants will reset after every update",
+            "the desktop bundle's designated requirement is cdhash-pinned "
+            "(pre-#73681 build) — rebuilds invalidate all permission grants. "
+            "Run `hermes update` to get the stable identifier-pinned signing "
+            "identity, then re-grant permissions once.",
+        )
+        return
+    check_ok(
+        "macOS TCC signing identity is stable",
+        "(identifier-pinned DR; grants survive rebuilds)",
+    )
+    check_info(
+        "If macOS still re-prompts for permissions (toggle shows ON): the stored "
+        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes`, "
+        "toggle it ON in System Settings, then fully quit & relaunch Hermes once."
+    )
+
+
+def _desktop_app_bundle() -> Path | None:
+    """Locate the locally-built desktop app bundle, if any.
+
+    Mirrors the install layout the self-updater produces
+    (``apps/desktop/release/mac-<arch>/Hermes.app``).
+    """
+    root = Path(__file__).resolve().parents[1]
+    release_dir = root / "apps" / "desktop" / "release"
+    for arch in ("mac-arm64", "mac-x64"):
+        app = release_dir / arch / "Hermes.app"
+        if app.is_dir():
+            return app
+    return None
+
+
+def _macos_desktop_dr(app: Path) -> str | None:
+    """Return the bundle's designated requirement string, or None on failure."""
+    codesign = shutil.which("codesign")
+    if not codesign:
+        return None
+    proc = subprocess.run(
+        [codesign, "-d", "--requirements", "-", str(app)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        return None
+    return (proc.stdout or "") + (proc.stderr or "")
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1216,6 +1296,12 @@ def run_doctor(args):
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).
     _check_version_consistency(issues)
+
+    # macOS TCC grant persistence (issue #86385): a locally-built desktop
+    # bundle whose DR is cdhash-pinned loses every permission grant on each
+    # rebuild; a post-#73681 identifier-pinned DR survives, but grants made
+    # to older binaries stay stale (toggle shows ON while macOS re-prompts).
+    check_macos_tcc_grants()
 
     _section("SSL / CA Certificates")
     check_certificates(should_fix=should_fix, issues=manual_issues)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1066,7 +1066,7 @@ def check_macos_tcc_grants() -> None:
     if app is None:
         return
     dr = _macos_desktop_dr(app)
-    if dr is None:
+    if not dr:
         check_warn(
             "macOS TCC grant check",
             "(could not read code-signing requirement of the desktop bundle)",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7011,6 +7011,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print(f"✓ Code updated!{_branch_head_suffix(git_cmd, _m().PROJECT_ROOT)}")
 
+        # ── macOS TCC stale-grant notice (#86385) ──────────────────────
+        # Locally-built desktop bundles are re-signed on every update. With the
+        # post-#73681 identifier-pinned DR, new grants survive rebuilds — but a
+        # grant made to a pre-fix binary stays stale: the System Settings toggle
+        # shows ON while macOS re-prompts on every capture, and the modern prompt
+        # has no Allow button, so users loop. One line of guidance after update
+        # tells affected users how to complete the one-time re-grant.
+        if sys.platform == "darwin" and has_desktop_app:
+            print()
+            print(
+                "  ℹ macOS: if Hermes re-prompts for permissions you already "
+                "granted (toggle shows ON), the stored grant is stale — run "
+                "`tccutil reset ScreenCapture com.nousresearch.hermes`, toggle "
+                "it ON in System Settings, then fully quit & relaunch once."
+            )
+
         # ── Post-update state.db integrity guard (#68474) ─────────────────
         # Verify that state.db survived the update intact.  If the live file
         # is now corrupted (zeroed, missing header, integrity failure),

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7023,8 +7023,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(
                 "  ℹ macOS: if Hermes re-prompts for permissions you already "
                 "granted (toggle shows ON), the stored grant is stale — run "
-                "`tccutil reset ScreenCapture com.nousresearch.hermes`, toggle "
-                "it ON in System Settings, then fully quit & relaunch once."
+                "`tccutil reset ScreenCapture com.nousresearch.hermes` (repeat "
+                "per affected service), toggle it ON in System Settings, then "
+                "fully quit & relaunch once."
             )
 
         # ── Post-update state.db integrity guard (#68474) ─────────────────

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1522,10 +1522,14 @@ class TestDoctorDeprecatedConfigAndEnv:
 class TestMacOSTCCGrants:
     """macOS TCC grant persistence check (issue #86385)."""
 
-    def test_silent_on_non_macos(self, monkeypatch, capsys):
-        """Non-macOS: the check must produce no output."""
+    def test_silent_on_non_macos(self, monkeypatch, capsys, tmp_path):
+        """Non-macOS: the check must produce no output even with a bundle present."""
         monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
-        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
         doctor_mod.check_macos_tcc_grants()
         assert capsys.readouterr().out == ""
 
@@ -1587,3 +1591,17 @@ class TestMacOSTCCGrants:
         doctor_mod.check_macos_tcc_grants()
         out = capsys.readouterr().out
         assert "could not read code-signing requirement" in out
+
+    def test_warns_when_dr_empty_string(self, monkeypatch, capsys, tmp_path):
+        """Empty DR output must not false-positive as a stable identity."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: "")
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1517,3 +1517,73 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestMacOSTCCGrants:
+    """macOS TCC grant persistence check (issue #86385)."""
+
+    def test_silent_on_non_macos(self, monkeypatch, capsys):
+        """Non-macOS: the check must produce no output."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
+        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        doctor_mod.check_macos_tcc_grants()
+        assert capsys.readouterr().out == ""
+
+    def test_silent_when_no_desktop_bundle(self, monkeypatch, capsys):
+        """No locally-built desktop bundle: nothing to check, no output."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        doctor_mod.check_macos_tcc_grants()
+        assert capsys.readouterr().out == ""
+
+    def test_warns_on_cdhash_pinned_dr(self, monkeypatch, capsys, tmp_path):
+        """Pre-#73681 builds have a cdhash-pinned DR → warn that grants reset."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_macos_desktop_dr",
+            lambda app: 'designated => identifier "com.nousresearch.hermes" and cdhash H"97e692f3890f781fa0ad5ad6cb9d769cfaf42628"',
+        )
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "TCC grants will reset after every update" in out
+        assert "cdhash-pinned" in out
+        assert "hermes update" in out
+
+    def test_ok_and_repair_info_on_identifier_dr(self, monkeypatch, capsys, tmp_path):
+        """Post-#73681 identifier-only DR → stable + stale-grant repair info."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_macos_desktop_dr",
+            lambda app: 'designated => identifier "com.nousresearch.hermes"',
+        )
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "TCC signing identity is stable" in out
+        assert "tccutil reset ScreenCapture com.nousresearch.hermes" in out
+        assert "toggle" in out
+        assert "relaunch" in out
+
+    def test_warns_when_dr_unreadable(self, monkeypatch, capsys, tmp_path):
+        """codesign failure → warn, never crash."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: None)
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1576,9 +1576,35 @@ class TestMacOSTCCGrants:
         doctor_mod.check_macos_tcc_grants()
         out = capsys.readouterr().out
         assert "TCC signing identity is stable" in out
+        assert "identifier-pinned" in out
+        # Identifier-pinned is stable but not the strongest anchor — the check
+        # should point at the cert-anchored upgrade path.
+        assert "--setup-tcc-identity" in out
         assert "tccutil reset ScreenCapture com.nousresearch.hermes" in out
         assert "toggle" in out
         assert "relaunch" in out
+
+    def test_ok_on_certificate_anchored_dr(self, monkeypatch, capsys, tmp_path):
+        """A cert-anchored DR (hermes desktop --setup-tcc-identity, or a
+        notarized release) classifies as stable in its own class — no upgrade
+        hint, still prints the stale-grant repair info."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_macos_desktop_dr",
+            lambda app: 'designated => identifier "com.nousresearch.hermes" and certificate root = H"aabbcc"',
+        )
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "TCC signing identity is stable" in out
+        assert "certificate-anchored" in out
+        assert "--setup-tcc-identity" not in out
+        assert "tccutil reset ScreenCapture com.nousresearch.hermes" in out
 
     def test_warns_when_dr_unreadable(self, monkeypatch, capsys, tmp_path):
         """codesign failure → warn, never crash."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.doctor."""
 
 import os
+import subprocess
 import sys
 import types
 import io
@@ -1601,6 +1602,38 @@ class TestMacOSTCCGrants:
             lambda: tmp_path / "Hermes.app",
         )
         monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: "")
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out
+
+    def test_warns_when_codesign_times_out(self, monkeypatch, capsys, tmp_path):
+        """A hanging codesign must degrade to the unreadable-DR warning, never crash."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+
+        def _timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["codesign"], timeout=15)
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", _timeout)
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out
+
+    def test_warns_when_codesign_missing(self, monkeypatch, capsys, tmp_path):
+        """No codesign binary → same graceful unreadable-DR warning."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda _name: None)
         doctor_mod.check_macos_tcc_grants()
         out = capsys.readouterr().out
         assert "could not read code-signing requirement" in out

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -543,8 +543,21 @@ macOS/Windows signing and notarization run automatically when the relevant crede
 macOS remembers permission grants (Full Disk Access, Desktop/Downloads/Documents,
 Accessibility, Automation, microphone) against the app's *code-signing identity*,
 not its path. Locally built and self-updated apps are signed with a stable
-identifier-pinned ad-hoc signature, so grants persist across updates out of the
-box.
+identifier-pinned ad-hoc signature, so grants persist across updates.
+
+One-time note: grants made to builds *before* the identifier-pinned signing
+fix (PR #73681) carry the old cdhash-pinned requirement. macOS keeps showing the
+toggle as ON for those stale grants but still re-prompts, because the stored
+grant no longer matches the rebuilt binary — and the modern prompt has no Allow
+button, so it looks like there is nothing to re-check. If that happens, reset
+the stale grant once and re-grant:
+
+```bash
+tccutil reset ScreenCapture com.nousresearch.hermes   # repeat per service
+```
+
+then toggle the fresh entry ON in System Settings and fully quit & relaunch
+Hermes. Grants are stable from then on.
 
 For the strongest guarantee — a certificate-anchored identity, the same
 mechanism yabai/skhd users rely on — create a self-signed code-signing


### PR DESCRIPTION
## Summary
`hermes doctor` now tells macOS users WHY their permission grants keep breaking and exactly how to fix them once — closing the diagnosis gap for the recurring "toggle shows ON but macOS keeps re-prompting" state (issue #86385) that prevention-side fixes can't retroactively repair. Salvage of #86391 by @DavidMetcalfe (commit cherry-picked, authorship preserved).

TCC keys grants to the app's code-signing requirement; pre-#73681 cdhash-pinned builds got a new identity on every rebuild, stranding a stale grant row that macOS won't honor but System Settings still displays as ON. TCC.db itself needs Full Disk Access to read, so the bundle's Designated Requirement is the one readable signal — this check classifies it and prescribes accordingly.

## Changes
- `hermes_cli/doctor.py` (@DavidMetcalfe): `check_macos_tcc_grants()` — reads the local desktop bundle's DR via `codesign -d --requirements -`; cdhash-pinned → warn + "run `hermes update`, then re-grant once"; stable DR → prints the exact one-time stale-grant repair (`tccutil reset <service>` → toggle ON → full relaunch). Silent on non-macOS / no bundle.
- `hermes_cli/update_cmd.py` (@DavidMetcalfe): one-line stale-grant notice after macOS updates that touch a desktop app.
- `website/docs/user-guide/desktop.md` (@DavidMetcalfe): troubleshooting section.
- Follow-up commit (ours):
  - certificate-anchored DRs (from `hermes desktop --setup-tcc-identity`, #95091, or notarized builds) classify as stable in their own class; the identifier-pinned message now points at `--setup-tcc-identity` for the strongest anchor.
  - fixed a pre-existing hermeticity bug this salvage's test run exposed: `collect_relay_plugin_cutover_findings` merged `os.environ` on top of an explicitly-passed `env_map`, so `test_report_does_not_count_as_blocking_issue` failed (10 findings vs 2) on any box exporting legacy relay vars — including pristine origin/main here. Process-env fallthrough now only applies when `env_map is None` (run_doctor's live path, behavior unchanged).

Complementary to #95091: that PR prevents future grant staleness; this one detects and repairs the already-stale state.

## Validation
| | Before | After |
|---|---|---|
| Stale-grant diagnosis | none (`doctor` silent on TCC) | DR classified, one-time repair printed |
| `tests/hermes_cli/test_doctor.py` on this box | 1 pre-existing fail (env leak) | 64/64 passed |

**Live repro:** the hermeticity bug fired live on pristine origin/main on this machine (legacy relay env vars exported → 10 findings where the test expects 2) and passes with the fix; the TCC DR classification itself is macOS-only — mocked across cdhash/identifier/certificate/missing-bundle cases (8 tests from the original PR + our additions), flagged for maintainer spot-check on a real Mac.

Credit: @DavidMetcalfe. Closes #86391. Refs #86385.

## Infographic

![hermes doctor now spots broken macOS permissions](https://v3b.fal.media/files/b/0aa7d149/lSbTQ_4fhAb9JKupNX7xp_tuaYVOf2.png)
