### PR TITLE
fix(discord): anchor cron handoff threads and preserve sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1881,6 +1881,14 @@ def _seed_cron_thread_session(
         from gateway.session import SessionSource
 
         seeded_session_id: Optional[str] = None
+        # Discord thread destinations use the thread's own ID as chat_id for
+        # both session creation and origin lookup. Other platforms keep the
+        # parent channel as chat_id and distinguish the thread separately.
+        session_chat_id = (
+            str(thread_id)
+            if str(platform_name).lower() == Platform.DISCORD.value
+            else str(chat_id)
+        )
         session_store = getattr(adapter, "_session_store", None)
         if session_store is not None:
             try:
@@ -1888,19 +1896,9 @@ def _seed_cron_thread_session(
             except (ValueError, KeyError):
                 platform_enum = None
             if platform_enum is not None:
-                # Discord thread destinations must key on the thread's OWN id
-                # to match how the Discord adapter keys organic in-thread
-                # messages (chat_id == thread_id). Other platforms (Slack,
-                # Telegram) use chat_id == parent_channel for thread messages,
-                # so the parent chat_id is correct for them. See the matching
-                # guard in GatewayRunner._process_handoff.
-                if platform_enum == Platform.DISCORD:
-                    seed_chat_id = str(thread_id)
-                else:
-                    seed_chat_id = str(chat_id)
                 dest_source = SessionSource(
                     platform=platform_enum,
-                    chat_id=seed_chat_id,
+                    chat_id=session_chat_id,
                     chat_name=chat_name,
                     # DM threads key through the DM arm (see docstring); the
                     # reply's chat_type is what the seed must reproduce.
@@ -1927,7 +1925,7 @@ def _seed_cron_thread_session(
         # thread-keyed session row we just created.
         ok = mirror_to_session(
             platform_name,
-            str(chat_id),
+            session_chat_id,
             f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
             source_label="cron",
             thread_id=str(thread_id),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7344,13 +7344,14 @@ class DiscordAdapter(BasePlatformAdapter):
         parent_chat_id: str,
         name: str,
     ) -> Optional[str]:
-        """Create a Discord thread under a text channel for a handoff.
+        """Create a visible, message-anchored Discord handoff thread.
 
-        Falls back to a seed-message + ``message.create_thread`` path if
-        ``parent.create_thread`` is rejected (some channel types or
-        permission setups). Returns the new thread id as a string, or
-        ``None`` on failure or when the parent isn't a text channel
-        (DMs, voice channels, threads themselves can't host threads).
+        The parent anchor contains only the sanitized thread name; the caller
+        delivers the actual handoff content into the returned child thread. If
+        the anchor send or anchored thread creation fails, return ``None`` so
+        callers can deliver flat to the parent. When creation fails after the
+        send, the terse anchor remains as a deterministic orphan; never replace
+        it with an unanchored channel thread.
         """
         if not self._client or not DISCORD_AVAILABLE:
             return None
@@ -7372,48 +7373,53 @@ class DiscordAdapter(BasePlatformAdapter):
             return None
 
         # DMs, voice channels, and existing threads can't host child threads.
-        if isinstance(parent, getattr(discord, "DMChannel", ())):
+        unsupported_parent_types = tuple(
+            parent_type
+            for name in ("DMChannel", "VoiceChannel", "Thread")
+            if isinstance((parent_type := getattr(discord, name, None)), type)
+        )
+        if unsupported_parent_types and isinstance(parent, unsupported_parent_types):
             logger.info(
-                "[%s] Handoff thread: parent %s is a DM; threads not supported here",
+                "[%s] Handoff thread: parent %s cannot host a child thread",
                 self.name, parent_chat_id,
             )
             return None
 
-        thread_name = (name or "handoff").strip()[:80] or "handoff"
-        reason = "Hermes session handoff"
+        thread_name = self._derive_auto_thread_name(name or "handoff")
+        if utf16_len(thread_name) > 80:
+            thread_name = _prefix_within_utf16_limit(thread_name, 77).rstrip() + "..."
+        anchor_name = re.sub(
+            r"([\\*_`~|])",
+            lambda match: f"\\{match.group(1)}",
+            thread_name,
+        )
+        anchor = (
+            f"\U0001f9f5 **{anchor_name}** \N{EM DASH} "
+            "open this thread to continue."
+        )
 
-        # First try: create a thread directly on the channel.
-        try:
-            create = getattr(parent, "create_thread", None)
-            if create is not None:
-                thread = await create(
-                    name=thread_name,
-                    auto_archive_duration=1440,
-                    reason=reason,
-                )
-                return str(thread.id)
-        except Exception as direct_error:
-            logger.debug(
-                "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
-                self.name, direct_error,
-            )
-
-        # Fallback: post a seed message and create the thread from it.
         try:
             send = getattr(parent, "send", None)
-            if send is None:
+            if not callable(send):
                 return None
-            seed_msg = await send(f"\U0001f9f5 Hermes handoff: **{thread_name}**")
-            thread = await seed_msg.create_thread(
+            seed_msg = await send(
+                anchor,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            create = getattr(seed_msg, "create_thread", None)
+            if not callable(create):
+                raise TypeError("anchor message cannot create a thread")
+            thread = await create(
                 name=thread_name,
                 auto_archive_duration=1440,
-                reason=reason,
+                reason="Hermes session handoff",
             )
             return str(thread.id)
-        except Exception as fallback_error:
+        except Exception as exc:
             logger.warning(
-                "[%s] Handoff thread: both create paths failed for parent %s: %s",
-                self.name, parent_chat_id, fallback_error,
+                "[%s] Handoff thread: visible anchor/thread creation failed "
+                "for parent %s; caller will fall back to flat delivery: %s",
+                self.name, parent_chat_id, exc,
             )
             return None
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7414,6 +7414,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason="Hermes session handoff",
             )
+            self._threads.mark(str(thread.id))
             return str(thread.id)
         except Exception as exc:
             logger.warning(

--- a/tests/cron/test_cron_discord_anchored_delivery.py
+++ b/tests/cron/test_cron_discord_anchored_delivery.py
@@ -1,0 +1,110 @@
+"""Cron delivery contracts around Discord handoff-thread creation."""
+
+import asyncio
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform
+
+
+PARENT_ID = "123456789"
+CHILD_ID = "987654321"
+RESPONSE = "Here is today's writing exercise."
+
+
+def _run_delivery(opened_thread_id):
+    captured = {}
+
+    class SpyRouter:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def _deliver_to_platform(self, target, text, metadata):
+            captured["target"] = target
+            captured["text"] = text
+            captured["metadata"] = metadata
+            return SimpleNamespace(
+                success=True,
+                message_id="delivered-message",
+                raw_response=None,
+            )
+
+    def run_now(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # pragma: no cover - surfaced by result()
+            future.set_exception(exc)
+        return future
+
+    platform_config = MagicMock()
+    platform_config.enabled = True
+    platform_config.extra = {}
+    gateway_config = MagicMock()
+    gateway_config.platforms = {Platform.DISCORD: platform_config}
+
+    adapter = MagicMock()
+    adapter.name = "Discord"
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    job = {
+        "id": "daily-writing",
+        "name": "Daily writing prompt",
+        "deliver": "origin",
+        "origin": {
+            "platform": "discord",
+            "chat_id": PARENT_ID,
+            "chat_type": "group",
+            "user_id": "writer",
+        },
+        "attach_to_session": True,
+    }
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=gateway_config),
+        patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ),
+        patch(
+            "cron.scheduler._open_continuable_cron_thread",
+            return_value=opened_thread_id,
+        ),
+        patch("gateway.delivery.DeliveryRouter", SpyRouter),
+        patch("agent.async_utils.safe_schedule_threadsafe", side_effect=run_now),
+        patch("cron.scheduler._seed_cron_thread_session") as seed_session,
+        patch("gateway.mirror.mirror_to_session", return_value=True),
+    ):
+        _deliver_result(
+            job,
+            RESPONSE,
+            adapters={Platform.DISCORD: adapter},
+            loop=loop,
+        )
+
+    return captured, seed_session
+
+
+def test_cron_thread_creation_failure_delivers_full_response_flat_to_parent():
+    captured, seed_session = _run_delivery(None)
+
+    assert captured["target"].chat_id == PARENT_ID
+    assert captured["target"].thread_id is None
+    assert captured["text"] == RESPONSE
+    assert "thread_id" not in captured["metadata"]
+    seed_session.assert_not_called()
+
+
+def test_cron_success_delivers_response_and_seeds_session_in_child_thread():
+    captured, seed_session = _run_delivery(CHILD_ID)
+
+    assert captured["target"].chat_id == PARENT_ID
+    assert captured["target"].thread_id == CHILD_ID
+    assert captured["metadata"]["thread_id"] == CHILD_ID
+    assert captured["text"] == RESPONSE
+    seed_session.assert_called_once()
+    assert seed_session.call_args.args[3] == PARENT_ID
+    assert seed_session.call_args.args[4] == CHILD_ID
+    assert seed_session.call_args.args[5] == RESPONSE

--- a/tests/cron/test_cron_thread_seed_dm_keying.py
+++ b/tests/cron/test_cron_thread_seed_dm_keying.py
@@ -17,13 +17,88 @@ not on SessionSource field shapes — pins the end-to-end contract.
 from unittest.mock import MagicMock, patch
 
 from cron.scheduler import _seed_cron_channel_session, _seed_cron_thread_session
-from gateway.config import Platform
-from gateway.session import SessionSource, build_session_key
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, build_session_key
 
 
 def _seeded_source(store):
     store.get_or_create_session.assert_called_once()
     return store.get_or_create_session.call_args[0][0]
+
+
+def test_discord_thread_seed_lookup_matches_inbound_reply(tmp_path, monkeypatch):
+    """Discord keys thread messages on the thread ID as both chat and thread.
+
+    Exercise mirror_to_session's origin lookup rather than its explicit-session
+    fast path so a parent-channel lookup cannot be masked. The seeded brief must
+    land in the same real session a later Discord reply resolves to.
+    """
+    import gateway.mirror as mirror
+    from hermes_state import SessionDB
+
+    home = tmp_path / "hermes-home"
+    sessions_dir = home / "sessions"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(mirror, "_SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(mirror, "_SESSIONS_INDEX", sessions_dir / "sessions.json")
+
+    store = SessionStore(
+        sessions_dir,
+        GatewayConfig(sessions_dir=sessions_dir),
+    )
+
+    class _Adapter:
+        _session_store = store
+
+    parent_channel_id = "111111111111111111"
+    thread_id = "222222222222222222"
+    brief = "Daily calibration brief"
+    real_mirror = mirror.mirror_to_session
+
+    def _lookup_only_mirror(*args, **kwargs):
+        # The active failing path had to rediscover the newly-created row. Keep
+        # that compatibility seam covered even though current code can also pass
+        # the exact session_id as a fast path.
+        kwargs["session_id"] = None
+        return real_mirror(*args, **kwargs)
+
+    with patch("gateway.mirror.mirror_to_session", side_effect=_lookup_only_mirror):
+        _seed_cron_thread_session(
+            {"id": "discord-brief", "name": "Calibration"},
+            _Adapter(),
+            "discord",
+            parent_channel_id,
+            thread_id,
+            brief,
+            chat_name="calibration",
+        )
+
+    inbound_reply = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=thread_id,
+        chat_type="thread",
+        user_id="discord-user",
+        thread_id=thread_id,
+    )
+
+    db = SessionDB()
+    try:
+        seeded_session_id = db.find_session_by_origin(
+            platform="discord",
+            chat_id=thread_id,
+            user_id="system:cron",
+            thread_id=thread_id,
+        )
+        reply_entry = store.get_or_create_session(inbound_reply)
+        messages = db.get_messages(reply_entry.session_id)
+    finally:
+        db.close()
+
+    assert seeded_session_id is not None
+    assert reply_entry.session_id == seeded_session_id
+    assert any(brief in str(message.get("content", "")) for message in messages), (
+        "Discord reply resolved to a session without the seeded cron brief"
+    )
 
 
 def test_dm_thread_seed_key_matches_dm_reply_key():
@@ -63,7 +138,7 @@ def test_channel_thread_seed_key_matches_thread_reply_key():
     adapter = MagicMock()
     adapter._session_store = store
 
-    with patch("gateway.mirror.mirror_to_session", return_value=True):
+    with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
         _seed_cron_thread_session(
             {"id": "j2", "name": "digest"}, adapter, "slack",
             "C0AAAAAAAA", "1787188000.000100", "Three bullets",
@@ -80,6 +155,7 @@ def test_channel_thread_seed_key_matches_thread_reply_key():
     assert build_session_key(_seeded_source(store)) == build_session_key(
         reply_source
     )
+    assert mirror_mock.call_args.args[1] == "C0AAAAAAAA"
 
 
 def test_dm_seed_default_is_backward_compatible():

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -228,6 +228,72 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
 
 
 @pytest.mark.asyncio
+async def test_marked_handoff_thread_accepts_plain_message_without_mention(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    thread = FakeThread(
+        channel_id=987654321,
+        parent=FakeTextChannel(channel_id=123456789, name="writers-room"),
+    )
+    adapter._threads.mark(str(thread.id))
+
+    admitted = await adapter._handle_message(
+        make_message(channel=thread, content="The scene continues without a mention.")
+    )
+
+    assert admitted is True
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "The scene continues without a mention."
+    assert event.source.chat_id == str(thread.id)
+    assert event.source.thread_id == str(thread.id)
+
+
+@pytest.mark.asyncio
+async def test_unmarked_handoff_thread_rejects_plain_message_without_mention(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    thread = FakeThread(
+        channel_id=987654321,
+        parent=FakeTextChannel(channel_id=123456789, name="writers-room"),
+    )
+
+    admitted = await adapter._handle_message(
+        make_message(channel=thread, content="The scene continues without a mention.")
+    )
+
+    assert admitted is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_require_mention_rejects_plain_message_in_marked_thread(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    thread = FakeThread(
+        channel_id=987654321,
+        parent=FakeTextChannel(channel_id=123456789, name="writers-room"),
+    )
+    adapter._threads.mark(str(thread.id))
+
+    admitted = await adapter._handle_message(
+        make_message(channel=thread, content="The scene continues without a mention.")
+    )
+
+    assert admitted is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
     """Quote-replies should stay in-channel instead of trying to create a thread."""
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)

--- a/tests/gateway/test_discord_handoff_thread.py
+++ b/tests/gateway/test_discord_handoff_thread.py
@@ -1,0 +1,187 @@
+"""Behavior contracts for visible Discord handoff threads."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+import plugins.platforms.discord.adapter as discord_adapter_module
+
+
+PARENT_ID = "123456789"
+THREAD_REASON = "Hermes session handoff"
+
+
+def _adapter_with_parent(parent):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._client = MagicMock()
+    adapter._client.get_channel.return_value = parent
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_handoff_posts_one_visible_anchor_before_message_thread_creation(
+    monkeypatch,
+):
+    events = []
+    thread = SimpleNamespace(id=987654321)
+    safe_mentions = object()
+    monkeypatch.setattr(
+        discord_adapter_module.discord.AllowedMentions,
+        "none",
+        lambda: safe_mentions,
+    )
+
+    async def send_anchor(content, **kwargs):
+        events.append(("send", content, kwargs))
+        return seed_message
+
+    async def create_from_anchor(**kwargs):
+        events.append(("create", kwargs))
+        return thread
+
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=create_from_anchor)
+    )
+    parent = SimpleNamespace(
+        send=AsyncMock(side_effect=send_anchor),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
+
+    assert result == "987654321"
+    assert events == [
+        (
+            "send",
+            "\N{SPOOL OF THREAD} **Daily writing prompt** \N{EM DASH} "
+            "open this thread to continue.",
+            {"allowed_mentions": safe_mentions},
+        ),
+        (
+            "create",
+            {
+                "name": "Daily writing prompt",
+                "auto_archive_duration": 1440,
+                "reason": THREAD_REASON,
+            },
+        ),
+    ]
+    parent.send.assert_awaited_once()
+    seed_message.create_thread.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_anchor_and_thread_name_are_sanitized_and_limited():
+    raw_name = f"  {'x' * 90}   <@123456789>  "
+    expected_name = f"{'x' * 77}..."
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(return_value=SimpleNamespace(id=246813579))
+    )
+    parent = SimpleNamespace(
+        send=AsyncMock(return_value=seed_message),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, raw_name)
+
+    assert result == "246813579"
+    assert parent.send.await_args.args[0] == (
+        f"\N{SPOOL OF THREAD} **{expected_name}** \N{EM DASH} "
+        "open this thread to continue."
+    )
+    seed_message.create_thread.assert_awaited_once_with(
+        name=expected_name,
+        auto_archive_duration=1440,
+        reason=THREAD_REASON,
+    )
+    parent.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_thread_name_respects_utf16_limit_for_emoji():
+    from gateway.platforms.base import utf16_len
+
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(return_value=SimpleNamespace(id=135792468))
+    )
+    parent = SimpleNamespace(
+        send=AsyncMock(return_value=seed_message),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "\N{ROBOT FACE}" * 50)
+
+    assert result == "135792468"
+    created_name = seed_message.create_thread.await_args.kwargs["name"]
+    assert utf16_len(created_name) <= 80
+    assert created_name.endswith("...")
+    parent.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_anchor_send_failure_returns_none_without_direct_thread():
+    parent = SimpleNamespace(
+        send=AsyncMock(side_effect=PermissionError("cannot send anchor")),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
+
+    assert result is None
+    parent.send.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_anchor_thread_failure_returns_none_and_leaves_terse_orphan():
+    seed_message = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=PermissionError("cannot create thread"))
+    )
+    parent = SimpleNamespace(
+        send=AsyncMock(return_value=seed_message),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
+
+    assert result is None
+    assert parent.send.await_args.args[0] == (
+        "\N{SPOOL OF THREAD} **Daily writing prompt** \N{EM DASH} "
+        "open this thread to continue."
+    )
+    seed_message.create_thread.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("discord_parent_type", ["DMChannel", "VoiceChannel", "Thread"])
+async def test_handoff_rejects_unsupported_parent_types(
+    monkeypatch, discord_parent_type
+):
+    class UnsupportedParent:
+        def __init__(self):
+            self.send = AsyncMock()
+            self.create_thread = AsyncMock()
+
+    monkeypatch.setattr(
+        discord_adapter_module.discord,
+        discord_parent_type,
+        UnsupportedParent,
+    )
+    parent = UnsupportedParent()
+    adapter = _adapter_with_parent(parent)
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
+
+    assert result is None
+    parent.send.assert_not_awaited()
+    parent.create_thread.assert_not_awaited()

--- a/tests/gateway/test_discord_handoff_thread.py
+++ b/tests/gateway/test_discord_handoff_thread.py
@@ -50,6 +50,9 @@ async def test_handoff_posts_one_visible_anchor_before_message_thread_creation(
         create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
     )
     adapter = _adapter_with_parent(parent)
+    adapter._threads.mark = MagicMock(
+        side_effect=lambda thread_id: events.append(("mark", thread_id))
+    )
 
     result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
 
@@ -69,7 +72,9 @@ async def test_handoff_posts_one_visible_anchor_before_message_thread_creation(
                 "reason": THREAD_REASON,
             },
         ),
+        ("mark", "987654321"),
     ]
