### PR TITLE
fix(verification): record evidence when a background command finishes

### DIFF
--- a/tests/tools/test_background_verification_evidence.py
+++ b/tests/tools/test_background_verification_evidence.py
@@ -1,0 +1,234 @@
+"""Background verification runs must reach the evidence ledger.
+
+``record_terminal_result()`` has exactly one production call site
+(``tools/terminal_tool.py``), and it sits on the FOREGROUND completion path.
+A ``background=True`` spawn returns early with a synthetic ``exit_code: 0``
+while the command is still running, so it never reaches that site.
+
+The consequence is not cosmetic. Any suite too slow for the foreground timeout
+*must* run in the background, therefore can never record evidence, so
+``verification_status()`` keeps returning ``stale`` (``last_edit_at`` stays
+newer than the last recorded event) and the verify-on-stop nudge replays an
+older foreground run forever — quoting test counts that no longer exist.
+
+These tests exercise the real registry against real short-lived processes. The
+project's canonical verify command (``pnpm run test``) is resolved through a
+PATH shim so the assertions are hermetic and never depend on a real pnpm.
+"""
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from agent.verification_evidence import mark_workspace_edited, verification_status
+from tools.process_registry import ProcessRegistry
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    return ProcessRegistry()
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A node project whose canonical verify command is `pnpm run test`."""
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"test": "vitest", "lint": "eslint ."}})
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def shim_env(tmp_path):
+    """Put a fake `pnpm` on PATH so no real toolchain is required.
+
+    The shim exits with the code named by HERMES_TEST_SHIM_RC (default 0), which
+    lets one shim serve both the passing and failing cases. It optionally sleeps
+    first (HERMES_TEST_SHIM_SLEEP) so a test can kill a still-running command
+    without appending shell syntax that the classifier would reject.
+    """
+    bin_dir = tmp_path / "shimbin"
+    bin_dir.mkdir()
+    shim = bin_dir / "pnpm"
+    shim.write_text(
+        "#!/bin/sh\n"
+        'echo "shim pnpm $*"\n'
+        'if [ -n "${HERMES_TEST_SHIM_SLEEP:-}" ]; then sleep "$HERMES_TEST_SHIM_SLEEP"; fi\n'
+        'exit "${HERMES_TEST_SHIM_RC:-0}"\n'
+    )
+    shim.chmod(0o755)
+    return {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+
+def _await_exit(registry, session_id, timeout=15.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        session = registry._finished.get(session_id)
+        if session is not None and session.exited:
+            # The evidence write happens on the same completion path; give the
+            # reader thread a moment to finish it before asserting.
+            time.sleep(0.05)
+            return session
+        time.sleep(0.05)
+    raise AssertionError(f"background process {session_id} did not finish in {timeout}s")
+
+
+def test_background_verification_run_records_evidence(registry, project, shim_env):
+    """A passing background test command must land in the ledger.
+
+    This is the regression: before the fix the ledger had no row for it,
+    because only the foreground path recorded.
+    """
+    session = registry.spawn_local(
+        "pnpm run test",
+        cwd=str(project),
+        task_id="t-bg-evidence",
+        env_vars=shim_env,
+    )
+    session.parent_session_id = "sess-bg"
+    _await_exit(registry, session.id)
+
+    status = verification_status(session_id="sess-bg", cwd=project)
+    assert status["status"] == "passed", (
+        f"background verification run was not recorded: {status}"
+    )
+    evidence = status["evidence"]
+    assert evidence is not None
+    assert evidence["canonical_command"] == "pnpm run test"
+    assert evidence["exit_code"] == 0
+
+
+def test_background_run_clears_stale_after_an_edit(registry, project, shim_env):
+    """The real user-visible symptom: stale must become passed again.
+
+    An edit marks the workspace stale. A background verification that passes
+    afterwards has to repoint the ledger, or the nudge keeps replaying the
+    older event forever.
+    """
+    mark_workspace_edited(
+        session_id="sess-bg",
+        cwd=project,
+        paths=[str(project / "src" / "app.ts")],
+    )
+    assert verification_status(session_id="sess-bg", cwd=project)["status"] in {
+        "unverified",
+        "stale",
+    }
+
+    session = registry.spawn_local(
+        "pnpm run test",
+        cwd=str(project),
+        task_id="t-bg-stale",
+        env_vars=shim_env,
+    )
+    session.parent_session_id = "sess-bg"
+    _await_exit(registry, session.id)
+
+    assert verification_status(session_id="sess-bg", cwd=project)["status"] == "passed"
+
+
+def test_failing_background_run_is_recorded_as_failed(registry, project, shim_env):
+    """A red background suite must never be recorded as passing."""
+    session = registry.spawn_local(
+        "pnpm run test",
+        cwd=str(project),
+        task_id="t-bg-fail",
+        env_vars={**shim_env, "HERMES_TEST_SHIM_RC": "1"},
+    )
+    session.parent_session_id = "sess-bg-fail"
+    _await_exit(registry, session.id)
+
+    status = verification_status(session_id="sess-bg-fail", cwd=project)
+    assert status["status"] != "passed"
+    assert status["evidence"] is not None
+    assert status["evidence"]["status"] == "failed"
+
+
+def test_non_verification_background_command_records_nothing(
+    registry, project, shim_env
+):
+    """Only verification commands are evidence; a plain command is not."""
+    session = registry.spawn_local(
+        "echo hello",
+        cwd=str(project),
+        task_id="t-bg-noise",
+        env_vars=shim_env,
+    )
+    session.parent_session_id = "sess-bg-noise"
+    _await_exit(registry, session.id)
+
+    status = verification_status(session_id="sess-bg-noise", cwd=project)
+    assert status["evidence"] is None
+    assert status["status"] == "unverified"
+
+
+def test_evidence_is_recorded_exactly_once(registry, project, shim_env):
+    """A re-entrant completion must not insert duplicate evidence rows.
+
+    ``_move_to_finished`` is reachable more than once for the same session
+    (kill racing the reader thread), which is why the notification path guards
+    on ``was_running``. The evidence write sits under the same guard and needs
+    its own proof, otherwise a duplicate-insert regression would be invisible.
+    """
+    session = registry.spawn_local(
+        "pnpm run test",
+        cwd=str(project),
+        task_id="t-bg-once",
+        env_vars=shim_env,
+    )
+    session.parent_session_id = "sess-bg-once"
+    finished = _await_exit(registry, session.id)
+
+    # Re-drive the completion path exactly as a racing kill would.
+    registry._move_to_finished(finished)
+    registry._move_to_finished(finished)
+
+    db = Path(os.environ["HERMES_HOME"]) / "verification_evidence.db"
+    with sqlite3.connect(db) as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM verification_events WHERE session_id = ?",
+            ("sess-bg-once",),
+        ).fetchone()[0]
+    assert rows == 1, f"expected exactly one evidence row, got {rows}"
+
+
+def test_killed_background_run_is_not_recorded_at_all(
+    registry, project, shim_env
+):
+    """A verification process the user killed is not proof of anything.
+
+    Asserting merely "not passed" would be too weak: a killed run exits
+    non-zero, so it would satisfy that even if the completion-reason guard
+    were removed and the kill were recorded as a genuine test *failure*.
+    Recording a spurious failure is its own bug — it would tell the user their
+    suite is red when they simply stopped it. So require that nothing is
+    recorded at all.
+
+    The command must also be the bare canonical verify command. A compound
+    like ``pnpm run test; sleep 30`` is rejected by the classifier on its own,
+    which would make this test pass whether or not the guard exists.
+    """
+    session = registry.spawn_local(
+        "pnpm run test",
+        cwd=str(project),
+        task_id="t-bg-killed",
+        # Hold the process open so there is a live run to kill, without
+        # turning the command into an unclassifiable compound.
+        env_vars={**shim_env, "HERMES_TEST_SHIM_SLEEP": "30"},
+    )
+    session.parent_session_id = "sess-bg-killed"
+    time.sleep(0.3)
+    registry.kill_process(session.id)
+    _await_exit(registry, session.id)
+
+    status = verification_status(session_id="sess-bg-killed", cwd=project)
+    assert status["evidence"] is None, (
+        f"a killed run must not be recorded as evidence: {status}"
+    )
+    assert status["status"] == "unverified"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -426,6 +426,11 @@ class ProcessSession:
     _watch_strike_candidate: bool = field(default=False, repr=False)
     _watch_consecutive_strikes: int = field(default=0, repr=False)
     _completion_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    # Set the instant a kill is requested, before the signal is sent. The
+    # reader thread can observe the dead process and finish the session before
+    # kill_process() gets to stamp completion_reason, so this is the reliable
+    # "this did not end on its own" marker for completion consumers.
+    _kill_requested: bool = field(default=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
@@ -1646,6 +1651,67 @@ class ProcessRegistry:
             _redact_process_result(notification)
             self.completion_queue.put(notification)
 
+        # Record evidence AFTER the notification is queued: delivery is
+        # user-facing and latency-sensitive, while evidence is advisory, and
+        # this does synchronous SQLite I/O on the reader thread.
+        if was_running:
+            self._record_verification_evidence(session)
+
+    def _record_verification_evidence(self, session: ProcessSession) -> None:
+        """Record a finished background command as verification evidence.
+
+        The foreground terminal path records evidence inline once the command
+        returns. A background spawn returns immediately with a synthetic
+        ``exit_code: 0`` and never reaches that code, so before this hook a
+        test suite too slow for the foreground timeout — i.e. exactly the
+        suites that must run in the background — could never record evidence
+        at all. ``verification_status()`` then stayed ``stale`` forever and the
+        verify-on-stop nudge replayed an older foreground run indefinitely.
+
+        This runs on the single completion convergence point, under the
+        ``was_running`` guard, so every exit route (reader thread, PTY reader,
+        kill, reconcile) records exactly once and a re-entrant
+        ``_move_to_finished`` cannot double-insert.
+
+        Only genuinely finished runs are eligible. A killed or lost process
+        proves nothing about the tree, so it is skipped rather than recorded
+        with its (possibly zero) exit code. ``_kill_requested`` is checked in
+        addition to ``completion_reason`` because a kill races the reader
+        thread: the process dies from the signal and the reader can publish it
+        as "exited" before kill_process() stamps "killed".
+        """
+        if session._kill_requested:
+            return
+        if session.completion_reason not in ("exited", "already_exited"):
+            return
+        if session.exit_code is None:
+            return
+        try:
+            from agent.verification_evidence import record_terminal_result
+            from tools.ansi_strip import strip_ansi
+
+            record_terminal_result(
+                command=session.command,
+                cwd=session.cwd,
+                # Mirror the foreground path's identity fallback so evidence
+                # lands under the key verification_status() later reads.
+                session_id=(
+                    session.parent_session_id
+                    or session.session_key
+                    or session.task_id
+                    or "default"
+                ),
+                exit_code=int(session.exit_code),
+                output=strip_ansi(session.output_buffer or ""),
+            )
+        except Exception:
+            # Evidence is advisory; never let it disturb process bookkeeping.
+            logger.debug(
+                "verification evidence recording failed for %s",
+                session.id,
+                exc_info=True,
+            )
+
     # ----- Query Methods -----
 
     def is_completion_consumed(self, session_id: str) -> bool:
@@ -2296,6 +2362,17 @@ class ProcessRegistry:
             if consume_output:
                 self._completion_consumed.add(session_id)
             return result
+
+        # Mark the kill intent BEFORE signalling. The reader thread wakes as
+        # soon as the process dies and calls _move_to_finished() itself; if it
+        # wins that race it sees the default completion_reason and publishes
+        # the kill as a clean "exited" with the shell's own status. Recording
+        # the intent up front makes the outcome deterministic for every
+        # completion consumer (notifications, and verification evidence, which
+        # must never bank a killed run as a real test result).
+        with session._lock:
+            session.termination_source = source
+            session._kill_requested = True
 
         # Kill via PTY, Popen (local), or env execute (non-local)
         try:


### PR DESCRIPTION
## Symptom

A verification suite that is too slow for the foreground timeout has to be run
with `terminal(background=true)`. Those runs never recorded verification
evidence, so verify-on-stop kept citing an older foreground event and reporting
`stale` no matter how many times the suite passed.

Observed in practice: an Android project whose Gradle suite takes minutes was
green at 927 tests, while the stop nudge kept replaying a much older event
(`TOTAL tests=925`) recorded before the newer edits. Nothing the user did could
clear it, because every fresh run had to be a background run.

## Root cause

The background branch of the terminal tool returns as soon as the process is
spawned:

```python
{
    "output": "Background process started",
    "session_id": proc_session.id,
    "pid": proc_session.pid,
    "exit_code": 0,
    "error": None,
}
```

That is a launch acknowledgement, not a result — it returns long before the
command exits, and its `exit_code: 0` says nothing about the outcome.

`record_terminal_result()` had exactly one production call site, on the
**foreground** completion path:

```console
$ grep -rn "record_terminal_result(" --include='*.py' . \
    | grep -v '/tests/' | grep -v 'def record_terminal_result'
./tools/terminal_tool.py:3803
```

So a background command never reached the recorder when it actually finished.
Once any later edit pushed `last_edit_at` past the stored evidence's
`created_at`, `verification_status()` correctly reported `stale` — and there was
no path by which a background run could ever replace it.

## Fix

Record on `ProcessRegistry._move_to_finished()`. It is the single point every
background exit route converges on — subprocess reader, PTY reader, kill, and
post-restart reconcile — and it already computes `was_running` to suppress
duplicate completion notifications. Reusing that guard makes the insert
exactly-once, and recording here captures the **real** exit code and final
output instead of the synthetic launch status.

It runs after the completion notification is queued: delivery is user-facing and
latency-sensitive, while evidence is advisory and does synchronous SQLite I/O on
the reader thread. Failures are swallowed to `logger.debug` — evidence must
never disturb process bookkeeping.

Killed and lost runs are skipped; they prove nothing about the tree.

### Second, pre-existing bug this surfaced

Skipping killed runs did not work at first. `kill_process()` sent SIGTERM
*before* stamping `completion_reason = "killed"`, so the reader thread could
wake on the freshly-dead process and publish it through `_move_to_finished()`
as a clean `"exited"` carrying the shell's own status. That banked a
user-killed suite as a genuine test result.

Kill intent is now marked before the signal. This is not scope creep — the
evidence fix is wrong without it — and it also makes the outcome deterministic
for the existing notification consumer, which had the same race.

## Tests

`tests/tools/test_background_verification_evidence.py` spawns real processes
through a real `ProcessRegistry` against a fake `pnpm` on `PATH`. The completion
path is not mocked; the tests wait on actual process exit. Every guard is
covered by a test that fails without it:

| Test | Guard |
|---|---|
| `test_background_verification_run_records_evidence` | the hook itself |
| `test_background_run_clears_stale_after_an_edit` | the original reported symptom |
| `test_failing_background_run_is_recorded_as_failed` | real exit code, not synthetic `0` |
| `test_non_verification_background_command_does_not_record_evidence` | `_move_to_finished` now sees *every* completion |
| `test_evidence_is_recorded_exactly_once` | `was_running` dedup (asserts one DB row) |
| `test_killed_background_run_is_not_recorded_at_all` | kill guard + the pre-signal race |

The first test was confirmed RED on unmodified `main` before the fix
(`status: unverified`, `evidence: None`).

Each guard was then mutation-tested: removing the hook fails 3 tests, removing
the kill guard fails 1, reverting the pre-signal marker fails 1, and dropping
the `was_running` dedup fails 1.

## Verification

Blast radius = every test touching `ProcessRegistry`, run on both trees:

| | Result |
|---|---|
| `main` (baseline) | 259 passed, 5 skipped, exit 0 |
| this branch | 265 passed, 5 skipped, exit 0 |

+6 is exactly the new tests; no regressions.

Blocking CI gates pass locally: `ruff check .` → `All checks passed!`, and
`scripts/check-windows-footguns.py --all` → no footguns (1014 files).

`ruff format` is not applied — it would reformat ~500 pre-existing lines of
`process_registry.py` unrelated to this change, and CI does not enforce it.

Note: `tests/tools/` as a whole does not currently run clean on `main` (an
unrelated `snowballstemmer` import error, plus a pathologically slow test that
stalls both trees identically at the same point). Both are pre-existing and
unaffected by this change.
