### PR TITLE
fix(web): resolve asset base path for code-split chunks under a proxy prefix

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -75,6 +75,25 @@ export default defineConfig({
     tailwindcss(),
     hermesDevToken(),
   ],
+  experimental: {
+    // Static index.html/CSS asset URLs are already rewritten server-side
+    // (see hermes_cli/web_server.py's X-Forwarded-Prefix handling) by
+    // string-replacing the literal "/assets/" paths baked into those files.
+    // That trick doesn't reach URLs baked into compiled JS for code-split
+    // chunks (React.lazy() route pages, the xterm vendor chunk, and any
+    // CSS those chunks pull in) -- those stay hardcoded to root-absolute
+    // paths and 404 once this app is proxied under a path prefix like
+    // /hermes. Route only JS-originated references through a runtime
+    // expression that reads the same window.__HERMES_BASE_PATH__ global
+    // web_server.py already injects (see src/lib/api.ts for the existing
+    // consumer). Leave html/css hosts on the default so the working
+    // server-side string-replacement path stays untouched.
+    renderBuiltUrl(filename, { hostType }) {
+      if (hostType === "js") {
+        return { runtime: `(window.__HERMES_BASE_PATH__ || "") + "/${filename}"` };
+      }
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

The dashboard's code-split route chunks (e.g. `ChatPage`, the `xterm` vendor
chunk, and CSS those chunks pull in) were built with hardcoded root-absolute
`/assets/...` URLs, since `web/vite.config.ts` had no `base` configured. That
works fine when the dashboard is served from `/`, but breaks when it's
reverse-proxied under a path prefix (e.g. `/hermes`), because unlike the
static `index.html` references, these URLs are baked directly into the
compiled JS and never pass through `web_server.py`'s existing
`X-Forwarded-Prefix` rewriting logic.

Concretely: navigating to the Chat route under a path-prefixed deployment
404s on `ChatPage-*.js` and `xterm-*.css`. The failed CSS preload throws an
uncaught error that aborts the chunk's dynamic import entirely, so the route
never renders anything — a fully blank page.

## Fix

Use Vite's `experimental.renderBuiltUrl` so JS-originated asset references
resolve at runtime via the `window.__HERMES_BASE_PATH__` global that
`web_server.py` already injects into `index.html` for API calls (see the
existing consumer in `src/lib/api.ts`). HTML/CSS-originated references are
left on Vite's default resolution, since the server-side string-replacement
path already handles those correctly.

## Test plan

- [x] `npm run build` in `web/` — bundle compiles, `ChatPage`/`xterm` chunk
      references confirmed to use the runtime `window.__HERMES_BASE_PATH__`
      expression instead of a hardcoded absolute path (verified by grepping
      the compiled output).
- [x] Reproduced the blank-Chat-page bug against a live path-prefixed
      deployment (Traefik `PathPrefix(/hermes)` + prefix-stripping), then
      confirmed the fix resolves it end-to-end with an authenticated headless
      browser run: `/hermes/chat` renders full content, and the chat/events/pty
      WebSocket connections open with zero console errors and zero failed
      requests.
- [ ] Not yet re-verified against the exact tip of `main` on this machine — a
      concurrent engine bump (`node >=22.22.0`) landed after this fix was
      built/tested, and this environment is on Node 20, so a fresh
      `npm install && npm run build` couldn't be re-run here after rebasing.
      The merge onto current `main` is a clean, non-overlapping textual
      resolution (this change only touches the `experimental` key; nothing
      else in `vite.config.ts` conflicts) and passed `tsc --noEmit`.