### PR TITLE
fix(desktop): classify missing Windows PIDs as ESRCH in the start-mar…

### DIFF
--- a/apps/desktop/electron/backend-claim.test.ts
+++ b/apps/desktop/electron/backend-claim.test.ts
@@ -71,6 +71,18 @@ test('processStartMarker rejects for a PID that does not exist', async () => {
   await assert.rejects(processStartMarker(2 ** 30 + 12345))
 })
 
+test('a missing PID is classified as gone, never left unknown (ESRCH on Windows)', async () => {
+  // Windows: the locale-independent sentinel answer maps to a synthetic ESRCH
+  // so reapOrphans() can drop the record. Linux: /proc read fails with ENOENT,
+  // which matchers already treat as gone.
+  const code = await processStartMarker(2 ** 30 + 12345).then(
+    () => null,
+    (error: NodeJS.ErrnoException | null | undefined) => error?.code ?? null
+  )
+
+  assert.equal(code, process.platform === 'win32' ? 'ESRCH' : 'ENOENT')
+})
+
 // --- PID-only marker helpers --------------------------------------------------
 
 test('pidOnlyStartMarker round-trips through isPidOnlyStartMarker', () => {

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -23,6 +23,14 @@ import fs from 'node:fs'
 import { electronProcessStartMarker } from './parent-process-identity'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
+/**
+ * Locale-independent answer for "Get-Process found nothing": PowerShell error
+ * text is localized (an English-only stderr match breaks on non-English
+ * Windows), so the probe asks PowerShell to emit this sentinel when the PID is
+ * absent and classifies it as ESRCH below.
+ */
+const WINDOWS_MISSING_PROCESS_SENTINEL = 'HERMES_PID_NOT_FOUND'
+
 export function execText(command: string, args: string[], { timeout = 3000 } = {}): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     execFile(command, args, hiddenWindowsChildOptions({ encoding: 'utf8', timeout }), (error, stdout) => {
@@ -65,24 +73,33 @@ export async function processStartMarker(pid: number): Promise<string> {
       return electronMarker
     }
 
-    const ticks = await execText(
+    // SilentlyContinue + sentinel keeps the script exit-neutral: a dead PID
+    // must be distinguishable from a flaky probe. The sentinel is rethrown as
+    // ESRCH — the errno shape main.ts identity/parent matchers already map to
+    // "process is gone" — so reapOrphans() drops dead ownership records
+    // instead of keeping them as permanent survivors.
+    const output = await execText(
       'powershell.exe',
       [
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        `$p = Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`
+        `$p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; if ($null -eq $p) { '${WINDOWS_MISSING_PROCESS_SENTINEL}' } else { $p.StartTime.ToUniversalTime().Ticks }`
       ],
       // PowerShell 5.1 cold starts routinely exceed the default 3s execText
       // budget (2.4-8s observed in #87169); give the marker probe headroom.
       { timeout: 30_000 }
     )
 
-    if (!/^\d+$/.test(ticks)) {
+    if (output === WINDOWS_MISSING_PROCESS_SENTINEL) {
+      throw Object.assign(new Error(`Process ${pid} does not exist (Windows start marker)`), { code: 'ESRCH' })
+    }
+
+    if (!/^\d+$/.test(output)) {
       throw new Error(`Invalid Windows start marker for PID ${pid}`)
     }
 
-    return `win:${ticks}`
+    return `win:${output}`
   }
 
   const started = await execText('ps', ['-p', String(pid), '-o', 'lstart='])


### PR DESCRIPTION
…ker probe

PowerShell error text is localized, so a dead PID's Get-Process failure carried no errno code: the identity/parent matchers in main.ts mapped it to "unknown" and reapOrphans() kept every dead record as a permanent survivor. Records accumulated across ugly backend exits and each cold start paid ~2 PowerShell probes (~3.4s) per dead record.

The Windows probe now asks PowerShell for a locale-independent sentinel when the PID is absent (Get-Process -ErrorAction SilentlyContinue) and rethrows it as ESRCH — the errno shape the matchers already treat as "process is gone" — so the sweep drops dead records on its own.

Related: #93608 (probe policy), #87169 (PS 5.1 cold-start budget).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