+    adapter._threads.mark.assert_called_once_with(result)
     parent.send.assert_awaited_once()
     seed_message.create_thread.assert_awaited_once()
     parent.create_thread.assert_not_awaited()
@@ -132,12 +137,31 @@ async def test_handoff_anchor_send_failure_returns_none_without_direct_thread():
         create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
     )
     adapter = _adapter_with_parent(parent)
+    adapter._threads.mark = MagicMock()
 
     result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
 
     assert result is None
     parent.send.assert_awaited_once()
     parent.create_thread.assert_not_awaited()
+    adapter._threads.mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_anchor_without_create_method_never_marks_participation():
+    parent = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace()),
+        create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
+    )
+    adapter = _adapter_with_parent(parent)
+    adapter._threads.mark = MagicMock()
+
+    result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
+
+    assert result is None
+    parent.send.assert_awaited_once()
+    parent.create_thread.assert_not_awaited()
+    adapter._threads.mark.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -150,6 +174,7 @@ async def test_handoff_anchor_thread_failure_returns_none_and_leaves_terse_orpha
         create_thread=AsyncMock(side_effect=AssertionError("unanchored thread path")),
     )
     adapter = _adapter_with_parent(parent)
+    adapter._threads.mark = MagicMock()
 
     result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
 
@@ -160,6 +185,21 @@ async def test_handoff_anchor_thread_failure_returns_none_and_leaves_terse_orpha
     )
     seed_message.create_thread.assert_awaited_once()
     parent.create_thread.assert_not_awaited()
