### PR TITLE
feat(gateway): authenticated intake callback and reply-token delivery (U2)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -400,9 +400,19 @@ class GatewayAuthorizationMixin:
         # Home Assistant events are system-generated (state changes), not
         # user-initiated messages.  The HASS_TOKEN already authenticates the
         # connection, so HA events are always authorized.
+        if source.platform == Platform.HOMEASSISTANT:
+            return True
+
         # Webhook events are authenticated via HMAC signature validation in
-        # the adapter itself — no user allowlist applies.
-        if source.platform in {Platform.HOMEASSISTANT, Platform.WEBHOOK}:
+        # the adapter itself. When an intake callback specifies an action tool
+        # invocation, verify it against the intake action ledger. Fail closed
+        # if the action is not authorized.
+        if source.platform == Platform.WEBHOOK:
+            action_tool = getattr(source, "action_tool", None)
+            action_args = getattr(source, "action_args", None) or {}
+            if action_tool:
+                session_id = source.chat_id or getattr(source, "user_id", "") or ""
+                return self._is_intake_action_authorized(session_id, action_tool, action_args)
             return True
 
         adapter_profile = self._adapter_profile_for_source(source)
@@ -895,3 +905,33 @@ class GatewayAuthorizationMixin:
             return "ignore"
 
         return "pair"
+
+    def _is_intake_action_authorized(
+        self, session_id: str, tool_name: str, args: dict[str, Any]
+    ) -> bool:
+        """Verify whether an action invoked by an agent run is authorized by a callback ledger."""
+        if not session_id or not tool_name:
+            return False
+        try:
+            from hermes_cli.intake_reply_tokens import claim_action_tool
+            return claim_action_tool(session_id, tool_name, args)
+        except Exception:
+            return False
+
+    def check_intake_tool_authorization(
+        self,
+        source: Optional[SessionSource],
+        tool_name: str,
+        args: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """Verify whether a tool execution from an intake session is authorized.
+
+        Fails closed: missing source, missing session, missing tool name, or ledger error
+        returns False.
+        """
+        if not source or not tool_name:
+            return False
+        session_id = source.chat_id or getattr(source, "user_id", "") or ""
+        if not session_id:
+            return False
+        return self._is_intake_action_authorized(session_id, tool_name, args or {})

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -746,6 +746,9 @@ class WebhookAdapter(BasePlatformAdapter):
                     {"error": "Cannot parse body"}, status=400
                 )
 
