### PR TITLE
fix(desktop): detach sidebar new sessions from projects

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -491,6 +491,31 @@ async function createWith(
 describe('startFreshSessionDraft', () => {
   afterEach(() => cleanup())
 
+  it('detaches the sidebar New session action from the current project', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    $projectTree.set([
+      {
+        id: 'p_app',
+        label: 'App',
+        path: '/repo/app',
+        repos: [{ groups: [], id: '/repo/app', label: 'app', path: '/repo/app', sessionCount: 0 }],
+        sessionCount: 0
+      }
+    ])
+    $projectScope.set('p_app')
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.selectSidebarItem({ action: 'new-session' } as never))
+
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect($currentCwd.get()).toBe('')
+    expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
   it('can reset machine-bound session state without closing the current overlay route', async () => {
     const navigate = vi.fn()
     const requestGateway = vi.fn(async () => ({}) as never)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -41,6 +41,7 @@ import {
   $projectScope,
   beginSessionMutation,
   endSessionMutation,
+  exitProjectScope,
   resolveNewSessionCwd,
   tombstoneSessions,
   untombstoneSessions
@@ -566,7 +567,8 @@ export function useSessionActions({
     (item: SidebarNavItem) => {
       if (item.action === 'new-session') {
         setWorkspaceScope('sessions')
-        startFreshSessionDraft()
+        exitProjectScope()
+        startFreshSessionDraft({ workspaceTarget: null })
 
         return
       }


### PR DESCRIPTION
## Summary
- make the sidebar **New session** action leave the current project scope
- give that new draft an explicit detached workspace target so it does not inherit a project
- preserve project-specific session creation paths and existing sessions/projects

## Test plan
- [x] Added a regression test that reproduces the previous project inheritance
- [x] `npm run test:ui --workspace apps/desktop` — 5,716 tests passed
- [x] `npm run typecheck --workspace apps/desktop`
- [x] Targeted ESLint for the changed source and test files
- [x] `npm run build --workspace apps/desktop`

Independent review gate: **APPROVE** (no blockers).
