### PR TITLE
fix(gateway): replay pending internal events after restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30695,6 +30695,21 @@ def _looks_like_profile_conflict_from_cmdline(command: str, our_home) -> bool:
 
 
 
+async def _recover_pending_internal_events_after_startup(runner) -> None:
+    """Resume shutdown-flushed synthetic events on a fully running gateway."""
+    from gateway.shutdown_flush import recover_pending_internal_events
+
+    replayed, remaining = await recover_pending_internal_events(runner.adapters)
+    if remaining:
+        logger.warning(
+            "%d pending internal event(s) remain queued for a future "
+            "gateway startup",
+            remaining,
+        )
+    elif replayed:
+        logger.info("Re-injected %d pending internal event(s)", replayed)
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -31246,6 +31261,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             return True
         finally:
             _shutdown_gateway_health_export(runner)
+
+    # Synthetic completion wakes must resume as real gateway turns, not merely
+    # appear as inert user rows in the session transcript. Replay only after a
+    # fully running startup; clean-exit and aborted-startup paths above must not
+    # start new work.
+    try:
+        await _recover_pending_internal_events_after_startup(runner)
+    except Exception:
+        logger.warning("Pending internal event recovery failed", exc_info=True)
 
     # Start the background cron scheduler via the resolved provider so
     # scheduled jobs fire automatically. The built-in provider is the

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -5,7 +5,7 @@ accumulates messages in ``_pending_messages`` (memory-only) and the live
 ``agent._session_messages`` cannot be flushed via ``_flush_messages_to_session_db``.
 On shutdown, ``.clear()`` discards the only surviving copy — permanent user data loss.
 
-This module provides three hooks:
+This module provides four hooks:
 
 1. ``flush_pending_to_file()`` — called BEFORE ``_pending_messages.clear()``
    during shutdown.  Serialises any non-empty pending slots to a JSON file
@@ -16,7 +16,11 @@ This module provides three hooks:
    (so FTS indexing, session metadata, and display_kind are handled correctly),
    then deletes the flush file on success.
 
-3. ``flush_agent_history_to_file()`` — called from ``_finalize_shutdown_agents``
+3. ``recover_pending_internal_events()`` — called after gateway adapters start.
+   Re-injects queued synthetic events so they resume as turns instead of inert
+   transcript rows.
+
+4. ``flush_agent_history_to_file()`` — called from ``_finalize_shutdown_agents``
    when ``_flush_messages_to_session_db`` raises.  Dumps the live
    ``agent._session_messages`` to the same atomic JSON recovery directory.
 
@@ -35,6 +39,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+PENDING_INTERNAL_EVENT_KIND = "pending_internal_event_v1"
 
 
 def _get_flush_dir():
@@ -256,8 +262,29 @@ def drain_transcript_spool(session_id: str, replay) -> tuple[int, int]:
 
 def _serialise_value(value: Any) -> Optional[dict]:
     """Convert a pending message value to a JSON-serialisable dict."""
-    # MessageEvent objects have a .text attribute and other fields
+    # MessageEvent objects have a .text attribute and other fields.
     if hasattr(value, "text"):
