### PR TITLE
fix(images): attach local images referenced by Windows paths

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -65,8 +65,19 @@ _IMAGE_EXT_PATTERN = "|".join(e.lstrip(".") for e in _IMAGE_EXTS)
 # Absolute / home-relative local image path. Matches the same shape gateway's
 # extract_local_files() uses: anchors to ``~/`` or ``/``, ignores matches inside
 # URLs (the ``(?<![/:\w.])`` lookbehind), and case-insensitive on the extension.
+#
+# The second alternative is the Windows drive-letter form (``C:\dir\x.png``
+# or ``C:/dir/x.png``). Without it a worker on Windows silently attaches
+# nothing: every native absolute path a task body can carry starts with a
+# drive letter, not ``/``. Its lookbehind refuses a drive letter preceded by
+# a word char, dot, colon or slash, so URL shapes like
+# ``https://host/s:/a.png`` still do not match.
 _LOCAL_IMAGE_PATH_RE = re.compile(
-    r"(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:" + _IMAGE_EXT_PATTERN + r")\b",
+    r"(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:" + _IMAGE_EXT_PATTERN + r")\b"
+    r"|"
+    r"(?<![\w:.\\/])[A-Za-z]:[\\/](?:[\w.\-]+[\\/])*[\w.\-]+\.(?:"
+    + _IMAGE_EXT_PATTERN
+    + r")\b",
     re.IGNORECASE,
 )
 
@@ -119,7 +130,12 @@ def extract_image_refs(text: str) -> Tuple[List[str], List[str]]:
         if _in_code(match.start()):
             continue
         raw = match.group(0)
-        expanded = os.path.expanduser(raw)
+        # normpath settles the separator: expanduser concatenates the home
+        # dir onto the rest of the match, so ``~/x.png`` on Windows comes
+        # back as ``C:\Users\me/x.png``. isfile() tolerates that, but the
+        # path is also echoed to the model in the text part and keyed for
+        # dedup, so it should read as one platform's path, not a mix.
+        expanded = os.path.normpath(os.path.expanduser(raw))
         try:
             if not os.path.isfile(expanded):
                 continue

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -364,8 +364,12 @@ class TestExtractImageRefs:
         assert urls == []
 
     def test_finds_home_relative_path(self, tmp_path: Path, monkeypatch):
-        # Simulate ~/foo.png by pointing HOME at tmp_path and creating the file
+        # Simulate ~/foo.png by pointing home at tmp_path and creating the
+        # file. ntpath.expanduser reads USERPROFILE and ignores HOME, so
+        # setting only HOME leaves the expansion pointing at the real
+        # profile on Windows.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         img = tmp_path / "foo.png"
         img.write_bytes(_png_bytes())
         paths, urls = extract_image_refs("see ~/foo.png please")


### PR DESCRIPTION
`extract_image_refs` anchors local paths to `~/` or `/`, so a task body naming a native Windows path never matches. Every absolute path a Windows task body can carry starts with a drive letter — so a worker on Windows attaches **no images at all**. No error, no entry in `skipped`; the model simply never sees the picture.

### The fix

Adds the drive-letter alternative (`C:\dir\x.png` and `C:/dir/x.png`). Its lookbehind refuses a drive letter preceded by a word character, dot, colon or slash, so URL shapes stay excluded.

Verified rather than assumed — every case measured against both the old and new pattern:

| input | before | after |
| --- | --- | --- |
| `C:\Users\...\screenshot.png` | *no match* | matched |
| `C:/Users/.../b.png` | *no match* | matched |
| `/home/u/pics/a.png` | matched | matched (unchanged) |
| `~/foo.png` | matched | matched (unchanged) |
| `https://example.com/photos/cat.png` | no match | no match |
| `https://x.io/s:/a.png` (adversarial) | no match | no match |

### Also: separator normalisation

`expanduser` concatenates the home dir onto the remainder, so `~/x.png` returned `C:\Users\me/x.png`. `isfile()` tolerates that, but the string is echoed to the model in the text part (`[Image attached at: …]`) and used as the dedup key, so it should read as one platform's path rather than a mix.

### Test change

`test_finds_home_relative_path` set only `HOME`. `ntpath.expanduser` reads `USERPROFILE` and ignores `HOME`, so on Windows the expansion pointed at the real profile directory instead of the fixture's `tmp_path`. It now sets both — the assertion itself is unchanged.

### How it was found

Running the suite on Windows. The `windows-latest` lane in `tests-os.yml` selects `-m windows_only`, and neither affected test carries that marker — so no lane would ever have executed them on Windows. That's the blind spot: a test that isn't *about* Windows but *breaks* on it.
