### PR TITLE
feat(kanban): add recursive scoped issue hierarchy

### DIFF
--- a/docs/architecture/kanban-recursive-scoped-issues.md
+++ b/docs/architecture/kanban-recursive-scoped-issues.md
@@ -12,7 +12,9 @@ Each physical board remains the hard dispatch, workspace, attachment, and worker
 
 ## Current implementation
 
-The additive SQLite migration adds `kind`, `parent_id`, and `product_id` plus exact-filter indexes. Existing rows read as root `task` issues. Creation validates the closed kind vocabulary, structured product IDs, and parent existence. Reparenting is atomic and rejects self-parenting, orphans, and ancestry cycles. Deletion refuses to orphan containment children. Archive and review-reopen paths leave containment and dependencies unchanged.
+The additive SQLite migration adds `kind`, `parent_id`, and `product_id` plus exact-filter indexes. Existing rows read as root `task` issues. Creation validates the closed kind vocabulary, structured product IDs, parent existence, and the shared 32-edge maximum containment depth. Reparenting is atomic and rejects self-parenting, orphans, ancestry cycles, and moves that would push any descendant over that boundary. Breadcrumb traversal uses the same boundary and fails closed on corrupt cycles, orphans, or over-depth legacy rows rather than presenting truncated ancestry. Deletion refuses to orphan containment children. Archive and review-reopen paths leave containment and dependencies unchanged.
+
+Portable scope IDs deliberately allow `:` as an internal namespace separator (for example, `company:zer0:product:hermes-agent`). This is unambiguous with qualified issue references because scope IDs are opaque task fields, while `<board>:<issue-id>` parsing applies only to issue references and generated issue IDs never contain `:`.
 
 Existing model tools, CLI commands, and dashboard API fields are extended rather than duplicated. `kanban_create`, `kanban_show`, and `kanban_list` create, return, and filter hierarchy fields. CLI create/list/show JSON and dashboard create/list/update expose the same fields. The official Kanban plugin renders kind/product badges, breadcrumbs, containment-child counts separately from dependency counts, exact filters, creation controls, and reparenting.
 

--- a/docs/architecture/kanban-recursive-scoped-issues.md
+++ b/docs/architecture/kanban-recursive-scoped-issues.md
@@ -1,0 +1,27 @@
+# Recursive scoped issues in Hermes Kanban
+
+Status: proposed architecture with the current implementation described below
+
+## Decision
+
+Hermes Kanban remains the only execution-lifecycle ledger. The existing `tasks` row is the universal issue record, with compatibility preserving “task” in existing APIs. Issues use the closed `kind` vocabulary `individual`, `group`, `company`, `portfolio`, `product`, `project`, `feature`, `task`, or `defect`; migrated rows default to `task`.
+
+Containment and execution dependency are deliberately separate. `tasks.parent_id` is the single recursive containment parent used for breadcrumbs and filtering. `task_links` remains the many-to-many dependency graph that gates dispatcher readiness. `product_id` is structured portable scope identity; it is never inferred from a title, tenant, or board activity.
+
+Each physical board remains the hard dispatch, workspace, attachment, and worker-visibility boundary. No hierarchy operation crosses that boundary and no issue is copied between boards.
+
+## Current implementation
+
+The additive SQLite migration adds `kind`, `parent_id`, and `product_id` plus exact-filter indexes. Existing rows read as root `task` issues. Creation validates the closed kind vocabulary, structured product IDs, and parent existence. Reparenting is atomic and rejects self-parenting, orphans, and ancestry cycles. Deletion refuses to orphan containment children. Archive and review-reopen paths leave containment and dependencies unchanged.
+
+Existing model tools, CLI commands, and dashboard API fields are extended rather than duplicated. `kanban_create`, `kanban_show`, and `kanban_list` create, return, and filter hierarchy fields. CLI create/list/show JSON and dashboard create/list/update expose the same fields. The official Kanban plugin renders kind/product badges, breadcrumbs, containment-child counts separately from dependency counts, exact filters, creation controls, and reparenting.
+
+Qualified `<board>:<issue-id>` references have one concrete read-only DB resolver. It requires explicit qualification, opens only the named board for lookup, and does not expose any cross-board mutation. A cross-board aggregate UI/API remains deferred.
+
+## Compatibility and rollback
+
+The migration is additive and idempotent. Older binaries ignore the new columns and indexes. Rollback is code rollback only; dropping columns would destroy hierarchy identity. Existing callers need not provide new fields and continue to create `task` roots. Existing `task_links` rows are never converted.
+
+## Deferred
+
+Board-level default product identity, cross-board aggregate projections, registry synchronization, arbitrary relation catalogs, multiple containment parents, and board auto-creation are not implemented by this slice. Product IDs must be explicit on issue rows when attribution is required.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,9 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "kind": t.kind,
+        "parent_id": t.parent_id,
+        "product_id": t.product_id,
     }
 
 
