### PR TITLE
fix(backup): exclude root browser-automation runtime

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -344,6 +344,25 @@ def _should_exclude(rel_path: Path) -> bool:
     return False
 
 
+def _prune_excluded_dirs(dirnames: List[str], rel_dir: Path) -> set[str]:
+    """Prune an ``os.walk`` directory list using root-aware exclusions.
+
+    ``rel_dir`` is relative to HERMES_HOME.  Runtime/code directories in
+    ``_ROOT_ONLY_EXCLUDED_DIRS`` are excluded only as direct children of the
+    root so identically named nested user content remains backup-eligible.
+    Returns the names removed from ``dirnames``.
+    """
+    is_root = rel_dir == Path(".")
+    original = set(dirnames)
+    dirnames[:] = [
+        name
+        for name in dirnames
+        if name not in _EXCLUDED_DIRS
+        or (name in _ROOT_ONLY_EXCLUDED_DIRS and not is_root)
+    ]
+    return original - set(dirnames)
+
+
 def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
     """Return True when a candidate file should not be written to a backup zip."""
     if _should_exclude(rel_path):
@@ -830,13 +849,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         # Prune excluded directories in-place so os.walk doesn't descend
         # Root runtime/code directories are pruned only at root; nested user
         # content with the same names must be preserved.
-        is_root = rel_dir == Path(".")
-        orig_dirnames = dirnames[:]
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d in _ROOT_ONLY_EXCLUDED_DIRS and not is_root)
-        ]
-        for removed in set(orig_dirnames) - set(dirnames):
+        for removed in _prune_excluded_dirs(dirnames, rel_dir):
             skipped_dirs.add(str(rel_dir / removed))
 
         for fname in filenames:
@@ -2095,7 +2108,8 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            rel_dir = dp.relative_to(hermes_root)
+            _prune_excluded_dirs(dirnames, rel_dir)
 
             for fname in filenames:
                 fpath = dp / fname

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -49,10 +49,9 @@ logger = logging.getLogger(__name__)
 # here because the exclusion set needs it.
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 
-# Directory names to skip entirely (matched against each path component)
-# ``hermes-agent`` is special-cased to root level only in ``_should_exclude``
-# so that skill directories like ``skills/autonomous-ai-agents/hermes-agent/``
-# are not accidentally excluded.
+# Directory names to skip entirely (matched against each path component).
+# ``hermes-agent`` and ``browser-automation`` are special-cased to root level
+# only so nested user content with those names is preserved.
 #
 # The dependency/cache entries below matter for more than tidiness: without
 # them a single plugin venv, MCP-server install, or pip/uv cache living under
