### PR TITLE
fix(agent): don't remap check_fn-gated tool names onto siblings

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -49,6 +49,7 @@ from agent.credential_pool import (
 )
 from agent.error_classifier import FailoverReason
 from agent.turn_context import drop_stale_api_content
+from tools.registry import registry
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -3544,6 +3545,18 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
+
+    # Refuse to fuzzy-match a real tool that is merely unavailable this turn.
+    # check_fn-gated names (e.g. kanban_list hidden from kanban workers via
+    # _check_kanban_orchestrator_mode) are absent from valid_tool_names, so the
+    # fuzzy fallback would otherwise remap them onto the nearest available
+    # sibling (kanban_list -> kanban_link), silently turning a read into a
+    # different operation. If any normalized spelling of the requested name is
+    # a real registered tool, fall through to the normal "unknown tool" path so
+    # the model learns the name is unavailable here instead of getting a
+    # substituted sibling. (See #94506.)
+    if cands & set(registry.get_all_tool_names()):
+        return None
 
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -125,3 +125,46 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+class TestGatedToolNotRemappedOntoSibling:
+    """Regression coverage for #94506.
+
+    A tool name the registry knows but ``check_fn`` withheld for this turn
+    (e.g. ``kanban_list`` hidden from dispatcher workers via
+    ``_check_kanban_orchestrator_mode``) is absent from ``valid_tool_names``.
+    Before the fix, the step-5 fuzzy fallback remapped it onto the nearest
+    available sibling (``kanban_list`` -> ``kanban_link``), silently turning a
+    read into a different operation. The fix refuses to substitute a sibling
+    for a real-but-gated name: it falls through to the normal "unknown tool"
+    path (returns None).
+    """
+
+    @pytest.fixture
+    def gated_repair(self):
+        """Bind _repair_tool_call on a stub whose valid_tool_names excludes the
+        orchestrator-only kanban tools, mimicking a dispatcher-spawned worker."""
+        from run_agent import AIAgent
+        from tools.registry import registry
+
+        all_names = set(registry.get_all_tool_names())
+        # A kanban worker's post-gating set omits the board-routing tools.
+        assert "kanban_list" in all_names, "kanban_list must be registered for this test"
+        assert "kanban_link" in all_names, "kanban_link must be registered for this test"
+        worker_valid = all_names - {"kanban_list", "kanban_unblock"}
+        stub = SimpleNamespace(valid_tool_names=worker_valid)
+        return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+    def test_gated_exact_name_is_not_remapped_to_sibling(self, gated_repair):
+        # A real tool that is gated this turn must NOT become its sibling.
+        assert gated_repair("kanban_list") is None
+
+    def test_gated_camel_case_name_is_not_remapped(self, gated_repair):
+        # Normalized spellings of the gated name are caught too (not just the
+        # exact lowercase form), so CamelCase can't dodge the guard.
+        assert gated_repair("KanbanList") is None
+
+    def test_genuine_typo_of_available_tool_still_repairs(self, gated_repair):
+        # A typo of an *available* tool must still fuzzy-match — the guard only
+        # covers names that resolve to a real registered tool.
+        assert gated_repair("broswe_click") == "browser_click"


### PR DESCRIPTION
# fix(agent): don't remap check_fn-gated tool names onto siblings

Closes #94506

## Problem
`repair_tool_call()`'s step-5 fuzzy fallback (`difflib.get_close_matches(cutoff=0.7)`) treats a real tool that `check_fn` withheld this turn as a typo and remaps it onto the nearest available sibling. A dispatcher-spawned kanban worker calling `kanban_list` (hidden by `_check_kanban_orchestrator_mode` at `tools/kanban_tools.py:122`) had it silently dispatched to `kanban_link`, turning a read into a `parent_id`/`child_id` dependency write that blocks the child from promoting to `ready`. The remap only surfaced because `kanban_link` requires args; a name that happened to validate would stall the board silently. `kanban_unblock → kanban_block` is the same collision class (a read becoming the *opposite* write).

## Root cause
`agent.valid_tool_names` is the post-gating set (built from `agent.tools` in `agent/agent_init.py:1590`). A `check_fn`-gated tool is absent from it, so step 5 sees a real-but-gated name as an unknown typo and picks the nearest neighbour (0.79 similarity ≥ 0.7 cutoff). Steps 1–4 normalize spellings of the *same* tool; step 5 selects a *different* one.

## Fix
Before the fuzzy fallback, refuse to substitute when any normalized spelling of the requested name is a real registered tool (`registry.get_all_tool_names()`): fall through to the normal "unknown tool" path so the model learns the name is unavailable here instead of getting a substituted sibling. Available tools are unaffected — the exact-match loop runs first and returns any candidate in `valid_tool_names` before the guard.

## Measured evidence
RED on pristine main (reproducer, live registry): `repair('kanban_list')` → `'kanban_link'` (and `'KanbanList'` → `'kanban_link'`).
GREEN with fix: both return `None`.

Regression tests added to `tests/run_agent/test_repair_tool_call_name.py`:
- gated exact name is not remapped (`kanban_list` → `None`)
- gated CamelCase name is not remapped (`KanbanList` → `None`)
- genuine typo of an available tool still repairs (`broswe_click` → `browser_click`)

`tests/run_agent/test_repair_tool_call_name.py`: 11 passed (8 pre-existing + 3 new).
Full `tests/run_agent/` suite: 1834 passed, 6 skipped — no collateral regression.
`tests/tools/test_kanban_tools.py`: 32 passed.

Scope: 2 files, +56 lines. Reviewed by two independent reviewers.

