### PR TITLE
fix(mattermost): use word-boundary checks for mention matching (#11901)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -894,8 +894,17 @@ class MattermostAdapter(BasePlatformAdapter):
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
             ]
+            # Use word-boundary checks so @hermes-bot does NOT match inside
+            # @hermes-bot2 or hermes-bot-helper.  Mattermost usernames are
+            # alphanumeric plus dashes/underscores/dots; a boundary is any
+            # character that is NOT one of those.
             has_mention = any(
-                pattern.lower() in message_text.lower()
+                re.search(
+                    re.escape(pattern) + r"(?!\w)",
+                    message_text,
+                    flags=re.IGNORECASE,
+                )
+                is not None
                 for pattern in mention_patterns
             )
 
@@ -910,7 +919,10 @@ class MattermostAdapter(BasePlatformAdapter):
             if has_mention:
                 for pattern in mention_patterns:
                     message_text = re.sub(
-                        re.escape(pattern), "", message_text, flags=re.IGNORECASE
+                        re.escape(pattern) + r"(?!\w)",
+                        "",
+                        message_text,
+                        flags=re.IGNORECASE,
                     ).strip()
 
         # Resolve sender info.


### PR DESCRIPTION
Fixes #11901

The previous substring match (`pattern.lower() in message_text.lower()`) treated `@hermes-bot2` as a mention of `@hermes-bot`, corrupting the message text into `"2 hello"` after stripping.

**Changes:**
- Replace both the detection and the stripping logic with a regex that requires a non-word boundary (`(?!\w)`) after the mention token
- This prevents false-positive mentions on similarly-named users while still allowing normal punctuation that follows a mention (space, comma, etc.)

Closes #11901