### PR TITLE
fix(desktop): isolate voice turn lifetimes

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type MicRecorderErrorCopy, useMicRecorder } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: '',
+  microphoneConstraintsUnsupported: '',
+  microphoneInUse: '',
+  microphonePermissionDenied: '',
+  microphoneStartFailed: '',
+  microphoneUnsupported: '',
+  noMicrophone: ''
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+describe('useMicRecorder acquisition ownership', () => {
+  const originalMediaRecorder = globalThis.MediaRecorder
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'MediaRecorder', { configurable: true, value: vi.fn() })
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { requestMicrophoneAccess: vi.fn(async () => true) }
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'MediaRecorder', { configurable: true, value: originalMediaRecorder })
+    vi.restoreAllMocks()
+  })
+
+  it('stops every late getUserMedia track after cancel', async () => {
+    const acquisition = deferred<MediaStream>()
+    const stop = vi.fn()
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn(() => acquisition.promise) }
+    })
+    const hook = renderHook(() => useMicRecorder(copy))
+
+    let started!: Promise<void>
+    act(() => {
+      started = hook.result.current.handle.start()
+    })
+    await act(async () => Promise.resolve())
+    act(() => hook.result.current.handle.cancel())
+    acquisition.resolve({ getTracks: () => [{ stop }] } as unknown as MediaStream)
+    await act(async () => started)
+
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(globalThis.MediaRecorder).not.toHaveBeenCalled()
+  })
+
+  it('stops every late getUserMedia track after unmount', async () => {
+    const acquisition = deferred<MediaStream>()
+    const stop = vi.fn()
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn(() => acquisition.promise) }
+    })
+    const hook = renderHook(() => useMicRecorder(copy))
+
+    let started!: Promise<void>
+    act(() => {
+      started = hook.result.current.handle.start()
+    })
+    await act(async () => Promise.resolve())
+    hook.unmount()
+    acquisition.resolve({ getTracks: () => [{ stop }] } as unknown as MediaStream)
+    await act(async () => started)
+
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(globalThis.MediaRecorder).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -39,6 +39,40 @@ describe('useMicRecorder acquisition ownership', () => {
     vi.restoreAllMocks()
   })
 
+  it('acquires and starts recording after StrictMode effect replay', async () => {
+    const starts = vi.fn()
+    const constructors = vi.fn()
+
+    class MediaRecorderMock {
+      static isTypeSupported() {
+        return false
+      }
+
+      mimeType = ''
+      ondataavailable = null
+      onerror = null
+      onstop = null
+      start = starts
+
+      constructor() {
+        constructors()
+      }
+    }
+
+    Object.defineProperty(globalThis, 'MediaRecorder', { configurable: true, value: MediaRecorderMock })
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn(async () => ({ getTracks: () => [] })) }
+    })
+    const hook = renderHook(() => useMicRecorder(copy), { reactStrictMode: true })
+
+    await act(async () => hook.result.current.handle.start())
+
+    expect(constructors).toHaveBeenCalledTimes(1)
+    expect(starts).toHaveBeenCalledTimes(1)
+    expect(hook.result.current.recording).toBe(true)
+  })
+
   it('stops every late getUserMedia track after cancel', async () => {
     const acquisition = deferred<MediaStream>()
     const stop = vi.fn()

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -102,14 +102,16 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     silenceTriggeredRef.current = false
   }
 
-  useEffect(
-    () => () => {
+  // eslint-disable-next-line no-restricted-syntax -- imperative mount lifetime, not mirrored reactive state
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
       mountedRef.current = false
       startSequenceRef.current += 1
       cleanup()
-    },
-    []
-  )
+    }
+  }, [])
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { AdaptiveAcousticThreshold } from '@/lib/voice-acoustics'
+
 type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
@@ -77,6 +79,8 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const startSequenceRef = useRef(0)
+  const mountedRef = useRef(true)
 
   const cleanup = () => {
     if (animationRef.current) {
@@ -89,12 +93,23 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     streamRef.current?.getTracks().forEach(track => track.stop())
     streamRef.current = null
     recorderRef.current = null
-    setLevel(0)
-    setRecording(false)
+
+    if (mountedRef.current) {
+      setLevel(0)
+      setRecording(false)
+    }
+
     silenceTriggeredRef.current = false
   }
 
-  useEffect(() => () => cleanup(), [])
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+      startSequenceRef.current += 1
+      cleanup()
+    },
+    []
+  )
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -111,6 +126,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
       analyser.fftSize = 256
       const data = new Uint8Array(analyser.fftSize)
