### PR TITLE
fix(compression): harden summary generation against local/thinking backends

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4203,6 +4203,36 @@ This compaction should PRIORITISE preserving all information related to the focu
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
+
+            # ── Bound the fallback summarizer's output to remaining context ──
+            # The main path intentionally sends NO max_tokens (see the "NO
+            # max_tokens" comment above): a hard adapter cap truncated thinking
+            # models mid-reasoning and caused compaction loops.  But when the
+            # summarizer FALLS BACK to the main model (no dedicated aux
+            # provider, or provider==custom), an unset cap lets it request the
+            # model's full native output ceiling (~65K) even when the context
+            # is already near-full, which can overrun the window mid-summary.
+            # Reconcile both: derive a ceiling from REMAINING context above a
+            # sane floor, so we never truncate a reasonable summary (the floor
+            # guarantees a usable budget) yet never request more output than the
+            # context can physically hold.  This is prompt-level / request-level
+            # bounding, distinct from the adapter-cap truncation the comment
+            # above warns against (a fixed default forwarded by the wire).
+            _fallback_to_main = not self.summary_model or getattr(
+                self, "provider", ""
+            ) == "custom"
+            if _fallback_to_main and self.max_tokens is not None:
+                try:
+                    _input_tokens = call_kwargs.get("messages", [{}])
+                    _in_est = sum(
+                        len(str(m.get("content", ""))) // 4 for m in _input_tokens
+                    )
+                    _remaining = max(0, (self.context_length or 0) - _in_est)
+                except Exception:
+                    _remaining = 0
+                _FLOOR = 2048  # never truncate below this many output tokens
+                _ceiling = max(_FLOOR, min(self.max_tokens, _remaining))
+                call_kwargs["max_tokens"] = _ceiling
             _aux_provider = ""
             _aux_model = self.summary_model or ""
             _aux_context = None
@@ -4245,10 +4275,51 @@ This compaction should PRIORITISE preserving all information related to the focu
             # OpenAI-compatible proxies / local backends return a dict- or
             # str-shaped message; coerce defensively instead of crashing.
             message = response.choices[0].message
-            if isinstance(message, dict):
-                content = message.get("content")
-            else:
-                content = getattr(message, "content", message)
+            # Normalize through one helper so dict- and object-shaped messages
+            # behave identically: both skip empty/whitespace content and, when
+            # the primary ``content`` is unusable, fall back to
+            # ``reasoning_content`` (Qwen thinking models / DeepSeek R1 return
+            # their output there) rather than hitting the empty-content
+            # RuntimeError and setting a compression-failure cooldown (#15892).
+            def _extract_content(msg) -> str:
+                if isinstance(msg, dict):
+                    content = msg.get("content")
+                    rc = msg.get("reasoning_content")
+                else:
+                    content = getattr(msg, "content", msg)
+                    rc = getattr(msg, "reasoning_content", None)
+                if (
+                    not content
+                    or not isinstance(content, str)
+                    or not content.strip()
+                ):
+                    # Primary content unusable — fall back to the reasoning
+                    # trace if it is real text, but BOUND it: a raw
+                    # chain-of-thought can be far longer and unbounded than the
+                    # intended final answer, so an un-capped fallback could
+                    # balloon the compressed prefix (defeating compression) and
+                    # inject raw reasoning traces into the structured handoff.
+                    # Truncate the trace and log a warning so a verbose thinking
+                    # backend can't silently blow up the buffer (#95231 review).
+                    if rc and isinstance(rc, str) and rc.strip():
+                        _REASONING_CAP_CHARS = 8000  # ~2K tokens of trace max
+                        _FALLBACK_LEN = len(rc)
+                        if _FALLBACK_LEN > _REASONING_CAP_CHARS:
+                            logger.warning(
+                                "summarizer fell back to reasoning_content (%d "
+                                "chars); truncating to %d for the compaction "
+                                "summary",
+                                _FALLBACK_LEN,
+                                _REASONING_CAP_CHARS,
+                            )
+                            content = rc[:_REASONING_CAP_CHARS]
+                        else:
+                            content = rc
+                    else:
+                        content = ""
+                return content
+
+            content = _extract_content(message)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""

