### PR TITLE
fix(background-review): inherit parent fallback chain (with provider-pin guard)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1265,6 +1265,19 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                # Inherit the parent's overflow chain so bg-review waiters bounce
+                # to Nemotron/etc. instead of hanging on a full primary engine.
+                # mirrors tools/delegate_tool.py's parent_fallback inheritance,
+                # with the same #80450 guard: when _rt pins a provider that
+                # differs from the parent (review config forcing another engine), a
+                # mid-run auth/429 failure must not silently reroute the review
+                # child onto a chain built for a different provider — it should
+                # fail loudly instead of dragging across engines.
+                fallback_model=(
+                    (getattr(agent, "_fallback_chain", None) or None)
+                    if not _rt.get("provider")
+                    else None
+                ),
                 **_fork_kwargs,
             )
             review_agent._memory_write_origin = "background_review"

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1268,14 +1268,22 @@ def _run_review_in_thread(
                 # Inherit the parent's overflow chain so bg-review waiters bounce
                 # to Nemotron/etc. instead of hanging on a full primary engine.
                 # mirrors tools/delegate_tool.py's parent_fallback inheritance,
-                # with the same #80450 guard: when _rt pins a provider that
-                # differs from the parent (review config forcing another engine), a
-                # mid-run auth/429 failure must not silently reroute the review
-                # child onto a chain built for a different provider — it should
-                # fail loudly instead of dragging across engines.
+                # with the same #80450 guard: when the review runtime is ROUTED
+                # to a different provider (auxiliary.background_review.provider
+                # names a concrete engine other than the parent's), a mid-run
+                # auth/429 failure must not silently reroute the review child
+                # onto a chain built for a different provider — it should fail
+                # loudly instead of dragging across engines.
+                #
+                # Use the _routed flag, NOT the presence of a provider: _rt
+                # always carries a truthy provider (the default path sets
+                # provider=agent.provider), so keying off it would make the
+                # inheritance dead code. _routed is False for same-as-parent
+                # (inherit) and True for a real pin, matching the cache-parity
+                # gates below.
                 fallback_model=(
                     (getattr(agent, "_fallback_chain", None) or None)
-                    if not _rt.get("provider")
+                    if not _routed
                     else None
                 ),
                 **_fork_kwargs,

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -85,6 +85,55 @@ def test_background_review_matches_parent_toolset_config():
     )
 
 
+def test_background_review_inherits_fallback_chain_unless_routed():
+    """Fork receives the parent's _fallback_chain when the runtime is NOT
+    routed (same provider); None when auxiliary.background_review routes to
+    another provider. Regression for #95230 review: the guard must key off the
+    _routed flag, not the presence of a provider (which is always populated)."""
+    import run_agent
+
+    parent_chain = [
+        {"provider": "openai", "model": "gpt-4o"},
+        {"provider": "anthropic", "model": "claude-sonnet"},
+    ]
+
+    def _run(routed_map):
+        agent = _make_agent_stub(run_agent.AIAgent)
+        # Set the overflow chain directly on the __new__ stub (no __init__ runs).
+        setattr(agent, "_fallback_chain", parent_chain)
+        captured = {}
+
+        def _capture_init(self, *args, **kwargs):
+            captured["fallback_model"] = kwargs.get("fallback_model", "UNSET")
+            raise RuntimeError("stop after capturing init args")
+
+        with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
+             patch("threading.Thread", _SyncThread), \
+             patch(
+                 "agent.background_review._resolve_review_runtime",
+                 return_value=routed_map,
+             ):
+            # The route map always carries a truthy provider (mirrors reality),
+            # plus the routed flag that the guard must key off.
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        return captured.get("fallback_model")
+
+    # Not routed (same provider): inherit the parent's chain.
+    not_routed = _run({"provider": "openai", "routed": False})
+    assert not_routed == parent_chain, (
+        f"expected fallback_model to inherit parent chain, got {not_routed!r}"
+    )
+    # Routed to a different provider: do NOT inherit (guard fires).
+    routed = _run({"provider": "anthropic", "routed": True})
+    assert routed is None, (
+        f"expected fallback_model None when routed, got {routed!r}"
+    )
+
+
 def test_background_review_installs_thread_local_whitelist():
     """The review fork must install a memory/skills-only thread-local whitelist.
 


### PR DESCRIPTION
## Summary
Background-review forks (`_run_review_in_thread`) previously did not inherit the parent's provider overflow chain, so a review waiter could hang or error when the primary engine was full while the parent would have bounced to a configured fallback.

This mirrors the established `tools/delegate_tool.py` `parent_fallback` inheritance: pass `parent_agent._fallback_chain` as the child's `fallback_model` (the param accepts a chain list).

## Guard (#80450-class)
When `_rt` pins a `provider` different from the parent (review config forcing another engine), inherit `None` instead — an explicit pin means the review runs on that engine and should fail loudly on auth/429 rather than silently drag across providers mid-run.

## Test Plan
No existing test asserts the fork's exact kwargs, so the additive kwarg is non-breaking. Local env lacks pytest; relying on CI to confirm the suite stays green.