### PR TITLE
fix(api-server): match the turn-start prefix on normalized message identity

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -59,7 +59,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -7006,7 +7006,19 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message: Any,
         result: Dict[str, Any],
     ) -> int:
-        """Detect transcript-shaped result["messages"] and return turn start."""
+        """Detect transcript-shaped result["messages"] and return turn start.
+
+        The prefix comparison matches on the normalized ``(role, content)``
+        pair, not full dict equality: the API layer builds bare
+        ``{"role", "content"}`` entries while the agent-layer copies in
+        ``result["messages"]`` carry extra keys stamped by the durability /
+        flush path (``timestamp``, ``_db_persisted``, and on assistant turns
+        ``reasoning`` / ``finish_reason`` / provider items). Full-dict equality
+        failed on every turn, so ``turn_start`` was always 0 and the fallback
+        concatenated the prior history on top of an agent transcript that
+        already contained it — the stored snapshot near-doubled per turn under
+        ``previous_response_id`` / ``conversation`` chaining (#95137).
+        """
         agent_messages = result.get("messages") if isinstance(result, dict) else None
         if not isinstance(agent_messages, list) or not agent_messages:
             return 0
@@ -7014,11 +7026,40 @@ class APIServerAdapter(BasePlatformAdapter):
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
         expected_prefix = prior + [current_user]
-        if agent_messages[:len(expected_prefix)] == expected_prefix:
+        if APIServerAdapter._normalized_prefix_match(agent_messages, expected_prefix):
             return len(expected_prefix)
-        if prior and agent_messages[:len(prior)] == prior:
+        if prior and APIServerAdapter._normalized_prefix_match(agent_messages, prior):
             return len(prior)
         return 0
