### PR TITLE
fix(mcp): correct inverted liveness check in _stdio_children_dead (#94335)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,7 +2994,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## Summary

Fixes #94335.

`_stdio_children_dead()` had an inverted return value: it returned `True` ("all children dead") when finding an ALIVE child process, and the correct `return False` was unreachable dead code.

## Root Cause

```python
# BEFORE (broken):
if not psutil.pid_exists(pid):
    continue  # this one is dead
return True  # alive ← WRONG: returns "all dead" when child is alive
return False  # at least one child alive ← UNREACHABLE
return True
```

## Fix

```python
# AFTER (correct):
if not psutil.pid_exists(pid):
    continue  # this one is dead
return False  # at least one child alive
return True
```

## Impact

- Every stdio MCP tool call in oneshot (`hermes -z`) mode was failing with `TimeoutError: MCP stdio subprocess ... has exited`, even though the subprocess was alive.
- Long-lived gateway sessions were unaffected only when `_stdio_child_pids` was empty.

## Changes

- `tools/mcp_tool.py`: Remove the erroneous `return True` line, making `return False` (at least one child alive) the correct early exit.

## Testing

- Verified syntax with `python3 -m py_compile tools/mcp_tool.py`
- The fix is a single-line deletion — minimal risk of regression