@@ -333,6 +336,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
+    p_create.add_argument("--kind", choices=sorted(kb.VALID_ISSUE_KINDS), default="task",
+                          help="Semantic issue kind (default: task)")
+    p_create.add_argument("--under", dest="hierarchy_parent_id", default=None,
+                          help="Containment parent issue id (does not gate dispatch)")
+    p_create.add_argument("--product-id", default=None,
+                          help="Structured portable product identity")
     p_create.add_argument("--workspace", default="scratch",
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
@@ -430,6 +439,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_list.add_argument("--status", default=None,
                         choices=sorted(kb.VALID_STATUSES))
     p_list.add_argument("--tenant", default=None)
+    p_list.add_argument("--kind", choices=sorted(kb.VALID_ISSUE_KINDS), default=None)
+    p_list.add_argument("--parent-id", default=None, help="Exact containment parent id")
+    p_list.add_argument("--product-id", default=None, help="Exact structured product id")
     p_list.add_argument("--session", default=None,
                         help="Filter by originating chat/agent session id "
                              "(set on tasks created from inside an ACP loop)")
@@ -1586,6 +1598,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            kind=getattr(args, "kind", "task"),
+            hierarchy_parent_id=getattr(args, "hierarchy_parent_id", None),
+            product_id=getattr(args, "product_id", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1651,6 +1666,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
             assignee=assignee,
             status=args.status,
             tenant=args.tenant,
+            kind=getattr(args, "kind", None),
+            hierarchy_parent_id=getattr(args, "parent_id", None),
+            product_id=getattr(args, "product_id", None),
             session_id=args.session,
             include_archived=args.archived,
             order_by=getattr(args, "sort", None),
@@ -1692,20 +1710,26 @@ def _cmd_show(args: argparse.Namespace) -> int:
         )
         return 2
     graph = None
-    with kb.connect_closing() as conn:
-        task = kb.get_task(conn, args.task_id)
+    board = None
+    task_id = args.task_id
+    if ":" in task_id:
+        board, task_id = kb.parse_issue_ref(task_id)
+    with kb.connect_closing(board=board) as conn:
+        task = kb.get_task(conn, task_id)
         if not task:
             print(f"no such task: {args.task_id}", file=sys.stderr)
             return 1
-        comments = kb.list_comments(conn, args.task_id)
-        events = kb.list_events(conn, args.task_id)
-        parents = kb.parent_ids(conn, args.task_id)
-        children = kb.child_ids(conn, args.task_id)
-        runs = kb.list_runs(conn, args.task_id, **rsk)
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        parents = kb.parent_ids(conn, task_id)
+        children = kb.child_ids(conn, task_id)
+        hierarchy_children = kb.hierarchy_child_ids(conn, task_id)
+        breadcrumbs = kb.issue_breadcrumbs(conn, task_id)
+        runs = kb.list_runs(conn, task_id, **rsk)
         # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
-        latest_summary = kb.latest_summary(conn, args.task_id)
+        latest_summary = kb.latest_summary(conn, task_id)
         if not getattr(args, "json", False):
             graph = kb.task_graph_context(conn, task.id)
 
@@ -1715,6 +1739,9 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "latest_summary": latest_summary,
             "parents": parents,
             "children": children,
+            "hierarchy_children": hierarchy_children,
+            "breadcrumbs": [_task_to_dict(item) for item in breadcrumbs],
+            "qualified_ref": kb.qualified_issue_ref(board, task_id) if board else None,
             "comments": [
                 {"author": c.author, "body": c.body, "created_at": c.created_at}
                 for c in comments

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -137,6 +137,10 @@ VALID_ISSUE_KINDS = {
     "individual", "group", "company", "portfolio", "product", "project",
     "feature", "task", "defect",
 }
+# A containment edge adds one level below a root issue.  Thirty-two levels is
+# intentionally generous for organizational/project decomposition while
+# bounding corrupt or adversarial chains across every hierarchy surface.
+MAX_CONTAINMENT_DEPTH = 32
 _SCOPE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
@@ -3477,6 +3481,13 @@ def create_task(
                     "SELECT 1 FROM tasks WHERE id = ?", (hierarchy_parent_id,)
                 ).fetchone():
                     raise ValueError(f"unknown hierarchy parent {hierarchy_parent_id}")
+                if hierarchy_parent_id:
+                    parent_by_id = {
+                        row["id"]: row["parent_id"]
+                        for row in conn.execute("SELECT id, parent_id FROM tasks")
+                    }
+                    parent_by_id[task_id] = hierarchy_parent_id
+                    _containment_chain(parent_by_id, task_id)
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3930,22 +3941,54 @@ def hierarchy_child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
     return [row["id"] for row in rows]
 
 
-def issue_breadcrumbs(conn: sqlite3.Connection, task_id: str) -> list[Task]:
-    """Return root-to-issue containment breadcrumbs, failing on corrupt cycles."""
-    chain: list[Task] = []
+def _containment_chain(
+    parent_by_id: Mapping[str, Optional[str]], task_id: str,
+) -> list[str]:
+    """Return root-to-task ids from a fetched relation, failing closed."""
+    chain: list[str] = []
     seen: set[str] = set()
     current: Optional[str] = task_id
     while current:
         if current in seen:
             raise ValueError(f"hierarchy cycle detected at {current}")
-        seen.add(current)
-        issue = get_task(conn, current)
-        if issue is None:
+        if current not in parent_by_id:
             raise ValueError(f"unknown hierarchy issue {current}")
-        chain.append(issue)
-        current = issue.parent_id
+        seen.add(current)
+        chain.append(current)
+        if len(chain) - 1 > MAX_CONTAINMENT_DEPTH:
+            raise ValueError(
+                f"maximum containment depth is {MAX_CONTAINMENT_DEPTH}"
+            )
+        current = parent_by_id[current]
     chain.reverse()
     return chain
+
+
+def hierarchy_projection(
+    conn: sqlite3.Connection, task_ids: Iterable[str],
+) -> tuple[dict[str, list[str]], dict[str, list[Task]]]:
+    """Batch children and breadcrumbs from one deterministic task fetch."""
+    rows = conn.execute("SELECT * FROM tasks ORDER BY created_at, id").fetchall()
+    tasks_by_id = {row["id"]: Task.from_row(row) for row in rows}
+    parent_by_id = {task_id: task.parent_id for task_id, task in tasks_by_id.items()}
+    children: dict[str, list[str]] = {task_id: [] for task_id in tasks_by_id}
+    for task in tasks_by_id.values():
+        if task.parent_id in children:
+            children[task.parent_id].append(task.id)
+
+    breadcrumbs: dict[str, list[Task]] = {}
+    for task_id in task_ids:
+        breadcrumbs[task_id] = [
+            tasks_by_id[item_id]
+            for item_id in _containment_chain(parent_by_id, task_id)
+        ]
+    return children, breadcrumbs
+
+
+def issue_breadcrumbs(conn: sqlite3.Connection, task_id: str) -> list[Task]:
+    """Return root-to-issue containment breadcrumbs, failing on corrupt cycles."""
+    _, breadcrumbs = hierarchy_projection(conn, [task_id])
+    return breadcrumbs[task_id]
 
 
 def reparent_issue(
@@ -3974,6 +4017,25 @@ def reparent_issue(
                 if row is None:
                     raise ValueError(f"unknown hierarchy parent {ancestor}")
                 ancestor = row["parent_id"]
+        parent_by_id = {
+            row["id"]: row["parent_id"]
+            for row in conn.execute("SELECT id, parent_id FROM tasks")
+        }
+        parent_by_id[task_id] = parent_id
+        # Validate the moved issue and every descendant because moving a subtree
+        # can push its deepest leaf over the shared boundary. Unrelated legacy
+        # corruption does not prevent repairing or extending a valid subtree.
+        descendants = {task_id}
+        while True:
+            added = {
+                candidate for candidate, candidate_parent in parent_by_id.items()
+                if candidate_parent in descendants
+            } - descendants
+            if not added:
+                break
+            descendants.update(added)
+        for candidate in descendants:
+            _containment_chain(parent_by_id, candidate)
         if issue.parent_id == parent_id:
             return False
         conn.execute("UPDATE tasks SET parent_id = ? WHERE id = ?", (parent_id, task_id))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -133,6 +133,11 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+VALID_ISSUE_KINDS = {
+    "individual", "group", "company", "portfolio", "product", "project",
+    "feature", "task", "defect",
+}
+_SCOPE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -1141,6 +1146,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    kind: str = "task"
+    parent_id: Optional[str] = None
+    product_id: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1235,6 +1243,9 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            kind=(row["kind"] if "kind" in keys and row["kind"] else "task"),
+            parent_id=(row["parent_id"] if "parent_id" in keys else None),
+            product_id=(row["product_id"] if "product_id" in keys else None),
         )
 
 
@@ -1422,7 +1433,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    kind                 TEXT NOT NULL DEFAULT 'task',
+    parent_id            TEXT,
+    product_id           TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2542,6 +2556,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "branch_name", "branch_name TEXT")
     if "project_id" not in cols:
         _add_column_if_missing(conn, "tasks", "project_id", "project_id TEXT")
+    if "kind" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "kind", "kind TEXT NOT NULL DEFAULT 'task'"
+        )
+    if "parent_id" not in cols:
+        _add_column_if_missing(conn, "tasks", "parent_id", "parent_id TEXT")
+    if "product_id" not in cols:
+        _add_column_if_missing(conn, "tasks", "product_id", "product_id TEXT")
     if "idempotency_key" not in cols:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
@@ -2693,6 +2715,9 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_kind ON tasks(kind)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_product_id ON tasks(product_id)")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -3183,6 +3208,9 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    kind: str = "task",
+    hierarchy_parent_id: Optional[str] = None,
+    product_id: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3229,6 +3257,13 @@ def create_task(
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
+    kind = str(kind or "").strip().lower()
+    if kind not in VALID_ISSUE_KINDS:
+        raise ValueError(f"kind must be one of {sorted(VALID_ISSUE_KINDS)}")
+    hierarchy_parent_id = str(hierarchy_parent_id or "").strip() or None
+    product_id = str(product_id or "").strip() or None
+    if product_id and not _SCOPE_ID_RE.fullmatch(product_id):
+        raise ValueError("product_id must be a structured identifier")
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -3438,6 +3473,10 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                if hierarchy_parent_id and not conn.execute(
+                    "SELECT 1 FROM tasks WHERE id = ?", (hierarchy_parent_id,)
+                ).fetchone():
+                    raise ValueError(f"unknown hierarchy parent {hierarchy_parent_id}")
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3497,8 +3536,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        kind, parent_id, product_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3524,6 +3564,9 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        kind,
+                        hierarchy_parent_id,
+                        product_id,
                     ),
                 )
                 for pid in parents:
@@ -3552,6 +3595,9 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "kind": kind,
+                        "parent_id": hierarchy_parent_id,
+                        "product_id": product_id,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -3659,6 +3705,9 @@ def list_tasks(
     order_by: Optional[str] = None,
     workflow_template_id: Optional[str] = None,
     current_step_key: Optional[str] = None,
+    kind: Optional[str] = None,
+    product_id: Optional[str] = None,
+    hierarchy_parent_id: Optional[str] = None,
 ) -> list[Task]:
     query = "SELECT * FROM tasks WHERE 1=1"
     params: list[Any] = []
@@ -3682,6 +3731,18 @@ def list_tasks(
     if current_step_key is not None:
         query += " AND current_step_key = ?"
         params.append(current_step_key)
+    if kind is not None:
+        kind = str(kind).strip().lower()
+        if kind not in VALID_ISSUE_KINDS:
+            raise ValueError(f"kind must be one of {sorted(VALID_ISSUE_KINDS)}")
+        query += " AND kind = ?"
+        params.append(kind)
+    if product_id is not None:
+        query += " AND product_id = ?"
+        params.append(product_id)
+    if hierarchy_parent_id is not None:
+        query += " AND parent_id = ?"
+        params.append(hierarchy_parent_id)
     if not include_archived and status != "archived":
         query += " AND status != 'archived'"
     if order_by is not None:
@@ -3825,6 +3886,102 @@ def set_reasoning_effort(
 # ---------------------------------------------------------------------------
 # Links
 # ---------------------------------------------------------------------------
+
+def qualified_issue_ref(board: str, issue_id: str) -> str:
+    """Return the stable, board-qualified reference for one issue."""
+    slug = _normalize_board_slug(board)
+    issue_id = str(issue_id or "").strip()
+    if not slug:
+        raise ValueError("board slug is required")
+    if not issue_id or ":" in issue_id:
+        raise ValueError("issue id must be non-empty and must not contain ':'")
+    return f"{slug}:{issue_id}"
+
+
+def parse_issue_ref(ref: str) -> tuple[str, str]:
+    """Parse a globally qualified issue reference, rejecting ambiguity."""
+    raw = str(ref or "").strip()
+    if ":" not in raw:
+        raise ValueError("issue reference must be qualified as <board>:<issue-id>")
+    board, issue_id = raw.split(":", 1)
+    try:
+        slug = _normalize_board_slug(board)
+    except ValueError as exc:
+        raise ValueError(f"invalid board slug in issue reference: {board!r}") from exc
+    if not slug or not issue_id or ":" in issue_id:
+        raise ValueError("issue reference must be qualified as <board>:<issue-id>")
+    return slug, issue_id
+
+
+def resolve_issue_ref(ref: str) -> dict[str, Any]:
+    """Resolve one qualified issue reference without mutating either board."""
+    board, issue_id = parse_issue_ref(ref)
+    with connect_closing(board=board) as conn:
+        task = get_task(conn, issue_id)
+    if task is None:
+        raise ValueError(f"issue {ref} not found")
+    return {"ref": qualified_issue_ref(board, issue_id), "board": board, "task": task}
+
+
+def hierarchy_child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    rows = conn.execute(
+        "SELECT id FROM tasks WHERE parent_id = ? ORDER BY created_at, id", (task_id,)
+    ).fetchall()
+    return [row["id"] for row in rows]
+
+
+def issue_breadcrumbs(conn: sqlite3.Connection, task_id: str) -> list[Task]:
+    """Return root-to-issue containment breadcrumbs, failing on corrupt cycles."""
+    chain: list[Task] = []
+    seen: set[str] = set()
+    current: Optional[str] = task_id
+    while current:
+        if current in seen:
+            raise ValueError(f"hierarchy cycle detected at {current}")
+        seen.add(current)
+        issue = get_task(conn, current)
+        if issue is None:
+            raise ValueError(f"unknown hierarchy issue {current}")
+        chain.append(issue)
+        current = issue.parent_id
+    chain.reverse()
+    return chain
+
+
+def reparent_issue(
+    conn: sqlite3.Connection, task_id: str, parent_id: Optional[str]
+) -> bool:
+    """Atomically move one issue in the containment tree."""
+    parent_id = str(parent_id or "").strip() or None
+    if parent_id == task_id:
+        raise ValueError("reparenting would create a hierarchy cycle")
+    with write_txn(conn):
+        issue = get_task(conn, task_id)
+        if issue is None:
+            raise ValueError(f"unknown issue {task_id}")
+        if parent_id is not None:
+            if get_task(conn, parent_id) is None:
+                raise ValueError(f"unknown hierarchy parent {parent_id}")
+            ancestor: Optional[str] = parent_id
+            seen: set[str] = set()
+            while ancestor:
+                if ancestor == task_id or ancestor in seen:
+                    raise ValueError("reparenting would create a hierarchy cycle")
+                seen.add(ancestor)
+                row = conn.execute(
+                    "SELECT parent_id FROM tasks WHERE id = ?", (ancestor,)
+                ).fetchone()
+                if row is None:
+                    raise ValueError(f"unknown hierarchy parent {ancestor}")
+                ancestor = row["parent_id"]
+        if issue.parent_id == parent_id:
+            return False
+        conn.execute("UPDATE tasks SET parent_id = ? WHERE id = ?", (parent_id, task_id))
+        _append_event(
+            conn, task_id, "reparented", {"from": issue.parent_id, "to": parent_id}
+        )
+    notify_task_updated(conn, task_id, ("parent_id",))
+    return True
 
 def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
     if parent_id == child_id:
@@ -7547,6 +7704,8 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     second deliberate action.
     """
     with write_txn(conn):
+        if hierarchy_child_ids(conn, task_id):
+            raise ValueError("cannot delete an issue with hierarchy children")
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
             (task_id,),
@@ -7576,6 +7735,8 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     if the task was not found.
     """
     with write_txn(conn):
+        if hierarchy_child_ids(conn, task_id):
+            raise ValueError("cannot delete an issue with hierarchy children")
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3939,6 +3939,8 @@
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
     const childResults = props.data.child_results || [];
+    const hierarchyChildren = props.data.hierarchy_child_results || [];
+    const hierarchyProgress = props.data.hierarchy_progress || { completed: 0, total: 0 };
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
@@ -4056,9 +4058,27 @@
         }
         return null;
       })(),
