### PR TITLE
feat(desktop): add explicit Sessions and Projects views

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -61,11 +61,13 @@ import {
   SESSION_SEARCH_FOCUS_EVENT,
   setPinnedSessionOrder,
   setSidebarCronOpen,
+  setSidebarGrouping,
   setSidebarPinsOpen,
   setSidebarProjectOrderIds,
   setSidebarRecentsOpen,
   setSidebarSessionOrderIds,
   setSidebarSessionOrderManual,
+  setSidebarShowArchived,
   setSidebarWorkspaceOrderIds,
   setSidebarWorkspaceParentOrderIds,
   SIDEBAR_SESSIONS_PAGE_SIZE,
@@ -174,6 +176,7 @@ import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } f
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
+import { type SidebarView, SidebarViewSwitcher } from './view-switcher'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
 // front, reveal more in larger steps on demand. Keeps a busy platform from
@@ -718,6 +721,28 @@ export function ChatSidebar({
   // workspaceParentOrderIds; worktrees within a parent via workspaceOrderIds.
   const worktreeGroupingActive = agentsGrouped && !showArchived
   const gatewayReady = gatewayState === 'open'
+
+  // Projects are a first-class sidebar view, not a discovery-only grouping
+  // option. Switching views must never open or replace the active chat: it only
+  // changes the sidebar presentation and reuses the existing project-tree path.
+  const selectSidebarView = useCallback(
+    (view: SidebarView) => {
+      exitProjectScope()
+
+      if (view === 'projects') {
+        // Archived sessions have their own flat view and cannot render the
+        // project tree. Selecting Projects explicitly leaves that view.
+        if (showArchived) {
+          setSidebarShowArchived(false)
+        }
+
+        setSidebarGrouping('project')
+      } else {
+        setSidebarGrouping('date')
+      }
+    },
+    [showArchived]
+  )
 
   // The backend project tree is a structural snapshot, NOT a per-message feed.
   // Refresh it on structural edges only — entering the grouped view, a profile
@@ -1576,6 +1601,16 @@ export function ChatSidebar({
             />
           </div>
         )}
+
+        <div className="shrink-0 px-2 pb-1 pt-1">
+          <SidebarViewSwitcher
+            active={worktreeGroupingActive ? 'projects' : 'sessions'}
+            ariaLabel="Sidebar view"
+            onChange={selectSidebarView}
+            projectsLabel={s.projects.sectionLabel}
+            sessionsLabel={s.sessions}
+          />
+        </div>
 
         {showSessionSections && (
           <div

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { refreshProjectTree } from '@/store/projects'
+
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
@@ -79,7 +81,8 @@ vi.mock('@/store/projects', () => ({
   $projectTree: atom<unknown[]>([]),
   moveSessionToProject: vi.fn(),
   projectIdForCwd: vi.fn(() => null),
-  projectRootCwd: vi.fn(() => '')
+  projectRootCwd: vi.fn(() => ''),
+  refreshProjectTree: vi.fn(async () => undefined)
 }))
 vi.mock('@/store/session', () => ({
   $activeSessionId: atom<null | string>(null),
@@ -139,6 +142,20 @@ describe('SessionActionsMenu', () => {
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+  })
+
+  it('refreshes the project tree when Move to project opens', async () => {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const move = await screen.findByRole('menuitem', { name: 'Move to project' })
+    fireEvent.keyDown(move, { key: 'ArrowRight' })
+
+    await waitFor(() => expect(refreshProjectTree).toHaveBeenCalledOnce())
   })
 
   it('opens the rename dialog focused on its input, not the row trigger', async () => {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -31,7 +31,13 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import {
+  $projectTree,
+  moveSessionToProject,
+  projectIdForCwd,
+  projectRootCwd,
+  refreshProjectTree
+} from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -156,6 +162,30 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
   const cwd = session?.cwd?.trim() || ''
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
+  const [refreshing, setRefreshing] = useState(true)
+
+  // `$projectTree` is also used by the grouped sidebar, but the menu is a valid
+  // consumer while the user remains in flat Sessions view. Populate the cache at
+  // the point of use so "Move to project" never depends on visiting Projects
+  // first or on the sidebar's delayed background warm-up.
+  useEffect(() => {
+    let mounted = true
+
+    void refreshProjectTree().finally(() => {
+      if (mounted) {
+        setRefreshing(false)
+      }
+    })
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  if (refreshing && tree.length === 0) {
+    return <kit.Item disabled>{t.sidebar.loading}</kit.Item>
+  }
+
   const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
 
   if (targets.length === 0) {

--- a/apps/desktop/src/app/chat/sidebar/view-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/view-switcher.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarViewSwitcher } from './view-switcher'
+
+afterEach(cleanup)
+
+describe('SidebarViewSwitcher', () => {
+  it('marks the active view and exposes both explicit destinations', () => {
+    render(
+      <SidebarViewSwitcher
+        active="sessions"
+        ariaLabel="Sidebar view"
+        onChange={vi.fn()}
+        projectsLabel="Projects"
+        sessionsLabel="Sessions"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Sessions' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: 'Projects' }).getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('requests the selected view without opening a session', () => {
+    const onChange = vi.fn()
+
+    render(
+      <SidebarViewSwitcher
+        active="sessions"
+        ariaLabel="Sidebar view"
+        onChange={onChange}
+        projectsLabel="Projects"
+        sessionsLabel="Sessions"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Projects' }))
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith('projects')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/view-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/view-switcher.tsx
@@ -1,0 +1,66 @@
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { cn } from '@/lib/utils'
+
+export type SidebarView = 'projects' | 'sessions'
+
+interface SidebarViewSwitcherProps {
+  active: SidebarView
+  ariaLabel: string
+  onChange: (view: SidebarView) => void
+  projectsLabel: string
+  sessionsLabel: string
+}
+
+/**
+ * The session pane has two deliberately explicit top-level views. Project
+ * grouping remains a layout preference underneath, but users should not have
+ * to discover it through the Filters menu just to reach their projects.
+ */
+export function SidebarViewSwitcher({
+  active,
+  ariaLabel,
+  onChange,
+  projectsLabel,
+  sessionsLabel
+}: SidebarViewSwitcherProps) {
+  const itemClass = (view: SidebarView) =>
+    cn(
+      'h-7 min-w-0 flex-1 gap-1 rounded-[5px] px-2 text-[0.6875rem] font-medium',
+      active === view
+        ? 'bg-(--ui-control-active-background) text-foreground shadow-none'
+        : 'text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground'
+    )
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="flex w-full gap-0.5 rounded-md border border-(--ui-stroke-tertiary) p-0.5"
+      data-sidebar-view-switcher="true"
+      role="group"
+    >
+      <Button
+        aria-pressed={active === 'sessions'}
+        className={itemClass('sessions')}
+        onClick={() => onChange('sessions')}
+        size="xs"
+        type="button"
+        variant="ghost"
+      >
+        <Codicon name="comment-discussion" size="0.75rem" />
+        <span className="truncate">{sessionsLabel}</span>
+      </Button>
+      <Button
+        aria-pressed={active === 'projects'}
+        className={itemClass('projects')}
+        onClick={() => onChange('projects')}
+        size="xs"
+        type="button"
+        variant="ghost"
+      >
+        <Codicon name="root-folder" size="0.75rem" />
+        <span className="truncate">{projectsLabel}</span>
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add an always-visible Sessions / Projects switcher to the Desktop sidebar.
- Let users enter the Projects overview without discovering `Filters → Grouping → Project` first.
- Keep view switching purely in the sidebar: it exits project drill-in scope without opening or replacing the active chat.
- Leave the archived-session view before entering Projects.
- Refresh the project tree when the session menu's **Move to project** submenu opens, with a loading state while the authoritative tree is fetched.
- Add regression coverage for the switcher and flat-view project-tree refresh.

## Motivation

The current Projects implementation is present, but the only normal entry point is hidden inside the Filters menu. In flat Sessions view, consumers of `$projectTree` could also see an empty project list until the grouped view or delayed background warm-up populated the renderer cache. This makes Projects and Move to project look unavailable even when the backend data is correct.

## Scope

This is the Plan A Desktop slice for #94643. It reuses the existing `projects.*` RPCs, project tree, profile routing, session `cwd`, and Git/worktree implementation. It does not change the backend project data model, add Cloud execution, or claim the larger archive/delete/project-manager follow-up scope from #94643.

## Related issues

- Fixes #80381
- Related to #94643

## Test plan

- `npm run test:ui` — 597 files, 5752 tests passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors; existing repository warnings remain
- `uv run pytest -q tests/tui_gateway/test_project_tree.py tests/tui_gateway/test_projects_rpc.py` — 64 passed
- `npm run build` — passed

`npm run test:desktop:platforms` was also run on Windows. This host's Electron platform run reported 27 failures across file-mode, POSIX-path, SSH, and Windows-path assumptions; the failures were in unrelated Electron test files and none involved the changed sidebar files. The UI suite and affected project/backend tests pass.
