### PR TITLE
fix(agent): load all subdirectory hint files, not just first match (#14537)

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -299,7 +299,7 @@ class SubdirectoryHintTracker:
                         hint_path,
                         digest[:12],
                     )
-                    break
+                    continue
                 self._loaded_digests.add(digest)
                 # Same security scan as startup context loading
                 content = _scan_context_content(content, filename)
@@ -319,8 +319,6 @@ class SubdirectoryHintTracker:
                     except (ValueError, RuntimeError):
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
-                # First match wins per directory (like startup loading)
-                break
             except Exception as exc:
                 logger.debug("Could not read %s: %s", hint_path, exc)
 


### PR DESCRIPTION
Fixes #14537

The module comment promises "we load ALL found (not first-wins)" but `_load_hints_for_directory()` appended one file and then broke the loop. When a directory legitimately contains both `AGENTS.md` and `.cursorrules`, the second file was silently dropped.

**Changes:**
- Remove the spurious `break` after the first match in `_load_hints_for_directory()`
- Change the duplicate-digest guard from `break` to `continue` so that finding a repeated hint file skips that file but still checks the remaining names

This aligns the implementation with the documented behavior and with user expectations for multi-convention projects.