### PR TITLE
feat(cron): expose the durable execution id to native plugins via session_context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5144,7 +5144,10 @@ def run_job(
     this attempt (see ``_run_one_job_body``), bound task-locally to
     ``HERMES_CRON_EXECUTION_ID`` alongside ``HERMES_CRON_SESSION`` for the
     duration of the run. Lets in-process trusted code (native plugins) join
-    a cron-triggered tool call back to this exact execution record.
+    a cron-triggered tool call back to this exact execution record. When
+    ``None`` (the default), the ContextVar is left at its ``_UNSET`` default
+    rather than bound to ``""`` -- same fallback semantics as
+    ``HERMES_CRON_SESSION``, and distinguishable from "bound but empty".
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -5629,9 +5632,14 @@ def run_job(
         # which would suppress the legacy os.environ fallback used by standalone
         # cron entrypoints and tests.
         _cron_session_token = _cron_session_var.set("1")
-        _cron_execution_id_token = _cron_execution_id_var.set(
-            str(execution_id) if execution_id else ""
-        )
+        # Leave the ContextVar at its _UNSET default when no execution_id was
+        # supplied, rather than binding "" -- an explicit "" would be
+        # indistinguishable from "no execution id" to a reader, when it
+        # actually means "not provided by this caller". Every call site in
+        # this module always has a real id in scope by this point; only a
+        # caller outside cron/scheduler.py omitting it would hit this branch.
+        if execution_id is not None:
+            _cron_execution_id_token = _cron_execution_id_var.set(str(execution_id))
 
         # Mark this job as NOT the dispatcher-owned kanban worker.
         #

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5121,6 +5121,7 @@ def run_job(
     defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    execution_id: Optional[str] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -5138,6 +5139,12 @@ def run_job(
     ``extra_prompt``: optional per-run context from ``cronjob(action='run',
     prompt=...)`` (#57331). Appended to the stored prompt for this fire only —
     never persisted to the job definition.
+
+    ``execution_id``: the caller's ``cron.executions.db`` execution id for
+    this attempt (see ``_run_one_job_body``), bound task-locally to
+    ``HERMES_CRON_EXECUTION_ID`` alongside ``HERMES_CRON_SESSION`` for the
+    duration of the run. Lets in-process trusted code (native plugins) join
+    a cron-triggered tool call back to this exact execution record.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -5596,7 +5603,9 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
+    _cron_execution_id_var = _VAR_MAP["HERMES_CRON_EXECUTION_ID"]
     _cron_session_token = None
+    _cron_execution_id_token = None
     _non_dispatcher_token = None
     try:
         if not _cwd_lock_acquired:
@@ -5620,6 +5629,9 @@ def run_job(
         # which would suppress the legacy os.environ fallback used by standalone
         # cron entrypoints and tests.
         _cron_session_token = _cron_session_var.set("1")
+        _cron_execution_id_token = _cron_execution_id_var.set(
+            str(execution_id) if execution_id else ""
+        )
 
         # Mark this job as NOT the dispatcher-owned kanban worker.
         #
@@ -6487,6 +6499,8 @@ def run_job(
         clear_session_vars(_ctx_tokens)
         if _cron_session_token is not None:
             _cron_session_var.reset(_cron_session_token)
+        if _cron_execution_id_token is not None:
+            _cron_execution_id_var.reset(_cron_execution_id_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
@@ -6882,6 +6896,7 @@ def _run_one_job_body(
                     job,
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
+                    execution_id=execution_id,
                 )
             else:
                 success, output, final_response, error = run_job(
@@ -6889,6 +6904,7 @@ def _run_one_job_body(
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
                     cancel_event=fire_claim_lost,
+                    execution_id=execution_id,
                 )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -115,6 +115,17 @@ _BROWSER_CONTROL_TRANSPORT_FAMILY: ContextVar = ContextVar(
 # masks any leaked process env value.
 _CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
 
+# The durable execution id (cron.executions.db primary key) for the cron job
+# currently bound to this task, set alongside HERMES_CRON_SESSION in
+# run_job(). Lets in-process trusted code (native plugins) correlate a
+# cron-triggered tool call back to the exact execution record -- e.g. for
+# audit journals that need to join against cron's own execution ledger --
+# without re-deriving an identifier from the session id's naming convention,
+# which is display-only and not guaranteed unique per attempt (retries reuse
+# the same job id). _UNSET outside a bound cron job (same fallback semantics
+# as HERMES_CRON_SESSION).
+_CRON_EXECUTION_ID: ContextVar = ContextVar("HERMES_CRON_EXECUTION_ID", default=_UNSET)
+
 # Whether the current session's delivery channel can route an ASYNC completion
 # back to the agent AFTER the current turn ends (i.e. wake a fresh turn).
 #
@@ -160,6 +171,7 @@ _VAR_MAP = {
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
+    "HERMES_CRON_EXECUTION_ID": _CRON_EXECUTION_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,

--- a/tests/cron/test_scheduler_cron_session_isolation.py
+++ b/tests/cron/test_scheduler_cron_session_isolation.py
@@ -43,6 +43,7 @@ class _FakeCronAgent:
         assert result["approved"] is False
         assert result["outcome"] == "blocked"
         assert get_session_env("HERMES_CRON_SESSION") == "1"
+        assert get_session_env("HERMES_CRON_EXECUTION_ID") == "test-execution-id"
         return {
             "completed": True,
             "failed": False,
@@ -121,7 +122,8 @@ def test_run_job_cron_execute_code_deny_does_not_pollute_later_gateway_execute_c
             "name": "Context Isolation",
             "prompt": "Run safely",
             "schedule_display": "manual",
-        }
+        },
+        execution_id="test-execution-id",
     )
 
     assert success is True
@@ -129,6 +131,8 @@ def test_run_job_cron_execute_code_deny_does_not_pollute_later_gateway_execute_c
     assert final_response == "cron execute_code blocked"
     assert os.environ.get("HERMES_CRON_SESSION") is None
     assert get_session_env("HERMES_CRON_SESSION") == ""
+    assert os.environ.get("HERMES_CRON_EXECUTION_ID") is None
+    assert get_session_env("HERMES_CRON_EXECUTION_ID") == ""
 
     # A completed in-process job must restore the truly-unset ContextVar state,
     # not leave an explicit empty value that shadows the standalone cron env

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -369,7 +369,7 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
         lost_seen.set()
         return False
 
-    def _run_job(job, *, defer_agent_teardown=None, extra_prompt=None, cancel_event=None):
+    def _run_job(job, *, defer_agent_teardown=None, extra_prompt=None, cancel_event=None, execution_id=None):
         assert lost_seen.wait(timeout=2)
         return True, "stale output", "stale response", None
 

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -370,6 +370,7 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
         return False
 
     def _run_job(job, *, defer_agent_teardown=None, extra_prompt=None, cancel_event=None, execution_id=None):
+        assert execution_id == "stale-execution"
         assert lost_seen.wait(timeout=2)
         return True, "stale output", "stale response", None
 


### PR DESCRIPTION
## Summary

Native (in-process) plugins that register tools via `ctx.register_tool` run inside the same task as the cron turn that invoked them, and can already read task-local facts through `gateway.session_context.get_session_env()` — e.g. `HERMES_CRON_SESSION`, used by `tools/approval.py` and `tools/cronjob_tools.py` to detect a real cron dispatch. There's no equivalent today for the job's own durable execution id (the `cron.executions.db` primary key): it's minted in `run_one_job()`/`_run_one_job_body()` but kept as a local Python variable, never bound to `session_context`.

A plugin that wants to correlate a cron-triggered tool call back to the exact execution record (an audit journal, say) has no stable way to do that. Deriving a substitute from the session id's naming convention (`cron_{job_id}_{timestamp}`) isn't safe either — it's not guaranteed unique per attempt, since retries of the same job reuse the same job id.

## Fix

Add `HERMES_CRON_EXECUTION_ID` as a `session_context` ContextVar, following the existing `HERMES_CRON_SESSION` pattern exactly: bound in `run_job()` for the task-local duration of a real cron dispatch, `_UNSET` otherwise (same `os.environ` CLI/test fallback as every other `_VAR_MAP` entry). `run_job` gains an optional `execution_id` kwarg (default `None`, so every existing caller outside `cron/scheduler.py` is unaffected); the two internal call sites in `_run_one_job_body` already have the execution id in scope and now pass it through.

## Related prior attempts (searched first per CONTRIBUTING.md)

Neither is a duplicate, but both touch the same neighborhood:
- #78248 (closed, unmerged, self-closed same day) exposed execution id to spawned *script subprocesses* via sanitized child-process env vars — a different problem (script ownership proof) with a different mechanism (child env, not `session_context`), and explicitly avoided changing `run_job`'s signature.
- #81567 (closed, unmerged) also adds an `execution_id` kwarg to `run_job`, but to link the execution row to its session id in a *different* ledger (`state.db`) for Desktop's run-history UI (issue #81523, still open) — a separate consumer/column, not `session_context` exposure to plugins. If #81567 is ever revived, reconciling the two `execution_id` additions on `run_job` should be straightforward — same call sites, same already-in-scope value, no conflicting semantics.

## Test plan

- [x] `scripts/run_tests.sh tests/cron/ tests/gateway/test_session_env.py` — 77 files, 969 tests passed, 0 failed (1 windows-only test skipped)
- [x] Extended `test_scheduler_cron_session_isolation.py` (the existing `HERMES_CRON_SESSION` isolation regression test) to assert `HERMES_CRON_EXECUTION_ID` is bound during the run and cleanly restored to `_UNSET` afterward, mirroring the existing `HERMES_CRON_SESSION` assertions in the same test.
- [x] `python3 -m py_compile cron/scheduler.py gateway/session_context.py`
- [x] `git diff --check`

## Platforms tested

Linux (WSL2). No platform-specific code touched (pure contextvars + existing `run_job` call sites); no reason to expect Windows/macOS divergence.