+      hierarchyChildren.length > 0 ? h("details", { className: "hermes-kanban-section", open: true },
+        h("summary", { className: "hermes-kanban-section-head" },
+          `Contained Issues (${hierarchyProgress.completed}/${hierarchyProgress.total} completed)`),
+        hierarchyChildren.map(function (child) {
+          return h("div", { key: child.id, className: "hermes-kanban-comment" },
+            h("div", { className: "hermes-kanban-comment-head" },
+              h("span", { className: "hermes-kanban-comment-author" },
+                `${child.kind || "task"} · ${child.title || child.id}`),
+              h(Badge, { variant: "outline" }, child.status),
+              h("button", {
+                type: "button",
+                className: "hermes-kanban-diag-action-btn",
+                onClick: function () { if (props.onOpenTask) props.onOpenTask(child.id); },
+              }, tx(i18n, "open", "Open")),
+            ),
+          );
+        }),
+      ) : null,
       childResults.length > 0 ? h("div", { className: "hermes-kanban-section" },
         h("div", { className: "hermes-kanban-section-head" },
-          `${tx(i18n, "childResults", "Child Results")} (${childResults.length})`),
+          `Dependency ${tx(i18n, "childResults", "Child Results")} (${childResults.length})`),
         childResults.map(function (child) {
           var childResult = child.result || child.latest_summary || null;
           return h("div", { key: child.id, className: "hermes-kanban-comment" },

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -623,6 +623,9 @@
 
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
+    const [kindFilter, setKindFilter] = useState("");
+    const [productFilter, setProductFilter] = useState("");
+    const [parentFilter, setParentFilter] = useState("");
     const [includeArchived, setIncludeArchived] = useState(false);
     const [search, setSearch] = useState("");
     const [laneByProfile, setLaneByProfile] = useState(true);
@@ -799,6 +802,9 @@
       const filterTask = function (t) {
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
+        if (kindFilter && t.kind !== kindFilter) return false;
+        if (productFilter && t.product_id !== productFilter) return false;
+        if (parentFilter && t.parent_id !== parentFilter) return false;
         if (q) {
           const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
@@ -810,7 +816,7 @@
           return Object.assign({}, col, { tasks: col.tasks.filter(filterTask) });
         }),
       });
-    }, [boardData, tenantFilter, assigneeFilter, search]);
+    }, [boardData, tenantFilter, assigneeFilter, kindFilter, productFilter, parentFilter, search]);
 
     // --- actions ------------------------------------------------------------
     // Performs the actual move (optimistic UI + PATCH) once any required
@@ -1288,6 +1294,9 @@
         h(BoardToolbar, {
           board: boardData,
           tenantFilter, setTenantFilter,
+          kindFilter, setKindFilter,
+          productFilter, setProductFilter,
+          parentFilter, setParentFilter,
           assigneeFilter, setAssigneeFilter,
           includeArchived, setIncludeArchived,
           laneByProfile, setLaneByProfile,
@@ -2455,6 +2464,23 @@
           }),
         ),
       ),
+      h("div", { className: "flex flex-col gap-1" },
+        h(Label, { className: "text-xs text-muted-foreground" }, "Kind"),
+        h(Select, Object.assign({ value: props.kindFilter, className: "h-8" }, selectChangeHandler(props.setKindFilter)),
+          h(SelectOption, { value: "" }, "All kinds"),
+          ["individual", "group", "company", "portfolio", "product", "project", "feature", "task", "defect"].map(function (kind) {
+            return h(SelectOption, { key: kind, value: kind }, kind);
+          }),
+        ),
+      ),
+      h("div", { className: "flex flex-col gap-1" },
+        h(Label, { className: "text-xs text-muted-foreground" }, "Product"),
+        h(Input, { value: props.productFilter, onChange: function (e) { props.setProductFilter(e.target.value); }, placeholder: "product id", className: "w-32 h-8" }),
+      ),
+      h("div", { className: "flex flex-col gap-1" },
+        h(Label, { className: "text-xs text-muted-foreground" }, "Parent"),
+        h(Input, { value: props.parentFilter, onChange: function (e) { props.setParentFilter(e.target.value); }, placeholder: "containment id", className: "w-36 h-8" }),
+      ),
       h("label", { className: "flex items-center gap-2 text-xs",
                    title: "Include archived tasks in the board view. Archived tasks are hidden by default." },
         h(Checkbox, {
@@ -2487,6 +2513,9 @@
           props.setSearch("");
           props.setTenantFilter("");
           props.setAssigneeFilter("");
+          props.setKindFilter("");
+          props.setProductFilter("");
+          props.setParentFilter("");
           props.setIncludeArchived(false);
         },
         size: "sm",
@@ -3102,6 +3131,8 @@
               ? h(Badge, { className: "hermes-kanban-priority",
                            title: `Priority ${t.priority}. Higher-priority tasks are claimed first by the dispatcher.` }, `P${t.priority}`)
               : null,
+            h(Badge, { variant: "outline", className: "hermes-kanban-kind", title: "Recursive issue kind" }, t.kind || "task"),
+            t.product_id ? h(Badge, { variant: "outline", title: "Structured product identity" }, t.product_id) : null,
             t.tenant
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
                            title: `Tenant: ${t.tenant}. Free-form tag for grouping tasks (customer, project, team).` }, t.tenant)
@@ -3125,6 +3156,10 @@
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
+          t.breadcrumbs && t.breadcrumbs.length > 1
+            ? h("div", { className: "text-xs text-muted-foreground", title: "Containment breadcrumb" },
+                t.breadcrumbs.map(function (x) { return x.title || x.id; }).join(" › "))
+            : null,
           h("div", { className: "hermes-kanban-card-row hermes-kanban-card-meta" },
             t.assignee
               ? h("span", { className: "hermes-kanban-assignee",
@@ -3142,6 +3177,9 @@
               ? h("span", { className: "hermes-kanban-count",
                             title: `${t.link_counts.parents} parent${t.link_counts.parents === 1 ? "" : "s"}, ${t.link_counts.children} child${t.link_counts.children === 1 ? "" : "ren"}. Children stay blocked until their parent is done.` },
                   "↔ ", t.link_counts.parents + t.link_counts.children)
+              : null,
+            t.hierarchy_children && t.hierarchy_children.length > 0
+              ? h("span", { className: "hermes-kanban-count", title: "Containment children (not dispatcher dependencies)" }, "⌂ ", t.hierarchy_children.length)
               : null,
             h("span", { className: "hermes-kanban-ago",
                         title: t.created_at ? `Created ${t.created_at}` : "" },
@@ -3167,6 +3205,9 @@
     const [assignee, setAssignee] = useState("");
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
+    const [hierarchyParent, setHierarchyParent] = useState("");
+    const [kind, setKind] = useState("task");
+    const [productId, setProductId] = useState("");
     const [skills, setSkills] = useState("");
     // A board with a configured workdir defaults to a persistent workspace:
     // worktree for git repositories, dir for ordinary directories. Boards
@@ -3191,8 +3232,11 @@
         assignee: assignee.trim() || null,
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
+        kind: kind,
       };
       if (parent) body.parents = [parent];
+      if (hierarchyParent) body.parent_id = hierarchyParent;
+      if (productId.trim()) body.product_id = productId.trim();
       // Parse comma-separated skills into a clean list. Blank = no
       // extras (omit key so backend leaves it null). The dispatcher
       // always auto-loads kanban-worker; these are extras on top.
@@ -3216,7 +3260,7 @@
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
       props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
+      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setHierarchyParent(""); setKind("task"); setProductId(""); setSkills("");
       setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
       setGoalMode(false); setGoalMaxTurns("");
     };
@@ -3347,6 +3391,27 @@
               (props.allTasks || []).map(function (task) {
                 return h(SelectOption, { key: task.id, value: task.id },
                   `${task.id} — ${(task.title || "").slice(0, 50)}`);
+              }),
+            ),
+          ),
+          h("div", { className: "flex gap-2" },
+            h("div", { className: "flex flex-col gap-1 flex-1" },
+              fieldLabel("Issue kind"),
+              h(Select, Object.assign({ value: kind, className: "h-8 text-sm" }, selectChangeHandler(setKind)),
+                ["individual", "group", "company", "portfolio", "product", "project", "feature", "task", "defect"].map(function (value) {
+                  return h(SelectOption, { key: value, value: value }, value);
+                }),
+              ),
+            ),
+            h("div", { className: "flex flex-col gap-1 flex-1" }, fieldLabel("Product id"),
+              h(Input, { value: productId, onChange: function (e) { setProductId(e.target.value); }, className: "h-8 text-sm", placeholder: "product_hermes" })),
+          ),
+          h("div", { className: "flex flex-col gap-1" },
+            fieldLabel("Containment parent", "(does not gate dispatch)"),
+            h(Select, Object.assign({ value: hierarchyParent, className: "h-8 text-sm" }, selectChangeHandler(setHierarchyParent)),
+              h(SelectOption, { value: "" }, "— root issue —"),
+              (props.allTasks || []).map(function (task) {
+                return h(SelectOption, { key: task.id, value: task.id }, `${task.kind || "task"}: ${task.title || task.id}`);
               }),
             ),
           ),
