### PR TITLE
fix(cli): persist only configurable toolsets

### DIFF
--- a/hermes_cli/tools_config_mcp.py
+++ b/hermes_cli/tools_config_mcp.py
@@ -152,9 +152,19 @@ def _configure_mcp_tools_interactive(config: dict):
 
 def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
     """Add or remove built-in toolsets for a platform."""
-    from hermes_cli.tools_config import _get_platform_tools, _save_platform_tools
+    from hermes_cli.tools_config import (
+        _get_effective_configurable_toolsets,
+        _get_platform_tools,
+        _save_platform_tools,
+    )
 
     enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
+    configurable = {
+        key
+        for key, _, _ in _get_effective_configurable_toolsets()
+        if _toolset_allowed_for_platform(key, platform)
+    }
+    enabled &= configurable
     updated = enabled - set(toolset_names) if action == "disable" else enabled | set(toolset_names)
     _save_platform_tools(config, platform, updated)
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -207,16 +207,25 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "terminal" not in saved_toolsets
 
 
-def test_apply_toolset_change_does_not_persist_runtime_injected_toolsets(monkeypatch):
+@pytest.mark.parametrize(
+    ("toolset_names", "action", "expected"),
+    [
+        (["homeassistant"], "disable", ["terminal", "web"]),
+        (["browser"], "enable", ["browser", "terminal", "web"]),
+    ],
+)
+def test_apply_toolset_change_does_not_persist_runtime_injected_toolsets(
+    monkeypatch, toolset_names, action, expected
+):
     config = {"platform_toolsets": {"cli": ["web", "terminal"]}}
     monkeypatch.setattr(
         "hermes_cli.tools_config._get_platform_tools",
         lambda *args, **kwargs: {"web", "terminal", "kanban"},
     )
 
-    _apply_toolset_change(config, "cli", ["homeassistant"], "disable")
+    _apply_toolset_change(config, "cli", toolset_names, action)
 
-    assert config["platform_toolsets"]["cli"] == ["terminal", "web"]
+    assert config["platform_toolsets"]["cli"] == expected
 
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -207,6 +207,18 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "terminal" not in saved_toolsets
 
 
+def test_apply_toolset_change_does_not_persist_runtime_injected_toolsets(monkeypatch):
+    config = {"platform_toolsets": {"cli": ["web", "terminal"]}}
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *args, **kwargs: {"web", "terminal", "kanban"},
+    )
+
+    _apply_toolset_change(config, "cli", ["homeassistant"], "disable")
+
+    assert config["platform_toolsets"]["cli"] == ["terminal", "web"]
+
+
 
 
 


### PR DESCRIPTION
Fixes #95100.

## What Changed

`hermes tools enable/disable` now filters the resolved effective toolset set to configurable built-in and plugin toolsets allowed on the selected platform before persisting a mutation. Runtime-injected, non-configurable entries such as `kanban` remain runtime state instead of being written into `platform_toolsets`.

The read-time resolver, configuration schema, and existing MCP-entry preservation in `_save_platform_tools` are unchanged.

## Evidence

Base: `d9833c5615b80e199a174cd67d90ab430695a972`
Head: `2f59682f55c263306d0c9565d3ab0c7f7ae5e886`
Environment: macOS, Python 3.11.15, isolated `HERMES_HOME` profiles.

On current main, `HERMES_HOME=<isolated> python hermes tools enable browser --platform cli` persisted `kanban` in `platform_toolsets.cli`. The candidate runs the same command and persists the configurable toolsets only.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -q` - 54 passed, 6 skipped
- `ruff check hermes_cli/tools_config_mcp.py tests/hermes_cli/test_tools_config.py`
- `python -m compileall -q hermes_cli/tools_config_mcp.py tests/hermes_cli/test_tools_config.py`
- `python scripts/check-windows-footguns.py hermes_cli/tools_config_mcp.py tests/hermes_cli/test_tools_config.py`
- `git diff --check origin/main...HEAD`
- `trufflehog filesystem --no-update --fail hermes_cli/tools_config_mcp.py tests/hermes_cli/test_tools_config.py` - zero findings

`ruff format --check` and `ty check` report the same pre-existing file-wide format debt and five existing diagnostics on both current main and this head. The full repository suite was not run.

## Scope

The change is limited to `hermes_cli/tools_config_mcp.py` and a command-level regression in `tests/hermes_cli/test_tools_config.py`. It covers both `enable` and `disable`; it does not alter toolset resolution, MCP configuration, or public configuration keys.

## Checklist

### Code

- [x] I read the Contributing Guide.
- [x] My commits follow Conventional Commits.
- [x] I searched open PRs and the #95100 timeline for competing routes.
- [x] This PR contains only the persistence bug fix and regression coverage.
- [x] I ran the focused ownership-path test suite and a real CLI reproduction.
- [x] I added regression coverage for both mutation paths.
- [x] I considered cross-platform impact.

### Documentation And Housekeeping

- [x] Documentation is N/A; no user-facing configuration contract changed.
- [x] `cli-config.yaml.example` is N/A; no configuration key changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed.
- [x] Tool descriptions and schemas are N/A; the tool surface is unchanged.