+
+    @staticmethod
+    def _normalized_message_identity(msg: Any) -> Optional[Tuple[str, Any]]:
+        """Identity of a transcript message for prefix comparison.
+
+        None (never equal to anything) for shapes that are not transcript
+        messages, so a non-dict or unknown-role entry on either side forces a
+        mismatch instead of a false prefix hit.
+        """
+        if not isinstance(msg, dict):
+            return None
+        role = msg.get("role")
+        if role not in {"system", "developer", "user", "assistant", "tool"}:
+            return None
+        return (str(role), msg.get("content"))
+
+    @classmethod
+    def _normalized_prefix_match(
+        cls, agent_messages: List[Any], expected_prefix: List[Any]
+    ) -> bool:
+        """True when agent_messages starts with expected_prefix by identity."""
+        if len(agent_messages) < len(expected_prefix):
+            return False
+        for agent_msg, prefix_msg in zip(agent_messages, expected_prefix):
+            agent_id = cls._normalized_message_identity(agent_msg)
+            prefix_id = cls._normalized_message_identity(prefix_msg)
+            if agent_id is None or prefix_id is None or agent_id != prefix_id:
+                return False
+        return True
 
     @classmethod
     def _turn_transcript_messages(

--- a/tests/gateway/test_api_server_turn_start_prefix.py
+++ b/tests/gateway/test_api_server_turn_start_prefix.py
@@ -1,0 +1,109 @@
+"""Regression tests for the Responses chaining turn-start prefix match (#95137).
+
+``previous_response_id`` / ``conversation`` chaining relied on a full-dict
+prefix comparison between the API layer's bare ``{"role", "content"}`` history
+and the agent-layer transcript copies, which carry extra keys stamped by the
+durability/flush path (``timestamp``, ``_db_persisted``, ``reasoning`` …).
+The comparison failed every turn, so the fallback concatenated the prior
+history on top of an agent transcript that already contained it — the stored
+snapshot near-doubled per turn (measured 3 → 8 → 17 → 34 → 67 over five short
+turns). The fix matches prefixes on the normalized ``(role, content)`` identity.
+"""
+
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _agent_copy(msg):
+    """A durability-stamped copy of a bare transcript entry."""
+    stamped = dict(msg)
+    stamped["timestamp"] = 1787702418.2069075
+    stamped["_db_persisted"] = True
+    return stamped
+
+
+class TestTurnStartPrefixMatch:
+    def test_stamped_agent_copies_match_bare_prefix(self):
+        prior = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        current_user_message = "what time is it?"
+        # The agent transcript echoes prior + the new user message, but every
+        # entry carries the durability-stamped extra keys.
+        agent_messages = [
+            _agent_copy(m) for m in prior + [{"role": "user", "content": current_user_message}]
+        ] + [_agent_copy({"role": "assistant", "content": "noon"})]
+        result = {"messages": agent_messages}
+
+        start = APIServerAdapter._response_messages_turn_start_index(
+            prior, current_user_message, result
+        )
+        assert start == len(prior) + 1
+        # And the stored transcript is exactly the agent transcript — no
+        # duplication of prior on front.
+        assert APIServerAdapter._build_response_conversation_history(
+            prior, current_user_message, {"messages": agent_messages}, "noon"
+        ) == agent_messages
+
+    def test_assistant_reasoning_keys_do_not_break_match(self):
+        prior = [{"role": "user", "content": "q1"}]
+        agent_messages = [
+            _agent_copy({"role": "user", "content": "q1"}),
+            {
+                "role": "user",
+                "content": "q2",
+                "timestamp": 1.0,
+                "_db_persisted": True,
+            },
+            {
+                "role": "assistant",
+                "content": "a2",
+                "reasoning": "thinking...",
+                "finish_reason": "stop",
+                "codex_message_items": [],
+            },
+        ]
+        start = APIServerAdapter._response_messages_turn_start_index(
+            prior, "q2", {"messages": agent_messages}
+        )
+        assert start == 2
+
+    def test_compression_summary_prefix_still_returns_zero(self):
+        # A compressed transcript starts with a summary that does NOT share
+        # the prior prefix — the (role, content) match must still fail so the
+        # caller's ``_compressed`` branch takes over.
+        prior = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        agent_messages = [
+            {"role": "assistant", "content": "[summary of earlier conversation]"},
+            {"role": "user", "content": "new question", "timestamp": 2.0},
+            {"role": "assistant", "content": "new answer"},
+        ]
+        start = APIServerAdapter._response_messages_turn_start_index(
+            prior, "new question", {"messages": agent_messages, "_compressed": True}
+        )
+        assert start == 0
+
+    def test_content_mismatch_still_returns_zero(self):
+        prior = [{"role": "user", "content": "first"}]
+        agent_messages = [
+            _agent_copy({"role": "user", "content": "a different message"}),
+        ]
+        start = APIServerAdapter._response_messages_turn_start_index(
+            prior, "second", {"messages": agent_messages}
+        )
+        assert start == 0
+
+    def test_non_dict_entry_forces_mismatch(self):
+        prior = [{"role": "user", "content": "hi"}]
+        agent_messages = ["not-a-dict", {"role": "user", "content": "hi"}]
+        assert not APIServerAdapter._normalized_prefix_match(agent_messages, prior)
+
+    def test_identity_is_none_for_unknown_role(self):
+        assert APIServerAdapter._normalized_message_identity("junk") is None
+        assert APIServerAdapter._normalized_message_identity({"role": "weird"}) is None
+        assert APIServerAdapter._normalized_message_identity(
+            {"role": "user", "content": "x"}
+        ) == ("user", "x")


### PR DESCRIPTION
## What does this PR do?

Multi-turn use of `/v1/responses` via `previous_response_id` chaining (or its `conversation` alias) stored a near-doubled transcript every turn: `_response_messages_turn_start_index` compared the API layer's bare `{"role", "content"}` history against agent-layer copies that carry extra keys stamped by the durability/flush path (`timestamp`, `_db_persisted`, and on assistant turns `reasoning` / `finish_reason` / provider items). Full-dict `==` requires identical key sets, so the prefix check failed on every turn, `turn_start` was always 0, and the fallback concatenated the prior history on top of an agent transcript that already contained it — the stored `conversation_history` grew super-linearly (measured 3 → 8 → 17 → 34 → 67 items over five short chat turns, #95137), and the duplicated/reordered transcript was replayed to the model on each subsequent turn, visibly degrading recall. The report's stateless control (full history in `input`, no chaining) stores cleanly, confirming the prefix check as the only faulty link.

The fix compares prefixes on a normalized `(role, content)` message identity (the report's suggested direction). Non-dict or unknown-role entries never match, so a malformed entry forces a mismatch instead of a false prefix hit, and a compressed summary prefix — which genuinely does not share the prior transcript's content — still fails the comparison, so the existing `_compressed` branch keeps taking over unchanged.

## Related Issue

Fixes #95137

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — add `_normalized_message_identity()` (role-whitelisted `(role, content)` projection, `None` for non-transcript shapes) and `_normalized_prefix_match()`; `_response_messages_turn_start_index()` now uses them for both prefix checks instead of full-dict slice equality. Add `Tuple` to the typing import.
- `tests/gateway/test_api_server_turn_start_prefix.py` — six regression tests: durability-stamped agent copies match the bare prefix and `_build_response_conversation_history` returns the agent transcript verbatim (no duplication); assistant reasoning keys don't break the match; a compression summary prefix still returns 0 so the `_compressed` branch takes over; content mismatch still returns 0; non-dict and unknown-role identities never match.

## How to Test

1. `.venv/bin/python -m pytest tests/gateway -k turn_start_prefix -v` — should pass (6 passed).
2. Adjacent suite stays green: `.venv/bin/python -m pytest tests/gateway/test_api_server.py -q` — should pass (109 passed).
3. Fail-on-main control: `git checkout HEAD~1 -- gateway/platforms/api_server.py` and rerun the new file — should fail (4 failed: both stamped-copy match tests plus the two identity unit pins; the compression-summary and content-mismatch tests pass on both sides by design — those negative paths return 0 in both versions), then restore. Observed result: `4 failed, 2 passed` pre-fix, `6 passed` post-fix.
4. Live check from the report's repro: `POST /v1/responses` with `conversation: "repro1"` for ~5 short turns, reading `len(json.loads(data)["conversation_history"])` from the snapshot after each — should now grow 2 → 4 → 6 → 8 → 10 instead of 3 → 8 → 17 → 34 → 67.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#39273 changes the session-reuse decision for the same parameter pair and #62758 validates `previous_response_id` type/length — neither touches the turn-start prefix computation this fixes, verified by diff inspection)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in the function docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python comparison logic, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (stored transcript content only; the wire contract is unchanged)
