### PR TITLE
fix(computer-use): carry snapshot_id for indexed actions

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2123,12 +2123,30 @@ class TestElementTokenAttachment:
             "click": {"input.pointer.click", "accessibility.element_tokens"},
         })
         backend._snapshot_tokens = {5: "s0001:5", 6: "s0001:6"}
+        backend._snapshot_id = "s00000001"
+        backend._session.supports_input_property = lambda tool, prop: True
         backend.click(element=5, button="left")
         name, args = backend._session.call_tool.call_args.args
         assert name == "click"
         assert args["element_index"] == 5
         # The matching token rode along — cua-driver will prefer it.
         assert args["element_token"] == "s0001:5"
+        assert "snapshot_id" not in args
+
+    def test_snapshot_id_omitted_when_tool_schema_does_not_accept_it(self):
+        backend = self._backend_with_session({
+            "click": {"input.pointer.click"},
+        })
+        backend._snapshot_id = "s00000001"
+        backend._session.supports_input_property = lambda tool, prop: False
+
+        backend.click(element=5, button="left")
+
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert "snapshot_id" not in args
+        assert "element_token" not in args
 
 
     def test_capture_refreshes_snapshot_tokens(self):
@@ -2173,6 +2191,144 @@ class TestElementTokenAttachment:
 
         # Stale 99 token is gone; only the two new tokens remain.
         assert backend._snapshot_tokens == {1: "snap2:1", 2: "snap2:2"}
+
+    def test_capture_snapshot_id_is_attached_when_element_tokens_are_absent(self):
+        """cua-driver 0.22 may return a snapshot handle without per-element tokens.
+        Numbered elements must remain actionable through snapshot_id + element_index.
+        """
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.supports_capability = lambda cap, tool=None: False
+        backend._session.supports_input_property = lambda tool, prop: prop == "snapshot_id"
+
+        windows_payload = {"windows": [{
+            "app_name": "Calculator", "pid": 9, "window_id": 1,
+            "is_on_screen": True, "title": "Calculator", "z_index": 0,
+        }]}
+
+        def fake_call_tool(name, args):
+            if name == "list_windows":
+                return {"data": "", "images": [], "image_mime_types": [],
+                        "structuredContent": windows_payload, "isError": False}
+            if name == "get_window_state":
+                return {
+                    "data": "Calculator snapshot",
+                    "images": [], "image_mime_types": [],
+                    "structuredContent": {
+                        "snapshot_id": "sdeadbeef",
+                        "elements": [
+                            {"element_index": 5, "role": "button", "label": "7"},
+                        ],
+                    },
+                    "isError": False,
+                }
+            return {"data": "ok", "images": [], "image_mime_types": [],
+                    "structuredContent": None, "isError": False}
+
+        backend._session.call_tool.side_effect = fake_call_tool
+        capture = backend.capture(mode="ax")
+        assert capture.elements[0].index == 5
+
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert args["snapshot_id"] == "sdeadbeef"
+
+    def test_vision_capture_invalidates_prior_snapshot_id(self):
+        """A pixel-only capture must not leave an AX snapshot actionable."""
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session._has_tool.return_value = False
+        backend._session.capabilities_discovered = True
+        backend._snapshot_id = "sold00001"
+        backend._snapshot_tokens = {5: "sold00001:5"}
+
+        windows_payload = {"windows": [{
+            "app_name": "NewApp", "pid": 10, "window_id": 2,
+            "is_on_screen": True, "title": "New", "z_index": 0,
+        }]}
+        tiny_png = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+            "/x8AAusB9Wl2JVEAAAAASUVORK5CYII="
+        )
+
+        def fake_call_tool(name, args):
+            if name == "list_windows":
+                return {"data": "", "images": [], "image_mime_types": [],
+                        "structuredContent": windows_payload, "isError": False}
+            if name == "get_window_state":
+                return {"data": "", "images": [tiny_png],
+                        "image_mime_types": ["image/png"],
+                        "structuredContent": {"elements": []}, "isError": False}
+            raise AssertionError(name)
+
+        backend._session.call_tool.side_effect = fake_call_tool
+        backend.capture(mode="vision", app="NewApp")
+
+        assert backend._snapshot_tokens == {}
+        assert backend._snapshot_id is None
+
+    def test_focus_app_invalidates_prior_snapshot_id(self):
+        """Selecting a different target must invalidate prior AX handles."""
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._snapshot_id = "sold00001"
+        backend._snapshot_tokens = {5: "sold00001:5"}
+        backend._load_windows = lambda: [{
+            "app_name": "NewApp", "pid": 10, "window_id": 2,
+            "is_on_screen": True, "title": "New", "z_index": 0,
+        }]
+
+        result = backend.focus_app("NewApp")
+
+        assert result.ok is True
+        assert backend._snapshot_tokens == {}
+        assert backend._snapshot_id is None
+
+    def test_failed_capture_invalidates_prior_snapshot_id(self):
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._snapshot_id = "s00000001"
+        backend._snapshot_tokens = {5: "s00000001:5"}
+        backend._session.call_tool.return_value = {
+            "data": "", "images": [], "image_mime_types": [],
+            "structuredContent": {"windows": []}, "isError": False,
+        }
+
+        capture = backend.capture(mode="ax", app="MissingApp")
+
+        assert capture.elements == []
+        assert backend._snapshot_tokens == {}
+        assert backend._snapshot_id is None
+
+    def test_transport_reset_invalidates_prior_snapshot_id(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._active_pid = 10
+        backend._active_window_id = 2
+        backend._snapshot_id = "s00000001"
+        backend._snapshot_tokens = {5: "s00000001:5"}
+
+        backend._handle_transport_reset()
+
+        assert backend._active_pid is None
+        assert backend._active_window_id is None
+        assert backend._snapshot_tokens == {}
+        assert backend._snapshot_id is None
 
 
 class TestSessionLifecycle:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2553,6 +2553,10 @@ class CuaDriverBackend(ComputerUseBackend):
         # element. Cleared whenever a fresh capture overwrites the
         # snapshot context.
         self._snapshot_tokens: Dict[int, str] = {}
+        # cua-driver 0.22 can expose one snapshot handle without duplicating
+        # an element_token on every indexed row. Actions addressed by index
+        # must carry this handle when the live schema accepts snapshot_id.
+        self._snapshot_id: Optional[str] = None
         # Per-instance public cua-driver session label. The MCP transport owns
         # the private lifecycle and releases it when the connection closes.
         # start_session/end_session attach this stable label to cursor,
@@ -2707,6 +2711,7 @@ class CuaDriverBackend(ComputerUseBackend):
         self._last_app = None
         self._last_target = None
         self._snapshot_tokens = {}
+        self._snapshot_id = None
 
     def _failed_capture(self, mode: str, message: str = "") -> CaptureResult:
         """Return an empty capture after disarming any prior target context."""
@@ -2986,6 +2991,7 @@ class CuaDriverBackend(ComputerUseBackend):
         # Tokens belong to the prior window snapshot. Disarm them before any
         # capture call so an exception cannot pair old tokens with this target.
         self._snapshot_tokens = {}
+        self._snapshot_id = None
         app_name = target["app_name"]
         # Record the resolved app name so capture_after= follow-ups can re-target
         # the same app rather than falling back to the frontmost window.
@@ -3151,7 +3157,8 @@ class CuaDriverBackend(ComputerUseBackend):
             # Falls back to markdown regex parsing for cua-driver builds
             # that didn't carry the structured shape — those bounds come
             # back (0,0,0,0); the structured path preserves real frames.
-            sc_elements = (gws_out.get("structuredContent") or {}).get("elements")
+            structured = gws_out.get("structuredContent") or {}
+            sc_elements = structured.get("elements")
             if isinstance(sc_elements, list) and sc_elements:
                 elements = _parse_elements_from_structured(sc_elements)
             else:
@@ -3167,6 +3174,10 @@ class CuaDriverBackend(ComputerUseBackend):
                 for e in elements
                 if e.element_token
             }
