### PR TITLE
fix(tools): drain high-fd pipes with selectors instead of select

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,6 +6,8 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
+import os
+
 import pytest
 
 import tools.terminal_tool_sudo as terminal_tool_sudo
@@ -509,3 +511,104 @@ class TestSanitizeTaskIdForPath:
         )
         target.mkdir(parents=True)
         assert target.is_dir()
+
+
+class TestWaitForProcessDrain:
+    """Regression tests for the POSIX stdout-drain path in _wait_for_process.
+
+    Covers #94928 (select() ValueError when a pipe fd exceeds FD_SETSIZE) and
+    the #8340 backgrounded-grandchild case (drain must terminate shortly after
+    bash exits even when a grandchild still holds the pipe open).
+    """
+
+    pytestmark = pytest.mark.skipif(
+        os.name != "posix", reason="POSIX-only drain path (needs /bin/bash)"
+    )
+
+    def _run(self, bash_script):
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["/bin/bash", "-c", bash_script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        return _TestableEnv(cwd="/tmp", timeout=20)._wait_for_process(
+            proc, timeout=15
+        )
+
+    def test_drain_captures_output_when_stdout_fd_above_fd_setsize(self):
+        """#94928: a pipe fd >= 1024 must still be drained.
+
+        Before the fix the POSIX drain used select.select(), which raises
+        ValueError for fds >= FD_SETSIZE (1024); the handler mistook that for
+        EOF and silently returned empty output with a correct exit code.
+        """
+        import resource
+
+        # Raise the soft fd limit so we can push a pipe fd past 1024.  Skip on
+        # hosts whose hard limit cannot reach 2048 (the bug cannot manifest).
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (max(soft, 2048), hard))
+        except (ValueError, OSError):
+            pytest.skip("cannot raise RLIMIT_NOFILE past FD_SETSIZE")
+
+        held = []
+        try:
+            # Hold fds open until the next allocation lands at >= 1024.
+            while True:
+                fd = os.open("/dev/null", os.O_RDONLY)
+                held.append(fd)
+                if fd >= 1024:
+                    break
+
+            result = self._run('printf "high-fd-output\\n"')
+            assert result["returncode"] == 0
+            assert "high-fd-output" in result["output"], result["output"]
+        finally:
+            for fd in held:
+                os.close(fd)
+            # Restore the original process-wide fd limit (do not leak the
+            # raised policy to later tests in the same worker).
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+            except (ValueError, OSError):
+                pass
+
+    def test_drain_captures_output_at_normal_fd(self):
+        """Low-fd path keeps capturing full stdout (no regression)."""
+        result = self._run("echo line-one; echo line-two")
+        assert result["returncode"] == 0
+        assert result["output"] == "line-one\nline-two\n", result["output"]
+
+    def test_drain_terminates_with_backgrounded_grandchild(self):
+        """#8340: bash exits but a grandchild holds the pipe open — the drain
+        must stop shortly after bash exits instead of hanging."""
+        result = self._run(
+            "echo before-bg; (sleep 30 &) 2>/dev/null; disown; echo after-bg"
+        )
+        assert result["returncode"] == 0
+        assert "before-bg" in result["output"], result["output"]
+
+    def test_drain_falls_back_to_read_when_selector_register_fails(self):
+        """If the selector cannot register the fd (e.g. EPERM for a regular
+        file, or an already-closed fd), the drain must fall back to a direct
+        non-blocking polling read instead of silently dropping all output."""
+        import selectors as _selectors
+        from unittest import mock
+
+        class _RejectingSelector:
+            def register(self, fd, flags):
+                raise OSError("EPERM: operation not permitted")
+
+            def close(self):
+                pass
+
+        with mock.patch.object(
+            _selectors, "DefaultSelector", lambda: _RejectingSelector()
+        ):
+            result = self._run('printf "fallback-output\\n"')
+        assert result["returncode"] == 0
+        assert "fallback-output" in result["output"], result["output"]