+    adapter._threads.mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handoff_invalid_parent_id_never_marks_participation():
+    adapter = _adapter_with_parent(SimpleNamespace())
+    adapter._threads.mark = MagicMock()
+
+    result = await adapter.create_handoff_thread("not-a-snowflake", "Daily writing prompt")
+
+    assert result is None
+    client = adapter._client
+    assert client is not None
+    client.get_channel.assert_not_called()
+    adapter._threads.mark.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -179,9 +219,11 @@ async def test_handoff_rejects_unsupported_parent_types(
     )
     parent = UnsupportedParent()
     adapter = _adapter_with_parent(parent)
+    adapter._threads.mark = MagicMock()
 
     result = await adapter.create_handoff_thread(PARENT_ID, "Daily writing prompt")
 
     assert result is None
     parent.send.assert_not_awaited()
     parent.create_thread.assert_not_awaited()
+    adapter._threads.mark.assert_not_called()

--- a/tests/gateway/test_discord_thread_persistence.py
+++ b/tests/gateway/test_discord_thread_persistence.py
@@ -47,4 +47,13 @@ class TestDiscordThreadPersistence:
         assert "aaa" in adapter2._threads
         assert "bbb" in adapter2._threads
 
+    def test_tracker_instance_reloads_marked_handoff_from_temp_home(self, tmp_path):
+        from gateway.platforms.helpers import ThreadParticipationTracker
 
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            tracker = ThreadParticipationTracker("discord")
+            tracker.mark("987654321")
+
+            restarted_tracker = ThreadParticipationTracker("discord")
+
+        assert "987654321" in restarted_tracker


