### PR TITLE
feat(discord): render short cron alerts as embeds

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1024,6 +1024,57 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+_CRON_DELIVERY_RE = re.compile(
+    r"^Cronjob Response: (?P<name>[^\n]+)\n"
+    r"\(job_id: (?P<job_id>[^)]+)\)\n"
+    r"-------------\n\n"
+    r"(?P<body>.*?)\n\n"
+    r"To stop or manage this job, send me a new message .*\.?$",
+    re.DOTALL,
+)
+
+
+def _discord_cron_embed_parts(
+    content: str,
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, str]]:
+    """Return safe presentation fields for a short wrapped cron delivery."""
+    if not metadata or not metadata.get("job_id"):
+        return None
+    match = _CRON_DELIVERY_RE.match((content or "").strip())
+    if not match:
+        return None
+    body = match.group("body").strip()
+    # Preserve long-form reports as ordinary split Discord messages. Embedding
+    # those would hit Discord's 4096-character description cap and clip data.
+    if not body or len(body) > 3800:
+        return None
+
+    lowered = body.lower()
+    if any(word in lowered for word in ("blocked", "escalat", "🚨")):
+        stage, color = "Self-healing blocked / attention required", "red"
+    elif any(word in lowered for word in ("debounc", "observing", "repairing", "⚠️")):
+        stage, color = "Self-healing observing / repairing", "orange"
+    elif any(word in lowered for word in ("self-healed", "recovered", "healthy", "✅")):
+        if "without intervention" in lowered or "recovered naturally" in lowered:
+            stage = "Transiently self-recovered"
+        else:
+            stage = "Verified self-healing recovery"
+        color = "green"
+    elif any(word in lowered for word in ("failed", "failure", "error")):
+        stage, color = "Self-healing blocked / attention required", "red"
+    else:
+        stage, color = "Cron state changed", "blue"
+
+    return {
+        "name": match.group("name").strip(),
+        "job_id": match.group("job_id").strip(),
+        "body": body,
+        "stage": stage,
+        "color": color,
+    }
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -3493,6 +3544,48 @@ class DiscordAdapter(BasePlatformAdapter):
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
+                await asyncio.to_thread(
+                    self._record_discord_response,
+                    reply_to=reply_to,
+                    result=result,
+                    content=content,
+                    final=final_delivery,
+                )
+                return result
+
+            cron_embed_parts = _discord_cron_embed_parts(content, metadata)
+            if cron_embed_parts:
+                color_factory = getattr(discord.Color, cron_embed_parts["color"])
+                embed = discord.Embed(
+                    title=f"🔄 {cron_embed_parts['name']}",
+                    description=cron_embed_parts["body"],
+                    color=color_factory(),
+                    timestamp=dt.datetime.now(dt.timezone.utc),
+                )
+                embed.add_field(
+                    name="Self-healing stage",
+                    value=cron_embed_parts["stage"],
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Job",
+                    value=f"`{cron_embed_parts['job_id']}`",
+                    inline=True,
+                )
+                embed.set_footer(text="Hermes Cron Reliability")
+                reference = self._reply_reference_for_send(reply_to, channel)
+                msg = await channel.send(embed=embed, reference=reference)
+                message_id = str(msg.id)
+                _target_id = thread_id or chat_id
+                if nonconversational:
+                    self._nonconversational_messages.mark_many([message_id])
+                else:
+                    self._last_self_message_id[_target_id] = message_id
+                result = SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={"message_ids": [message_id], "embedded": True},
+                )
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -44,7 +44,10 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _discord_cron_embed_parts,
+)
 
 
 @pytest.mark.asyncio
@@ -80,6 +83,95 @@ async def test_send_rejects_whitespace_and_records_failed_final_reply(
     )
     assert tuple(row) == ("failed", 0, 0, None)
     assert "Dropped empty message to chat=555" in caplog.text
+
+
+def _wrapped_cron(body: str) -> str:
+    return (
+        "Cronjob Response: Camera health watchdog\n"
+        "(job_id: test-job)\n"
+        "-------------\n\n"
+        f"{body}\n\n"
+        "To stop or manage this job, send me a new message "
+        '(e.g. "stop reminder Camera health watchdog").'
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "stage", "color"),
+    [
+        ("⚠️ Observing/debouncing two pipelines.", "Self-healing observing / repairing", "orange"),
+        ("🚨 Self-healing blocked and escalated.", "Self-healing blocked / attention required", "red"),
+        ("✅ Recovered naturally without intervention from the failed probe.", "Transiently self-recovered", "green"),
+    ],
+)
+def test_cron_embed_stage_and_color(body, stage, color):
+    parts = _discord_cron_embed_parts(
+        _wrapped_cron(body),
+        {"job_id": "test-job"},
+    )
+    assert parts is not None
+    assert parts["stage"] == stage
+    assert parts["color"] == color
+
+
+@pytest.mark.asyncio
+async def test_short_cron_recovery_delivery_uses_green_embed(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(id=9001)))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    embed = MagicMock()
+    embed_factory = MagicMock(return_value=embed)
+    monkeypatch.setattr(_discord_mod, "Embed", embed_factory)
+    monkeypatch.setattr(_discord_mod.Color, "green", MagicMock(return_value=222))
+
+    result = await adapter.send(
+        "555",
+        _wrapped_cron(
+            "✅ Verified self-healed: Frigate restarted and all pipelines are healthy."
+        ),
+        metadata={"job_id": "test-job", "notify": True},
+    )
+
+    assert result.success is True
+    assert result.raw_response["embedded"] is True
+    embed_factory.assert_called_once()
+    kwargs = embed_factory.call_args.kwargs
+    assert kwargs["title"] == "🔄 Camera health watchdog"
+    assert "Verified self-healed" in kwargs["description"]
+    assert kwargs["color"] == 222
+    embed.add_field.assert_any_call(
+        name="Self-healing stage",
+        value="Verified self-healing recovery",
+        inline=False,
+    )
+    embed.set_footer.assert_called_once_with(text="Hermes Cron Reliability")
+    channel.send.assert_awaited_once_with(embed=embed, reference=None)
+
+
+@pytest.mark.asyncio
+async def test_long_cron_delivery_falls_back_to_split_text(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(id=9002)))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    embed_factory = MagicMock()
+    monkeypatch.setattr(_discord_mod, "Embed", embed_factory)
+
+    result = await adapter.send(
+        "555",
+        _wrapped_cron("x" * 3801),
+        metadata={"job_id": "test-job", "notify": True},
+    )
+
+    assert result.success is True
+    embed_factory.assert_not_called()
+    assert channel.send.await_count >= 2
+    assert all("content" in call.kwargs for call in channel.send.await_args_list)
 
 
 def _voice_adapter(reference_obj, *, native_result=None, native_error=None):


### PR DESCRIPTION
## Summary

- Render short wrapped cron deliveries as native Discord embeds when cron metadata is present.
- Color-code verified recovery (green), observing/repairing (orange), blocked/escalated (red), and neutral state changes (blue).
- Add explicit self-healing stage and job ID fields.
- Preserve long-form cron reports as ordinary split text so Discord's 4096-character embed cap never truncates content.

## Verification

- `117 passed` across `tests/gateway/test_discord_send.py` and `tests/cron/test_scheduler.py`
- Python compilation passed
- Diff check passed

## Scope

Discord live-adapter cron delivery only. Forum parents and standalone fallback delivery retain their current text behavior.
