### PR TITLE
test(desktop): JS lane no longer fails in the 5 minutes after midnight (salvage #88876)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -231,6 +231,10 @@ describe('SidebarSessionRow running arc', () => {
 })
 
 describe('SidebarSessionRow', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('keeps an aria-label on the kebab without wrapping it in a Tip', () => {
     render(
       <SidebarSessionRow
@@ -322,6 +326,17 @@ describe('SidebarSessionRow', () => {
   })
 
   it('exposes the exact session time through a focusable Tip trigger', () => {
+    // Pin the clock before deriving the timestamp.  The assertion below is
+    // about the *composition* of the label (relative age + absolute time),
+    // but "5 minutes ago" only falls on today when the run does not straddle
+    // local midnight.  Between 00:00 and 00:05 the row correctly renders
+    // "Yesterday at 11:5x PM" and this test failed for a day boundary it was
+    // never written to exercise.  Only `Date` is faked, so the component's
+    // own timers (the running arc, the tooltip open delay) keep running for
+    // real.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date(2026, 2, 5, 12, 0, 0))
+
     const startedAt = Math.floor(Date.now() / 1000) - 5 * 60
 
     render(


### PR DESCRIPTION
## Summary
The desktop JS lane no longer fails for any PR whose CI runs in the five minutes after local midnight: the session-row timestamp test derived "5 minutes ago" from the real clock, so between 00:00 and 00:05 the row correctly rendered "Yesterday at 11:5x PM" and the `/^5m, Today at /` assertion failed for a day boundary it never meant to exercise. The clock is now pinned to noon for that test — only `Date` is faked, so the component's real timers (running arc, tooltip delay) are untouched.

This flake just fired live: #95126's first CI run dispatched at 00:00:27 and failed at exactly this assertion ("expected '5m, Yesterday at 11:56 PM' to match /^5m, Today at /").

Salvage of #88876 by @jackulau (authorship preserved via cherry-pick; filed Aug 18, a week before it bit us).

## Changes
- `session-row.test.tsx`: `vi.useFakeTimers({ toFake: ['Date'] })` + `setSystemTime(2026-03-05 12:00)` before deriving the timestamp; `afterEach(vi.useRealTimers)` on the describe block. Test-only, +15 lines.

## Validation
| | Before | After |
|---|---|---|
| CI run between 00:00–00:05 local | lane fails (live: #95126 run at 00:02) | deterministic |
| `vitest run session-row.test.tsx` | — | 12/12 pass |

## Infographic

![The midnight flake](https://v3b.fal.media/files/b/0aa7d1bb/WDwhMVmjKgNeb2uRaU84e_7tYLC4Yt.png)
