### PR TITLE
fix(desktop): keep Routines controls visible in narrow panes (salvage #91625)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -10860,12 +10860,12 @@ function RoutineRow({ job, onOpen, owner }) {
 
   return jsxs('div', {
     className: cn(
-      'group grid gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
+      'group grid min-w-0 gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
       'hover:border-(--ui-stroke-primary, var(--ui-stroke-secondary))'
     ),
     children: [
       jsxs('div', {
-        className: 'flex items-center gap-2',
+        className: 'flex min-w-0 items-center gap-2',
         children: [
           // The row's own button, not a click handler on the card: the switch
           // and delete control are siblings, so opening the details can never
@@ -10897,7 +10897,7 @@ function RoutineRow({ job, onOpen, owner }) {
               type: 'button',
               disabled: busy,
               className:
-                'flex size-5 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
+                'flex size-5 shrink-0 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
               onClick: () => act('remove'),
               children: jsx(Codicon, { name: 'trash', className: 'text-[0.75rem]' })
             })
@@ -10905,7 +10905,7 @@ function RoutineRow({ job, onOpen, owner }) {
         ]
       }),
       jsxs('div', {
-        className: 'flex items-center justify-between gap-2 pl-3.5',
+        className: 'flex min-w-0 items-center justify-between gap-2 pl-3.5',
         children: [
           jsxs('span', {
             className:
@@ -10921,7 +10921,7 @@ function RoutineRow({ job, onOpen, owner }) {
       legacyUnsafe
         ? jsx('div', {
             className:
-              'rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
+              'min-w-0 rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
             children: 'Paused for security: delete and recreate this legacy cronjob before running it again.'
           })
         : null

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import vm from 'node:vm'
 
 // RoutineRow narrow-pane layout contract (#91623):
 // The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
@@ -11,27 +12,130 @@ import test from 'node:test'
 // Switch + delete button became invisible (title truncation also never
 // engaged). Every grid/flex node in the row's width chain must carry
 // min-w-0 so the title and metadata can actually shrink.
+//
+// These tests render the real RoutineRow (extracted from plugin.js, with
+// the React runtime and SDK components stubbed) and assert the contract on
+// the resulting JSX tree — not on source formatting. Tailwind class order,
+// cn() composition, or whitespace can change freely without false reds; a
+// real regression in the width chain (dropped min-w-0 / shrink-0) fails.
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
-  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+function slice(from, to) {
+  const start = source.indexOf(from)
+  const end = source.indexOf(to, start)
+  assert.ok(start >= 0 && end > start, `slice ${JSON.stringify(from)} must remain extractable`)
+  return source.slice(start, end)
+}
+
+function renderRoutineRow(job) {
+  // Real helper logic rides along with the row; only the React runtime,
+  // SDK components, and host bridge are stubbed.
+  const helpers = slice('const BOT_TAG_RE = ', '\nasync function loadRoutines(')
+  const scheduleLabel = slice('function scheduleLabel(', '\nfunction RoutineRow(')
+  const row = slice('function RoutineRow(', '\n// Structured schedule picker')
+
+  const context = {
+    jsx: (type, props) => ({ type, props: props || {} }),
+    jsxs: (type, props) => ({ type, props: props || {} }),
+    useState: initial => [initial, () => {}],
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    relativeTime: () => 'now',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    Codicon: 'Codicon',
+    host: { request: async () => ({}), notifyError: () => {} },
+    invalidateRoutineOwner: async () => {}
+  }
+  vm.runInNewContext(
+    `${helpers}\n${scheduleLabel}\n${row}\nglobalThis.__row = RoutineRow;`,
+    context
+  )
+  // RoutineRow takes { job, owner } since the bot-owner routing rework;
+  // the width-chain contract does not depend on the owner value.
+  return context.__row({ job, owner: undefined })
+}
+
+// Flatten the JSX tree into nodes. Nodes with a className get
+// { type, tokens } (tokens = the cn()-joined class set); classless nodes
+// (Switch etc.) are still listed so their presence can be asserted.
+function collect(node, acc = []) {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  const { props } = node
+  const entry = { type: node.type }
+  if (typeof props?.className === 'string') {
+    entry.tokens = new Set(props.className.split(/\s+/))
+  }
+  acc.push(entry)
+  const children = props?.children
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collect(child, acc)
+    }
+  } else {
+    collect(children, acc)
+  }
+  return acc
+}
+
+const hasAll = (el, ...tokens) => !!el.tokens && tokens.every(t => el.tokens.has(t))
+const findRow = (els, ...tokens) => els.find(el => hasAll(el, ...tokens))
+
+const JOB = {
+  job_id: 'j1',
+  name: '[bot:researcher] Daily digest',
+  schedule: 'every 60m',
+  enabled: true,
+  state: 'active',
+  next_run_at: '2026-08-23T00:00:00Z'
+}
+
+test('row root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  const els = collect(renderRoutineRow(JOB))
+  const root = findRow(els, 'grid')
+  assert.ok(root, 'row root must be a grid')
+  assert.ok(hasAll(root, 'min-w-0'), 'row root grid must be min-w-0')
 })
 
 test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
-  // The old pinned-width form must not come back.
-  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+  const els = collect(renderRoutineRow(JOB))
+  // The title line is the first flex row; the metadata line also uses
+  // justify-between, so require its absence to pin the right line.
+  const line = els.find(el => hasAll(el, 'flex', 'gap-2') && !hasAll(el, 'justify-between'))
+  assert.ok(line, 'title/controls line must be a flex row')
+  assert.ok(hasAll(line, 'min-w-0'), 'title/controls line must be min-w-0')
+
+  const title = findRow(els, 'flex-1', 'truncate')
+  assert.ok(title, 'job title span must be flex-1 truncate')
+  assert.ok(hasAll(title, 'min-w-0'), 'title must carry min-w-0 for truncation to engage')
+
+  assert.ok(els.some(el => el.type === 'Switch'), 'enable/disable Switch must render')
 })
 
 test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+  const els = collect(renderRoutineRow(JOB))
+  const meta = findRow(els, 'flex', 'justify-between', 'pl-3.5')
+  assert.ok(meta, 'metadata line must be a flex row')
+  assert.ok(hasAll(meta, 'min-w-0'), 'metadata line must be min-w-0')
 })
 
 test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
-  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+  const els = collect(renderRoutineRow(JOB))
+  const del = findRow(els, 'size-5')
+  assert.ok(del, 'delete button must render')
+  assert.ok(hasAll(del, 'shrink-0'), 'delete button must be shrink-0')
 })
 
 test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
-  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+  const legacyJob = {
+    ...JOB,
+    prompt_preview:
+      'You are running the scheduled routine "Daily digest" for agent \'researcher\'. Execute it AS that agent...'
+  }
+  const els = collect(renderRoutineRow(legacyJob))
+  const strip = findRow(els, 'px-2', 'py-1.5')
+  assert.ok(strip, 'legacy warning strip must render for legacy jobs')
+  assert.ok(hasAll(strip, 'min-w-0'), 'legacy warning strip must be min-w-0')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// RoutineRow narrow-pane layout contract (#91623):
+// The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
+// display:grid node inside the pane's grid list; grid items default to
+// min-width:auto, so the row could not shrink below its min-content width.
+// A nowrap job title pinned the row at ~284px inside the 250px pane, the
+// overflow-hidden ScrollArea clipped the right edge, and the enable/disable
+// Switch + delete button became invisible (title truncation also never
+// engaged). Every grid/flex node in the row's width chain must carry
+// min-w-0 so the title and metadata can actually shrink.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+})
+
+test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
+  // The old pinned-width form must not come back.
+  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+})
+
+test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+})
+
+test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
+  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+})
+
+test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
+  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+})


