### PR TITLE
fix(desktop): avoid unnecessary Linux SUID sandbox setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8044,33 +8044,62 @@ def _force_adhoc_macos_signing(env: dict, *, source_mode: bool) -> bool:
 
 
 def _desktop_linux_needs_no_sandbox() -> bool:
-    """Return True when Chromium/Electron should bypass the Linux sandbox.
+    """Return True when host policy blocks Chromium's namespace sandbox.
 
-    Ubuntu 23.10+ can enable AppArmor's
-    ``apparmor_restrict_unprivileged_userns`` hardening, which breaks
-    Chromium/Electron's user-namespace sandbox for normal users unless the app
-    ships a working root-owned 4755 ``chrome-sandbox`` helper. In headless or
-    non-interactive CLI contexts we may be unable to ``sudo chown/chmod`` that
-    helper, so detect the host restriction and fall back to ``--no-sandbox``
-    rather than hard-failing the launcher.
+    Linux Chromium normally uses unprivileged user namespaces and does not need
+    a privileged ``chrome-sandbox`` helper. A disabled
+    ``unprivileged_userns_clone`` sysctl or zero user-namespace limit always
+    blocks that path. Ubuntu's AppArmor restriction is more nuanced: a profile
+    can explicitly grant an executable ``userns`` access, so on such hosts we
+    probe a throwaway child namespace before requesting the SUID helper.
 
     We intentionally do NOT return True for root users here: running Electron as
     root without a sandbox is a qualitatively riskier path than launching as an
-    unprivileged desktop user on an AppArmor-restricted host. The root case
-    should remain an explicit user choice.
+    unprivileged desktop user on a restricted host. The root case should remain
+    an explicit user choice.
     """
-    if os.environ.get("ELECTRON_DISABLE_SANDBOX", 0) == "1":
+    if os.environ.get("ELECTRON_DISABLE_SANDBOX", "0") == "1":
         return True
 
     if sys.platform != "linux":
         return False
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         return False
-    try:
-        with open("/proc/sys/kernel/apparmor_restrict_unprivileged_userns", encoding="utf-8") as f:
-            return f.read().strip() == "1"
-    except OSError:
+
+    def read_proc(path: str) -> str | None:
+        try:
+            with open(path, encoding="utf-8") as f:
+                return f.read().strip()
+        except OSError:
+            return None
+
+    if read_proc("/proc/sys/kernel/unprivileged_userns_clone") == "0":
+        return True
+
+    namespace_limit = read_proc("/proc/sys/user/max_user_namespaces")
+    if namespace_limit is not None:
+        try:
+            if int(namespace_limit) <= 0:
+                return True
+        except ValueError:
+            return False
+
+    if read_proc("/proc/sys/kernel/apparmor_restrict_unprivileged_userns") != "1":
         return False
+
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return True
+    try:
+        return subprocess.run(
+            [unshare, "--user", "--map-root-user", "true"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=1,
+        ).returncode != 0
+    except (OSError, subprocess.TimeoutExpired):
+        return True
 
 
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
@@ -8512,8 +8541,12 @@ def cmd_gui(args: argparse.Namespace):
         sys.exit(1)
 
     launch_command = [str(packaged_executable)]
-    if not _desktop_linux_sandbox_fixup(packaged_executable):
-        if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
+    # Rebuilt packages live beneath the user's home, so chrome-sandbox cannot
+    # retain root:root 4755 ownership across ordinary self-updates. On hosts
+    # with a usable user-namespace sandbox this is expected and secure; only
+    # request the privileged helper when host policy blocks that normal path.
+    if _desktop_linux_needs_no_sandbox() and not _desktop_linux_sandbox_fixup(packaged_executable):
+        if _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
             print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")
             launch_command.append("--no-sandbox")
         else:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8051,7 +8051,8 @@ def _desktop_linux_needs_no_sandbox() -> bool:
     ``unprivileged_userns_clone`` sysctl or zero user-namespace limit always
     blocks that path. Ubuntu's AppArmor restriction is more nuanced: a profile
     can explicitly grant an executable ``userns`` access, so on such hosts we
-    probe a throwaway child namespace before requesting the SUID helper.
+    probe the same identity-map and second namespace sequence Chromium uses
+    before requesting the SUID helper.
 
     We intentionally do NOT return True for root users here: running Electron as
     root without a sandbox is a qualitatively riskier path than launching as an
@@ -8092,7 +8093,15 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return True
     try:
         return subprocess.run(
-            [unshare, "--user", "--map-root-user", "true"],
+            [
+                unshare,
+                "--user",
+                "--map-current-user",
+                "--",
+                unshare,
+                "--user",
+                "true",
+            ],
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import subprocess
 import sys
 from pathlib import Path
@@ -80,10 +81,9 @@ def _make_packaged_executable(root: Path, monkeypatch) -> Path:
     branch, so faking the platform here only proved the test and the code
     agreed about a host neither was running on.
 
-    Note the Linux arm also lays down ``chrome-sandbox``. ``cmd_gui`` refuses to
-    launch without it (Electron's setuid sandbox helper), which the old
-    darwin-by-default fake concealed — on Linux the packaged tree genuinely has
-    to include it.
+    Note the Linux arm also lays down ``chrome-sandbox`` because packaged
+    Electron bundles it. ``cmd_gui`` only needs to configure it on hosts whose
+    policy blocks Chromium's normal user-namespace sandbox.
     """
     desktop_dir = root / "apps" / "desktop"
     if sys.platform == "darwin":
@@ -920,6 +920,41 @@ def test_relaunchable_fixup_legacy_adhoc_success_still_verifies_and_never_delete
 
 
 @pytest.mark.linux_only