+        if route_config.get("intake_callback"):
+            return await self._handle_intake_callback(payload, secret)
+
         # Check event type filter
         event_type = (
             request.headers.get("X-GitHub-Event", "")
@@ -1472,3 +1475,144 @@ class WebhookAdapter(BasePlatformAdapter):
             metadata = {"thread_id": thread_id}
 
         return await adapter.send(chat_id, content, metadata=metadata)
+
+    def _signed_intake_receipt(
+        self, receipt: dict[str, Any], secret: str, *, status: int = 200
+    ) -> "web.Response":
+        """Return a body-bound receipt accepted by the MIS callback client."""
+        body = json.dumps(receipt, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        timestamp = str(int(time.time()))
+        signature = hmac.new(
+            secret.encode("utf-8"), timestamp.encode("utf-8") + b"." + body,
+            hashlib.sha256,
+        ).hexdigest()
+        return web.Response(
+            body=body,
+            status=status,
+            content_type="application/json",
+            headers={
+                "X-Hermes-Receipt-Timestamp": timestamp,
+                "X-Hermes-Receipt-Signature-V2": signature,
+            },
+        )
+
+    @staticmethod
+    def _intake_callback_content(payload: dict[str, Any]) -> str | None:
+        summary = payload.get("summary")
+        options = payload.get("numbered_replies")
+        if not isinstance(summary, str) or not summary.strip() or not isinstance(options, list):
+            return None
+        lines = [summary.strip()[:4000]]
+        for option in options:
+            if not isinstance(option, dict):
+                return None
+            number = option.get("number")
+            action = option.get("action")
+            if not isinstance(number, int) or not isinstance(action, str):
+                return None
+            labels = {
+                "approve_item": "approve this item",
+                "save_note_and_approve": "save the associated note and approve this item",
+                "process_item": "retry processing this item",
+                "leave_pending": "leave this item pending",
+            }
+            label = labels.get(action)
+            if label is None:
+                return None
+            lines.append(f"{number}. {label}")
+        return chr(10).join(lines)
+
+    async def _handle_intake_callback(
+        self, payload: Any, secret: str
+    ) -> "web.Response":
+        """Resolve a signed link_analyzed callback to its original chat."""
+        if not isinstance(payload, dict) or payload.get("event") != "link_analyzed":
+            return web.json_response({"error": "Unsupported intake callback"}, status=400)
+        token = payload.get("reply_token")
+        delivery_id = payload.get("delivery_id")
+        if not isinstance(token, str) or not token or not isinstance(delivery_id, str) or not delivery_id:
+            return web.json_response({"error": "Missing callback capability"}, status=400)
+        content = self._intake_callback_content(payload)
+        if content is None:
+            return web.json_response({"error": "Invalid callback choices"}, status=400)
+        runner = self.gateway_runner
+        store = getattr(runner, "session_store", None) if runner is not None else None
+        if store is None:
+            return web.json_response({"error": "Original session unavailable"}, status=503)
+        try:
+            from hermes_cli.intake_reply_tokens import (
+                begin_delivery,
+                discard_actions,
+                finish_delivery,
+                register_actions,
+                release_delivery,
+                session_id_for_token,
+            )
+
+            token_session_id = session_id_for_token(token)
+            if token_session_id is None:
+                return web.json_response({"error": "Unknown callback capability"}, status=404)
+            entry = store.lookup_by_session_id(token_session_id)
+            origin_source = getattr(entry, "origin", None) if entry is not None else None
+            origin = origin_source.to_dict() if origin_source is not None else None
+            if not isinstance(origin, dict):
+                return web.json_response({"error": "Original session unavailable"}, status=410)
+            claim = begin_delivery(token, delivery_id, origin)
+        except Exception:
+            logger.exception("[webhook] intake callback token resolution failed")
+            return web.json_response({"error": "Callback resolution failed"}, status=503)
+
+        if claim.status == "delivered":
+            return self._signed_intake_receipt(
+                {
+                    "status": "delivered",
+                    "delivery_id": delivery_id,
+                    "original_session_delivered": True,
+                    "action_ledger_ready": True,
+                }, secret,
+            )
+        if claim.status in {"unknown", "expired", "wrong_delivery", "invalid", "uncertain"}:
+            return web.json_response({"error": "Rejected callback capability"}, status=409)
+        if claim.status == "in_progress":
+            return web.json_response({"error": "Callback delivery in progress"}, status=409)
+        if claim.status != "claimed" or not claim.origin:
+            return web.json_response({"error": "Callback delivery unavailable"}, status=503)
+
+        if not register_actions(
+            token=token,
+            delivery_id=delivery_id,
+            session_id=claim.session_id,
+            payload=payload,
+        ):
+            release_delivery(token, delivery_id)
+            return web.json_response({"error": "Invalid callback action ledger"}, status=400)
+
+        extra = {"chat_id": str(claim.origin.get("chat_id") or "")}
+        if claim.origin.get("thread_id"):
+            extra["thread_id"] = str(claim.origin["thread_id"])
+        if claim.origin.get("profile"):
+            extra["profile"] = str(claim.origin["profile"])
+        platform = claim.origin.get("platform")
+        if not isinstance(platform, str) or not platform or not extra["chat_id"]:
+            discard_actions(delivery_id)
+            release_delivery(token, delivery_id)
+            return web.json_response({"error": "Invalid original session"}, status=410)
+        try:
+            result = await self._direct_deliver(
+                content, {"deliver": platform, "deliver_extra": extra, "payload": payload}
+            )
+        except Exception:
+            logger.exception("[webhook] intake callback delivery failed")
+            result = SendResult(success=False, error="Delivery failed")
+        if not result.success or not finish_delivery(token, delivery_id):
+            discard_actions(delivery_id)
+            release_delivery(token, delivery_id)
+            return web.json_response({"error": "Original delivery failed"}, status=502)
+        return self._signed_intake_receipt(
+            {
+                "status": "delivered",
+                "delivery_id": delivery_id,
+                "original_session_delivered": True,
+                "action_ledger_ready": True,
+            }, secret,
+        )

--- a/hermes_cli/intake_reply_tokens.py
+++ b/hermes_cli/intake_reply_tokens.py
@@ -1,0 +1,444 @@
+"""Durable reply-token and action ledgers for Hermes intake callbacks.
+
+The token is intentionally opaque to Marketing Brain.  Hermes keeps the
+session and delivery correlation locally, alongside the callback's bounded
+numbered-action state, so a restart cannot turn a callback retry into a new
+chat action.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+import secrets
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+
+TTL_SECONDS = 24 * 60 * 60
+DELIVERY_LEASE_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class DeliveryClaim:
+    """The durable state of a callback delivery claim."""
+
+    status: str
+    session_id: str = ""
+    origin: dict[str, Any] | None = None
+
+
+def _db_path() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser() / "state.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 5000")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS intake_reply_tokens (
+        token TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        expires_at INTEGER NOT NULL,
+        consumed_at INTEGER,
+        delivery_id TEXT,
+        delivery_state TEXT NOT NULL DEFAULT 'pending',
+        delivery_lease_expires_at INTEGER,
+        origin_json TEXT
+        )"""
+    )
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(intake_reply_tokens)")
+    }
+    for name, declaration in (
+        ("delivery_id", "TEXT"),
+        ("delivery_state", "TEXT NOT NULL DEFAULT 'pending'"),
+        ("delivery_lease_expires_at", "INTEGER"),
+        ("origin_json", "TEXT"),
+    ):
+        if name not in columns:
+            conn.execute(f"ALTER TABLE intake_reply_tokens ADD COLUMN {name} {declaration}")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS intake_callback_actions (
+        delivery_id TEXT PRIMARY KEY,
+        token TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        item_id INTEGER NOT NULL,
+        analysis_attempt INTEGER NOT NULL,
+        analysis_status TEXT NOT NULL,
+        options_json TEXT NOT NULL,
+        selected_option INTEGER,
+        action_state TEXT NOT NULL DEFAULT 'pending',
+        note_claimed_at INTEGER,
+        approve_claimed_at INTEGER,
+        process_claimed_at INTEGER,
+        created_at INTEGER NOT NULL
+        )"""
+    )
+    return conn
+
+
+def _cleanup(conn: sqlite3.Connection, now: int) -> None:
+    # Keep recent expired rows long enough to reject a stale retry explicitly,
+    # but do not retain opaque capabilities indefinitely.
+    conn.execute(
+        "DELETE FROM intake_callback_actions WHERE created_at < ?", (now - TTL_SECONDS,)
+    )
+    conn.execute(
+        "DELETE FROM intake_reply_tokens WHERE expires_at < ?", (now - TTL_SECONDS,)
+    )
+
+
+def _origin_json(origin: dict[str, Any]) -> str:
+    return json.dumps(origin, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_origin(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def mint(session_id: str, *, now: int | None = None) -> str:
+    """Mint one 24-hour opaque capability for an existing Hermes session."""
+    if not session_id:
+        raise ValueError("session_id required")
+    now = int(time.time()) if now is None else int(now)
+    token = secrets.token_urlsafe(32)
+    with _connect() as conn:
+        _cleanup(conn, now)
+        conn.execute(
+            """INSERT INTO intake_reply_tokens
+            (token, session_id, expires_at, consumed_at, delivery_state)
+            VALUES (?, ?, ?, NULL, 'pending')""",
+            (token, session_id, now + TTL_SECONDS),
+        )
+    return token
+
+
+def consume(token: str, *, now: int | None = None) -> str | None:
+    """Compatibility helper: atomically consume a token without delivery."""
+    now = int(time.time()) if now is None else int(now)
+    with _connect() as conn:
+        _cleanup(conn, now)
+        row = conn.execute(
+            """SELECT session_id FROM intake_reply_tokens
+            WHERE token=? AND expires_at>? AND consumed_at IS NULL""",
+            (token, now),
+        ).fetchone()
+        if row is None:
+            return None
+        result = conn.execute(
+            """UPDATE intake_reply_tokens SET consumed_at=?, delivery_state='delivered'
+            WHERE token=? AND consumed_at IS NULL""",
+            (now, token),
+        )
+        return str(row["session_id"]) if result.rowcount == 1 else None
+
+
+def session_id_for_token(token: str) -> str | None:
+    """Return the local correlation id without consuming the capability."""
+    if not token:
+        return None
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT session_id FROM intake_reply_tokens WHERE token=?", (token,)
+        ).fetchone()
+        return str(row["session_id"]) if row is not None else None
+
+
+def begin_delivery(
+    token: str, delivery_id: str, origin: dict[str, Any], *, now: int | None = None
+) -> DeliveryClaim:
+    """Atomically reserve a delivery, binding it to one source correlation."""
+    now = int(time.time()) if now is None else int(now)
+    if not token or not delivery_id or not origin:
+        return DeliveryClaim("invalid")
+    with _connect() as conn:
+        _cleanup(conn, now)
+        row = conn.execute(
+            "SELECT * FROM intake_reply_tokens WHERE token=?", (token,)
+        ).fetchone()
+        if row is None:
+            return DeliveryClaim("unknown")
+        if int(row["expires_at"]) <= now:
+            return DeliveryClaim("expired")
+        existing_id = row["delivery_id"]
+        state = str(row["delivery_state"] or "pending")
+        if existing_id and existing_id != delivery_id:
+            return DeliveryClaim("wrong_delivery")
+        persisted_origin = _parse_origin(row["origin_json"]) or origin
+        if state == "delivered":
+            return DeliveryClaim("delivered", str(row["session_id"]), persisted_origin)
+        if state == "delivering":
+            lease = row["delivery_lease_expires_at"]
+            if lease is not None and int(lease) > now:
+                return DeliveryClaim("in_progress", str(row["session_id"]), persisted_origin)
+            # A process may have died after sending but before recording the
+            # receipt.  Retrying it could duplicate a chat message, so retain
+            # an auditable terminal state instead of an immortal lease.
+            conn.execute(
+                """UPDATE intake_reply_tokens SET delivery_state='uncertain',
+                   delivery_lease_expires_at=NULL
+                   WHERE token=? AND delivery_id=? AND delivery_state='delivering'""",
+                (token, delivery_id),
+            )
+            return DeliveryClaim("uncertain", str(row["session_id"]), persisted_origin)
+        if state == "uncertain":
+            return DeliveryClaim("uncertain", str(row["session_id"]), persisted_origin)
+        updated = conn.execute(
+            """UPDATE intake_reply_tokens
+            SET delivery_id=?, delivery_state='delivering',
+                delivery_lease_expires_at=?, origin_json=?
+            WHERE token=? AND delivery_state!='delivering'""",
+            (delivery_id, now + DELIVERY_LEASE_SECONDS, _origin_json(persisted_origin), token),
+        )
+        if updated.rowcount != 1:
+            return DeliveryClaim("in_progress", str(row["session_id"]), persisted_origin)
+        return DeliveryClaim("claimed", str(row["session_id"]), persisted_origin)
+
+
+def finish_delivery(token: str, delivery_id: str, *, now: int | None = None) -> bool:
+    """Commit a successful original-session delivery exactly once."""
+    now = int(time.time()) if now is None else int(now)
+    with _connect() as conn:
+        result = conn.execute(
+            """UPDATE intake_reply_tokens
+            SET delivery_state='delivered', consumed_at=?, delivery_lease_expires_at=NULL
+            WHERE token=? AND delivery_id=? AND delivery_state='delivering'""",
+            (now, token, delivery_id),
+        )
+        return result.rowcount == 1
+
+
+def release_delivery(token: str, delivery_id: str) -> None:
+    """Make an unsuccessful delivery retryable with the same delivery id."""
+    with _connect() as conn:
+        conn.execute(
+            """UPDATE intake_reply_tokens
+            SET delivery_state='pending', delivery_lease_expires_at=NULL
+            WHERE token=? AND delivery_id=? AND delivery_state='delivering'""",
+            (token, delivery_id),
+        )
+
+
+def register_actions(
+    *, token: str, delivery_id: str, session_id: str, payload: dict[str, Any], now: int | None = None
+) -> bool:
+    """Persist only the fixed callback choices which Hermes is allowed to run."""
+    now = int(time.time()) if now is None else int(now)
+    try:
+        item_id = int(payload["item_id"])
+        attempt = int(payload["analysis_attempt"])
+        status = str(payload["analysis_status"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    expected = (
+        {1: "approve_item", 2: "save_note_and_approve", 3: "leave_pending"}
+        if status == "succeeded"
+        else {1: "process_item", 2: "leave_pending"}
+        if status == "failed"
+        else None
+    )
+    raw_options = payload.get("numbered_replies")
+    if not expected or not isinstance(raw_options, list) or item_id <= 0 or attempt <= 0:
+        return False
+    options: dict[int, dict[str, Any]] = {}
+    for option in raw_options:
+        if not isinstance(option, dict):
+            return False
+        try:
+            number = int(option.get("number"))
+        except (TypeError, ValueError):
+            return False
+        action = option.get("action")
+        option_attempt = option.get("attempt")
+        idempotency_key = option.get("idempotency_key")
+        expected_key = f"link:{item_id}:attempt:{attempt}:{action}"
+        if (
+            expected.get(number) != action
+            or option_attempt != attempt
+            or not isinstance(idempotency_key, str)
+            or idempotency_key != expected_key
+        ):
+            return False
+        options[number] = {
+            "action": action,
+            "analysis_attempt": attempt,
+            "idempotency_key": idempotency_key,
+        }
+    if {number: option["action"] for number, option in options.items()} != expected:
+        return False
+    options_json = json.dumps(options, sort_keys=True)
+    with _connect() as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO intake_callback_actions
+            (delivery_id, token, session_id, item_id, analysis_attempt,
+             analysis_status, options_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (delivery_id, token, session_id, item_id, attempt, status, options_json, now),
+        )
+        persisted = conn.execute(
+            """SELECT token, session_id, item_id, analysis_attempt,
+                      analysis_status, options_json
+            FROM intake_callback_actions WHERE delivery_id=?""",
+            (delivery_id,),
+        ).fetchone()
+        return bool(
+            persisted is not None
+            and persisted["token"] == token
+            and persisted["session_id"] == session_id
+            and int(persisted["item_id"]) == item_id
+            and int(persisted["analysis_attempt"]) == attempt
+            and persisted["analysis_status"] == status
+            and persisted["options_json"] == options_json
+        )
+
+
+def discard_actions(delivery_id: str) -> None:
+    with _connect() as conn:
+        conn.execute("DELETE FROM intake_callback_actions WHERE delivery_id=?", (delivery_id,))
+
+
+def select_action(session_id: str, choice: str, *, now: int | None = None) -> dict[str, Any] | None:
+    """Record one numbered choice for a delivered callback, idempotently."""
+    try:
+        number = int(choice.strip())
+    except (AttributeError, TypeError, ValueError):
+        return None
+    now = int(time.time()) if now is None else int(now)
+    with _connect() as conn:
+        _cleanup(conn, now)
+        rows = conn.execute(
+            """SELECT a.* FROM intake_callback_actions a
+            JOIN intake_reply_tokens t ON t.token=a.token
+            WHERE a.session_id=? AND a.action_state IN ('pending', 'selected')
+              AND t.delivery_state='delivered' AND t.expires_at>?
+            ORDER BY a.created_at DESC""",
+            (session_id, now),
+        ).fetchall()
+        if len(rows) != 1:
+            return None
+        row = rows[0]
+        options = json.loads(row["options_json"])
+        selected = row["selected_option"]
+        if selected is not None:
+            return {"duplicate": True, "choice": int(selected), "delivery_id": row["delivery_id"]}
+        option = options.get(str(number))
+        if not isinstance(option, dict):
+            return None
+        result = conn.execute(
+            """UPDATE intake_callback_actions
+            SET selected_option=?, action_state='selected'
+            WHERE delivery_id=? AND selected_option IS NULL AND action_state='pending'""",
+            (number, row["delivery_id"]),
+        )
+        if result.rowcount != 1:
+            return None
+        return {
+            "duplicate": False,
+            "choice": number,
+            "action": option["action"],
+            "item_id": int(row["item_id"]),
+            "analysis_attempt": int(option["analysis_attempt"]),
+            "idempotency_key": option["idempotency_key"],
+            "delivery_id": row["delivery_id"],
+        }
+
+
+def claim_action_tool(session_id: str, tool_name: str, args: dict[str, Any]) -> bool:
+    """Allow a selected callback action once, and only for its exact item."""
+    name = tool_name.removeprefix("mcp_mis_")
+    with _connect() as conn:
+        row = conn.execute(
+            """SELECT * FROM intake_callback_actions
+            WHERE session_id=? AND action_state IN ('selected', 'note_claimed')
+            ORDER BY created_at DESC LIMIT 1""",
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        options = json.loads(row["options_json"])
+        option = options.get(str(row["selected_option"]))
+        if not isinstance(option, dict):
+            return False
+        action = option.get("action")
+        attempt = option.get("analysis_attempt")
+        idempotency_key = option.get("idempotency_key")
+        if (
+            attempt != int(row["analysis_attempt"])
+            or not isinstance(idempotency_key, str)
+            or args.get("analysis_attempt") != attempt
+            or args.get("idempotency_key") != idempotency_key
+        ):
+            return False
+        if name != "ingest_note":
+            try:
+                item_id = int(args.get("item_id"))
+            except (AttributeError, TypeError, ValueError):
+                return False
+            if item_id != int(row["item_id"]):
+                return False
+        if action == "approve_item" and name == "approve_item":
+            column, state = "approve_claimed_at", "completed"
+        elif action == "process_item" and name == "process_item":
+            column, state = "process_claimed_at", "completed"
+        elif action == "save_note_and_approve" and name == "ingest_note" and row["action_state"] == "selected":
+            column, state = "note_claimed_at", "note_claimed"
+        elif action == "save_note_and_approve" and name == "approve_item" and row["action_state"] == "note_claimed":
+            column, state = "approve_claimed_at", "completed"
+        else:
+            return False
+        result = conn.execute(
+            f"UPDATE intake_callback_actions SET {column}=?, action_state=? "
+            "WHERE delivery_id=? AND action_state=?",
+            (int(time.time()), state, row["delivery_id"], row["action_state"]),
+        )
+        return result.rowcount == 1
+
+
+def bound_action_args(session_id: str, tool_name: str, args: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the exact, attempt-bound arguments for a selected callback action.
+
+    The callback option is the source of truth.  Model-provided attempts and
+    keys are ignored rather than trusted; a mismatched tool or stale selection
+    returns ``None`` and remains approval-gated.
+    """
+    name = tool_name.removeprefix("mcp_mis_")
+    with _connect() as conn:
+        row = conn.execute(
+            """SELECT * FROM intake_callback_actions
+            WHERE session_id=? AND action_state IN ('selected', 'note_claimed')
+            ORDER BY created_at DESC LIMIT 1""",
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        option = json.loads(row["options_json"]).get(str(row["selected_option"]))
+        if not isinstance(option, dict):
+            return None
+        action = option.get("action")
+        if action == "approve_item" and name != "approve_item":
+            return None
+        if action == "process_item" and name != "process_item":
+            return None
+        # The callback contract has no immutable note body.  Do not let a
+        # later conversational turn turn option 2 into arbitrary text intake.
+        if action == "save_note_and_approve":
+            return None
+        if action not in {"approve_item", "process_item"}:
+            return None
+        return {
+            "item_id": int(row["item_id"]),
+            "analysis_attempt": int(option["analysis_attempt"]),
+            "idempotency_key": str(option["idempotency_key"]),
+        }

--- a/tests/gateway/test_intake_callback.py
+++ b/tests/gateway/test_intake_callback.py
@@ -1,0 +1,381 @@
+"""Durable, original-session delivery tests for Hermes intake callbacks."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter
+from gateway.session import SessionSource
+from hermes_cli.intake_reply_tokens import (
+    DELIVERY_LEASE_SECONDS,
+    TTL_SECONDS,
+    begin_delivery,
+    bound_action_args,
+    claim_action_tool,
+    finish_delivery,
+    mint,
+    register_actions,
+    select_action,
+)
+
+
+SECRET = "callback-secret"
+
+
+def _payload(token: str, *, delivery_id: str = "delivery-1") -> dict:
+    return {
+        "event": "link_analyzed",
+        "reply_token": token,
+        "delivery_id": delivery_id,
+        "item_id": 42,
+        "analysis_status": "succeeded",
+        "analysis_attempt": 1,
+        "summary": "Link analysis complete item 42.",
+        "numbered_replies": [
+            {
+                "number": 1,
+                "action": "approve_item",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:approve_item",
+            },
+            {
+                "number": 2,
+                "action": "save_note_and_approve",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:save_note_and_approve",
+            },
+            {
+                "number": 3,
+                "action": "leave_pending",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:leave_pending",
+            },
+        ],
+    }
+
+
+def _sign(body: bytes, timestamp: str) -> str:
+    return hmac.new(
+        SECRET.encode(), timestamp.encode() + b"." + body, hashlib.sha256
+    ).hexdigest()
+
+
+def _adapter() -> WebhookAdapter:
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "routes": {
+                    "intake": {
+                        "secret": SECRET,
+                        "events": ["link_analyzed"],
+                        "intake_callback": True,
+                    }
+                },
+            },
+        )
+    )
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _wire_original_session(adapter: WebhookAdapter, session_id: str) -> AsyncMock:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="original-chat",
+        chat_type="dm",
+        user_id="operator",
+        thread_id="topic-7",
+    )
+    target = AsyncMock()
+    target.send = AsyncMock(return_value=SendResult(success=True))
+    store = MagicMock()
+    store.lookup_by_session_id.return_value = SimpleNamespace(origin=source)
+    runner = MagicMock()
+    runner.session_store = store
+    runner.adapters = {Platform.TELEGRAM: target}
+    runner.config.get_home_channel.return_value = None
+    adapter.gateway_runner = runner
+    return target
+
+
+async def _post(client: TestClient, payload: dict) -> web.Response:
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    timestamp = str(int(time.time()))
+    return await client.post(
+        "/webhooks/intake",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Webhook-Timestamp": timestamp,
+            "X-Webhook-Signature-V2": _sign(body, timestamp),
+        },
+    )
+
+
+def test_reply_token_delivery_survives_restart_and_rejects_ttl(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = mint("session-1", now=100)
+    origin = {"platform": "telegram", "chat_id": "chat-1", "thread_id": "topic"}
+    assert begin_delivery(token, "d-1", origin, now=101).status == "claimed"
+    assert finish_delivery(token, "d-1", now=102)
+    # A fresh process reads the committed state.db receipt rather than sending
+    # the original chat a second time.
+    assert begin_delivery(token, "d-1", origin, now=103).status == "delivered"
+
+    expired = mint("session-2", now=100)
+    assert begin_delivery(expired, "d-2", origin, now=100 + TTL_SECONDS).status == "expired"
+
+    stuck = mint("session-3", now=100)
+    assert begin_delivery(stuck, "d-3", origin, now=101).status == "claimed"
+    assert begin_delivery(stuck, "d-3", origin, now=101 + DELIVERY_LEASE_SECONDS).status == "uncertain"
+    assert begin_delivery(stuck, "d-3", origin, now=102 + DELIVERY_LEASE_SECONDS).status == "uncertain"
+
+
+def test_action_ledger_is_attempt_bound_idempotent_and_fail_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = mint("session-1", now=100)
+    assert begin_delivery(token, "d-1", {"platform": "telegram", "chat_id": "c"}, now=101).status == "claimed"
+    assert finish_delivery(token, "d-1", now=102)
+    payload = _payload(token)
+    assert register_actions(token=token, delivery_id="d-1", session_id="session-1", payload=payload, now=103)
+
+    selected = select_action("session-1", "1", now=104)
+    assert selected and selected["action"] == "approve_item"
+    duplicate = select_action("session-1", "1", now=105)
+    assert duplicate == {"duplicate": True, "choice": 1, "delivery_id": "d-1"}
+    bound = bound_action_args("session-1", "mcp_mis_approve_item", {})
+    assert bound == {
+        "item_id": 42,
+        "analysis_attempt": 1,
+        "idempotency_key": "link:42:attempt:1:approve_item",
+    }
+    assert not claim_action_tool(
+        "session-1", "mcp_mis_approve_item", {"item_id": 42, "analysis_attempt": 2,
+                                                   "idempotency_key": "link:42:attempt:2:approve_item"}
+    )
+    assert claim_action_tool("session-1", "mcp_mis_approve_item", bound)
+    assert not claim_action_tool("session-1", "mcp_mis_approve_item", bound)
+    assert not claim_action_tool("session-1", "mcp_mis_process_item", bound)
+
+    prohibited = _payload(token, delivery_id="d-2")
+    prohibited["numbered_replies"][0]["action"] = "clone_repository"
+    assert not register_actions(token=token, delivery_id="d-2", session_id="session-1", payload=prohibited)
+
+    collision = _payload("different-token", delivery_id="d-1")
+    assert not register_actions(
+        token="different-token", delivery_id="d-1", session_id="session-2", payload=collision
+    )
+
+
+def test_stale_callback_attempt_cannot_claim_newer_attempt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = mint("session-1", now=100)
+    origin = {"platform": "telegram", "chat_id": "c"}
+    assert begin_delivery(token, "d-1", origin, now=101).status == "claimed"
+    assert finish_delivery(token, "d-1", now=102)
+    first = _payload(token, delivery_id="d-1")
+    assert register_actions(token=token, delivery_id="d-1", session_id="session-1", payload=first, now=103)
+    # A separate later callback in the same session makes an unqualified
+    # numeric reply ambiguous; Hermes fails closed instead of acting on either.
+    token2 = mint("session-1", now=104)
+    assert begin_delivery(token2, "d-2", origin, now=105).status == "claimed"
+    assert finish_delivery(token2, "d-2", now=106)
+    later = _payload(token2, delivery_id="d-2")
+    later["analysis_attempt"] = 2
+    for option in later["numbered_replies"]:
+        option["attempt"] = 2
+        option["idempotency_key"] = f"link:42:attempt:2:{option['action']}"
+    assert register_actions(token=token2, delivery_id="d-2", session_id="session-1", payload=later, now=107)
+    assert select_action("session-1", "1", now=108) is None
+
+
+@pytest.mark.asyncio
+async def test_callback_delivers_once_and_returns_body_bound_signed_receipt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = mint("session-1")
+    adapter = _adapter()
+    target = _wire_original_session(adapter, "session-1")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        first = await _post(client, _payload(token))
+        assert first.status == 200
+        receipt_body = await first.read()
+        receipt = json.loads(receipt_body)
+        assert receipt == {
+            "status": "delivered",
+            "delivery_id": "delivery-1",
+            "original_session_delivered": True,
+            "action_ledger_ready": True,
+        }
+        receipt_timestamp = first.headers["X-Hermes-Receipt-Timestamp"]
+        assert hmac.compare_digest(
+            first.headers["X-Hermes-Receipt-Signature-V2"],
+            _sign(receipt_body, receipt_timestamp),
+        )
+        repeated = await _post(client, _payload(token))
+        assert repeated.status == 200
+    target.send.assert_awaited_once()
+    assert target.send.await_args.args[0] == "original-chat"
+    assert target.send.await_args.kwargs["metadata"] == {"thread_id": "topic-7"}
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_wrong_token_without_delivery(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    adapter = _adapter()
+    target = _wire_original_session(adapter, "session-1")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await _post(client, _payload("not-a-real-token"))
+        assert response.status == 404
+    target.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_replay_attack_rejected(monkeypatch, tmp_path):
+    """Replaying a delivery ID with mismatched payload or after delivery fails closed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = mint("session-replay")
+    adapter = _adapter()
+    target = _wire_original_session(adapter, "session-replay")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        # First valid delivery
+        p1 = _payload(token, delivery_id="delivery-replay-1")
+        r1 = await _post(client, p1)
+        assert r1.status == 200
+
+        # Immediate replay with different payload content
+        p2 = _payload(token, delivery_id="delivery-replay-1")
+        p2["summary"] = "Tampered summary replay"
+        r2 = await _post(client, p2)
+        # Idempotent receipt returned without re-dispatching
+        assert r2.status == 200
+    # Target only received the message exactly once
+    assert target.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_callback_expired_token_rejected(monkeypatch, tmp_path):
+    """Callback after TTL expiration is refused and fails closed with expired status."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    past_time = int(time.time()) - (25 * 3600)  # 25 hours ago
+    token = mint("session-expired", now=past_time)
+    adapter = _adapter()
+    target = _wire_original_session(adapter, "session-expired")
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await _post(client, _payload(token, delivery_id="delivery-expired-1"))
+        assert response.status == 409
+        body = await response.read()
+        parsed = json.loads(body)
+        assert parsed["error"] == "Rejected callback capability"
+    target.send.assert_not_awaited()
+
+
+def test_authz_mixin_intake_action_authorized_positive(tmp_path, monkeypatch):
+    """Positive test: an intake action tool call registered in the ledger is authorized."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from gateway.authz_mixin import GatewayAuthorizationMixin as AuthzMixin
+    from gateway.session import SessionSource
+    from hermes_cli.intake_reply_tokens import mint, register_actions, select_action, begin_delivery, finish_delivery
+
+    session_id = "session-authz-pos"
+    token = mint(session_id)
+    begin_delivery(token=token, delivery_id="deliv-pos", origin={"platform": "cli", "chat_id": "c1"})
+    finish_delivery(token, "deliv-pos")
+    payload = {
+        "item_id": 42,
+        "analysis_attempt": 1,
+        "analysis_status": "succeeded",
+        "numbered_replies": [
+            {
+                "number": 1,
+                "action": "approve_item",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:approve_item",
+            },
+            {
+                "number": 2,
+                "action": "save_note_and_approve",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:save_note_and_approve",
+            },
+            {
+                "number": 3,
+                "action": "leave_pending",
+                "attempt": 1,
+                "idempotency_key": "link:42:attempt:1:leave_pending",
+            },
+        ],
+    }
+    assert register_actions(token=token, delivery_id="deliv-pos", session_id=session_id, payload=payload) is True
+    assert select_action(session_id, "1") is not None
+
+    mixin = AuthzMixin()
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id=session_id,
+        user_id="webhook-user",
+    )
+    source.action_tool = "approve_item"
+    source.action_args = {
+        "item_id": 42,
+        "analysis_attempt": 1,
+        "idempotency_key": "link:42:attempt:1:approve_item",
+    }
+    # The authorized intake action proceeds
+    assert mixin._is_user_authorized(source) is True
+
+
+def test_authz_mixin_intake_action_unauthorized_negative_denied(tmp_path, monkeypatch):
+    """Negative test: an unauthorized intake action tool call is refused and denied."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from gateway.authz_mixin import GatewayAuthorizationMixin as AuthzMixin
+    from gateway.session import SessionSource
+
+    session_id = "session-authz-neg"
+    mixin = AuthzMixin()
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id=session_id,
+        user_id="webhook-user",
+    )
+    source.action_tool = "arbitrary_unauthorized_tool"
+    source.action_args = {"item_id": 999}
+    # Refused because no ledger claim exists
+    assert mixin._is_user_authorized(source) is False
+
+
+def test_authz_mixin_intake_action_fails_closed_on_missing_session_or_tool(tmp_path, monkeypatch):
+    """Negative test: missing session or missing tool name fails closed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from gateway.authz_mixin import GatewayAuthorizationMixin as AuthzMixin
+    from gateway.session import SessionSource
+
+    mixin = AuthzMixin()
+    # Missing session
+    source_no_session = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id="",
+        user_id="webhook-user",
+    )
+    source_no_session.action_tool = "approve_item"
+    assert mixin._is_user_authorized(source_no_session) is False
+
+    # Empty tool name
+    assert mixin.check_intake_tool_authorization(source_no_session, "", {}) is False
+    assert mixin.check_intake_tool_authorization(None, "approve_item", {}) is False


### PR DESCRIPTION
## What does this PR do?

Introduces authenticated intake callbacks and HMAC-signed reply-token delivery for webhook/gateway message ingestion.

This establishes cryptographic verification and non-replayable token delivery for asynchronous callback responses, ensuring that incoming webhook callbacks authenticate the originating session context without exposing raw internal session keys or accepting forged payloads.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/authz_mixin.py`: Intake authorization mixin and signature check hooks.
- `gateway/platforms/webhook.py`: Webhook intake callback endpoint and reply-token dispatch logic.
- `hermes_cli/intake_reply_tokens.py`: HMAC token generation, expiration tracking, replay prevention, and signature verification.
- `tests/gateway/test_intake_callback.py`: Full test suite testing authenticated callbacks, token expiry, tampered payload rejection, and delivery workflows.

## How to Test

1. Run the test suite:
   ```bash
   pytest tests/gateway/test_intake_callback.py
   ```
2. Verify all 10 tests pass covering valid callback delivery, expired/tampered token rejection, and replay protections.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x / Darwin aarch64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A