### PR DESCRIPTION

<img width="1172" height="744" alt="routines-250px-salvage-95136-current-main-cropped" src="https://github.com/user-attachments/assets/83b2cfc6-c559-4480-aa13-57290ea8a9bf" />
# Draft PR: Routines controls remain usable in the default narrow pane


## Summary

The Routines pane keeps each job's enable/disable switch and delete action visible at its default 250 px width. Long job titles now ellipsize inside the row instead of forcing the row beyond the pane and clipping its controls.

Salvage of #91625 by @MicroWearld. Both commits were cherry-picked onto current `main` with authorship preserved, including the follow-up that replaced source-string checks with rendered-JSX behavior tests.

## Root cause

`RoutineRow` sits in a grid and contains nested flex rows. Their default `min-width: auto` values let a long unbroken title propagate its min-content width through the row. The surrounding scroll area hides horizontal overflow, so the switch and hover delete action become unreachable.

## Changes

- Let the row root, title/control line, metadata line, and legacy warning strip shrink with `min-w-0`.
- Keep the delete action intact with `shrink-0`.
- Preserve title truncation and the existing control hierarchy.
- Render the real `RoutineRow` in the regression suite and verify the complete width-chain contract without depending on Tailwind class order or source formatting.

## User-visible validation

Measured in the default 250 px right pane with long routine titles:

| Variant | Row client / scroll width | Switch visible |
| --- | ---: | --- |
| current main before fix | 622 / 622 px | No |
| this fix | 229 / 229 px | Yes |

The same fixture was checked in light and dark themes and at 150% UI scale. The title ellipsizes, schedule pills remain intact, and the switch stays reachable. This salvage replays the identical two production/test commits cleanly onto `f751a8c546`; the screenshot below is from that current-main build with an isolated mock backend.

## Validation

- Focused rendered `RoutineRow` regression: 5/5
- Full Desktop Bot plugin suite: 571/571
- Desktop typecheck: pass
- Desktop production build: pass
- `git diff --check origin/main...HEAD`: pass

## Scope

- Fixes #91623.
- #89557 is adjacent: it changes timing-metadata wrapping but does not break the parent min-content chain or restore the clipped controls by itself.
- #95031 is a separate switch-click routing bug and is not changed here.

## Screenshot

The long title truncates inside the default-width Cronjobs pane while the enabled switch and next-run metadata remain visible.

<img width="1172" height="768" alt="Routines pane keeps controls visible at its default width" src="https://github.com/user-attachments/assets/633e1866-4b62-4856-8f59-14a02470e23b" />
