### PR TITLE
fix(kanban): stop the drifted-table rebuild leaving a dangling trigger

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2933,6 +2933,17 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
     if not drifted:
         return
 
+    # SQLite rewrites references to a renamed table inside triggers and
+    # views, so ``ALTER TABLE task_events RENAME TO task_events_legacy``
+    # silently repoints the ``tasks_status_transition_history`` trigger at
+    # the legacy table -- which this function then DROPs, leaving a trigger
+    # that raises "no such table: main.task_events_legacy" on the next
+    # status update. A board migrates cleanly and then breaks on its first
+    # transition. ``legacy_alter_table`` suppresses that rewrite, which is
+    # what a rename-based rebuild wants: the trigger keeps naming
+    # ``task_events`` and the freshly created table takes over that name.
+    prior_legacy_alter = conn.execute("PRAGMA legacy_alter_table").fetchone()[0]
+    conn.execute("PRAGMA legacy_alter_table=ON")
     conn.execute("BEGIN IMMEDIATE")
     try:
         for table in drifted:
@@ -2969,6 +2980,10 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
         except sqlite3.OperationalError:
             pass
         raise
+    finally:
+        conn.execute(
+            "PRAGMA legacy_alter_table=" + ("ON" if prior_legacy_alter else "OFF")
+        )
 
 
 def _check_file_length_invariant(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
`_rebuild_drifted_tables` renames each drifted table aside, recreates it, copies the rows and drops the old one. SQLite **rewrites references to a renamed table inside triggers and views**, so

```sql
ALTER TABLE task_events RENAME TO task_events_legacy
```

silently repoints the `tasks_status_transition_history` trigger — installed by `_migrate_add_optional_columns` — at `task_events_legacy`. The rebuild then `DROP`s that table, leaving the trigger naming something that no longer exists.

The board **migrates cleanly and reports success**, then breaks on the first status update afterwards:

```
sqlite3.OperationalError: error in trigger tasks_status_transition_history:
no such table: main.task_events_legacy
```

### Scope

Not Windows-specific, and it doesn't need unusual drift — only a board old enough for `_table_has_drifted` to fire, which is exactly the population this function exists to repair.

### Verified as a mechanism, not inferred

Standalone reproduction on sqlite 3.53.1, both legs:

| | trigger ends up referencing | next `UPDATE tasks SET status=…` |
| --- | --- | --- |
| current behaviour | `task_events_legacy` | **fails** — no such table |
| `legacy_alter_table=ON` | `task_events` | succeeds |

`legacy_alter_table` is the documented requirement for the rename-based rebuild pattern: the trigger must keep naming the table so the freshly created table takes over that name. The pragma is saved and restored around the rebuild rather than left set, and the restore sits in a `finally` so an aborted rebuild can't leak the setting into the caller's connection.

### How it was found

Running the kanban suite on Windows — where CI doesn't run it. The three `test_kanban_db_init.py` legacy-migration tests fail on this. They pass with this change and **needed no edits**; they were already asserting the right thing.