--- a/tests/agent/test_context_compressor_summary_fallback_hardening.py
+++ b/tests/agent/test_context_compressor_summary_fallback_hardening.py
@@ -1,0 +1,144 @@
+"""Regression tests for PR #95231 summary-generation hardening.
+
+Covers the reviewer findings on fix(compression): harden summary generation
+against local/thinking backends:
+
+1. The fallback-to-main output cap is derived from REMAINING context above a
+   sane floor, not a hard ``max_tokens`` — so it never truncates a reasonable
+   summary but never requests more output than the context can hold. When a
+   dedicated aux model is in use, ``max_tokens`` stays unset (honouring the
+   ``NO max_tokens`` invariant).
+
+2. Falling back to raw ``reasoning_content`` as the compaction summary is
+   bounded (truncated) and doesn't balloon the compressed prefix.
+
+3. dict- and object-shaped messages normalize through ONE helper, so
+   whitespace-only content falls back to reasoning_content in both shapes
+   (no drift toward the empty-content RuntimeError).
+"""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _compressor(**overrides: Any) -> ContextCompressor:
+    """Minimal ContextCompressor with a stub context probe."""
+    kwargs: Dict[str, Any] = dict(
+        model="test/model",
+        threshold_percent=0.85,
+        protect_first_n=1,
+        protect_last_n=1,
+        quiet_mode=True,
+    )
+    kwargs.update(overrides)
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(**kwargs)
+
+
+def _response(message):
+    """Wrap a message (dict or object) in an LLM-response-shaped mock."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message = message
+    return mock_response
+
+
+def _capture_call_llm(captured, message):
+    """Patch call_llm to record kwargs and return a fixed response."""
+    def _fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response(message)
+    return patch("agent.context_compressor.call_llm", side_effect=_fake_call_llm)
+
+
+def test_fallback_to_main_bounds_output_cap_to_remaining_context():
+    """FALLBACK (no aux model): max_tokens is set and bounded by context."""
+    captured = {}
+    with _capture_call_llm(captured, {"content": "summary body"}) as _:
+        compressor = _compressor(config_context_length=10000)
+        compressor.max_tokens = 32000
+        out = compressor._generate_summary(
+            [{"role": "user", "content": "some earlier turns"}], focus_topic="t"
+        )
+    assert out is not None, "expected a produced summary"
+    assert "summary body" in out, f"expected summary body in output, got {out!r}"
+    # A max_tokens IS set (fallback bounding active), and it must never exceed
+    # the remaining-context bound (context - input-estimate), and must be >= floor.
+    cap = captured["max_tokens"]
+    assert cap is not None
+    assert cap >= 2048, f"cap {cap} dropped below the sane floor"
+    assert cap <= 10000, f"cap {cap} exceeds remaining context (10K)"
+    assert cap <= 32000, f"cap {cap} exceeded configured max"
+
+
+def test_aux_model_path_omits_max_tokens():
+    """Dedicated aux model (NOT fallback): max_tokens stays unset (no truncation)."""
+    captured = {}
+    with _capture_call_llm(captured, {"content": "aux summary"}) as _:
+        compressor = _compressor(summary_model_override="aux/model", provider="anthropic")
+        out = compressor._generate_summary(
+            [{"role": "user", "content": "turns"}], focus_topic="t"
+        )
+    assert out is not None, "expected aux summary to be produced"
+    assert "aux summary" in out, f"expected aux summary in output, got {out!r}"
+    assert "max_tokens" not in captured, (
+        "dedicated aux path must omit max_tokens (NO max_tokens invariant)"
+    )
+
+
+def test_reasoning_content_fallback_when_content_empty():
+    """Empty content -> falls back to reasoning_content, bounded."""
+    captured = {}
+    reasoning = "step 1 ... " + ("t" * 20000)  # long chain-of-thought
+    msg = {"content": "", "reasoning_content": reasoning}
+    with _capture_call_llm(captured, msg) as _:
+        compressor = _compressor()
+        out = compressor._generate_summary(
+            [{"role": "user", "content": "turns"}], focus_topic="t"
+        )
+    assert out is not None and len(out) > 0, "expected reasoning fallback summary"
+    # Bounded — the 20K-char CoT must have been truncated; if it had been used
+    # whole, out would be ~22K (20K CoT + ~2K handoff preamble). The handoff
+    # preamble inflates out, so bound against the full-trace size instead.
+    assert len(out) < 15000, (
+        f"reasoning fallback not truncated (full CoT leaked): {len(out)} chars"
+    )
+    assert reasoning not in out, "full unbounded reasoning trace leaked into summary"
+
+
+def test_short_reasoning_content_fallback_not_truncated():
+    """Short reasoning_content (within cap) is used whole."""
+    captured = {}
+    msg = {"content": "", "reasoning_content": "short reasoning trace"}
+    with _capture_call_llm(captured, msg) as _:
+        compressor = _compressor()
+        out = compressor._generate_summary(
+            [{"role": "user", "content": "turns"}], focus_topic="t"
+        )
+    assert out is not None, "expected a produced summary"
+    assert "short reasoning trace" in out, f"got {out!r}"
+
+
+def test_whitespace_content_falls_back_in_dict_and_object_shapes():
+    """Finding #3: whitespace-only content must fall back to reasoning_content
+    for BOTH dict- and object-shaped messages (no drift)."""
+    reasoning = "dict reasoning"
+
+    class _Msg:
+        content = " "  # whitespace-only
+        reasoning_content = "object reasoning"
+
+    for i, message in enumerate([{"content": " ", "reasoning_content": reasoning}, _Msg()]):
+        cap = {}
+        with _capture_call_llm(cap, message) as _:
+            compressor = _compressor()
+            out = compressor._generate_summary(
+                [{"role": "user", "content": "turns"}], focus_topic="t"
+            )
+        assert out is not None, "expected a produced summary"
+        if i == 0:
+            assert "dict reasoning" in out, f"dict branch got {out!r}"
+        else:
+            assert "object reasoning" in out, f"object branch got {out!r}"


### PR DESCRIPTION
## Summary
Two independent robustness fixes for `_generate_summary` on local and thinking-model OpenAI-compatible backends.

### 1) Conditional summarizer output cap
When the compression summarizer falls back to the main model (no dedicated aux provider, or `provider==custom`), cap its output at the configured `model.max_tokens` so it never requests ~65K of output from a model already near its context ceiling. With a dedicated auxiliary provider the cap stays unset so thorough summaries keep the full output budget.

### 2) `reasoning_content` fallback
Qwen thinking models and DeepSeek R1 return their output in `reasoning_content` (with `content` empty or whitespace). Fall back to `reasoning_content` so those backends yield a usable summary instead of tripping the empty-content failure path (#15892). The `isinstance(rc, str)` check prevents fake/mock messages from masquerading as real reasoning content.

## Test note
The existing `test_no_max_tokens_wire_cap_on_summary_call` stays green: it exercises the dedicated-aux / `max_tokens=None` path where no cap is injected. The empty-content failure test (#11978) stays green because `reasoning_content` on a MagicMock is not a str, so the fallback is not taken.