### PR TITLE
fix(doctor): drop --json authenticated for gh CLI 2.98+ compatibility

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2990,10 +2990,17 @@ def run_doctor(args):
     from hermes_cli.config import get_env_value
 
     def _gh_authenticated() -> bool:
-        """Check if gh CLI is authenticated via token file or device flow."""
+        """Check if gh CLI is authenticated via token file or device flow.
+
+        Uses ``gh auth status`` without ``--json`` for broad compatibility:
+        gh 2.98+ removed the ``authenticated`` JSON field (only ``hosts``
+        remains), causing ``--json authenticated`` to fail with exit code 1
+        even when logged in. Exit-code semantics are stable across all gh
+        versions (0 = authenticated), and output is captured anyway.
+        """
         try:
             result = subprocess.run(
-                ["gh", "auth", "status", "--json", "authenticated"],
+                ["gh", "auth", "status"],
                 capture_output=True, timeout=10,
             )
             return result.returncode == 0


### PR DESCRIPTION
## Problem

`gh auth status --json authenticated` fails on gh CLI 2.98+ because the `authenticated` JSON field was removed (only `hosts` remains). The command exits with code 1 and prints:

```
Unknown JSON field: "authenticated"
Available fields:
  hosts
```

This causes `_gh_authenticated()` in `hermes_cli/doctor.py` to return `False` even when the user is logged in via `gh auth login`, so the doctor falsely reports:

> ⚠ No GITHUB_TOKEN (60 req/hr rate limit)

## Fix

Drop `--json authenticated` and use plain `gh auth status`. The code only checks `returncode == 0` and never parses stdout, so `--json` was unnecessary. Plain `gh auth status` works across all gh versions and returns exit 0 when authenticated.

## Verification

- Tested with gh 2.98.0 (2026-08-20): `gh auth status` → exit 0 ✓, `gh auth status --json authenticated` → exit 1 ✗
- Doctor now correctly shows: `✓ GitHub authenticated via gh CLI`
- Existing tests (`test_gh_authenticated_without_env_token_shows_ok`) only assert `cmd[:2] == ['gh', 'auth']`, so they remain green