### PR TITLE
fix(buzz): let the requirement gate see externally managed secrets

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -50,6 +50,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import current_secret_scope as _current_secret_scope
 from agent.secret_scope import get_secret as _scoped_get_secret
 
 
@@ -65,11 +66,58 @@ def _get_scoped_secret(name, default=None):
     profile's own value, so fall back to it. Same pattern as the Slack
     ``SLACK_APP_TOKEN`` read (#59739) and
     ``gateway/platforms/whatsapp_common.py::_get_wsecret``.
+
+    The no-scope path has one more rung for the platform requirement gate:
+    ``check_requirements()`` runs at gateway startup BEFORE any per-profile
+    secret scope is installed, and ``get_secret`` without a scope simply
+    reads ``os.environ`` — so a Bitwarden-managed ``BUZZ_PRIVATE_KEY``
+    (only ``BWS_ACCESS_TOKEN`` in ``.env``) was invisible to the check and
+    Buzz was silently skipped (#95216). When no scope is active and the
+    process env has no value, consult a one-shot build of the profile's
+    secret mapping (``build_profile_secret_scope`` resolves external secret
+    sources) so externally managed credentials pass the gate. An ACTIVE
+    scope still shadows this rung entirely — it never runs under
+    multiplexing, so cross-profile isolation is unchanged.
     """
     try:
-        val = _scoped_get_secret(name, default)
+        val = _scoped_get_secret(name, None)
     except _UnscopedSecretError:
         val = os.getenv(name)
+    if val is None and _current_secret_scope() is None:
+        val = _unscoped_profile_secrets().get(name)
+    return val if val is not None else default
+
+
+_UNSCOPED_PROFILE_SECRETS: Optional[Dict[str, str]] = None
+
+
+def _unscoped_profile_secrets() -> Dict[str, str]:
+    """One-shot build of the active profile's secret mapping.
+
+    Cached for the process: the build shells out to external secret
+    resolvers (Bitwarden via ``BWS_ACCESS_TOKEN``), and the requirement
+    gate / validate / is_connected probes all want the same snapshot. Any
+    failure degrades to an empty mapping — callers then simply report the
+    platform as not configured, which is the pre-fix behavior.
+    """
+    global _UNSCOPED_PROFILE_SECRETS
+    if _UNSCOPED_PROFILE_SECRETS is None:
+        try:
+            from agent.secret_scope import build_profile_secret_scope
+            from hermes_constants import get_hermes_home
+
+            _UNSCOPED_PROFILE_SECRETS = dict(
+                build_profile_secret_scope(get_hermes_home())
+            )
+        except Exception:
+            logger.warning(
+                "Buzz requirement probe could not build the profile secret "
+                "scope; Bitwarden-managed credentials will not be visible "
+                "to the startup gate (#95216)",
+                exc_info=True,
+            )
+            _UNSCOPED_PROFILE_SECRETS = {}
+    return _UNSCOPED_PROFILE_SECRETS
     return val if val is not None else default
 
 
@@ -1256,15 +1304,17 @@ class BuzzAdapter(BasePlatformAdapter):
 
 def check_requirements() -> bool:
     """Check if Buzz is configured: a relay URL plus a resolvable key."""
-    if not os.getenv("BUZZ_RELAY_URL", "").strip():
+    # Scope-aware read: the gate runs before per-profile scopes install, and
+    # BUZZ_RELAY_URL can be externally managed just like the key (#95216).
+    if not (_get_scoped_secret("BUZZ_RELAY_URL", "") or "").strip():
         return False
     return bool(_resolve_private_key())
 
 
 def validate_config(config) -> bool:
-    """Validate that the platform config has enough info to connect."""
+    """Validate that the platform config has enough information to connect."""
     extra = getattr(config, "extra", {}) or {}
-    relay = os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")
+    relay = _get_scoped_secret("BUZZ_RELAY_URL", "") or extra.get("relay_url", "")
     return bool(relay and _resolve_private_key(extra))
 
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -98,7 +98,10 @@ def _unscoped_profile_secrets() -> Dict[str, str]:
     resolvers (Bitwarden via ``BWS_ACCESS_TOKEN``), and the requirement
     gate / validate / is_connected probes all want the same snapshot. Any
     failure degrades to an empty mapping — callers then simply report the
-    platform as not configured, which is the pre-fix behavior.
+    platform as not configured, which is the pre-fix behavior. The cache
+    is startup-gate-only: it pins whatever ``get_hermes_home()`` resolved
+    on first build, so it must not be reused off the startup path (where
+    a profile scope is always active and shadows it anyway).
     """
     global _UNSCOPED_PROFILE_SECRETS
     if _UNSCOPED_PROFILE_SECRETS is None:
@@ -118,7 +121,6 @@ def _unscoped_profile_secrets() -> Dict[str, str]:
             )
             _UNSCOPED_PROFILE_SECRETS = {}
     return _UNSCOPED_PROFILE_SECRETS
-    return val if val is not None else default
 
 
 logger = logging.getLogger(__name__)

--- a/tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py
+++ b/tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py
@@ -1,0 +1,125 @@
+"""Regression tests for the Buzz requirement gate vs external secrets (#95216).
+
+``check_requirements()`` runs at gateway startup BEFORE the per-profile
+secret scope is installed, so a Bitwarden-managed ``BUZZ_PRIVATE_KEY`` (only
+``BWS_ACCESS_TOKEN`` in ``.env``) was invisible to the bare env read and Buzz
+was silently skipped. The fix adds a one-shot ``build_profile_secret_scope``
+consultation to the unscoped fallback of ``_get_scoped_secret``.
+
+The key values below are synthesized placeholders (never a usable secret).
+"""
+
+import os
+
+import pytest
+
+# Synthesized, non-credential placeholder (any non-empty string exercises
+# the gate; no real key material is ever embedded here).
+_STUB_KEY = os.environ.get("BUZZ_TEST_STUB_KEY") or ("k" * 8)
+
+
+@pytest.fixture(autouse=True)
+def _reset_unscoped_cache():
+    import plugins.platforms.buzz.adapter as adapter
+
+    prev = adapter._UNSCOPED_PROFILE_SECRETS
+    adapter._UNSCOPED_PROFILE_SECRETS = None
+    yield
+    adapter._UNSCOPED_PROFILE_SECRETS = prev
+
+
+def _install_fake_scope(monkeypatch, secrets):
+    """Point build_profile_secret_scope at a fake external-secret snapshot."""
+    import agent.secret_scope as secret_scope
+
+    calls = []
+
+    def fake_build(home):  # noqa: ANN001 - test double
+        calls.append(home)
+        return dict(secrets)
+
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", fake_build)
+    return calls
+
+
+class TestRequirementGateSeesExternalSecrets:
+    def test_externally_managed_key_passes_gate(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "stub-token")
+        _install_fake_scope(
+            monkeypatch,
+            {"BUZZ_RELAY_URL": "wss://relay.example", "BUZZ_PRIVATE_KEY": _STUB_KEY},
+        )
+
+        assert adapter.check_requirements() is True
+
+    def test_gate_fails_cleanly_when_nothing_resolves(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        _install_fake_scope(monkeypatch, {})
+
+        assert adapter.check_requirements() is False
+
+    def test_relay_from_env_still_passes_with_external_key(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        _install_fake_scope(monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY})
+
+        assert adapter.check_requirements() is True
+
+    def test_profile_scope_build_failure_degrades_to_not_configured(
+        self, monkeypatch
+    ):
+        import agent.secret_scope as secret_scope
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.delenv("BUZZ_RELAY_URL", raising=False)
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+
+        def boom(home):  # noqa: ANN001 - test double
+            raise RuntimeError("external secret resolver unavailable")
+
+        monkeypatch.setattr(secret_scope, "build_profile_secret_scope", boom)
+        assert adapter.check_requirements() is False
+
+    def test_scope_snapshot_is_built_once_and_cached(self, monkeypatch):
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        calls = _install_fake_scope(monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY})
+
+        assert adapter.check_requirements() is True
+        assert adapter.check_requirements() is True
+        assert adapter.validate_config(type("Cfg", (), {"extra": {}})()) is True
+        assert len(calls) == 1, "the external-secret snapshot must be cached"
+
+
+class TestScopedSemanticsUnchanged:
+    def test_active_scope_miss_does_not_fall_through_to_unscoped_build(
+        self, monkeypatch
+    ):
+        """A scoped miss must keep returning default: the unscoped build is
+        only for the no-scope startup gate, never a cross-profile borrow."""
+        import agent.secret_scope as secret_scope
+        import plugins.platforms.buzz.adapter as adapter
+
+        monkeypatch.setenv("BUZZ_RELAY_URL", "wss://relay.example")
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        calls = _install_fake_scope(
+            monkeypatch, {"BUZZ_PRIVATE_KEY": _STUB_KEY * 2}
+        )
+        token = secret_scope.set_secret_scope({})  # active, empty scope
+
+        try:
+            assert adapter.check_requirements() is False
+            assert calls == [], "an active scope must shadow the unscoped build"
+        finally:
+            secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## What does this PR do?

The Buzz platform requirement gate runs at gateway startup BEFORE any per-profile secret scope is installed, and the scope-less `get_secret` path reads only `os.environ`. A Bitwarden-managed `BUZZ_PRIVATE_KEY` (canonical setup: only `BWS_ACCESS_TOKEN` in `.env`, the key itself resolved by the external secret source) was therefore invisible to `check_requirements()`, and the gateway logged `Platform 'Buzz' requirements not met` with a misleading CLI install hint, silently skipping the platform even though both the key and the `buzz` CLI were available (#95216; the report verifies `check without secret scope: False / check with default Bitwarden secret scope: True`).

The fix adds one rung to the existing `_get_scoped_secret` fallback chain: when **no scope is active** and the process env has no value, consult a cached one-shot build of the profile's secret mapping (`build_profile_secret_scope` already resolves external secret sources such as Bitwarden). An active scope shadows this rung entirely — it never executes under multiplexing, so cross-profile isolation semantics are unchanged, and a build failure degrades to the pre-fix "not configured" outcome rather than crashing the gate. The `BUZZ_RELAY_URL` reads in `check_requirements`/`validate_config` now go through the same helper, so an externally managed relay passes the gate too.

## Related Issue

Fixes #95216

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py` — `_get_scoped_secret()` consults a new `_unscoped_profile_secrets()` helper (cached `build_profile_secret_scope(get_hermes_home())`, empty on failure with a warning) when no scope is active and the env read misses; `check_requirements()`/`validate_config()` read `BUZZ_RELAY_URL` through the helper instead of bare `os.getenv`.
- `tests/plugins/platforms/buzz/test_buzz_unscoped_requirement_gate.py` — six regression tests: an externally managed key (with relay) passes the gate; nothing resolving fails cleanly; env relay + external key passes; a scope-build failure degrades to not-configured; the snapshot is built once and cached across gate/validate probes; an active empty scope still returns not-configured and never consults the unscoped build (cross-profile isolation pin).

## How to Test

1. `.venv/bin/python -m pytest tests/plugins/platforms/buzz -v` — should pass (6 passed).
2. Adjacent suites stay green: `.venv/bin/python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py tests/gateway/test_adapter_startup_secret_scope.py -q` — should pass (102 passed).
3. Fail-on-main control: `git checkout HEAD~1 -- plugins/platforms/buzz` and rerun the new file — should fail (6 errors: the cache attribute does not exist pre-fix), then restore. Observed result: `6 errors` pre-fix, `6 passed` post-fix.
4. Live check from the report's setup: store canonical `BUZZ_PRIVATE_KEY` in Bitwarden, keep only `BWS_ACCESS_TOKEN` in `.env`, install the `buzz` CLI, start the gateway — Buzz should now load instead of logging `Platform 'Buzz' requirements not met`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the open buzz PRs cover dispatch kinds, npub normalization, group addressing, reply threads, and CLI-missing degradation — none touch the requirement gate's secret resolution)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in the helper docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `get_hermes_home()`/`build_profile_secret_scope` are the existing cross-platform resolution paths; no new platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
