### PR TITLE
fix(desktop): honor per-profile remembered cwd for local new sessions

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -606,6 +606,10 @@ describe('workspaceCwdForNewSession', () => {
     $currentCwd.set('')
     $activeSessionId.set(null)
     window.localStorage.removeItem('hermes.desktop.workspace-cwd')
+    // setCurrentCwd() now persists the per-profile local key
+    // (hermes.desktop.workspace-cwd.local.<profile>) — clear it too, or a
+    // remembered workspace leaks into the next test (#95194 review).
+    window.localStorage.removeItem('hermes.desktop.workspace-cwd.local.default')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-b.default')
     delete (window as { hermesDesktop?: unknown }).hermesDesktop
@@ -673,8 +677,25 @@ describe('workspaceCwdForNewSession', () => {
 
     applyConfiguredDefaultProjectDir('/home/user/configured')
 
-    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
+    // A remembered local-profile workspace is now honored for a new session
+    // (per-profile scoping, #81492) — it wins over the configured default.
+    expect(workspaceCwdForNewSession()).toBe('/home/user/repo/.worktrees/feature')
     expect($currentCwd.get()).toBe('/home/user/repo/.worktrees/feature')
+  })
+
+  it('does not leak a local profile workspace across profile switches', () => {
+    // Per-profile scoping of the local workspace key (#81492): profile A's
+    // remembered cwd must not become profile B's, and vice versa.
+    $connection.set({ mode: 'local', profile: 'profile-a' } as never)
+    setCurrentCwd('/home/user/a/repo')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/a/repo')
+
+    $connection.set({ mode: 'local', profile: 'profile-b' } as never)
+    expect(workspaceCwdForNewSession()).toBe('')
+
+    $connection.set({ mode: 'local', profile: 'profile-a' } as never)
+    expect(workspaceCwdForNewSession()).toBe('/home/user/a/repo')
   })
 
   it('starts detached (no inherited cwd) when no default project dir is configured', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -213,12 +213,15 @@ export function setRememberedRoute(path: null | string, profile: string): void {
 let configuredDefaultProjectDir = ''
 
 function workspaceCwdKey(connection: HermesConnection | null = $connection.get()): string {
+  const profile = encodeURIComponent(connection?.profile || 'default')
+
   if (connection?.mode !== 'remote') {
-    return WORKSPACE_CWD_KEY
+    // Scope per-profile for local connections too — previously all local
+    // profiles shared one key, leaking cwd across profile switches (#81492).
+    return `${WORKSPACE_CWD_KEY}.local.${profile}`
   }
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
-  const profile = encodeURIComponent(connection.profile || 'default')
 
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }
@@ -1230,8 +1233,13 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  if ($connection.get()?.mode === 'remote') {
-    return getRememberedWorkspaceCwd()
+  // Both remote and local connections check the remembered workspace cwd,
+  // which is now scoped per-profile (see workspaceCwdKey above). This
+  // prevents a profile switch from inheriting the previous profile's
+  // working directory (#81492).
+  const remembered = getRememberedWorkspaceCwd()
+  if (remembered) {
+    return remembered
   }
 
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1233,10 +1233,10 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  // Both remote and local connections check the remembered workspace cwd,
-  // which is now scoped per-profile (see workspaceCwdKey above). This
-  // prevents a profile switch from inheriting the previous profile's
-  // working directory (#81492).
+  // Check the remembered workspace cwd for BOTH remote and local connections.
+  // The remembered cwd is scoped per-profile (see workspaceCwdKey), so this
+  // honors each profile's own workspace instead of leaking the previous
+  // profile's directory (#81492 follow-up to the key-scoping fix).
   const remembered = getRememberedWorkspaceCwd()
   if (remembered) {
     return remembered


### PR DESCRIPTION
fix(desktop): honor per-profile remembered cwd for local new sessions

Self-contained fix for #81492 (supersedes #94556, which covered only the key-scoping half).

1. **\workspaceCwdKey()\** — scope per-profile for local connections (matching the existing per-profile scoping for remote). Previously all local profiles shared one key, leaking the working directory across profile switches.
2. **\workspaceCwdForNewSession()\** — check the remembered cwd for local connections too, so a profile switch resolves the NEW profile's remembered workspace instead of always returning the global default.