### PR TITLE
fix(xai): make tool_search wire alias collision-safe

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1960,6 +1960,42 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()
 
+    # xAI's chat-completions endpoint reserves the function name
+    # ``tool_search`` for its native server-side tool and rejects the whole
+    # request when the client Tool Search bridge declares it (HTTP 400
+    # "The function name tool_search is reserved for the tool_search tool",
+    # #95003) — same reserved-name class the codex_responses branch above
+    # already sanitizes tools for (#27197). Rename the bridge's wire
+    # declaration to an alias; normalize_response maps model calls back.
+    # Deep-copy first (the #27907 in-place-mutation lesson): tools_for_api
+    # aliases agent.tools, and renaming in place would corrupt the shared
+    # per-agent tool registry for every later non-xAI request.
+    _is_xai_chat = (
+        agent.provider in {"xai", "xai-oauth"}
+        or agent._base_url_hostname == "api.x.ai"
+    )
+    if _is_xai_chat and tools_for_api:
+        try:
+            import copy as _copy_xai
+
+            from agent.transports.chat_completions import (
+                _rename_tool_search_bridge_for_xai,
+            )
+
+            _has_bridge = any(
+                (t.get("function") or {}).get("name") == "tool_search"
+                for t in tools_for_api
+                if isinstance(t, dict)
+            )
+            if _has_bridge:
+                tools_for_api = _copy_xai.deepcopy(tools_for_api)
+                tools_for_api = _rename_tool_search_bridge_for_xai(tools_for_api)
+        except Exception as exc:
+            logger.warning(
+                "%s⚠️ Failed to alias tool_search bridge for xAI: %s",
+                getattr(agent, "log_prefix", ""), exc,
+            )
+
     # Provider detection flags
     _is_qwen = agent._is_qwen_portal()
     _is_or = agent._is_openrouter_url()

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1960,42 +1960,6 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()
 
-    # xAI's chat-completions endpoint reserves the function name
-    # ``tool_search`` for its native server-side tool and rejects the whole
-    # request when the client Tool Search bridge declares it (HTTP 400
-    # "The function name tool_search is reserved for the tool_search tool",
-    # #95003) — same reserved-name class the codex_responses branch above
-    # already sanitizes tools for (#27197). Rename the bridge's wire
-    # declaration to an alias; normalize_response maps model calls back.
-    # Deep-copy first (the #27907 in-place-mutation lesson): tools_for_api
-    # aliases agent.tools, and renaming in place would corrupt the shared
-    # per-agent tool registry for every later non-xAI request.
-    _is_xai_chat = (
-        agent.provider in {"xai", "xai-oauth"}
-        or agent._base_url_hostname == "api.x.ai"
-    )
-    if _is_xai_chat and tools_for_api:
-        try:
-            import copy as _copy_xai
-
-            from agent.transports.chat_completions import (
-                _rename_tool_search_bridge_for_xai,
-            )
-
-            _has_bridge = any(
-                (t.get("function") or {}).get("name") == "tool_search"
-                for t in tools_for_api
-                if isinstance(t, dict)
-            )
-            if _has_bridge:
-                tools_for_api = _copy_xai.deepcopy(tools_for_api)
-                tools_for_api = _rename_tool_search_bridge_for_xai(tools_for_api)
-        except Exception as exc:
-            logger.warning(
-                "%s⚠️ Failed to alias tool_search bridge for xAI: %s",
-                getattr(agent, "log_prefix", ""), exc,
-            )
-
     # Provider detection flags
     _is_qwen = agent._is_qwen_portal()
     _is_or = agent._is_openrouter_url()
@@ -2080,6 +2044,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             messages=api_messages,
             tools=tools_for_api,
             base_url=agent.base_url,
+            provider=agent.provider,
             timeout=agent._resolved_api_call_timeout(),
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
@@ -2113,6 +2078,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         messages=_msgs_for_chat,
         tools=tools_for_api,
         base_url=agent.base_url,
+        provider=agent.provider,
         timeout=agent._resolved_api_call_timeout(),
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,

