### PR TITLE
fix(tui_gateway): surface model fallback switches as durable chat markers

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11788,6 +11788,48 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             server._sessions.pop("sid", None)
 
 
+def test_append_fallback_marker_dedups_and_persists():
+    """Fallback-chain switches become durable model_switch-kind markers.
+
+    The latest fallback marker stays in the live (re-sent) history while every
+    notice persists to the session DB, so the desktop transcript explains why
+    the model changed. Fallback markers use their own prefix and are never
+    mistaken for (or clobbered by) user-initiated model-switch markers.
+    """
+    from tui_gateway.server import _MODEL_SWITCH_MARKER_PREFIX
+    from tui_gateway.server import _append_fallback_marker, _is_fallback_marker
+
+    class _FakeDB:
+        def __init__(self):
+            self.rows = []
+
+        def append_message(self, **kw):
+            self.rows.append(kw)
+
+    class _FakeAgent:
+        _session_db = _FakeDB()
+
+    session = {"session_key": "sid", "history": [], "agent": _FakeAgent()}
+    notice1 = "⚠️ Model fallback: opus via nous unavailable (connection error); using ox via nous."
+    notice2 = "⚠️ Model fallback: deepseek via nous unavailable (timeout); using ox via nous."
+
+    _append_fallback_marker(session, notice1)
+    assert len(session["history"]) == 1
+    assert session["history"][0]["role"] == "user"
+    assert session["history"][0]["display_kind"] == "model_switch"
+
+    _append_fallback_marker(session, notice2)
+    assert len(session["history"]) == 1, "latest fallback marker replaces the old one"
+    assert "timeout" in session["history"][0]["content"]
+    assert len(session["agent"]._session_db.rows) == 2, "every notice persists to the DB"
+    assert all(r["display_kind"] == "model_switch" for r in session["agent"]._session_db.rows)
+    assert _is_fallback_marker(session["history"][0])
+
+    # A user-initiated switch marker is not a fallback marker (and vice versa).
+    user_switch = {"role": "user", "content": f"{_MODEL_SWITCH_MARKER_PREFIX}x.]"}
+    assert not _is_fallback_marker(user_switch)
+
+
 def test_prompt_submit_merges_on_personality_pivot_marker(monkeypatch):
     """A personality pivot injected mid-turn must merge like a model switch.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2368,6 +2368,16 @@ def _status_update(sid: str, kind: str, text: str | None = None):
 
         if COMPACTION_STATUS_MARKER in body:
             out_kind = "compacting"
+    # Surface fallback-chain switches as durable chat markers, not just a
+    # transient status flash: "why did my model change" should be answerable
+    # from the transcript.
+    if out_kind == "lifecycle" and body.startswith(_FALLBACK_MARKER_PREFIX):
+        try:
+            _session = _sessions.get(sid)
+            if _session is not None:
+                _append_fallback_marker(_session, body)
+        except Exception:
+            logger.debug("failed to append fallback marker", exc_info=True)
     _emit("status.update", sid, {"kind": out_kind, "text": body})
 
 
@@ -5046,6 +5056,76 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
                 )
     except Exception:
         logger.debug("failed to persist model switch marker", exc_info=True)
+
+
+# Stable leading text of the fallback notice built in
+# ``agent.chat_completion_helpers.try_activate_fallback``. Shared by the
+# detection hook in ``_status_update`` and the marker dedup below.
+_FALLBACK_MARKER_PREFIX = "⚠️ Model fallback:"
+
+
+def _is_fallback_marker(entry: Any) -> bool:
+    """Whether a history entry is a (self-replacing) fallback marker."""
+    content = entry.get("content") if isinstance(entry, dict) else None
+    return isinstance(content, str) and content.startswith(_FALLBACK_MARKER_PREFIX)
+
+
+def _append_fallback_marker(session: dict | None, notice: str) -> None:
+    """Record a durable, user-visible marker when the fallback chain fires.
+
+    Mirrors ``_append_model_switch_marker``: the latest fallback marker is kept
+    in the live (re-sent) history and the row is persisted to the session DB, so
+    the desktop transcript shows why the model changed even after a reload.
+    Fallback markers use their own prefix and never clobber user-initiated
+    ``model_switch`` markers (and vice versa).
+    """
+    if not session:
+        return
+    session_key = str(session.get("session_key") or "").strip()
+    if not session_key:
+        return
+
+    entry = {"role": "user", "content": notice, "display_kind": "model_switch"}
+
+    def _replace_markers() -> None:
+        history = session.setdefault("history", [])
+        # Drop any earlier fallback markers in place before appending the new
+        # one, so N fallbacks leave one marker instead of N stale ones that
+        # would otherwise be re-sent on every later API call.
+        history[:] = [h for h in history if not _is_fallback_marker(h)]
+        history.append(entry)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+
+    lock = session.get("history_lock")
+    if lock is not None:
+        with lock:
+            _replace_markers()
+    else:
+        _replace_markers()
+
+    try:
+        agent = session.get("agent")
+        db = getattr(agent, "_session_db", None) if agent is not None else None
+        if db is not None:
+            db.append_message(
+                session_id=session_key,
+                role="user",
+                content=notice,
+                display_kind="model_switch",
+            )
+            return
+
+        _ensure_session_db_row(session)
+        with _session_db(session) as scoped_db:
+            if scoped_db is not None:
+                scoped_db.append_message(
+                    session_id=session_key,
+                    role="user",
+                    content=notice,
+                    display_kind="model_switch",
+                )
+    except Exception:
+        logger.debug("failed to persist fallback marker", exc_info=True)
 
 
 def _write_config_key(key_path: str, value):


### PR DESCRIPTION
## What

When the model fallback chain activates, the notice (`⚠️ Model fallback: X via Y unavailable (reason); using Z via Y`) was only emitted as a transient `status.update` event. On the desktop the status stack is easy to miss, so users saw the model change mid-session with no explanation in the transcript.

This makes the fallback switch a durable chat marker, mirroring how user-initiated `/model` switches already surface (`_append_model_switch_marker`):

- `_status_update` detects fallback notices by their stable prefix (built in `try_activate_fallback`) and appends a `display_kind: "model_switch"` marker to the session history + DB.
- Only the latest fallback marker stays in the live (re-sent) payload; every notice persists to the DB, so the transcript explains the switch even after a reload.
- Fallback markers use their own prefix (`_FALLBACK_MARKER_PREFIX`) and never clobber user-initiated switch markers (and vice versa).

## Why

Silent model switching is confusing when it happens mid-turn, and there was no durable record of the reason. This closes that gap with the smallest surface: reuse the existing marker plumbing, no frontend changes.

## Test

Added `test_append_fallback_marker_dedups_and_persists` covering append, dedup (latest fallback marker replaces the old one in live history), DB persistence, and prefix isolation from user switch markers.

Verified: `pytest tests/test_tui_gateway_server.py -k "fallback_marker or model_switch_marker"` → 2 passed.
