### PR TITLE
fix(kanban): stop reviewer-less review dispatch from self-looping

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -312,8 +312,12 @@ model:
 # is spawned with the bundled sdlc-review skill and can approve, request changes
 # back to the original implementer, or escalate a genuine external blocker.
 # Disable this only when every review is performed manually from the dashboard.
+# A request_review with no distinct reviewer parks for a human instead of
+# spawning the implementer. repeated_self_review_limit auto-blocks after that
+# many consecutive reviewer-less handoffs (0 disables).
 kanban:
   review_dispatch: true
+  repeated_self_review_limit: 3
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2701,6 +2701,10 @@ DEFAULT_CONFIG = {
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.
         "review_dispatch": True,
+        # Consecutive reviewer-less (or implementer-as-reviewer)
+        # review_requested handoffs before request_review auto-blocks.
+        # 0 disables the breaker. Distinct-reviewer handoffs are unbounded.
+        "repeated_self_review_limit": 3,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2682,6 +2682,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_self_review": res.skipped_self_review,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2723,6 +2724,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.skipped_self_review:
+        print(
+            f"Skipped (self-review park — no distinct reviewer): "
+            f"{', '.join(res.skipped_self_review)}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -344,6 +344,7 @@ def _fire_dispatch_tick_hook(
             result.skipped_per_profile_capped,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
+            result.skipped_self_review,
         )):
             outcome = "idle"
         invoke_hook(
@@ -6487,6 +6488,83 @@ def redact_review_value(value: Any) -> Any:
     return value
 
 
+DEFAULT_REPEATED_SELF_REVIEW_LIMIT = 3
+
+
+def _is_self_review_handoff(
+    reviewer: Optional[str], implementer: Optional[str]
+) -> bool:
+    """True when review would be claimed by the implementer (or by nobody)."""
+    resolved = _canonical_assignee(reviewer) if reviewer is not None else None
+    impl = _canonical_assignee(implementer) if implementer is not None else None
+    if resolved is None:
+        return True
+    return impl is not None and resolved == impl
+
+
+def _repeated_self_review_limit() -> int:
+    try:
+        from hermes_cli.config import load_config
+        raw = (load_config() or {}).get("kanban", {}).get(
+            "repeated_self_review_limit", DEFAULT_REPEATED_SELF_REVIEW_LIMIT
+        )
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_REPEATED_SELF_REVIEW_LIMIT
+    except Exception:
+        return DEFAULT_REPEATED_SELF_REVIEW_LIMIT
+
+
+def _consecutive_review_requested_count(
+    conn: sqlite3.Connection, task_id: str
+) -> int:
+    rows = conn.execute(
+        "SELECT outcome FROM task_runs "
+        "WHERE task_id = ? AND outcome IS NOT NULL "
+        "ORDER BY id DESC",
+        (task_id,),
+    ).fetchall()
+    count = 0
+    for row in rows:
+        if row["outcome"] != "review_requested":
+            break
+        count += 1
+    return count
+
+
+def _latest_review_requested_payload(
+    conn: sqlite3.Connection, task_id: str
+) -> dict:
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_requested' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["payload"]:
+        return {}
+    try:
+        payload = json.loads(row["payload"])
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def review_handoff_is_self_review(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Park-for-human: latest request_review has no distinct reviewer.
+
+    Rows parked in ``review`` without a ``review_requested`` event (CLI
+    status edits, older fixtures) keep the previous spawn rule: an
+    assigned profile is still dispatchable.
+    """
+    payload = _latest_review_requested_payload(conn, task_id)
+    if not payload:
+        return False
+    return _is_self_review_handoff(
+        payload.get("reviewer"), payload.get("implementer")
+    )
+
+
 def request_review(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6503,9 +6581,12 @@ def request_review(
     Unlike :func:`block_task`, this transition never touches block recurrence
     accounting.  The current implementer and resolved reviewer are recorded on
     the event so an autonomous reviewer can route requested changes back to the
-    right profile.  Supplying ``reviewer`` reassigns the task before it is
+    right profile. Supplying ``reviewer`` reassigns the task before it is
     exposed to the review dispatcher.  On re-review, omitting it reuses the
     reviewer provenance persisted by the latest ``changes_requested`` event.
+    A reviewer-less (or implementer-as-reviewer) handoff parks for a human:
+    the review lane will not spawn the implementer. Repeated self-review
+    handoffs trip ``kanban.repeated_self_review_limit`` (default 3; 0 disables).
 
     When the task is ``running`` under a live claim, a caller that supplies no
     ``expected_run_id`` must pass ``force=True`` (explicit human/CLI override)
@@ -6586,6 +6667,75 @@ def request_review(
                     )
                 reviewer = prior_reviewer
         reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
+        self_review = _is_self_review_handoff(reviewer, implementer)
+        limit = _repeated_self_review_limit()
+        if self_review and limit > 0:
+            streak = _consecutive_review_requested_count(conn, task_id)
+            if streak >= limit:
+                block_params: tuple[Any, ...]
+                if expected_run_id is None:
+                    block_params = (task_id,)
+                    block_guard = ""
+                else:
+                    block_params = (task_id, int(expected_run_id))
+                    block_guard = " AND current_run_id = ?"
+                blocked = conn.execute(
+                    """
+                    UPDATE tasks
+                       SET status        = 'blocked',
+                           claim_lock    = NULL,
+                           claim_expires = NULL,
+                           worker_pid    = NULL,
+                           block_kind    = 'needs_input'
+                     WHERE id = ?
+                       AND status IN ('running', 'ready')
+                    """ + block_guard,
+                    block_params,
+                )
+                if blocked.rowcount != 1:
+                    return _ret(
+                        False,
+                        "task is not in running/ready (or expected_run_id did not "
+                        "match the current run)",
+                    )
+                reason = (
+                    f"self-review loop detected: {streak} consecutive "
+                    f"review_requested handoffs with no distinct reviewer "
+                    f"(limit={limit})"
+                )
+                run_id = _end_run(
+                    conn,
+                    task_id,
+                    outcome="blocked",
+                    status="blocked",
+                    summary=reason,
+                    metadata=metadata,
+                )
+                _append_event(
+                    conn,
+                    task_id,
+                    "blocked",
+                    {
+                        "reason": reason,
+                        "kind": "needs_input",
+                        "source": "self_review_loop",
+                    },
+                    run_id=run_id,
+                )
+                _append_event(
+                    conn,
+                    task_id,
+                    "self_review_loop_detected",
+                    {
+                        "summary": reason,
+                        "implementer": implementer,
+                        "reviewer": reviewer,
+                        "streak": streak,
+                        "limit": limit,
+                    },
+                    run_id=run_id,
+                )
+                return _ret(False, reason)
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         params: tuple[Any, ...]
         if expected_run_id is None:
@@ -8041,6 +8191,10 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_self_review: list[str] = field(default_factory=list)
+    """Review-lane task ids left parked because the latest handoff has no
+    distinct reviewer (reviewer is missing or is the implementer). Human
+    review, not an auto-spawn."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -10066,9 +10220,15 @@ def _dispatch_once_locked(
         except Exception:
             # Profiles module unavailable (test stubs, exotic envs) —
             # assume spawnable, matching the review loop's own fallback.
-            return any(row["assignee"] for row in review_rows)
+            return any(
+                row["assignee"] and not review_handoff_is_self_review(conn, row["id"])
+                for row in review_rows
+            )
         return any(
-            row["assignee"] and _rpe(row["assignee"]) for row in review_rows
+            row["assignee"]
+            and _rpe(row["assignee"])
+            and not review_handoff_is_self_review(conn, row["id"])
+            for row in review_rows
         )
 
     ready_budget = spawn_budget
@@ -10328,6 +10488,9 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        if review_handoff_is_self_review(conn, row["id"]):
+            result.skipped_self_review.append(row["id"])
             continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -120,24 +120,24 @@ def test_request_review_transitions_running_to_review(kanban_home: Path) -> None
 
 
 def test_repeated_review_requests_never_triage(kanban_home: Path) -> None:
-    """A task that goes review -> rerun -> review again (the executor
-    follow-up cycle) must stay in ``review`` every time. Under the old
-    ``kanban_block(review-required:)`` approach the second pass hit
-    ``block_recurrences >= 2`` and was wrongly routed to ``triage`` with a
-    ``block_loop_detected`` event. ``request_review`` must never do that."""
+    """A task that goes review -> rerun -> review again must not escalate
+    through ``block_recurrences`` into ``triage``. The old
+    ``kanban_block(review-required:)`` path did that on the second pass.
+    Self-review handoffs stay in ``review`` until
+    ``repeated_self_review_limit``, then block with
+    ``self_review_loop_detected`` instead of triaging."""
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="cycle me", assignee="worker")
 
-        for _ in range(4):
-            # Executor claims (ready->running or review->running) and finishes
-            # with a review request. claim_review_task handles review->running.
+        for i in range(4):
             task = kb.get_task(conn, tid)
             if task.status == "ready":
                 kb.claim_task(conn, tid)
-            else:
-                assert task.status == "review"
+            elif task.status == "review":
                 claimed = kb.claim_review_task(conn, tid)
                 assert claimed is not None
+            elif task.status != "running":
+                raise AssertionError(f"unexpected status {task.status}")
 
             run_id = kb.get_task(conn, tid).current_run_id
             ok = kb.request_review(
@@ -145,15 +145,20 @@ def test_repeated_review_requests_never_triage(kanban_home: Path) -> None:
                 summary="pass complete",
                 expected_run_id=run_id,
             )
-            assert ok is True
             row = _row(conn, tid)
-            assert row["status"] == "review", "must never leave the review lane"
             assert (row["block_recurrences"] or 0) == 0
+            if i < 3:
+                assert ok is True
+                assert row["status"] == "review"
+            else:
+                assert ok is False
+                assert row["status"] == "blocked"
 
-        # After several cycles: never triaged, never a false loop.
-        assert _row(conn, tid)["status"] == "review"
+        assert _row(conn, tid)["status"] == "blocked"
         assert _events(conn, tid, kind="block_loop_detected") == []
-        assert len(_events(conn, tid, kind="review_requested")) == 4
+        assert _row(conn, tid)["status"] != "triage"
+        assert len(_events(conn, tid, kind="review_requested")) == 3
+        assert len(_events(conn, tid, kind="self_review_loop_detected")) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +392,7 @@ def test_review_dispatch_gate_prevents_phantom_reviewer(
         kb.claim_task(conn, tid)
         kb.request_review(
             conn, tid, summary="done",
+            reviewer="reviewer",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "review"
@@ -443,6 +449,7 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         kb.add_comment(conn, review_id, author="worker", body=pr_comment)
         assert kb.request_review(
             conn, review_id, summary="PR ready",
+            reviewer="lead-reviewer",
             expected_run_id=claimed.current_run_id,
         )
         # Ready-lane task with the same fresh PR comment.
@@ -506,6 +513,7 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
             conn,
             task_id,
             summary="ready",
+            reviewer="lead-reviewer",
             expected_run_id=implementation.current_run_id,
         )
         monkeypatch.setattr(
@@ -555,6 +563,7 @@ def test_review_dispatch_honors_global_and_per_profile_caps(
                 conn,
                 task_id,
                 summary="ready",
+                reviewer="lead-reviewer",
                 expected_run_id=implementation.current_run_id,
             )
             review_ids.append(task_id)
@@ -708,3 +717,137 @@ def test_reviewer_reassigns_for_autonomous_dispatch(kanban_home: Path) -> None:
         ev = _events(conn, tid, kind="review_requested")[0][1]
         assert ev["reviewer"] == "lead-reviewer"
         assert ev["implementer"] == "worker"
+
+
+def test_self_review_handoff_is_not_auto_dispatched(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """reviewer=None keeps the implementer and must not spawn them as reviewer."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    spawned: list[str] = []
+
+    def spawn(task, workspace, board=None):
+        spawned.append(task.assignee or "")
+        return 7
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="human gated", assignee="P")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.request_review(
+            conn, tid, summary="waiting for human approval",
+            expected_run_id=claimed.current_run_id,
+        )
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+        assert task.assignee == "p"
+        ev = _events(conn, tid, kind="review_requested")[0][1]
+        assert ev["reviewer"] is None
+        assert ev["implementer"] == "p"
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+        parked = kb.get_task(conn, tid)
+        assert tid in result.skipped_self_review
+        assert tid not in [s[0] for s in result.spawned]
+        assert parked.status == "review"
+        assert parked.assignee == "p"
+        assert spawned == []
+
+        again = kb.dispatch_once(conn, spawn_fn=spawn)
+        assert tid in again.skipped_self_review
+        assert spawned == []
+
+
+def test_implementer_named_as_reviewer_is_not_auto_dispatched(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="same profile", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.request_review(
+            conn, tid, summary="self",
+            reviewer="worker",
+            expected_run_id=claimed.current_run_id,
+        )
+        result = kb.dispatch_once(conn, dry_run=True)
+        assert tid in result.skipped_self_review
+        assert tid not in [s[0] for s in result.spawned]
+
+
+def test_self_review_loop_trips_breaker(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.config as cfgmod
+
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"repeated_self_review_limit": 3}},
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="loop", assignee="P")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        for i in range(3):
+            assert kb.request_review(
+                conn, tid, summary=f"park {i}",
+                expected_run_id=claimed.current_run_id,
+            )
+            assert kb.get_task(conn, tid).status == "review"
+            claimed = kb.claim_review_task(conn, tid)
+            assert claimed is not None
+
+        ok, reason = kb.request_review(
+            conn, tid, summary="park 3",
+            expected_run_id=claimed.current_run_id,
+            with_reason=True,
+        )
+        assert ok is False
+        assert reason is not None and "self-review loop" in reason
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        kinds = [kind for kind, _ in _events(conn, tid, kind="self_review_loop_detected")]
+        assert kinds == ["self_review_loop_detected"]
+        assert _events(conn, tid, kind="blocked")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_self_review_breaker_disabled_when_limit_zero(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.config as cfgmod
+
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"repeated_self_review_limit": 0}},
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="unbounded park", assignee="P")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        for i in range(4):
+            assert kb.request_review(
+                conn, tid, summary=f"park {i}",
+                expected_run_id=claimed.current_run_id,
+            )
+            assert kb.get_task(conn, tid).status == "review"
+            if i < 3:
+                claimed = kb.claim_review_task(conn, tid)
+                assert claimed is not None
+        assert _events(conn, tid, kind="self_review_loop_detected") == []

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -226,9 +226,14 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
-  review_dispatch: true            # default: spawn the assigned profile with
-                                   # the bundled sdlc-review skill. Set false
-                                   # for human-only review boards.
+  review_dispatch: true            # default: spawn a distinct reviewer with
+                                   # the bundled sdlc-review skill. A handoff
+                                   # with no reviewer (or reviewer=implementer)
+                                   # parks for a human instead of self-spawning.
+                                   # Set false for fully human-only review boards.
+  repeated_self_review_limit: 3    # auto-block after this many consecutive
+                                   # reviewer-less review_requested handoffs.
+                                   # 0 disables.
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`


### PR DESCRIPTION
## What does this PR do?

A Kanban worker that calls `kanban_request_review` without a distinct reviewer is re-claimed on every dispatch tick and re-run as its own reviewer. `review_dispatch` defaults to true, `request_review` leaves the implementer as assignee when `reviewer` is omitted, and the review-lane respawn guard skips the usual success/PR dedup. That loop is a clean lifecycle exit, so neither `consecutive_failures` nor the protocol-violation breaker counts it. In the reported incident that burned 89 runs across 4 cards until the model plan ran out.

This change parks reviewer-less (or implementer-as-reviewer) handoffs for a human instead of spawning the same profile, and auto-blocks after `kanban.repeated_self_review_limit` consecutive `review_requested` self-handoffs (default 3, 0 disables). Distinct-reviewer dispatch is unchanged.

## Related Issue

Fixes #95141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py` - skip review-lane spawn when the latest `review_requested` event has no distinct reviewer; auto-block self-review streaks with a sticky `blocked` event plus `self_review_loop_detected`
- `hermes_cli/config_defaults.py` - add `kanban.repeated_self_review_limit` (default 3)
- `hermes_cli/kanban.py` - surface `skipped_self_review` on dispatch CLI/JSON
- `cli-config.yaml.example` - document the new review-dispatch defaults
- `tests/hermes_cli/test_kanban_review_lifecycle.py` - park, same-profile reviewer, breaker, and sticky-block coverage
- `website/docs/user-guide/features/kanban.md` - document park-for-human and the breaker

## How to Test

1. Create a task assigned to profile `P`, claim it, and call `request_review` with no `reviewer`. Confirm status is `review` and the event payload has `reviewer: null`.
2. Run `dispatch_once` (or wait one gateway tick). Confirm the task stays in `review` and is listed as skipped self-review, not spawned as `P`.
3. Repeat claim-via-`claim_review_task` + reviewer-less `request_review` three times, then once more. The fourth call should move the task to `blocked` with a `self_review_loop_detected` event. `recompute_ready` must leave it blocked.
4. Repeat step 1 with `reviewer=` set to a different profile. Dispatch should still spawn that reviewer with `sdlc-review`.
5. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_host_cap.py -q
```

Result: 56 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (isolated `HERMES_HOME`, `request_review` with no reviewer, then `dispatch_once` x3):

```
AFTER request_review(no reviewer):
  ok=True status=review assignee=p
  review_requested payload={'summary': 'waiting for human approval', 'implementer': 'p', 'reviewer': None}
TICK 1: spawned=[('t_2b15205a', 'p', '...')] status=running
  latest claimed={..., 'source_status': 'review'}
TICK 2: spawned=[('t_2b15205a', 'p', '...')]
TICK 3: spawned=[('t_2b15205a', 'p', '...')]
RUN OUTCOMES: [('review_requested', 4)]
TOTAL SPAWNS OF P: 3
```

After the same script against this patch:

```
AFTER request_review(no reviewer): True review p
TICK 1: spawned=[] skipped_self=['t_b5c19ed6'] status=review
TOTAL SPAWNS: []
```
