### PR TITLE
fix(mcp): correct inverted _stdio_children_dead return value (#95150)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,9 +2994,8 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            return False  # at least one child is alive → not all dead
+        return True  # every child checked and all are dead
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
Fixes #95150, fixes #95165

`_stdio_children_dead()` is documented to return `True` when **every** child has exited. The previous implementation returned `True` as soon as it found a **living** child, which made the method always report "dead" for any healthy stdio MCP server. This caused every stdio MCP tool call to fail fast with:

```
TimeoutError: MCP stdio subprocess for '<name>' has exited
```

**Changes:**
- `return True` on alive PID → `return False` (at least one alive → not all dead)
- Remove the unreachable `return False` that followed the dead `return True`
- Loop now correctly returns `True` only after confirming every PID is dead

Closes #95150, closes #95165