### PR TITLE
fix(process): return running wait checkpoints

### DIFF
--- a/tests/tools/test_process_wait_clarity.py
+++ b/tests/tools/test_process_wait_clarity.py
@@ -1,8 +1,12 @@
-"""Tests for process wait timeout-result clarity (not-an-error semantics)."""
+"""Tests for truthful process wait checkpoints and terminal states."""
+
+import sys
+import time
+from typing import Any, cast
 
 import pytest
 
-from tools.process_registry import ProcessRegistry
+from tools.process_registry import ProcessRegistry, ProcessSession
 
 
 @pytest.fixture
@@ -12,17 +16,19 @@ def registry(tmp_path, monkeypatch):
 
 
 def _spawn_sleeper(registry, notify=False):
-    session = registry.spawn_local("sleep 30", cwd="/tmp", task_id="t-waitclar")
+    command = f'"{sys.executable}" -c "import time; time.sleep(30)"'
+    session = registry.spawn_local(command, cwd="/tmp", task_id="t-waitclar")
     session.notify_on_complete = notify
     return session.id
 
 
 class TestWaitTimeoutClarity:
-    def test_wait_timeout_marks_process_running(self, registry):
+    def test_wait_window_expiry_is_a_running_checkpoint(self, registry):
         sid = _spawn_sleeper(registry)
         try:
             r = registry.wait(sid, timeout=1)
-            assert r["status"] == "timeout"
+            assert r["status"] == "running"
+            assert r["wait_window_expired"] is True
             assert r["process_running"] is True
             assert "not an error" in r["timeout_note"]
             assert "Uptime" in r["timeout_note"]
@@ -45,12 +51,15 @@ class TestWaitTimeoutClarity:
         finally:
             registry.kill_process(sid)
 
-    def test_clamped_wait_keeps_clamp_note_and_running_semantics(self, registry, monkeypatch):
+    def test_clamped_wait_keeps_clamp_note_and_running_semantics(
+        self, registry, monkeypatch
+    ):
         monkeypatch.setenv("TERMINAL_TIMEOUT", "1")
         sid = _spawn_sleeper(registry)
         try:
             r = registry.wait(sid, timeout=600)
-            assert r["status"] == "timeout"
+            assert r["status"] == "running"
+            assert r["wait_window_expired"] is True
             assert "clamped" in r["timeout_note"]
             assert "not an error" in r["timeout_note"]
             assert r["process_running"] is True
@@ -62,3 +71,94 @@ class TestWaitTimeoutClarity:
         r = registry.wait(session.id, timeout=10)
         assert r["status"] == "exited"
         assert "process_running" not in r
+        assert "wait_window_expired" not in r
+
+    @pytest.mark.parametrize(
+        ("exit_code", "completion_reason", "termination_source"),
+        [
+            (0, "exited", ""),
+            (7, "exited", ""),
+            (124, "exited", ""),
+            (-15, "killed", "process.kill"),
+        ],
+    )
+    def test_terminal_states_remain_machine_detectable(
+        self, registry, exit_code, completion_reason, termination_source
+    ):
+        session = ProcessSession(
+            id=f"proc_terminal_{exit_code}",
+            command="controlled child",
+            started_at=time.time(),
+            exited=True,
+            exit_code=exit_code,
+            completion_reason=completion_reason,
+            termination_source=termination_source,
+        )
+        session._completion_event.set()
+        registry._finished[session.id] = session
+
+        r = registry.wait(session.id, timeout=1)
+
+        assert r["status"] == "exited"
+        assert r["exit_code"] == exit_code
+        assert r["completion_reason"] == completion_reason
+        assert r["termination_source"] == termination_source
+        assert "wait_window_expired" not in r
+
+    def test_unknown_session_remains_distinct(self, registry):
+        r = registry.wait("proc_unknown", timeout=1)
+        assert r["status"] == "not_found"
+        assert "error" in r
+        assert "wait_window_expired" not in r
+
+    def test_interrupt_at_wait_deadline_remains_distinct(self, registry, monkeypatch):
+        session = ProcessSession(
+            id="proc_deadline_interrupt",
+            command="controlled child",
+            started_at=time.time(),
+        )
+        registry._running[session.id] = session
+        interrupted = False
+
+        class InterruptAtDeadline:
+            def wait(self, timeout=None):
+                nonlocal interrupted
+                time.sleep(timeout or 0)
+                interrupted = True
+                return False
+
+            def set(self):
+                pass
+
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: interrupted)
+        session._completion_event = cast(Any, InterruptAtDeadline())
+        r = registry.wait(session.id, timeout=1)
+
+        assert r["status"] == "interrupted"
+        assert "wait_window_expired" not in r
+
+    def test_exit_at_wait_deadline_never_returns_a_live_checkpoint(self, registry):
+        session = ProcessSession(
+            id="proc_deadline_exit",
+            command="controlled child",
+            started_at=time.time(),
+        )
+        registry._running[session.id] = session
+
+        class ExitAtDeadline:
+            def wait(self, timeout=None):
+                time.sleep(timeout or 0)
+                session.exited = True
+                session.exit_code = 0
+                session.completion_reason = "exited"
+                return True
+
+            def set(self):
+                pass
+
+        session._completion_event = cast(Any, ExitAtDeadline())
+        r = registry.wait(session.id, timeout=1)
+
+        assert r["status"] == "exited"
+        assert r["exit_code"] == 0
+        assert "wait_window_expired" not in r

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2142,8 +2142,9 @@ class ProcessRegistry:
             timeout: Max seconds to block. Falls back to TERMINAL_TIMEOUT config.
 
         Returns:
