### PR TITLE
fix(desktop): keep the composer mounted through session-loading flickers (#88621)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -517,10 +517,17 @@ const ChatViewContent = memo(function ChatViewContent({
     !resumeExhausted && isRoutedSessionView && (routeSessionMismatch || (messagesEmpty && !activeSessionId))
 
   const threadLoading = threadLoadingState(loadingSession, busy, awaitingResponse, lastVisibleIsUser)
-  // Hide the composer in the exhausted error state too: there's no live runtime
-  // to send to until a retry rebinds one. Watch windows are pure spectators of a
-  // subagent run driven elsewhere — no composer, transcript is read-only.
-  const showChatBar = !loadingSession && !resumeExhausted && !isWatchWindow()
+  // The composer mount deliberately does NOT follow `routeSessionMismatch`.
+  // That flag is a transient split-write flicker during session switches (the
+  // routed id and the active id land in two separate store writes), and
+  // unmounting the composer mid-typing destroys DOM focus and the caret — the
+  // #88621 class of "it stopped letting me type" bugs. The transcript still
+  // shows the loader; the composer stays mounted and the draft-swap layout
+  // effect handles the session transition. Hide it only when there is
+  // genuinely no session yet (route not resumed), the resume gave up (no live
+  // runtime to send to), or the window is a read-only watch spectator.
+  const showChatBar =
+    !(isRoutedSessionView && messagesEmpty && !activeSessionId) && !resumeExhausted && !isWatchWindow()
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({


### PR DESCRIPTION
## What

Fixes the #88621 class of "the composer stopped letting me type" bugs: the composer is **conditionally mounted** behind `showChatBar`, and `loadingSession` (specifically its `routeSessionMismatch` branch) could unmount it for a single render mid-typing. Unmounting a focused contenteditable destroys DOM focus and the caret; on remount the focus-effect refocuses but the selection is gone, so the box looks normal and keystrokes go nowhere until the user clicks to plant a caret again.

## Why

`routeSessionMismatch` is a transient split-write flicker: a delivery updates the routed session id and the active session id in two separate store writes, so there is a render where they disagree. That flip made `loadingSession` true, `showChatBar` false, and the composer unmounted — once per triggering update, exactly the "happens sometimes while typing" report.

## The fix

`src/app/chat/index.tsx`: the composer mount no longer follows `routeSessionMismatch`. The transcript still shows the loader (that path is unchanged), the composer stays mounted, and the existing draft-swap layout effect handles the session transition. The composer is still hidden when:

- there is genuinely no session yet (`isRoutedSessionView && messagesEmpty && !activeSessionId`),
- the resume gave up (`resumeExhausted` — no live runtime to send to),
- the window is a read-only watch spectator.

All other `showChatBar` behaviors are preserved bit-for-bit; only the transient-mismatch unmount is removed.

## Related

- https://github.com/NousResearch/hermes-agent/issues/88621 (P2, open)
- https://github.com/NousResearch/hermes-agent/issues/84058 (same caret-loss class)

No existing fix PR was found for either issue. A second seam from the issue — `contentEditable={!inputDisabled}` flipping on gateway-socket flaps — is deliberately out of scope here; it is a different trigger and needs its own reproduction.
