### PR TITLE
fix(desktop): Quick Entry reports unreachable shortcut services instead of false conflicts; composer state now delivered reliably

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -279,6 +279,7 @@ import {
   spliceRegistrySessionRows
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import { createQuickEntryStateRelay, sameQuickEntryState } from './quick-entry-state-relay'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
@@ -12468,6 +12469,11 @@ let quickEntryWindow = null
 // replayed to a quick window that spawns after the push happened.
 let quickEntryLastState = null
 
+// Acknowledged-retry policy delivering that cached truth to the CURRENT quick
+// window; recreated on every spawn, cancelled when the window closes. See
+// electron/quick-entry-state-relay.ts for why the blind replay raced (#95132).
+let quickEntryStateRelay = null
+
 function readQuickEntrySettings() {
   try {
     return sanitizeQuickEntrySettings(JSON.parse(fs.readFileSync(QUICK_ENTRY_CONFIG_PATH, 'utf8')))
@@ -12558,15 +12564,20 @@ function spawnQuickEntryWindow() {
   win.on('closed', () => {
     if (quickEntryWindow === win) {
       quickEntryWindow = null
+      quickEntryStateRelay?.cancel()
+      quickEntryStateRelay = null
     }
   })
 
   // Replay the last known gateway state as soon as the page can hear it — a
   // freshly spawned quick window must not sit "disconnected" when the primary
-  // renderer already reported a live gateway.
+  // renderer already reported a live gateway. `did-finish-load` only promises
+  // that resources finished loading, not that React has mounted and wired its
+  // `hermesDesktop.quickEntry.onState` listener yet (#95132), so delivery goes
+  // through the acknowledged-retry relay instead of one blind send.
   win.webContents.on('did-finish-load', () => {
     if (!win.isDestroyed() && quickEntryLastState) {
-      win.webContents.send('hermes:quick-entry:state', quickEntryLastState)
+      quickEntryStateRelay?.deliver(quickEntryLastState)
     }
   })
 
@@ -12593,6 +12604,13 @@ function showQuickEntryWindow() {
     // points at by the time the event lands.
     const win = spawnQuickEntryWindow()
     quickEntryWindow = win
+    quickEntryStateRelay?.cancel()
+    quickEntryStateRelay = createQuickEntryStateRelay({
+      equals: sameQuickEntryState,
+      isTargetAlive: () => Boolean(quickEntryWindow && !quickEntryWindow.isDestroyed()),
+      latest: () => quickEntryLastState,
+      send: payload => quickEntryWindow?.webContents.send('hermes:quick-entry:state', payload)
+    })
 
     wireWindowReveal(win, {
       show: () => {
@@ -12609,6 +12627,15 @@ function showQuickEntryWindow() {
   quickEntryWindow.focus()
   // Re-summoned: tell the renderer to clear any stale draft and refocus.
   quickEntryWindow.webContents.send('hermes:quick-entry:shown')
+
+  // The renderer keeps its composer state across hides, but a reload (crash
+  // recovery, dev reload) remounts it at the initial disconnected state — the
+  // same gap the did-finish-load replay covers for a cold spawn (#95132).
+  // Re-deliver the cached truth so a re-summoned window never shows "Not
+  // connected" while the primary window is live.
+  if (quickEntryLastState) {
+    quickEntryStateRelay?.deliver(quickEntryLastState)
+  }
 }
 
 function hideQuickEntryWindow() {
@@ -12631,8 +12658,8 @@ function toggleQuickEntryWindow() {
 
 const quickEntryShortcut = createQuickEntryShortcut(globalShortcut, toggleQuickEntryWindow)
 
-function applyQuickEntrySettings(settings) {
-  const state = quickEntryShortcut.apply(settings)
+async function applyQuickEntrySettings(settings) {
+  const state = await quickEntryShortcut.apply(settings)
 
   if (!settings.enabled) {
     // Turning the feature off must not leave an orphan always-on-top window.
@@ -12645,6 +12672,11 @@ function applyQuickEntrySettings(settings) {
 
   if (state.error === 'taken') {
     rememberLog(`[quick-entry] shortcut ${state.shortcut} is already taken by another application`)
+  } else if (state.error === 'unavailable') {
+    rememberLog(
+      `[quick-entry] shortcut ${state.shortcut} cannot be registered in this desktop session ` +
+        `(global shortcut service unreachable${state.detail ? `: ${state.detail}` : ''})`
+    )
   } else if (state.error === 'invalid') {
     rememberLog(`[quick-entry] shortcut ${state.shortcut} is not a valid accelerator`)
   }
@@ -15073,7 +15105,8 @@ ipcMain.handle('hermes:quick-entry:settings:get', async () => {
     enabled: settings.enabled,
     error: state.error,
     registered: state.registered,
-    shortcut: settings.enabled ? state.shortcut : settings.shortcut
+    shortcut: settings.enabled ? state.shortcut : settings.shortcut,
+    ...(state.detail ? { detail: state.detail } : {})
   }
 })
 
@@ -15124,8 +15157,19 @@ ipcMain.on('hermes:quick-entry:state', (_event, payload) => {
   quickEntryLastState = payload ?? null
 
   if (quickEntryWindow && !quickEntryWindow.isDestroyed()) {
-    quickEntryWindow.webContents.send('hermes:quick-entry:state', payload)
+    quickEntryStateRelay?.deliver(payload)
   }
+})
+
+// The quick window echoes each adopted state payload back; a matching echo
+// proves a mounted composer received it, so the acknowledged-retry relay can
+// stop resending its replay.
+ipcMain.on('hermes:quick-entry:state-ack', (event, payload) => {
+  if (!quickEntryWindow || quickEntryWindow.isDestroyed() || event.sender !== quickEntryWindow.webContents) {
+    return
+  }
+
+  quickEntryStateRelay?.acknowledge(payload ?? null)
 })
 
 ipcMain.on('hermes:quick-entry:dismiss', () => hideQuickEntryWindow())

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -145,6 +145,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     // recent-session options the target picker offers. Main caches the latest
     // payload so a freshly spawned quick window starts from truth.
     pushState: payload => ipcRenderer.send('hermes:quick-entry:state', payload),
+    // Quick window → main: echo of the last adopted state payload, proving a
+    // mounted composer received it (main retries un-acked replays).
+    ackState: payload => ipcRenderer.send('hermes:quick-entry:state-ack', payload),
     // Quick window subscribes to those pushes.
     onState: callback => {
       const listener = (_event, payload) => callback(payload)

--- a/apps/desktop/electron/quick-entry-state-relay.test.ts
+++ b/apps/desktop/electron/quick-entry-state-relay.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createQuickEntryStateRelay, sameQuickEntryState } from './quick-entry-state-relay'
+
+const payload = (connected: boolean, sessions: Array<{ id: string; title: string }> = []) => ({
+  connected,
+  sessions
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function harness(overrides: Partial<Parameters<typeof createQuickEntryStateRelay>[0]> = {}) {
+  const sent: unknown[] = []
+  let targetAlive = true
+  let latest: null | Record<string, unknown> = payload(true)
+
+  const relay = createQuickEntryStateRelay({
+    equals: sameQuickEntryState,
+    isTargetAlive: () => targetAlive,
+    latest: () => latest,
+    send: p => void sent.push(p),
+    ...overrides
+  })
+
+  return {
+    get latestValue() {
+      return latest
+    },
+    get sent() {
+      return sent
+    },
+    killTarget() {
+      targetAlive = false
+    },
+    relay,
+    setLatest(value: null | Record<string, unknown>) {
+      latest = value
+    }
+  }
+}
+
+describe('quick entry state relay (#95132)', () => {
+  it('retries delivery until an ack arrives, then stops', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+
+    h.relay.deliver(payload(true))
+
+    expect(h.sent).toHaveLength(1)
+
+    // No ack yet → resend on the backoff.
+    vi.advanceTimersByTime(100)
+    expect(h.sent).toHaveLength(2)
+
+    vi.advanceTimersByTime(100)
+    expect(h.sent).toHaveLength(3)
+
+    // A mounted composer adopts the payload and echoes it back.
+    h.relay.acknowledge(payload(true))
+    vi.advanceTimersByTime(500)
+    expect(h.sent).toHaveLength(3)
+  })
+
+  it('stops after the retry budget instead of spinning forever behind a dead composer', () => {
+    const h = harness({ retryMs: 50, maxSends: 3 })
+
+    h.relay.deliver(payload(true))
+
+    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(50)
+    expect(h.sent).toHaveLength(3)
+
+    // Budget exhausted: no fourth send ever.
+    vi.advanceTimersByTime(10_000)
+    expect(h.sent).toHaveLength(3)
+  })
+
+  it('abandons retries when the window dies mid-cycle', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+
+    h.relay.deliver(payload(true))
+    expect(h.sent).toHaveLength(1)
+
+    h.killTarget()
+    vi.advanceTimersByTime(10_000)
+    expect(h.sent).toHaveLength(1)
+  })
+
+  it('a newer cached push supersedes an in-flight replay', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+    const first = payload(false)
+
+    h.setLatest(first)
+    h.relay.deliver(first)
+    expect(h.sent).toEqual([first])
+
+    // Gateway came up while the disconnected replay was still retrying.
+    const second = payload(true)
+    h.setLatest(second)
+    h.relay.deliver(second)
+
+    vi.advanceTimersByTime(10_000)
+
+    // The stale truth must NEVER be delivered again after supersession; the
+    // fresh truth gets its own full bounded budget (default 5 sends).
+    expect(h.sent[0]).toEqual(first)
+    expect(h.sent).toHaveLength(6)
+
+    for (const delivered of h.sent.slice(1)) {
+      expect(delivered).toEqual(second)
+    }
+  })
+
+  it('a duplicate deliver of the same truth does not add sends to the in-flight cycle', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+    const value = payload(true)
+
+    h.relay.deliver(value)
+    h.relay.deliver(value) // e.g. re-summon racing the first cycle
+
+    vi.advanceTimersByTime(10_000)
+
+    // Exactly one bounded cycle (5 sends), not two.
+    expect(h.sent).toHaveLength(5)
+  })
+
+  it('a fresh deliver after a spent budget starts a clean cycle', () => {
+    const h = harness({ retryMs: 10, maxSends: 2 })
+
+    h.relay.deliver(payload(true))
+    vi.advanceTimersByTime(100)
+    expect(h.sent).toHaveLength(2)
+
+    // The window reloads and the user summons again: the next request gets its
+    // own full budget.
+    h.relay.deliver(payload(true))
+    expect(h.sent).toHaveLength(3)
+    vi.advanceTimersByTime(10)
+    expect(h.sent).toHaveLength(4)
+  })
+
+  it('refuses stale requests whose payload no longer matches the cache', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+    const stale = payload(false)
+
+    h.setLatest(payload(true))
+
+    h.relay.deliver(stale)
+
+    vi.advanceTimersByTime(10_000)
+    expect(h.sent).toHaveLength(0)
+  })
+
+  it('cancel stops everything', () => {
+    const h = harness({ retryMs: 100, maxSends: 5 })
+
+    h.relay.deliver(payload(true))
+    h.relay.cancel()
+
+    vi.advanceTimersByTime(10_000)
+    expect(h.sent).toHaveLength(1)
+  })
+})
+
+describe('sameQuickEntryState', () => {
+  it('compares gateway truth structurally, not by reference', () => {
+    expect(
+      sameQuickEntryState(payload(true, [{ id: 'a', title: 'A' }]), payload(true, [{ id: 'a', title: 'A' }]))
+    ).toBe(true)
+    expect(sameQuickEntryState(payload(true), payload(false))).toBe(false)
+    expect(
+      sameQuickEntryState(payload(true, [{ id: 'a', title: 'A' }]), payload(true, [{ id: 'b', title: 'A' }]))
+    ).toBe(false)
+    expect(sameQuickEntryState(payload(true, []), payload(true, [{ id: 'a', title: 'A' }]))).toBe(false)
+  })
+
+  it('treats missing fields defensively (null/undefined payloads)', () => {
+    expect(sameQuickEntryState(null, undefined)).toBe(true)
+    expect(sameQuickEntryState(null, payload(false))).toBe(true)
+    expect(sameQuickEntryState(payload(true), undefined)).toBe(false)
+  })
+})

--- a/apps/desktop/electron/quick-entry-state-relay.ts
+++ b/apps/desktop/electron/quick-entry-state-relay.ts
@@ -1,0 +1,169 @@
+/**
+ * Replay policy for the Quick Entry window's pushed gateway truth.
+ *
+ * The quick window carries NO gateway connection of its own: the primary
+ * renderer pushes connection state + recent sessions through main, which
+ * caches the latest payload. A window that loads AFTER a push must be replayed
+ * the cached copy, but the historical blind `webContents.send` from
+ * `did-finish-load` raced React's mount — a payload sent before the composer
+ * wired its `onState` listener vanished and the composer stayed stuck at its
+ * initial "Not connected" placeholder even while the primary window chatted
+ * away (#95132).
+ *
+ * The fix is an acknowledged, bounded retry: every delivery is retried on a
+ * short backoff until the quick window ECHOES the adopted payload back (its
+ * store keeps the payload verbatim, so an echo proves a mounted composer
+ * accepted exactly this state). Newest cached truth supersedes an in-flight
+ * replay; a dead window or an exhausted budget abandons the retry instead of
+ * spinning forever. Everything here is Electron-free so the policy is
+ * unit-testable; main.ts owns the actual windows and IPC channels.
+ */
+
+/** Default cadence: short enough to outlive React's mount, bounded forever. */
+const DEFAULT_RETRY_MS = 200
+const DEFAULT_MAX_SENDS = 5
+
+/** Structural shape of a pushed payload (kept loose — policy never inspects fields). */
+export type QuickEntryStatePayloadLike = null | undefined | Record<string, unknown>
+
+export interface QuickEntryStateRelayOptions {
+  /**
+   * Equality over gateway truth. Used both to detect supersession (a newer
+   * cached payload replaced the one being replayed) and to match acks.
+   */
+  equals: (a: QuickEntryStatePayloadLike, b: QuickEntryStatePayloadLike) => boolean
+  /** The latest payload main has cached; replays of anything older are stale. */
+  latest: () => QuickEntryStatePayloadLike
+  /** False once the target window is gone. */
+  isTargetAlive: () => boolean
+  /** Deliver the payload to the window. */
+  send: (payload: Record<string, unknown>) => void
+  retryMs?: number
+  maxSends?: number
+}
+
+export interface QuickEntryStateRelay {
+  /**
+   * Deliver a payload, replacing any in-flight replay it supersedes. Retries
+   * continue (bounded) until {@link acknowledge} matches it or the target dies.
+   */
+  deliver: (payload: Record<string, unknown>) => void
+  /** The window echoed an adopted payload; settle a matching in-flight replay. */
+  acknowledge: (payload: QuickEntryStatePayloadLike) => void
+  /** Stop retrying (target window closed, feature torn down). */
+  cancel: () => void
+}
+
+export function createQuickEntryStateRelay(options: QuickEntryStateRelayOptions): QuickEntryStateRelay {
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS
+  const maxSends = options.maxSends ?? DEFAULT_MAX_SENDS
+
+  let outstanding: null | Record<string, unknown> = null
+  let attempts = 0
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  const sendNow = () => {
+    if (!options.isTargetAlive() || !outstanding) {
+      outstanding = null
+      clearTimer()
+
+      return
+    }
+
+    options.send(outstanding)
+    attempts += 1
+    clearTimer()
+
+    // Budget spent: settle so a FUTURE delivery request (window reload,
+    // re-summon, fresh push) can start a clean cycle instead of inheriting a
+    // dead counter.
+    if (attempts >= maxSends) {
+      outstanding = null
+
+      return
+    }
+
+    timer = setTimeout(() => {
+      timer = null
+
+      if (!outstanding) {
+        return
+      }
+
+      // Superseded meanwhile: the newer truth owns the channel now.
+      const current = options.latest()
+
+      if (!current || !options.equals(outstanding, current)) {
+        outstanding = null
+
+        return
+      }
+
+      sendNow()
+    }, retryMs)
+  }
+
+  return {
+    deliver(payload) {
+      if (!payload || !options.isTargetAlive()) {
+        return
+      }
+
+      const current = options.latest()
+
+      // Stale request: something newer is already cached.
+      if (!current || !options.equals(payload, current)) {
+        return
+      }
+
+      // Already being retried for this exact truth — the in-flight loop owns
+      // the delivery; a duplicate request must not add sends.
+      if (outstanding && options.equals(outstanding, payload)) {
+        return
+      }
+
+      // A genuinely new cycle (different truth, or the previous one settled):
+      // the payload gets its own full retry budget.
+      attempts = 0
+      outstanding = payload
+      sendNow()
+    },
+    acknowledge(payload) {
+      if (outstanding && options.equals(payload, outstanding)) {
+        outstanding = null
+        clearTimer()
+      }
+    },
+    cancel() {
+      outstanding = null
+      clearTimer()
+    }
+  }
+}
+
+/** True when two pushed payloads carry the same gateway truth. */
+export function sameQuickEntryState(a: QuickEntryStatePayloadLike, b: QuickEntryStatePayloadLike): boolean {
+  const leftSessions = Array.isArray((a as { sessions?: unknown[] } | null)?.sessions)
+    ? (a as { sessions: Array<{ id?: unknown; title?: unknown }> }).sessions
+    : []
+
+  const rightSessions = Array.isArray((b as { sessions?: unknown[] } | null)?.sessions)
+    ? (b as { sessions: Array<{ id?: unknown; title?: unknown }> }).sessions
+    : []
+
+  return (
+    ((a as { connected?: unknown } | null)?.connected ?? false) ===
+      ((b as { connected?: unknown } | null)?.connected ?? false) &&
+    leftSessions.length === rightSessions.length &&
+    leftSessions.every(
+      (session, index) => session.id === rightSessions[index]?.id && session.title === rightSessions[index]?.title
+    )
+  )
+}

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -101,46 +101,46 @@ describe('sanitizeQuickEntrySettings', () => {
 })
 
 describe('createQuickEntryShortcut', () => {
-  it('registers the normalized accelerator when enabled', () => {
+  it('registers the normalized accelerator when enabled', async () => {
     const { globalShortcut } = fakeGlobalShortcut()
     const onTrigger = vi.fn()
-    const controller = createQuickEntryShortcut(globalShortcut, onTrigger)
+    const controller = createQuickEntryShortcut(globalShortcut, onTrigger, async () => ({ available: true }))
 
-    const state = controller.apply({ enabled: true, shortcut: 'cmdorctrl+shift+space' })
+    const state = await controller.apply({ enabled: true, shortcut: 'cmdorctrl+shift+space' })
 
     expect(state).toEqual({ error: null, registered: true, shortcut: 'CommandOrControl+Shift+Space' })
     expect(globalShortcut.register).toHaveBeenCalledWith('CommandOrControl+Shift+Space', onTrigger)
     expect(controller.current()).toEqual(state)
   })
 
-  it('never registers while the setting is disabled', () => {
+  it('never registers while the setting is disabled', async () => {
     const { globalShortcut } = fakeGlobalShortcut()
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: false }))
 
-    const state = controller.apply({ enabled: false, shortcut: DEFAULT_QUICK_ENTRY_SHORTCUT })
+    const state = await controller.apply({ enabled: false, shortcut: DEFAULT_QUICK_ENTRY_SHORTCUT })
 
     expect(globalShortcut.register).not.toHaveBeenCalled()
     expect(state).toEqual({ error: null, registered: false, shortcut: DEFAULT_QUICK_ENTRY_SHORTCUT })
   })
 
-  it('releases the old accelerator before registering a new one', () => {
+  it('releases the old accelerator before registering a new one', async () => {
     const { globalShortcut, held } = fakeGlobalShortcut()
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
 
-    controller.apply({ enabled: true, shortcut: 'Alt+J' })
-    controller.apply({ enabled: true, shortcut: 'Alt+K' })
+    await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+    await controller.apply({ enabled: true, shortcut: 'Alt+K' })
 
     expect(globalShortcut.unregister).toHaveBeenCalledWith('Alt+J')
     expect(held.has('Alt+J')).toBe(false)
     expect(held.has('Alt+K')).toBe(true)
   })
 
-  it('turning the feature off releases the live accelerator', () => {
+  it('turning the feature off releases the live accelerator', async () => {
     const { globalShortcut, held } = fakeGlobalShortcut()
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
 
     controller.apply({ enabled: true, shortcut: 'Alt+J' })
-    const off = controller.apply({ enabled: false, shortcut: 'Alt+J' })
+    const off = await controller.apply({ enabled: false, shortcut: 'Alt+J' })
 
     expect(globalShortcut.unregister).toHaveBeenCalledWith('Alt+J')
     expect(held.size).toBe(0)
@@ -148,32 +148,32 @@ describe('createQuickEntryShortcut', () => {
     expect(off.error).toBeNull()
   })
 
-  it("surfaces 'taken' when another app already owns the chord", () => {
+  it("surfaces 'taken' when another app already owns the chord", async () => {
     const { globalShortcut } = fakeGlobalShortcut({ taken: ['Alt+J'] })
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: false }))
 
-    const state = controller.apply({ enabled: true, shortcut: 'alt+j' })
+    const state = await controller.apply({ enabled: true, shortcut: 'alt+j' })
 
     expect(globalShortcut.register).not.toHaveBeenCalled()
     expect(state).toEqual({ error: 'taken', registered: false, shortcut: 'Alt+J' })
   })
 
-  it("surfaces 'taken' when the OS refuses the registration", () => {
+  it("surfaces 'taken' when the OS refuses the registration", async () => {
     const { globalShortcut } = fakeGlobalShortcut({ register: false })
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
 
-    expect(controller.apply({ enabled: true, shortcut: 'Alt+J' })).toEqual({
+    expect(await controller.apply({ enabled: true, shortcut: 'Alt+J' })).toEqual({
       error: 'taken',
       registered: false,
       shortcut: 'Alt+J'
     })
   })
 
-  it("surfaces 'invalid' for an unusable shortcut without asking the OS", () => {
+  it("surfaces 'invalid' for an unusable shortcut without asking the OS", async () => {
     const { globalShortcut } = fakeGlobalShortcut()
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: false }))
 
-    expect(controller.apply({ enabled: true, shortcut: 'J' })).toEqual({
+    expect(await controller.apply({ enabled: true, shortcut: 'J' })).toEqual({
       error: 'invalid',
       registered: false,
       shortcut: 'J'
@@ -181,7 +181,7 @@ describe('createQuickEntryShortcut', () => {
     expect(globalShortcut.register).not.toHaveBeenCalled()
   })
 
-  it('survives a throwing globalShortcut', () => {
+  it('survives a throwing globalShortcut', async () => {
     const globalShortcut: GlobalShortcutLike = {
       isRegistered: () => false,
       register: () => {
@@ -190,16 +190,16 @@ describe('createQuickEntryShortcut', () => {
       unregister: () => {}
     }
 
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
 
-    expect(controller.apply({ enabled: true, shortcut: 'Alt+J' }).error).toBe('taken')
+    expect((await controller.apply({ enabled: true, shortcut: 'Alt+J' })).error).toBe('taken')
   })
 
-  it('dispose releases the accelerator and is idempotent', () => {
+  it('dispose releases the accelerator and is idempotent', async () => {
     const { globalShortcut, held } = fakeGlobalShortcut()
-    const controller = createQuickEntryShortcut(globalShortcut, vi.fn())
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
 
-    controller.apply({ enabled: true, shortcut: 'Alt+J' })
+    await controller.apply({ enabled: true, shortcut: 'Alt+J' })
     controller.dispose()
     controller.dispose()
 
@@ -236,5 +236,118 @@ describe('quickEntryWindowBounds', () => {
 
   it('falls back to the origin without a work area', () => {
     expect(quickEntryWindowBounds()).toEqual({ height: 168, width: 640, x: 0, y: 0 })
+  })
+})
+
+// ── #95132 scenario A: a session that cannot host global shortcuts must not
+// be reported as "taken by another application" ──────────────────────────────
+
+describe('createQuickEntryShortcut portal probing (#95132)', () => {
+  it("reports 'unavailable' — not 'taken' — when a Linux/Wayland registration fails and no GlobalShortcuts portal answers", async () => {
+    const { globalShortcut } = fakeGlobalShortcut({ register: false })
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: false }))
+
+    const state = await controller.apply({ enabled: true, shortcut: 'Control+Shift+Space' })
+
+    expect(state.registered).toBe(false)
+    expect(state.error).toBe('unavailable')
+  })
+
+  it("keeps reporting 'taken' when the portal probe proves the service IS reachable", async () => {
+    const { globalShortcut } = fakeGlobalShortcut({ taken: ['Alt+J'] })
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({ available: true }))
+
+    const state = await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+
+    expect(state.error).toBe('taken')
+  })
+
+  it('carries the probe detail on the unavailable state for logs and Settings', async () => {
+    const { globalShortcut } = fakeGlobalShortcut({ register: false })
+
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => ({
+      available: false,
+      detail: 'busctl: No such file or directory'
+    }))
+
+    const state = await controller.apply({ enabled: true, shortcut: 'Super+-' })
+
+    expect(state.error).toBe('unavailable')
+    expect(state.detail).toBe('busctl: No such file or directory')
+  })
+
+  it('falls back to taken when the probe itself throws', async () => {
+    const { globalShortcut } = fakeGlobalShortcut({ register: false })
+
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () => {
+      throw new Error('probe exploded')
+    })
+
+    const state = await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+
+    expect(state.error).toBe('taken')
+  })
+
+  it('never probes for a plain conflict detected before registering', async () => {
+    const { globalShortcut } = fakeGlobalShortcut({ taken: ['Alt+J'] })
+    const probePortal = vi.fn(async () => ({ available: false }))
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), probePortal)
+
+    await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+
+    expect(probePortal).not.toHaveBeenCalled()
+  })
+
+  it('does not probe or reclassify on macOS-like platforms', async () => {
+    vi.stubGlobal('process', { platform: 'darwin' })
+
+    try {
+      const { globalShortcut } = fakeGlobalShortcut({ register: false })
+      const probePortal = vi.fn(async () => ({ available: false }))
+      const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), probePortal)
+
+      const state = await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+
+      expect(probePortal).not.toHaveBeenCalled()
+      expect(state.error).toBe('taken')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('releases nothing extra after an unavailable classification and can retry later', async () => {
+    // The OS refuses while the session's shortcut service is down…
+    let osRefuses = true
+    const { globalShortcut, held } = fakeGlobalShortcut()
+
+    globalShortcut.register = vi.fn((accelerator: string) => {
+      if (osRefuses) {
+        return false
+      }
+
+      held.add(accelerator)
+
+      return true
+    })
+
+    // …and the portal comes back up afterwards (user fixed their desktop
+    // session): a settings re-apply retries the registration instead of
+    // staying stuck at 'unavailable'.
+    let portalUp = false
+
+    const controller = createQuickEntryShortcut(globalShortcut, vi.fn(), async () =>
+      portalUp ? { available: true } : { available: false }
+    )
+
+    const first = await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+    expect(first.error).toBe('unavailable')
+
+    osRefuses = false
+    portalUp = true
+    const second = await controller.apply({ enabled: true, shortcut: 'Alt+J' })
+
+    expect(second.error).toBeNull()
+    expect(second.registered).toBe(true)
+    expect(controller.current()).toEqual(second)
   })
 })

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -14,6 +14,9 @@
  * `globalShortcut`.
  */
 
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
 // Default matches the muscle memory of the apps this ports from (Claude
 // Desktop's quick entry / ChatGPT's Quick Chat sit on a Cmd+Shift chord).
 const DEFAULT_QUICK_ENTRY_SHORTCUT = 'CommandOrControl+Shift+Space'
@@ -299,16 +302,85 @@ export interface GlobalShortcutLike {
 
 /**
  * What Settings shows. `registered` is the ground truth (we asked the OS);
- * `error` distinguishes "you turned it off" from "another app owns that chord",
- * which is the failure this feature must never swallow.
+ * `error` distinguishes "you turned it off" from "another app owns that chord"
+ * from "this desktop session cannot host global shortcuts at all", which are
+ * the failures this feature must never swallow.
  */
 export interface QuickEntryRegistration {
   error: null | QuickEntryRegistrationError
   registered: boolean
   shortcut: string
+  /** Probe reason when `error` is `'unavailable'`; absent otherwise. */
+  detail?: string
 }
 
-export type QuickEntryRegistrationError = 'invalid' | 'taken'
+export type QuickEntryRegistrationError = 'invalid' | 'taken' | 'unavailable'
+
+/**
+ * Result of asking the session whether the GlobalShortcuts portal is actually
+ * serviceable. `detail` carries a short human-readable reason for logs.
+ */
+export interface GlobalShortcutsPortalProbeResult {
+  available: boolean
+  detail?: string
+}
+
+/** Async probe shape (injected for testing). */
+export type GlobalShortcutsPortalProbe = () => Promise<GlobalShortcutsPortalProbeResult>
+
+const PORTAL_DBUS_TIMEOUT_MS = 1_500
+
+/**
+ * Ask the session bus whether `org.freedesktop.portal.GlobalShortcuts` — the
+ * interface Electron's Linux/Wayland globalShortcut path goes through — is
+ * reachable. `busctl --user` is the primary tool with `dbus-send` as the
+ * fallback; a successful DBus Peer.Ping against the portal's bus name proves
+ * the portal process is up and owning that name. Anything else (tools missing,
+ * portal name unowned, session bus dead, timeout) means registration attempts
+ * will fail for reasons that are NOT another application holding the chord.
+ */
+export const probeGlobalShortcutsPortalViaCli: GlobalShortcutsPortalProbe = async () => {
+  const attempts: Array<{ args: string[]; command: string }> = [
+    {
+      args: [
+        '--user',
+        'call',
+        'org.freedesktop.portal.Desktop',
+        '/org/freedesktop/portal/desktop',
+        'org.freedesktop.DBus.Peer',
+        'Ping'
+      ],
+      command: 'busctl'
+    },
+    {
+      args: [
+        '--session',
+        '--dest=org.freedesktop.portal.Desktop',
+        '--type=method_call',
+        '--print-reply',
+        '/org/freedesktop/portal/desktop',
+        'org.freedesktop.DBus.Peer.Ping'
+      ],
+      command: 'dbus-send'
+    }
+  ]
+
+  const failures: string[] = []
+
+  for (const attempt of attempts) {
+    try {
+      await promisify(execFile)(attempt.command, attempt.args, { timeout: PORTAL_DBUS_TIMEOUT_MS })
+
+      return { available: true }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      failures.push(`${attempt.command}: ${message.split('\n')[0]?.slice(0, 160) || 'failed'}`)
+    }
+  }
+
+  return { available: false, detail: failures.join(' | ') }
+}
 
 export interface QuickEntryShortcutController {
   /** Registration state as of the last apply. */
@@ -316,7 +388,25 @@ export interface QuickEntryShortcutController {
   /** Release the shortcut (quit / feature off). Idempotent. */
   dispose(): void
   /** Re-register to match `settings`. Returns the resulting state. */
-  apply(settings: QuickEntrySettings): QuickEntryRegistration
+  apply(settings: QuickEntrySettings): Promise<QuickEntryRegistration>
+}
+
+/**
+ * Platforms whose globalShortcut registration can fail because the desktop
+ * session's shortcut service is missing or unreachable rather than because
+ * another application owns the chord: Linux/Wayland routes the chord through
+ * the GlobalShortcuts portal, and remote/secure Windows sessions can refuse
+ * RegisterHotKey without a real conflict. On those, a failed registration
+ * must be probed before blaming a conflict. macOS registration goes through
+ * Carbon APIs with no such session service, so it keeps the plain 'taken'
+ * report.
+ */
+function sessionCanRefuseShortcutsWithoutConflict(): boolean {
+  try {
+    return process.platform === 'linux' || process.platform === 'win32'
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -326,10 +416,18 @@ export interface QuickEntryShortcutController {
  *
  * Disabled settings never touch `register()` at all: a user who turned Quick
  * Entry off must not have their chord silently held hostage.
+ *
+ * When a registration attempt fails, a Linux/Wayland session is probed for the
+ * GlobalShortcuts portal (the path Electron's globalShortcut goes through
+ * there) before blaming another application: on KDE/GNOME Wayland a dead or
+ * unreachable portal fails every chord, and "already taken" sends users
+ * chasing conflicts that do not exist (#95132). The probe is injectable so
+ * tests stay hermetic.
  */
 export function createQuickEntryShortcut(
   globalShortcut: GlobalShortcutLike,
-  onTrigger: () => void
+  onTrigger: () => void,
+  probePortal: GlobalShortcutsPortalProbe = probeGlobalShortcutsPortalViaCli
 ): QuickEntryShortcutController {
   let active: null | string = null
   let state: QuickEntryRegistration = { error: null, registered: false, shortcut: DEFAULT_QUICK_ENTRY_SHORTCUT }
@@ -346,8 +444,16 @@ export function createQuickEntryShortcut(
     }
   }
 
+  const tryRegister = (accelerator: string): boolean => {
+    try {
+      return globalShortcut.register(accelerator, onTrigger)
+    } catch {
+      return false
+    }
+  }
+
   return {
-    apply(settings) {
+    async apply(settings) {
       const parsed = parseQuickEntryShortcut(settings.shortcut)
       const shortcut = parsed.ok ? parsed.accelerator : settings.shortcut
 
@@ -365,21 +471,56 @@ export function createQuickEntryShortcut(
         return state
       }
 
-      // `isRegistered` catches the common conflict before we ask, and
-      // `register()` returning false catches the rest (another process owns it
-      // OS-wide). Both land in the same surfaced 'taken' state.
-      let ok = false
+      if (!parsed.accelerator) {
+        state = { error: 'invalid', registered: false, shortcut }
 
-      try {
-        ok = globalShortcut.isRegistered(parsed.accelerator)
-          ? false
-          : globalShortcut.register(parsed.accelerator, onTrigger)
-      } catch {
-        ok = false
+        return state
       }
 
-      active = ok ? parsed.accelerator : null
-      state = { error: ok ? null : 'taken', registered: ok, shortcut: parsed.accelerator }
+      // A chord the OS reports as already held is DIRECT evidence of a
+      // conflict — no probe needed, report 'taken'.
+      if (globalShortcut.isRegistered(parsed.accelerator)) {
+        active = null
+        state = { error: 'taken', registered: false, shortcut: parsed.accelerator }
+
+        return state
+      }
+
+      if (tryRegister(parsed.accelerator)) {
+        active = parsed.accelerator
+        state = { error: null, registered: true, shortcut: parsed.accelerator }
+
+        return state
+      }
+
+      // Ambiguous failure: `register()` refused or threw without saying who
+      // owns the chord. On Linux/Wayland that is usually the session's
+      // GlobalShortcuts portal being unreachable — not a conflict — so probe
+      // before reporting 'taken' (#95132). A probe that throws defaults to
+      // the historical 'taken' report.
+      let error: QuickEntryRegistrationError = 'taken'
+      let detail: undefined | string
+
+      if (sessionCanRefuseShortcutsWithoutConflict()) {
+        try {
+          const probe = await probePortal()
+
+          if (!probe.available) {
+            error = 'unavailable'
+            detail = probe.detail
+          }
+        } catch {
+          // Probe failures keep the historical 'taken' report.
+        }
+      }
+
+      active = null
+
+      if (detail) {
+        state = { error, registered: false, shortcut: parsed.accelerator, detail }
+      } else {
+        state = { error, registered: false, shortcut: parsed.accelerator }
+      }
 
       return state
     },

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -56,6 +56,10 @@ export function QuickEntryApp() {
     })
 
     const offState = api?.onState(payload => {
+      // Echo the adopted payload back so main stops retrying its replay (see
+      // electron/quick-entry-state-relay.ts); optional-chained because an
+      // older preload may not expose it yet.
+      api?.ackState?.(payload)
       dispatch({
         connected: payload?.connected === true,
         sessions: Array.isArray(payload?.sessions) ? payload.sessions : [],

--- a/apps/desktop/src/app/settings/quick-entry-settings.tsx
+++ b/apps/desktop/src/app/settings/quick-entry-settings.tsx
@@ -53,9 +53,11 @@ export function QuickEntrySettings() {
         ? q.takenBy
         : state.error === 'invalid'
           ? q.invalidShortcut
-          : state.enabled && state.registered
-            ? q.active
-            : null
+          : state.error === 'unavailable'
+            ? q.sessionUnavailable
+            : state.enabled && state.registered
+              ? q.active
+              : null
 
   return (
     <>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -137,6 +137,9 @@ declare global {
         // the recent-session options. Main caches the latest push and replays
         // it to a quick window spawned later.
         pushState: (payload: QuickEntryStatePush) => void
+        // Quick window → main: echo of the state payload the composer just
+        // adopted, so the shell stops retrying its did-finish-load replay.
+        ackState?: (payload: QuickEntryStatePush) => void
         // Quick window subscribes to those pushes.
         onState: (callback: (payload: QuickEntryStatePush) => void) => () => void
         // Primary renderer subscribes to submits captured by the quick window.

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -712,7 +712,9 @@ export const ar = defineLocale({
       shortcutDesc: 'يحتاج إلى مفتاح تعديل واحد على الأقل، مثل CommandOrControl+Shift+Space.',
       active: 'الاختصار مفعّل.',
       takenBy: 'يستخدم تطبيق آخر هذا الاختصار — اختر اختصارا مختلفا.',
-      invalidShortcut: 'ليس اختصارا صالحا. أضف مفتاح تعديل واحدا على الأقل.'
+      invalidShortcut: 'ليس اختصارا صالحا. أضف مفتاح تعديل واحدا على الأقل.',
+      sessionUnavailable:
+        'الاختصارات العامة غير متاحة في جلسة سطح المكتب هذه (لم تستجب خدمة الاختصار). استخدم نافذة Hermes مباشرة.'
     },
     credentials: {
       pasteKey: 'لصق المفتاح',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -728,7 +728,9 @@ export const en: Translations = {
       shortcutDesc: 'Needs at least one modifier, e.g. CommandOrControl+Shift+Space.',
       active: 'Shortcut is active.',
       takenBy: 'Another app already uses this shortcut — pick a different one.',
-      invalidShortcut: 'Not a valid shortcut. Include at least one modifier key.'
+      invalidShortcut: 'Not a valid shortcut. Include at least one modifier key.',
+      sessionUnavailable:
+        'Global shortcuts are unavailable in this desktop session (the shortcut service did not respond). Use the Hermes window directly.'
     },
     credentials: {
       pasteKey: 'Paste key',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -764,7 +764,9 @@ export const ja = defineLocale({
       shortcutDesc: '修飾キーが 1 つ以上必要です（例: CommandOrControl+Shift+Space）。',
       active: 'ショートカットは有効です。',
       takenBy: 'このショートカットは他のアプリが使用しています。別のものを選んでください。',
-      invalidShortcut: '有効なショートカットではありません。修飾キーを 1 つ以上含めてください。'
+      invalidShortcut: '有効なショートカットではありません。修飾キーを 1 つ以上含めてください。',
+      sessionUnavailable:
+        'このデスクトップセッションではグローバルショートカットを利用できません（ショートカットサービスが応答しません）。Hermes のウィンドウを直接ご利用ください。'
     },
     credentials: {
       pasteKey: 'キーを貼り付け',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -609,6 +609,7 @@ export interface Translations {
       active: string
       takenBy: string
       invalidShortcut: string
+      sessionUnavailable: string
     }
     credentials: {
       pasteKey: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -747,7 +747,8 @@ export const zhHant = defineLocale({
       shortcutDesc: '至少需要一個修飾鍵，例如 CommandOrControl+Shift+Space。',
       active: '快速鍵已生效。',
       takenBy: '此快速鍵已被其他應用程式占用，請換一個。',
-      invalidShortcut: '不是有效的快速鍵。請至少包含一個修飾鍵。'
+      invalidShortcut: '不是有效的快速鍵。請至少包含一個修飾鍵。',
+      sessionUnavailable: '此桌面工作階段無法使用全域快速鍵（快速鍵服務未回應）。請直接使用 Hermes 視窗。'
     },
     credentials: {
       pasteKey: '貼上金鑰',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -930,7 +930,8 @@ export const zh: Translations = {
       shortcutDesc: '至少需要一个修饰键，例如 CommandOrControl+Shift+Space。',
       active: '快捷键已生效。',
       takenBy: '此快捷键已被其他应用占用，请换一个。',
-      invalidShortcut: '不是有效的快捷键。请至少包含一个修饰键。'
+      invalidShortcut: '不是有效的快捷键。请至少包含一个修饰键。',
+      sessionUnavailable: '当前桌面会话无法使用全局快捷键（快捷键服务未响应）。请直接使用 Hermes 窗口。'
     },
     credentials: {
       pasteKey: '粘贴密钥',

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -21,18 +21,22 @@ export interface QuickEntryState {
   enabled: boolean
   /** null before the first read; the settings row shows a skeleton until then. */
   registered: boolean | null
-  /** Why the OS shortcut isn't live: taken by another app, or unusable. */
+  /** Why the OS shortcut isn't live: taken, unusable, or no shortcut service. */
   error: null | QuickEntryRegistrationError
   shortcut: string
+  /** Probe reason when `error` is `'unavailable'`; absent otherwise. */
+  detail?: string
 }
 
-export type QuickEntryRegistrationError = 'invalid' | 'taken'
+export type QuickEntryRegistrationError = 'invalid' | 'taken' | 'unavailable'
 
 export interface QuickEntryStatus {
   enabled: boolean
   error: null | QuickEntryRegistrationError
   registered: boolean
   shortcut: string
+  /** Probe reason when `error` is `'unavailable'`; absent otherwise. */
+  detail?: string
 }
 
 export const QUICK_ENTRY_DEFAULT_SHORTCUT = 'CommandOrControl+Shift+Space'
@@ -49,12 +53,18 @@ function applyStatus(status: QuickEntryStatus | undefined): void {
     return
   }
 
-  $quickEntry.set({
+  const next: QuickEntryState = {
     enabled: status.enabled === true,
     error: status.error ?? null,
     registered: status.registered === true,
     shortcut: typeof status.shortcut === 'string' && status.shortcut ? status.shortcut : QUICK_ENTRY_DEFAULT_SHORTCUT
-  })
+  }
+
+  if (status.detail !== undefined) {
+    next.detail = status.detail
+  }
+
+  $quickEntry.set(next)
 }
 
 /** True when the shell exposes the Quick Entry capability (desktop only). */


### PR DESCRIPTION
Fixes #95132

## What breaks

Quick Entry has two Linux-visible failures:

**A. Every registration failure is blamed on a conflict.** On KDE Plasma Wayland (portal-capable!), every chord tried — default `CommandOrControl+Shift+Space`, `Control+Shift+Space`, `Super+-`, `Control+Shift+L` — is logged as *"already taken by another application"* although KDE's own shortcut settings show them unbound. `createQuickEntryShortcut` mapped **any** failed `register()` to `'taken'` (`apps/desktop/electron/quick-entry.ts`). Electron's Linux/Wayland globalShortcut path goes through the `org.freedesktop.portal.GlobalShortcuts` portal; when that service is dead/unreachable, *every* chord fails and the message sends users chasing conflicts that don't exist.

**B. The X11 fallback composer opens stuck at "Not connected"** (`quick-entry-app.tsx:134`) while the primary window chats away. The replay that should carry cached gateway truth into a freshly loaded quick window was one blind `webContents.send` on `did-finish-load` (`main.ts`) — which only promises resources finished loading, not that React mounted and wired `hermesDesktop.quickEntry.onState`. The payload vanishes into the pre-mount void and the composer keeps its initial `connected: false`.

## The fix

**A — classify before blaming.**
- A chord the OS already reports as held stays **direct conflict evidence**: `'taken'`, no probe.
- An ambiguous refusal (register returns false / throws) on platforms whose session can refuse shortcuts without a real conflict (Linux/Wayland portal, Windows remote sessions) now probes the session bus — `busctl --user` then `dbus-send --session`, a DBus `Peer.Ping` against `org.freedesktop.portal.Desktop`, 1.5s timeout, injectable for tests — and reports a new `'unavailable'` state instead of `'taken'`.
- `'unavailable'` surfaces an actionable Settings hint ("global shortcuts are unavailable in this desktop session… use the Hermes window directly") plus a desktop.log line carrying the probe detail. Probe failures keep the historical `'taken'` report; macOS never probes (Carbon path, no session service).
- A later re-apply (settings change) retries cleanly once the portal comes back.

**B — acknowledged-retry delivery.** New `electron/quick-entry-state-relay.ts` owns the policy (main.ts keeps windows/IPC):
- Replays retry on a short bounded backoff (200ms × max 5) until the quick window **echoes the adopted payload back** over a new `hermesDesktop.quickEntry.ackState` channel — its store keeps the payload verbatim, so an echo proves a *mounted* composer adopted exactly this state.
- Newest cached truth supersedes an in-flight stale replay (never delivered again); duplicate deliver requests can't stack sends; dead window or spent budget abandons cleanly, and a fresh request starts a new full budget.
- Re-summons re-deliver after a reload remounts the renderer (same gap, cold-spawn fix aside). The relay is recreated per spawn and cancelled on close.

## Tests

Behavior-contract style, RED proven against pristine `origin/main` before the fix:

- 7 new controller tests: portal-unreachable ⇒ `'unavailable'` not `'taken'`; probe-reachable ⇒ `'taken'`; detail carried through; throwing probe falls back; direct-conflict short-circuits (no probe); darwin never probes; recovery re-register once the service returns. Existing 23 tests updated for the now-async `apply()` with hermetic probes (no test spawns a real subprocess).
- 10 new tests for the relay policy: ack stops retries; bounded budget; supersession; dedup; fresh cycle after spend; stale-request refusal; cancel; structural equality incl. null/undefined payloads.
- RED on pristine main: 3 classification tests fail + relay module absent. GREEN on the branch: 57/57 across the three files; full electron project 1694 passed / 3 skipped (only pre-existing env failure: `window-below.test.ts` needs the Electron binary, which isn't installed here — fails identically on pristine main); store suite 17/17; `tsc --build` clean for electron + renderer projects (renderer shows only pre-existing `@tabler/icons-react` declaration errors present on main); prettier/eslint clean on touched files.

## Notes

- `ackState` is optional in the bridge type and optional-chained at the call site, so an older preload paired with a newer renderer degrades to today's behavior instead of throwing.
- Related: #82654 (wlroots/niri sibling — same misleading error where the portal genuinely doesn't exist; the actionable message now also covers that case honestly) and #94253 (@Ddibirov's `--quick-entry` compositor-keybind summon flag, complementary escape hatch for compositors without the portal).

🧡 Contribution by Bruno Bza (@BrunoBza)