-            dict with status ("exited", "timeout", "interrupted", "not_found")
-            and output snapshot.
+            dict with status ("running", "exited", "interrupted", "not_found")
+            and output snapshot. A running result with wait_window_expired=true
+            is a non-terminal checkpoint, not a command timeout.
         """
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
@@ -2182,6 +2183,33 @@ class ProcessRegistry:
 
         deadline = time.monotonic() + effective_timeout
 
+        def exited_result(current: ProcessSession) -> dict | None:
+            if not current.exited:
+                return None
+            self._completion_consumed.add(session_id)
+            result = {
+                "status": "exited",
+                "command": current.command,
+                "exit_code": current.exit_code,
+                "completion_reason": current.completion_reason,
+                "termination_source": current.termination_source,
+                "output": strip_ansi(current.output_buffer[-2000:]),
+            }
+            if timeout_note:
+                result["timeout_note"] = timeout_note
+            return result
+
+        def interrupted_result(current: ProcessSession) -> dict:
+            result = {
+                "status": "interrupted",
+                "command": current.command,
+                "output": strip_ansi(current.output_buffer[-1000:]),
+                "note": "User sent a new message -- wait interrupted",
+            }
+            if timeout_note:
+                result["timeout_note"] = timeout_note
+            return result
+
         while time.monotonic() < deadline:
             session = self._refresh_detached_session(session)
             if session is None:
@@ -2190,38 +2218,34 @@ class ProcessRegistry:
             # pipe reader hangs where the reader is blocked but the direct
             # child has already exited (issue #17327).
             self._reconcile_local_exit(session)
-            if session.exited:
-                self._completion_consumed.add(session_id)
-                result = {
-                    "status": "exited",
-                    "command": session.command,
-                    "exit_code": session.exit_code,
-                    "completion_reason": session.completion_reason,
-                    "termination_source": session.termination_source,
-                    "output": strip_ansi(session.output_buffer[-2000:]),
-                }
-                if timeout_note:
-                    result["timeout_note"] = timeout_note
-                return result
+            terminal_result = exited_result(session)
+            if terminal_result is not None:
+                return terminal_result
 
             if _is_interrupted():
-                result = {
-                    "status": "interrupted",
-                    "command": session.command,
-                    "output": strip_ansi(session.output_buffer[-1000:]),
-                    "note": "User sent a new message -- wait interrupted",
-                }
-                if timeout_note:
-                    result["timeout_note"] = timeout_note
-                return result
+                return interrupted_result(session)
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
             session._completion_event.wait(timeout=min(1.0, remaining))
 
+        # The child can exit while the final bounded event wait returns. Check
+        # once more before emitting a live checkpoint so terminal state wins
+        # at the deadline boundary.
+        session = self._refresh_detached_session(session)
+        if session is None:
+            return {"status": "not_found", "error": f"No process with ID {session_id}"}
+        self._reconcile_local_exit(session)
+        terminal_result = exited_result(session)
+        if terminal_result is not None:
+            return terminal_result
+        if _is_interrupted():
+            return interrupted_result(session)
+
         result = {
-            "status": "timeout",
+            "status": "running",
+            "wait_window_expired": True,
             "command": session.command,
             "output": strip_ansi(session.output_buffer[-1000:]),
             # A wait window elapsing is NOT a failure — 511 exact-duplicate
@@ -3193,7 +3217,8 @@ PROCESS_SCHEMA = {
     "description": (
         "Manage background processes started with terminal(background=true). "
         "Actions: 'list' (show all), 'poll' (check status + new output), "
-        "'log' (full output with pagination), 'wait' (block until done or timeout), "
+        "'log' (full output with pagination), 'wait' (block until done or a bounded "
+        "running checkpoint), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
         "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
     ),
@@ -3215,7 +3240,7 @@ PROCESS_SCHEMA = {
             },
             "timeout": {
                 "type": "integer",
-                "description": "Max seconds to block for 'wait' action. Returns partial output on timeout.",
+                "description": "Max seconds to block for 'wait'. If the child remains live, returns status='running' with wait_window_expired=true and partial output.",
                 "minimum": 1
             },
             "offset": {


### PR DESCRIPTION
## Problem

`process(action=wait)` used `status="timeout"` when only the bounded wait window expired and the child was still alive. Machine consumers could therefore count ordinary checkpoints as failures.

## Change

- Return `status="running"`, `wait_window_expired=true`, and the existing `process_running=true` for live bounded-wait checkpoints.
- Reconcile child exit once more at the deadline boundary before emitting a running checkpoint.
- Preserve terminal exit details (`exit_code`, `completion_reason`, `termination_source`) and give terminal exit precedence over interruption, then interruption over a running checkpoint.
- Update the process tool schema text to describe the structured checkpoint.

Repository caller search found no production caller that branches on `status="timeout"`; the only direct expectation was the existing wait-clarity regression test.

## Verification

- RED: focused test failed on the old `status="timeout"` result and on an exit at the deadline boundary.
- `scripts/run_tests.sh tests/tools/test_process_registry.py tests/tools/test_process_wait_clarity.py tests/tools/test_zombie_process_cleanup.py -q` — 114 passed, 4 Windows-only skipped.
- `ruff check tools/process_registry.py tests/tools/test_process_wait_clarity.py` — passed.
- Live `_handle_process` probes with controlled children: running checkpoint, exit 0, exit 7, GNU `timeout` exit 124, explicit kill, and unknown session all returned distinct structured states.
- Independent review approved the final commit with no security or logic findings.

## Scope

No changes to process output, polling, logging, cancellation, notifications, application behavior, providers, models, benchmarks, or Kanban dispatch.