### PR TITLE
fix(tools): DaemonThreadPoolExecutor on Python 3.14 — worker signature changed to (ref, ctx, queue)

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,14 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's implementation with two changes: daemon=True and no
+        # _threads_queues registration. The worker-thread signature changed in 3.14:
+        #   3.8–3.13: _worker(executor_ref, work_queue, initializer, initargs)
+        #   3.14+:    _worker(executor_ref, ctx, work_queue)  — initializer/initargs
+        #             live in a WorkerContext from self._create_worker_context(), and
+        #             the executor no longer has ``_initializer`` / ``_initargs``.
+        # Without this branch every tool call on 3.14 died with
+        # "'DaemonThreadPoolExecutor' object has no attribute '_initializer'".
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +55,23 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_create_worker_context"):  # Python >= 3.14
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:  # Python 3.8–3.13
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
Fixes Python 3.14 breakage where every tool call via `DaemonThreadPoolExecutor` died with `'DaemonThreadPoolExecutor' object has no attribute '_initializer'`.

## Root cause

CPython 3.14 changed `concurrent.futures.thread._worker` signature:

- 3.8–3.13: `_worker(executor_ref, work_queue, initializer, initargs)`
- 3.14+:    `_worker(executor_ref, ctx, work_queue)` — `initializer`/`initargs` live in a `WorkerContext` from `self._create_worker_context()`, and the executor no longer has `_initializer`/`_initargs` attributes.

`DaemonThreadPoolExecutor._adjust_thread_count` unconditionally passed the old 4-tuple, hitting the missing attribute on every dispatch.

## Fix

Branch on `hasattr(self, "_create_worker_context")` (present only on 3.14+):

- 3.14+: `(weakref.ref(self, cb), self._create_worker_context(), self._work_queue)`
- <3.14: `(weakref.ref(self, cb), self._work_queue, self._initializer, self._initargs)`

No behavior change on older Pythons. One file, 21 insertions.

## Repro

On Python 3.14, any concurrent tool batch via the daemon pool raised `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'` and no tool executed.

## Tests

`pytest tests/tools/test_daemon_pool.py` — 3 passed (daemon workers, idle reuse, wedged-worker exit).