+      const acoustics = new AdaptiveAcousticThreshold()
 
       source.connect(analyser)
       audioContextRef.current = audioContext
@@ -132,7 +148,9 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
         setLevel(normalized)
         options.onLevel?.(normalized)
 
-        const speechThreshold = options.silenceLevel ?? 0
+        const configuredThreshold = options.silenceLevel ?? 0
+        const speechThreshold = Math.max(configuredThreshold, acoustics.startThreshold)
+        const endThreshold = Math.max(configuredThreshold, acoustics.endThreshold)
         const silenceMs = options.silenceMs ?? 0
         const idleSilenceMs = options.idleSilenceMs ?? 0
 
@@ -140,7 +158,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
           if (normalized >= speechThreshold) {
             heardSpeechRef.current = true
             silenceStartedAtRef.current = null
-          } else if (heardSpeechRef.current && silenceMs > 0) {
+          } else if (heardSpeechRef.current && normalized < endThreshold && silenceMs > 0) {
             silenceStartedAtRef.current ??= now
 
             if (now - silenceStartedAtRef.current >= silenceMs) {
@@ -154,6 +172,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
             options.onSilence()
 
             return
+          }
+
+          if (!heardSpeechRef.current && normalized < speechThreshold) {
+            acoustics.observeQuiet(normalized)
           }
         }
 
@@ -175,7 +197,12 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       throw new Error(copy.microphoneUnsupported)
     }
 
+    const startSequence = ++startSequenceRef.current
     const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+
+    if (!mountedRef.current || startSequence !== startSequenceRef.current) {
+      return
+    }
 
     if (permitted === false) {
       throw new Error(copy.microphoneAccessDenied)
@@ -189,6 +216,15 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       })
     } catch (error) {
       throw micError(error, copy)
+    }
+
+    // cancel(), mute, or unmount may land while getUserMedia is pending. The
+    // browser still resolves with live tracks; reject the stale acquisition
+    // and stop every track before it can become an unowned microphone.
+    if (!mountedRef.current || startSequence !== startSequenceRef.current) {
+      stream.getTracks().forEach(track => track.stop())
+
+      return
     }
 
     const mimeType =
