### PR TITLE
fix(kanban): release terminal PR respawn guards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8008,9 +8008,10 @@ _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
 # Pattern matching a GitHub PR URL in task comments.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
-    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
+    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+(?![\w-])",
     re.IGNORECASE,
 )
+_RESPAWN_GUARD_PR_LOOKUP_TIMEOUT_SECONDS = 5
 
 
 @dataclass
@@ -9386,6 +9387,41 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _github_pr_is_terminal(pr_url: str) -> Optional[bool]:
+    """Return whether a GitHub PR is closed/merged, or ``None`` if unknown.
+
+    The respawn guard must fail closed: missing ``gh`` authentication, network
+    errors, timeouts, non-zero exits, and unexpected output all remain an
+    ``active_pr`` signal.  ``gh pr view`` is used instead of reading credentials
+    directly so public and authenticated private repositories share the user's
+    established GitHub CLI setup without exposing tokens.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_url, "--json", "state"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_RESPAWN_GUARD_PR_LOOKUP_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        state = json.loads(result.stdout).get("state")
+    except (AttributeError, json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(state, str):
+        return None
+    normalized = state.upper()
+    if normalized == "OPEN":
+        return False
+    if normalized in {"CLOSED", "MERGED"}:
+        return True
+    return None
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -9436,8 +9472,10 @@ def check_respawn_guard(
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) and is open or its state cannot
+        be verified. A prior worker may still own the work; re-spawning risks
+        a duplicate PR on the same task. Verifiably closed/merged PRs do not
+        block a resumable lane.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9525,14 +9563,19 @@ def check_respawn_guard(
         if not requeued_after:
             return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. GitHub PR URL in a recent comment. Open or unverifiable PRs remain a
+    #    fail-closed duplicate-work signal; terminal PRs no longer strand a
+    #    resumable lane for the rest of the 24-hour comment window.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if not c["body"]:
+            continue
+        for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"]):
+            if _github_pr_is_terminal(match.group(0)) is not True:
+                return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8006,11 +8006,18 @@ DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
-# Pattern matching a GitHub PR URL in task comments.
+# Match the complete URL-like token so malformed text after the numeric PR id
+# cannot be silently discarded before terminal-state lookup.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
-    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+(?![\w-])",
+    r'''https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+[^\s<>()\[\]{}"']*''',
     re.IGNORECASE,
 )
+_RESPAWN_GUARD_PR_URL_VALID_RE = re.compile(
+    r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+"
+    r"(?:/[^\s?#]*)?(?:\?[^\s#]*)?(?:#[^\s]*)?",
+    re.IGNORECASE,
+)
+_RESPAWN_GUARD_PR_URL_TRAILING_PUNCTUATION = ".,;:!?"
 _RESPAWN_GUARD_PR_LOOKUP_TIMEOUT_SECONDS = 5
 
 
@@ -9574,7 +9581,12 @@ def check_respawn_guard(
         if not c["body"]:
             continue
         for match in _RESPAWN_GUARD_PR_URL_RE.finditer(c["body"]):
-            if _github_pr_is_terminal(match.group(0)) is not True:
+            pr_url = match.group(0).rstrip(
+                _RESPAWN_GUARD_PR_URL_TRAILING_PUNCTUATION
+            )
+            if _RESPAWN_GUARD_PR_URL_VALID_RE.fullmatch(pr_url) is None:
+                return "active_pr"
+            if _github_pr_is_terminal(pr_url) is not True:
                 return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -21,7 +21,9 @@ down:
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -433,6 +435,7 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         cfgmod, "load_config",
         lambda *a, **k: {"kanban": {"review_dispatch": True}},
     )
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", lambda _url: False)
     pr_comment = "Opened https://github.com/example/repo/pull/123 for review."
 
     with kb.connect() as conn:
@@ -473,6 +476,127 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         assert kb.check_respawn_guard(
             conn, review_id, lane="review"
         ) == "rate_limit_cooldown"
+
+
+@pytest.mark.parametrize("terminal", [False, None])
+def test_active_pr_guard_fails_closed_for_open_or_ambiguous_pr(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal: bool | None,
+) -> None:
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", lambda _url: terminal)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="resume implementation", assignee="worker")
+        kb.add_comment(
+            conn,
+            task_id,
+            author="worker",
+            body="Candidate: https://github.com/example/repo/pull/123",
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_active_pr_guard_allows_verifiably_terminal_pr(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    looked_up: list[str] = []
+
+    def terminal(url: str) -> bool:
+        looked_up.append(url)
+        return True
+
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", terminal)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="resume implementation", assignee="worker")
+        kb.add_comment(
+            conn,
+            task_id,
+            author="worker",
+            body="Merged https://github.com/example/repo/pull/123; resume the lane.",
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+    assert looked_up == ["https://github.com/example/repo/pull/123"]
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "MERGED"])
+def test_github_pr_terminal_lookup_accepts_closed_and_merged(
+    monkeypatch: pytest.MonkeyPatch, state: str
+) -> None:
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"state": state}),
+            stderr="",
+        ),
+    )
+
+    assert kb._github_pr_is_terminal("https://github.com/example/repo/pull/123") is True
+
+
+def test_github_pr_terminal_lookup_reports_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"state": "OPEN"}),
+            stderr="",
+        ),
+    )
+
+    assert kb._github_pr_is_terminal("https://github.com/example/repo/pull/123") is False
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        subprocess.TimeoutExpired(cmd=["gh"], timeout=5),
+        FileNotFoundError("gh is unavailable"),
+    ],
+)
+def test_github_pr_terminal_lookup_is_ambiguous_when_unreachable(
+    monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    def fail(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(kb.subprocess, "run", fail)
+
+    assert kb._github_pr_is_terminal("https://github.com/example/repo/pull/123") is None
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "Not GitHub: https://gitlab.com/example/repo/pull/123",
+        "Malformed: https://github.com/example/repo/pull/not-a-number",
+        "Ordinary progress comment with no URL",
+    ],
+)
+def test_active_pr_guard_ignores_non_pr_comments(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    comment: str,
+) -> None:
+    def unexpected_lookup(_url: str) -> bool:
+        raise AssertionError("non-PR comments must not trigger a GitHub lookup")
+
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", unexpected_lookup)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ordinary task", assignee="worker")
+        kb.add_comment(conn, task_id, author="worker", body=comment)
+
+        assert kb.check_respawn_guard(conn, task_id) is None
 
 
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -523,6 +523,71 @@ def test_active_pr_guard_allows_verifiably_terminal_pr(
     assert looked_up == ["https://github.com/example/repo/pull/123"]
 
 
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "%2Fevil",
+        ".example",
+    ],
+)
+def test_active_pr_guard_fails_closed_for_malformed_numeric_suffix(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+) -> None:
+    looked_up: list[str] = []
+
+    def terminal(url: str) -> bool:
+        looked_up.append(url)
+        return True
+
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", terminal)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="resume implementation", assignee="worker")
+        kb.add_comment(
+            conn,
+            task_id,
+            author="worker",
+            body=f"Candidate: https://github.com/example/repo/pull/123{suffix}",
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+    assert looked_up == []
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "?diff=split",
+        "#discussion_r123",
+        "/files",
+    ],
+)
+def test_active_pr_guard_preserves_unambiguous_url_suffixes(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+) -> None:
+    url = f"https://github.com/example/repo/pull/123{suffix}"
+    looked_up: list[str] = []
+
+    def terminal(candidate: str) -> bool:
+        looked_up.append(candidate)
+        return True
+
+    monkeypatch.setattr(kb, "_github_pr_is_terminal", terminal)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="resume implementation", assignee="worker")
+        kb.add_comment(conn, task_id, author="worker", body=f"Merged ({url}).")
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+    assert looked_up == [url]
+
+
 @pytest.mark.parametrize("state", ["CLOSED", "MERGED"])
 def test_github_pr_terminal_lookup_accepts_closed_and_merged(
     monkeypatch: pytest.MonkeyPatch, state: str

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -814,7 +814,7 @@ hermes kanban create "nightly backup audit" \
 
 ### Respawn guard
 
-The dispatcher refuses to re-spawn a ready task when it hit a quota/auth/429 error on the previous run (`blocker_auth`), or completed a run successfully within the guard window (`recent_success`), or a recent task comment links to a GitHub PR (`active_pr`). This prevents repeat worker storms on the same bug or task while a human catches up. See the `respawn_guarded` row in the [event reference](#event-reference).
+The dispatcher refuses to re-spawn a ready task when it hit a quota/auth/429 error on the previous run (`blocker_auth`), or completed a run successfully within the guard window (`recent_success`), or a recent task comment links to a GitHub PR that is open or cannot be verified (`active_pr`). A PR that GitHub CLI verifiably reports as closed or merged does not block a resumable ready-lane task. Missing GitHub CLI authentication, network failures, timeouts, and malformed responses fail closed as `active_pr`; review-lane handoffs continue to skip this check. This prevents repeat worker storms on the same bug or task without stranding work behind a terminal PR. See the `respawn_guarded` row in the [event reference](#event-reference).
 
 ### Drag-to-delete and bulk delete (dashboard)
 


### PR DESCRIPTION
## Summary
- resolve recently referenced GitHub pull requests before applying the non-review `active_pr` respawn guard
- release CLOSED/MERGED PR references while preserving fail-closed behavior for OPEN, unknown, and malformed references
- document the terminal-PR behavior and add focused lifecycle regression coverage

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py -q` — 65 passed, 1 skipped
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py` — passed
- reviewed immutable head: `6c9467758b66ce5f778db87e095067aabc50b186`

The lookup is bounded, argv-only, shell-free, and fail-closed on timeout, command failure, malformed output, or ambiguous URL suffixes.