### PR TITLE
fix(error-classifier): classify LM Studio list-tool-content rejection

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -311,6 +311,8 @@ _MULTIMODAL_TOOL_CONTENT_PATTERNS = [
     "expected string, got array",
     # Alibaba/DashScope variant
     "tool_call.content must be string",
+    # LM Studio: rejects list-type tool content with a generic messages error
+    "invalid 'messages' in payload",
 ]
 
 # Context overflow patterns

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -196,3 +196,13 @@ class TestRecoveryEndToEndClassification:
         )
         result = classify_api_error(err, provider="alibaba", model="qwen3.5-plus")
         assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+
+    def test_lmstudio_variant_classifies(self):
+        """LM Studio rejects list-type tool content with a generic
+        'invalid messages in payload' messages error."""
+        err = _FakeApiError(
+            status_code=400,
+            message="invalid 'messages' in payload",
+        )
+        result = classify_api_error(err, provider="lmstudio", model="local")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported


### PR DESCRIPTION
## Summary
LM Studio (llama.cpp OpenAI-compat wire) rejects list-type `role: \tool\\` content with a generic `invalid 'messages' in payload` 400 error — not the provider-specific wording the existing patterns match.  Add the pattern to `_MULTIMODAL_TOOL_CONTENT_PATTERNS` so the error classifies as `multimodal_tool_content_unsupported` (retryable) and the reactive strip-image-parts recovery in run_agent rescues the turn, matching the existing Xiaomi/Alibaba handling.

## Why
Observed against local LM Studio endpoints. The generic wording otherwise falls through to a generic classification and the turn is lost instead of downgraded to text and retried.

## Test Plan
- [x] New `test_lmstudio_variant_classifies` mirrors the existing Alibaba variant test.
- [ ] CI green