### PR DESCRIPTION
## Summary
- create Discord handoff threads from a concise visible parent-channel anchor instead of an unanchored channel thread
- return `None` when anchor send or anchored thread creation fails so cron delivers the full response flat to the parent
- key Discord cron thread sessions and mirror lookup by the child thread ID so replies resolve the seeded brief
- preserve parent-channel session lookup for Slack, Telegram, and other platforms

## Root causes
1. `DiscordAdapter.create_handoff_thread()` preferred `parent.create_thread(...)`. Discord produced an unanchored thread that did not appear as a visible row in the parent channel and could be inaccessible to a non-member.
2. After thread creation, the scheduler created the Discord session with `chat_id=<child_thread_id>` but could mirror through `chat_id=<parent_channel_id>`, so later replies could resolve a session without the cron brief.

## Behavior
The normal Discord path now:
1. posts `🧵 **{sanitized_thread_name}** — open this thread to continue.` to the parent channel with mentions disabled;
2. calls `seed_msg.create_thread(...)` with the existing 1440-minute archive duration and handoff reason;
3. returns the child thread ID, which the existing scheduler uses for delivery and session seeding.

There is no direct `parent.create_thread(...)` fallback. If the anchor send or anchored creation fails, the adapter returns `None` and the scheduler sends the full response flat to the parent. If creation fails after the anchor was posted, the terse name-only anchor remains as a deterministic orphan; no prompt content is exposed in it.

DMs, voice channels, and existing threads remain unsupported as parent surfaces. Thread names retain mention stripping, whitespace normalization, Markdown escaping in the anchor, and the 80 UTF-16-unit limit.

## Verification
- RED: new anchor-first contracts failed 6 tests against the direct-thread implementation; follow-up safe-mention/UTF-16 contracts failed 2 tests before those guards were added
- GREEN: focused handoff contracts — 8 passed
- impacted adapter/handoff/cron/session set — 139 passed across 6 files
- Ruff on changed files — passed
- `py_compile` on changed files — passed
- `git diff --check` — passed
- independent staged-diff review — pass, no blocking findings

No gateway restart, deployment, cron activation/resume, or live Discord delivery was performed.
