### PR TITLE
feat(desktop): make a delivered file findable from the chat

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
@@ -39,7 +39,12 @@ describe('markdown documents delivered via MEDIA', () => {
 
     render(<MarkdownTextContent isRunning={false} text={`[archive.zip](${href})`} />)
 
-    expect(await screen.findByText(/archive\.zip/)).toBeTruthy()
-    expect(screen.queryByRole('button')).toBeNull()
+    // The card names the file and, below it, where the file lives — so the
+    // basename legitimately appears twice. Match the name row exactly.
+    expect(await screen.findByText('archive.zip')).toBeTruthy()
+
+    // The fallback is the file card (one Open action), NOT the preview rail's
+    // open/hide toggle — that distinction is what #84951 fixed.
+    expect(screen.queryByRole('button', { name: /preview/i })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -11,6 +11,7 @@ import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
+import { MediaFileAttachment } from '@/components/chat/media-file-attachment'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
@@ -226,19 +227,9 @@ function MediaAttachment({ path }: { path: string }) {
   }
 
   return (
-    <span className="wrap-anywhere">
-      <a
-        className="ref wrap-anywhere"
-        href="#"
-        onClick={event => {
-          event.preventDefault()
-          open()
-        }}
-      >
-        {failed ? `Open ${name}` : `Loading ${name}...`}
-      </a>
+    <MediaFileAttachment failed={failed} onOpen={open} path={path}>
       {openFailed && <OpenMediaFailedNote name={name} />}
-    </span>
+    </MediaFileAttachment>
   )
 }
 

--- a/apps/desktop/src/components/chat/media-file-attachment.test.tsx
+++ b/apps/desktop/src/components/chat/media-file-attachment.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MediaFileAttachment } from './media-file-attachment'
+
+const isDesktopFsRemoteMode = vi.fn(() => false)
+
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode: () => isDesktopFsRemoteMode()
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  isDesktopFsRemoteMode.mockReturnValue(false)
+})
+
+// A delivered file the chat can't render inline used to be a bare `Open <name>`
+// anchor. It named the file without saying where the file was, so reaching it
+// on disk meant copying the basename out of the sentence and searching for it.
+describe('a delivered file says where it is', () => {
+  it('shows the containing path under the name', () => {
+    render(<MediaFileAttachment failed onOpen={vi.fn()} path="/Users/someone/Downloads/report.csv" />)
+
+    expect(screen.getByText('report.csv')).toBeTruthy()
+    expect(screen.getByText('~/Downloads/report.csv')).toBeTruthy()
+  })
+
+  // The tildified path is for reading; the absolute one is what you paste.
+  it('keeps the absolute path available on hover', () => {
+    render(<MediaFileAttachment failed onOpen={vi.fn()} path="/Users/someone/Downloads/report.csv" />)
+
+    expect(screen.getByText('~/Downloads/report.csv').getAttribute('title')).toBe(
+      '/Users/someone/Downloads/report.csv'
+    )
+  })
+
+  it('resolves a file: URL delivery to its real path', () => {
+    render(<MediaFileAttachment failed onOpen={vi.fn()} path="file:///Users/someone/Downloads/report.csv" />)
+
+    expect(screen.getByText('~/Downloads/report.csv')).toBeTruthy()
+  })
+
+  it('still opens the file, which was the only action before', () => {
+    const onOpen = vi.fn()
+
+    render(<MediaFileAttachment failed onOpen={onOpen} path="/Users/someone/Downloads/report.csv" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    expect(onOpen).toHaveBeenCalled()
+  })
+})
+
+// Printing a path the user cannot navigate to is worse than printing none: a
+// gateway path names another machine's disk, and a URL names no disk at all.
+describe('the path is shown only when the file is on this disk', () => {
+  it('omits it in remote-gateway mode', () => {
+    isDesktopFsRemoteMode.mockReturnValue(true)
+
+    render(<MediaFileAttachment failed onOpen={vi.fn()} path="/srv/gateway/out/report.csv" />)
+
+    expect(screen.getByText('report.csv')).toBeTruthy()
+    expect(screen.queryByText('/srv/gateway/out/report.csv')).toBeNull()
+  })
+
+  it('omits it for an http delivery', () => {
+    render(<MediaFileAttachment failed onOpen={vi.fn()} path="https://example.com/report.csv" />)
+
+    expect(screen.getByText('report.csv')).toBeTruthy()
+    expect(screen.queryByText(/example\.com/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/chat/media-file-attachment.tsx
+++ b/apps/desktop/src/components/chat/media-file-attachment.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+
+import { useI18n } from '@/i18n'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { displayPath } from '@/lib/display-path'
+import { FileText } from '@/lib/icons'
+import { filePathFromMediaPath, isFileMediaPath, mediaName } from '@/lib/media'
+
+interface MediaFileAttachmentProps {
+  /** Rendered under the card (the gateway-fetch failure note). */
+  children?: ReactNode
+  /** Whether the delivered file failed to load as playable/inline media. */
+  failed: boolean
+  /** Fires the existing open/download behaviour for this attachment. */
+  onOpen: () => void
+  /** The delivered MEDIA path, as written by the agent. */
+  path: string
+}
+
+/**
+ * A delivered file the chat cannot render inline (a `.csv`, a `.zip`).
+ *
+ * The old shape was a bare `Open <name>` anchor, which told you a file existed
+ * without telling you where: the label carried the basename only, so locating
+ * the file on disk meant copying that name out of the sentence and searching
+ * for it. This card keeps the same single action and adds the answer to "where
+ * is it" — the home-relative path under the name, with the absolute path on
+ * hover.
+ *
+ * Shape follows `PreviewAttachment`, the sibling card for delivered files the
+ * rail CAN render, so the two deliveries read as the same kind of object.
+ */
+export function MediaFileAttachment({ children, failed, onOpen, path }: MediaFileAttachmentProps) {
+  const { t } = useI18n()
+  const name = mediaName(path)
+  const filePath = filePathFromMediaPath(path)
+
+  // Only a path on THIS disk is worth printing. A remote gateway's paths point
+  // at the gateway machine and a URL delivery has no local file, so showing
+  // either would name a location the user cannot navigate to.
+  const local = !isDesktopFsRemoteMode() && isFileMediaPath(path)
+  const shown = displayPath(filePath)
+
+  return (
+    <span className="block">
+      <span className="my-2 flex w-full max-w-160 items-center gap-2 rounded-lg border border-(--ui-stroke-tertiary) bg-card/55 px-2.5 py-1.5 text-sm">
+        <span className="grid size-6 shrink-0 place-items-center rounded-md bg-muted/55 text-muted-foreground/85">
+          <FileText className="size-3.5" />
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[0.78rem] font-medium text-foreground/90">{name}</span>
+          {local && shown !== name ? (
+            <span className="truncate text-[0.68rem] text-muted-foreground" title={filePath}>
+              {shown}
+            </span>
+          ) : null}
+        </span>
+        <button
+          className="shrink-0 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground"
+          onClick={onOpen}
+          type="button"
+        >
+          {failed ? t.fileMenu.open : t.fileMenu.opening}
+        </button>
+      </span>
+      {children}
+    </span>
+  )
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -66,6 +66,8 @@ export const ar = defineLocale({
     revealExplorer: 'إظهار في File Explorer',
     revealFileManager: 'فتح المجلد الحاوي',
     revealInSidebar: 'إظهار في شجرة الملفات',
+    open: 'فتح',
+    opening: 'جارٍ التحميل…',
     copyPath: 'نسخ المسار',
     copyRelativePath: 'نسخ المسار النسبي',
     download: 'تنزيل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -50,6 +50,8 @@ export const en: Translations = {
     revealExplorer: 'Reveal in File Explorer',
     revealFileManager: 'Open Containing Folder',
     revealInSidebar: 'Reveal in filetree',
+    open: 'Open',
+    opening: 'Loading…',
     copyPath: 'Copy Path',
     copyRelativePath: 'Copy Relative Path',
     download: 'Download',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -50,6 +50,8 @@ export const ja = defineLocale({
     revealExplorer: 'エクスプローラーで表示',
     revealFileManager: '格納フォルダーを開く',
     revealInSidebar: 'ファイルツリーで表示',
+    open: '開く',
+    opening: '読み込み中…',
     copyPath: 'パスをコピー',
     copyRelativePath: '相対パスをコピー',
     download: 'ダウンロード',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -96,6 +96,8 @@ export interface Translations {
     revealExplorer: string
     revealFileManager: string
     revealInSidebar: string
+    open: string
+    opening: string
     copyPath: string
     copyRelativePath: string
     download: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -50,6 +50,8 @@ export const zhHant = defineLocale({
     revealExplorer: '在檔案總管中顯示',
     revealFileManager: '開啟所在資料夾',
     revealInSidebar: '在檔案樹中顯示',
+    open: '開啟',
+    opening: '載入中…',
     copyPath: '複製路徑',
     copyRelativePath: '複製相對路徑',
     download: '下載',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -50,6 +50,8 @@ export const zh: Translations = {
     revealExplorer: '在文件资源管理器中显示',
     revealFileManager: '打开所在文件夹',
     revealInSidebar: '在文件树中显示',
+    open: '打开',
+    opening: '加载中…',
     copyPath: '复制路径',
     copyRelativePath: '复制相对路径',
     download: '下载',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -843,11 +843,23 @@
   box-decoration-break: clone;
 }
 
-/* Affordance without chrome: only the ones you can actually activate respond,
-   and they do it with an underline rather than a background. */
-:where(a, button).ref:hover {
+/* Activatable references carry a visible underline AT REST, not only on hover.
+   A reference you can click has to say so before the pointer arrives: hover is
+   not an affordance on a touch screen, it is invisible to anyone scanning the
+   transcript, and it cost a user a delivered file they could see but could not
+   tell was interactive. The rest state is deliberately quiet (a hairline at 45%
+   of the text color) and hover promotes it to the full-strength underline, so
+   the hover response the old rule provided survives. Static `.ref` chips, which
+   are neither `a` nor `button`, stay undecorated. */
+:where(a, button).ref {
   text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
   text-underline-offset: 0.15em;
+}
+
+:where(a, button).ref:hover {
+  text-decoration-color: currentColor;
 }
 
 /* The leading glyph. Sized in `em` so it tracks the text at any scale, and


### PR DESCRIPTION
## What does this PR do?

Two things about a file the agent delivered into the chat: making it obvious the reference is clickable, and saying where the file actually is.

**A clickable reference underlines only on hover.** Nothing about it reads as interactive until the pointer is already on it, which is invisible while scanning a transcript and absent entirely on a touch screen. Activatable references now carry the underline at rest, drawn at 45% of the text color, and hover promotes it to full strength so the existing hover response survives. Static `.ref` chips are neither `a` nor `button`, so the existing `:where(a, button)` selector keeps them undecorated.

This overrides a deliberate choice. The old rule was commented "affordance without chrome", so it deserves an argument rather than a silent flip: the design system already documents a persistent underline as a sanctioned affordance (`textStrong`, "bold underlined inline affordance"), and the cost of the hover-only version is a delivered file that a user can see but cannot tell is interactive. The rest state is deliberately quiet so the chrome objection still mostly holds.

**A non-renderable delivery says a file exists without saying where.** A `.csv` or a `.zip` falls through to `MediaAttachment`'s file branch, which rendered a bare `Open <name>` anchor carrying the basename alone. Reaching the file on disk meant copying that name out of the sentence and searching for it in the file manager. The fallback is now a card that prints the home-relative path under the name, with the absolute path on hover.

The card's shape follows `PreviewAttachment`, the sibling card for deliveries the rail can render, so the two kinds of delivered file read as the same kind of object.

The path is printed only for a file on this disk. A remote gateway's paths name the gateway machine and a URL delivery names no disk at all, so printing either would send the user somewhere they cannot go.

### What this deliberately leaves alone

No reveal-in-file-manager action. #90669, #91664, and #58997 are all open against this surface and each adds one, so this PR stays clear of that work and covers the parts none of them touch. Worth flagging for whoever triages that cluster: those three overlap each other, and #94189 was closed as a duplicate of #84986 while describing the MEDIA fallback, which is a different component from the Preview card #84986 is about.

## Related Issue

Refs #84986

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/styles.css`: `:where(a, button).ref` gains a rest-state underline at 45% of the text color; the hover rule now promotes it to full strength instead of introducing it.
- `apps/desktop/src/components/chat/media-file-attachment.tsx` (new): the file-delivery card. Name, home-relative path via the existing `displayPath`, absolute path on hover, and the same Open action the anchor had.
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`: the file branch of `MediaAttachment` renders that card. Open behavior is unchanged, still `useOpenMediaFile`.
- `apps/desktop/src/i18n/`: `fileMenu.open` and `fileMenu.opening` in types plus all five locales.
- `apps/desktop/src/components/chat/media-file-attachment.test.tsx` (new): path display, the absolute-path title, `file:` URL resolution, the Open action, and the two cases where the path must be withheld.
- `apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx`: the #84951 regression asserted `queryByRole('button')` is null on the file fallback, using "no buttons at all" as a proxy for "not the preview rail". The card has an Open button by design, so the assertion now names the preview toggle it was actually guarding against. Same guarantee, stated directly.

## How to Test

1. Have the agent deliver a non-renderable file, e.g. `MEDIA:/absolute/path/to/report.csv`.
2. The chat shows a card with the filename, the path below it as `~/…/report.csv`, and an Open button. Hover the path for the absolute form.
3. Any clickable reference in the transcript (a link, a session ref, this card) is underlined before you hover it, and the underline darkens on hover.
4. Connect to a remote gateway and repeat step 1: the card shows the name and Open, and prints no path.

```
cd apps/desktop
npx tsc -p . --noEmit
TMPDIR=/tmp npx vitest run --project ui     # 597 files, 5755 tests passing
npx eslint src/components/chat/media-file-attachment.tsx src/components/assistant-ui/markdown-text.tsx src/i18n
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the renderer gate (`tsc --noEmit`, `vitest run --project ui`, `eslint`) and all of it passes. This PR touches no Python, so `pytest tests/ -q` is not the relevant gate.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `displayPath` already handles Windows drive paths and backslashes, and the underline is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