@@ -274,6 +310,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     })
 
   const cancel: MicRecorderHandle['cancel'] = () => {
+    startSequenceRef.current += 1
     const recorder = recorderRef.current
     const resolver = stopResolverRef.current
     stopResolverRef.current = null

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -27,10 +27,15 @@ vi.mock('@/lib/voice-barge-in', () => ({
 const markVoicePlaybackInterrupted = vi.fn()
 const stopVoicePlayback = vi.fn()
 
+const playbackMocks = vi.hoisted(() => ({
+  playSpeechText: vi.fn(async () => true),
+  startSpeechStream: vi.fn(async () => null)
+}))
+
 vi.mock('@/lib/voice-playback', () => ({
   markVoicePlaybackInterrupted: () => markVoicePlaybackInterrupted(),
-  playSpeechText: vi.fn(async () => true),
-  startSpeechStream: vi.fn(async () => null),
+  playSpeechText: playbackMocks.playSpeechText,
+  startSpeechStream: playbackMocks.startSpeechStream,
   stopVoicePlayback: () => stopVoicePlayback()
 }))
 
@@ -74,6 +79,8 @@ vi.mock('@/store/notifications', () => ({
 interface HookProps {
   busy: boolean
 }
+
+type SettleCancellation = 'end' | 'mute' | 'supersede' | 'unmount'
 
 function renderConversation(overrides: { onInterrupt?: () => void; transcript?: string } = {}) {
   const onInterrupt = overrides.onInterrupt ?? vi.fn()
@@ -200,6 +207,78 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('no, do it differently'))
   })
 
+  it.each<SettleCancellation>(['end', 'mute', 'supersede', 'unmount'])(
+    'abandons a captured interruption when %s invalidates its busy-settle wait',
+    async cancellation => {
+      const { hook, onSubmit, onTranscribeAudio } = renderConversation({ transcript: 'stale interruption' })
+
+      await enterThinking(hook)
+      await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
+      const monitor = monitorCalls.at(-1)
+      vi.useFakeTimers()
+
+      act(() => monitor?.onSpeech())
+      act(() => monitor?.onUtterance?.(new Blob(['stale'], { type: 'audio/webm' })))
+      await act(async () => Promise.resolve())
+      expect(onTranscribeAudio).toHaveBeenCalledTimes(2)
+      expect(hook.result.current.status).toBe('transcribing')
+
+      if (cancellation === 'end') {
+        await act(async () => hook.result.current.end())
+      } else if (cancellation === 'mute') {
+        act(() => hook.result.current.toggleMute())
+      } else if (cancellation === 'supersede') {
+        await act(async () => hook.result.current.end())
+      } else {
+        hook.unmount()
+      }
+
+      // Cancellation is allowed to perform its own cleanup. Nothing owned by
+      // the stale capture may run after this point when busy settles.
+      const callsAfterCancellation = {
+        micCancel: micHandle.cancel.mock.calls.length,
+        micStart: micHandle.start.mock.calls.length,
+        playback: playbackMocks.playSpeechText.mock.calls.length,
+        stopPlayback: stopVoicePlayback.mock.calls.length,
+        stream: playbackMocks.startSpeechStream.mock.calls.length,
+        stopMonitor: stopMonitor.mock.calls.length
+      }
+
+      if (cancellation !== 'unmount') {
+        hook.rerender({ busy: false })
+      }
+
+      if (cancellation === 'supersede') {
+        await act(async () => hook.result.current.start())
+      }
+
+      await act(async () => vi.advanceTimersByTimeAsync(5_100))
+      vi.useRealTimers()
+
+      // The kickoff is the sole submit; the stale interruption never submits.
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).not.toHaveBeenCalledWith('stale interruption')
+
+      const callsAfterSettle = {
+        micCancel: micHandle.cancel.mock.calls.length,
+        micStart: micHandle.start.mock.calls.length,
+        playback: playbackMocks.playSpeechText.mock.calls.length,
+        stopPlayback: stopVoicePlayback.mock.calls.length,
+        stream: playbackMocks.startSpeechStream.mock.calls.length,
+        stopMonitor: stopMonitor.mock.calls.length
+      }
+
+      if (cancellation === 'supersede') {
+        // The replacement conversation may open its own mic once busy clears;
+        // the stale capture must neither cancel nor otherwise clean it up.
+        expect(callsAfterSettle).toEqual({ ...callsAfterCancellation, micStart: callsAfterCancellation.micStart + 1 })
+        expect(hook.result.current.status).toBe('listening')
+      } else {
+        expect(callsAfterSettle).toEqual(callsAfterCancellation)
+      }
+    }
+  )
+
   it('does not interrupt when speech trips during playback (turn already done)', async () => {
     const { hook, onInterrupt } = renderConversation()
 
@@ -262,5 +341,44 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     hook.rerender({ busy: true })
 
     expect(monitorCalls.length).toBe(armed)
+  })
+
+  it('rejects late STT completion after the conversation ends', async () => {
+    let resolveTranscript!: (value: string) => void
+
+    const onTranscribeAudio = vi.fn(
+      () =>
+        new Promise<string>(resolve => {
+          resolveTranscript = resolve
+        })
+    )
+
+    const onSubmit = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        onSubmit,
+        onTranscribeAudio,
+        pendingResponse: () => null
+      })
+    )
+
+    await act(async () => hook.result.current.start())
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['late'], { type: 'audio/webm' }),
+      durationMs: 200,
+      heardSpeech: true
+    })
+    act(() => hook.result.current.stopTurn())
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalledTimes(1))
+
+    await act(async () => hook.result.current.end())
+    await act(async () => resolveTranscript('must not submit'))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(hook.result.current.status).toBe('idle')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -151,6 +151,26 @@ describe('useVoiceConversation full-duplex barge-in', () => {
 
   afterEach(cleanup)
 
+  it('enters listening after StrictMode effect replay', async () => {
+    const hook = renderHook(
+      () =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(),
+          onTranscribeAudio: vi.fn(async () => 'hello'),
+          pendingResponse: () => null
+        }),
+      { reactStrictMode: true }
+    )
+
+    await act(async () => hook.result.current.start())
+
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+  })
+
   it('arms the barge monitor during generation (before any reply audio exists)', async () => {
     const { hook } = renderConversation()
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -801,8 +801,11 @@ export function useVoiceConversation({
 
   // Unmount-only: `handle` is recreated by the recorder hook on every render,
   // so depending on it would tear down the active turn during normal updates.
-  useEffect(
-    () => () => {
+  // eslint-disable-next-line no-restricted-syntax -- imperative mount lifetime, not mirrored reactive state
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
       mountedRef.current = false
       lifetimeRef.current += 1
       pendingStartRef.current = false
@@ -810,9 +813,8 @@ export function useVoiceConversation({
       stopVoicePlayback()
       handle.cancel()
       dropSpeechSession()
-    },
-    [] // eslint-disable-line react-hooks/exhaustive-deps
-  )
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return { end, level, muted, start, status, stopTurn, toggleMute }
 }

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -64,7 +64,9 @@ export function useVoiceConversation({
   const [muted, setMuted] = useState(false)
   const turnTimeoutRef = useRef<number | null>(null)
   const pendingStartRef = useRef(false)
-  const turnClosingRef = useRef(false)
+  const turnClosingRef = useRef<number | null>(null)
+  const lifetimeRef = useRef(0)
+  const mountedRef = useRef(true)
   const awaitingSpokenResponseRef = useRef(false)
   const responseIdRef = useRef<string | null>(null)
   const spokenSourceLengthRef = useRef(0)
@@ -137,16 +139,23 @@ export function useVoiceConversation({
 
   const handleTurn = useCallback(
     async (forceTranscribe = false) => {
-      if (turnClosingRef.current) {
+      if (turnClosingRef.current !== null) {
         return
       }
 
-      turnClosingRef.current = true
+      // Closing capture commits a new conversational turn. Advancing here
+      // invalidates every async stage and owned callback from the prior turn.
+      const lifetime = ++lifetimeRef.current
+      turnClosingRef.current = lifetime
       clearTurnTimeout()
       setStatus('transcribing')
 
       try {
         const result = await handle.stop()
+
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
 
         if (!result || (!result.heardSpeech && !forceTranscribe) || !onTranscribeAudio) {
           if (enabledRef.current && !mutedRef.current && !busyRef.current && statusRef.current !== 'speaking') {
@@ -160,6 +169,10 @@ export function useVoiceConversation({
 
         try {
           const transcript = (await onTranscribeAudio(result.audio)).trim()
+
+          if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+            return
+          }
 
           if (!transcript) {
             if (enabledRef.current) {
@@ -186,6 +199,11 @@ export function useVoiceConversation({
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
           await onSubmit(transcript)
+
+          if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+            return
+          }
+
           setStatus('thinking')
         } catch (error) {
           notifyError(error, voiceCopy.transcriptionFailed)
@@ -197,13 +215,16 @@ export function useVoiceConversation({
           setStatus('idle')
         }
       } finally {
-        turnClosingRef.current = false
+        if (turnClosingRef.current === lifetime) {
+          turnClosingRef.current = null
+        }
       }
     },
     [handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
   )
 
   const startListening = useCallback(async () => {
+    const lifetime = lifetimeRef.current
     pendingStartRef.current = false
 
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
@@ -227,6 +248,10 @@ export function useVoiceConversation({
       // A pause failure shouldn't block the user's explicit start.
     }
 
+    if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+      return
+    }
+
     // enabled/muted/busy or an interleaved turn may have changed while we waited.
     if (!enabledRef.current || mutedRef.current || busyRef.current || statusRef.current !== 'idle') {
       return
@@ -245,6 +270,13 @@ export function useVoiceConversation({
         },
         onSilence: () => void handleTurn()
       })
+
+      if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+        handle.cancel()
+
+        return
+      }
+
       setStatus('listening')
       // Clear any prior turn-timeout before arming a fresh one. Each listen
       // cycle reassigns turnTimeoutRef; without clearing first, a stale 60s
@@ -307,7 +339,13 @@ export function useVoiceConversation({
    */
   const submitCapturedUtterance = useCallback(
     async (audio: Blob | null) => {
+      const lifetime = lifetimeRef.current
+
       const resumeListening = () => {
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
+
         if (enabledRef.current && !mutedRef.current) {
           pendingStartRef.current = true
         }
@@ -325,6 +363,10 @@ export function useVoiceConversation({
 
       try {
         const transcript = (await onTranscribeAudio(audio)).trim()
+
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
 
         if (!transcript) {
           resumeListening()
@@ -351,10 +393,22 @@ export function useVoiceConversation({
           await new Promise(resolve => window.setTimeout(resolve, 100))
         }
 
+        // The settle wait belongs to the same captured turn as STT. Ending,
+        // muting, unmounting, or starting a newer turn while it waited must
+        // invalidate the capture before it can submit or mutate shared state.
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
+
         awaitingSpokenResponseRef.current = true
         dropSpeechSession()
         consumePendingResponse()
         await onSubmit(transcript)
+
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
+
         setStatus('thinking')
       } catch (error) {
         notifyError(error, voiceCopy.transcriptionFailed)
@@ -383,9 +437,14 @@ export function useVoiceConversation({
       return
     }
 
+    const lifetime = lifetimeRef.current
     stopBargeMonitorRef.current = monitorSpeechDuringPlayback({
       isPlaying: () => $voicePlayback.get().status === 'speaking',
       onSpeech: () => {
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
+
         bargeCapturePendingRef.current = true
         bargedRef.current = true
         markVoicePlaybackInterrupted()
@@ -398,6 +457,10 @@ export function useVoiceConversation({
         }
       },
       onUtterance: audio => {
+        if (!mountedRef.current || lifetime !== lifetimeRef.current) {
+          return
+        }
+
         bargeCapturePendingRef.current = false
         stopBargeMonitorRef.current = null
         void submitCapturedUtterance(audio)
@@ -487,6 +550,7 @@ export function useVoiceConversation({
    */
   const openLiveSpeech = useCallback(
     (responseId: string) => {
+      const lifetime = lifetimeRef.current
       const sequenceBeforeStart = $voicePlayback.get().sequence
 
       responseIdRef.current = responseId
@@ -503,7 +567,7 @@ export function useVoiceConversation({
         const session = await startSpeechStream({ source: 'voice-conversation' })
 
         // The session may resolve after the loop moved on (barge, disable).
-        if (responseIdRef.current !== responseId) {
+        if (!mountedRef.current || lifetime !== lifetimeRef.current || responseIdRef.current !== responseId) {
           if (session) {
             stopVoicePlayback()
           }
@@ -584,6 +648,7 @@ export function useVoiceConversation({
       return
     }
 
+    lifetimeRef.current += 1
     setMuted(false)
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
@@ -600,11 +665,12 @@ export function useVoiceConversation({
   ])
 
   const end = useCallback(async () => {
+    lifetimeRef.current += 1
     pendingStartRef.current = false
     clearTurnTimeout()
     stopVoicePlayback()
     handle.cancel()
-    turnClosingRef.current = false
+    turnClosingRef.current = null
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
     consumePendingResponse()
@@ -623,6 +689,7 @@ export function useVoiceConversation({
       const next = !value
 
       if (next) {
+        lifetimeRef.current += 1
         clearTurnTimeout()
         handle.cancel()
         setStatus('idle')
@@ -731,6 +798,21 @@ export function useVoiceConversation({
 
     wasEnabledRef.current = enabled
   }, [enabled, end, start])
+
+  // Unmount-only: `handle` is recreated by the recorder hook on every render,
+  // so depending on it would tear down the active turn during normal updates.
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+      lifetimeRef.current += 1
+      pendingStartRef.current = false
+      clearTurnTimeout()
+      stopVoicePlayback()
+      handle.cancel()
+      dropSpeechSession()
+    },
+    [] // eslint-disable-line react-hooks/exhaustive-deps
+  )
 
   return { end, level, muted, start, status, stopTurn, toggleMute }
 }

--- a/apps/desktop/src/lib/voice-acoustics.test.ts
+++ b/apps/desktop/src/lib/voice-acoustics.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { AdaptiveAcousticThreshold } from './voice-acoustics'
+
+describe('AdaptiveAcousticThreshold', () => {
+  it('raises both capture and barge-in thresholds with quiet ambient drift', () => {
+    const threshold = new AdaptiveAcousticThreshold()
+    const initial = threshold.startThreshold
+
+    for (let index = 0; index < 40; index += 1) {
+      threshold.observeQuiet(0.04)
+    }
+
+    expect(threshold.noiseFloor).toBeGreaterThan(0.01)
+    expect(threshold.startThreshold).toBeGreaterThan(initial)
+    expect(threshold.endThreshold).toBeLessThan(threshold.startThreshold)
+  })
+
+  it('does not learn from speech spikes or exceed the bounded floor', () => {
+    const threshold = new AdaptiveAcousticThreshold(0.08)
+    threshold.observeQuiet(0.8)
+    expect(threshold.noiseFloor).toBe(0.01)
+
+    for (let index = 0; index < 200; index += 1) {
+      threshold.observeQuiet(0.07)
+    }
+
+    expect(threshold.noiseFloor).toBeLessThanOrEqual(0.08)
+  })
+})

--- a/apps/desktop/src/lib/voice-acoustics.ts
+++ b/apps/desktop/src/lib/voice-acoustics.ts
@@ -1,0 +1,29 @@
+/** Shared ambient-floor estimator for capture endpointing and barge-in. */
+export class AdaptiveAcousticThreshold {
+  private floor = 0.01
+
+  constructor(private readonly maximumFloor = 0.08) {}
+
+  get noiseFloor(): number {
+    return this.floor
+  }
+
+  get startThreshold(): number {
+    return Math.min(1, this.floor + 0.045)
+  }
+
+  get endThreshold(): number {
+    return Math.min(1, this.floor + 0.02)
+  }
+
+  /** Call only for known-quiet samples; callers freeze this during speech/TTS. */
+  observeQuiet(rawLevel: number): void {
+    const level = Math.max(0, Math.min(this.maximumFloor, Number.isFinite(rawLevel) ? rawLevel : 0))
+
+    if (level >= this.startThreshold) {
+      return
+    }
+
+    this.floor = Math.min(this.maximumFloor, this.floor * 0.92 + level * 0.08)
+  }
+}

--- a/apps/desktop/src/lib/voice-barge-in.ts
+++ b/apps/desktop/src/lib/voice-barge-in.ts
@@ -19,18 +19,20 @@
 // - Detection is a windowed majority (>=80% of the last SUSTAINED_MS above
 //   trigger) so intra-word energy dips don't reset progress.
 
+import { AdaptiveAcousticThreshold } from './voice-acoustics'
+
 const CALIBRATION_MS = 400
 const SUSTAINED_MS = 300
 const SUSTAINED_MAJORITY = 0.8
 const MIN_TRIGGER_LEVEL = 0.075 // matches the voice loop's silenceLevel
-const FLOOR_MULTIPLIER = 3.5
+
 // Playback clamps, scaled from the Python constants (int16 RMS 1500 / 4000
 // ≈ byte-domain level 0.14 / 0.37 with the /42 normalization below).
 const PLAYBACK_MIN_TRIGGER_LEVEL = 0.14
 const TRIGGER_CEILING_LEVEL = 0.37
 const PLAYBACK_GRACE_MS = 500
 const PLAYBACK_GAP_FOR_GRACE_MS = 1_000
-const FLOOR_SAMPLE_CAP = 200 // ~3s of quiet-phase levels at rAF cadence
+
 const PRE_ROLL_RESTART_MS = 5_000 // cap pre-roll: restart the recorder while quiet
 const UTTERANCE_SILENCE_MS = 1_250 // matches the voice loop's silenceMs
 const UTTERANCE_MAX_MS = 30_000
@@ -175,11 +177,11 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
       context.createMediaStreamSource(stream).connect(analyser)
 
       const data = new Uint8Array(analyser.fftSize)
-      const floorSamples: number[] = []
+      const acoustics = new AdaptiveAcousticThreshold()
       const recentAbove: { above: boolean; at: number }[] = []
       let calibratedSince: number | null = null
       let floorLocked = false
-      let quietFloor = 0
+
       let segmentStartedAt = Date.now()
       let wasPlaying = false
       let playbackSeen = false
@@ -188,16 +190,6 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
       let tripped = false
       let trippedAt = 0
       let quietSince: number | null = null
-
-      const pushFloorSample = (level: number) => {
-        floorSamples.push(level)
-
-        if (floorSamples.length > FLOOR_SAMPLE_CAP) {
-          floorSamples.shift()
-        }
-
-        quietFloor = [...floorSamples].sort((a, b) => a - b)[floorSamples.length >> 1] ?? 0
-      }
 
       const tick = () => {
         if (disposed) {
@@ -223,7 +215,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
           if (!floorLocked) {
             if (!playing) {
               calibratedSince ??= now
-              pushFloorSample(level)
+              acoustics.observeQuiet(level)
             }
 
             if (playing || (calibratedSince !== null && now - calibratedSince >= CALIBRATION_MS)) {
@@ -250,7 +242,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
           // Phase-aware trigger: quiet baseline x multiplier; playback clamps
           // it up (bleed alone can't trip) but a ceiling keeps speech
           // reachable even over loud playback.
-          let trigger = Math.max(MIN_TRIGGER_LEVEL, quietFloor * FLOOR_MULTIPLIER)
+          let trigger = Math.max(MIN_TRIGGER_LEVEL, acoustics.startThreshold)
 
           if (playing) {
             trigger = Math.min(Math.max(trigger, PLAYBACK_MIN_TRIGGER_LEVEL), TRIGGER_CEILING_LEVEL)
@@ -258,7 +250,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
 
           // Track ambient drift while quiet and below trigger.
           if (floorLocked && !playing && level < trigger) {
-            pushFloorSample(level)
+            acoustics.observeQuiet(level)
           }
 
           const above = floorLocked && level >= trigger && now >= graceUntil


### PR DESCRIPTION
## Summary

- isolate Desktop continuous-voice work by capture/turn lifetime so stale async completion cannot submit, stop, or re-arm a superseded turn
- keep capture active while the assistant is busy, then use sustained-speech barge-in with adaptive ambient thresholds instead of a fixed instantaneous level
- make mute, stop, unmount, supersession, playback completion, and React StrictMode replay deterministically invalidate or restore the right lifetime

This is the current-`main` Desktop safety slice of #94462. It ports the relevant behavior from the `zer0-voice` donor architecture into Hermes' existing Desktop hooks; it does **not** import donor code, add a runtime dependency, or introduce a second voice control plane. #77111 is architecture context only.

## Problem

The existing Desktop path could let late `getUserMedia`, transcription, playback, or busy-state completion act on a turn that had already been muted, stopped, unmounted, or superseded. Listening also stopped during generation/playback, preventing natural barge-in, while a fixed input threshold was brittle across microphones and rooms.

## Approach

The change stays within seven Desktop files:

- monotonic capture and turn lifetimes reject stale asynchronous work
- cancellation checks cover every post-await boundary and invalidate pending submission/re-arm work
- recording continues through the busy phase so sustained speech can interrupt playback and the active request
- a bounded ambient noise floor produces adaptive start/continue thresholds
- monitor setup/teardown is idempotent and React StrictMode effect replay restores mounted ownership without allowing real-unmount resurrection

Hermes remains authoritative for prompt submission, cancellation, durable history, tools, approvals, and actions. The acoustic monitor consumes local amplitude samples only; it adds no network path, transcript sink, credential path, or server-side tool authority.

## Current-main overlap and scope

This branch is based on current upstream `main` at `f751a8c5467c41500e505d90cb0eb8b70929080f`. A fresh issue/PR sweep found adjacent voice work (including provider transcription, silence-duration, playback, and re-arm changes), but no open PR owning this exact lifetime + adaptive-barge behavior. The diff is Desktop-only: 7 files, 461 insertions, 30 deletions.

## Verification

The regression suite was exercised RED/GREEN, including sabotage runs that restored the old lifetime behavior and confirmed the new tests fail before passing with the fix.

- focused Desktop Vitest: 4 files, 22/22 tests passed
  - StrictMode effect replay and real-unmount cleanup
  - late `getUserMedia` cleanup
  - end/mute/unmount/supersede after busy settlement
  - cancellation and stale-turn invalidation
  - barge-in, stop, monitor idempotency, playback re-arm, and adaptive acoustics
- Desktop typecheck passed
- targeted ESLint with `--max-warnings=0` passed
- targeted Prettier check passed
- `git diff --check` passed

The repository's Python wrapper tests could not run in the review worktree because no pytest-capable virtualenv was available; those tests do not execute the changed Desktop TypeScript paths.

## Risk and rollback

The main risk is browser media timing across effect replay and teardown. Tests cover stale completion, StrictMode replay, and each cancellation boundary. Rollback is the two commits in this PR; there is no schema, migration, config, or backend dependency.

## Attribution and disclosure

Behavior and architecture were selectively reimplemented from `kvnloo/zer0-voice`, authored by Kevin Loo (`kvnloo`), behind Hermes-native Desktop contracts. No `zer0-voice` source or runtime dependency was copied into this repository.

This contribution was developed and reviewed with AI assistance from Hermes Agent; Kevin Loo directed the work, supplied the donor architecture, and is the human contributor/submitter.

Part of #94462.
