### PR TITLE
feat(slack): outbound link-preview suppression across native + relay planes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1214,6 +1214,10 @@ platform_toolsets:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.
 #       native_task_cards: false
+#       # Suppress automatic link-preview cards without removing clickable links.
+#       # Omit either key to preserve Slack's default for that preview type.
+#       unfurl_links: false
+#       unfurl_media: false
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/contributors/emails/potatosaladx@gmail.com
+++ b/contributors/emails/potatosaladx@gmail.com
@@ -1,0 +1,1 @@
+potatosalad

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -317,10 +317,23 @@ class RelayAdapter(BasePlatformAdapter):
             if chat_id is not None
             else self.descriptor
         )
-        return (
+        if not (
             desc.supports_draft_streaming
             and "draft" in (desc.supported_ops or ())
-        )
+        ):
+            return False
+        # Slack chat.*Stream has no unfurl_links / unfurl_media. Native
+        # SlackAdapter already refuses streaming when those knobs are set
+        # so chat.postMessage can carry them. Mirror that here or a
+        # configured true never reaches Slack (bot default = no preview).
+        platform = None
+        if chat_id is not None:
+            platform = self._platform_by_chat.get(str(chat_id))
+        if platform is None:
+            platform = getattr(desc, "platform", None)
+        if self._slack_unfurl_hints(platform):
+            return False
+        return True
 
     def stream_is_message_for_chat(self, chat_id: str) -> bool:
         """Per-chat stream-is-the-message semantic (review r2, finding 2).
@@ -1098,8 +1111,27 @@ class RelayAdapter(BasePlatformAdapter):
         hints: Dict[str, bool] = {}
         for knob in ("unfurl_links", "unfurl_media"):
             val = extra.get(knob)
+            if val is None:
+                continue
+            # Railway / `hermes config set` write YAML strings ("true"/"false").
+            # A Slack bot that omits the fields does NOT get human-default
+            # previews — so a string "true" that we drop looks like
+            # suppression. Coerce the same way as reply_in_thread; still drop
+            # junk (empty, 0, "maybe") so omitted stays omitted.
             if isinstance(val, bool):
                 hints[knob] = val
+                continue
+            if isinstance(val, str) and val.strip().lower() in {
+                "1",
+                "0",
+                "true",
+                "false",
+                "yes",
+                "no",
+                "on",
+                "off",
+            }:
+                hints[knob] = val.strip().lower() in {"1", "true", "yes", "on"}
         return hints or None
 
     def _stamp_slack_session_thread(self, event) -> None:

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1960,7 +1960,10 @@ class RelayAdapter(BasePlatformAdapter):
         effective_reply_to = self._apply_slack_thread_anchor(
             chat_id, reply_to, send_metadata
         )
-        _unfurl = self._slack_unfurl_hints(self._platform_by_chat.get(str(chat_id)))
+        _unfurl = self._slack_unfurl_hints(
+            self._platform_by_chat.get(str(chat_id))
+            or getattr(self.descriptor, "platform", None)
+        )
         if _unfurl:
             send_metadata.update(_unfurl)
         result = await self._transport.send_outbound(
@@ -2459,7 +2462,10 @@ class RelayAdapter(BasePlatformAdapter):
         effective_reply_to = self._apply_slack_thread_anchor(
             chat_id, reply_to, media_metadata
         )
-        _media_unfurl = self._slack_unfurl_hints(self._platform_by_chat.get(str(chat_id)))
+        _media_unfurl = self._slack_unfurl_hints(
+            self._platform_by_chat.get(str(chat_id))
+            or getattr(self.descriptor, "platform", None)
+        )
         if _media_unfurl:
             media_metadata.update(_media_unfurl)
         action: Dict[str, Any] = {

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1080,6 +1080,28 @@ class RelayAdapter(BasePlatformAdapter):
         except Exception:  # noqa: BLE001 - config shape is operator-owned
             return True
 
+    def _slack_unfurl_hints(self, platform: Optional[str]) -> Optional[Dict[str, bool]]:
+        """Slack-only outbound link-preview suppression, relay-namespaced.
+
+        Mirrors the native SlackAdapter's unfurl controls
+        (``platforms.slack.extra.unfurl_links`` / ``unfurl_media``) but reads
+        the relay namespace (``platforms.relay.extra.slack.*``) per the
+        ``reply_in_thread`` seam: relay-fronted Slack reads its subset here;
+        the native ``platforms.slack`` block keeps meaning native-adapter
+        settings. Only explicitly-configured booleans are returned — omitted
+        keys preserve Slack's default unfurling. Non-Slack platforms return
+        None so the metadata is never polluted for other fronted platforms.
+        """
+        if str(platform or "").lower() != Platform.SLACK.value:
+            return None
+        extra = self._relay_slack_extra()
+        hints: Dict[str, bool] = {}
+        for knob in ("unfurl_links", "unfurl_media"):
+            val = extra.get(knob)
+            if isinstance(val, bool):
+                hints[knob] = val
+        return hints or None
+
     def _stamp_slack_session_thread(self, event) -> None:
         """Native session-keying parity for fronted Slack DMs.
 
