### PR TITLE
feat(voice): add realtime provider session contract

### DIFF
--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+from uuid import UUID, uuid4
 
 
 class RealtimeEventType(str, Enum):
@@ -43,6 +44,7 @@ class RealtimeEvent:
     tool_name: str | None = None
     item_id: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
+    emission_id: UUID = field(default_factory=uuid4, compare=False, repr=False)
 
     @classmethod
     def audio(cls, pcm: bytes, *, item_id: str | None = None) -> "RealtimeEvent":

--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -12,7 +12,6 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
-from uuid import UUID, uuid4
 
 
 class RealtimeEventType(str, Enum):
@@ -45,7 +44,6 @@ class RealtimeEvent:
     item_id: str | None = None
     role: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
-    emission_id: UUID = field(default_factory=uuid4, compare=False, repr=False)
 
     @classmethod
     def audio(cls, pcm: bytes, *, item_id: str | None = None) -> "RealtimeEvent":

--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -43,6 +43,7 @@ class RealtimeEvent:
     call_id: str | None = None
     tool_name: str | None = None
     item_id: str | None = None
+    role: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
     emission_id: UUID = field(default_factory=uuid4, compare=False, repr=False)
 
@@ -51,8 +52,15 @@ class RealtimeEvent:
         return cls(type=RealtimeEventType.AUDIO, audio_bytes=pcm, item_id=item_id)
 
     @classmethod