+        source = getattr(value, "source", None)
+        source_to_dict = getattr(source, "to_dict", None)
+        if getattr(value, "internal", False) is True and callable(source_to_dict):
+            message_type = getattr(value, "message_type", None)
+            return {
+                "kind": PENDING_INTERNAL_EVENT_KIND,
+                "text": getattr(value, "text", ""),
+                "message_type": getattr(message_type, "value", "text"),
+                "source": source_to_dict(),
+                "user_id": getattr(value, "user_id", None),
+                "user_name": getattr(value, "user_name", None),
+                "message_id": getattr(value, "message_id", None),
+                "media_urls": list(getattr(value, "media_urls", None) or []),
+                "media_types": list(getattr(value, "media_types", None) or []),
+                "reply_to_message_id": getattr(value, "reply_to_message_id", None),
+                "reply_to_text": getattr(value, "reply_to_text", None),
+                "metadata": dict(getattr(value, "metadata", None) or {}),
+                "allow_gateway_control": bool(
+                    getattr(value, "allow_gateway_control", False)
+                ),
+            }
         result: Dict[str, Any] = {"text": getattr(value, "text", "")}
         # Preserve additional fields if present
         for attr in ("session_id", "platform", "sender_id", "sender_name",
@@ -281,6 +308,94 @@ def _serialise_value(value: Any) -> Optional[dict]:
         except (TypeError, ValueError):
             return {"text": str(value)}
     return {"text": str(value)}
+
+
+async def recover_pending_internal_events(adapters: Dict[Any, Any]) -> tuple[int, int]:
+    """Re-inject shutdown-flushed synthetic events into live adapters.
+
+    Files are removed only after the adapter accepts the event. Missing
+    adapters, malformed payloads, and delivery failures leave the recovery
+    file intact for the next gateway startup.
+    """
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    flush_dir = _get_flush_dir()
+    replayed = 0
+    remaining = 0
+
+    for path in sorted(flush_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("recovery payload must be an object")
+            data = payload.get("data")
+            # Other recovery schemas (for example agent-history snapshots)
+            # intentionally have no data member and are not internal events.
+            if data is None:
+                continue
+            if not isinstance(data, dict):
+                raise ValueError("recovery payload data must be an object")
+        except Exception as exc:
+            remaining += 1
+            logger.warning(
+                "Cannot inspect malformed recovery file %s; keeping it and "
+                "continuing with later events: %s",
+                path,
+                exc,
+            )
+            continue
+        if data.get("kind") != PENDING_INTERNAL_EVENT_KIND:
+            continue
+
+        try:
+            source_data = data.get("source")
+            if not isinstance(source_data, dict):
+                raise ValueError("internal event source must be an object")
+            source = SessionSource.from_dict(source_data)
+            adapter = adapters.get(source.platform)
+            if adapter is None:
+                remaining += 1
+                logger.warning(
+                    "Cannot replay pending internal event from %s: adapter %s "
+                    "is not active; keeping recovery file",
+                    path,
+                    source.platform.value,
+                )
+                continue
+            event = MessageEvent(
+                text=str(data.get("text") or ""),
+                message_type=MessageType(data.get("message_type", "text")),
+                source=source,
+                user_id=data.get("user_id"),
+                user_name=data.get("user_name"),
+                message_id=data.get("message_id"),
+                media_urls=list(data.get("media_urls") or []),
+                media_types=list(data.get("media_types") or []),
+                reply_to_message_id=data.get("reply_to_message_id"),
+                reply_to_text=data.get("reply_to_text"),
+                internal=True,
+                metadata=dict(data.get("metadata") or {}),
+                allow_gateway_control=bool(data.get("allow_gateway_control", False)),
+            )
+            await adapter.handle_message(event)
+            path.unlink(missing_ok=True)
+            replayed += 1
+        except Exception as exc:
+            remaining += 1
+            logger.warning(
+                "Failed to replay pending internal event from %s; keeping "
+                "recovery file: %s",
+                path,
+                exc,
+            )
+
+    if replayed:
+        logger.info(
+            "Replayed %d pending internal event(s) after gateway startup",
+            replayed,
+        )
+    return replayed, remaining
 
 
 def recover_pending_to_db(
@@ -356,8 +471,13 @@ def recover_pending_to_db(
                 recovered += 1
                 path.unlink(missing_ok=True)
                 continue
-            session_key = payload.get("session_key", "")
             data = payload.get("data", {})
+            # Synthetic events must resume through their platform adapter. Do
+            # not degrade them into inert transcript rows when replay is
+            # temporarily unavailable.
+            if data.get("kind") == PENDING_INTERNAL_EVENT_KIND:
+                continue
+            session_key = payload.get("session_key", "")
             text = data.get("text", "")
             if not text or not session_key:
                 logger.warning(

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,11 +1,28 @@
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 from gateway.run import GatewayRunner
 from gateway.status import read_runtime_status
+
+
+@pytest.mark.asyncio
+async def test_pending_internal_recovery_uses_live_startup_adapters(monkeypatch):
+    replay = AsyncMock(return_value=(1, 0))
+    monkeypatch.setattr(
+        "gateway.shutdown_flush.recover_pending_internal_events", replay
+    )
+    adapters = {Platform.TELEGRAM: object()}
+
+    await gateway_run._recover_pending_internal_events_after_startup(
+        SimpleNamespace(adapters=adapters)
+    )
+
+    replay.assert_awaited_once_with(adapters)
 
 
 class _RetryableFailureAdapter(BasePlatformAdapter):

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -5,10 +5,14 @@ import os
 import stat
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import gateway.shutdown_flush as shutdown_flush
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
 from gateway.shutdown_flush import (
     _serialise_value,
     flush_pending_to_file,
@@ -63,6 +67,134 @@ def test_flush_writes_message_event_to_file(tmp_path, monkeypatch):
     payload = json.loads(files[0].read_text(encoding="utf-8"))
     assert payload["data"]["text"] == "user message"
     assert payload["data"]["session_id"] == "20260728_120000_abc"
+
+
+@pytest.mark.asyncio
+async def test_recover_reinjects_internal_event_and_deletes_file(
+    tmp_path, monkeypatch
+):
+    """A queued synthetic wake must resume as an event, not inert transcript text."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="owner-1",
+        thread_id="topic-7",
+        profile="operator",
+    )
+    event = MessageEvent(
+        text="[kanban] Task t_test completed.",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="wake-1",
+        internal=True,
+        metadata={
+            "gateway_session_key": "agent:operator:telegram:dm:chat-1:topic-7",
+            "kanban_task_id": "t_test",
+        },
+        allow_gateway_control=False,
+    )
+    assert flush_pending_to_file({"session-key": event}, reason="shutdown") == 1
+
+    adapter = MagicMock()
+    adapter.handle_message = AsyncMock()
+    replayed, remaining = await shutdown_flush.recover_pending_internal_events(
+        {Platform.TELEGRAM: adapter}
+    )
+
+    assert (replayed, remaining) == (1, 0)
+    adapter.handle_message.assert_awaited_once()
+    await_args = adapter.handle_message.await_args
+    assert await_args is not None
+    recovered = await_args.args[0]
+    assert recovered.text == event.text
+    assert recovered.message_type is MessageType.TEXT
+    assert recovered.internal is True
+    assert recovered.allow_gateway_control is False
+    assert recovered.message_id == "wake-1"
+    assert recovered.source == source
+    assert recovered.metadata == event.metadata
+    assert list(flush_dir.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_recover_keeps_internal_event_when_adapter_rejects_it(
+    tmp_path, monkeypatch
+):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    event = MessageEvent(
+        text="[kanban] Task t_retry completed.",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        internal=True,
+        allow_gateway_control=False,
+    )
+    assert flush_pending_to_file({"session-key": event}, reason="shutdown") == 1
+
+    adapter = MagicMock()
+    adapter.handle_message = AsyncMock(side_effect=RuntimeError("not ready"))
+    replayed, remaining = await shutdown_flush.recover_pending_internal_events(
+        {Platform.TELEGRAM: adapter}
+    )
+
+    assert (replayed, remaining) == (0, 1)
+    assert len(list(flush_dir.glob("*.json"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_skips_malformed_entry_and_replays_later_event(
+    tmp_path, monkeypatch
+):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    (flush_dir / "000-poison.json").write_text(
+        json.dumps({"data": ["not", "an", "object"]}),
+        encoding="utf-8",
+    )
+    event = MessageEvent(
+        text="[kanban] Task t_after_poison completed.",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        internal=True,
+        allow_gateway_control=False,
+    )
+    assert flush_pending_to_file({"session-key": event}, reason="shutdown") == 1
+
+    adapter = MagicMock()
+    adapter.handle_message = AsyncMock()
+    replayed, remaining = await shutdown_flush.recover_pending_internal_events(
+        {Platform.TELEGRAM: adapter}
+    )
+
+    assert (replayed, remaining) == (1, 1)
+    adapter.handle_message.assert_awaited_once()
+    assert (flush_dir / "000-poison.json").exists()
+
+
+def test_transcript_recovery_does_not_consume_internal_event(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    event = MessageEvent(
+        text="[kanban] Task t_pending completed.",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        internal=True,
+        allow_gateway_control=False,
+    )
+    assert flush_pending_to_file({"session-key": event}, reason="shutdown") == 1
+
+    mock_db = MagicMock()
+    assert recover_pending_to_db(mock_db) == 0
+    mock_db.append_message.assert_not_called()
+    assert len(list(flush_dir.glob("*.json"))) == 1
 
 
 def test_recover_inserts_via_append_message_and_deletes_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- preserve queued synthetic `MessageEvent` routing metadata during shutdown flushes
- replay pending internal events through live gateway adapters after a successful startup
- keep failed or malformed recovery files for retry while allowing later valid wakes to continue
- prevent synthetic wakes from degrading into inert `role=user` transcript rows

## Root cause

Shutdown serialized pending events as plain text and startup recovery only appended them to `state.db`. A Kanban completion wake queued behind a busy operator could therefore survive as transcript text but never resume an agent turn after a gateway restart.

## Verification

- RED reproduced missing restart reinjection before implementation
- `scripts/run_tests.sh tests/gateway/test_shutdown_flush.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_startup_restart_race.py -q` — 21 passed
- `.venv/bin/ruff check gateway/shutdown_flush.py gateway/run.py tests/gateway/test_shutdown_flush.py tests/gateway/test_runner_startup_failures.py` — passed
- `.venv/bin/ty check gateway/shutdown_flush.py tests/gateway/test_shutdown_flush.py` — passed
- gateway suite showed no new failures; the remaining three macOS-only failures matched clean `origin/main` exactly (`test_systemd_notify` abstract socket and two `test_scale_to_zero` AF_UNIX path-length cases)
- exact-tree independent review passed after fixing a poison-spool finding; final staged tree: `9027c66b88852a50cb8e6c51b9a9b7b85d7c9615`

## Safety

- replay runs only after the gateway reaches its fully running startup path
- missing adapters and delivery failures retain their recovery files
- malformed entries are isolated per file and cannot block later valid events
- ordinary transcript and agent-history recovery behavior remains unchanged