@@ -3894,6 +3959,19 @@
       ),
       h("div", { className: "hermes-kanban-drawer-meta" },
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
+        h(MetaRow, { label: "Kind", value: t.kind || "task" }),
+        t.product_id ? h(MetaRow, { label: "Product", value: t.product_id }) : null,
+        h("div", { className: "hermes-kanban-meta-row" },
+          h("span", { className: "hermes-kanban-meta-label" }, "Containment parent"),
+          h(Select, Object.assign({ value: t.parent_id || "", className: "h-8 text-sm" }, selectChangeHandler(function (value) {
+            props.onPatch(value ? { parent_id: value } : { clear_parent: true });
+          })),
+            h(SelectOption, { value: "" }, "— root issue —"),
+            (props.allTasks || []).filter(function (task) { return task.id !== t.id; }).map(function (task) {
+              return h(SelectOption, { key: task.id, value: task.id }, `${task.kind || "task"}: ${task.title || task.id}`);
+            }),
+          ),
+        ),
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         h(ModelEditor, { task: t, onPatch: props.onPatch }),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -467,6 +467,12 @@ def get_board(
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        try:
+            hierarchy_children, breadcrumbs = kanban_db.hierarchy_projection(
+                conn, [t.id for t in tasks],
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -475,10 +481,10 @@ def get_board(
             )
             d = _task_dict(t, latest_summary=preview)
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
-            d["hierarchy_children"] = kanban_db.hierarchy_child_ids(conn, t.id)
+            d["hierarchy_children"] = hierarchy_children.get(t.id, [])
             d["breadcrumbs"] = [
                 {"id": item.id, "title": item.title, "kind": item.kind}
-                for item in kanban_db.issue_breadcrumbs(conn, t.id)
+                for item in breadcrumbs[t.id]
             ]
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -1091,6 +1097,11 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 board=board,
             )
 
+        if payload.parent_id is not None and payload.clear_parent:
+            raise HTTPException(
+                status_code=400,
+                detail="parent_id and clear_parent=true are mutually exclusive",
+            )
         if payload.parent_id is not None or payload.clear_parent:
             try:
                 kanban_db.reparent_issue(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -575,6 +575,21 @@ def get_task(
                 "latest_summary": child_summaries.get(child.id),
                 "result": child.result,
             })
+        hierarchy_child_ids = kanban_db.hierarchy_child_ids(conn, task_id)
+        hierarchy_summaries = kanban_db.latest_summaries(conn, hierarchy_child_ids)
+        hierarchy_child_results = []
+        for child_id in hierarchy_child_ids:
+            child = kanban_db.get_task(conn, child_id)
+            if child is None:
+                continue
+            hierarchy_child_results.append({
+                "id": child.id,
+                "title": child.title,
+                "status": child.status,
+                "kind": child.kind,
+                "latest_summary": hierarchy_summaries.get(child.id),
+                "result": child.result,
+            })
         # Attach diagnostics so the drawer's Diagnostics section can
         # render recovery actions without a second round-trip.
         diags = _compute_task_diagnostics(conn, task_ids=[task_id])
@@ -589,6 +604,13 @@ def get_task(
             "attachments": [_attachment_dict(a) for a in kanban_db.list_attachments(conn, task_id)],
             "links": links,
             "child_results": child_results,
+            "hierarchy_child_results": hierarchy_child_results,
+            "hierarchy_progress": {
+                "completed": sum(
+                    child["status"] == "done" for child in hierarchy_child_results
+                ),
+                "total": len(hierarchy_child_results),
+            },
             "runs": [
                 _run_dict(r)
                 for r in kanban_db.list_runs(
@@ -1070,9 +1092,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             )
 
         if payload.parent_id is not None or payload.clear_parent:
-            kanban_db.reparent_issue(
-                conn, task_id, None if payload.clear_parent else payload.parent_id,
-            )
+            try:
+                kanban_db.reparent_issue(
+                    conn, task_id, None if payload.clear_parent else payload.parent_id,
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
@@ -1089,7 +1114,10 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.delete_task(conn, task_id)
+        try:
+            ok = kanban_db.delete_task(conn, task_id)
+        except ValueError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         if not ok:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         return {"deleted": True, "task_id": task_id}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -389,6 +389,9 @@ def get_board(
     current_step_key: Optional[str] = Query(
         None, description="Restrict to tasks at this workflow step key",
     ),
+    kind: Optional[str] = Query(None, description="Exact issue-kind filter"),
+    parent_id: Optional[str] = Query(None, description="Exact containment-parent filter"),
+    product_id: Optional[str] = Query(None, description="Exact structured product filter"),
 ):
     """Return the full board grouped by status column.
 
@@ -408,6 +411,9 @@ def get_board(
             include_archived=include_archived,
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
+            kind=kind,
+            hierarchy_parent_id=parent_id,
+            product_id=product_id,
         )
         # Pre-fetch link counts per task (cheap: one query).
         link_counts: dict[str, dict[str, int]] = {}
@@ -469,6 +475,11 @@ def get_board(
             )
             d = _task_dict(t, latest_summary=preview)
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
+            d["hierarchy_children"] = kanban_db.hierarchy_child_ids(conn, t.id)
+            d["breadcrumbs"] = [
+                {"id": item.id, "title": item.title, "kind": item.kind}
+                for item in kanban_db.issue_breadcrumbs(conn, t.id)
+            ]
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
             diags = diagnostics_per_task.get(t.id)
@@ -619,6 +630,9 @@ class CreateTaskBody(BaseModel):
     # Explicit project link; when omitted, create_task inherits the board's
     # scoped project (if any) so a project-scoped board anchors every task.
     project_id: Optional[str] = None
+    kind: str = "task"
+    parent_id: Optional[str] = None
+    product_id: Optional[str] = None
 
 
 @router.post("/tasks")
@@ -647,6 +661,9 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
+            kind=payload.kind,
+            hierarchy_parent_id=payload.parent_id,
+            product_id=payload.product_id,
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
@@ -852,6 +869,8 @@ class UpdateTaskBody(BaseModel):
     # override doesn't silently reset the depth the operator chose.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    parent_id: Optional[str] = None
+    clear_parent: bool = False
 
 
 def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
@@ -1048,6 +1067,11 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 conn, task_id,
                 [f for f in ("title", "body") if getattr(payload, f) is not None],
                 board=board,
+            )
+
+        if payload.parent_id is not None or payload.clear_parent:
+            kanban_db.reparent_issue(
+                conn, task_id, None if payload.clear_parent else payload.parent_id,
             )
 
         updated = kanban_db.get_task(conn, task_id)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,26 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_cli_create_list_and_qualified_show_hierarchy_fields(kanban_home):
+    product = json.loads(kc.run_slash(
+        "create Product --kind product --product-id product_hermes --json"
+    ))
+    feature = json.loads(kc.run_slash(
+        f"create Feature --kind feature --under {product['id']} "
+        "--product-id product_hermes --json"
+    ))
+    listed = json.loads(kc.run_slash(
+        f"list --kind feature --parent-id {product['id']} "
+        "--product-id product_hermes --json"
+    ))
+    assert [row["id"] for row in listed] == [feature["id"]]
+
+    shown = json.loads(kc.run_slash(f"show default:{feature['id']} --json"))
+    assert shown["task"]["kind"] == "feature"
+    assert shown["qualified_ref"] == f"default:{feature['id']}"
+    assert [row["id"] for row in shown["breadcrumbs"]] == [product["id"], feature["id"]]
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/hermes_cli/test_kanban_issue_hierarchy.py
+++ b/tests/hermes_cli/test_kanban_issue_hierarchy.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    with kb.connect() as conn:
+        yield conn
+
+
+def test_existing_rows_migrate_to_root_task_issues(tmp_path):
+    db = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL, body TEXT, assignee TEXT, status TEXT NOT NULL, priority INTEGER DEFAULT 0, created_by TEXT, created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER, workspace_kind TEXT NOT NULL DEFAULT 'scratch', workspace_path TEXT, claim_lock TEXT, claim_expires INTEGER)")
+    conn.execute("CREATE TABLE task_events (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL, kind TEXT NOT NULL, payload TEXT, created_at INTEGER NOT NULL)")
+    conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('legacy', 'Legacy', 'todo', 1)")
+    conn.commit()
+    conn.close()
+    with kb.connect(db) as migrated:
+        issue = kb.get_task(migrated, "legacy")
+        columns = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+    assert {"kind", "parent_id", "product_id"} <= columns
+    assert (issue.kind, issue.parent_id, issue.product_id) == ("task", None, None)
+
+
+def test_recursive_hierarchy_is_independent_from_dependencies(board):
+    product = kb.create_task(board, title="Hermes", kind="product", product_id="product_hermes")
+    project = kb.create_task(board, title="Hierarchy", kind="project", hierarchy_parent_id=product, product_id="product_hermes")
+    feature = kb.create_task(board, title="Breadcrumbs", kind="feature", hierarchy_parent_id=project, product_id="product_hermes")
+    assert kb.get_task(board, feature).status == "ready"
+    assert kb.hierarchy_child_ids(board, product) == [project]
+    assert [item.id for item in kb.issue_breadcrumbs(board, feature)] == [product, project, feature]
+    blocker = kb.create_task(board, title="Design accepted")
+    kb.link_tasks(board, blocker, feature)
+    assert kb.get_task(board, feature).status == "todo"
+    assert kb.get_task(board, feature).parent_id == project
+
+
+def test_reparent_rejects_cycles_orphans_and_self_parent(board):
+    root = kb.create_task(board, title="Root", kind="product")
+    child = kb.create_task(board, title="Child", kind="project", hierarchy_parent_id=root)
+    leaf = kb.create_task(board, title="Leaf", kind="feature", hierarchy_parent_id=child)
+    for issue, parent in ((root, leaf), (root, root), (leaf, "missing")):
+        with pytest.raises(ValueError):
+            kb.reparent_issue(board, issue, parent)
+    assert kb.get_task(board, root).parent_id is None
+
+
+def test_archive_and_review_reopen_preserve_hierarchy_and_dependencies(board):
+    parent = kb.create_task(board, title="Parent", kind="feature")
+    blocker = kb.create_task(board, title="Blocker")
+    child = kb.create_task(board, title="Child", hierarchy_parent_id=parent)
+    kb.link_tasks(board, blocker, child)
+    kb.archive_task(board, child)
+    assert kb.get_task(board, child).parent_id == parent
+    assert kb.parent_ids(board, child) == [blocker]
+
+    review_child = kb.create_task(board, title="Review child", hierarchy_parent_id=parent)
+    kb.request_review(board, review_child)
+    kb.reopen_review_task(board, review_child)
+    assert kb.get_task(board, review_child).parent_id == parent
+
+
+def test_hierarchy_validation_and_filters_fail_closed(board):
+    with pytest.raises(ValueError, match="kind"):
+        kb.create_task(board, title="Bad", kind="epic")
+    with pytest.raises(ValueError, match="unknown hierarchy parent"):
+        kb.create_task(board, title="Orphan", hierarchy_parent_id="t_missing")
+    root = kb.create_task(board, title="Hermes", kind="product", product_id="product_hermes")
+    feature = kb.create_task(board, title="Hierarchy", kind="feature", hierarchy_parent_id=root, product_id="product_hermes")
+    assert [x.id for x in kb.list_tasks(board, kind="feature")] == [feature]
+    assert [x.id for x in kb.list_tasks(board, hierarchy_parent_id=root)] == [feature]
+    assert {x.id for x in kb.list_tasks(board, product_id="product_hermes")} == {root, feature}
+
+
+def test_qualified_issue_reference_resolves_read_only_with_pinned_board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    with kb.connect(board="alpha") as alpha:
+        issue = kb.create_task(alpha, title="Alpha issue")
+    assert kb.resolve_issue_ref(f"alpha:{issue}")["task"].id == issue
+    with pytest.raises(ValueError, match="qualified"):
+        kb.resolve_issue_ref(issue)
+    with pytest.raises(ValueError):
+        kb.resolve_issue_ref(f"beta:{issue}")
+
+
+def test_delete_refuses_to_orphan_hierarchy_children(board):
+    parent = kb.create_task(board, title="Parent", kind="feature")
+    kb.create_task(board, title="Child", hierarchy_parent_id=parent)
+    with pytest.raises(ValueError, match="hierarchy children"):
+        kb.delete_task(board, parent)

--- a/tests/hermes_cli/test_kanban_issue_hierarchy.py
+++ b/tests/hermes_cli/test_kanban_issue_hierarchy.py
@@ -105,3 +105,45 @@ def test_delete_refuses_to_orphan_hierarchy_children(board):
     kb.create_task(board, title="Child", hierarchy_parent_id=parent)
     with pytest.raises(ValueError, match="hierarchy children"):
         kb.delete_task(board, parent)
+
+
+def test_containment_depth_boundary_is_shared_by_create_reparent_and_breadcrumbs(board):
+    chain = [kb.create_task(board, title="root")]
+    for depth in range(1, kb.MAX_CONTAINMENT_DEPTH + 1):
+        chain.append(kb.create_task(
+            board, title=f"level {depth}", hierarchy_parent_id=chain[-1],
+        ))
+
+    assert len(kb.issue_breadcrumbs(board, chain[-1])) == kb.MAX_CONTAINMENT_DEPTH + 1
+    with pytest.raises(ValueError, match="maximum containment depth"):
+        kb.create_task(board, title="too deep", hierarchy_parent_id=chain[-1])
+
+    movable = kb.create_task(board, title="movable")
+    with pytest.raises(ValueError, match="maximum containment depth"):
+        kb.reparent_issue(board, movable, chain[-1])
+
+    # Corrupt legacy rows are never rendered with silently truncated ancestry.
+    with kb.write_txn(board):
+        board.execute("UPDATE tasks SET parent_id = ? WHERE id = ?", (movable, chain[0]))
+    with pytest.raises(ValueError, match="maximum containment depth"):
+        kb.issue_breadcrumbs(board, chain[-1])
+
+
+def test_breadcrumbs_fail_closed_for_corrupt_orphan_and_cycle_rows(board):
+    root = kb.create_task(board, title="root")
+    child = kb.create_task(board, title="child", hierarchy_parent_id=root)
+    with kb.write_txn(board):
+        board.execute("UPDATE tasks SET parent_id = 'missing' WHERE id = ?", (root,))
+    with pytest.raises(ValueError, match="unknown hierarchy issue missing"):
+        kb.issue_breadcrumbs(board, child)
+
+    with kb.write_txn(board):
+        board.execute("UPDATE tasks SET parent_id = ? WHERE id = ?", (child, root))
+    with pytest.raises(ValueError, match="hierarchy cycle"):
+        kb.issue_breadcrumbs(board, child)
+
+
+def test_product_scope_ids_deliberately_allow_colon(board):
+    product_id = "company:zer0:product:hermes-agent"
+    task_id = kb.create_task(board, title="portable", product_id=product_id)
+    assert kb.get_task(board, task_id).product_id == product_id

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -142,6 +142,73 @@ def test_dashboard_filters_and_reparents_recursive_issues(client):
     assert moved.json()["task"]["parent_id"] == other["id"]
 
 
+@pytest.mark.parametrize("case", ["cycle", "self", "orphan"])
+def test_dashboard_reparent_validation_returns_4xx(client, case):
+    root = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "root", "kind": "project"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parent_id": root["id"]},
+    ).json()["task"]
+    parent_id = {
+        "cycle": child["id"],
+        "self": root["id"],
+        "orphan": "t_missing",
+    }[case]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{root['id']}", json={"parent_id": parent_id},
+    )
+
+    assert 400 <= response.status_code < 500, response.text
+    assert response.json()["detail"]
+
+
+def test_dashboard_parent_delete_validation_returns_4xx(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "contained", "parent_id": parent["id"]},
+    )
+
+    response = client.delete(f"/api/plugins/kanban/tasks/{parent['id']}")
+
+    assert 400 <= response.status_code < 500, response.text
+    assert response.json()["detail"]
+
+
+def test_task_detail_separates_hierarchy_children_from_dependencies(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    contained_open = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "contained open", "parent_id": parent["id"]},
+    ).json()["task"]
+    contained_done = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "contained done", "parent_id": parent["id"]},
+    ).json()["task"]
+    dependency = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "dependency child", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert client.patch(
+        f"/api/plugins/kanban/tasks/{contained_done['id']}", json={"status": "done"},
+    ).status_code == 200
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{parent['id']}").json()
+
+    assert {row["id"] for row in detail["hierarchy_child_results"]} == {
+        contained_open["id"], contained_done["id"],
+    }
+    assert detail["hierarchy_progress"] == {"completed": 1, "total": 2}
+    assert [row["id"] for row in detail["child_results"]] == [dependency["id"]]
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -142,6 +142,75 @@ def test_dashboard_filters_and_reparents_recursive_issues(client):
     assert moved.json()["task"]["parent_id"] == other["id"]
 
 
+def test_dashboard_rejects_ambiguous_parent_clear_payload(client):
+    parent = client.post("/api/plugins/kanban/tasks", json={"title": "parent"}).json()["task"]
+    child = client.post("/api/plugins/kanban/tasks", json={"title": "child"}).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"parent_id": parent["id"], "clear_parent": True},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "parent_id and clear_parent=true are mutually exclusive"
+
+
+def test_board_batches_hierarchy_projection_in_one_query(client, monkeypatch):
+    root = client.post("/api/plugins/kanban/tasks", json={"title": "root"}).json()["task"]
+    parent = root["id"]
+    for depth in range(5):
+        parent = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"level {depth}", "parent_id": parent},
+        ).json()["task"]["id"]
+
+    statements = []
+    original_connect = kb.connect
+
+    def traced_connect(*args, **kwargs):
+        conn = original_connect(*args, **kwargs)
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(kb, "connect", traced_connect)
+    response = client.get("/api/plugins/kanban/board")
+    assert response.status_code == 200, response.text
+    per_task_reads = [
+        sql for sql in statements
+        if sql.startswith("SELECT id FROM tasks WHERE parent_id = ")
+    ]
+    batch_reads = [
+        sql for sql in statements
+        if sql == "SELECT * FROM tasks ORDER BY created_at, id"
+    ]
+    assert per_task_reads == []
+    assert batch_reads == ["SELECT * FROM tasks ORDER BY created_at, id"]
+
+
+def test_dashboard_depth_boundary_and_corrupt_projection_return_explicit_4xx(client):
+    chain = [client.post("/api/plugins/kanban/tasks", json={"title": "root"}).json()["task"]]
+    for depth in range(1, kb.MAX_CONTAINMENT_DEPTH + 1):
+        response = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"level {depth}", "parent_id": chain[-1]["id"]},
+        )
+        assert response.status_code == 200, response.text
+        chain.append(response.json()["task"])
+
+    too_deep = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "too deep", "parent_id": chain[-1]["id"]},
+    )
+    assert too_deep.status_code == 400
+    assert "maximum containment depth" in too_deep.json()["detail"]
+
+    with kb.connect_closing() as conn, kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET parent_id = 'missing' WHERE id = ?", (chain[0]["id"],))
+    corrupt = client.get("/api/plugins/kanban/board")
+    assert corrupt.status_code == 409
+    assert corrupt.json()["detail"] == "unknown hierarchy issue missing"
+
+
 @pytest.mark.parametrize("case", ["cycle", "self", "orphan"])
 def test_dashboard_reparent_validation_returns_4xx(client, case):
     root = client.post(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -116,6 +116,32 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_dashboard_filters_and_reparents_recursive_issues(client):
+    product = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Hermes", "kind": "product", "product_id": "product_hermes"},
+    ).json()["task"]
+    other = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Other", "kind": "product"},
+    ).json()["task"]
+    feature = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Hierarchy", "kind": "feature", "parent_id": product["id"], "product_id": "product_hermes"},
+    ).json()["task"]
+
+    filtered = client.get(
+        "/api/plugins/kanban/board",
+        params={"kind": "feature", "parent_id": product["id"], "product_id": "product_hermes"},
+    ).json()
+    assert [t["id"] for c in filtered["columns"] for t in c["tasks"]] == [feature["id"]]
+
+    moved = client.patch(
+        f"/api/plugins/kanban/tasks/{feature['id']}", json={"parent_id": other["id"]},
+    )
+    assert moved.status_code == 200, moved.text
+    assert moved.json()["task"]["parent_id"] == other["id"]
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,37 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+def test_existing_tools_round_trip_hierarchy_fields(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+
+    parent = json.loads(kt._handle_create({
+        "title": "Product", "assignee": "factory", "kind": "product",
+        "product_id": "product_hermes",
+    }))
+    child = json.loads(kt._handle_create({
+        "title": "Feature", "assignee": "factory", "kind": "feature",
+        "parent_id": parent["task_id"], "product_id": "product_hermes",
+    }))
+    assert child["kind"] == "feature"
+    assert child["parent_id"] == parent["task_id"]
+    assert child["product_id"] == "product_hermes"
+
+    shown = json.loads(kt._handle_show({"task_id": child["task_id"]}))
+    assert shown["task"]["kind"] == "feature"
+    assert shown["hierarchy_children"] == []
+    assert [x["id"] for x in shown["breadcrumbs"]] == [parent["task_id"], child["task_id"]]
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    listed = json.loads(kt._handle_list({
+        "kind": "feature", "parent_id": parent["task_id"],
+        "product_id": "product_hermes",
+    }))
+    assert [x["id"] for x in listed["tasks"]] == [child["task_id"]]
+
+    properties = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert {"kind", "parent_id", "product_id"} <= properties.keys()
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -496,6 +496,9 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "workspace_kind": task.workspace_kind,
         "workspace_path": task.workspace_path,
         "project_id": task.project_id,
+        "kind": task.kind,
+        "parent_id": task.parent_id,
+        "product_id": task.product_id,
         "created_by": task.created_by,
         "created_at": task.created_at,
         "started_at": task.started_at,
@@ -549,6 +552,8 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "kind": t.kind, "parent_id": t.parent_id,
+                    "product_id": t.product_id,
                 }
 
             def _run_dict(r):
@@ -564,6 +569,11 @@ def _handle_show(args: dict, **kw) -> str:
                 "task": _task_dict(task),
                 "parents": parents,
                 "children": children,
+                "hierarchy_children": kb.hierarchy_child_ids(conn, tid),
+                "breadcrumbs": [
+                    _task_summary_dict(kb, conn, item)
+                    for item in kb.issue_breadcrumbs(conn, tid)
+                ],
                 "comments": [
                     {"author": c.author, "body": c.body,
                      "created_at": c.created_at}
@@ -599,6 +609,9 @@ def _handle_list(args: dict, **kw) -> str:
     assignee = args.get("assignee")
     status = args.get("status")
     tenant = args.get("tenant")
+    kind = args.get("kind")
+    parent_id = args.get("parent_id")
+    product_id = args.get("product_id")
     include_archived, bool_error = _parse_bool_arg(args, "include_archived")
     if bool_error:
         return tool_error(bool_error)
@@ -628,6 +641,9 @@ def _handle_list(args: dict, **kw) -> str:
                 status=status,
                 tenant=tenant,
                 include_archived=include_archived,
+                kind=kind,
+                hierarchy_parent_id=parent_id,
+                product_id=product_id,
                 limit=limit + 1,
             )
             truncated = len(rows) > limit
@@ -1461,6 +1477,9 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                kind=args.get("kind") or "task",
+                hierarchy_parent_id=args.get("parent_id"),
+                product_id=args.get("product_id"),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1470,6 +1489,9 @@ def _handle_create(args: dict, **kw) -> str:
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
+                kind=new_task.kind if new_task else None,
+                parent_id=new_task.parent_id if new_task else None,
+                product_id=new_task.product_id if new_task else None,
                 subscribed=subscribed,
             )
         finally:
@@ -1747,6 +1769,9 @@ KANBAN_LIST_SCHEMA = {
                 "type": "string",
                 "description": "Optional tenant/project namespace filter.",
             },
+            "kind": {"type": "string", "enum": ["individual", "group", "company", "portfolio", "product", "project", "feature", "task", "defect"], "description": "Optional exact issue-kind filter."},
+            "parent_id": {"type": "string", "description": "Optional exact containment-parent filter."},
+            "product_id": {"type": "string", "description": "Optional exact structured product filter."},
             "include_archived": {
                 "type": "boolean",
                 "description": "Include archived tasks. Defaults to false.",
@@ -2174,6 +2199,9 @@ KANBAN_CREATE_SCHEMA = {
                     "synthesizer task."
                 ),
             },
+            "kind": {"type": "string", "enum": ["individual", "group", "company", "portfolio", "product", "project", "feature", "task", "defect"], "description": "Typed issue kind. Defaults to task."},
+            "parent_id": {"type": "string", "description": "Containment parent id; unlike parents, this never gates dispatch."},
+            "product_id": {"type": "string", "description": "Structured portable product identity."},
             "tenant": {
                 "type": "string",
                 "description": (


### PR DESCRIPTION
## What does this PR do?

Implements the recursive company → portfolio → product hierarchy proposed in #95154 inside the existing Hermes Kanban lifecycle.

- adds typed issue kinds: `individual`, `group`, `company`, `portfolio`, `product`, `project`, `feature`, `task`, `defect`
- adds optional containment `parent_id` and structured `product_id`
- keeps existing `task_links` as dispatcher dependencies, separate from containment
- preserves each board as its own SQLite, workspace, log, dispatcher, and worker-visibility boundary
- extends existing `kanban_create`, `kanban_show`, and `kanban_list` model tools rather than adding another tool
- adds CLI and dashboard API hierarchy fields and filters
- adds official plugin kind badges, breadcrumbs, hierarchy filters, creation/reparent controls, expandable containment children, and completed/total child progress
- adds read-only qualified cross-board references without cross-board mutation or duplicate rows

Existing rows migrate additively to `kind=task` with no parent or product attribution.

## Safety and scope

Containment does not gate dispatch. Existing dependency promotion is unchanged.

The implementation rejects:

- missing parents
- self-parenting
- containment cycles
- deleting a parent that still has containment children

Expected validation failures return explicit 400/409 responses rather than 500s.

This PR does not add a scheduler, second issue tracker, cross-board dependency writer, automatic product inference, or automatic migration of existing cards.

## Verification

- hierarchy, CLI, tool, API, and plugin suites: 89 focused passing checks across the final review runs
- plugin file: 44 passed
- hierarchy CLI/tool suites: 45 passed
- Ruff: passed
- dashboard bundle `node --check`: passed
- `git diff --check`: passed
- mounted official-plugin browser flow at 1440×1000 and 390×844:
  - create
  - breadcrumb
  - parent filter
  - reparent
  - containment versus dependency distinction
  - expandable containment progress
- browser network summary: all plugin requests 2xx
- browser console errors: 0

Independent review approved exact SHA `18547566aaf69889405cf5ddce75af2366e9231e`.

## Deferred intentionally

A future read-only company/portfolio aggregate can traverse qualified board references. This PR does not add cross-board lifecycle mutation or make one board authoritative over another.

Assisted-by: Hermes Agent:gpt-5.6-sol