-    def transcript(cls, text: str, *, final: bool = False) -> "RealtimeEvent":
-        return cls(type=RealtimeEventType.TRANSCRIPT, text=text, final=final)
+    def transcript(
+        cls, text: str, *, final: bool = False, role: str | None = None
+    ) -> "RealtimeEvent":
+        return cls(
+            type=RealtimeEventType.TRANSCRIPT,
+            text=text,
+            final=final,
+            role=role,
+        )
 
     @classmethod
     def tool_call(
@@ -80,6 +88,11 @@ class RealtimeSession(abc.ABC):
     @abc.abstractmethod
     async def submit_tool_result(self, call_id: str, output: str) -> None:
         """Return a Hermes-dispatched tool result to the voice model."""
+
+    async def add_context(self, item_id: str, text: str) -> None:
+        """Append silent system context while a Hermes tool call is in flight."""
+
+        raise NotImplementedError("realtime provider does not support context updates")
 
     async def truncate_response(self, boundary: HeardAudioBoundary) -> None:
         """Truncate provider history to heard audio when supported."""

--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -1,0 +1,108 @@
+"""Provider-neutral contracts for persistent, bidirectional voice sessions.
+
+Realtime providers own audio transport and turn-taking. Hermes remains the
+owner of tools, approvals, conversation history, and memory; provider tool
+calls are events that a host-side coordinator dispatches through Hermes.
+"""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class RealtimeEventType(str, Enum):
+    AUDIO = "audio"
+    TRANSCRIPT = "transcript"
+    TOOL_CALL = "tool_call"
+    TURN_STARTED = "turn_started"
+    TURN_ENDED = "turn_ended"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class RealtimeEvent:
+    """One ordered event emitted by a :class:`RealtimeSession`."""
+
+    type: RealtimeEventType
+    audio_bytes: bytes | None = None
+    text: str | None = None
+    final: bool = False
+    call_id: str | None = None
+    tool_name: str | None = None
+    arguments: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def audio(cls, pcm: bytes) -> "RealtimeEvent":
+        return cls(type=RealtimeEventType.AUDIO, audio_bytes=pcm)
+
+    @classmethod
+    def transcript(cls, text: str, *, final: bool = False) -> "RealtimeEvent":
+        return cls(type=RealtimeEventType.TRANSCRIPT, text=text, final=final)
+
+    @classmethod
+    def tool_call(
+        cls, call_id: str, name: str, arguments: dict[str, Any]
+    ) -> "RealtimeEvent":
+        return cls(
+            type=RealtimeEventType.TOOL_CALL,
+            call_id=call_id,
+            tool_name=name,
+            arguments=dict(arguments),
+        )
+
+
+class RealtimeSession(abc.ABC):
+    """An open provider transport; it never dispatches Hermes tools itself."""
+
+    @abc.abstractmethod
+    async def send_audio(self, pcm: bytes) -> None:
+        """Send a chunk of PCM input audio."""
+
+    @abc.abstractmethod
+    def events(self) -> AsyncIterator[RealtimeEvent]:
+        """Yield ordered audio, transcript, tool-call, and turn events."""
+
+    @abc.abstractmethod
+    async def submit_tool_result(self, call_id: str, output: str) -> None:
+        """Return a Hermes-dispatched tool result to the voice model."""
+
+    @abc.abstractmethod
+    async def cancel_response(self) -> None:
+        """Cancel current output for barge-in."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Release provider and audio resources. Must be idempotent."""
+
+
+class RealtimeVoiceProvider(abc.ABC):
+    """Factory for provider-specific realtime voice sessions."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Stable lowercase plugin identifier."""
+
+    @property
+    def display_name(self) -> str:
+        return self.name.title()
+
+    def is_available(self) -> bool:
+        return True
+
+    def get_setup_schema(self) -> dict[str, Any]:
+        return {"name": self.display_name, "badge": "", "tag": "", "env_vars": []}
+
+    @abc.abstractmethod
+    async def open_session(
+        self,
+        *,
+        instructions: str,
+        tools: list[dict[str, Any]],
+        voice: str | None = None,
+    ) -> RealtimeSession:
+        """Open a session using Hermes-supplied instructions and tool schemas."""

--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -24,6 +24,14 @@ class RealtimeEventType(str, Enum):
 
 
 @dataclass(frozen=True)
+class HeardAudioBoundary:
+    """Provider output position that the playback surface actually rendered."""
+
+    item_id: str
+    audio_end_ms: int
+
+
+@dataclass(frozen=True)
 class RealtimeEvent:
     """One ordered event emitted by a :class:`RealtimeSession`."""
 
@@ -33,11 +41,12 @@ class RealtimeEvent:
     final: bool = False
     call_id: str | None = None
     tool_name: str | None = None
+    item_id: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def audio(cls, pcm: bytes) -> "RealtimeEvent":
-        return cls(type=RealtimeEventType.AUDIO, audio_bytes=pcm)
+    def audio(cls, pcm: bytes, *, item_id: str | None = None) -> "RealtimeEvent":
+        return cls(type=RealtimeEventType.AUDIO, audio_bytes=pcm, item_id=item_id)
 
     @classmethod
     def transcript(cls, text: str, *, final: bool = False) -> "RealtimeEvent":
@@ -69,6 +78,9 @@ class RealtimeSession(abc.ABC):
     @abc.abstractmethod
     async def submit_tool_result(self, call_id: str, output: str) -> None:
         """Return a Hermes-dispatched tool result to the voice model."""
+
+    async def truncate_response(self, boundary: HeardAudioBoundary) -> None:
+        """Truncate provider history to heard audio when supported."""
 
     @abc.abstractmethod
     async def cancel_response(self) -> None:

--- a/agent/realtime_voice.py
+++ b/agent/realtime_voice.py
@@ -22,6 +22,9 @@ class RealtimeEventType(str, Enum):
     TURN_ENDED = "turn_ended"
     ERROR = "error"
 
+    SESSION_READY = "session_ready"
+    WARNING = "warning"
+
 
 @dataclass(frozen=True)
 class HeardAudioBoundary:
@@ -44,6 +47,7 @@ class RealtimeEvent:
     item_id: str | None = None
     role: str | None = None
     arguments: dict[str, Any] = field(default_factory=dict)
+    session_id: str | None = None
 
     @classmethod
     def audio(cls, pcm: bytes, *, item_id: str | None = None) -> "RealtimeEvent":

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 from agent.realtime_voice import (
+    HeardAudioBoundary,
     RealtimeEvent,
     RealtimeEventType,
     RealtimeSession,
@@ -25,6 +26,9 @@ class RealtimeVoiceCoordinator:
         self._provider = provider
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
+        self._current_item_id: str | None = None
+        self._current_audio_events: set[int] = set()
+        self._heard_boundary: HeardAudioBoundary | None = None
 
     async def open(
         self,
@@ -38,6 +42,7 @@ class RealtimeVoiceCoordinator:
         self._session = await self._provider.open_session(
             instructions=instructions, tools=tools, voice=voice
         )
+        self._reset_output_state()
 
     def _require_session(self) -> RealtimeSession:
         if self._session is None:
@@ -47,12 +52,39 @@ class RealtimeVoiceCoordinator:
     async def send_audio(self, pcm: bytes) -> None:
         await self._require_session().send_audio(pcm)
 
+    def report_audio_heard(self, event: RealtimeEvent, *, audio_end_ms: int) -> bool:
+        """Record playback progress only for audio emitted by this open epoch."""
+        if (
+            self._session is None
+            or event.type is not RealtimeEventType.AUDIO
+            or not event.item_id
+            or event.item_id != self._current_item_id
+            or id(event) not in self._current_audio_events
+            or audio_end_ms < 0
+        ):
+            return False
+        boundary = HeardAudioBoundary(event.item_id, audio_end_ms)
+        if self._heard_boundary and audio_end_ms < self._heard_boundary.audio_end_ms:
+            return False
+        self._heard_boundary = boundary
+        return True
+
     async def cancel_response(self) -> None:
-        await self._require_session().cancel_response()
+        session = self._require_session()
+        boundary, self._heard_boundary = self._heard_boundary, None
+        if boundary is not None:
+            await session.truncate_response(boundary)
+        await session.cancel_response()
 
     async def events(self) -> AsyncIterator[RealtimeEvent]:
         session = self._require_session()
         async for event in session.events():
+            if event.type is RealtimeEventType.AUDIO and event.item_id:
+                if event.item_id != self._current_item_id:
+                    self._current_item_id = event.item_id
+                    self._current_audio_events.clear()
+                    self._heard_boundary = None
+                self._current_audio_events.add(id(event))
             if event.type is RealtimeEventType.TOOL_CALL:
                 await self._dispatch(event, session)
             yield event
@@ -73,5 +105,11 @@ class RealtimeVoiceCoordinator:
 
     async def close(self) -> None:
         session, self._session = self._session, None
+        self._reset_output_state()
         if session is not None:
             await session.close()
+
+    def _reset_output_state(self) -> None:
+        self._current_item_id = None
+        self._current_audio_events.clear()
+        self._heard_boundary = None

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -7,7 +7,6 @@ import logging
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
-from uuid import UUID
 
 from agent.realtime_voice import (
     HeardAudioBoundary,
@@ -45,7 +44,7 @@ class RealtimeVoiceCoordinator:
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
         self._current_item_id: str | None = None
-        self._current_audio_events: dict[UUID, RealtimeEvent] = {}
+        self._current_audio_event: RealtimeEvent | None = None
         self._heard_boundary: HeardAudioBoundary | None = None
         self._max_in_flight_tool_calls = max_in_flight_tool_calls
         self._max_completed_tool_calls = max_completed_tool_calls
@@ -98,7 +97,7 @@ class RealtimeVoiceCoordinator:
             or event.type is not RealtimeEventType.AUDIO
             or not event.item_id
             or event.item_id != self._current_item_id
-            or self._current_audio_events.get(event.emission_id) is not event
+            or self._current_audio_event is not event
             or audio_end_ms < 0
         ):
             return False
@@ -142,8 +141,7 @@ class RealtimeVoiceCoordinator:
                     if event.item_id != self._current_item_id:
                         self._current_item_id = event.item_id
                         self._heard_boundary = None
-                    self._current_audio_events.clear()
-                    self._current_audio_events[event.emission_id] = event
+                    self._current_audio_event = event
                 if event.type is RealtimeEventType.TOOL_CALL:
                     self._start_tool_dispatch(event, session, generation)
                 if not self._is_current_session(session, generation):
@@ -296,5 +294,5 @@ class RealtimeVoiceCoordinator:
 
     def _reset_output_state(self) -> None:
         self._current_item_id = None
-        self._current_audio_events.clear()
+        self._current_audio_event = None
         self._heard_boundary = None

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -27,7 +27,7 @@ class RealtimeVoiceCoordinator:
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
         self._current_item_id: str | None = None
-        self._current_audio_events: set[int] = set()
+        self._current_audio_events: dict[int, RealtimeEvent] = {}
         self._heard_boundary: HeardAudioBoundary | None = None
 
     async def open(
@@ -59,7 +59,7 @@ class RealtimeVoiceCoordinator:
             or event.type is not RealtimeEventType.AUDIO
             or not event.item_id
             or event.item_id != self._current_item_id
-            or id(event) not in self._current_audio_events
+            or self._current_audio_events.get(id(event)) is not event
             or audio_end_ms < 0
         ):
             return False
@@ -84,7 +84,7 @@ class RealtimeVoiceCoordinator:
                     self._current_item_id = event.item_id
                     self._current_audio_events.clear()
                     self._heard_boundary = None
-                self._current_audio_events.add(id(event))
+                self._current_audio_events[id(event)] = event
             if event.type is RealtimeEventType.TOOL_CALL:
                 await self._dispatch(event, session)
             yield event

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
+from uuid import UUID
 
 from agent.realtime_voice import (
     HeardAudioBoundary,
@@ -15,6 +17,7 @@ from agent.realtime_voice import (
 )
 
 ToolDispatcher = Callable[[str, dict[str, Any]], str | Awaitable[str]]
+logger = logging.getLogger(__name__)
 
 
 class RealtimeVoiceCoordinator:
@@ -27,7 +30,7 @@ class RealtimeVoiceCoordinator:
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
         self._current_item_id: str | None = None
-        self._current_audio_events: dict[int, RealtimeEvent] = {}
+        self._current_audio_events: dict[UUID, RealtimeEvent] = {}
         self._heard_boundary: HeardAudioBoundary | None = None
 
     async def open(
@@ -59,7 +62,7 @@ class RealtimeVoiceCoordinator:
             or event.type is not RealtimeEventType.AUDIO
             or not event.item_id
             or event.item_id != self._current_item_id
-            or self._current_audio_events.get(id(event)) is not event
+            or self._current_audio_events.get(event.emission_id) is not event
             or audio_end_ms < 0
         ):
             return False
@@ -84,7 +87,7 @@ class RealtimeVoiceCoordinator:
                     self._current_item_id = event.item_id
                     self._current_audio_events.clear()
                     self._heard_boundary = None
-                self._current_audio_events[id(event)] = event
+                self._current_audio_events[event.emission_id] = event
             if event.type is RealtimeEventType.TOOL_CALL:
                 await self._dispatch(event, session)
             yield event
@@ -100,6 +103,11 @@ class RealtimeVoiceCoordinator:
                 result = await result
             output = str(result)
         except Exception as exc:
+            logger.warning(
+                "Realtime voice tool dispatch failed",
+                extra={"tool_name": event.tool_name, "call_id": event.call_id},
+                exc_info=True,
+            )
             output = f"Error: {exc}"
         await session.submit_tool_result(event.call_id, output)
 

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -1,6 +1,7 @@
 """Hermes-owned coordination for provider-neutral realtime voice sessions."""
 
 from __future__ import annotations
+import asyncio
 
 import inspect
 import logging
@@ -24,14 +25,24 @@ class RealtimeVoiceCoordinator:
     """Relay audio while dispatching every tool call through the Hermes host."""
 
     def __init__(
-        self, provider: RealtimeVoiceProvider, *, dispatch_tool: ToolDispatcher
+        self,
+        provider: RealtimeVoiceProvider,
+        *,
+        dispatch_tool: ToolDispatcher,
+        max_in_flight_tool_calls: int = 16,
     ) -> None:
+        if max_in_flight_tool_calls < 1:
+            raise ValueError("max_in_flight_tool_calls must be positive")
         self._provider = provider
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
         self._current_item_id: str | None = None
         self._current_audio_events: dict[UUID, RealtimeEvent] = {}
         self._heard_boundary: HeardAudioBoundary | None = None
+        self._max_in_flight_tool_calls = max_in_flight_tool_calls
+        self._tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
+        self._tool_results: dict[str, str] = {}
+        self._tool_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def open(
         self,
@@ -89,8 +100,41 @@ class RealtimeVoiceCoordinator:
                     self._heard_boundary = None
                 self._current_audio_events[event.emission_id] = event
             if event.type is RealtimeEventType.TOOL_CALL:
-                await self._dispatch(event, session)
+                await self._start_tool_dispatch(event, session)
             yield event
+        if self._tool_tasks:
+            await asyncio.gather(*tuple(self._tool_tasks.values()))
+
+    async def _start_tool_dispatch(
+        self, event: RealtimeEvent, session: RealtimeSession
+    ) -> None:
+        if not event.call_id or not event.tool_name:
+            raise ValueError("Realtime tool_call events require call_id and tool_name")
+        call = (event.tool_name, dict(event.arguments))
+        previous = self._tool_calls.get(event.call_id)
+        if previous is not None:
+            if previous != call:
+                raise ValueError(
+                    f"Realtime tool call {event.call_id!r} was reused with different arguments"
+                )
+            if event.call_id in self._tool_results:
+                await session.submit_tool_result(
+                    event.call_id, self._tool_results[event.call_id]
+                )
+            return
+        self._tool_calls[event.call_id] = call
+        if len(self._tool_tasks) >= self._max_in_flight_tool_calls:
+            output = "Error: too many realtime voice tool calls are already in flight"
+            self._tool_results[event.call_id] = output
+            await session.submit_tool_result(event.call_id, output)
+            return
+        task = asyncio.create_task(self._dispatch(event, session))
+        self._tool_tasks[event.call_id] = task
+        task.add_done_callback(
+            lambda completed, call_id=event.call_id: self._tool_tasks.pop(
+                call_id, None
+            )
+        )
 
     async def _dispatch(
         self, event: RealtimeEvent, session: RealtimeSession
@@ -109,10 +153,19 @@ class RealtimeVoiceCoordinator:
                 exc_info=True,
             )
             output = f"Error: {exc}"
+        self._tool_results[event.call_id] = output
         await session.submit_tool_result(event.call_id, output)
 
     async def close(self) -> None:
         session, self._session = self._session, None
+        tasks = tuple(self._tool_tasks.values())
+        self._tool_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tool_calls.clear()
+        self._tool_results.clear()
         self._reset_output_state()
         if session is not None:
             await session.close()

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -1,0 +1,77 @@
+"""Hermes-owned coordination for provider-neutral realtime voice sessions."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+from agent.realtime_voice import (
+    RealtimeEvent,
+    RealtimeEventType,
+    RealtimeSession,
+    RealtimeVoiceProvider,
+)
+
+ToolDispatcher = Callable[[str, dict[str, Any]], str | Awaitable[str]]
+
+
+class RealtimeVoiceCoordinator:
+    """Relay audio while dispatching every tool call through the Hermes host."""
+
+    def __init__(
+        self, provider: RealtimeVoiceProvider, *, dispatch_tool: ToolDispatcher
+    ) -> None:
+        self._provider = provider
+        self._dispatch_tool = dispatch_tool
+        self._session: RealtimeSession | None = None
+
+    async def open(
+        self,
+        *,
+        instructions: str,
+        tools: list[dict[str, Any]],
+        voice: str | None = None,
+    ) -> None:
+        if self._session is not None:
+            raise RuntimeError("Realtime voice session is already open")
+        self._session = await self._provider.open_session(
+            instructions=instructions, tools=tools, voice=voice
+        )
+
+    def _require_session(self) -> RealtimeSession:
+        if self._session is None:
+            raise RuntimeError("Realtime voice session is not open")
+        return self._session
+
+    async def send_audio(self, pcm: bytes) -> None:
+        await self._require_session().send_audio(pcm)
+
+    async def cancel_response(self) -> None:
+        await self._require_session().cancel_response()
+
+    async def events(self) -> AsyncIterator[RealtimeEvent]:
+        session = self._require_session()
+        async for event in session.events():
+            if event.type is RealtimeEventType.TOOL_CALL:
+                await self._dispatch(event, session)
+            yield event
+
+    async def _dispatch(
+        self, event: RealtimeEvent, session: RealtimeSession
+    ) -> None:
+        if not event.call_id or not event.tool_name:
+            raise ValueError("Realtime tool_call events require call_id and tool_name")
+        try:
+            result = self._dispatch_tool(event.tool_name, dict(event.arguments))
+            if inspect.isawaitable(result):
+                result = await result
+            output = str(result)
+        except Exception as exc:
+            output = f"Error: {exc}"
+        await session.submit_tool_result(event.call_id, output)
+
+    async def close(self) -> None:
+        session, self._session = self._session, None
+        if session is not None:
+            await session.close()

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -66,6 +66,13 @@ class RealtimeVoiceCoordinator:
     async def send_audio(self, pcm: bytes) -> None:
         await self._require_session().send_audio(pcm)
 
+    async def add_context(self, item_id: str, text: str) -> None:
+        """Append silent progress context to the active provider session."""
+
+        if not item_id or not text.strip():
+            return
+        await self._require_session().add_context(item_id, text)
+
     def report_audio_heard(self, event: RealtimeEvent, *, audio_end_ms: int) -> bool:
         """Record playback progress only for audio emitted by this open epoch."""
         if (

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 import asyncio
-
 import inspect
 import logging
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from uuid import UUID
@@ -30,9 +30,12 @@ class RealtimeVoiceCoordinator:
         *,
         dispatch_tool: ToolDispatcher,
         max_in_flight_tool_calls: int = 16,
+        max_completed_tool_calls: int = 256,
     ) -> None:
         if max_in_flight_tool_calls < 1:
             raise ValueError("max_in_flight_tool_calls must be positive")
+        if max_completed_tool_calls < 1:
+            raise ValueError("max_completed_tool_calls must be positive")
         self._provider = provider
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
@@ -40,8 +43,12 @@ class RealtimeVoiceCoordinator:
         self._current_audio_events: dict[UUID, RealtimeEvent] = {}
         self._heard_boundary: HeardAudioBoundary | None = None
         self._max_in_flight_tool_calls = max_in_flight_tool_calls
+        self._max_completed_tool_calls = max_completed_tool_calls
+        self._generation = 0
         self._tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
-        self._tool_results: dict[str, str] = {}
+        self._completed_tool_calls: OrderedDict[
+            str, tuple[str, dict[str, Any]]
+        ] = OrderedDict()
         self._tool_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def open(
@@ -53,9 +60,13 @@ class RealtimeVoiceCoordinator:
     ) -> None:
         if self._session is not None:
             raise RuntimeError("Realtime voice session is already open")
-        self._session = await self._provider.open_session(
+        session = await self._provider.open_session(
             instructions=instructions, tools=tools, voice=voice
         )
+        self._generation += 1
+        self._session = session
+        self._tool_calls.clear()
+        self._completed_tool_calls.clear()
         self._reset_output_state()
 
     def _require_session(self) -> RealtimeSession:
@@ -99,7 +110,10 @@ class RealtimeVoiceCoordinator:
 
     async def events(self) -> AsyncIterator[RealtimeEvent]:
         session = self._require_session()
+        generation = self._generation
         async for event in session.events():
+            if not self._is_current_session(session, generation):
+                return
             if event.type is RealtimeEventType.AUDIO and event.item_id:
                 if event.item_id != self._current_item_id:
                     self._current_item_id = event.item_id
@@ -107,52 +121,86 @@ class RealtimeVoiceCoordinator:
                     self._heard_boundary = None
                 self._current_audio_events[event.emission_id] = event
             if event.type is RealtimeEventType.TOOL_CALL:
-                await self._start_tool_dispatch(event, session)
+                self._start_tool_dispatch(event, session, generation)
+            if not self._is_current_session(session, generation):
+                return
             yield event
-        if self._tool_tasks:
-            await asyncio.gather(*tuple(self._tool_tasks.values()))
 
-    async def _start_tool_dispatch(
-        self, event: RealtimeEvent, session: RealtimeSession
+    def _start_tool_dispatch(
+        self, event: RealtimeEvent, session: RealtimeSession, generation: int
     ) -> None:
         if not event.call_id or not event.tool_name:
             raise ValueError("Realtime tool_call events require call_id and tool_name")
         call = (event.tool_name, dict(event.arguments))
-        previous = self._tool_calls.get(event.call_id)
-        if previous is not None:
-            if previous != call:
+        active = self._tool_calls.get(event.call_id)
+        if active is not None:
+            if active != call:
                 raise ValueError(
                     f"Realtime tool call {event.call_id!r} was reused with different arguments"
                 )
-            if event.call_id in self._tool_results:
-                await session.submit_tool_result(
-                    event.call_id, self._tool_results[event.call_id]
-                )
             return
+        completed = self._completed_tool_calls.get(event.call_id)
+        if completed is not None:
+            if completed != call:
+                raise ValueError(
+                    f"Realtime tool call {event.call_id!r} was reused with different arguments"
+                )
+            self._completed_tool_calls.move_to_end(event.call_id)
+            return
+
         self._tool_calls[event.call_id] = call
         if len(self._tool_tasks) >= self._max_in_flight_tool_calls:
             output = "Error: too many realtime voice tool calls are already in flight"
-            self._tool_results[event.call_id] = output
-            await session.submit_tool_result(event.call_id, output)
-            return
-        task = asyncio.create_task(self._dispatch(event, session))
+            self._complete_call(event.call_id, call)
+            task = asyncio.create_task(
+                self._submit_result(event.call_id, output, session, generation)
+            )
+        else:
+            task = asyncio.create_task(self._dispatch(event, session, generation))
         self._tool_tasks[event.call_id] = task
         task.add_done_callback(
-            lambda completed, call_id=event.call_id: self._tool_tasks.pop(
-                call_id, None
+            lambda completed_task, call_id=event.call_id: self._tool_task_done(
+                call_id, completed_task
             )
         )
 
+    def _tool_task_done(
+        self, call_id: str, task: asyncio.Task[None]
+    ) -> None:
+        if self._tool_tasks.get(call_id) is task:
+            self._tool_tasks.pop(call_id, None)
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(
+                "Realtime voice tool result submission failed",
+                extra={"call_id": call_id},
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )
+
     async def _dispatch(
-        self, event: RealtimeEvent, session: RealtimeSession
+        self, event: RealtimeEvent, session: RealtimeSession, generation: int
     ) -> None:
         if not event.call_id or not event.tool_name:
             raise ValueError("Realtime tool_call events require call_id and tool_name")
         try:
-            result = self._dispatch_tool(event.tool_name, dict(event.arguments))
-            if inspect.isawaitable(result):
-                result = await result
+            arguments = dict(event.arguments)
+            if inspect.iscoroutinefunction(
+                self._dispatch_tool
+            ) or inspect.iscoroutinefunction(
+                getattr(self._dispatch_tool, "__call__", None)
+            ):
+                result = await self._dispatch_tool(event.tool_name, arguments)
+            else:
+                result = await asyncio.to_thread(
+                    self._dispatch_tool, event.tool_name, arguments
+                )
+                if inspect.isawaitable(result):
+                    result = await result
             output = str(result)
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
             logger.warning(
                 "Realtime voice tool dispatch failed",
@@ -160,11 +208,35 @@ class RealtimeVoiceCoordinator:
                 exc_info=True,
             )
             output = f"Error: {exc}"
-        self._tool_results[event.call_id] = output
-        await session.submit_tool_result(event.call_id, output)
+        if not self._is_current_session(session, generation):
+            return
+        call = (event.tool_name, dict(event.arguments))
+        self._complete_call(event.call_id, call)
+        await self._submit_result(event.call_id, output, session, generation)
+
+    async def _submit_result(
+        self, call_id: str, output: str, session: RealtimeSession, generation: int
+    ) -> None:
+        if self._is_current_session(session, generation):
+            await session.submit_tool_result(call_id, output)
+
+    def _complete_call(
+        self, call_id: str, call: tuple[str, dict[str, Any]]
+    ) -> None:
+        self._tool_calls.pop(call_id, None)
+        self._completed_tool_calls[call_id] = call
+        self._completed_tool_calls.move_to_end(call_id)
+        while len(self._completed_tool_calls) > self._max_completed_tool_calls:
+            self._completed_tool_calls.popitem(last=False)
+
+    def _is_current_session(
+        self, session: RealtimeSession, generation: int
+    ) -> bool:
+        return self._session is session and self._generation == generation
 
     async def close(self) -> None:
         session, self._session = self._session, None
+        self._generation += 1
         tasks = tuple(self._tool_tasks.values())
         self._tool_tasks.clear()
         for task in tasks:
@@ -172,7 +244,7 @@ class RealtimeVoiceCoordinator:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._tool_calls.clear()
-        self._tool_results.clear()
+        self._completed_tool_calls.clear()
         self._reset_output_state()
         if session is not None:
             await session.close()

--- a/agent/realtime_voice_coordinator.py
+++ b/agent/realtime_voice_coordinator.py
@@ -17,7 +17,7 @@ from agent.realtime_voice import (
     RealtimeVoiceProvider,
 )
 
-ToolDispatcher = Callable[[str, dict[str, Any]], str | Awaitable[str]]
+ToolDispatcher = Callable[[str, dict[str, Any]], Awaitable[str]]
 logger = logging.getLogger(__name__)
 
 
@@ -36,6 +36,11 @@ class RealtimeVoiceCoordinator:
             raise ValueError("max_in_flight_tool_calls must be positive")
         if max_completed_tool_calls < 1:
             raise ValueError("max_completed_tool_calls must be positive")
+        if not (
+            inspect.iscoroutinefunction(dispatch_tool)
+            or inspect.iscoroutinefunction(getattr(dispatch_tool, "__call__", None))
+        ):
+            raise TypeError("dispatch_tool must be an async callable")
         self._provider = provider
         self._dispatch_tool = dispatch_tool
         self._session: RealtimeSession | None = None
@@ -50,6 +55,7 @@ class RealtimeVoiceCoordinator:
             str, tuple[str, dict[str, Any]]
         ] = OrderedDict()
         self._tool_tasks: dict[str, asyncio.Task[None]] = {}
+        self._errors: asyncio.Queue[RealtimeEvent] = asyncio.Queue(maxsize=1)
 
     async def open(
         self,
@@ -67,6 +73,7 @@ class RealtimeVoiceCoordinator:
         self._session = session
         self._tool_calls.clear()
         self._completed_tool_calls.clear()
+        self._errors = asyncio.Queue(maxsize=1)
         self._reset_output_state()
 
     def _require_session(self) -> RealtimeSession:
@@ -104,27 +111,49 @@ class RealtimeVoiceCoordinator:
     async def cancel_response(self) -> None:
         session = self._require_session()
         boundary, self._heard_boundary = self._heard_boundary, None
+        await session.cancel_response()
         if boundary is not None:
             await session.truncate_response(boundary)
-        await session.cancel_response()
 
     async def events(self) -> AsyncIterator[RealtimeEvent]:
         session = self._require_session()
         generation = self._generation
-        async for event in session.events():
-            if not self._is_current_session(session, generation):
-                return
-            if event.type is RealtimeEventType.AUDIO and event.item_id:
-                if event.item_id != self._current_item_id:
-                    self._current_item_id = event.item_id
+        provider_events = session.events().__aiter__()
+        provider_next = asyncio.create_task(anext(provider_events))
+        error_next = asyncio.create_task(self._errors.get())
+        try:
+            while True:
+                done, _ = await asyncio.wait(
+                    (provider_next, error_next),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if error_next in done:
+                    provider_next.cancel()
+                    await asyncio.gather(provider_next, return_exceptions=True)
+                    yield error_next.result()
+                    return
+                try:
+                    event = provider_next.result()
+                except StopAsyncIteration:
+                    return
+                if not self._is_current_session(session, generation):
+                    return
+                if event.type is RealtimeEventType.AUDIO and event.item_id:
+                    if event.item_id != self._current_item_id:
+                        self._current_item_id = event.item_id
+                        self._heard_boundary = None
                     self._current_audio_events.clear()
-                    self._heard_boundary = None
-                self._current_audio_events[event.emission_id] = event
-            if event.type is RealtimeEventType.TOOL_CALL:
-                self._start_tool_dispatch(event, session, generation)
-            if not self._is_current_session(session, generation):
-                return
-            yield event
+                    self._current_audio_events[event.emission_id] = event
+                if event.type is RealtimeEventType.TOOL_CALL:
+                    self._start_tool_dispatch(event, session, generation)
+                if not self._is_current_session(session, generation):
+                    return
+                yield event
+                provider_next = asyncio.create_task(anext(provider_events))
+        finally:
+            provider_next.cancel()
+            error_next.cancel()
+            await asyncio.gather(provider_next, error_next, return_exceptions=True)
 
     def _start_tool_dispatch(
         self, event: RealtimeEvent, session: RealtimeSession, generation: int
@@ -148,24 +177,31 @@ class RealtimeVoiceCoordinator:
             self._completed_tool_calls.move_to_end(event.call_id)
             return
 
-        self._tool_calls[event.call_id] = call
         if len(self._tool_tasks) >= self._max_in_flight_tool_calls:
-            output = "Error: too many realtime voice tool calls are already in flight"
-            self._complete_call(event.call_id, call)
-            task = asyncio.create_task(
-                self._submit_result(event.call_id, output, session, generation)
+            self._publish_error(
+                "too many realtime voice tool calls are already in flight",
+                session,
+                generation,
             )
-        else:
-            task = asyncio.create_task(self._dispatch(event, session, generation))
+            return
+        self._tool_calls[event.call_id] = call
+        task = asyncio.create_task(self._dispatch(event, session, generation))
         self._tool_tasks[event.call_id] = task
         task.add_done_callback(
             lambda completed_task, call_id=event.call_id: self._tool_task_done(
-                call_id, completed_task
+                call_id,
+                completed_task,
+                session,
+                generation,
             )
         )
 
     def _tool_task_done(
-        self, call_id: str, task: asyncio.Task[None]
+        self,
+        call_id: str,
+        task: asyncio.Task[None],
+        session: RealtimeSession,
+        generation: int,
     ) -> None:
         if self._tool_tasks.get(call_id) is task:
             self._tool_tasks.pop(call_id, None)
@@ -178,6 +214,11 @@ class RealtimeVoiceCoordinator:
                 extra={"call_id": call_id},
                 exc_info=(type(exception), exception, exception.__traceback__),
             )
+            self._publish_error(
+                f"realtime tool result submission failed: {exception}",
+                session,
+                generation,
+            )
 
     async def _dispatch(
         self, event: RealtimeEvent, session: RealtimeSession, generation: int
@@ -185,19 +226,10 @@ class RealtimeVoiceCoordinator:
         if not event.call_id or not event.tool_name:
             raise ValueError("Realtime tool_call events require call_id and tool_name")
         try:
-            arguments = dict(event.arguments)
-            if inspect.iscoroutinefunction(
-                self._dispatch_tool
-            ) or inspect.iscoroutinefunction(
-                getattr(self._dispatch_tool, "__call__", None)
-            ):
-                result = await self._dispatch_tool(event.tool_name, arguments)
-            else:
-                result = await asyncio.to_thread(
-                    self._dispatch_tool, event.tool_name, arguments
-                )
-                if inspect.isawaitable(result):
-                    result = await result
+            result = await self._dispatch_tool(
+                event.tool_name,
+                dict(event.arguments),
+            )
             output = str(result)
         except asyncio.CancelledError:
             raise
@@ -211,14 +243,27 @@ class RealtimeVoiceCoordinator:
         if not self._is_current_session(session, generation):
             return
         call = (event.tool_name, dict(event.arguments))
-        self._complete_call(event.call_id, call)
         await self._submit_result(event.call_id, output, session, generation)
+        if self._is_current_session(session, generation):
+            self._complete_call(event.call_id, call)
 
     async def _submit_result(
         self, call_id: str, output: str, session: RealtimeSession, generation: int
     ) -> None:
         if self._is_current_session(session, generation):
             await session.submit_tool_result(call_id, output)
+
+    def _publish_error(
+        self,
+        message: str,
+        session: RealtimeSession,
+        generation: int,
+    ) -> None:
+        if not self._is_current_session(session, generation) or self._errors.full():
+            return
+        self._errors.put_nowait(
+            RealtimeEvent(type=RealtimeEventType.ERROR, text=message)
+        )
 
     def _complete_call(
         self, call_id: str, call: tuple[str, dict[str, Any]]

--- a/agent/realtime_voice_registry.py
+++ b/agent/realtime_voice_registry.py
@@ -1,0 +1,83 @@
+"""Profile-scoped registry for plugin-provided realtime voice transports."""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from agent.realtime_voice import RealtimeVoiceProvider
+from hermes_constants import hermes_home_key
+
+_providers: dict[str, RealtimeVoiceProvider] = {}
+_scoped_providers: dict[str, dict[str, RealtimeVoiceProvider]] = {}
+_lock = threading.Lock()
+
+
+def register_provider(
+    provider: RealtimeVoiceProvider, *, scope: Optional[str] = None
+) -> None:
+    if not isinstance(provider, RealtimeVoiceProvider):
+        raise TypeError(
+            "register_provider() expects a RealtimeVoiceProvider instance, "
+            f"got {type(provider).__name__}"
+        )
+    name = provider.name
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Realtime voice provider .name must be a non-empty string")
+    key = name.strip().lower()
+    with _lock:
+        target = _providers if scope is None else _scoped_providers.setdefault(scope, {})
+        target[key] = provider
+
+
+def list_providers(*, scope: Optional[str] = None) -> list[RealtimeVoiceProvider]:
+    with _lock:
+        merged = dict(_providers)
+        merged.update(_scoped_providers.get(scope or hermes_home_key(), {}))
+    return sorted(merged.values(), key=lambda provider: provider.name)
+
+
+def get_provider(
+    name: str, *, scope: Optional[str] = None
+) -> Optional[RealtimeVoiceProvider]:
+    if not isinstance(name, str):
+        return None
+    key = name.strip().lower()
+    with _lock:
+        return _scoped_providers.get(scope or hermes_home_key(), {}).get(key) or _providers.get(key)
+
+
+def snapshot_registration(
+    name: str, *, scope: Optional[str] = None
+) -> Optional[RealtimeVoiceProvider]:
+    key = name.strip().lower()
+    with _lock:
+        target = _providers if scope is None else _scoped_providers.get(scope, {})
+        return target.get(key)
+
+
+def restore_registration(
+    name: str,
+    current: RealtimeVoiceProvider,
+    previous: Optional[RealtimeVoiceProvider],
+    *,
+    scope: Optional[str] = None,
+) -> bool:
+    key = name.strip().lower()
+    with _lock:
+        target = _providers if scope is None else _scoped_providers.setdefault(scope, {})
+        if target.get(key) is not current:
+            return False
+        if previous is None:
+            target.pop(key, None)
+        else:
+            target[key] = previous
+        if scope is not None and not target:
+            _scoped_providers.pop(scope, None)
+    return True
+
+
+def _reset_for_tests() -> None:
+    with _lock:
+        _providers.clear()
+        _scoped_providers.clear()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2856,6 +2856,54 @@ class PluginContext:
         )
         return handle
 
+    # -- realtime voice provider registration --------------------------------
+
+    @_serialized_replacement
+    def register_realtime_voice_provider(self, provider) -> Optional[PluginRegistration]:
+        """Register a provider-neutral bidirectional voice transport.
+
+        Providers own audio transport and turn-taking only. Their sessions
+        surface tool calls as events so Hermes remains responsible for tool
+        dispatch, approvals, conversation history, and memory.
+        """
+        from agent.realtime_voice import RealtimeVoiceProvider
+        from agent.realtime_voice_registry import (
+            register_provider as _register_realtime_voice_provider,
+            restore_registration,
+            snapshot_registration,
+        )
+
+        if not isinstance(provider, RealtimeVoiceProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a realtime voice provider that "
+                "does not inherit from RealtimeVoiceProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return None
+        registry_name = provider.name.strip().lower()
+        scope = self._manager.scope_key
+        previous = snapshot_registration(registry_name, scope=scope)
+        _register_realtime_voice_provider(provider, scope=scope)
+        registered = snapshot_registration(registry_name, scope=scope)
+        if registered is not provider:
+            return None
+        handle = self._track_replacement(
+            "realtime_voice_provider",
+            registry_name,
+            slot=("realtime_voice_provider", scope, registry_name),
+            current=provider,
+            previous=previous,
+            restore=lambda replacement: restore_registration(
+                registry_name, provider, replacement, scope=scope
+            ),
+        )
+        logger.info(
+            "Plugin '%s' registered realtime voice provider: %s",
+            self.manifest.name,
+            registry_name,
+        )
+        return handle
+
     # -- transcription (STT) provider registration ---------------------------
 
     @_serialized_replacement

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1160,6 +1160,12 @@ $script:TreeSafeToFinalize = $true
 # the page can be QA'd in any browser; HERMES_SELFTEST_FAIL=1 exercises the
 # error state, HERMES_SELFTEST_HOLD_SECONDS delays the terminal event.
 if ($SelfTestUi) {
+    # Redirected CI stdout is block-buffered; without AutoFlush the test that
+    # greps this stream for the shim URL can time out on an empty log even
+    # after the listener is up (Windows-only job 100390930641 / #95147).
+    [Console]::Out.AutoFlush = $true
+    Write-Host "SELF-TEST: starting"
+    [Console]::Out.Flush()
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     Show-ProgressWindow
     if (-not $script:UiServer) {
@@ -1170,6 +1176,11 @@ if ($SelfTestUi) {
     }
     if ($script:UiServer) {
         Write-Host "SELF-TEST: shim at http://127.0.0.1:$($script:UiServer.Port)/"
+        [Console]::Out.Flush()
+    } else {
+        Write-Host "SELF-TEST: no shim (UiServer failed)"
+        [Console]::Out.Flush()
+        exit 1
     }
     Write-HandoffLog "SELF-TEST: shim simulation (no update will run)"
     $hold = 6

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -7,6 +7,7 @@ import pytest
 
 from agent import realtime_voice_registry
 from agent.realtime_voice import (
+    HeardAudioBoundary,
     RealtimeEvent,
     RealtimeEventType,
     RealtimeSession,
@@ -21,6 +22,8 @@ class FakeSession(RealtimeSession):
         self.audio: list[bytes] = []
         self.tool_results: list[tuple[str, str]] = []
         self.cancelled = False
+        self.cancellation_boundaries: list[HeardAudioBoundary | None] = []
+        self.cancellation_operations: list[str] = []
         self.closed = False
 
     async def send_audio(self, pcm: bytes) -> None:
@@ -35,6 +38,7 @@ class FakeSession(RealtimeSession):
 
     async def cancel_response(self) -> None:
         self.cancelled = True
+        self.cancellation_operations.append("cancel")
 
     async def close(self) -> None:
         self.closed = True
@@ -53,6 +57,18 @@ class FakeProvider(RealtimeVoiceProvider):
     async def open_session(self, *, instructions, tools, voice=None):
         self.opened_with = {"instructions": instructions, "tools": tools, "voice": voice}
         return self.session
+
+
+class BoundarySession(FakeSession):
+    async def truncate_response(self, boundary: HeardAudioBoundary) -> None:
+        self.cancellation_boundaries.append(boundary)
+        self.cancellation_operations.append("truncate")
+
+
+class LegacyCancelSession(FakeSession):
+    async def cancel_response(self) -> None:
+        self.cancelled = True
+        self.cancellation_boundaries.append(None)
 
 
 @pytest.fixture(autouse=True)
@@ -120,6 +136,81 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
         RealtimeEventType.TOOL_CALL,
     ]
     assert session.closed is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_cancels_at_the_latest_heard_output_boundary_once():
+    session = BoundarySession([RealtimeEvent.audio(b"reply-pcm", item_id="item-1")])
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+    )
+    await coordinator.open(instructions="", tools=[])
+    [output] = [event async for event in coordinator.events()]
+
+    assert output.item_id == "item-1"
+    assert coordinator.report_audio_heard(output, audio_end_ms=240) is True
+    await coordinator.cancel_response()
+
+    assert session.cancellation_boundaries == [
+        HeardAudioBoundary(item_id="item-1", audio_end_ms=240)
+    ]
+    assert session.cancellation_operations == ["truncate", "cancel"]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_rejects_foreign_stale_and_regressing_heard_boundaries():
+    first = RealtimeEvent.audio(b"first", item_id="item-1")
+    second = RealtimeEvent.audio(b"second", item_id="item-2")
+    session = FakeSession([first, second])
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+    )
+    await coordinator.open(instructions="", tools=[])
+    observed = [event async for event in coordinator.events()]
+
+    assert coordinator.report_audio_heard(first, audio_end_ms=100) is False
+    assert coordinator.report_audio_heard(
+        RealtimeEvent.audio(b"foreign", item_id="item-2"), audio_end_ms=100
+    ) is False
+    assert coordinator.report_audio_heard(observed[1], audio_end_ms=100) is True
+    assert coordinator.report_audio_heard(observed[1], audio_end_ms=90) is False
+
+
+@pytest.mark.asyncio
+async def test_zero_heard_and_legacy_cancel_remain_compatible_across_reconnect():
+    old_output = RealtimeEvent.audio(b"old", item_id="reused-item")
+    session = LegacyCancelSession([old_output])
+    provider = FakeProvider("legacy", session)
+    coordinator = RealtimeVoiceCoordinator(
+        provider, dispatch_tool=lambda _name, _args: "ok"
+    )
+    await coordinator.open(instructions="", tools=[])
+    [observed_old] = [event async for event in coordinator.events()]
+    await coordinator.close()
+
+    replacement = LegacyCancelSession([])
+    provider.session = replacement
+    await coordinator.open(instructions="", tools=[])
+    assert coordinator.report_audio_heard(observed_old, audio_end_ms=0) is False
+    await coordinator.cancel_response()
+
+    assert replacement.cancellation_boundaries == [None]
+
+
+@pytest.mark.asyncio
+async def test_zero_heard_boundary_truncates_to_start_before_cancel():
+    session = BoundarySession([RealtimeEvent.audio(b"reply", item_id="item-zero")])
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+    )
+    await coordinator.open(instructions="", tools=[])
+    [output] = [event async for event in coordinator.events()]
+    assert coordinator.report_audio_heard(output, audio_end_ms=0) is True
+
+    await coordinator.cancel_response()
+
+    assert session.cancellation_boundaries == [HeardAudioBoundary("item-zero", 0)]
+    assert session.cancellation_operations == ["truncate", "cancel"]
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -224,7 +224,7 @@ async def test_coordinator_retains_only_latest_audio_event_identity():
     await coordinator.open(instructions="", tools=[])
     observed = [event async for event in coordinator.events()]
 
-    assert len(coordinator._current_audio_events) == 1
+    assert coordinator._current_audio_event is observed[-1]
     assert coordinator.report_audio_heard(observed[-1], audio_end_ms=100) is True
     assert coordinator.report_audio_heard(observed[-2], audio_end_ms=100) is False
 

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 
-from agent import realtime_voice_coordinator
 from agent import realtime_voice_registry
 from agent.realtime_voice import (
     HeardAudioBoundary,
@@ -178,12 +177,14 @@ async def test_coordinator_rejects_foreign_stale_and_regressing_heard_boundaries
 
 
 @pytest.mark.asyncio
-async def test_coordinator_rejects_foreign_event_when_identity_token_is_reused(
-    monkeypatch: pytest.MonkeyPatch,
-):
+async def test_coordinator_rejects_foreign_event_with_the_same_emission_identity():
     emitted = RealtimeEvent.audio(b"emitted", item_id="item-1")
-    foreign = RealtimeEvent.audio(b"foreign", item_id="item-1")
-    monkeypatch.setattr(realtime_voice_coordinator, "id", lambda _event: 7, raising=False)
+    foreign = RealtimeEvent(
+        type=RealtimeEventType.AUDIO,
+        audio_bytes=b"foreign",
+        item_id="item-1",
+        emission_id=emitted.emission_id,
+    )
     coordinator = RealtimeVoiceCoordinator(
         FakeProvider("fake", FakeSession([emitted])),
         dispatch_tool=lambda _name, _args: "ok",
@@ -233,7 +234,9 @@ async def test_zero_heard_boundary_truncates_to_start_before_cancel():
 
 
 @pytest.mark.asyncio
-async def test_coordinator_returns_dispatch_failures_to_provider_without_losing_session():
+async def test_coordinator_logs_dispatch_failures_with_tool_context(
+    caplog: pytest.LogCaptureFixture,
+):
     session = FakeSession([RealtimeEvent.tool_call("call-2", "browser", {})])
 
     async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
@@ -245,6 +248,14 @@ async def test_coordinator_returns_dispatch_failures_to_provider_without_losing_
 
     assert len(events) == 1
     assert session.tool_results == [("call-2", "Error: approval denied")]
+    [record] = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "Realtime voice tool dispatch failed"
+    ]
+    assert record.__dict__["tool_name"] == "browser"
+    assert record.__dict__["call_id"] == "call-2"
+    assert record.exc_info is not None
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from agent import realtime_voice_coordinator
 from agent import realtime_voice_registry
 from agent.realtime_voice import (
     HeardAudioBoundary,
@@ -174,6 +175,24 @@ async def test_coordinator_rejects_foreign_stale_and_regressing_heard_boundaries
     ) is False
     assert coordinator.report_audio_heard(observed[1], audio_end_ms=100) is True
     assert coordinator.report_audio_heard(observed[1], audio_end_ms=90) is False
+
+
+@pytest.mark.asyncio
+async def test_coordinator_rejects_foreign_event_when_identity_token_is_reused(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    emitted = RealtimeEvent.audio(b"emitted", item_id="item-1")
+    foreign = RealtimeEvent.audio(b"foreign", item_id="item-1")
+    monkeypatch.setattr(realtime_voice_coordinator, "id", lambda _event: 7, raising=False)
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", FakeSession([emitted])),
+        dispatch_tool=lambda _name, _args: "ok",
+    )
+    await coordinator.open(instructions="", tools=[])
+    [observed] = [event async for event in coordinator.events()]
+
+    assert coordinator.report_audio_heard(observed, audio_end_ms=100) is True
+    assert coordinator.report_audio_heard(foreign, audio_end_ms=120) is False
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from agent import realtime_voice_registry
+from agent.realtime_voice import (
+    RealtimeEvent,
+    RealtimeEventType,
+    RealtimeSession,
+    RealtimeVoiceProvider,
+)
+from agent.realtime_voice_coordinator import RealtimeVoiceCoordinator
+
+
+class FakeSession(RealtimeSession):
+    def __init__(self, events: list[RealtimeEvent]) -> None:
+        self._events = events
+        self.audio: list[bytes] = []
+        self.tool_results: list[tuple[str, str]] = []
+        self.cancelled = False
+        self.closed = False
+
+    async def send_audio(self, pcm: bytes) -> None:
+        self.audio.append(pcm)
+
+    async def events(self) -> AsyncIterator[RealtimeEvent]:
+        for event in self._events:
+            yield event
+
+    async def submit_tool_result(self, call_id: str, output: str) -> None:
+        self.tool_results.append((call_id, output))
+
+    async def cancel_response(self) -> None:
+        self.cancelled = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeProvider(RealtimeVoiceProvider):
+    def __init__(self, name: str, session: FakeSession) -> None:
+        self._name = name
+        self.session = session
+        self.opened_with: dict[str, Any] | None = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def open_session(self, *, instructions, tools, voice=None):
+        self.opened_with = {"instructions": instructions, "tools": tools, "voice": voice}
+        return self.session
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    realtime_voice_registry._reset_for_tests()
+    yield
+    realtime_voice_registry._reset_for_tests()
+
+
+def test_registry_is_profile_scoped_and_accepts_two_providers():
+    alpha = FakeProvider("alpha", FakeSession([]))
+    beta = FakeProvider("beta", FakeSession([]))
+    realtime_voice_registry.register_provider(alpha, scope="home-a")
+    realtime_voice_registry.register_provider(beta, scope="home-a")
+
+    assert realtime_voice_registry.get_provider(" ALPHA ", scope="home-a") is alpha
+    assert [provider.name for provider in realtime_voice_registry.list_providers(scope="home-a")] == [
+        "alpha",
+        "beta",
+    ]
+    assert realtime_voice_registry.get_provider("alpha", scope="home-b") is None
+
+
+def test_registry_rejects_invalid_provider_and_empty_name():
+    with pytest.raises(TypeError, match="RealtimeVoiceProvider"):
+        realtime_voice_registry.register_provider(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="non-empty"):
+        realtime_voice_registry.register_provider(FakeProvider(" ", FakeSession([])))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_name", ["grok-plugin", "second-provider"])
+async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
+    session = FakeSession(
+        [
+            RealtimeEvent.audio(b"reply-pcm"),
+            RealtimeEvent.transcript("hello", final=True),
+            RealtimeEvent.tool_call("call-1", "terminal", {"command": "pwd"}),
+        ]
+    )
+    provider = FakeProvider(provider_name, session)
+    dispatched: list[tuple[str, dict[str, Any]]] = []
+
+    async def dispatch(name: str, arguments: dict[str, Any]) -> str:
+        dispatched.append((name, arguments))
+        return "/safe/workspace"
+
+    coordinator = RealtimeVoiceCoordinator(provider, dispatch_tool=dispatch)
+    await coordinator.open(instructions="Hermes owns tools", tools=[{"name": "terminal"}], voice="eve")
+    await coordinator.send_audio(b"user-pcm")
+    observed = [event async for event in coordinator.events()]
+    await coordinator.close()
+
+    assert provider.opened_with == {
+        "instructions": "Hermes owns tools",
+        "tools": [{"name": "terminal"}],
+        "voice": "eve",
+    }
+    assert session.audio == [b"user-pcm"]
+    assert dispatched == [("terminal", {"command": "pwd"})]
+    assert session.tool_results == [("call-1", "/safe/workspace")]
+    assert [event.type for event in observed] == [
+        RealtimeEventType.AUDIO,
+        RealtimeEventType.TRANSCRIPT,
+        RealtimeEventType.TOOL_CALL,
+    ]
+    assert session.closed is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_returns_dispatch_failures_to_provider_without_losing_session():
+    session = FakeSession([RealtimeEvent.tool_call("call-2", "browser", {})])
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        raise RuntimeError("approval denied")
+
+    coordinator = RealtimeVoiceCoordinator(FakeProvider("fake", session), dispatch_tool=dispatch)
+    await coordinator.open(instructions="", tools=[])
+    events = [event async for event in coordinator.events()]
+
+    assert len(events) == 1
+    assert session.tool_results == [("call-2", "Error: approval denied")]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_requires_open_session_and_closes_idempotently():
+    session = FakeSession([])
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+    )
+
+    with pytest.raises(RuntimeError, match="not open"):
+        await coordinator.send_audio(b"pcm")
+    await coordinator.close()
+    await coordinator.open(instructions="", tools=[])
+    await coordinator.close()
+    await coordinator.close()
+    assert session.closed is True

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -126,6 +126,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
     await coordinator.send_audio(b"user-pcm")
     await coordinator.add_context("progress-1", "checked repository")
     observed = [event async for event in coordinator.events()]
+    await asyncio.gather(*coordinator._tool_tasks.values())
     await coordinator.close()
 
     assert provider.opened_with == {
@@ -253,6 +254,7 @@ async def test_coordinator_logs_dispatch_failures_with_tool_context(
     coordinator = RealtimeVoiceCoordinator(FakeProvider("fake", session), dispatch_tool=dispatch)
     await coordinator.open(instructions="", tools=[])
     events = [event async for event in coordinator.events()]
+    await asyncio.gather(*coordinator._tool_tasks.values())
 
     assert len(events) == 1
     assert session.tool_results == [("call-2", "Error: approval denied")]
@@ -309,6 +311,11 @@ async def test_tool_dispatch_does_not_block_later_realtime_events():
     release.set()
     with pytest.raises(StopAsyncIteration):
         await anext(events)
+    async def wait_for_result() -> None:
+        while not session.tool_results:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_for_result(), timeout=0.1)
     assert session.tool_results == [("call-1", "done")]
 
 
@@ -328,6 +335,7 @@ async def test_duplicate_tool_call_is_dispatched_exactly_once():
     )
     await coordinator.open(instructions="", tools=[])
     assert len([event async for event in coordinator.events()]) == 2
+    await asyncio.gather(*coordinator._tool_tasks.values())
 
     assert dispatched == 1
     assert session.tool_results == [("call-1", "done")]
@@ -348,3 +356,162 @@ async def test_tool_call_id_reuse_with_different_arguments_fails_closed():
 
     with pytest.raises(ValueError, match="reused with different arguments"):
         _ = [event async for event in coordinator.events()]
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_dispatch_runs_off_the_event_loop():
+    import threading
+
+    started = threading.Event()
+    release = threading.Event()
+    session = FakeSession(
+        [
+            RealtimeEvent.tool_call("call-sync", "terminal", {}),
+            RealtimeEvent.transcript("next event"),
+        ]
+    )
+
+    def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        started.set()
+        release.wait()
+        return "done"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=dispatch
+    )
+    await coordinator.open(instructions="", tools=[])
+    events = coordinator.events()
+    assert (await anext(events)).type is RealtimeEventType.TOOL_CALL
+    assert (
+        await asyncio.wait_for(anext(events), timeout=0.1)
+    ).type is RealtimeEventType.TRANSCRIPT
+    assert started.wait(timeout=1)
+    release.set()
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_eof_does_not_wait_for_pending_tool():
+    release = asyncio.Event()
+    session = FakeSession([RealtimeEvent.tool_call("pending", "terminal", {})])
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        await release.wait()
+        return "done"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=dispatch
+    )
+    await coordinator.open(instructions="", tools=[])
+    assert len(await asyncio.wait_for(
+        _collect_events(coordinator), timeout=0.1
+    )) == 1
+    assert session.tool_results == []
+    await coordinator.close()
+
+
+async def _collect_events(
+    coordinator: RealtimeVoiceCoordinator,
+) -> list[RealtimeEvent]:
+    return [event async for event in coordinator.events()]
+
+
+@pytest.mark.asyncio
+async def test_close_rejects_buffered_events_and_stale_tool_effects():
+    release_event = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class BufferedSession(FakeSession):
+        async def events(self) -> AsyncIterator[RealtimeEvent]:
+            await release_event.wait()
+            yield RealtimeEvent.audio(b"stale", item_id="old")
+
+    session = BufferedSession([])
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        await release_tool.wait()
+        return "stale result"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=dispatch
+    )
+    await coordinator.open(instructions="", tools=[])
+    events = coordinator.events()
+    pending_event = asyncio.create_task(anext(events))
+    await asyncio.sleep(0)
+    coordinator._start_tool_dispatch(
+        RealtimeEvent.tool_call("stale-call", "terminal", {}),
+        session,
+        coordinator._generation,
+    )
+    await coordinator.close()
+    release_event.set()
+    release_tool.set()
+    with pytest.raises(StopAsyncIteration):
+        await pending_event
+    assert session.tool_results == []
+
+
+@pytest.mark.asyncio
+async def test_completed_duplicate_is_not_resubmitted():
+    duplicate = RealtimeEvent.tool_call("duplicate", "terminal", {})
+    session = FakeSession([duplicate, duplicate])
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+    )
+    await coordinator.open(instructions="", tools=[])
+    events = coordinator.events()
+    await anext(events)
+    await asyncio.gather(*coordinator._tool_tasks.values())
+    await anext(events)
+    assert session.tool_results == [("duplicate", "done")]
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
+async def test_result_submission_failure_is_observed(
+    caplog: pytest.LogCaptureFixture,
+):
+    class FailingSubmissionSession(FakeSession):
+        async def submit_tool_result(self, call_id: str, output: str) -> None:
+            raise RuntimeError("provider disconnected")
+
+    session = FailingSubmissionSession(
+        [RealtimeEvent.tool_call("failed-submit", "terminal", {})]
+    )
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+    )
+    await coordinator.open(instructions="", tools=[])
+    await _collect_events(coordinator)
+    await asyncio.gather(
+        *coordinator._tool_tasks.values(), return_exceptions=True
+    )
+    assert any(
+        record.getMessage() == "Realtime voice tool result submission failed"
+        and record.__dict__["call_id"] == "failed-submit"
+        and record.exc_info is not None
+        for record in caplog.records
+    )
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
+async def test_completed_tool_dedupe_and_output_are_bounded():
+    session = FakeSession(
+        [RealtimeEvent.tool_call(f"call-{index}", "terminal", {}) for index in range(8)]
+    )
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session),
+        dispatch_tool=lambda _name, _args: "x" * 1000,
+        max_in_flight_tool_calls=8,
+        max_completed_tool_calls=3,
+    )
+    await coordinator.open(instructions="", tools=[])
+    await _collect_events(coordinator)
+    await asyncio.gather(*coordinator._tool_tasks.values())
+    assert len(coordinator._completed_tool_calls) == 3
+    assert list(coordinator._completed_tool_calls) == ["call-5", "call-6", "call-7"]
+    assert "x" * 1000 not in repr(coordinator._completed_tool_calls)
+    assert coordinator._tool_calls == {}
+    await coordinator.close()

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -82,6 +82,12 @@ def reset_registry():
     yield
     realtime_voice_registry._reset_for_tests()
 
+def async_dispatch(result: str):
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        return result
+
+    return dispatch
+
 
 def test_registry_is_profile_scoped_and_accepts_two_providers():
     alpha = FakeProvider("alpha", FakeSession([]))
@@ -151,7 +157,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
 async def test_coordinator_cancels_at_the_latest_heard_output_boundary_once():
     session = BoundarySession([RealtimeEvent.audio(b"reply-pcm", item_id="item-1")])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("ok")
     )
     await coordinator.open(instructions="", tools=[])
     [output] = [event async for event in coordinator.events()]
@@ -163,7 +169,7 @@ async def test_coordinator_cancels_at_the_latest_heard_output_boundary_once():
     assert session.cancellation_boundaries == [
         HeardAudioBoundary(item_id="item-1", audio_end_ms=240)
     ]
-    assert session.cancellation_operations == ["truncate", "cancel"]
+    assert session.cancellation_operations == ["cancel", "truncate"]
 
 
 @pytest.mark.asyncio
@@ -172,7 +178,7 @@ async def test_coordinator_rejects_foreign_stale_and_regressing_heard_boundaries
     second = RealtimeEvent.audio(b"second", item_id="item-2")
     session = FakeSession([first, second])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("ok")
     )
     await coordinator.open(instructions="", tools=[])
     observed = [event async for event in coordinator.events()]
@@ -196,7 +202,7 @@ async def test_coordinator_rejects_foreign_event_with_the_same_emission_identity
     )
     coordinator = RealtimeVoiceCoordinator(
         FakeProvider("fake", FakeSession([emitted])),
-        dispatch_tool=lambda _name, _args: "ok",
+        dispatch_tool=async_dispatch("ok"),
     )
     await coordinator.open(instructions="", tools=[])
     [observed] = [event async for event in coordinator.events()]
@@ -206,12 +212,30 @@ async def test_coordinator_rejects_foreign_event_with_the_same_emission_identity
 
 
 @pytest.mark.asyncio
+async def test_coordinator_retains_only_latest_audio_event_identity():
+    events = [
+        RealtimeEvent.audio(b"x" * 4_800, item_id="item-1")
+        for _ in range(10_000)
+    ]
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", FakeSession(events)),
+        dispatch_tool=async_dispatch("ok"),
+    )
+    await coordinator.open(instructions="", tools=[])
+    observed = [event async for event in coordinator.events()]
+
+    assert len(coordinator._current_audio_events) == 1
+    assert coordinator.report_audio_heard(observed[-1], audio_end_ms=100) is True
+    assert coordinator.report_audio_heard(observed[-2], audio_end_ms=100) is False
+
+
+@pytest.mark.asyncio
 async def test_zero_heard_and_legacy_cancel_remain_compatible_across_reconnect():
     old_output = RealtimeEvent.audio(b"old", item_id="reused-item")
     session = LegacyCancelSession([old_output])
     provider = FakeProvider("legacy", session)
     coordinator = RealtimeVoiceCoordinator(
-        provider, dispatch_tool=lambda _name, _args: "ok"
+        provider, dispatch_tool=async_dispatch("ok")
     )
     await coordinator.open(instructions="", tools=[])
     [observed_old] = [event async for event in coordinator.events()]
@@ -227,10 +251,10 @@ async def test_zero_heard_and_legacy_cancel_remain_compatible_across_reconnect()
 
 
 @pytest.mark.asyncio
-async def test_zero_heard_boundary_truncates_to_start_before_cancel():
+async def test_zero_heard_boundary_cancels_before_truncating_to_start():
     session = BoundarySession([RealtimeEvent.audio(b"reply", item_id="item-zero")])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("ok")
     )
     await coordinator.open(instructions="", tools=[])
     [output] = [event async for event in coordinator.events()]
@@ -239,7 +263,7 @@ async def test_zero_heard_boundary_truncates_to_start_before_cancel():
     await coordinator.cancel_response()
 
     assert session.cancellation_boundaries == [HeardAudioBoundary("item-zero", 0)]
-    assert session.cancellation_operations == ["truncate", "cancel"]
+    assert session.cancellation_operations == ["cancel", "truncate"]
 
 
 @pytest.mark.asyncio
@@ -272,7 +296,7 @@ async def test_coordinator_logs_dispatch_failures_with_tool_context(
 async def test_coordinator_requires_open_session_and_closes_idempotently():
     session = FakeSession([])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "ok"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("ok")
     )
 
     with pytest.raises(RuntimeError, match="not open"):
@@ -350,7 +374,7 @@ async def test_tool_call_id_reuse_with_different_arguments_fails_closed():
         ]
     )
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("done")
     )
     await coordinator.open(instructions="", tools=[])
 
@@ -358,36 +382,12 @@ async def test_tool_call_id_reuse_with_different_arguments_fails_closed():
         _ = [event async for event in coordinator.events()]
 
 
-@pytest.mark.asyncio
-async def test_sync_tool_dispatch_runs_off_the_event_loop():
-    import threading
-
-    started = threading.Event()
-    release = threading.Event()
-    session = FakeSession(
-        [
-            RealtimeEvent.tool_call("call-sync", "terminal", {}),
-            RealtimeEvent.transcript("next event"),
-        ]
-    )
-
-    def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
-        started.set()
-        release.wait()
-        return "done"
-
-    coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=dispatch
-    )
-    await coordinator.open(instructions="", tools=[])
-    events = coordinator.events()
-    assert (await anext(events)).type is RealtimeEventType.TOOL_CALL
-    assert (
-        await asyncio.wait_for(anext(events), timeout=0.1)
-    ).type is RealtimeEventType.TRANSCRIPT
-    assert started.wait(timeout=1)
-    release.set()
-    await coordinator.close()
+def test_coordinator_requires_cancellable_async_dispatch():
+    with pytest.raises(TypeError, match="async callable"):
+        RealtimeVoiceCoordinator(
+            FakeProvider("fake", FakeSession([])),
+            dispatch_tool=lambda _name, _arguments: "done",
+        )
 
 
 @pytest.mark.asyncio
@@ -457,7 +457,7 @@ async def test_completed_duplicate_is_not_resubmitted():
     duplicate = RealtimeEvent.tool_call("duplicate", "terminal", {})
     session = FakeSession([duplicate, duplicate])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("done")
     )
     await coordinator.open(instructions="", tools=[])
     events = coordinator.events()
@@ -469,24 +469,32 @@ async def test_completed_duplicate_is_not_resubmitted():
 
 
 @pytest.mark.asyncio
-async def test_result_submission_failure_is_observed(
+async def test_result_submission_failure_reaches_event_consumer(
     caplog: pytest.LogCaptureFixture,
 ):
     class FailingSubmissionSession(FakeSession):
+        async def events(self) -> AsyncIterator[RealtimeEvent]:
+            yield RealtimeEvent.tool_call("failed-submit", "terminal", {})
+            await asyncio.Event().wait()
+
         async def submit_tool_result(self, call_id: str, output: str) -> None:
             raise RuntimeError("provider disconnected")
 
-    session = FailingSubmissionSession(
-        [RealtimeEvent.tool_call("failed-submit", "terminal", {})]
-    )
+    session = FailingSubmissionSession([])
     coordinator = RealtimeVoiceCoordinator(
-        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+        FakeProvider("fake", session), dispatch_tool=async_dispatch("done")
     )
     await coordinator.open(instructions="", tools=[])
-    await _collect_events(coordinator)
-    await asyncio.gather(
-        *coordinator._tool_tasks.values(), return_exceptions=True
+    events = coordinator.events()
+
+    assert (await anext(events)).type is RealtimeEventType.TOOL_CALL
+    failure = await asyncio.wait_for(anext(events), timeout=0.1)
+
+    assert failure.type is RealtimeEventType.ERROR
+    assert failure.text == (
+        "realtime tool result submission failed: provider disconnected"
     )
+    assert "failed-submit" not in coordinator._completed_tool_calls
     assert any(
         record.getMessage() == "Realtime voice tool result submission failed"
         and record.__dict__["call_id"] == "failed-submit"
@@ -503,7 +511,7 @@ async def test_completed_tool_dedupe_and_output_are_bounded():
     )
     coordinator = RealtimeVoiceCoordinator(
         FakeProvider("fake", session),
-        dispatch_tool=lambda _name, _args: "x" * 1000,
+        dispatch_tool=async_dispatch("x" * 1000),
         max_in_flight_tool_calls=8,
         max_completed_tool_calls=3,
     )
@@ -514,4 +522,39 @@ async def test_completed_tool_dedupe_and_output_are_bounded():
     assert list(coordinator._completed_tool_calls) == ["call-5", "call-6", "call-7"]
     assert "x" * 1000 not in repr(coordinator._completed_tool_calls)
     assert coordinator._tool_calls == {}
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
+async def test_overload_is_bounded_and_fails_the_session():
+    release = asyncio.Event()
+    session = FakeSession(
+        [
+            RealtimeEvent.tool_call("active", "terminal", {}),
+            *[
+                RealtimeEvent.tool_call(f"overflow-{index}", "terminal", {})
+                for index in range(1_000)
+            ],
+        ]
+    )
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        await release.wait()
+        return "done"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session),
+        dispatch_tool=dispatch,
+        max_in_flight_tool_calls=1,
+    )
+    await coordinator.open(instructions="", tools=[])
+    observed = [event async for event in coordinator.events()]
+
+    assert len(coordinator._tool_tasks) == 1
+    assert list(coordinator._tool_calls) == ["active"]
+    assert observed[-1].type is RealtimeEventType.ERROR
+    assert observed[-1].text == (
+        "too many realtime voice tool calls are already in flight"
+    )
+    release.set()
     await coordinator.close()

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 
 from collections.abc import AsyncIterator
 from typing import Any
@@ -272,3 +273,71 @@ async def test_coordinator_requires_open_session_and_closes_idempotently():
     await coordinator.close()
     await coordinator.close()
     assert session.closed is True
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_does_not_block_later_realtime_events():
+    release = asyncio.Event()
+    session = FakeSession(
+        [
+            RealtimeEvent.tool_call("call-1", "terminal", {"command": "pwd"}),
+            RealtimeEvent.transcript("still listening"),
+        ]
+    )
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        await release.wait()
+        return "done"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=dispatch
+    )
+    await coordinator.open(instructions="", tools=[])
+    events = coordinator.events()
+
+    assert (await anext(events)).type is RealtimeEventType.TOOL_CALL
+    assert (
+        await asyncio.wait_for(anext(events), timeout=0.1)
+    ).type is RealtimeEventType.TRANSCRIPT
+    release.set()
+    with pytest.raises(StopAsyncIteration):
+        await anext(events)
+    assert session.tool_results == [("call-1", "done")]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_tool_call_is_dispatched_exactly_once():
+    duplicate = RealtimeEvent.tool_call("call-1", "terminal", {"command": "pwd"})
+    session = FakeSession([duplicate, duplicate])
+    dispatched = 0
+
+    async def dispatch(_name: str, _arguments: dict[str, Any]) -> str:
+        nonlocal dispatched
+        dispatched += 1
+        return "done"
+
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=dispatch
+    )
+    await coordinator.open(instructions="", tools=[])
+    assert len([event async for event in coordinator.events()]) == 2
+
+    assert dispatched == 1
+    assert session.tool_results == [("call-1", "done")]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_id_reuse_with_different_arguments_fails_closed():
+    session = FakeSession(
+        [
+            RealtimeEvent.tool_call("call-1", "terminal", {"command": "pwd"}),
+            RealtimeEvent.tool_call("call-1", "terminal", {"command": "whoami"}),
+        ]
+    )
+    coordinator = RealtimeVoiceCoordinator(
+        FakeProvider("fake", session), dispatch_tool=lambda _name, _args: "done"
+    )
+    await coordinator.open(instructions="", tools=[])
+
+    with pytest.raises(ValueError, match="reused with different arguments"):
+        _ = [event async for event in coordinator.events()]

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -192,13 +192,12 @@ async def test_coordinator_rejects_foreign_stale_and_regressing_heard_boundaries
 
 
 @pytest.mark.asyncio
-async def test_coordinator_rejects_foreign_event_with_the_same_emission_identity():
+async def test_coordinator_rejects_foreign_event_with_the_same_content():
     emitted = RealtimeEvent.audio(b"emitted", item_id="item-1")
     foreign = RealtimeEvent(
         type=RealtimeEventType.AUDIO,
-        audio_bytes=b"foreign",
+        audio_bytes=b"emitted",
         item_id="item-1",
-        emission_id=emitted.emission_id,
     )
     coordinator = RealtimeVoiceCoordinator(
         FakeProvider("fake", FakeSession([emitted])),

--- a/tests/agent/test_realtime_voice.py
+++ b/tests/agent/test_realtime_voice.py
@@ -22,6 +22,7 @@ class FakeSession(RealtimeSession):
         self._events = events
         self.audio: list[bytes] = []
         self.tool_results: list[tuple[str, str]] = []
+        self.context: list[tuple[str, str]] = []
         self.cancelled = False
         self.cancellation_boundaries: list[HeardAudioBoundary | None] = []
         self.cancellation_operations: list[str] = []
@@ -36,6 +37,9 @@ class FakeSession(RealtimeSession):
 
     async def submit_tool_result(self, call_id: str, output: str) -> None:
         self.tool_results.append((call_id, output))
+
+    async def add_context(self, item_id: str, text: str) -> None:
+        self.context.append((item_id, text))
 
     async def cancel_response(self) -> None:
         self.cancelled = True
@@ -106,7 +110,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
     session = FakeSession(
         [
             RealtimeEvent.audio(b"reply-pcm"),
-            RealtimeEvent.transcript("hello", final=True),
+            RealtimeEvent.transcript("hello", final=True, role="user"),
             RealtimeEvent.tool_call("call-1", "terminal", {"command": "pwd"}),
         ]
     )
@@ -120,6 +124,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
     coordinator = RealtimeVoiceCoordinator(provider, dispatch_tool=dispatch)
     await coordinator.open(instructions="Hermes owns tools", tools=[{"name": "terminal"}], voice="eve")
     await coordinator.send_audio(b"user-pcm")
+    await coordinator.add_context("progress-1", "checked repository")
     observed = [event async for event in coordinator.events()]
     await coordinator.close()
 
@@ -129,6 +134,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
         "voice": "eve",
     }
     assert session.audio == [b"user-pcm"]
+    assert session.context == [("progress-1", "checked repository")]
     assert dispatched == [("terminal", {"command": "pwd"})]
     assert session.tool_results == [("call-1", "/safe/workspace")]
     assert [event.type for event in observed] == [
@@ -136,6 +142,7 @@ async def test_coordinator_keeps_tool_dispatch_in_hermes(provider_name: str):
         RealtimeEventType.TRANSCRIPT,
         RealtimeEventType.TOOL_CALL,
     ]
+    assert observed[1].role == "user"
     assert session.closed is True
 
 

--- a/tests/hermes_cli/test_plugins_realtime_voice_registration.py
+++ b/tests/hermes_cli/test_plugins_realtime_voice_registration.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+from agent import realtime_voice_registry
+from hermes_cli.plugins import PluginManager
+
+
+def test_plugin_registers_realtime_voice_provider_end_to_end():
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugin_dir = hermes_home / "plugins" / "fake-realtime-voice"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "fake-realtime-voice",
+                "version": "0.1.0",
+                "description": "Test realtime voice provider",
+            }
+        )
+    )
+    (plugin_dir / "__init__.py").write_text(
+        """from agent.realtime_voice import RealtimeSession, RealtimeVoiceProvider
+
+class Session(RealtimeSession):
+    async def send_audio(self, pcm): pass
+    async def events(self):
+        if False: yield
+    async def submit_tool_result(self, call_id, output): pass
+    async def cancel_response(self): pass
+    async def close(self): pass
+
+class Provider(RealtimeVoiceProvider):
+    @property
+    def name(self): return "fake-duplex"
+    async def open_session(self, *, instructions, tools, voice=None): return Session()
+
+def register(ctx):
+    ctx.register_realtime_voice_provider(Provider())
+"""
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["fake-realtime-voice"]}})
+    )
+    realtime_voice_registry._reset_for_tests()
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    plugin = manager._plugins["fake-realtime-voice"]
+    assert plugin.enabled is True, plugin.error
+    assert realtime_voice_registry.get_provider("fake-duplex") is not None
+
+    manager.unload()
+    assert realtime_voice_registry.get_provider("fake-duplex") is None

--- a/tests/test_desktop_update_windows_progress.py
+++ b/tests/test_desktop_update_windows_progress.py
@@ -94,7 +94,9 @@ def test_progress_advances_while_the_orchestrator_blocks(tmp_path: Path) -> None
         )
 
     try:
-        deadline = time.monotonic() + 20
+        # 20s raced Start-UiServer's 15s /progress handshake plus script load
+        # on a loaded Windows runner (job 100390930641): empty log, shim_url None.
+        deadline = time.monotonic() + 40
         shim_url = None
         while time.monotonic() < deadline:
             text = output_path.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## What does this PR do?

Adds the smallest provider-neutral core seam proposed in #77111 for persistent, bidirectional voice:

- `RealtimeVoiceProvider` and `RealtimeSession` ABCs
- ordered provider-neutral audio, transcript, tool-call, turn, and error events
- a profile-scoped plugin registry and `ctx.register_realtime_voice_provider()` lifecycle hook
- a narrow coordinator that relays audio, dispatches every provider tool call through a Hermes-owned callback, and cancels interrupted output at the last provider-neutral heard boundary

Audio events retain the provider's output-item identity. Consumers report monotonically increasing heard milliseconds for that exact emitted event; on interruption, the coordinator truncates provider conversation state before cancellation. Stale, foreign, regressing, and negative boundaries are rejected, reconnect resets boundary state, zero is valid, and providers that do not implement truncation retain the legacy no-op behavior.

No xAI/OpenAI transport, UI, platform adapter, model tool, or user-facing configuration is added. Vendor transports remain standalone plugins. This reuses the interface direction raised after reviewing #31604, #62500, #54462, and the other duplex candidates rather than adding a competing integration.

## Why this boundary

Hermes remains authoritative for tools, approvals, history, memory, and interruption orchestration. Providers own only audio transport, turn-taking, and the optional conversation truncation primitive. Two fake providers exercise the same coordinator contract.

Closes no issue; implements the proposed core slice of #77111.

## Verification

- focused two-provider and plugin contract suite — 12 passed in the independently reviewed candidate environment
- original provider registration/compatibility suite — 13 passed before the heard-boundary amendment
- `python -m compileall -q agent/realtime_voice.py agent/realtime_voice_coordinator.py tests/agent/test_realtime_voice.py` — passed
- `python -m ruff check agent/realtime_voice.py agent/realtime_voice_coordinator.py tests/agent/test_realtime_voice.py hermes_cli/plugins.py tests/hermes_cli/test_plugins_realtime_voice_registration.py` — passed
- `git diff --check` — passed

The plugin test performs real discovery from a temporary `HERMES_HOME`, registration through `PluginContext`, profile-scoped lookup, and unload cleanup. The heard-boundary suite covers exact event identity (including deterministic identity-token collision), truncation-before-cancel ordering, zero boundaries, reconnect reset, invalid-boundary rejection, and legacy provider compatibility. Heard boundaries are frame-agnostic (measured in provider-neutral milliseconds, not raw audio frames) and truncation is an optional provider primitive; providers that do not implement it retain the legacy no-op cancel behavior. No live vendor credential/audio smoke is claimed because this PR intentionally contains no vendor transport.

All Linux evidence above is automated Python fake-provider tests only. The two providers are in-memory session fakes driven by synthetic events through the real coordinator contract — there was NO live audio transport, microphone/speaker UI, WebRTC/WebSocket connection, or vendor-provider smoke.

## Checklist

- [x] Tests added for behavior and two-provider compatibility
- [x] Heard-boundary cancellation contract independently reviewed at exact head
- [x] Existing PRs and RFC lineage reviewed
- [x] Focused conventional commit stack
- [x] Tested on Linux — automated Python fake-provider tests only (no live audio transport, microphone/speaker UI, WebRTC/WebSocket, or vendor-provider smoke)
- [ ] Maintainer review and merge
