### PR TITLE
Windows auto-update refreshes cua-driver again — unattended-safe, hangs fail in seconds (salvage #79871 #87720 #87196)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1006,8 +1006,11 @@ def install_cua_driver(
     a further ~600s wait on Windows). ``hermes computer-use install
     --upgrade`` leaves it False — an explicit upgrade request should still
     reinstall when the check is indeterminate. On Windows this flag also
-    prevents every installer run, because install.ps1 may require console or
-    UAC consent; automatic updates instead point at the explicit command.
+    defers contract REPAIRS and fresh INSTALLS to the explicit command
+    (those paths can legitimately need a human: first-time autostart
+    elevation, SmartScreen). Routine confirmed upgrades DO run, in
+    unattended-safe mode: stdin closed, version pinned, lock/network
+    preflights, and the shorter background ceiling below.
 
     ``show_installer_progress`` controls the installer's own progress line.
     ``hermes update`` already prints a contextual line before its update
@@ -1194,25 +1197,15 @@ def install_cua_driver(
             )
             return True
         if _state is not None and _state.get("update_available"):
-            if is_windows and require_confirmed_update:
-                _latest = _state.get("latest_version")
-                if _latest:
-                    _print_info(
-                        f"    {driver_cmd} {_latest} is available; keeping the "
-                        "installed version because its Windows installer may "
-                        "require interactive consent."
-                    )
-                else:
-                    _print_info(
-                        f"    A newer {driver_cmd} release is available; "
-                        "keeping the installed version because its Windows "
-                        "installer may require interactive consent."
-                    )
-                _print_info(
-                    "    Update it from an interactive terminal with: "
-                    "hermes computer-use install --upgrade"
-                )
-                return True
+            # Windows routine upgrades run UNATTENDED-SAFE rather than
+            # deferring: stdin is closed (a consent Read-Host can't block),
+            # the version is pinned, the ceiling is
+            # _CUA_BACKGROUND_UPDATE_TIMEOUT, and _run_cua_driver_installer's
+            # preflights skip in seconds when the install lock is held or
+            # GitHub is unreachable. Only contract repairs and fresh installs
+            # stay interactive-only (guards above/below) — those are the
+            # paths where upstream legitimately needs a human (first-time
+            # autostart elevation, SmartScreen).
             # Pin the installer to the release check-update just confirmed.
             # `latest_version` comes from the GitHub Releases API, so its
             # assets are published — unlike the installer script's baked
@@ -1477,6 +1470,67 @@ def _clear_stale_cua_install_lock() -> None:
         logger.debug("stale cua install lock check failed: %s", e)
 
 
