### PR TITLE
fix(mcp): treat empty cacheScope as omitted to prevent discovery failure (#94992)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -975,7 +975,7 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
             _scope = mcp_field(result, "cache_scope", "cacheScope")
             if _ttl is not None:
                 cache_meta_out["ttl_ms"] = _ttl
-            if _scope is not None:
+            if _scope is not None and _scope != "":
                 cache_meta_out["cache_scope"] = _scope
         items.extend(getattr(result, items_attr, None) or [])
         cursor = mcp_field(result, "next_cursor", "nextCursor")


### PR DESCRIPTION
## Summary

Fixes #94992.

An MCP server returning `"cacheScope": ""` (empty string) causes the Python MCP SDK to reject the response with a `literal_error` validation error, making all tools from that server unavailable. The MCP spec only permits `"public"` or `"private"`; omission is safe (SDK defaults to private).

## Root Cause

```python
# BEFORE: empty string passes the None check
_scope = mcp_field(result, "cache_scope", "cacheScope")
if _scope is not None:
    cache_meta_out["cache_scope"] = _scope  # stores "" → SDK rejects later
```

## Fix

```python
# AFTER: empty string treated as omitted
_scope = mcp_field(result, "cache_scope", "cacheScope")
if _scope is not None and _scope != "":
    cache_meta_out["cache_scope"] = _scope
```

## Impact

- Reproducible with Upwork's official MCP endpoint (`https://mcp.upwork.com/mcp`) after OAuth
- Any MCP server returning `cacheScope: ""` would have all its tools silently disabled

## Changes

- `tools/mcp_tool.py`: Add empty-string guard for `cacheScope` before storing in cache metadata.

## Testing

- Verified syntax with `python3 -m py_compile tools/mcp_tool.py`
- The fix is a single condition addition — minimal risk