--- a/agent/tool_name_aliases.py
+++ b/agent/tool_name_aliases.py
@@ -1,0 +1,12 @@
+"""Internal wire aliases that must never be registered as real tools."""
+
+TOOL_SEARCH_WIRE_ALIAS = "hermes_tool_search"
+RESERVED_WIRE_TOOL_NAMES = frozenset({TOOL_SEARCH_WIRE_ALIAS})
+
+
+def reject_reserved_wire_tool_name(name: str) -> None:
+    """Fail when a public tool tries to claim an internal wire alias."""
+    if name in RESERVED_WIRE_TOOL_NAMES:
+        raise ValueError(
+            f"Tool name {name!r} is a reserved wire alias and cannot be registered"
+        )

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -27,6 +27,43 @@ from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
+# xAI's chat-completions API reserves the function name ``tool_search`` for
+# its own server-side tool and rejects any request declaring a client
+# function with that name (HTTP 400 "The function name tool_search is
+# reserved for the tool_search tool", #95003). The Tool Search bridge
+# (tools/tool_search.py) assembles its client-side discovery tool under the
+# same literal name for every provider, so Grok providers are unusable
+# whenever the bridge is active. Mirror the web_search treatment in
+# transports/codex.py (_rename_client_web_search_for_xai): alias the wire
+# declaration and map the alias back in normalize_response. The alias value
+# matches _CODEX_TOOL_SEARCH_ALIAS from the Codex-side fix for the same
+# reserved-name class (#83122) so the two transports stay consistent.
+_XAI_TOOL_SEARCH_ALIAS = "hermes_tool_search"
+
+
+def _rename_tool_search_bridge_for_xai(
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Rename the client ``tool_search`` bridge declaration to a wire alias.
+
+    Only the wire name changes: descriptions, schemas, and the other two
+    bridge names (``tool_describe`` / ``tool_call`` — not reserved by xAI)
+    pass through untouched. The alias is mapped back to ``tool_search`` in
+    ``normalize_response`` before dispatch.
+    """
+    rewritten: list[dict[str, Any]] = []
+    for tool in tools:
+        if (
+            isinstance(tool, dict)
+            and (tool.get("function") or {}).get("name") == "tool_search"
+        ):
+            aliased = dict(tool)
+            aliased["function"] = {**tool["function"], "name": _XAI_TOOL_SEARCH_ALIAS}
+            rewritten.append(aliased)
+        else:
+            rewritten.append(tool)
+    return rewritten
+
 
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
     """Return the stable system/developer prefix used for cache routing.
@@ -904,6 +941,13 @@ class ChatCompletionsTransport(ProviderTransport):
                 # preserve an explicit blank name for Hermes's recovery path.
                 if tc_function is None or function_name is None:
                     continue
+                # Map the xAI wire alias back to the bridge's real name.
+                # Unconditional is correct here: ``hermes_tool_search`` only
+                # exists on the wire because _rename_tool_search_bridge_for_xai
+                # put it there (xAI rejects the literal ``tool_search``), so
+                # any model call carrying the alias is a bridge invocation.
+                if function_name == _XAI_TOOL_SEARCH_ALIAS:
+                    function_name = "tool_search"
                 function_arguments = getattr(tc_function, "arguments", None)
                 # Preserve provider-specific extras on the tool call.
                 # Gemini 3 thinking models attach extra_content with

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -11,6 +11,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 
 import json
 from typing import Any, Dict
+from urllib.parse import urlsplit
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.reasoning_effort import (
@@ -24,6 +25,7 @@ from agent.reasoning_effort import (
 )
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
+from agent.tool_name_aliases import TOOL_SEARCH_WIRE_ALIAS, reject_reserved_wire_tool_name
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
@@ -35,10 +37,21 @@ from agent.transports.types import NormalizedResponse, ToolCall, Usage
 # same literal name for every provider, so Grok providers are unusable
 # whenever the bridge is active. Mirror the web_search treatment in
 # transports/codex.py (_rename_client_web_search_for_xai): alias the wire
-# declaration and map the alias back in normalize_response. The alias value
-# matches _CODEX_TOOL_SEARCH_ALIAS from the Codex-side fix for the same
-# reserved-name class (#83122) so the two transports stay consistent.
-_XAI_TOOL_SEARCH_ALIAS = "hermes_tool_search"
+# declaration and map the alias back in normalize_response. The shared wire
+# alias comes from ``agent.tool_name_aliases`` so both transports stay
+# consistent.
+_XAI_TOOL_SEARCH_ALIAS = TOOL_SEARCH_WIRE_ALIAS
+
+
+def _is_xai_target(params: dict[str, Any]) -> bool:
+    provider = str(params.get("provider") or params.get("provider_name") or "")
+    if provider.strip().lower() in {"xai", "xai-oauth"}:
+        return True
+    base_url = str(params.get("base_url") or "").strip()
+    try:
+        return (urlsplit(base_url).hostname or "").lower() == "api.x.ai"
+    except ValueError:
+        return False
 
 
 def _rename_tool_search_bridge_for_xai(
@@ -51,6 +64,12 @@ def _rename_tool_search_bridge_for_xai(
     pass through untouched. The alias is mapped back to ``tool_search`` in
     ``normalize_response`` before dispatch.
     """
+    for tool in tools:
+        if isinstance(tool, dict):
+            name = (tool.get("function") or {}).get("name")
+            if isinstance(name, str):
+                reject_reserved_wire_tool_name(name)
+
     rewritten: list[dict[str, Any]] = []
     for tool in tools:
         if (
@@ -62,6 +81,38 @@ def _rename_tool_search_bridge_for_xai(
             rewritten.append(aliased)
         else:
             rewritten.append(tool)
+    return rewritten
+
+
+def _rename_replayed_tool_search_for_xai(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Alias canonical tool-search calls in replayed assistant history."""
+    rewritten: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            rewritten.append(message)
+            continue
+        tool_calls = message.get("tool_calls")
+        if message.get("role") != "assistant" or not isinstance(tool_calls, list):
+            rewritten.append(message)
+            continue
+
+        calls: list[Any] = []
+        changed = False
+        for tool_call in tool_calls:
+            function = tool_call.get("function") if isinstance(tool_call, dict) else None
+            if isinstance(function, dict) and function.get("name") == "tool_search":
+                calls.append(
+                    {
+                        **tool_call,
+                        "function": {**function, "name": _XAI_TOOL_SEARCH_ALIAS},
+                    }
+                )
+                changed = True
+            else:
+                calls.append(tool_call)
+        rewritten.append({**message, "tool_calls": calls} if changed else message)
     return rewritten
 
 
@@ -542,6 +593,11 @@ class ChatCompletionsTransport(ProviderTransport):
         # Pass model so the Gemini thought_signature (extra_content) is kept for
         # Gemini targets and stripped for strict non-Gemini providers.
         sanitized = self.convert_messages(messages, model=model)
+
+        if _is_xai_target(params):
+            sanitized = _rename_replayed_tool_search_for_xai(sanitized)
+            if tools:
+                tools = _rename_tool_search_bridge_for_xai(tools)
 
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -8,7 +8,7 @@ streaming, or the _run_codex_stream() call path.
 import hashlib
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Cron fires build session_id as ``cron_<job_id>_<YYYYMMDD_HHMMSS>`` (see
 # cron/scheduler.py). The trailing timestamp is per-fire noise; stripped so
@@ -67,10 +67,24 @@ _XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
 # rename on the wire (hermes_<name>), map back in normalize_response so
 # Hermes dispatch is unaffected.
 _OPENCODE_RESERVED_TOOL_NAMES = ("web_search", "search_files")
+
+# xAI reserves ``tool_search`` server-side for Grok's own native Tool Search
+# and rejects *any* client function declared with that name:
+#   HTTP 400 {"code":"invalid-argument","error":"The function name
+#   tool_search is reserved for the tool_search tool"}
+# Hermes's progressive-disclosure bridge registers exactly that literal
+# (``tools.tool_search.TOOL_SEARCH_NAME``), and assembly is not provider
+# gated, so with ``tools.tool_search.enabled: auto`` a grok turn dies the
+# moment the catalog crosses the threshold — mid-session, and only for
+# sessions large enough to activate the bridge. Same treatment as the two
+# collisions above. ``tool_describe`` / ``tool_call`` are not reserved.
+# Refs #95003.
+_XAI_RESERVED_TOOL_NAMES = ("tool_search",)
+
 _RESERVED_TOOL_ALIAS_PREFIX = "hermes_"
 _RESERVED_ALIAS_TO_NAME = {
     f"{_RESERVED_TOOL_ALIAS_PREFIX}{name}": name
-    for name in _OPENCODE_RESERVED_TOOL_NAMES
+    for name in (*_OPENCODE_RESERVED_TOOL_NAMES, *_XAI_RESERVED_TOOL_NAMES)
 }
 
 
@@ -97,11 +111,19 @@ def _is_opencode_responses_backend(params: Dict[str, Any]) -> bool:
         return False
 
 
-def _rename_reserved_tools_for_opencode(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Alias OpenCode-reserved client function names on the wire."""
+def _alias_reserved_tools(
+    response_tools: List[Dict[str, Any]],
+    reserved_names: Tuple[str, ...],
+) -> List[Dict[str, Any]]:
+    """Alias provider-reserved client function names on the wire.
+
+    Single owner for every reserved-name collision on this transport; the
+    reverse mapping lives in :data:`_RESERVED_ALIAS_TO_NAME`, applied in
+    ``normalize_response`` so Hermes dispatch never sees the alias.
+    """
     rewritten: List[Dict[str, Any]] = []
     for tool in response_tools:
-        if isinstance(tool, dict) and tool.get("name") in _OPENCODE_RESERVED_TOOL_NAMES:
+        if isinstance(tool, dict) and tool.get("name") in reserved_names:
             aliased = dict(tool)
             aliased["name"] = f"{_RESERVED_TOOL_ALIAS_PREFIX}{tool['name']}"
             rewritten.append(aliased)
@@ -557,7 +579,17 @@ class ResponsesApiTransport(ProviderTransport):
         # function names (HTTP 400 "custom function name 'X' is reserved",
         # #85589). Alias them on the wire; normalize_response maps them back.
         if response_tools and _is_opencode_responses_backend(params):
-            response_tools = _rename_reserved_tools_for_opencode(response_tools)
+            response_tools = _alias_reserved_tools(
+                response_tools, _OPENCODE_RESERVED_TOOL_NAMES
+            )
+
+        # xAI reserves ``tool_search`` for its native server-side tool and
+        # rejects the client declaration outright (#95003). Alias it on the
+        # wire; normalize_response maps it back before dispatch.
+        if is_xai_responses and response_tools:
+            response_tools = _alias_reserved_tools(
+                response_tools, _XAI_RESERVED_TOOL_NAMES
+            )
 
         # ``tools`` MUST be omitted entirely when there are no functions to
         # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -34,6 +34,7 @@ from agent.reasoning_effort import (
     clamp_effort,
     codex_supported_efforts,
 )
+from agent.tool_name_aliases import reject_reserved_wire_tool_name
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
@@ -121,14 +122,45 @@ def _alias_reserved_tools(
     reverse mapping lives in :data:`_RESERVED_ALIAS_TO_NAME`, applied in
     ``normalize_response`` so Hermes dispatch never sees the alias.
     """
+    for tool in response_tools:
+        if isinstance(tool, dict):
+            name = tool.get("name")
+            if isinstance(name, str):
+                reject_reserved_wire_tool_name(name)
+
     rewritten: List[Dict[str, Any]] = []
     for tool in response_tools:
         if isinstance(tool, dict) and tool.get("name") in reserved_names:
             aliased = dict(tool)
-            aliased["name"] = f"{_RESERVED_TOOL_ALIAS_PREFIX}{tool['name']}"
+            canonical_name = tool["name"]
+            wire_name = f"{_RESERVED_TOOL_ALIAS_PREFIX}{canonical_name}"
+            aliased["name"] = wire_name
+            description = aliased.get("description")
+            if isinstance(description, str):
+                aliased["description"] = description.replace(canonical_name, wire_name)
             rewritten.append(aliased)
         else:
             rewritten.append(tool)
+    return rewritten
+
+
+def _alias_reserved_function_calls(
+    response_input: List[Dict[str, Any]],
+    reserved_names: Tuple[str, ...],
+) -> List[Dict[str, Any]]:
+    """Alias replayed function-call names without mutating conversation history."""
+    rewritten: List[Dict[str, Any]] = []
+    for item in response_input:
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "function_call"
+            and item.get("name") in reserved_names
+        ):
+            aliased = dict(item)
+            aliased["name"] = f"{_RESERVED_TOOL_ALIAS_PREFIX}{item['name']}"
+            rewritten.append(aliased)
+        else:
+            rewritten.append(item)
     return rewritten
 
 
@@ -605,20 +637,26 @@ class ResponsesApiTransport(ProviderTransport):
         from agent.model_metadata import (
             strip_codex_context_variant_suffix as _strip_ctx_variant,
         )
+        response_input = _chat_messages_to_responses_input(
+            payload_messages,
+            is_xai_responses=is_xai_responses,
+            is_github_responses=is_github_responses,
+            replay_encrypted_reasoning=replay_encrypted_reasoning,
+            current_issuer_kind=issuer_kind,
+            native_compaction_eligible=native_compaction_active,
+        )
+        if is_xai_responses:
+            response_input = _alias_reserved_function_calls(
+                response_input, ("tool_search",)
+            )
+
         kwargs = {
             # ``-900k`` large-context picker variants are Hermes-side aliases
             # (gpt-5.6-sol-900k etc.) — the Codex/OpenAI backend only knows
             # the base slug, so strip the suffix before it hits the wire.
             "model": _strip_ctx_variant(model),
             "instructions": instructions,
-            "input": _chat_messages_to_responses_input(
-                payload_messages,
-                is_xai_responses=is_xai_responses,
-                is_github_responses=is_github_responses,
-                replay_encrypted_reasoning=replay_encrypted_reasoning,
-                current_issuer_kind=issuer_kind,
-                native_compaction_eligible=native_compaction_active,
-            ),
+            "input": response_input,
             "store": False,
         }
         if response_tools:
@@ -833,7 +871,7 @@ class ResponsesApiTransport(ProviderTransport):
                     name = "web_search"
                 # Undo the OpenCode reserved-name wire aliases the same way
                 # (hermes_web_search / hermes_search_files, #85589).
-                elif name in _RESERVED_ALIAS_TO_NAME:
+                if name in _RESERVED_ALIAS_TO_NAME:
                     name = _RESERVED_ALIAS_TO_NAME[name]
                 tool_calls.append(ToolCall(
                     id=tc.id if hasattr(tc, "id") else (name or None),

--- a/tests/agent/transports/test_chat_completions_xai_tool_search_alias.py
+++ b/tests/agent/transports/test_chat_completions_xai_tool_search_alias.py
@@ -1,0 +1,94 @@
+"""Tests for the xAI ``tool_search`` reserved-name alias (#95003).
+
+xAI's chat-completions API reserves the function name ``tool_search`` for
+its native server-side tool and rejects the whole request when the client
+Tool Search bridge declares it (HTTP 400 "The function name tool_search is
+reserved for the tool_search tool"). The fix mirrors the web_search treatment
+in ``transports/codex.py``: rename the bridge's wire declaration to
+``hermes_tool_search`` for xAI targets and map the alias back to
+``tool_search`` in ``normalize_response`` so dispatch is unchanged.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports import get_transport
+from agent.transports.chat_completions import (
+    _XAI_TOOL_SEARCH_ALIAS,
+    _rename_tool_search_bridge_for_xai,
+)
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+class TestRenameToolSearchBridgeForXai:
+    def test_tool_search_renamed_alias_value(self):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "tool_search",
+                "description": "Search deferred tools",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+        out = _rename_tool_search_bridge_for_xai(tools)
+        assert out[0]["function"]["name"] == _XAI_TOOL_SEARCH_ALIAS
+        assert out[0]["function"]["name"] == "hermes_tool_search"
+
+    def test_schema_and_description_untouched(self):
+        fn = {
+            "name": "tool_search",
+            "description": "Search the deferred tool catalog",
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        }
+        out = _rename_tool_search_bridge_for_xai([{"type": "function", "function": fn}])
+        assert out[0]["function"]["description"] == fn["description"]
+        assert out[0]["function"]["parameters"] == fn["parameters"]
+
+    def test_sibling_bridge_names_not_reserved(self):
+        # xAI's error names only tool_search; tool_describe / tool_call stay
+        # on the wire unchanged so the model keeps calling them directly.
+        tools = [
+            {"type": "function", "function": {"name": "tool_describe"}},
+            {"type": "function", "function": {"name": "tool_call"}},
+        ]
+        out = _rename_tool_search_bridge_for_xai(tools)
+        assert [t["function"]["name"] for t in out] == ["tool_describe", "tool_call"]
+
+    def test_ordinary_tools_untouched(self):
+        tools = [{"type": "function", "function": {"name": "web_search"}}]
+        out = _rename_tool_search_bridge_for_xai(tools)
+        assert out[0]["function"]["name"] == "web_search"
+
+    def test_input_not_mutated(self):
+        # The helper feeds a deep-copied list on the helper-layer path, but
+        # pin copy semantics anyway: the shared per-agent tool registry must
+        # never see the alias (#27907 lesson).
+        tools = [{"type": "function", "function": {"name": "tool_search"}}]
+        _rename_tool_search_bridge_for_xai(tools)
+        assert tools[0]["function"]["name"] == "tool_search"
+
+
+def _fake_response(tool_name):
+    tc = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name=tool_name, arguments='{"query": "x"}'),
+    )
+    msg = SimpleNamespace(tool_calls=[tc], reasoning=None, reasoning_content=None)
+    choice = SimpleNamespace(message=msg, finish_reason="tool_calls")
+    return SimpleNamespace(choices=[choice], usage=None)
+
+
+class TestNormalizeResponseMapsAliasBack:
+    def test_alias_call_maps_back_to_bridge_name(self, transport):
+        resp = transport.normalize_response(_fake_response(_XAI_TOOL_SEARCH_ALIAS))
+        assert resp.tool_calls[0].name == "tool_search"
+
+    def test_ordinary_call_name_preserved(self, transport):
+        resp = transport.normalize_response(_fake_response("tool_describe"))
+        assert resp.tool_calls[0].name == "tool_describe"

--- a/tests/agent/transports/test_chat_completions_xai_tool_search_alias.py
+++ b/tests/agent/transports/test_chat_completions_xai_tool_search_alias.py
@@ -73,6 +73,117 @@ class TestRenameToolSearchBridgeForXai:
         _rename_tool_search_bridge_for_xai(tools)
         assert tools[0]["function"]["name"] == "tool_search"
 
+    def test_transport_build_aliases_xai_tool_search(self, transport):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "tool_search",
+                    "description": "Search deferred tools.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "Find a tool"}],
+            tools=tools,
+            provider="xai-oauth",
+            base_url="https://api.x.ai/v1",
+        )
+
+        assert kwargs["tools"][0]["function"]["name"] == "hermes_tool_search"
+
+    def test_transport_rejects_xai_bridge_alias_collision(self, transport):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "tool_search",
+                    "description": "Search deferred tools.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "hermes_tool_search",
+                    "description": "Conflicting caller-supplied tool.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+        with pytest.raises(ValueError, match="reserved wire alias"):
+            transport.build_kwargs(
+                model="grok-4.6",
+                messages=[{"role": "user", "content": "Find a tool"}],
+                tools=tools,
+                provider="xai-oauth",
+            )
+
+    def test_transport_aliases_replayed_xai_tool_search_call(self, transport):
+        messages = [
+            {"role": "user", "content": "Find a tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_search",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_search",
+                            "arguments": '{"queries":["calendar"]}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_search", "content": "{}"},
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="grok-4.6",
+            messages=messages,
+            tools=[],
+            provider="xai-oauth",
+        )
+
+        assert kwargs["messages"][1]["tool_calls"][0]["function"]["name"] == (
+            "hermes_tool_search"
+        )
+        assert messages[1]["tool_calls"][0]["function"]["name"] == "tool_search"
+
+    def test_transport_keeps_non_xai_tool_search_names(self, transport):
+        tools = [{"type": "function", "function": {"name": "tool_search"}}]
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_search",
+                        "type": "function",
+                        "function": {"name": "tool_search", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=tools,
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+        )
+
+        assert kwargs["tools"][0]["function"]["name"] == "tool_search"
+        assert kwargs["messages"][0]["tool_calls"][0]["function"]["name"] == (
+            "tool_search"
+        )
+
 
 def _fake_response(tool_name):
     tc = SimpleNamespace(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -937,6 +937,109 @@ class TestOpencodeReservedToolAliases:
         assert names == ["search_files", "web_search"]
 
 
+class TestXaiReservedToolSearchAlias:
+    """xAI reserves ``tool_search`` for Grok's native Tool Search and rejects
+    the client declaration with HTTP 400 (#95003). The transport aliases the
+    progressive-disclosure bridge on the wire and maps it back on dispatch."""
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    _TOOLS = [
+        {"type": "function", "function": {
+            "name": "tool_search", "description": "Search deferred tools.",
+            "parameters": {"type": "object",
+                           "properties": {"query": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "tool_describe", "description": "Describe a deferred tool.",
+            "parameters": {"type": "object",
+                           "properties": {"name": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "read_file", "description": "Read a file.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}}}},
+    ]
+
+    def _names(self, kw):
+        return [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
+
+    def test_xai_aliases_reserved_tool_search(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_xai_responses=True,
+        )
+        names = self._names(kw)
+        assert "hermes_tool_search" in names
+        assert "tool_search" not in names
+        # Only ``tool_search`` is reserved — the sibling bridge tools and
+        # ordinary tools go out untouched.
+        assert "tool_describe" in names
+        assert "read_file" in names
+
+    def test_non_xai_backend_keeps_tool_search_name(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_codex_backend=True,
+            base_url="https://api.openai.com/v1",
+        )
+        names = self._names(kw)
+        assert "tool_search" in names
+        assert "hermes_tool_search" not in names
+
+    def test_alias_composes_with_native_web_search_swap(self, transport, monkeypatch):
+        """The bridge alias must survive the xAI web_search branch (#48108)."""
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_xai_prefers_native_web_search", lambda: True)
+        tools = list(self._TOOLS) + [
+            {"type": "function", "function": {
+                "name": "web_search", "description": "Search the web.",
+                "parameters": {"type": "object",
+                               "properties": {"query": {"type": "string"}}}}},
+        ]
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            is_xai_responses=True,
+        )
+        assert any(t.get("type") == "web_search" for t in kw.get("tools", []))
+        names = self._names(kw)
+        assert "hermes_tool_search" in names
+        assert "tool_search" not in names
+
+    def test_normalize_maps_tool_search_alias_back(self, transport, monkeypatch):
+        msg = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1", call_id="call_1", response_item_id="fc_1",
+                    function=SimpleNamespace(
+                        name="hermes_tool_search",
+                        arguments='{"query":"create github issue"}',
+                    ),
+                ),
+            ],
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            reasoning_details=None,
+        )
+        response = SimpleNamespace(output=[], status="completed")
+        monkeypatch.setattr(
+            "agent.codex_responses_adapter._normalize_codex_response",
+            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+        )
+        normalized = transport.normalize_response(response)
+        assert [tc.name for tc in normalized.tool_calls] == ["tool_search"]
+
+
 class TestXaiWebSearchBackendPreference:
     """``_xai_prefers_native_web_search`` must honor web backend config."""
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -36,7 +36,6 @@ class TestCodexTransportBasic:
         assert result[0]["type"] == "function"
         assert result[0]["name"] == "terminal"
 
-
 class TestCodexBuildKwargs:
 
     def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
@@ -979,6 +978,89 @@ class TestXaiReservedToolSearchAlias:
         # ordinary tools go out untouched.
         assert "tool_describe" in names
         assert "read_file" in names
+
+    def test_xai_aliases_description_without_mutating_tool_registry(self, transport):
+        tools = [
+            {
+                **self._TOOLS[0],
+                "function": {
+                    **self._TOOLS[0]["function"],
+                    "description": "Call tool_search before tool_describe.",
+                },
+            },
+            *self._TOOLS[1:],
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            is_xai_responses=True,
+        )
+
+        aliased = next(t for t in kwargs["tools"] if t.get("name") == "hermes_tool_search")
+        assert "hermes_tool_search" in aliased["description"]
+        assert tools[0]["function"]["description"] == "Call tool_search before tool_describe."
+        assert tools[0]["function"]["name"] == "tool_search"
+
+    def test_reserved_tool_search_is_aliased_in_replayed_history(self, transport):
+        messages = [
+            {"role": "user", "content": "Find a calendar tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_search",
+                        "call_id": "call_search",
+                        "response_item_id": "fc_search",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_search",
+                            "arguments": '{"queries":["calendar"]}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_search",
+                "content": '{"matches":[]}',
+            },
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="grok-4.6",
+            messages=messages,
+            tools=list(self._TOOLS),
+            is_xai_responses=True,
+        )
+
+        function_call = next(
+            item for item in kwargs["input"] if item.get("type") == "function_call"
+        )
+        assert function_call["name"] == "hermes_tool_search"
+        assert messages[1]["tool_calls"][0]["function"]["name"] == "tool_search"
+
+    def test_xai_rejects_bridge_alias_collision(self, transport):
+        tools = list(self._TOOLS) + [
+            {
+                "type": "function",
+                "function": {
+                    "name": "hermes_tool_search",
+                    "description": "Conflicting caller-supplied tool.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        with pytest.raises(ValueError, match="reserved wire alias"):
+            transport.build_kwargs(
+                model="grok-4.6",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=tools,
+                is_xai_responses=True,
+            )
 
     def test_non_xai_backend_keeps_tool_search_name(self, transport):
         kw = transport.build_kwargs(

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -40,6 +40,21 @@ class TestRegisterAndDispatch:
         result = json.loads(reg.dispatch("alpha", {}))
         assert result == {"ok": True}
 
+    def test_reserved_wire_alias_is_rejected(self):
+        import pytest
+
+        reg = ToolRegistry()
+
+        with pytest.raises(ValueError, match="reserved wire alias"):
+            reg.register(
+                name="hermes_tool_search",
+                toolset="plugin",
+                schema=_make_schema("hermes_tool_search"),
+                handler=_dummy_handler,
+            )
+
+        assert reg.get_entry("hermes_tool_search") is None
+
 
     def test_cross_mcp_toolsets_do_not_overwrite_atomically(self, caplog):
         """Parallel MCP registrations with one name leave exactly one owner."""
@@ -107,6 +122,21 @@ class TestGetDefinitions:
         assert all(d["type"] == "function" for d in defs)
         names = {d["function"]["name"] for d in defs}
         assert names == {"t1", "t2"}
+
+    def test_dynamic_schema_cannot_expose_reserved_wire_alias(self):
+        import pytest
+
+        reg = ToolRegistry()
+        reg.register(
+            name="safe_name",
+            toolset="plugin",
+            schema=_make_schema("safe_name"),
+            handler=_dummy_handler,
+            dynamic_schema_overrides=lambda: {"name": "hermes_tool_search"},
+        )
+
+        with pytest.raises(ValueError, match="reserved wire alias"):
+            reg.get_definitions({"safe_name"})
 
 
     def test_reuses_shared_check_fn_once_per_call(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -25,6 +25,7 @@ import time
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
+from agent.tool_name_aliases import reject_reserved_wire_tool_name
 from hermes_constants import hermes_home_key
 
 logger = logging.getLogger(__name__)
@@ -784,6 +785,7 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        reject_reserved_wire_tool_name(name)
         handler_owner = self._plugin_owner_of(handler)
         caller_owner = self._plugin_namespace_of_module(self._caller_module())
         owner = caller_owner or handler_owner
@@ -1087,6 +1089,9 @@ class ToolRegistry:
                         "using static schema",
                         name, exc,
                     )
+            schema_name = schema_with_name.get("name")
+            if isinstance(schema_name, str):
+                reject_reserved_wire_tool_name(schema_name)
             result.append({"type": "function", "function": schema_with_name})
         return result
 


### PR DESCRIPTION
## Problem

xAI reserves the function name `tool_search` for its native server-side tool. When Hermes progressive tool disclosure exposes its client bridge under the same name, xAI rejects the request with HTTP 400 (`The function name tool_search is reserved for the tool_search tool`).

Two open PRs address complementary paths:

- #95019 covers xAI Responses.
- #95011 covers xAI Chat Completions.

Taken independently, each leaves a sibling transport uncovered. Both also need an explicit collision invariant so the internal wire alias cannot silently hijack a real plugin/MCP tool with the same name.

## Approach

This PR preserves both contributors' commits and consolidates the xAI-only fix:

- Alias the client bridge to `hermes_tool_search` on xAI Responses and Chat Completions wires.
- Keep alias ownership inside the transports rather than a best-effort caller helper.
- Rewrite replayed assistant `function_call` / `tool_calls` names so post-tool turns do not reintroduce the reserved name.
- Map model-returned aliases back to canonical `tool_search` before Hermes dispatch.
- Reserve `hermes_tool_search` at tool-registration and dynamic-schema boundaries; direct transport callers fail closed on a collision.
- Use copy-on-write rewrites so the shared tool registry and persisted conversation history remain canonical and non-xAI routes are unchanged.

## Verification

```text
221 passed in 4.23s
Ruff: All checks passed
Static security scan: clean
git diff --check: clean
```

Focused suite:

```bash
uv run --frozen --with pytest pytest \
  tests/agent/transports/test_codex_transport.py \
  tests/agent/transports/test_chat_completions_xai_tool_search_alias.py \
  tests/tools/test_registry.py \
  tests/tools/test_tool_search.py \
  tests/tools/test_tool_search_multiquery.py \
  -o 'addopts=' -q
```

Real xAI OAuth smoke test from this branch:

```bash
uv run --frozen hermes chat \
  -q '请务必调用 tool_search 搜索 X docs 相关工具，再只回复命中的工具名；不要凭记忆回答。' \
  --provider xai-oauth -m grok-4.6 \
  --source probe-xai-tool-search-pr
```

Result: exit 0, `tool_search` executed, returned `x_search`, and the post-tool turn completed successfully (4 messages / 2 tool calls; session `20260826_114431_228534`).

## Compatibility note

`hermes_tool_search` becomes an internal reserved wire name. A plugin attempting to register that exact name now receives an explicit `ValueError` instead of being silently shadowed or mis-dispatched. Ordinary tool names and non-xAI wire payloads are unchanged.

Closes #95003
Consolidates #95011 and #95019
