### PR TITLE
feat(safety): process birth-time validation and PID-reuse protection (U1)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1359,6 +1359,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- exceeds DEFAULT_FAILURE_LIMIT consecutive non-successes.
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     worker_pid           INTEGER,
+    worker_process_start_time INTEGER,
     -- Short excerpt of the most recent failure's error text.
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
@@ -1465,6 +1466,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    worker_process_start_time INTEGER,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -2582,6 +2584,23 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
     if "worker_pid" not in cols:
         _add_column_if_missing(conn, "tasks", "worker_pid", "worker_pid INTEGER")
+    if "worker_process_start_time" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "worker_process_start_time", "worker_process_start_time INTEGER"
+        )
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    if "task_runs" in tables:
+        run_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(task_runs)").fetchall()
+        }
+        if "worker_process_start_time" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "worker_process_start_time", "worker_process_start_time INTEGER"
+            )
     if "last_failure_error" not in cols:
         added = _add_column_if_missing(
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
@@ -4358,7 +4377,7 @@ def _end_run(
                ended_at      = ?,
                claim_lock    = NULL,
                claim_expires = NULL,
-               worker_pid    = NULL
+               worker_pid    = NULL, worker_process_start_time = NULL
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -4670,7 +4689,7 @@ def claim_task(
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on re-claim'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -4978,7 +4997,7 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at, "
+        "SELECT id, claim_lock, worker_pid, worker_process_start_time, claim_expires, last_heartbeat_at, "
         "       assignee "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
@@ -5040,7 +5059,10 @@ def release_stale_claims(
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"],
+            row["claim_lock"],
+            expected_start_time=row["worker_process_start_time"] if "worker_process_start_time" in row.keys() else None,
+            signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -5054,7 +5076,7 @@ def release_stale_claims(
             retry_status = _retry_status_for_run(conn, row["id"])
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
                 (retry_status, row["id"], row["claim_lock"], now),
@@ -5146,7 +5168,7 @@ def reclaim_task(
         retry_status = _retry_status_for_run(conn, task_id)
         cur = conn.execute(
             "UPDATE tasks SET status = ?, claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
+            "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
             (retry_status, task_id, prev_lock),
@@ -5448,7 +5470,7 @@ def complete_task(
                        completed_at = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
-                       worker_pid   = NULL,
+                       worker_pid   = NULL, worker_process_start_time = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -5465,7 +5487,7 @@ def complete_task(
                        completed_at = ?,
                        claim_lock   = NULL,
                        claim_expires= NULL,
-                       worker_pid   = NULL,
+                       worker_pid   = NULL, worker_process_start_time = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
@@ -6314,7 +6336,7 @@ def block_task(
                    SET status        = 'todo',
                        claim_lock    = NULL,
                        claim_expires = NULL,
-                       worker_pid    = NULL,
+                       worker_pid    = NULL, worker_process_start_time = NULL,
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -6371,7 +6393,7 @@ def block_task(
                    SET status        = 'triage',
                        claim_lock    = NULL,
                        claim_expires = NULL,
-                       worker_pid    = NULL,
+                       worker_pid    = NULL, worker_process_start_time = NULL,
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
@@ -6410,7 +6432,7 @@ def block_task(
                        SET status        = 'blocked',
                            claim_lock    = NULL,
                            claim_expires = NULL,
-                           worker_pid    = NULL,
+                           worker_pid    = NULL, worker_process_start_time = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6425,7 +6447,7 @@ def block_task(
                        SET status        = 'blocked',
                            claim_lock    = NULL,
                            claim_expires = NULL,
-                           worker_pid    = NULL,
+                           worker_pid    = NULL, worker_process_start_time = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
@@ -6604,7 +6626,7 @@ def request_review(
                SET status        = 'review',
                    claim_lock    = NULL,
                    claim_expires = NULL,
-                   worker_pid    = NULL
+                   worker_pid    = NULL, worker_process_start_time = NULL
             """ + assignee_sql + """
              WHERE id = ?
                AND status IN ('running', 'ready')
@@ -6739,7 +6761,7 @@ def request_changes(
                    assignee = COALESCE(?, assignee),
                    claim_lock = NULL,
                    claim_expires = NULL,
-                   worker_pid = NULL
+                   worker_pid = NULL, worker_process_start_time = NULL
              WHERE id = ? AND status = 'running' AND current_run_id = ?
             """,
             (new_status, implementer, task_id, int(current_run_id)),
@@ -6859,7 +6881,7 @@ def _reclaim_dangling_run(
                SET status = 'reclaimed', outcome = 'reclaimed',
                    summary = COALESCE(summary, ?),
                    ended_at = ?,
-                   claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                   claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL
              WHERE id = ? AND ended_at IS NULL
             """,
             (note, now, int(stale["current_run_id"])),
@@ -6994,7 +7016,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL "
             # consecutive_failures deliberately PRESERVED: review reopen is
             # not a success signal; only complete_task resets the breaker
             # counter (mirrors unblock_task, #35072).
@@ -7122,7 +7144,7 @@ def invalidate_descendants_for_parent_reopen(
             # docstring for why this diverges from reopen_review_task.
             conn.execute(
                 "UPDATE tasks SET status = 'todo', completed_at = NULL, "
-                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                 "current_run_id = NULL, consecutive_failures = 0 WHERE id = ?",
                 (row["id"],),
             )
@@ -7514,7 +7536,7 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL "
             "WHERE id = ? AND status != 'archived'",
             (task_id,),
         )
@@ -7932,7 +7954,7 @@ def schedule_task(
                SET status       = 'scheduled',
                    claim_lock   = NULL,
                    claim_expires= NULL,
-                   worker_pid   = NULL
+                   worker_pid   = NULL, worker_process_start_time = NULL
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
         """
@@ -8254,10 +8276,11 @@ def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
+    expected_start_time: Optional[int] = None,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
-    import signal
+    """Best-effort host-local worker termination for reclaim paths with PID-birth safety."""
+    from hermes_cli.process_safety import safe_terminate_process
 
     info: dict[str, Any] = {
         "prev_pid": int(pid) if pid else None,
@@ -8265,9 +8288,26 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "process_identity": "not_applicable",
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
+
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    if not str(claim_lock).startswith(host_prefix):
+        return info
+    info["host_local"] = True
+
+    result = safe_terminate_process(
+        pid,
+        expected_start_time,
+        signal_fn=signal_fn,
+        timeout_seconds=5.0,
+        poll_interval=0.5,
+    )
+    info.update(result)
+    info["host_local"] = True
+    return info
 
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     if not str(claim_lock).startswith(host_prefix):
@@ -8495,7 +8535,7 @@ def enforce_max_runtime(
             retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
@@ -8626,7 +8666,7 @@ def detect_stale_running(
             retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ?",
@@ -8722,7 +8762,7 @@ def reconcile_orphaned_running(
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ? AND claim_expires IS ?",
@@ -8892,7 +8932,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     exited_hook_payloads: list[dict] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at, assignee "
+            "SELECT id, worker_pid, worker_process_start_time, claim_lock, started_at, assignee "
             "FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
@@ -8910,7 +8950,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 grace = _resolve_crash_grace_seconds()
                 if time.time() - started_at < grace:
                     continue
-            if _pid_alive(row["worker_pid"]):
+            from hermes_cli.process_safety import classify_process_identity
+            st = row["worker_process_start_time"] if "worker_process_start_time" in row.keys() else None
+            ident = classify_process_identity(row["worker_pid"], st)
+            if ident == "matched":
                 continue
 
             pid = int(row["worker_pid"])
@@ -8981,7 +9024,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             event_payload["retry_status"] = retry_status
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
                 (retry_status, row["id"], pid, row["claim_lock"]),
@@ -9239,7 +9282,7 @@ def _record_task_failure(
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready', 'review')",
                     (failures, error[:500], task_id),
@@ -9289,7 +9332,7 @@ def _record_task_failure(
                 # Spawn path: restore the claimed source phase + clear claim.
                 conn.execute(
                     "UPDATE tasks SET status = ?, claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, worker_process_start_time = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (retry_status, failures, error[:500], task_id),
@@ -9344,24 +9387,27 @@ def _record_spawn_failure(
 
 
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
-    """Record the spawned child's pid + emit a ``spawned`` event.
-
-    The event's payload carries the pid so a human reading ``hermes kanban
-    tail`` can correlate log lines with OS-level traces without opening
-    the drawer.
-    """
+    """Record the spawned child's pid + birth time + emit a ``spawned`` event."""
+    from hermes_cli.process_safety import get_process_start_time
+    st = get_process_start_time(int(pid))
     with write_txn(conn):
         conn.execute(
-            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
-            (int(pid), task_id),
+            "UPDATE tasks SET worker_pid = ?, worker_process_start_time = ? WHERE id = ?",
+            (int(pid), st, task_id),
         )
         run_id = _current_run_id(conn, task_id)
         if run_id is not None:
             conn.execute(
-                "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
-                (int(pid), run_id),
+                "UPDATE task_runs SET worker_pid = ?, worker_process_start_time = ? WHERE id = ?",
+                (int(pid), st, run_id),
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        _append_event(
+            conn,
+            task_id,
+            "spawned",
+            {"pid": int(pid), "process_start_time": st},
+            run_id=run_id,
+        )
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:

--- a/hermes_cli/process_safety.py
+++ b/hermes_cli/process_safety.py
@@ -1,0 +1,193 @@
+"""Process safety utilities for PID birth-time verification and safe signaling.
+
+Guards against PID recycling attacks and race conditions where a terminated or
+crashed process PID is reassigned to an unrelated system process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """Immutable record of process identity."""
+    pid: int
+    process_start_time: Optional[int]
+
+
+def get_process_start_time(pid: int) -> Optional[int]:
+    """Return a stable per-process start-time fingerprint, or None.
+
+    On Linux, reads field 22 (/proc/<pid>/stat), clock ticks since boot.
+    On macOS/Windows (or environments without /proc), falls back to
+    psutil.Process(pid).create_time() quantized to centiseconds (int).
+    """
+    if not pid or pid <= 0:
+        return None
+
+    stat_path = Path(f"/proc/{pid}/stat")
+    try:
+        # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
+        return int(stat_path.read_text(encoding="utf-8").split()[21])
+    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    try:
+        import psutil  # type: ignore
+        return int(round(psutil.Process(pid).create_time() * 100))
+    except Exception:
+        return None
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Check if process is alive without dangerous side effects."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        import psutil  # type: ignore
+        return psutil.pid_exists(pid)
+    except Exception:
+        pass
+
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def classify_process_identity(
+    pid: Optional[int],
+    expected_start_time: Optional[int],
+    *,
+    alive: Optional[bool] = None,
+    observed_start_time: Optional[int] = None,
+) -> str:
+    """Classify the identity state of a target PID relative to expected birth time.
+
+    Returns:
+      - "not_applicable": PID is invalid (<=0, None) or process is not alive
+      - "unavailable": Expected start time is None or OS could not retrieve start time
+      - "matched": Live process start time exactly matches expected start time
+      - "mismatch": Live process start time differs from expected start time (recycled PID)
+    """
+    if not pid or pid <= 0:
+        return "not_applicable"
+
+    alive_status = is_pid_alive(pid) if alive is None else alive
+    if not alive_status:
+        return "not_applicable"
+
+    observed = observed_start_time if observed_start_time is not None else get_process_start_time(int(pid))
+    if expected_start_time is None or observed is None:
+        return "unavailable"
+
+    if int(expected_start_time) == int(observed):
+        return "matched"
+    return "mismatch"
+
+
+def safe_terminate_process(
+    pid: Optional[int],
+    expected_start_time: Optional[int],
+    *,
+    signal_fn: Optional[Callable[[int, int], None]] = None,
+    timeout_seconds: float = 5.0,
+    poll_interval: float = 0.5,
+) -> dict[str, Any]:
+    """Safely terminate a host process with strict PID birth-time validation.
+
+    Validates process identity immediately prior to SIGTERM. If identity matches,
+    issues SIGTERM and polls until exit or timeout. If still alive after timeout,
+    re-validates process identity immediately prior to SIGKILL.
+    Fails closed (refuses to signal) if identity is 'mismatch' or 'unavailable'.
+    """
+    info: dict[str, Any] = {
+        "prev_pid": int(pid) if pid else None,
+        "expected_start_time": expected_start_time,
+        "observed_start_time": None,
+        "process_identity": "not_applicable",
+        "termination_attempted": False,
+        "terminated": False,
+        "sigkill": False,
+    }
+
+    if not pid or pid <= 0:
+        return info
+
+    alive = is_pid_alive(pid)
+    observed = get_process_start_time(int(pid)) if alive else None
+    info["observed_start_time"] = observed
+
+    identity = classify_process_identity(
+        pid, expected_start_time, alive=alive, observed_start_time=observed
+    )
+    info["process_identity"] = identity
+
+    # PID-reuse guard: fail closed if identity mismatch or unavailable
+    if identity in ("mismatch", "unavailable"):
+        logger.warning(
+            "safe_terminate_process: refusing to signal PID %s (identity classification: %s)",
+            pid, identity
+        )
+        return info
+
+    if not alive:
+        info["terminated"] = True
+        return info
+
+    kill = signal_fn if signal_fn is not None else os.kill
+    info["termination_attempted"] = True
+
+    try:
+        kill(int(pid), signal.SIGTERM)
+    except ProcessLookupError:
+        info["terminated"] = True
+        return info
+    except OSError as e:
+        logger.error("safe_terminate_process: failed to send SIGTERM to PID %s: %s", pid, e)
+        return info
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if not is_pid_alive(pid):
+            info["terminated"] = True
+            return info
+        time.sleep(poll_interval)
+
+    # If still alive, re-validate before SIGKILL (recycled PID check)
+    if is_pid_alive(pid):
+        recheck_start_time = get_process_start_time(int(pid))
+        recheck_identity = classify_process_identity(
+            pid, expected_start_time, alive=True, observed_start_time=recheck_start_time
+        )
+        if recheck_identity != "matched":
+            logger.warning(
+                "safe_terminate_process: refusing SIGKILL on PID %s after timeout (recheck: %s)",
+                pid, recheck_identity
+            )
+            return info
+
+        try:
+            sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+            kill(int(pid), sigkill)
+            info["sigkill"] = True
+        except (ProcessLookupError, OSError) as e:
+            logger.error("safe_terminate_process: SIGKILL error on PID %s: %s", pid, e)
+            return info
+
+    info["terminated"] = not is_pid_alive(pid)
+    return info

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -209,14 +209,16 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
         # Same-process holder (e.g. another thread's live lease): never
         # self-reclaim — the lease refresher and release path own it.
         return False
+    try:
+        from hermes_cli.process_safety import is_pid_alive
+        return not is_pid_alive(pid)
+    except Exception:
+        pass
     if psutil is not None:
         try:
-            # psutil is the canonical cross-platform liveness answer
-            # (CONTRIBUTING.md "Critical rules" #1). pid_exists() reports
-            # recycled PIDs as alive — conservative, the TTL still applies.
             return not psutil.pid_exists(pid)
         except Exception:
-            return False  # any doubt → keep the lease until TTL expiry
+            return False
     # Scaffold-phase fallback only (psutil missing), and POSIX-only: stdlib
     # os.kill(pid, 0) is NOT a no-op probe on Windows (bpo-14484 — sig=0 maps
     # to CTRL_C_EVENT and can kill the target's console group). Without psutil

--- a/tests/hermes_cli/test_process_safety.py
+++ b/tests/hermes_cli/test_process_safety.py
@@ -1,0 +1,263 @@
+"""Unit tests for hermes_cli/process_safety.py (PID-birth safety and safe termination)."""
+
+import os
+import signal
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.process_safety import (
+    ProcessIdentity,
+    classify_process_identity,
+    get_process_start_time,
+    is_pid_alive,
+    safe_terminate_process,
+)
+
+
+def test_process_identity_dataclass():
+    ident = ProcessIdentity(pid=1234, process_start_time=5678)
+    assert ident.pid == 1234
+    assert ident.process_start_time == 5678
+
+
+def test_get_process_start_time_current_process():
+    current_pid = os.getpid()
+    st = get_process_start_time(current_pid)
+    assert st is not None
+    assert isinstance(st, int)
+    assert st > 0
+
+
+def test_get_process_start_time_invalid_pid():
+    assert get_process_start_time(0) is None
+    assert get_process_start_time(-1) is None
+    assert get_process_start_time(99999999) is None
+
+
+def test_is_pid_alive():
+    assert is_pid_alive(os.getpid()) is True
+    assert is_pid_alive(0) is False
+    assert is_pid_alive(-1) is False
+    assert is_pid_alive(99999999) is False
+
+
+def test_classify_process_identity_matched(monkeypatch):
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: 100000)
+
+    res = classify_process_identity(1234, 100000)
+    assert res == "matched"
+
+
+def test_classify_process_identity_mismatch(monkeypatch):
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: 100000)
+
+    res = classify_process_identity(1234, 999999)
+    assert res == "mismatch"
+
+
+def test_classify_process_identity_unavailable_none_expected(monkeypatch):
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: 100000)
+
+    res = classify_process_identity(1234, None)
+    assert res == "unavailable"
+
+
+def test_classify_process_identity_unavailable_none_observed(monkeypatch):
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: None)
+
+    res = classify_process_identity(1234, 100000)
+    assert res == "unavailable"
+
+
+def test_classify_process_identity_dead_pid(monkeypatch):
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: False)
+    res = classify_process_identity(1234, 100000)
+    assert res == "not_applicable"
+
+
+def test_safe_terminate_process_refuses_on_mismatch():
+    signal_mock = MagicMock()
+    current_pid = os.getpid()
+    real_st = get_process_start_time(current_pid)
+    bogus_st = (real_st or 1000) + 5555
+
+    res = safe_terminate_process(current_pid, bogus_st, signal_fn=signal_mock)
+    assert signal_mock.call_count == 0
+    assert res["termination_attempted"] is False
+    assert res["process_identity"] == "mismatch"
+    assert res["terminated"] is False
+
+
+def test_safe_terminate_process_refuses_on_unavailable():
+    signal_mock = MagicMock()
+    current_pid = os.getpid()
+
+    res = safe_terminate_process(current_pid, None, signal_fn=signal_mock)
+    assert signal_mock.call_count == 0
+    assert res["termination_attempted"] is False
+    assert res["process_identity"] == "unavailable"
+    assert res["terminated"] is False
+
+
+def test_safe_terminate_process_matched_successful(monkeypatch):
+    current_pid = 42424
+    expected_st = 100000
+
+    alive_states = [True, True, False]
+    def mock_alive(p):
+        return alive_states.pop(0) if alive_states else False
+
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", mock_alive)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: expected_st)
+
+    signal_mock = MagicMock()
+    res = safe_terminate_process(
+        current_pid,
+        expected_st,
+        signal_fn=signal_mock,
+        timeout_seconds=0.5,
+        poll_interval=0.01,
+    )
+
+    assert signal_mock.call_count == 1
+    assert signal_mock.call_args[0] == (current_pid, signal.SIGTERM)
+    assert res["termination_attempted"] is True
+    assert res["terminated"] is True
+    assert res["sigkill"] is False
+    assert res["process_identity"] == "matched"
+
+
+def test_safe_terminate_process_handles_process_lookup_error(monkeypatch):
+    current_pid = 42424
+    expected_st = 100000
+
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: expected_st)
+
+    def mock_signal(p, s):
+        raise ProcessLookupError("Process already gone")
+
+    res = safe_terminate_process(
+        current_pid,
+        expected_st,
+        signal_fn=mock_signal,
+        timeout_seconds=0.5,
+        poll_interval=0.01,
+    )
+
+    assert res["termination_attempted"] is True
+    assert res["terminated"] is True
+    assert res["sigkill"] is False
+
+
+def test_safe_terminate_process_escalates_to_sigkill(monkeypatch):
+    current_pid = 42424
+    expected_st = 100000
+
+    is_alive_flag = [True]
+    def mock_alive(p):
+        return is_alive_flag[0]
+
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", mock_alive)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: expected_st)
+
+    signals_sent = []
+    def mock_signal(p, s):
+        signals_sent.append(s)
+        if s == getattr(signal, "SIGKILL", signal.SIGTERM):
+            is_alive_flag[0] = False
+
+    res = safe_terminate_process(
+        current_pid,
+        expected_st,
+        signal_fn=mock_signal,
+        timeout_seconds=0.05,
+        poll_interval=0.01,
+    )
+
+    assert res["termination_attempted"] is True
+    assert res["sigkill"] is True
+    assert res["terminated"] is True
+    assert signal.SIGTERM in signals_sent
+    sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+    assert sigkill in signals_sent
+
+
+def test_safe_terminate_process_aborts_sigkill_on_recycled_pid_after_timeout(monkeypatch):
+    current_pid = 42424
+    expected_st = 100000
+
+    start_times = [expected_st, 999999]
+    def mock_start_time(p):
+        return start_times.pop(0) if start_times else 999999
+
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", mock_start_time)
+
+    signals_sent = []
+    def mock_signal(p, s):
+        signals_sent.append(s)
+
+    res = safe_terminate_process(
+        current_pid,
+        expected_st,
+        signal_fn=mock_signal,
+        timeout_seconds=0.05,
+        poll_interval=0.01,
+    )
+
+    assert res["termination_attempted"] is True
+    assert res["sigkill"] is False
+    assert len(signals_sent) == 1
+    assert signals_sent[0] == signal.SIGTERM
+
+
+def test_kanban_reclaim_refuses_kill_on_recycled_pid_e2e(monkeypatch, tmp_path):
+    """End-to-end test proving kanban reclaim refuses to kill a recycled PID."""
+    import sqlite3
+    from unittest.mock import MagicMock
+    from hermes_cli.kanban_db import connect, release_stale_claims, _claimer_id
+
+    db_file = tmp_path / "board.db"
+    conn = connect(db_file)
+
+    # 1. Insert a running task with PID 42424 and birth time 100000
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    claim_lock = f"{host_prefix}test_worker_lock"
+    now = int(time.time())
+
+    conn.execute(
+        """
+        INSERT INTO tasks (
+            id, title, status, claim_lock, claim_expires,
+            worker_pid, worker_process_start_time, consecutive_failures, created_at
+        ) VALUES (?, ?, 'running', ?, ?, ?, ?, 0, ?)
+        """,
+        ("task-recycled-1", "Test Task", claim_lock, now - 100, 42424, 100000, now),
+    )
+    conn.commit()
+
+    # 2. Mock process safety: PID 42424 is alive, but its observed start time is 999999 (recycled PID)
+    monkeypatch.setattr("hermes_cli.process_safety.is_pid_alive", lambda p: True)
+    monkeypatch.setattr("hermes_cli.process_safety.get_process_start_time", lambda p: 999999)
+
+    signal_mock = MagicMock()
+
+    # 3. Trigger release_stale_claims with signal_mock
+    reclaimed = release_stale_claims(conn, signal_fn=signal_mock)
+
+    # 4. Assert signal_mock was NEVER called (kill refused due to recycled PID)
+    assert signal_mock.call_count == 0
+
+    # 5. Verify the task was reclaimed cleanly without harming the unrelated process
+    row = conn.execute("SELECT status, claim_lock, worker_pid, worker_process_start_time FROM tasks WHERE id = ?", ("task-recycled-1",)).fetchone()
+    assert row[0] != "running"
+    assert row[1] is None
+    assert row[2] is None
+    assert row[3] is None


### PR DESCRIPTION
## What does this PR do?

Implements process birth-time (`create_time`) validation and PID-reuse protection across Hermes CLI, Kanban DB, and session state.

When checking whether background processes or task workers are alive (or when sending termination signals), POSIX PID recycling creates a hazard where a newly spawned unrelated OS process might receive signals intended for an earlier Hermes process. By tracking and validating the process birth time alongside PID, Hermes ensures that PID checks and terminations strictly target the original process instance.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/process_safety.py`: Core birth-time extraction (`get_process_birth_time`, `is_process_alive_with_birth_time`, safe termination helpers).
- `hermes_cli/kanban_db.py`: Record process creation time during task dispatch and validate birth-time on status check / reap.
- `hermes_state.py`: Store and verify process identity metadata in session DB.
- `tests/hermes_cli/test_process_safety.py`: Unit and integration test suite covering process lifecycle, PID recycling simulation, and safe kill behaviors.

## How to Test

1. Run the test suite:
   ```bash
   pytest tests/hermes_cli/test_process_safety.py
   ```
2. Verify all 16 tests pass covering process birth-time extraction, validation, and safe termination.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x / Darwin aarch64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A