+def test_desktop_linux_needs_no_sandbox_when_user_namespaces_are_disabled(monkeypatch):
+    """A disabled kernel user-namespace policy still requires the SUID helper."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    monkeypatch.setattr(cli_main.os, "geteuid", lambda: 1000)
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/sys/kernel/unprivileged_userns_clone":
+            return io.StringIO("0\n")
+        raise OSError(path)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    assert cli_main._desktop_linux_needs_no_sandbox() is True
+
+
+@pytest.mark.linux_only
+def test_desktop_linux_namespace_probe_allows_app_profile_exception(monkeypatch):
+    """An AppArmor-enabled executable may still be granted user namespaces."""
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+    monkeypatch.setattr(cli_main.os, "geteuid", lambda: 1000)
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/sys/kernel/apparmor_restrict_unprivileged_userns":
+            return io.StringIO("1\n")
+        raise OSError(path)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    monkeypatch.setattr(cli_main.shutil, "which", lambda name: "/usr/bin/unshare" if name == "unshare" else None)
+    with patch("hermes_cli.main.subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run:
+        assert cli_main._desktop_linux_needs_no_sandbox() is False
+
+    assert run.call_args.args[0] == ["/usr/bin/unshare", "--user", "--map-root-user", "true"]
+
+
+@pytest.mark.linux_only
 def test_gui_registers_linux_desktop_entry_before_launch(tmp_path, monkeypatch):
     """`hermes desktop` gives the app a launcher presence on Linux."""
     root = _make_desktop_tree(tmp_path)
@@ -943,6 +978,26 @@ def test_gui_registers_linux_desktop_entry_before_launch(tmp_path, monkeypatch):
         cli_main.cmd_gui(_ns())
 
     assert registered == [root]
+
+
+@pytest.mark.linux_only
+def test_gui_linux_namespace_sandbox_launch_skips_suid_fixup(tmp_path, monkeypatch):
+    """Hosts with user namespaces launch without a mutable SUID helper."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup") as mock_fixup, \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_fixup.assert_not_called()
+    assert mock_run.call_args.args[0] == [str(packaged_exe)]
 
 
 @pytest.mark.linux_only

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -114,6 +114,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main._register_linux_desktop_entry"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
@@ -169,6 +170,7 @@ def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatc
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
          pytest.raises(SystemExit):
@@ -1106,6 +1108,7 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1122,6 +1125,7 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1203,6 +1207,7 @@ def test_gui_linux_packaged_launch_bridges_detected_password_store(tmp_path, mon
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value={}), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1254,6 +1259,7 @@ def test_gui_config_password_store_skips_detection(tmp_path, monkeypatch):
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1283,6 +1289,7 @@ def test_gui_explicit_password_store_env_wins_over_config_and_detection(tmp_path
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_needs_no_sandbox", return_value=False), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -938,8 +938,8 @@ def test_desktop_linux_needs_no_sandbox_when_user_namespaces_are_disabled(monkey
 
 
 @pytest.mark.linux_only
-def test_desktop_linux_namespace_probe_allows_app_profile_exception(monkeypatch):
-    """An AppArmor-enabled executable may still be granted user namespaces."""
+def test_desktop_linux_namespace_probe_matches_chromium_identity_mapping(monkeypatch):
+    """AppArmor probe requires Chromium's identity map and second user namespace."""
     monkeypatch.setattr(cli_main.sys, "platform", "linux")
     monkeypatch.setattr(cli_main.os, "geteuid", lambda: 1000)
 
@@ -953,7 +953,15 @@ def test_desktop_linux_namespace_probe_allows_app_profile_exception(monkeypatch)
     with patch("hermes_cli.main.subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run:
         assert cli_main._desktop_linux_needs_no_sandbox() is False
 
-    assert run.call_args.args[0] == ["/usr/bin/unshare", "--user", "--map-root-user", "true"]
+    assert run.call_args.args[0] == [
+        "/usr/bin/unshare",
+        "--user",
+        "--map-current-user",
+        "--",
+        "/usr/bin/unshare",
+        "--user",
+        "true",
+    ]
 
 
 @pytest.mark.linux_only


### PR DESCRIPTION
## Summary
- Skip privileged `chrome-sandbox` ownership repair on Linux hosts where Chromium can use its normal user-namespace sandbox.
- Detect kernel policies that disable user namespaces, and on Ubuntu AppArmor-restricted hosts run a bounded throwaway namespace probe so profiles explicitly granted `userns` are not treated as blocked.
- Preserve the existing SUID-helper and last-resort `--no-sandbox` behavior only for hosts that actually cannot create a user namespace.

## Why
The unpacked desktop bundle is rebuilt beneath the user home directory during self-update, so `chrome-sandbox` naturally loses `root:root 4755`. Requiring that privileged repair on every Linux launch makes normal self-updates sudo-gated even where Electron's secure namespace sandbox is available.

## Validation
- `env -u ELECTRON_OZONE_PLATFORM_HINT /home/quatro/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_linux_desktop_entry.py -q` → 59 passed, 7 skipped
- `ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
- `python -m compileall -q hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
- `hermes desktop --build-only --force-build` produced the Linux unpacked Electron artifact successfully.

## Evidence
Confirmed current upstream `main` unconditionally invokes `_desktop_linux_sandbox_fixup()` before every packaged Linux desktop launch. On the validating Arch host: `unprivileged_userns_clone=1`, `max_user_namespaces=62267`, AppArmor restriction absent, and `unshare --user --map-root-user true` succeeds.