@@ -1720,6 +1742,9 @@ class RelayAdapter(BasePlatformAdapter):
             )
         if self._transport is None:
             return SendResult(success=False, error="no transport")
+        _sfp_unfurl = self._slack_unfurl_hints(str(platform_value))
+        if _sfp_unfurl:
+            _sfp_metadata.update(_sfp_unfurl)
         result = await self._transport.send_outbound(
             {
                 "op": "send",
@@ -1903,6 +1928,9 @@ class RelayAdapter(BasePlatformAdapter):
         effective_reply_to = self._apply_slack_thread_anchor(
             chat_id, reply_to, send_metadata
         )
+        _unfurl = self._slack_unfurl_hints(self._platform_by_chat.get(str(chat_id)))
+        if _unfurl:
+            send_metadata.update(_unfurl)
         result = await self._transport.send_outbound(
             {
                 "op": "send",
@@ -2399,6 +2427,9 @@ class RelayAdapter(BasePlatformAdapter):
         effective_reply_to = self._apply_slack_thread_anchor(
             chat_id, reply_to, media_metadata
         )
+        _media_unfurl = self._slack_unfurl_hints(self._platform_by_chat.get(str(chat_id)))
+        if _media_unfurl:
+            media_metadata.update(_media_unfurl)
         action: Dict[str, Any] = {
             "op": "send_media",
             "chat_id": chat_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -85,13 +85,32 @@ def _slack_unfurl_kwargs(extra: Optional[Dict[str, Any]]) -> Dict[str, bool]:
     Omitting a key preserves Slack's existing default.  Passing ``False``
     suppresses only the automatic preview while leaving the link text and URL
     in the message untouched.
+
+    String booleans are coerced the same way as the relay plane's
+    ``_slack_unfurl_hints``: ``hermes config set`` and Railway persist YAML
+    ``"true"``/``"false"`` as strings, and a silently dropped string would
+    make the knob a no-op on the native plane only. Unrecognized values are
+    dropped (NOT coerced to False) so junk config keeps Slack's default
+    instead of accidentally suppressing previews.
     """
     settings = extra or {}
-    return {
-        key: settings[key]
-        for key in ("unfurl_links", "unfurl_media")
-        if isinstance(settings.get(key), bool)
-    }
+    kwargs: Dict[str, bool] = {}
+    for key in ("unfurl_links", "unfurl_media"):
+        val = settings.get(key)
+        if isinstance(val, bool):
+            kwargs[key] = val
+        elif isinstance(val, str) and val.strip().lower() in {
+            "1",
+            "0",
+            "true",
+            "false",
+            "yes",
+            "no",
+            "on",
+            "off",
+        }:
+            kwargs[key] = val.strip().lower() in {"1", "true", "yes", "on"}
+    return kwargs
 
 
 async def _read_error_text_limited(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3152,8 +3152,13 @@ class SlackAdapter(BasePlatformAdapter):
         chat_type: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> bool:
-        """Slack native streaming works in DMs, threads, and channels."""
+        """Return whether Slack's native stream can preserve configured behavior."""
         if self._native_stream_unsupported:
+            return False
+        # Slack's chat.*Stream API contract has no unfurl controls. Route
+        # explicitly configured behavior through the edit-based transport,
+        # whose initial chat.postMessage carries these options.
+        if _slack_unfurl_kwargs(self.config.extra):
             return False
         return self._app is not None
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -9142,8 +9142,10 @@ async def _standalone_send(
     treats every upload as a generic file share.
 
     When ``caption`` is set (single captionable MEDIA:<path> + short text), the
-    text rides as ``initial_comment`` on the upload instead of a separate
-    ``chat.postMessage``.
+    text normally rides as ``initial_comment`` on the upload instead of a
+    separate ``chat.postMessage``. If link-preview controls are explicit, the
+    text is posted separately because Slack's file-upload API cannot carry
+    those controls.
     """
     del force_document  # signature parity with other standalone senders
     # Profile-scoped read: under multiplex os.environ may hold ANOTHER
@@ -9213,6 +9215,7 @@ async def _standalone_send(
 
     formatted = _format_mrkdwn(message) if message else message
     formatted_caption = _format_mrkdwn(caption) if caption else caption
+    unfurl_kwargs = _slack_unfurl_kwargs(getattr(pconfig, "extra", None))
 
     # --- Media path: AsyncWebClient.files_upload_v2 (+ optional text) ---
     if media_files:
@@ -9233,14 +9236,19 @@ async def _standalone_send(
         _apply_slack_proxy(client, resolve_proxy_url())
         last_message_id = None
 
-        # Caption mode: skip a separate text post; comment rides the upload.
-        text_to_send = "" if formatted_caption else (formatted or "")
+        # Slack's file-upload API cannot accept chat.postMessage's unfurl
+        # controls. When either control is explicit, keep the caption as a
+        # separate text post so the configured behavior is actually honored.
+        caption_as_upload_comment = bool(formatted_caption) and not unfurl_kwargs
+        text_to_send = (
+            "" if caption_as_upload_comment else (formatted_caption or formatted or "")
+        )
         if text_to_send.strip():
             post_kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "text": text_to_send,
                 "mrkdwn": True,
-                **_slack_unfurl_kwargs(pconfig.extra),
+                **unfurl_kwargs,
             }
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
@@ -9256,7 +9264,7 @@ async def _standalone_send(
             except Exception as e:
                 return {"error": f"Slack send failed: {e}"}
 
-        caption_pending = bool(formatted_caption)
+        caption_pending = caption_as_upload_comment
         uploaded_any = False
         for media_path, _is_voice in media_files:
             if not os.path.exists(media_path):
@@ -9270,6 +9278,7 @@ async def _standalone_send(
                             "channel": chat_id,
                             "text": formatted_caption,
                             "mrkdwn": True,
+                            **unfurl_kwargs,
                         }
                         if thread_id:
                             fallback_kwargs["thread_ts"] = thread_id
@@ -9290,7 +9299,7 @@ async def _standalone_send(
                     client,
                     chat_id,
                     media_path,
-                    initial_comment=formatted_caption if caption_pending else "",
+                    initial_comment=(formatted_caption or "") if caption_pending else "",
                     thread_id=thread_id,
                 )
                 if upload_result.get("error"):
@@ -9360,7 +9369,7 @@ async def _standalone_send(
                 "channel": chat_id,
                 "text": formatted,
                 "mrkdwn": True,
-                **_slack_unfurl_kwargs(pconfig.extra),
+                **unfurl_kwargs,
             }
             if thread_id:
                 payload["thread_ts"] = thread_id

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -79,6 +79,21 @@ _HERMES_SLACK_USER_AGENT_PREFIX = f"HermesAgent/{_HERMES_VERSION}"
 _SLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 
 
+def _slack_unfurl_kwargs(extra: Optional[Dict[str, Any]]) -> Dict[str, bool]:
+    """Return explicitly configured Slack link-preview controls.
+
+    Omitting a key preserves Slack's existing default.  Passing ``False``
+    suppresses only the automatic preview while leaving the link text and URL
+    in the message untouched.
+    """
+    settings = extra or {}
+    return {
+        key: settings[key]
+        for key in ("unfurl_links", "unfurl_media")
+        if isinstance(settings.get(key), bool)
+    }
+
+
 async def _read_error_text_limited(
     response: Any,
     *,
@@ -2807,6 +2822,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
+                    **_slack_unfurl_kwargs(self.config.extra),
                 }
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
@@ -9224,6 +9240,7 @@ async def _standalone_send(
                 "channel": chat_id,
                 "text": text_to_send,
                 "mrkdwn": True,
+                **_slack_unfurl_kwargs(pconfig.extra),
             }
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
@@ -9339,7 +9356,12 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
-            payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+            payload = {
+                "channel": chat_id,
+                "text": formatted,
+                "mrkdwn": True,
+                **_slack_unfurl_kwargs(pconfig.extra),
+            }
             if thread_id:
                 payload["thread_ts"] = thread_id
             for tok in tokens:

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -88,8 +88,16 @@ class TestUnfurlHints:
         a = _slack_adapter({"slack": {}})
         assert a._slack_unfurl_hints("slack") is None
 
-    def test_non_bool_values_dropped(self):
-        a = _slack_adapter({"slack": {"unfurl_links": "false", "unfurl_media": 0}})
+    def test_string_bools_from_config_set_are_coerced(self):
+        # Railway knobs / `hermes config set` persist YAML strings.
+        a = _slack_adapter({"slack": {"unfurl_links": "true", "unfurl_media": "false"}})
+        assert a._slack_unfurl_hints("slack") == {
+            "unfurl_links": True,
+            "unfurl_media": False,
+        }
+
+    def test_junk_values_dropped(self):
+        a = _slack_adapter({"slack": {"unfurl_links": "maybe", "unfurl_media": 0}})
         assert a._slack_unfurl_hints("slack") is None
 
     def test_flat_legacy_key_fallback(self):
@@ -155,3 +163,40 @@ class TestSendForPlatformStampsUnfurl:
         await a.send_for_platform(P.SLACK, "C123", "brief")
         assert "unfurl_links" not in a._transport.sent["metadata"]
         assert "unfurl_media" not in a._transport.sent["metadata"]
+
+class TestUnfurlDisablesDraftStreaming:
+    def test_explicit_unfurl_disables_slack_draft_stream(self):
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(
+                platform="slack",
+                supports_draft_streaming=True,
+                supported_ops=("send", "draft"),
+            ),
+            transport=_CaptureTransport(),
+        )
+        assert a.supports_draft_streaming() is False
+
+    def test_omitted_unfurl_keeps_slack_draft_stream(self):
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {}}),
+            make_desc(
+                platform="slack",
+                supports_draft_streaming=True,
+                supported_ops=("send", "draft"),
+            ),
+            transport=_CaptureTransport(),
+        )
+        assert a.supports_draft_streaming() is True
+
+    def test_string_true_also_disables_stream(self):
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": "true"}}),
+            make_desc(
+                platform="slack",
+                supports_draft_streaming=True,
+                supported_ops=("send", "draft"),
+            ),
+            transport=_CaptureTransport(),
+        )
+        assert a.supports_draft_streaming() is False

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -143,6 +143,16 @@ class TestSendStampsUnfurl:
         await a.send("chan-1", "see https://example.com")
         assert "unfurl_links" not in a._transport.sent["metadata"]
 
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_descriptor_platform(self):
+        """No inbound frame yet (e.g. gateway restart): _platform_by_chat is
+        empty, so the platform must resolve from the negotiated descriptor —
+        the same fallback the streaming gate and delivery resolver use."""
+        a = _slack_adapter({"slack": {"unfurl_links": False}})
+        assert not a._platform_by_chat
+        await a.send("chan-1", "see https://example.com")
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+
 
 class TestSendForPlatformStampsUnfurl:
     @pytest.mark.asyncio

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -1,0 +1,157 @@
+"""Relay-side Slack unfurl suppression: gateway-directed metadata stamping.
+
+The gateway resolves ``platforms.relay.extra.slack.unfurl_links`` /
+``unfurl_media`` and stamps them onto the outbound frame metadata; the
+connector just forwards whatever the gateway resolved (no connector config).
+Contract under test:
+- Slack chats: explicit booleans are stamped; omitted keys are absent.
+- Non-Slack chats: never stamped (metadata not polluted cross-platform).
+- Non-boolean values (hostile/hand-edited config) are dropped.
+- The scheduled/cron lane (send_for_platform) stamps too.
+"""
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+
+
+def make_desc(**kw) -> CapabilityDescriptor:
+    base = dict(
+        contract_version=CONTRACT_VERSION,
+        platform="slack",
+        label="Slack",
+        max_message_length=39000,
+        supports_draft_streaming=False,
+        supports_edit=True,
+        supports_threads=True,
+        markdown_dialect="slack",
+        len_unit="char",
+        emoji="\U0001f4bc",
+        platform_hint="",
+        pii_safe=False,
+    )
+    base.update(kw)
+    return CapabilityDescriptor(**base)
+
+
+class _CaptureTransport:
+    def __init__(self):
+        self.sent = None
+        self.sent_platform = None
+        # Advertise a slack identity so fronts_platform() passes for the
+        # send_for_platform (cron) lane.
+        self._identities = [("slack", None)]
+
+    def set_inbound_handler(self, h):  # noqa: D401
+        self._h = h
+
+    async def send_outbound(self, action, *, platform=None):
+        self.sent = action
+        self.sent_platform = platform
+        return {"success": True, "message_id": "m1"}
+
+
+def _slack_adapter(extra):
+    a = RelayAdapter(
+        PlatformConfig(extra=extra), make_desc(platform="slack"), transport=_CaptureTransport()
+    )
+    return a
+
+
+def _mark_slack_chat(a, chat_id="chan-1"):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    src = SessionSource(
+        platform=Platform.SLACK, chat_id=chat_id, chat_type="channel", scope_id="w-1"
+    )
+    ev = MessageEvent(text="hi", source=src, message_type=MessageType.TEXT)
+    a._capture_scope(ev)
+
+
+class TestUnfurlHints:
+    def test_non_slack_returns_none(self):
+        a = _slack_adapter({"slack": {"unfurl_links": False}})
+        assert a._slack_unfurl_hints("discord") is None
+        assert a._slack_unfurl_hints(None) is None
+
+    def test_slack_explicit_bools_returned(self):
+        a = _slack_adapter({"slack": {"unfurl_links": False, "unfurl_media": False}})
+        assert a._slack_unfurl_hints("slack") == {
+            "unfurl_links": False,
+            "unfurl_media": False,
+        }
+
+    def test_omitted_keys_return_none(self):
+        a = _slack_adapter({"slack": {}})
+        assert a._slack_unfurl_hints("slack") is None
+
+    def test_non_bool_values_dropped(self):
+        a = _slack_adapter({"slack": {"unfurl_links": "false", "unfurl_media": 0}})
+        assert a._slack_unfurl_hints("slack") is None
+
+    def test_flat_legacy_key_fallback(self):
+        # _relay_slack_extra falls back to the flat extra when no "slack"
+        # object exists (legacy staging configs).
+        a = _slack_adapter({"unfurl_links": False})
+        assert a._slack_unfurl_hints("slack") == {"unfurl_links": False}
+
+
+class TestSendStampsUnfurl:
+    @pytest.mark.asyncio
+    async def test_send_stamps_explicit_bools(self):
+        a = _slack_adapter({"slack": {"unfurl_links": False, "unfurl_media": False}})
+        _mark_slack_chat(a)
+        await a.send("chan-1", "see https://example.com")
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+        assert a._transport.sent["metadata"]["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_omits_when_unconfigured(self):
+        a = _slack_adapter({"slack": {}})
+        _mark_slack_chat(a)
+        await a.send("chan-1", "plain text")
+        assert "unfurl_links" not in a._transport.sent["metadata"]
+        assert "unfurl_media" not in a._transport.sent["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_non_slack_chat_never_stamped(self):
+        a = _slack_adapter({"slack": {"unfurl_links": False}})
+        # A chat mapped to discord, not slack, must not carry the hint.
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        src = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan-1",
+            chat_type="channel",
+            scope_id="w-1",
+        )
+        a._capture_scope(
+            MessageEvent(text="hi", source=src, message_type=MessageType.TEXT)
+        )
+        await a.send("chan-1", "see https://example.com")
+        assert "unfurl_links" not in a._transport.sent["metadata"]
+
+
+class TestSendForPlatformStampsUnfurl:
+    @pytest.mark.asyncio
+    async def test_cron_lane_stamps_explicit_bools(self):
+        a = _slack_adapter({"slack": {"unfurl_links": False, "unfurl_media": False}})
+        from gateway.config import Platform as P
+
+        res = await a.send_for_platform(P.SLACK, "C123", "brief https://x.dev")
+        assert res.success is True
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+        assert a._transport.sent["metadata"]["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_cron_lane_omits_when_unconfigured(self):
+        a = _slack_adapter({"slack": {}})
+        from gateway.config import Platform as P
+
+        await a.send_for_platform(P.SLACK, "C123", "brief")
+        assert "unfurl_links" not in a._transport.sent["metadata"]
+        assert "unfurl_media" not in a._transport.sent["metadata"]

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -154,6 +154,50 @@ class TestSendStampsUnfurl:
         assert a._transport.sent["metadata"]["unfurl_links"] is False
 
 
+class TestMediaLaneStampsUnfurl:
+    """The send_media lane egresses through the connector's Slack sender too,
+    so it must stamp the same unfurl hints as the text lane."""
+
+    def _media_adapter(self, extra):
+        a = RelayAdapter(
+            PlatformConfig(extra=extra),
+            make_desc(platform="slack", supported_ops=("send", "send_media")),
+            transport=_CaptureTransport(),
+        )
+        return a
+
+    @pytest.mark.asyncio
+    async def test_media_lane_stamps_explicit_bools(self):
+        a = self._media_adapter({"slack": {"unfurl_links": False, "unfurl_media": False}})
+        _mark_slack_chat(a)
+        res = await a.send_image("chan-1", "https://img.example/x.png", caption="cap")
+        assert res.success is True
+        assert a._transport.sent["op"] == "send_media"
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+        assert a._transport.sent["metadata"]["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_media_lane_falls_back_to_descriptor_platform(self):
+        """Regression: _send_media resolved platform only from
+        _platform_by_chat; after a gateway restart a proactive media send to a
+        Slack chat missed the stamp. Must fall back to descriptor.platform."""
+        a = self._media_adapter({"slack": {"unfurl_links": False}})
+        assert not a._platform_by_chat
+        res = await a.send_image("chan-1", "https://img.example/x.png")
+        assert res.success is True
+        assert a._transport.sent["op"] == "send_media"
+        assert a._transport.sent["metadata"]["unfurl_links"] is False
+
+    @pytest.mark.asyncio
+    async def test_media_lane_omits_when_unconfigured(self):
+        a = self._media_adapter({"slack": {}})
+        _mark_slack_chat(a)
+        await a.send_image("chan-1", "https://img.example/x.png")
+        assert a._transport.sent["op"] == "send_media"
+        assert "unfurl_links" not in a._transport.sent["metadata"]
+        assert "unfurl_media" not in a._transport.sent["metadata"]
+
+
 class TestSendForPlatformStampsUnfurl:
     @pytest.mark.asyncio
     async def test_cron_lane_stamps_explicit_bools(self):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1092,6 +1092,30 @@ class TestStandaloneSendUserDmResolution:
         assert session.post.call_count == 1
         assert "chat.postMessage" in session.post.call_args.args[0]
 
+    @pytest.mark.asyncio
+    async def test_channel_delivery_honors_unfurl_config(self):
+        _slack_mod._slack_dm_cache.clear()
+        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
+        session = self._mock_session(post_resp)
+        config = PlatformConfig(
+            enabled=True,
+            token="«redacted:xox…»",
+            extra={"unfurl_links": False, "unfurl_media": False},
+        )
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(
+                config,
+                "C123",
+                "[Hermes](https://example.com/hermes)",
+            )
+
+        assert result["success"] is True
+        payload = session.post.call_args.kwargs["json"]
+        assert payload["text"] == "<https://example.com/hermes|Hermes>"
+        assert payload["unfurl_links"] is False
+        assert payload["unfurl_media"] is False
+
 
     @pytest.mark.asyncio
     async def test_user_id_media_delivery_resolves_dm_before_upload(self, tmp_path):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3228,6 +3228,36 @@ class TestMessageSplitting:
         assert "unfurl_media" not in kwargs
 
     @pytest.mark.asyncio
+    async def test_send_coerces_string_unfurl_options(self, adapter):
+        """`hermes config set` / Railway persist YAML booleans as strings.
+
+        Relay-plane parity: string "false"/"true" must coerce instead of
+        being silently dropped (which would leave previews on with no error).
+        """
+        adapter.config.extra["unfurl_links"] = "false"
+        adapter.config.extra["unfurl_media"] = "true"
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com")
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["unfurl_links"] is False
+        assert kwargs["unfurl_media"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_drops_junk_unfurl_values(self, adapter):
+        """Unrecognized values keep Slack's default rather than suppressing."""
+        adapter.config.extra["unfurl_links"] = "maybe"
+        adapter.config.extra["unfurl_media"] = 0
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com")
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "unfurl_links" not in kwargs
+        assert "unfurl_media" not in kwargs
+
+    @pytest.mark.asyncio
     async def test_send_passes_unfurl_options_to_every_chunk(self, adapter):
         adapter.config.extra["unfurl_links"] = False
         adapter.config.extra["unfurl_media"] = False
@@ -3239,18 +3269,6 @@ class TestMessageSplitting:
         for call in adapter._app.client.chat_postMessage.call_args_list:
             assert call.kwargs["unfurl_links"] is False
             assert call.kwargs["unfurl_media"] is False
-
-    @pytest.mark.asyncio
-    async def test_send_ignores_non_boolean_unfurl_options(self, adapter):
-        adapter.config.extra["unfurl_links"] = "false"
-        adapter.config.extra["unfurl_media"] = 0
-        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
-
-        await adapter.send("C123", "https://example.com")
-
-        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
-        assert "unfurl_links" not in kwargs
-        assert "unfurl_media" not in kwargs
 
     @pytest.mark.asyncio
     async def test_send_does_not_double_escape_entities(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3206,6 +3206,53 @@ class TestMessageSplitting:
 
 
     @pytest.mark.asyncio
+    async def test_send_passes_explicit_unfurl_options(self, adapter):
+        adapter.config.extra["unfurl_links"] = False
+        adapter.config.extra["unfurl_media"] = False
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com")
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["unfurl_links"] is False
+        assert kwargs["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_default_unfurl_behavior(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com")
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "unfurl_links" not in kwargs
+        assert "unfurl_media" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_passes_unfurl_options_to_every_chunk(self, adapter):
+        adapter.config.extra["unfurl_links"] = False
+        adapter.config.extra["unfurl_media"] = False
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com/" + "x" * 45000)
+
+        assert adapter._app.client.chat_postMessage.call_count >= 2
+        for call in adapter._app.client.chat_postMessage.call_args_list:
+            assert call.kwargs["unfurl_links"] is False
+            assert call.kwargs["unfurl_media"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_ignores_non_boolean_unfurl_options(self, adapter):
+        adapter.config.extra["unfurl_links"] = "false"
+        adapter.config.extra["unfurl_media"] = 0
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send("C123", "https://example.com")
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "unfurl_links" not in kwargs
+        assert "unfurl_media" not in kwargs
+
+    @pytest.mark.asyncio
     async def test_send_does_not_double_escape_entities(self, adapter):
         """Pre-escaped &amp; in sent messages must not become &amp;amp;."""
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -66,6 +66,20 @@ class TestSendMessageBlocks:
         assert "blocks" not in kwargs
         assert kwargs["text"]  # plain text still sent
 
+    @pytest.mark.asyncio
+    async def test_unfurl_config_suppresses_previews_without_changing_link_text(self):
+        adapter, client = _make_adapter(
+            {"unfurl_links": False, "unfurl_media": False}
+        )
+        content = "[Hermes](https://example.com/hermes)"
+
+        await adapter.send("C1", content)
+
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert kwargs["text"] == "<https://example.com/hermes|Hermes>"
+        assert kwargs["unfurl_links"] is False
+        assert kwargs["unfurl_media"] is False
+
 
     @pytest.mark.asyncio
     async def test_enabled_but_unrenderable_falls_back_to_text(self):

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -1,8 +1,9 @@
 """Tests: SlackAdapter native streaming (chat.startStream/appendStream/stopStream).
 
 Behaviour contract:
-  * supports_draft_streaming: True when connected, False after a cached
-    feature-gate failure or when disconnected.
+  * supports_draft_streaming: True when connected with default unfurl behavior;
+    False after a cached feature-gate failure, when disconnected, or when an
+    explicit unfurl control requires the chat.postMessage fallback.
   * send_draft first frame: chat_startStream with thread_ts + initial text;
     returns the stream ts as message_id.
   * send_draft subsequent frames: chat_appendStream with only the delta;
@@ -48,6 +49,22 @@ class TestSupportsDraftStreaming:
     def test_supported_when_connected(self):
         adapter, _ = _make_adapter()
         assert adapter.supports_draft_streaming(chat_type="dm") is True
+
+    @pytest.mark.parametrize(
+        ("unfurl_key", "configured_value"),
+        [
+            ("unfurl_links", False),
+            ("unfurl_links", True),
+            ("unfurl_media", False),
+            ("unfurl_media", True),
+        ],
+    )
+    def test_explicit_unfurl_control_disables_native_streaming(
+        self, unfurl_key, configured_value
+    ):
+        adapter, _ = _make_adapter({unfurl_key: configured_value})
+
+        assert adapter.supports_draft_streaming(chat_type="dm") is False
 
     def test_unsupported_when_disconnected(self):
         adapter, _ = _make_adapter()

--- a/tests/gateway/test_slack_sdk_response.py
+++ b/tests/gateway/test_slack_sdk_response.py
@@ -223,7 +223,7 @@ class TestSendPaths:
     def test_upload_returns_the_message_id(self, make_response, tmp_path):
         """A lost message_id breaks threading of follow-up sends."""
         media = tmp_path / "note.txt"
-        media.write_text("x")
+        media.write_text("x", encoding="utf-8")
         client = MagicMock()
         client.files_upload_v2 = AsyncMock(
             return_value=make_response(
@@ -242,7 +242,7 @@ class TestSendPaths:
     @response_shape
     def test_upload_error_is_surfaced(self, make_response, tmp_path):
         media = tmp_path / "note.txt"
-        media.write_text("x")
+        media.write_text("x", encoding="utf-8")
         client = MagicMock()
         client.files_upload_v2 = AsyncMock(
             return_value=make_response({"ok": False, "error": "not_in_channel"})
@@ -355,6 +355,41 @@ class TestStandaloneSendMediaPath:
             )
         assert "channel_not_found" in result["error"]
         client.files_upload_v2.assert_not_awaited()
+
+    @response_shape
+    def test_caption_with_unfurl_controls_posts_text_separately(
+        self, make_response, tmp_path
+    ):
+        """Upload comments cannot carry unfurl flags, so configured text is separate."""
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 x")
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value=make_response({"ok": True, "ts": "111.222"})
+        )
+        client.files_upload_v2 = AsyncMock(
+            return_value=make_response({"ok": True, "file": {}})
+        )
+        with _fake_slack_sdk(client):
+            result = asyncio.run(
+                _standalone_send(
+                    SimpleNamespace(
+                        token="xoxb-test",
+                        extra={"unfurl_links": False, "unfurl_media": False},
+                    ),
+                    "C_GEN",
+                    "",
+                    media_files=[(str(media), False)],
+                    caption="[Report](https://example.com/report)",
+                )
+            )
+
+        assert result["success"] is True
+        post_kwargs = client.chat_postMessage.await_args.kwargs
+        assert post_kwargs["text"] == "<https://example.com/report|Report>"
+        assert post_kwargs["unfurl_links"] is False
+        assert post_kwargs["unfurl_media"] is False
+        assert client.files_upload_v2.await_args.kwargs["initial_comment"] == ""
 
     @response_shape
     def test_caption_fallback_delivers_when_media_is_missing(

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -410,6 +410,12 @@ platforms:
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
 
+      # Control Slack's automatic link-preview cards without changing or
+      # removing clickable links from message text. Omit either key to keep
+      # Slack's default behavior for that preview type.
+      unfurl_links: false
+      unfurl_media: false
+
       # Render agent messages as Slack Block Kit blocks (default: false).
       # When true, the final agent message is sent with structured blocks —
       # section headers, dividers, true nested lists (via rich_text), and
@@ -458,6 +464,8 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
+| `platforms.slack.extra.unfurl_links` | Slack default | Set to `false` to suppress automatic previews for linked web pages while preserving clickable links. |
+| `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. This is an explicit progress opt-in independent of Slack's default `tool_progress: off`; native API failures fall back to one continuously edited text update. |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -464,8 +464,8 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
-| `platforms.slack.extra.unfurl_links` | Slack default | Set to `false` to suppress automatic previews for linked web pages while preserving clickable links. |
-| `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. |
+| `platforms.slack.extra.unfurl_links` | Slack default | Set to `false` to suppress automatic previews for linked web pages while preserving clickable links. When either unfurl key is set, media captions are posted as a separate message *before* the file (Slack's upload API cannot carry unfurl controls), and native draft streaming falls back to edit-based delivery. |
+| `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. Same caption-ordering and streaming notes as `unfurl_links`. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. This is an explicit progress opt-in independent of Slack's default `tool_progress: off`; native API failures fall back to one continuously edited text update. |


### PR DESCRIPTION
## Summary

Adds configurable outbound link-preview suppression for Slack across both delivery planes.

The native adapter already has open PR #81128 (will-lynas) implementing this for standalone Hermes. This PR salvages those commits (authorship preserved: potatosalad + will-lynas) and adds the relay-plane half, so Team Gateway deployments get the same control.

## Change

**Native adapter** (`platforms.slack.extra.unfurl_links` / `unfurl_media`) — salvaged from #81128:
- `_slack_unfurl_kwargs` helper: only explicit booleans are sent; omitted keys preserve Slack's default unfurling.
- Applied to send chunks, standalone text, and the media caption path (upload API can't carry unfurl flags, so configured captions fall back to a separate text post).
- `supports_draft_streaming()` returns `False` when unfurl controls are configured (Slack's `chat.*Stream` API has no unfurl controls).

**Relay plane** (`platforms.relay.extra.slack.unfurl_links` / `unfurl_media`) — new:
- `RelayAdapter._slack_unfurl_hints` resolves explicit booleans from the relay namespace (mirroring `reply_in_thread`'s `_relay_slack_extra` seam) and stamps them onto outbound frame metadata.
- Stamped on `send`, `send_for_platform` (scheduled/cron), and `send_media` lanes, gated to Slack-fronted chats only.
- The connector has no config of its own for this; it forwards whatever the gateway resolved.

Config keys are symmetric: same leaf keys (`unfurl_links`/`unfurl_media`) under the native `platforms.slack.extra` and relay `platforms.relay.extra.slack` namespaces.

## Verification

- `scripts/run_tests.sh tests/gateway/relay/ tests/gateway/test_slack*.py` — 44 files, 483 tests passed, 0 failed.
- New relay tests (10) cover: Slack vs non-Slack gating, explicit-bool stamping, omitted-key absence, non-boolean drop, legacy flat-key fallback, and the cron lane.
- Mutation check: stubbing `_slack_unfurl_hints` to pass-through turns 4 stamping tests red; restore green.

## Companion PR

gateway-gateway: connector reads `action.metadata.unfurl_links/unfurl_media` and forwards to `chat.postMessage` (no connector config).