--- a/tools/environments/base_output.py
+++ b/tools/environments/base_output.py
@@ -6,8 +6,9 @@ stdout drain thread used by ``BaseEnvironment._wait_for_process``.
 """
 
 import codecs
+import logging
 import os
-import select
+import selectors
 import subprocess
 import threading
 import time
@@ -17,6 +18,8 @@ from typing import IO, Callable, Protocol
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
+
+logger = logging.getLogger(__name__)
 
 # Sentinel capacity for full-fidelity capture: large enough that the collector
 # never evicts, so bounded and unbounded modes share one code path.
@@ -398,31 +401,95 @@ def _drain_stdout(proc: ProcessHandle, output: _BoundedOutputCollector, stop: "t
 
 
 def _drain_fd_select(proc, fd: int, output: _BoundedOutputCollector, decoder, stop=None) -> None:
-    """POSIX drain: select() poll, stopping ~300ms after bash exits with the pipe idle, or
-    when *stop* is set (the pipe is being handed to another reader — yield-to-background)."""
+    """POSIX drain: selectors-based poll, stopping ~300ms after bash exits with the pipe idle,
+    or when *stop* is set (the pipe is being handed to another reader — yield-to-background).
+
+    select.select() only accepts fds < FD_SETSIZE (1024), so a pipe fd >= 1024
+    raised ValueError — misread as EOF, silently discarding all output
+    (#94928). selectors.DefaultSelector() has no fd limit and logs a genuine
+    readiness error instead. A non-pollable fd (regular file -> EPERM from
+    epoll, or an already-closed one) falls back to direct reads rather than
+    dropping output.
+    """
     idle_after_exit = 0
-    while True:
-        if stop is not None and stop.is_set():
-            return
+    _selector = selectors.DefaultSelector()
+    try:
         try:
-            ready, _, _ = select.select([fd], [], [], 0.1)
-        except (ValueError, OSError):
-            return  # fd already closed
-        if ready:
+            _selector.register(fd, selectors.EVENT_READ)
+        except (ValueError, OSError) as _exc:
+            # register() fails for a non-pollable fd (e.g. a regular file,
+            # which epoll rejects with EPERM) or an already-closed one. Drain
+            # with direct reads instead of silently dropping the output. Switch
+            # the fd to non-blocking and reuse the idle-after-exit bound so a
+            # still-live pipe (whose register failure is pathological) cannot
+            # hold the drain for the full timeout: regular files read to EOF
+            # without ever blocking, and the bound mirrors the selector path.
+            logger.warning(
+                "drain: could not register fd %s with selector (%r); falling back to polling read",
+                fd, _exc,
+            )
             try:
-                chunk = os.read(fd, 4096)
+                os.set_blocking(fd, False)
             except (ValueError, OSError):
-                return
-            if not chunk:
-                return  # true EOF — all writers closed
-            output.append(decoder.decode(chunk))
-            idle_after_exit = 0
-        elif proc.poll() is not None:
-            # bash is gone and the pipe was idle ~100ms; allow two more cycles
-            # for a buffered tail, then stop (a grandchild may hold the pipe).
-            idle_after_exit += 1
-            if idle_after_exit >= 3:
-                return
+                pass
+            try:
+                while True:
+                    if stop is not None and stop.is_set():
+                        return
+                    try:
+                        chunk = os.read(fd, 4096)
+                    except BlockingIOError:
+                        chunk = None
+                    except (ValueError, OSError):
+                        break
+                    if chunk:
+                        output.append(decoder.decode(chunk))
+                        idle_after_exit = 0
+                        continue
+                    if chunk == b"":
+                        break  # true EOF — all writers closed
+                    # No data right now; idle bound like the selector path.
+                    if proc.poll() is not None:
+                        idle_after_exit += 1
+                        if idle_after_exit >= 3:
+                            break
+                    time.sleep(0.1)
+            finally:
+                try:
+                    os.set_blocking(fd, True)
+                except (ValueError, OSError):
+                    pass
+        else:
+            while True:
+                if stop is not None and stop.is_set():
+                    return
+                try:
+                    ready = _selector.select(timeout=0.1)
+                except (ValueError, OSError) as _exc:
+                    logger.warning(
+                        "drain: readiness poll failed for fd %s (%r); "
+                        "stopping drain — output may be truncated",
+                        fd, _exc,
+                    )
+                    break
+                if ready:
+                    try:
+                        chunk = os.read(fd, 4096)
+                    except (ValueError, OSError):
+                        break
+                    if not chunk:
+                        break  # true EOF — all writers closed
+                    output.append(decoder.decode(chunk))
+                    idle_after_exit = 0
+                elif proc.poll() is not None:
+                    # bash is gone and the pipe was idle ~100ms; allow two more
+                    # cycles for a buffered tail, then stop (a grandchild may
+                    # hold the pipe).
+                    idle_after_exit += 1
+                    if idle_after_exit >= 3:
+                        break
+    finally:
+        _selector.close()
 
 
 def _start_drain_thread(


### PR DESCRIPTION
# fix(tools): drain high-fd pipes with selectors instead of select

Closes #94928

## Problem
The POSIX stdout drain in `_wait_for_process` (`tools/environments/base.py`) used `select.select([fd], [], [], 0.1)` to check pipe readability. `select.select()` only accepts fds below `FD_SETSIZE` (typically 1024). Once the Electron desktop process accumulates more than 1024 open fds, the terminal's stdout pipe lands at `fd >= 1024` and `select()` raises `ValueError: filedescriptor out of range in select()` — which the old `except (ValueError, OSError): break  # fd already closed` handler mistook for EOF. The result: every `terminal`/`read_file` command silently returned `{"output": "", "exit_code": <correct>, "error": null}` — all stdout/stderr discarded while the command actually ran. `execute_code`/Python subprocesses kept working, masking the failure.

## Root cause
`tools/environments/base.py` — the POSIX drain's `select.select()` cannot handle fds >= 1024; the exception is swallowed as "fd already closed" with no log.

## Fix
Replace `select.select()` with `selectors.DefaultSelector()` (epoll/kqueue/poll on POSIX), which has no fd-number limit. Guard the `register()` call and log a genuine readiness error instead of swallowing it. The `#8340` backgrounded-grandchild idle-exit logic is preserved unchanged.

## Measured evidence (RED → GREEN)
**RED (unfixed upstream main)** — hold >1024 fds open so the subprocess stdout pipe lands at fd 1104, run `printf "hello-from-high-fd\n"; echo line2`:
```
stdout fd: 1104
RESULT OUTPUT: ''
RETURNCODE: 0
```
Empty output, exit_code 0 — exactly the reported bug.

**GREEN (with fix)** — same reproduction:
```
stdout fd: 1104
RESULT OUTPUT: 'hello-from-high-fd\nline2\n'
RETURNCODE: 0
```
Output correctly captured at fd >= 1024. Normal (low-fd) path and backgrounded-grandchild termination (#8340) still behave correctly.

## Tests
3 new targeted regression tests in `tests/tools/test_base_environment.py` (TestWaitForProcessDrain):
- `test_drain_captures_output_when_stdout_fd_above_fd_setsize` — the core #94928 repro (fails on pre-fix code, passes now).
- `test_drain_captures_output_at_normal_fd` — low-fd no-regression guard.
- `test_drain_terminates_with_backgrounded_grandchild` — #8340 termination preserved.

All 30 tests in the file pass via `scripts/run_tests.sh`. POSIX-gated; restores `RLIMIT_NOFILE` after the high-fd test.


---

## Follow-up (commit `8abfb88`)

Addressed the AI-review point on selector-registration failure: if `register()` fails (EPERM on a non-pollable regular-file fd, or an already-closed fd), the drain now falls back to a bounded non-blocking read loop instead of silently dropping all output. It reuses the selector paths idle-after-exit bound — measured `0.304s` post-exit on a grandchild-held pipe, no hang; regular-file stdout drains fully (`0.101s` for ~9 KB). New regression test `test_drain_falls_back_to_read_when_selector_register_fails` (RED on pre-fallback, GREEN now).
