### PR TITLE
fix(providers): make Desktop chats fail over on Codex account quota

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9908,37 +9908,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
         """Keep a cached agent's fallback chain aligned with current config.
 
-        Skips rewrite while a cooldown is holding the agent on an already-
-        activated fallback provider — ``restore_primary_runtime`` owns that
-        turn-scoped lifecycle. When primary is active (or cooldown expired),
-        replace the chain so mid-uptime ``fallback_providers`` edits take
-        effect without requiring a gateway restart (#60955).
+        Thin delegate over the shared ``apply_fallback_chain_to_agent`` helper
+        (#95066) — the Desktop/TUI server applies the same contract per turn.
         """
-        if agent is None:
-            return
-        new_chain = list(chain or [])
-        rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
-        if (
-            getattr(agent, "_fallback_activated", False)
-            and rate_limited_until > time.monotonic()
-        ):
-            return
-        old_chain = list(getattr(agent, "_fallback_chain", []) or [])
-        agent._fallback_chain = new_chain
-        agent._fallback_model = new_chain[0] if new_chain else None
-        if not getattr(agent, "_fallback_activated", False):
-            agent._fallback_index = 0
-        # A config edit signals the user changed something — drop the
-        # session-scoped unavailability memo so re-configured entries
-        # (e.g. credentials added mid-uptime for a previously-failing
-        # provider) get retried instead of staying suppressed for the
-        # cached agent's lifetime.  Only on actual content change, so
-        # the per-message no-op refresh keeps the memo's rate-limiting
-        # benefit (#60955).
-        if new_chain != old_chain:
-            unavailable = getattr(agent, "_unavailable_fallback_keys", None)
-            if unavailable:
-                unavailable.clear()
+        from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+        apply_fallback_chain_to_agent(agent, chain)
 
     def _snapshot_running_agents(self) -> Dict[str, Any]:
         return {

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -99,3 +99,73 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def apply_fallback_chain_to_agent(
+    agent: Any, chain: list[dict[str, Any]] | None
+) -> None:
+    """Keep a live agent's fallback chain aligned with current config.
+
+    Shared by the messaging gateway (per message) and the Desktop/TUI server
+    (per turn) so a chain configured *after* a chat was opened still reaches
+    that chat's next turn without recreating it (#95066).
+
+    Skips the rewrite while a rate-limit cooldown is holding the agent on an
+    already-activated fallback provider — ``restore_primary_runtime`` owns
+    that turn-scoped lifecycle. When the primary is active (or the cooldown
+    expired), replace the chain so mid-session ``fallback_providers`` edits
+    take effect.
+    """
+    import time
+
+    if agent is None:
+        return
+    new_chain = list(chain or [])
+    rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
+    if (
+        getattr(agent, "_fallback_activated", False)
+        and rate_limited_until > time.monotonic()
+    ):
+        return
+    old_chain = list(getattr(agent, "_fallback_chain", []) or [])
+    agent._fallback_chain = new_chain
+    agent._fallback_model = new_chain[0] if new_chain else None
+    if not getattr(agent, "_fallback_activated", False):
+        agent._fallback_index = 0
+    # A config edit signals the user changed something — drop the session-
+    # scoped unavailability memo so re-configured entries (e.g. credentials
+    # added mid-session for a previously-failing provider) get retried
+    # instead of staying suppressed for the cached agent's lifetime. Only on
+    # actual content change, so repeated no-op refreshes keep the memo's
+    # rate-limiting benefit (#60955).
+    if new_chain != old_chain:
+        unavailable = getattr(agent, "_unavailable_fallback_keys", None)
+        if unavailable:
+            unavailable.clear()
+
+
+def codex_pool_account_ids(entries: Any) -> set[str]:
+    """Distinct ChatGPT account ids backing a credential-pool snapshot.
+
+    Codex OAuth access tokens are JWTs whose ``chatgpt_account_id`` claim
+    scopes usage quota: two stored rows that re-authenticate the same
+    ChatGPT account share one quota wall, so rotating between them can
+    never clear an account-quota 429. Entries whose token cannot be decoded
+    contribute nothing — callers treat a missing id as "cannot prove these
+    rows share an account".
+    """
+    from hermes_cli.auth import _decode_jwt_claims
+
+    accounts: set[str] = set()
+    for entry in entries or []:
+        token = getattr(entry, "access_token", None)
+        claims = _decode_jwt_claims(token) if isinstance(token, str) else {}
+        auth_claims = claims.get("https://api.openai.com/auth")
+        account_id = (
+            auth_claims.get("chatgpt_account_id")
+            if isinstance(auth_claims, dict)
+            else None
+        )
+        if isinstance(account_id, str) and account_id.strip():
+            accounts.add(account_id.strip())
+    return accounts

--- a/run_agent.py
+++ b/run_agent.py
@@ -332,13 +332,48 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
     In that case we must fall back to the configured ``fallback_model``
     instead.  Returns True only when rotation has somewhere to go.
 
+    Codex OAuth pools add a second trap: usage quota is scoped by the JWT's
+    ``chatgpt_account_id``, so several stored rows re-authenticating the SAME
+    ChatGPT account share one quota wall. Rotating between duplicate rows of
+    one account cannot clear an account-quota 429 (``usage_limit_reached``,
+    multi-hour ``resets_in_seconds``) — the wall is account-wide, so treat a
+    single-account snapshot like a single-credential pool and defer to the
+    fallback chain (#95066). Pools with two or more distinct ChatGPT accounts
+    (or any non-Codex pool, where rows are independent keys) keep rotation.
+
     See issues #11314 and #13636.
     """
     if pool is None:
         return False
     if not pool.has_available():
         return False
-    return len(pool.entries()) > 1
+    entries = pool.entries()
+    if len(entries) <= 1:
+        return False
+    # Codex OAuth rows: quota is scoped by the ChatGPT account the row's JWT
+    # re-authenticates, so N rows of ONE account share a single quota wall —
+    # rotating between them cannot clear an account-quota 429. When every
+    # entry that decodes resolves to the SAME single account id, rotation has
+    # nowhere to go (rows that fail to decode cannot demonstrate a second
+    # account either). Distinct ids prove independent quotas and keep
+    # rotation; pools where nothing decodes (plain API keys: Vertex, custom
+    # providers) never reach the Codex branch and always keep rotation.
+    try:
+        from hermes_cli.fallback_config import codex_pool_account_ids
+
+        accounts = codex_pool_account_ids(entries)
+        if len(accounts) == 1:
+            logger.info(
+                "Codex credential pool resolves to a single ChatGPT account "
+                "(quota is account-scoped) — deferring to fallback chain"
+            )
+            return False
+    except Exception:
+        logger.debug(
+            "codex_pool_account_ids failed; keeping pool-rotation recovery",
+            exc_info=True,
+        )
+    return True
 
 
 def _qwen_portal_headers() -> dict:

--- a/tests/run_agent/test_95066_desktop_codex_quota_fallback.py
+++ b/tests/run_agent/test_95066_desktop_codex_quota_fallback.py
@@ -1,0 +1,362 @@
+"""Behavior-contract tests for #95066 — Desktop chats must fail over on Codex quota.
+
+Two defects chained into the reported symptom:
+
+1. A Desktop/TUI chat freezes its fallback chain at agent-create time, so a
+   chat opened before ``hermes fallback add`` keeps an empty in-memory chain
+   forever and a provider-quota 429 ends in a provider error even though a
+   healthy fallback is configured. Contract: the live agent's chain is
+   re-aligned with config.yaml at turn start (same per-message contract the
+   messaging gateway applies to its cached agents).
+2. A Codex OAuth credential pool holding several rows for the SAME ChatGPT
+   account looks recoverable to the rate-limit hinge because quota is keyed
+   by stored rows, but Codex usage quota is scoped by the JWT's
+   ``chatgpt_account_id``: N rows of one account share one quota wall and
+   rotating between them cannot clear ``usage_limit_reached``. Contract:
+   rotation counts *accounts*, not rows.
+
+The helper contracts are pinned against the shared module both surfaces now
+use (``hermes_cli.fallback_config``), so the gateway delegate and the TUI
+turn-start sync cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_jwt(account_id: str | None) -> str:
+    """Minimal unsigned JWT whose auth claim carries a ChatGPT account id."""
+    import base64
+    import json
+
+    def _b64(payload: dict) -> str:
+        raw = json.dumps(payload).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    auth: dict = {}
+    if account_id is not None:
+        auth["chatgpt_account_id"] = account_id
+    header = {"alg": "none", "typ": "JWT"}
+    claims = {"https://api.openai.com/auth": auth}
+    return f"{_b64(header)}.{_b64(claims)}."
+
+
+def _pool_entry(access_token: str, label: str):
+    from agent.credential_pool import PooledCredential
+
+    return PooledCredential(
+        provider="openai-codex",
+        id=label,
+        label=label,
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token=access_token,
+    )
+
+
+class _FakePool:
+    """has_available/entries surface the recovery hinge actually consumes."""
+
+    def __init__(self, entries, *, available=True):
+        self._entries = entries
+        self._available = available
+
+    def has_available(self) -> bool:
+        return self._available
+
+    def entries(self):
+        return self._entries
+
+
+# ── 1. the rate-limit hinge counts ChatGPT accounts, not rows (#95066) ──────
+
+
+def test_codex_duplicate_account_rows_defer_to_fallback():
+    """Two Codex OAuth rows re-authenticating ONE ChatGPT account share a
+    quota wall — the hinge must NOT claim rotation may recover."""
+    from run_agent import _pool_may_recover_from_rate_limit
+
+    pool = _FakePool(
+        [
+            _pool_entry(_make_jwt("acct-111"), "row-a"),
+            _pool_entry(_make_jwt("acct-111"), "row-b"),
+        ]
+    )
+    assert _pool_may_recover_from_rate_limit(pool) is False
+
+
+def test_codex_distinct_accounts_keep_rotation():
+    """Rows backed by DIFFERENT ChatGPT accounts have independent quotas —
+    rotation remains a real recovery path."""
+    from run_agent import _pool_may_recover_from_rate_limit
+
+    pool = _FakePool(
+        [
+            _pool_entry(_make_jwt("acct-111"), "row-a"),
+            _pool_entry(_make_jwt("acct-222"), "row-b"),
+        ]
+    )
+    assert _pool_may_recover_from_rate_limit(pool) is True
+
+
+def test_non_jwt_pool_entries_keep_rotation():
+    """Plain API-key pools (Vertex service accounts, custom providers) never
+    reach the Codex branch: rows without a decodable JWT keep legacy rotation."""
+    from run_agent import _pool_may_recover_from_rate_limit
+
+    plain_a = _pool_entry("", "key-a")
+    plain_b = _pool_entry("", "key-b")
+    plain_a.access_token = ""
+    plain_b.access_token = ""
+    assert _pool_may_recover_from_rate_limit(_FakePool([plain_a, plain_b])) is True
+
+
+def test_single_row_and_unavailable_pools_still_defer():
+    """Original #11314/#13636 contracts survive untouched."""
+    from run_agent import _pool_may_recover_from_rate_limit
+
+    solo = _FakePool([_pool_entry(_make_jwt("acct-111"), "row-a")])
+    assert _pool_may_recover_from_rate_limit(solo) is False
+
+    exhausted = _FakePool(
+        [_pool_entry(_make_jwt("acct-111"), "row-a")], available=False
+    )
+    assert _pool_may_recover_from_rate_limit(exhausted) is False
+    assert _pool_may_recover_from_rate_limit(None) is False
+
+
+# ── 2. shared chain-application helper (gateway + desktop parity) ───────────
+
+
+def test_apply_fallback_chain_updates_live_agent_and_clears_memo():
+    """A chain added AFTER the chat opened reaches the cached agent: the new
+    entries land, the index resets, and the unavailability memo clears so a
+    previously-failing provider gets retried (#95066)."""
+    from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+    stale = [{"provider": "grok", "model": "grok-4.6"}]
+    memo = {("openrouter", "anthropic/claude-sonnet-4.6")}
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=memo,
+    )
+
+    fresh = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    apply_fallback_chain_to_agent(agent, fresh)
+
+    assert agent._fallback_chain == fresh
+    assert agent._fallback_model == fresh[0]
+    assert agent._fallback_index == 0
+    assert memo == set()
+
+
+def test_apply_fallback_chain_noop_preserves_unavailability_memo():
+    """Repeated no-op refreshes must not clear the memo (#60955 rate-limiting
+    benefit), only real content changes do."""
+    from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+    chain = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    memo = {("openrouter", "some/model")}
+    agent = SimpleNamespace(
+        _fallback_chain=list(chain),
+        _fallback_model=chain[0],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+        _unavailable_fallback_keys=memo,
+    )
+
+    apply_fallback_chain_to_agent(agent, [dict(chain[0])])
+
+    assert memo == {("openrouter", "some/model")}
+
+
+def test_apply_fallback_chain_skips_cooldown_held_activation():
+    """While a rate-limit cooldown holds the agent on an activated fallback,
+    the refresh must not clobber the turn-scoped activation state."""
+    from hermes_cli.fallback_config import apply_fallback_chain_to_agent
+
+    live = [{"provider": "grok", "model": "grok-4.6"}]
+    agent = SimpleNamespace(
+        _fallback_chain=live,
+        _fallback_model=live[0],
+        _fallback_index=1,
+        _fallback_activated=True,
+        _rate_limited_until=time.monotonic() + 30,
+    )
+
+    apply_fallback_chain_to_agent(agent, [{"provider": "other", "model": "m"}])
+
+    assert agent._fallback_chain == live
+    assert agent._fallback_index == 1
+    assert agent._fallback_activated is True
+
+
+def test_gateway_delegate_shares_the_helper():
+    """GatewayRunner._apply_fallback_chain_to_agent delegates to the shared
+    helper so messaging and desktop cannot drift apart."""
+    from gateway.run import GatewayRunner
+    from hermes_cli.fallback_config import apply_fallback_chain_to_agent as shared
+
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    fresh = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    GatewayRunner._apply_fallback_chain_to_agent(agent, fresh)
+
+    expected = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    shared(expected, fresh)
+    assert agent._fallback_chain == expected._fallback_chain
+    assert agent._fallback_model == expected._fallback_model
+
+
+# ── 3. Desktop/TUI turn-start sync adopts fallback edits (#95066) ───────────
+
+
+def test_tui_turn_start_sync_adopts_fallback_added_after_chat_opened(monkeypatch):
+    """The exact reported scenario: chat opened before `hermes fallback add`,
+    chain configured afterwards — the NEXT turn must carry the fresh chain."""
+    from tui_gateway import server
+
+    fresh = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    monkeypatch.setattr(server, "_load_cfg", lambda: {
+        "fallback_providers": fresh,
+    })
+
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    session = {"agent": agent}
+
+    server._sync_agent_fallback_chain_with_config("sid-1", session)
+
+    assert agent._fallback_chain == fresh
+    assert agent._fallback_model == fresh[0]
+
+
+def test_tui_turn_start_sync_survives_broken_config(monkeypatch):
+    """A transiently broken config read keeps the current chain and never
+    blocks the turn (fail-open, mirroring the gateway's refresh)."""
+    from tui_gateway import server
+
+    def _boom():
+        raise RuntimeError("torn mid-edit config.yaml")
+
+    monkeypatch.setattr(server, "_load_cfg", _boom)
+
+    existing = [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    agent = SimpleNamespace(
+        _fallback_chain=existing,
+        _fallback_model=existing[0],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    session = {"agent": agent}
+
+    server._sync_agent_fallback_chain_with_config("sid-1", session)
+
+    assert agent._fallback_chain == existing
+
+
+def test_tui_turn_start_sync_noop_without_agent():
+    """Sessions without a built agent have nothing to sync."""
+    from tui_gateway import server
+
+    server._sync_agent_fallback_chain_with_config("sid-1", {"agent": None})
+    server._sync_agent_fallback_chain_with_config("sid-1", {})
+
+
+def test_tui_turn_start_sync_reads_real_config_disk(tmp_path, monkeypatch):
+    """Integration over the REAL read path (no config mock): `hermes fallback
+    add` writes config.yaml between two turns; the next turn's sync adopts
+    it from disk through _load_cfg's managed-overlay pipeline."""
+    from tui_gateway import server
+
+    (tmp_path / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: xai-oauth\n"
+        "    model: grok-4.6\n"
+    )
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path))
+    monkeypatch.setattr(server, "get_hermes_home_override", lambda: None)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    session = {"agent": agent}
+
+    server._sync_agent_fallback_chain_with_config("sid-1", session)
+
+    assert agent._fallback_chain == [{"provider": "xai-oauth", "model": "grok-4.6"}]
+    assert agent._fallback_model == {"provider": "xai-oauth", "model": "grok-4.6"}
+
+
+# ── 4. wiring invariants (call sites that resist unit testing) ──────────────
+
+
+def _server_source() -> str:
+    return (
+        Path(__file__).resolve().parent.parent.parent
+        / "tui_gateway"
+        / "server.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_turn_start_calls_both_syncs_in_order():
+    """At turn start the pending-model switch runs first, then the config
+    model sync, then the fallback-chain sync — all before the turn's first
+    model call."""
+    source = _server_source()
+    model_call = source.find("_sync_agent_model_with_config(sid, session)")
+    fb_call = source.find("_sync_agent_fallback_chain_with_config(sid, session)")
+    assert model_call != -1, "config model sync call site vanished"
+    assert fb_call != -1, "fallback chain sync must be wired at turn start"
+    pending_call = source.find("_apply_pending_model_switch(sid, session)")
+    assert pending_call < model_call < fb_call
+
+
+def test_hinge_wiring_feeds_error_context_into_recovery():
+    """The conversation loop consults the hinge before activating a fallback;
+    the upstream-aggregator bypass stays intact (its contract predates this
+    fix and must not regress)."""
+    loop_source = (
+        Path(__file__).resolve().parent.parent.parent
+        / "agent"
+        / "conversation_loop.py"
+    ).read_text(encoding="utf-8")
+    assert "_pool_may_recover_from_rate_limit(" in loop_source
+    assert "FailoverReason.upstream_rate_limit" in loop_source

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5819,6 +5819,34 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
         )
 
 
+def _sync_agent_fallback_chain_with_config(sid: str, session: dict) -> None:
+    """Adopt a config.yaml fallback-chain change into the live agent.
+
+    Desktop/TUI chats cache their agent across turns and used to freeze the
+    fallback chain at agent-create time (#95066): a chat opened before
+    ``hermes fallback add`` kept an empty in-memory chain forever, so a
+    provider-quota 429 ended in a provider error even though a healthy
+    fallback was configured. The messaging gateway already re-applies its
+    cached agents' chain per message; this is the same contract at turn
+    start. Fail-open — a failed read keeps the current chain and never
+    blocks the turn.
+    """
+    agent = session.get("agent")
+    if agent is None:
+        return
+    try:
+        from hermes_cli.fallback_config import (
+            apply_fallback_chain_to_agent,
+            get_fallback_chain,
+        )
+
+        apply_fallback_chain_to_agent(agent, get_fallback_chain(_load_cfg()))
+    except Exception as e:
+        logger.warning(
+            "fallback chain sync failed for %s: %s", sid, e, exc_info=True
+        )
+
+
 def _apply_pending_model_switch(sid: str, session: dict) -> None:
     """Apply a model switch queued while a turn was running.
 
@@ -11493,6 +11521,11 @@ def _run_prompt_submit(
                 # config sync so an explicit pick wins over a config.yaml change.
                 _apply_pending_model_switch(sid, session)
                 _sync_agent_model_with_config(sid, session)
+                # Adopt fallback_providers edits into the cached agent too —
+                # a chain added after the chat opened must reach the next
+                # turn (#95066), same per-message contract the messaging
+                # gateway applies to its cached agents.
+                _sync_agent_fallback_chain_with_config(sid, session)
             # Bot Chat capability sync — adopt Settings→Capabilities edits
             # (skills/toolsets/MCP/SOUL) into the eternal bot session before
             # the turn runs. No-op for every other session shape.


### PR DESCRIPTION
## What does this PR do?

Live Desktop/TUI chats now adopt `fallback_providers` edits before each turn (parity with the messaging gateway), so a chat opened before `hermes fallback add` can fail over without being recreated. The credential-pool recovery hinge also stops treating duplicate Codex OAuth rows of the same ChatGPT account as independent recovery options, because usage quota is scoped by the JWT's `chatgpt_account_id`, not by stored rows.

Fixes #95066.

### Symptom

An already-open Desktop chat could keep an empty in-memory fallback chain after `hermes fallback add`. When Codex returned HTTP 429 with `usage_limit_reached` (`plan_type=plus`, multi-hour `resets_in_seconds`), two OAuth entries for the same ChatGPT account made the pool look recoverable, so the turn retried Codex three times instead of activating the configured fallback — and surfaced a provider error.

### Impact

Affected Desktop turns end in a provider error even though the user configured a healthy fallback. New chats or pinning another model work around it; existing chats stay broken.

### Bug Cause

**Trigger:** `tui_gateway/server.py` turn start + `run_agent.py:_pool_may_recover_from_rate_limit`

**Causal chain:**
1. A Desktop agent is created before `fallback_providers` is added, freezing an empty `_fallback_chain`; later turns reuse that agent without re-reading config. The messaging gateway refreshes cached agents per message (#60955); the desktop had no equivalent.
2. On a 429, the hinge counts credential rows rather than ChatGPT accounts: `len(pool.entries()) > 1` treats two device-code rows of one account as recoverable rotation, though quota is account-scoped and rotation cannot clear it.
3. The user gets a provider error; `switching to fallback` never logs.

**Ruled out:** generic 429 classification is not the missing link — `agent/error_classifier.py` already recognizes `usage_limit_reached` (recent quota-classifier work #0c3a50753/#654d53708/#c2090ba6b); the failure is the stale Desktop chain plus the row-counting recovery decision made after classification.

### Fix

- **Shared helper** (`hermes_cli/fallback_config.py`): extract `apply_fallback_chain_to_agent` verbatim from `GatewayRunner._apply_fallback_chain_to_agent` so messaging and desktop share one contract, and add `codex_pool_account_ids` (decodes each row's access-token JWT `chatgpt_account_id` claim via the existing `_decode_jwt_claims`).
- **Gateway**: `_apply_fallback_chain_to_agent` becomes a thin delegate to the shared helper (no behavior change; covered by the existing `test_fallback_chain_reload.py` suite).
- **Desktop/TUI** (`tui_gateway/server.py`): new `_sync_agent_fallback_chain_with_config` runs at turn start next to `_sync_agent_model_with_config`, re-aligning the live agent's chain with config.yaml. Fail-open like every other per-turn sync; honors the cooldown-held activation state.
- **Hinge** (`run_agent.py`): when a pool has >1 entry but every decodable entry resolves to ONE ChatGPT account id, defer to the fallback chain. Distinct ids prove independent quotas and keep rotation; pools where nothing decodes (plain API keys — Vertex, custom providers) never reach the Codex branch and keep legacy rotation. Single-entry and unavailable-pool contracts from #11314/#13636 are untouched.

## Related Issue

Fixes #95066

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/fallback_config.py` — shared live-agent chain application + Codex account identity
- `gateway/run.py` — delegate `_apply_fallback_chain_to_agent` to the shared helper
- `tui_gateway/server.py` — per-turn fallback-chain sync for Desktop/TUI chats
- `run_agent.py` — account-aware `_pool_may_recover_from_rate_limit`
- `tests/run_agent/test_95066_desktop_codex_quota_fallback.py` — 14 behavior-contract tests (9 fail on pristine main)

## How to Test

1. Configure a Codex primary plus any fallback, open a Desktop chat, run `hermes fallback add` afterwards; the NEXT message of the already-open chat carries the fresh chain without recreating the session.
2. Return `usage_limit_reached` for two Codex OAuth entries whose JWTs carry the same `chatgpt_account_id`; an available fallback activates instead of rotating the duplicate row. Two distinct account ids keep rotating as today.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_95066_desktop_codex_quota_fallback.py tests/gateway/test_fallback_chain_reload.py tests/hermes_cli/test_fallback_config.py -q
```

Result: all green locally — new suite 14 passed; neighbor suites green: provider fallback 26, gateway chain reload ~13, run_agent 283, conversation/fallback state 25, gemini fast fallback 2, credential pool routing + cooldown 24, fallback cmd 14, auto_continue 15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8

Note: an earlier PR on this surface (#95077) was closed unmerged by its author ~8 minutes after opening; upstream main remains without either half of the fix (verified against f751a8c54), and this PR covers both mechanisms with credit preserved where the approach overlapped.

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and regression tests document the change
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow contract changed
- [x] I've considered cross-platform impact; the implementation uses existing Python config and JWT helpers
- [x] Tool description/schema updates are N/A; no model tool behavior changed