### PR TITLE
fix(state): retag legacy kanban worker rows on Windows

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13760,9 +13760,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             cursor = conn.execute(
+                # Match either separator. The stored cwd uses the platform's
+                # own, so a '/'-only pattern retags nothing on Windows and
+                # those legacy worker rows stay in the session list forever --
+                # and the state_meta gate below then marks this root done, so
+                # the miss is permanent rather than retried. Mirrors the
+                # both-separator shape _cwd_prefix_clause already uses.
                 "UPDATE sessions SET source = 'kanban' "
-                "WHERE source = 'cli' AND (cwd = ? OR cwd LIKE ? ESCAPE '\\')",
-                (prefix, _escape_like(prefix) + "/%"),
+                "WHERE source = 'cli' AND (cwd = ? OR cwd LIKE ? ESCAPE '\\' "
+                "OR cwd LIKE ? ESCAPE '\\')",
+                (prefix, _escape_like(prefix) + "/%",
+                 _escape_like(prefix) + "\\\\%"),
             )
             # Read rowcount before set_meta reuses this cursor for its INSERT,
             # which would otherwise overwrite it with the meta write's count.


### PR DESCRIPTION
`retag_kanban_worker_sessions` matches child paths with a hardcoded `/`:

```sql
cwd LIKE <prefix> || '/%'
```

The stored `cwd` uses the platform separator, so on Windows **no legacy worker row ever matches** and the retag reports zero. Those rows keep `source='cli'`, so every old kanban worker run stays visible in the session list this function exists to clean up.

The miss is **permanent, not transient**: the `state_meta` gate is written immediately after, marking the root reclaimed, so it is never retried.

### This repo already considers the fix correct

`_cwd_prefix_clause` builds exactly the both-separator shape, and its own comment says why:

> *"the literal separator backslash in the Windows pattern needs escaping for the same reason"*

Four call sites use that helper. `retag_kanban_worker_sessions` is the one that doesn't — and it's the one that breaks. This change mirrors that established shape rather than inventing a new one.

### The prefix match does not widen

Measured, since a LIKE change is exactly where an over-broad match would hide:

| row | before | after |
| --- | --- | --- |
| `<prefix>\t_b21733fb` | not matched | **matched** |
| `<prefix>\t_c0ffee` | not matched | **matched** |
| `<prefix>` (exact) | matched | matched |
| `<prefix>-other\t_x` (sibling) | not matched | **still not matched** |
| unrelated dir | not matched | not matched |

POSIX result set is byte-identical before and after.

### How it was found

Running the kanban suite on Windows, where CI doesn't run it — the `windows-latest` lane selects `-m windows_only` and these tests don't carry that marker. The two `test_kanban_worker_session_source.py` retag tests fail without this and pass with it; they needed no edits.
