### PR TITLE
fix(cli): normalize printable extended-key payloads

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -48,6 +48,47 @@ def _clear_vt100_prefix_cache() -> None:
         pass
 
 
+def _install_printable_extended_key_payload_patch() -> bool:
+    """Make recognized extended printable keys self-insert their character.
+
+    ``Vt100Parser`` normally preserves the complete matched escape sequence in
+    ``KeyPress.data``. That is correct for control keys, but prompt_toolkit's
+    generic self-insert binding inserts ``data`` for printable keys. Therefore
+    an alias such as ``ESC[27;2;83~ -> "S"`` otherwise inserts the literal
+    escape payload instead of ``S``.
+
+    Normalize only a one-character string key whose payload is a CSI sequence.
+    ``Keys`` enum values keep prompt_toolkit's native data behavior. Hermes'
+    current multi-key tuples begin with a ``Keys`` control value, so their
+    payload handling is unchanged. The class patch is process-global and
+    deliberately idempotent.
+    """
+    try:
+        from importlib import import_module
+
+        Vt100Parser = import_module("prompt_toolkit.input.vt100_parser").Vt100Parser
+    except Exception:
+        return False
+
+    original = Vt100Parser._call_handler
+    if getattr(original, "_hermes_printable_payload_patch", False):
+        return False
+
+    def _call_handler(self, key, insert_text):  # noqa: ANN001
+        if (
+            type(key) is str
+            and len(key) == 1
+            and isinstance(insert_text, str)
+            and insert_text.startswith("\x1b[")
+        ):
+            insert_text = key
+        return original(self, key, insert_text)
+
+    setattr(_call_handler, "_hermes_printable_payload_patch", True)
+    Vt100Parser._call_handler = _call_handler
+    return True
+
+
 def install_shift_enter_alias() -> int:
     """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple
     that Alt+Enter produces, so the existing Alt+Enter newline handler
@@ -238,6 +279,8 @@ def install_modify_other_keys_aliases() -> int:
         from prompt_toolkit.keys import Keys
     except Exception:
         return 0
+
+    _install_printable_extended_key_payload_patch()
 
     # -- Ctrl+letter / Ctrl+digit / Ctrl+symbol → Keys.Control* ----
     # codepoint -> Keys value.  The raw control byte for Ctrl+<ch> is

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -31,8 +31,10 @@ def _ensure_alias_installed():
     sibling test files."""
     from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES as _seq
     saved = dict(_seq)
+    saved_call_handler = Vt100Parser._call_handler
     install_modify_other_keys_aliases()
     yield
+    Vt100Parser._call_handler = saved_call_handler
     _seq.clear()
     _seq.update(saved)
     # Drop the parser's prefix cache too — it was computed against the
@@ -262,6 +264,48 @@ def test_modify_other_keys_shift_letter_produces_uppercase(letter):
     assert _parse(csiu_seq) == [upper], (
         f"CSI-u Shift+{letter} ({csiu_seq!r}) should produce '{upper}'"
     )
+
+
+@pytest.mark.parametrize("seq", [
+    "\x1b[27;2;83~",   # modifyOtherKeys, already-shifted codepoint
+    "\x1b[27;2;115~",  # modifyOtherKeys, lowercase codepoint
+    "\x1b[83;2u",      # Kitty CSI-u
+])
+def test_modify_other_keys_shift_letter_inserts_uppercase_not_escape_payload(seq):
+    """The printable key and its insertion payload must both be uppercase.
+
+    prompt_toolkit's generic self-insert binding inserts ``KeyPress.data``, not
+    ``KeyPress.key``.  Mapping the sequence to ``"S"`` while leaving ``data``
+    as the raw escape sequence reproduces the user-visible ``[27;2;83~`` leak.
+    """
+    out = []
+    parser = Vt100Parser(out.append)
+    parser.feed(seq)
+    parser.flush()
+
+    assert len(out) == 1
+    assert out[0].key == "S"
+    assert out[0].data == "S"
+
+
+def test_printable_payload_patch_is_idempotent():
+    from hermes_cli.pt_input_extras import _install_printable_extended_key_payload_patch
+
+    assert _install_printable_extended_key_payload_patch() is False
+
+
+def test_printable_payload_patch_does_not_rewrite_control_tuple_data():
+    from hermes_cli.pt_input_extras import install_shift_enter_alias
+
+    install_shift_enter_alias()
+    seq = "\x1b[27;2;13~"
+    out = []
+    parser = Vt100Parser(out.append)
+    parser.feed(seq)
+    parser.flush()
+
+    assert [press.key for press in out] == [Keys.Escape, Keys.ControlM]
+    assert [press.data for press in out] == [seq, ""]
 
 
 def test_does_not_clobber_shift_enter_alias():


### PR DESCRIPTION
## Summary

- Normalize `KeyPress.data` for recognized one-character CSI key mappings.
- Prevent Ghostty Shift+letter input from inserting the raw `modifyOtherKeys` escape sequence.
- Preserve control-key and multi-key tuple payload behavior.
- Add regression coverage for Ghostty, CSI-u, lowercase codepoints, idempotency, and test isolation.

## Root cause

The classic CLI enables `modifyOtherKeys` in Ghostty so modified keys can be distinguished.

Hermes correctly mapped a sequence such as:

```text
ESC[27;2;83~
```

to the printable key `"S"`. However, prompt_toolkit preserved the original escape sequence in `KeyPress.data`.

Its generic self-insert handler inserts `KeyPress.data`, not `KeyPress.key`, so pressing Shift+S inserted the raw terminal sequence instead of `S`.

This change normalizes the payload only when:

- the resolved key is exactly one printable character; and
- the original payload is a CSI escape sequence.

`Keys` enum values and Hermes's existing control-key tuples retain their native payload behavior.

## Test plan

```text
235 passed
```

Focused suites:

- `tests/cli/test_modify_other_keys_aliases.py`
- `tests/cli/test_cli_shift_enter_newline.py`
- `tests/cli/test_cli_cmd_backspace.py`

Additional verification:

- Ruff passed
- Python compilation passed
- `git diff --check` passed
- Exact Ghostty reproduction produces `KeyPress(key="S", data="S")`