@@ -67,6 +66,7 @@ _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 # restorable user skills that must survive a backup.
 _EXCLUDED_DIRS = {
     "hermes-agent",     # the codebase repo — re-clone instead
+    "browser-automation",  # downloaded Chrome + live profile runtime — regenerate instead
     "__pycache__",      # bytecode caches — regenerated on import
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps — reinstalled on demand
@@ -95,6 +95,7 @@ _EXCLUDED_DIRS = {
     ".mypy_cache",
     ".ruff_cache",
 }
+_ROOT_ONLY_EXCLUDED_DIRS = {"hermes-agent", "browser-automation"}
 
 # File-name suffixes to skip
 _EXCLUDED_SUFFIXES = (
@@ -327,10 +328,8 @@ def _should_exclude(rel_path: Path) -> bool:
     for part in parts:
         if part not in _EXCLUDED_DIRS:
             continue
-        # ``hermes-agent`` only matches at the root level (first component).
-        # Nested directories with the same name — e.g.
-        # ``skills/autonomous-ai-agents/hermes-agent/`` — must be preserved.
-        if part == "hermes-agent" and part != parts[0]:
+        # Root runtime/code directories only match the first component.
+        if part in _ROOT_ONLY_EXCLUDED_DIRS and part != parts[0]:
             continue
         return True
 
@@ -829,13 +828,13 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         rel_dir = dp.relative_to(hermes_root)
 
         # Prune excluded directories in-place so os.walk doesn't descend
-        # ``hermes-agent`` is only pruned at the root level; nested dirs
-        # with the same name (e.g. in skills/) must be preserved.
+        # Root runtime/code directories are pruned only at root; nested user
+        # content with the same names must be preserved.
         is_root = rel_dir == Path(".")
         orig_dirnames = dirnames[:]
         dirnames[:] = [
             d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
+            if d not in _EXCLUDED_DIRS or (d in _ROOT_ONLY_EXCLUDED_DIRS and not is_root)
         ]
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -194,6 +194,30 @@ class TestBackup:
         assert "skills/example/browser-automation/README.md" in names
 
 
+    @pytest.mark.parametrize("factory_name", ["create_pre_update_backup", "create_pre_migration_backup"])
+    def test_automatic_full_zip_prunes_root_browser_automation_but_keeps_nested_user_content(
+        self, tmp_path, factory_name
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        runtime = hermes_home / "browser-automation/chrome-profile"
+        runtime.mkdir(parents=True)
+        (runtime / "first_party_sets.db").write_bytes(b"locked runtime")
+        nested = hermes_home / "skills/example/browser-automation"
+        nested.mkdir(parents=True)
+        (nested / "README.md").write_text("user content\n")
+
+        import hermes_cli.backup as backup_mod
+
+        out_zip = getattr(backup_mod, factory_name)(hermes_home=hermes_home, keep=2)
+
+        assert out_zip is not None
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(name.startswith("browser-automation/") for name in names)
+        assert "skills/example/browser-automation/README.md" in names
+
     def test_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):
         """SQLite staging temp files must be created on the output zip's
         filesystem (dir=out_path.parent), NOT the system /tmp default — a

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -127,6 +127,12 @@ class TestShouldExclude:
         assert _should_exclude(Path("hermes-agent/run_agent.py"))
         assert _should_exclude(Path("hermes-agent/.git/HEAD"))
 
+    def test_excludes_only_root_browser_automation_runtime(self):
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("browser-automation/chrome-profile/first_party_sets.db"))
+        assert _should_exclude(Path("browser-automation/chrome-mac-arm64/Chrome"))
+        assert not _should_exclude(Path("skills/example/browser-automation/README.md"))
+
 
     def test_excludes_backups_dir(self):
         """backups/ is excluded so pre-update backups don't nest exponentially."""
@@ -164,6 +170,28 @@ class TestShouldExclude:
 # ---------------------------------------------------------------------------
 
 class TestBackup:
+
+    def test_backup_prunes_root_browser_automation_but_keeps_nested_user_content(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        runtime = hermes_home / "browser-automation/chrome-profile"
+        runtime.mkdir(parents=True)
+        (runtime / "first_party_sets.db").write_bytes(b"locked runtime")
+        nested = hermes_home / "skills/example/browser-automation"
+        nested.mkdir(parents=True)
+        (nested / "README.md").write_text("user content\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out_zip = tmp_path / "backup.zip"
+
+        from hermes_cli.backup import run_backup
+        run_backup(Namespace(output=str(out_zip)))
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert not any(name.startswith("browser-automation/") for name in names)
+        assert "skills/example/browser-automation/README.md" in names
 
 
     def test_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):


### PR DESCRIPTION
### Summary

- exclude the root `HERMES_HOME/browser-automation` runtime from full backups;
- preserve nested user content whose directory happens to be named `browser-automation`;
- use one shared root-only exclusion set in both path classification and `os.walk` pruning.

### Problem

The Browser Use harness stores downloaded Chrome binaries and its live Chromium profile under `HERMES_HOME/browser-automation`. Full `hermes backup` currently descends into that regeneratable runtime because the existing `browser-profiles` exclusion does not cover this path.

The runtime is large and contains live Chromium SQLite/cache files. Walking and snapshotting it can make full backups extremely slow or hang on locked databases. It should be regenerated rather than restored.

The exclusion must be root-only: user-authored nested content such as `skills/example/browser-automation/README.md` still belongs in the backup.

### Verification

- RED before implementation: root path classification failed while the ZIP-membership fixture exposed the path distinction.
- Focused regression: 2/2 passed.
- Full `tests/hermes_cli/test_backup.py`: 58/58 passed.
- `git diff --check`: passed.
- Independent pre-commit review: PASS; no security or logic findings.

### Scope

Two files only:

- `hermes_cli/backup.py`
- `tests/hermes_cli/test_backup.py`

No provider, network, credential, telemetry, browser runtime or unrelated backup behaviour changes.