+def _cua_install_lock_held() -> bool:
+    """True when the upstream installer's lock is held by a LIVE process.
+
+    Called after ``_clear_stale_cua_install_lock()``: anything provably
+    stale is already gone, so a surviving lock artifact means a concurrent
+    (or orphaned-but-alive) install owns it. Upstream waits up to
+    ``LOCK_STALE_AFTER_SECONDS=600`` on a held lock before probing —
+    unattended refreshes must not eat that wait (the 11-minute hang class,
+    #87703): they skip instead. Best-effort: unreadable state reports
+    not-held so a probe failure can never block an install.
+    """
+    try:
+        if sys.platform == "win32":
+            lock_file = _cua_windows_install_lock_file()
+            if not lock_file.is_file():
+                return False
+            # install.ps1 holds the file open with FileShare::None — any
+            # open attempt fails with a sharing violation while it's held.
+            # _clear_stale_windows_cua_install_lock() already deleted it if
+            # it was unheld, so surviving = held; confirm with an open probe.
+            try:
+                with open(lock_file, "r+b"):
+                    return False  # opened fine → not held (racy leftover)
+            except PermissionError:
+                return True
+            except OSError:
+                return True
+        lock_dir = _cua_install_lock_dir()
+        return lock_dir.is_dir()
+    except Exception as e:
+        logger.debug("cua install lock probe failed: %s", e)
+        return False
+
+
+def _cua_release_endpoint_reachable(timeout: float = 5.0) -> bool:
+    """Fast probe: can we reach GitHub's release download host at all?
+
+    The upstream installers (install.ps1 / _install-rust.sh) download from
+    ``github.com/<repo>/releases/download/...``. When that host is
+    unreachable (outage, DNS, firewall), the installer dies slowly inside
+    its own retries while the unattended refresh eats the whole ceiling.
+    A 5s HEAD tells us in seconds. Only a *connection-level* failure counts
+    as unreachable — any HTTP response (including 4xx/5xx) proves the path
+    works and lets the installer make its own decisions.
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(
+            "https://github.com/trycua/cua/releases", method="HEAD"
+        )
+        with urllib.request.urlopen(req, timeout=timeout):
+            return True
+    except urllib.error.HTTPError:
+        return True  # server answered → reachable
+    except Exception as e:
+        logger.debug("cua release endpoint probe failed: %s", e)
+        return False
+
+
 def _ps_single_quote(value: str) -> str:
     """Return a PowerShell single-quoted string literal."""
     return "'" + value.replace("'", "''") + "'"
@@ -1677,6 +1731,50 @@ def _run_cua_driver_installer(
     # refresh doesn't wedge waiting on a dead holder (issue #58762).
     _clear_stale_cua_install_lock()
 
+    # Unattended refreshes (installer_timeout set by `hermes update`) fail
+    # FAST on the two conditions that otherwise consume the whole ceiling:
+    #
+    # 1. Install lock held by a live process — upstream would poll it for up
+    #    to LOCK_STALE_AFTER_SECONDS=600 before probing the holder. That is
+    #    the 11-minute silent hang class (#87703; observed live 2026-08-25:
+    #    "cua-driver refreshing timed out after 660s"). Skip in ~0s instead.
+    # 2. Release host unreachable (outage/DNS/firewall) — the installer
+    #    would die slowly inside its own retries. A 5s HEAD answers now.
+    #
+    # Explicit `computer-use install --upgrade` runs keep upstream's full
+    # lock-recovery semantics — a human is watching and can wait or Ctrl-C.
+    if installer_timeout is not None:
+        if _cua_install_lock_held():
+            _print_info(
+                "    Another cua-driver install is in progress (upstream "
+                "install lock is held) — skipping this refresh."
+            )
+            _print_info(
+                "    If no install is really running, retry with: "
+                "hermes computer-use install --upgrade"
+            )
+            return False
+        if not _cua_release_endpoint_reachable():
+            _print_info(
+                "    github.com is unreachable — skipping cua-driver "
+                "refresh (will retry on the next update)."
+            )
+            return False
+        if is_windows:
+            # -NoAutoStart skips Register-CuaDriverAutostart entirely — the
+            # ONLY branch of install.ps1 that self-elevates (UAC). Cost: an
+            # existing cua-driver-serve task keeps pointing at the previous
+            # binary until the next interactive upgrade re-registers it.
+            # scriptblock invocation (instead of `| iex`) is what lets us
+            # pass the parameter to a piped script.
+            install_cmd = [
+                "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                "-Command",
+                "$sc = irm https://raw.githubusercontent.com/trycua/cua/"
+                "main/libs/cua-driver/scripts/install.ps1; "
+                "& ([scriptblock]::Create($sc)) -NoAutoStart",
+            ]
+
     # POSIX: run the installer in its own process group so a timeout kill
     # takes out the whole `curl | bash` pipeline (and the exec'd
     # _install-rust.sh), not just the outer shell. Otherwise the surviving
@@ -1759,7 +1857,17 @@ def _run_cua_driver_installer(
         """
         _kill_installer_tree(proc)
         try:
-            proc.communicate(timeout=_CUA_INSTALLER_DRAIN_GRACE)
+            drained_out, _ = proc.communicate(timeout=_CUA_INSTALLER_DRAIN_GRACE)
+            # Diagnosability (#87703 post-mortem): the partial output names
+            # WHERE the installer was stuck (lock wait, consent prompt,
+            # download) — before this, the answer died with the process and
+            # the timeout line was unactionable.
+            if drained_out:
+                logger.warning(
+                    "cua-driver installer timed out; last output before "
+                    "kill:\n%s",
+                    drained_out[-2000:],
+                )
         except subprocess.TimeoutExpired:
             # Deliberately not closing proc.stdout here. communicate()'s
             # reader threads are still blocked on that handle and closing it

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1725,6 +1725,7 @@ def _run_cua_driver_installer(
         else:
             proc = subprocess.Popen(
                 install_cmd, shell=use_shell, env=installer_env,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, encoding="utf-8", errors="replace",
                 creationflags=_post_setup_no_window_flags(),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1291,6 +1291,15 @@ def install_cua_driver(
 # headroom for the actual download/swap.
 _CUA_INSTALLER_TIMEOUT = 660
 
+# Grace period for draining the installer's pipes after a timeout kill. The
+# kill is best-effort (see _reap_after_timeout), so this drain has to be
+# bounded: a descendant that survived the kill still holds the inherited
+# stdout handle, and an unbounded read waits on an EOF that never comes,
+# which turns the ceiling above into no ceiling at all (issue #87703). A
+# successful kill closes the pipe immediately, so this costs nothing in the
+# normal case; it only caps how long a failed one can stall the update.
+_CUA_INSTALLER_DRAIN_GRACE = 15
+
 # Upstream installer's stale-lock threshold (LOCK_STALE_AFTER_SECONDS in
 # _install-rust.sh). Used by the pre-clear below to avoid yanking a lock
 # that a live-but-slow install still holds.
@@ -1701,6 +1710,44 @@ def _run_cua_driver_installer(
         except (OSError, ProcessLookupError):
             proc.kill()
 
+    def _reap_after_timeout(proc):
+        """Kill the installer tree, then drain its pipes under a deadline.
+
+        ``_kill_installer_tree`` is best-effort by construction: every
+        ``psutil.Error`` it can raise is logged at debug level and stepped
+        over, on the reasoning that a partly-killed tree beats none. The case
+        that matters is an ``install.ps1`` which self-elevated through
+        ``Start-Process -Verb RunAs``: that descendant runs at High integrity,
+        a medium-integrity kill gets ``AccessDenied``, and the survivor is
+        still holding the ``stdout=PIPE`` write handle it inherited.
+
+        Draining with no deadline then blocks on an EOF that only arrives when
+        someone kills that process by hand, so the ``_CUA_INSTALLER_TIMEOUT``
+        ceiling stops bounding anything and ``hermes update`` hangs past its
+        own timeout warning (#87703). Bound the drain instead: a kill that
+        landed closes the pipe at once, and one that did not costs
+        ``_CUA_INSTALLER_DRAIN_GRACE`` rather than forever. The caller
+        re-raises the original ``TimeoutExpired`` either way, so the manual
+        re-run hint still prints and the update unwinds. Losing the tail of a
+        timed-out installer's log is the cheaper half of that trade.
+        """
+        _kill_installer_tree(proc)
+        try:
+            proc.communicate(timeout=_CUA_INSTALLER_DRAIN_GRACE)
+        except subprocess.TimeoutExpired:
+            # Deliberately not closing proc.stdout here. communicate()'s
+            # reader threads are still blocked on that handle and closing it
+            # underneath them races; they are daemon threads, so abandoning
+            # them does not keep the interpreter alive.
+            logger.debug(
+                "cua-driver installer pipes still open %ss after the kill — "
+                "abandoning the drain, a surviving descendant holds the "
+                "inherited handle",
+                _CUA_INSTALLER_DRAIN_GRACE,
+            )
+        except (OSError, ValueError) as e:
+            logger.debug("cua-driver installer drain failed: %s", e)
+
     try:
         # When not verbose (e.g. `hermes update`'s refresh), capture the
         # installer's chatty "Next steps" wall instead of dumping it to the
@@ -1716,8 +1763,7 @@ def _run_cua_driver_installer(
             try:
                 proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
             except subprocess.TimeoutExpired:
-                _kill_installer_tree(proc)
-                proc.communicate()
+                _reap_after_timeout(proc)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=None, stderr=None
@@ -1734,8 +1780,7 @@ def _run_cua_driver_installer(
             try:
                 out, _ = proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
             except subprocess.TimeoutExpired:
-                _kill_installer_tree(proc)
-                proc.communicate()
+                _reap_after_timeout(proc)
                 raise
             result = subprocess.CompletedProcess(
                 install_cmd, proc.returncode, stdout=out, stderr=None

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1013,6 +1013,11 @@ def install_cua_driver(
     ``hermes update`` already prints a contextual line before its update
     check, so it disables this to avoid printing the refresh twice.
 
+    The confirmed-update path is also bounded by
+    ``_CUA_BACKGROUND_UPDATE_TIMEOUT``. It runs as an optional, quiet part of
+    ``hermes update`` and must not inherit the explicit install command's
+    11-minute ceiling when an upstream prompt or UAC dialog is unattended.
+
     Returns True iff cua-driver is installed (or successfully refreshed)
     when the function returns. Supported on macOS, Windows, and Linux
     (Linux is alpha). Silently returns False on unsupported platforms.
@@ -1255,6 +1260,11 @@ def install_cua_driver(
         verbose=False,
         pin_version=confirmed_version,
         show_progress=show_installer_progress,
+        installer_timeout=(
+            _CUA_BACKGROUND_UPDATE_TIMEOUT
+            if require_confirmed_update
+            else None
+        ),
     )
     if ok and repair_existing:
         repaired = _cua_driver_contract_status()
@@ -1299,6 +1309,13 @@ _CUA_INSTALLER_TIMEOUT = 660
 # successful kill closes the pipe immediately, so this costs nothing in the
 # normal case; it only caps how long a failed one can stall the update.
 _CUA_INSTALLER_DRAIN_GRACE = 15
+
+# Optional refreshes launched by ``hermes update`` are quiet and unattended.
+# Keep their interruption bounded even when upstream waits on Read-Host or a
+# consent prompt. Explicit ``computer-use install --upgrade`` runs retain the
+# full installer ceiling above. (The lock/network preflights below make a
+# legitimate long wait impossible on this path, so a short ceiling is safe.)
+_CUA_BACKGROUND_UPDATE_TIMEOUT = 120
 
 # Upstream installer's stale-lock threshold (LOCK_STALE_AFTER_SECONDS in
 # _install-rust.sh). Used by the pre-clear below to avoid yanking a lock
@@ -1552,6 +1569,7 @@ def _run_cua_driver_installer(
     verbose: bool = True,
     pin_version: Optional[str] = None,
     show_progress: bool = True,
+    installer_timeout: Optional[float] = None,
 ) -> bool:
     """Run the upstream cua-driver installer for this platform.
 
@@ -1568,6 +1586,9 @@ def _run_cua_driver_installer(
     is bumped by Release Please *before* the release assets are published,
     so an unpinned run inside that window fails with a 404; pinning to the
     version ``check-update`` confirmed sidesteps the race entirely.
+
+    ``installer_timeout`` lets quiet callers use a shorter ceiling without
+    weakening the explicit install path's stale-lock recovery window.
     """
     import platform as _plat
     import shutil
@@ -1639,6 +1660,11 @@ def _run_cua_driver_installer(
         else:
             _print_info(f"→ {label} cua-driver (Computer Use)...")
     driver_cmd = _cua_driver_cmd()
+    timeout = (
+        _CUA_INSTALLER_TIMEOUT
+        if installer_timeout is None
+        else installer_timeout
+    )
 
     installer_env = _cua_driver_env()
     if pin_version:
@@ -1761,7 +1787,7 @@ def _run_cua_driver_installer(
                 **popen_kwargs
             )
             try:
-                proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
+                proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _reap_after_timeout(proc)
                 raise
@@ -1778,7 +1804,7 @@ def _run_cua_driver_installer(
                 **popen_kwargs
             )
             try:
-                out, _ = proc.communicate(timeout=_CUA_INSTALLER_TIMEOUT)
+                out, _ = proc.communicate(timeout=timeout)
             except subprocess.TimeoutExpired:
                 _reap_after_timeout(proc)
                 raise
@@ -1831,7 +1857,7 @@ def _run_cua_driver_installer(
     except subprocess.TimeoutExpired:
         _print_warning(
             f"    cua-driver {label.lower()} timed out after "
-            f"{_CUA_INSTALLER_TIMEOUT}s."
+            f"{timeout}s."
         )
         if not is_windows:
             _print_info(

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1079,7 +1079,7 @@ class TestInstallerTimeoutKillsProcessGroup:
         assert fake_proc.communicate.call_count == 2
         assert (
             fake_proc.communicate.call_args_list[1].kwargs["timeout"]
-            == tools_config._CUA_INSTALLER_REAP_TIMEOUT
+            == tools_config._CUA_INSTALLER_DRAIN_GRACE
         )
 
     @pytest.mark.windows_only

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1081,6 +1081,189 @@ class TestInstallerTimeoutKillsProcessGroup:
         assert fake_proc.communicate.call_count == 2
 
 
+class TestInstallerTimeoutDrainIsBounded:
+    """The drain that follows the timeout kill must carry its own deadline.
+
+    ``_kill_installer_tree`` is best-effort: every ``psutil.Error`` it can hit
+    is logged at debug level and stepped over, so the tree it leaves behind
+    can still contain a live process — on Windows, most concretely, an
+    ``install.ps1`` that self-elevated through ``Start-Process -Verb RunAs``
+    and cannot be killed from a medium-integrity parent. That survivor holds
+    the ``stdout=PIPE`` write handle it inherited, so reading to EOF is
+    reading for something that will not happen, and ``_CUA_INSTALLER_TIMEOUT``
+    stops being a ceiling (#87703).
+
+    Asserted through the ``timeout`` kwarg rather than by timing: a test that
+    proved the hang by hanging would be the same defect wearing a test's name.
+    """
+
+    def test_drain_grace_is_short_relative_to_the_run_ceiling(self):
+        from hermes_cli import tools_config
+
+        # This is a grace period for a pipe that a live process is holding
+        # open, not a second budget for the install itself — the install is
+        # already over by the time it is used.
+        assert 0 < tools_config._CUA_INSTALLER_DRAIN_GRACE
+        assert (
+            tools_config._CUA_INSTALLER_DRAIN_GRACE
+            < tools_config._CUA_INSTALLER_TIMEOUT / 10
+        )
+
+    @pytest.mark.linux_only
+    def test_post_kill_drain_passes_a_deadline(self):
+        """``linux_only``: reaches the timeout handler through the real POSIX
+        ``killpg`` branch, so the drain under test is the one this lane runs.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="x", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config.os, "getpgid", return_value=99999, create=True), \
+             patch.object(tools_config.os, "killpg", create=True), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is False
+        assert fake_proc.communicate.call_count == 2
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "the post-kill drain was issued without a deadline, so a survivor "
+            "of the kill can hold it open indefinitely"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.linux_only
+    def test_verbose_path_drains_under_the_same_deadline(self):
+        """The streaming install has the same handler and had the same hole.
+
+        Its child inherits the console rather than a pipe, so the stall is
+        harder to hit there, but the two branches should not be allowed to
+        drift on a rule this small.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="x", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config.os, "getpgid", return_value=99999, create=True), \
+             patch.object(tools_config.os, "killpg", create=True), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(label="Installing", verbose=True)
+
+        assert ok is False
+        assert fake_proc.communicate.call_count == 2
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "the streaming path's drain was issued without a deadline"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.windows_only
+    def test_unkillable_elevated_descendant_does_not_stall_the_drain(self):
+        """The reported scenario, with the kill refused exactly where it is.
+
+        ``install.ps1`` self-elevates, so the descendant is High-IL and
+        ``child.kill()`` raises ``AccessDenied`` — which the tree-kill catches
+        and logs, by design. The survivor is then still holding the pipe, and
+        the drain is the only thing standing between that and an indefinite
+        hang.
+        """
+        import psutil
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        child = MagicMock()
+        child.kill.side_effect = psutil.AccessDenied(pid=999)
+        parent = MagicMock()
+        parent.children.return_value = [child]
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=1),
+            ("", None),
+        ]
+
+        with patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        # The refused child kill must not abort the rest of the sweep.
+        parent.kill.assert_called_once_with()
+        drain_timeout = fake_proc.communicate.call_args_list[1].kwargs.get("timeout")
+        assert drain_timeout is not None, (
+            "a High-IL descendant survived the kill and the drain was issued "
+            "without a deadline, which is the reported hang"
+        )
+        assert drain_timeout == tools_config._CUA_INSTALLER_DRAIN_GRACE
+
+    @pytest.mark.windows_only
+    def test_drain_that_times_out_still_surfaces_the_run_timeout(self):
+        """A guardrail, not a regression test — it passes without the fix too.
+
+        What it pins is that the drain's own ``TimeoutExpired`` must not be
+        the one that escapes: the caller has to see the original run timeout
+        so the existing manual re-run hint prints and ``hermes update``
+        unwinds. That is the behaviour a future refactor of the drain is most
+        likely to break silently.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        parent = MagicMock()
+        parent.children.return_value = []
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 12345
+        fake_proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="powershell", timeout=660),
+            subprocess.TimeoutExpired(cmd="powershell", timeout=15),
+        ]
+
+        with patch("subprocess.Popen", return_value=fake_proc), \
+             patch("psutil.Process", return_value=parent), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_print_warning") as warn, \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False
+            )
+
+        assert ok is False
+        warned = " ".join(str(c.args[0]) for c in warn.call_args_list if c.args)
+        assert "timed out after" in warned
+
+
 @pytest.mark.linux_only
 class TestInstallerNoShell:
     """The POSIX installer path must not use shell=True or command

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -239,6 +239,46 @@ class TestInstallCuaDriverUpgrade:
 
         info.assert_not_called()
 
+    def test_quiet_refresh_closes_stdin_and_honors_custom_timeout(self):
+        """A background refresh must neither wait on a hidden prompt nor
+        inherit the explicit install command's 11-minute ceiling."""
+        import subprocess
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+
+        with patch(
+                 "subprocess.run",
+                 return_value=MagicMock(returncode=0, stderr=""),
+             ), \
+             patch("subprocess.Popen", return_value=fake_proc) as popen, \
+             patch.object(
+                 tools_config.shutil,
+                 "which",
+                 return_value="/usr/local/bin/cua-driver",
+             ), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(
+                 tools_config,
+                 "_repair_cua_driver_autostart_windows",
+                 return_value=True,
+             ), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            assert tools_config._run_cua_driver_installer(
+                label="Refreshing",
+                verbose=False,
+                installer_timeout=120,
+            ) is True
+
+        assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+        fake_proc.communicate.assert_called_once_with(timeout=120)
+
     def test_upgrade_can_suppress_installer_progress(self):
         from hermes_cli import tools_config
 
@@ -517,6 +557,7 @@ class TestRequireConfirmedUpdate:
         ok, runner, _ = self._install(state, require_confirmed=True)
         assert ok is True
         runner.assert_called_once()
+        assert runner.call_args.kwargs["installer_timeout"] == 120
 
     @pytest.mark.windows_only
     def test_windows_confirmed_update_defers_interactive_installer(self):
@@ -1049,6 +1090,10 @@ class TestInstallerTimeoutKillsProcessGroup:
         parent.kill.assert_called_once_with()
         fake_proc.kill.assert_not_called()
         assert fake_proc.communicate.call_count == 2
+        assert (
+            fake_proc.communicate.call_args_list[1].kwargs["timeout"]
+            == tools_config._CUA_INSTALLER_REAP_TIMEOUT
+        )
 
     @pytest.mark.windows_only
     def test_windows_tree_enumeration_failure_falls_back_to_direct_kill(self):

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -547,30 +547,17 @@ class TestRequireConfirmedUpdate:
             for call in info.call_args_list
         )
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="automatic Windows updates must not launch an interactive installer",
-    )
-    def test_confirmed_update_still_runs_installer_on_posix(self):
+    def test_confirmed_update_runs_installer_bounded(self):
+        """Every platform: a positively confirmed newer release runs the
+        installer in unattended-safe mode (background ceiling). On Windows
+        the actual command adds -NoAutoStart and the preflights guard the
+        launch (covered by their own test classes below)."""
         state = {"current_version": "0.5.0", "latest_version": "0.6.0",
                  "update_available": True}
         ok, runner, _ = self._install(state, require_confirmed=True)
         assert ok is True
         runner.assert_called_once()
         assert runner.call_args.kwargs["installer_timeout"] == 120
-
-    @pytest.mark.windows_only
-    def test_windows_confirmed_update_defers_interactive_installer(self):
-        state = {"current_version": "0.5.0", "latest_version": "0.6.0",
-                 "update_available": True}
-        ok, runner, info = self._install(state, require_confirmed=True)
-
-        assert ok is True
-        runner.assert_not_called()
-        assert any(
-            "computer-use install --upgrade" in call.args[0]
-            for call in info.call_args_list
-        )
 
     @pytest.mark.windows_only
     def test_windows_incompatible_driver_defers_interactive_repair(self):
@@ -1679,3 +1666,95 @@ class TestCuaVersionSummary:
     def test_empty_output_stays_empty(self):
         assert self._summary("") == ""
         assert self._summary("   \n  \n") == ""
+
+
+class TestUnattendedRefreshPreflights:
+    """Unattended refreshes (installer_timeout set) fail FAST instead of
+    eating the ceiling: a held install lock or an unreachable release host
+    skips the run in seconds. Explicit installs (installer_timeout=None)
+    bypass both preflights — a human is watching upstream's own recovery.
+    """
+
+    def _run(self, installer_timeout, lock_held=False, reachable=True,
+             system="Linux"):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok", None)
+        proc.returncode = 0
+
+        with patch("platform.system", return_value=system), \
+             patch.object(tools_config, "_cua_install_lock_held",
+                          return_value=lock_held) as lock_probe, \
+             patch.object(tools_config, "_cua_release_endpoint_reachable",
+                          return_value=reachable) as net_probe, \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config.shutil, "which",
+                          side_effect=lambda n: "/x/" + n), \
+             patch.object(tools_config.subprocess, "run",
+                          return_value=SimpleNamespace(
+                              returncode=0, stdout="", stderr="")), \
+             patch.object(tools_config.subprocess, "Popen",
+                          return_value=proc) as popen, \
+             patch.object(tools_config, "_print_success"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info") as info:
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing",
+                verbose=False,
+                show_progress=False,
+                installer_timeout=installer_timeout,
+            )
+        return ok, popen, info, lock_probe, net_probe
+
+    def test_held_lock_skips_unattended_run(self):
+        ok, popen, info, _, _ = self._run(120, lock_held=True)
+        assert ok is False
+        popen.assert_not_called()
+        assert any("install lock is held" in c.args[0]
+                   for c in info.call_args_list)
+
+    def test_unreachable_host_skips_unattended_run(self):
+        ok, popen, info, _, _ = self._run(120, reachable=False)
+        assert ok is False
+        popen.assert_not_called()
+        assert any("unreachable" in c.args[0] for c in info.call_args_list)
+
+    def test_explicit_install_bypasses_preflights(self):
+        """installer_timeout=None (explicit `computer-use install --upgrade`):
+        neither probe runs; upstream's own lock recovery stays in charge."""
+        ok, popen, _, lock_probe, net_probe = self._run(None)
+        lock_probe.assert_not_called()
+        net_probe.assert_not_called()
+        popen.assert_called_once()
+        assert ok is True
+
+    def test_clean_preflights_run_installer(self):
+        ok, popen, _, lock_probe, net_probe = self._run(120)
+        lock_probe.assert_called_once()
+        net_probe.assert_called_once()
+        popen.assert_called_once()
+        assert ok is True
+
+    def test_windows_unattended_command_passes_noautostart(self):
+        """The unattended Windows command must invoke install.ps1 with
+        -NoAutoStart — Register-CuaDriverAutostart is the only branch that
+        self-elevates (UAC)."""
+        ok, popen, _, _, _ = self._run(120, system="Windows")
+        assert ok is True
+        cmd = popen.call_args.args[0]
+        joined = " ".join(cmd)
+        assert "-NoAutoStart" in joined
+        assert "scriptblock" in joined
+
+    def test_windows_explicit_command_keeps_plain_oneliner(self):
+        """Explicit installs keep upstream's documented `irm | iex` shape
+        (autostart re-registration included — human present for UAC)."""
+        ok, popen, _, _, _ = self._run(None, system="Windows")
+        assert ok is True
+        cmd = popen.call_args.args[0]
+        joined = " ".join(cmd)
+        assert "-NoAutoStart" not in joined
+        assert "| iex" in joined


### PR DESCRIPTION
## Summary
`hermes update` auto-refreshes cua-driver again on Windows — safely: routine confirmed upgrades run unattended (stdin closed, `-NoAutoStart`, 120s ceiling), and the two conditions behind the 11-minute hang class now fail in seconds via preflights instead of eating the whole ceiling. Restores the capability #95008 deferred wholesale.

Root cause correction from the live post-mortem (Teknium's 2026-08-25 hang, confirmed with trycua): the base installer is no-admin by upstream design — UAC was a red herring. The real waits are upstream's 600s held-lock poll window and its Read-Host consent prompts, both invisible in a hidden console.

## Changes
- Salvaged (authorship preserved, rebase-merge):
  - #79871 @RelaxJonh — `stdin=DEVNULL` on the installer: Read-Host can't block (fixes #79684)
  - #87720 @jackulau — bounded pipe-drain after a failed timeout kill: a surviving descendant can't strand the update (fixes the "ceiling stops bounding anything" half of #87703)
  - #87196 @blunkjamie-dev — 120s `_CUA_BACKGROUND_UPDATE_TIMEOUT` for unattended refreshes
- New on top:
  - Lock preflight — upstream install lock held by a live process → skip in ~0s (the observed 11-min wait) with the holder pointed out
  - Network preflight — 5s HEAD on github.com → unreachable skips immediately (the outage scenario)
  - Windows unattended runs invoke install.ps1 via scriptblock with `-NoAutoStart`, skipping the ONLY branch that self-elevates (autostart task re-registration); explicit installs keep upstream's documented `irm | iex` shape
  - Timeout diagnosability — partial installer output logged on kill, so the next hang names its stage
  - Windows confirmed-upgrade defer from #95008 lifted; contract repairs and fresh installs stay interactive-only (SmartScreen / first-time elevation legitimately need a human)

## Validation
| Windows auto-update scenario | Before (#95008) | After |
|---|---|---|
| Confirmed newer release, clean world | deferred to manual | installs unattended, ≤120s, `-NoAutoStart` |
| Install lock held by live process | deferred | skips in ~0s with message |
| github.com unreachable | deferred | skips in ~5s |
| Contract repair / missing binary | deferred | still deferred (unchanged) |
| Explicit `computer-use install --upgrade` | full upstream semantics | unchanged, preflights bypassed |

Targeted tests: 63 passed, 14 platform-skipped. E2E: real `install_cua_driver()` → real `_run_cua_driver_installer()` (mocked at Popen/network edges) across 7 scenarios incl. `-NoAutoStart` command shape and `CUA_DRIVER_RS_VERSION` pin propagation; live probe of `_cua_release_endpoint_reachable()` against real GitHub (0.27s true / 0.01s forced-timeout false).

**Live repro:** before-side from the production hang (2026-08-25 `desktop-update-handoff.log`: `cua-driver refreshing timed out after 660s` inside a 15-min update); the Windows-only paths are covered by the `windows_only` CI job — no native Windows host here for a live after-side.

Upstream asks filed with Francesco (trycua): probe lock-holder liveness immediately instead of after 600s; a `-NonInteractive` mode that skips consent prompts with a distinct exit code.

Fixes #79684. Completes the #87703 hang class (defer floor: #95008).

## Infographic

![Unattended CUA refresh infographic](https://v3b.fal.media/files/b/0aa7d15f/ws19EwvfZtHOTyU9gNUYd_yNSK2E2z.png)
