### PR TITLE
fix(tools): treat around_message_id=0 as unset in session_search (#94792)

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -990,7 +990,7 @@ def _session_search_impl(
             current_session_id = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
-    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None and around_message_id != 0:
         return _scroll(
             db=db,
             session_id=session_id,


### PR DESCRIPTION
## Summary

Fixes #94792.

`session_search` treated `around_message_id=0` as a valid scroll anchor because the guard used `is not None`. Many models emit complete argument objects filling every optional field with its zero value, causing `around_message_id: 0` to force scroll mode and hard-fail.

## Root Cause

```python
# BEFORE: 0 passes the None check
if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
    return _scroll(...)  # around_message_id=0 → scroll to nonexistent message → error
```

## Fix

```python
# AFTER: 0 is treated as unset, same as None
if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None and around_message_id != 0:
    return _scroll(...)
```

This matches how other optional fields (`query`, `profile`, `role_filter`) already tolerate empty/zero values.

## Changes

- `tools/session_search_tool.py`: Add `and around_message_id != 0` guard to the scroll-mode condition.

## Testing

- Verified syntax with `python3 -m py_compile tools/session_search_tool.py`
- The fix is a single condition addition — minimal risk
