### PR TITLE
fix(desktop): keep venv interpreter unresolved in .desktop Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -77,12 +77,15 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly. Do NOT .resolve() it: the
+            # venv python is usually a symlink to the base interpreter, and
+            # resolving it escapes the venv — the entry then dies on the first
+            # third-party import just like a bad shebang would.
+            argv = [sys.executable, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,10 +107,41 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # sys.executable verbatim — never resolved (see the symlink test below).
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+def test_exec_keeps_venv_symlink_interpreter_unresolved(tmp_path, xdg_home, monkeypatch):
+    """#94058: uv-created venvs make ``bin/python`` a symlink into a shared
+    base-interpreter tree. CPython discovers ``pyvenv.cfg`` from the
+    executable path *as invoked*, so resolving the symlink escapes the venv
+    and the entry dies on the first third-party import. Exec must use the
+    unresolved venv path.
+    """
+    root = _make_project(tmp_path)
+    base_python = tmp_path / "uv-store" / "cpython-3.11" / "bin" / "python3.11"
+    base_python.parent.mkdir(parents=True)
+    base_python.write_text("", encoding="utf-8")
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base_python)
+    assert venv_python.resolve() == base_python
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base_python) not in exec_line
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux launcher icon silently failing after every update on uv-based installs (the standard installer layout).

**Root cause:** `resolve_exec_command()` prefixes the resolved `hermes` script with `str(Path(sys.executable).resolve())`. uv-created venvs make `venv/bin/python` a **symlink** into the shared base-interpreter tree (`~/.local/share/uv/python/cpython-3.11.16-.../bin/python3.11`), and `.resolve()` follows that symlink. CPython discovers `pyvenv.cfg` from the executable path *as invoked*, so the generated `Exec=` line ran the **bare base interpreter with no venv site-packages** and died instantly on the first third-party import:

```
ModuleNotFoundError: No module named 'yaml'
```

— silently, because `Terminal=false`. `hermes desktop` from a terminal worked (the bash wrapper execs the venv python), and each launch/rewrite of the entry re-broke it, which is why it recurred after every update.

**Fix:** use `sys.executable` verbatim (it is already absolute). The running process's imports came through exactly that path, so it is always at least as correct as the resolved path — resolving can only lose venv context, never gain anything.

The existing code comment already states the intent ("sys.executable is the interpreter actually running Hermes (the venv one)"); `.resolve()` defeated it.

## Related Issue

Fixes #94058

(Also matches the symptoms in #92882, #92095, #92086, #91504, and duplicates #94564 / #94110. Related prior PR #94593 was closed by its author; this takes the simpler root-cause approach instead of the sibling-venv heuristic, and also fixes the `-m hermes_cli.main` fallback branch which had the same `.resolve()`.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/linux_desktop_entry.py` — `resolve_exec_command()`: use `sys.executable` without `.resolve()` in both the script-prefix branch and the `-m hermes_cli.main` fallback branch; comment explains why resolving is wrong.
- `tests/hermes_cli/test_linux_desktop_entry.py` — updated `test_exec_prefixes_interpreter_for_env_shebang_python_script` to expect the unresolved interpreter; added `test_exec_keeps_venv_symlink_interpreter_unresolved`, a regression test that builds a uv-style layout (venv `bin/python` → base-store symlink) and asserts `Exec=` uses the unresolved venv path and never mentions the base interpreter.

## How to Test

1. On a standard uv-based install, check out this branch and run the entry generator as the launcher would (venv python, argv[0] = repo script):
   ```bash
   venv/bin/python -c "
   import sys; sys.argv = ['<repo>/hermes', 'desktop']
   from pathlib import Path
   from hermes_cli.linux_desktop_entry import install_desktop_entry
   print(install_desktop_entry(Path('<repo>')))"
   ```
2. Inspect `~/.local/share/applications/hermes.desktop` — `Exec=` must start with `<repo>/venv/bin/python`, **not** `~/.local/share/uv/python/...`.
3. Run the Exec line's interpreter against a third-party import (`<repo>/venv/bin/python -c "import yaml"`) — succeeds; the previously generated base interpreter fails.
4. Launch Hermes from the desktop launcher icon — the app starts.

Verified on a live Omarchy/Arch install: before the fix the generated `Exec=` failed with `ModuleNotFoundError: No module named 'yaml'`; after the fix the regenerated entry imports cleanly and `desktop-file-validate` passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` — `tests/hermes_cli/test_linux_desktop_entry.py`: **16/16 pass**. Full suite: 37,409 passed, 202 failed; **all failures reproduce identically on unmodified `main`** in this environment (15 in update-flow tests verified by re-running those files on `main`; the rest are `ImportError`s in gateway/messaging tests because the throwaway test venv has only `.[dev]`, not `.[all,dev]`, extras). Zero failures overlap with this change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Omarchy/Hyprland), Python 3.11.16, uv-managed venv, Hermes v0.20.5 (f751a8c5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-only fix; updated the code comment that documented the old approach)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A: module is already gated to Linux/BSD via `is_supported()`; `sys.executable` is absolute on all platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Generated entry **before** (broken):

```
Exec=/home/hamsti/.local/share/uv/python/cpython-3.11.16-linux-x86_64-gnu/bin/python3.11 /home/hamsti/.hermes/hermes-agent/hermes desktop
$ <that Exec line>
ModuleNotFoundError: No module named 'yaml'
```

Generated entry **after** (works):

```
Exec=/home/hamsti/.hermes/hermes-agent/venv/bin/python /home/hamsti/.hermes/hermes-agent/hermes desktop
$ /home/hamsti/.hermes/hermes-agent/venv/bin/python -c "import yaml; print(yaml.__version__)"
6.0.3
```
