### PR TITLE
fix(tui): adopt live compression config on the next Desktop/TUI turn

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -1,0 +1,109 @@
+"""Desktop/TUI sessions must adopt live compression config on the next turn.
+
+Regression for #95151: ``_sync_agent_model_with_config`` only compared the
+model/provider. After ``hermes config set compression.threshold_tokens 100000``
+the already-open session kept the computed threshold from agent creation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.context_compressor import ContextCompressor
+from tui_gateway import server
+
+
+def _session_with_compressor(**compression_ctor):
+    compressor = ContextCompressor(
+        model="gpt-5.6-sol",
+        threshold_percent=0.85,
+        config_context_length=272_000,
+        quiet_mode=True,
+        **compression_ctor,
+    )
+    agent = SimpleNamespace(
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+    )
+    return {
+        "agent": agent,
+        "session_key": "session-95151",
+    }, compressor
+
+
+def test_live_threshold_tokens_applies_on_next_turn_without_rebuild(monkeypatch):
+    session, compressor = _session_with_compressor()
+    stale = compressor.threshold_tokens
+    assert stale > 100_000
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "context_length": 272_000,
+            },
+            "compression": {
+                "threshold_tokens": 100_000,
+                "proactive_prune_tokens": 48_000,
+                "idle_compact_after_seconds": 1800,
+                "tail_mode": "lean",
+            },
+        },
+    )
+
+    live_agent = session["agent"]
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"] is live_agent
+    assert compressor.threshold_tokens == 100_000
+    assert compressor.proactive_prune_tokens == 48_000
+    assert compressor.tail_mode == "lean"
+    assert live_agent.compression_idle_compact_after_seconds == 1800
+
+
+def test_unchanged_compression_config_is_noop(monkeypatch):
+    session, compressor = _session_with_compressor(threshold_tokens_cap=100_000)
+    cfg = {
+        "model": {"context_length": 272_000},
+        "compression": {"threshold_tokens": 100_000},
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    session["config_compression_seen"] = server._tui_compression_config_signature(cfg)
+
+    compressor.threshold_tokens = 99_999
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert compressor.threshold_tokens == 99_999
+
+
+def test_clearing_threshold_tokens_restores_ratio_trigger(monkeypatch):
+    session, compressor = _session_with_compressor(threshold_tokens_cap=100_000)
+    assert compressor.threshold_tokens == 100_000
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {"context_length": 272_000},
+            "compression": {},
+        },
+    )
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert compressor.threshold_tokens > 100_000
+    assert compressor.threshold_tokens_cap is None
+
+
+def test_prompt_submit_calls_compression_sync_after_model_sync():
+    source = open(server.__file__, encoding="utf-8").read()
+    model_idx = source.find("_sync_agent_model_with_config(sid, session)")
+    compression_idx = source.find("_sync_agent_compression_with_config(sid, session)")
+    assert model_idx != -1
+    assert compression_idx != -1
+    assert model_idx < compression_idx

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5819,6 +5819,190 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
         )
 
 
+def _tui_compression_config_signature(cfg: dict | None) -> tuple:
+    """Stable snapshot of compression/context keys that must apply next turn.
+
+    Reuses the messaging-gateway cache-busting extract so Desktop/TUI and
+    messaging stay on the same key set. Adds ``idle_compact_after_seconds``
+    and ``tail_mode``, which affect live TUI sessions but are not in the
+    gateway tuple today.
+    """
+    from gateway.run import GatewayRunner
+
+    keys = GatewayRunner._extract_cache_busting_config(cfg)
+    picked = {
+        key: value
+        for key, value in keys.items()
+        if key.startswith("compression.") or key == "model.context_length"
+    }
+    compression = cfg.get("compression") if isinstance(cfg, dict) and isinstance(cfg.get("compression"), dict) else {}
+    for extra in ("idle_compact_after_seconds", "tail_mode"):
+        picked[f"compression.{extra}"] = compression.get(extra)
+    return tuple(sorted(picked.items()))
+
+
+def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
+    """Update a live session's compressor from current config.yaml.
+
+    Preserves the agent object, session identity, history, and callbacks.
+    Recomputes the trigger from the ratio-based threshold and then applies
+    ``compression.threshold_tokens`` so raising, lowering, or clearing the
+    cap all take effect on the next preflight.
+    """
+    cfg = cfg if isinstance(cfg, dict) else {}
+    compression = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+    model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+
+    enabled_raw = compression.get("enabled", True)
+    if isinstance(enabled_raw, bool):
+        agent.compression_enabled = enabled_raw
+    else:
+        agent.compression_enabled = str(enabled_raw).lower() in {"true", "1", "yes"}
+
+    idle_raw = compression.get(
+        "idle_compact_after_seconds",
+        getattr(agent, "compression_idle_compact_after_seconds", 0),
+    )
+    try:
+        agent.compression_idle_compact_after_seconds = max(0, int(idle_raw or 0))
+    except (TypeError, ValueError):
+        pass
+
+    cc = getattr(agent, "context_compressor", None)
+    if cc is None:
+        return
+
+    if "tail_mode" in compression:
+        mode = str(compression.get("tail_mode") or "legacy").strip().lower()
+        cc.tail_mode = mode if mode in ("legacy", "lean") else "legacy"
+
+    def _assign_int(key: str, attr: str, default: int, min_value: int = 0) -> None:
+        if key not in compression:
+            return
+        try:
+            raw = compression.get(key)
+            value = default if raw is None else int(raw)
+            setattr(cc, attr, max(min_value, value))
+        except (TypeError, ValueError):
+            return
+
+    _assign_int("proactive_prune_tokens", "proactive_prune_tokens", 0)
+    _assign_int("proactive_prune_min_result_chars", "proactive_prune_min_result_chars", 8000)
+    _assign_int("proactive_prune_min_reclaim_tokens", "proactive_prune_min_reclaim_tokens", 0)
+    _assign_int("protect_last_n", "protect_last_n", 20)
+    _assign_int("min_tail_user_messages", "min_tail_user_messages", 1, min_value=1)
+
+    if "target_ratio" in compression:
+        try:
+            cc.summary_target_ratio = max(0.10, min(float(compression["target_ratio"]), 0.80))
+        except (TypeError, ValueError):
+            pass
+
+    raw_thresholds = compression.get("model_thresholds")
+    if isinstance(raw_thresholds, dict):
+        cc.model_thresholds = {
+            str(k): float(v)
+            for k, v in raw_thresholds.items()
+            if isinstance(v, (int, float)) and not isinstance(v, bool)
+        }
+
+    if "threshold" in compression:
+        try:
+            pct = float(compression["threshold"])
+            cc._config_threshold_percent = pct
+            cc._configured_threshold_percent = pct
+            base = pct
+            model_thresholds = getattr(cc, "model_thresholds", None) or {}
+            if model_thresholds:
+                from agent.context_compressor import resolve_model_threshold
+
+                base = resolve_model_threshold(
+                    getattr(agent, "model", "") or "",
+                    model_thresholds,
+                    pct,
+                )
+            cc._base_threshold_percent = base
+            if hasattr(cc, "_effective_threshold_percent"):
+                try:
+                    cc.threshold_percent = cc._effective_threshold_percent(
+                        cc.context_length, base
+                    )
+                except Exception:
+                    cc.threshold_percent = pct
+            else:
+                cc.threshold_percent = pct
+        except (TypeError, ValueError):
+            pass
+
+    raw_ctx = model_cfg.get("context_length")
+    if raw_ctx is not None:
+        try:
+            new_ctx = int(raw_ctx)
+        except (TypeError, ValueError):
+            new_ctx = 0
+        if new_ctx > 0:
+            cc._config_context_length = new_ctx
+            try:
+                cc.context_length = new_ctx
+            except Exception:
+                pass
+
+    coerce_cap = getattr(cc, "_coerce_threshold_tokens_cap", None)
+    if callable(coerce_cap):
+        cc.threshold_tokens_cap = coerce_cap(compression.get("threshold_tokens"))
+    elif "threshold_tokens" in compression:
+        try:
+            cap = int(compression.get("threshold_tokens"))
+            cc.threshold_tokens_cap = cap if cap > 0 else None
+        except (TypeError, ValueError):
+            cc.threshold_tokens_cap = None
+
+    # Invalidate cached trigger so the next preflight re-derives from the
+    # current percent/window and then applies the (possibly new) cap.
+    if hasattr(cc, "_threshold_tokens"):
+        cc._threshold_tokens = None
+        if hasattr(cc, "_tail_token_budget"):
+            cc._tail_token_budget = None
+    elif hasattr(cc, "_apply_threshold_tokens_cap"):
+        compute = getattr(cc, "_compute_threshold_tokens", None)
+        if callable(compute):
+            cc.threshold_tokens = compute(
+                getattr(cc, "context_length", 0) or 0,
+                getattr(cc, "threshold_percent", 0.5),
+                getattr(cc, "max_tokens", None),
+            )
+        cc._apply_threshold_tokens_cap()
+    else:
+        cap = getattr(cc, "threshold_tokens_cap", None)
+        current = getattr(cc, "threshold_tokens", None)
+        if cap and current:
+            cc.threshold_tokens = min(int(current), int(cap))
+
+
+def _sync_agent_compression_with_config(sid: str, session: dict) -> None:
+    """Adopt compression.* / model.context_length edits at turn start.
+
+    Messaging gateways already rebuild a cached agent when these keys change.
+    Desktop/TUI only synced the model; the live compressor kept the threshold
+    captured at agent creation (#95151).
+    """
+    agent = session.get("agent")
+    if agent is None:
+        return
+    cfg = _load_cfg() or {}
+    signature = _tui_compression_config_signature(cfg)
+    seen = session.get("config_compression_seen")
+    session["config_compression_seen"] = signature
+    if signature == seen:
+        return
+    try:
+        _apply_live_compression_config(agent, cfg)
+    except Exception as e:
+        logger.warning(
+            "Could not apply live compression config for %s: %s", sid, e
+        )
+
+
 def _apply_pending_model_switch(sid: str, session: dict) -> None:
     """Apply a model switch queued while a turn was running.
 
@@ -11493,6 +11677,7 @@ def _run_prompt_submit(
                 # config sync so an explicit pick wins over a config.yaml change.
                 _apply_pending_model_switch(sid, session)
                 _sync_agent_model_with_config(sid, session)
+                _sync_agent_compression_with_config(sid, session)
             # Bot Chat capability sync — adopt Settings→Capabilities edits
             # (skills/toolsets/MCP/SOUL) into the eternal bot session before
             # the turn runs. No-op for every other session shape.


### PR DESCRIPTION
## What does this PR do?

A running Desktop/TUI session kept the context-compression threshold captured when its agent was created. `hermes config set compression.threshold_tokens 100000` (and other `compression.*` / `model.context_length` edits) showed up in `config.yaml` and `hermes config get`, but the next turn on the already-open session still used the old computed trigger (for example 231,200).

Messaging gateways already bust the cached agent when those keys change. Desktop/TUI only synced the model. This PR compares the same cache-busting signature at turn start and applies the live compression settings in place, so the next preflight uses the new threshold without a restart, reset, or new chat.

## Related Issue

Fixes #95151

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: add `_tui_compression_config_signature` (reuses `GatewayRunner._extract_cache_busting_config`), `_apply_live_compression_config`, and `_sync_agent_compression_with_config`; call it from `_run_prompt_submit` after the existing model sync.
- `tests/tui_gateway/test_compression_config_hot_reload.py`: assert a default computed trigger becomes 100,000 on the next sync without replacing the agent; also cover noop, cap-clear restore, and the turn-start call order.

## How to Test

1. Start a Desktop or `hermes --tui` session so an agent is created with the default computed compression threshold.
2. From another terminal: `hermes config set compression.threshold_tokens 100000`. Confirm `hermes config get compression.threshold_tokens` is `100000`.
3. Send the next message on the existing session. The live compressor/preflight threshold should be 100,000 (not the old computed value). Session id, history, and callbacks stay the same.
4. `pytest tests/tui_gateway/test_compression_config_hot_reload.py tests/test_tui_gateway_server.py::test_config_sync_switches_unpinned_session tests/test_tui_gateway_server.py::test_config_sync_noop_when_config_unchanged -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

```
before 231200
after_model_only 231200
after_compression_sync 100000 same_agent True
```

```
......  [100%]
6 passed in 3.39s
```