+            snapshot_id = structured.get("snapshot_id")
+            self._snapshot_id = (
+                snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
+            )
 
             # Image may arrive as an MCP image part or inside
             # structuredContent (screenshot_png_b64) depending on the driver
@@ -3548,6 +3559,7 @@ class CuaDriverBackend(ComputerUseBackend):
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
             self._snapshot_tokens = {}
+            self._snapshot_id = None
             self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
             self._last_target = {
                 "pid": self._active_pid,
@@ -3905,13 +3917,16 @@ class CuaDriverBackend(ComputerUseBackend):
         if not isinstance(idx, int):
             return
         token = self._snapshot_tokens.get(idx)
-        if not token:
-            return
-        if not self._session.supports_capability(
+        if token and self._session.supports_capability(
             "accessibility.element_tokens", tool=tool
         ):
+            args["element_token"] = token
             return
-        args["element_token"] = token
+        if (
+            self._snapshot_id
+            and self._session.supports_input_property(tool, "snapshot_id")
+        ):
+            args["snapshot_id"] = self._snapshot_id
 
     def _action(
         self,


### PR DESCRIPTION
## Summary

- cache `structuredContent.snapshot_id` from cua-driver window captures
- attach it to indexed actions when no usable per-element token is available and the live action schema accepts `snapshot_id`
- preserve `element_token` precedence
- invalidate snapshot state on capture replacement, failed capture, transport reset, and `focus_app` retargeting

## Root cause

With cua-driver 0.22, `get_window_state` can return numbered elements plus a top-level `snapshot_id`. Indexed actions require either `element_token` or `snapshot_id + element_index`.

Hermes only cached per-element tokens. When a capture did not yield usable tokens, `click(element=N)` sent a bare `element_index` and cua-driver refused it with `snapshot_id_required`.

## Verification

- Regression test observed RED before implementation: missing `snapshot_id` raised `KeyError`
- `TestElementTokenAttachment`: 8 passed
- `tests/tools/test_computer_use.py`: 105 passed
- Ruff: passed
- `git diff --check`: passed
- Added-line security scan: no findings
- Live Calculator proof with cua-driver 0.22:
  - captured button `7` as element index 5
  - capture returned `snapshot_id=s00000001`
  - patched wrapper returned `Clicked element [5]`
  - independent fresh capture read Calculator display value `7`

Pytest emitted an existing non-failing `vision_analyze_tool was never awaited` cleanup warning.

## Safety

The snapshot fallback is fail-closed:

- sent only when the live tool schema declares `snapshot_id`
- never sent alongside a supported `element_token`
- cleared before target/capture replacement and on all disarm/reset paths
- tests cover vision retargeting, `focus_app`, failed capture, transport reset, schema omission, and token precedence
