### PR TITLE
fix(models): resolve slash-qualified ids through the parsed provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3048,6 +3048,41 @@ def get_model_context_length(
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
+    #
+    # The slash-qualified spelling ("opencode-go/qwen3.7-plus") carries the
+    # provider in the prefix: strip it when the prefix names a registered
+    # provider and the caller is not on OpenRouter (whose slugs like
+    # "anthropic/claude-fable-5" are model ids whose first segment is a
+    # vendor, not a Hermes provider). When the caller supplied no explicit
+    # provider, the parsed prefix ALSO propagates into the provider-aware
+    # lookup (step 5f) — without it the leftover bare id keeps its "qwen"
+    # substring, which matches the generic DEFAULT_CONTEXT_LENGTHS entry
+    # before the real per-model lookup scores: the bare-vs-prefixed
+    # divergence in #47782 (1,000,000 vs 131,072). An explicitly supplied
+    # provider always wins over the parsed one, and an endpoint-URL
+    # inference wins over both.
+    parsed_provider = ""
+    if not (provider or "").strip() and "/" in model:
+        prefix, rest = model.split("/", 1)
+        prefix = prefix.strip().lower()
+        if rest.strip() and prefix:
+            # Only when the caller supplied NO provider, and only for a
+            # prefix that names a REGISTERED provider, treat the id as the
+            # provider/model convention: strip it and propagate the parsed
+            # provider into the provider-aware lookup. Every other slash
+            # form stays whole — explicit-provider ids are server-side
+            # spellings (local/custom endpoints know "NousResearch/Hermes-…"
+            # org-qualified names; NVIDIA NIM uses "deepseek-ai/…"; OpenRouter
+            # slugs use "anthropic/…"), and stripping those breaks the
+            # downstream catalog/cache lookups.
+            try:
+                from providers import get_provider_profile
+
+                if get_provider_profile(prefix) is not None:
+                    parsed_provider = prefix
+                    model = rest.strip()
+            except Exception:
+                pass
     model = _strip_provider_prefix(model)
 
     # Endpoint-scoped provider metadata. Keep this ahead of the persistent
@@ -3281,8 +3316,17 @@ def get_model_context_length(
     # since the same model can have different context limits per provider
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
     # If provider is generic (openrouter/custom/empty), try to infer from URL.
-    effective_provider = provider
-    if not effective_provider or effective_provider in {"openrouter", "custom"}:
+    # A provider parsed off a slash-qualified model id (#47782) sits between
+    # the two: it beats generic/empty, but a real inference from the
+    # endpoint URL is still more authoritative.
+    effective_provider = provider or parsed_provider
+    if (
+        not effective_provider
+        or effective_provider in {"openrouter", "custom"}
+        # A provider parsed off the model id is the weakest signal — an
+        # endpoint URL inference is more authoritative and overrides it.
+        or (parsed_provider and not (provider or "").strip())
+    ):
         if base_url:
             inferred = _infer_provider_from_url(base_url)
             if inferred:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3050,39 +3050,47 @@ def get_model_context_length(
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     #
     # The slash-qualified spelling ("opencode-go/qwen3.7-plus") carries the
-    # provider in the prefix: strip it when the prefix names a registered
-    # provider and the caller is not on OpenRouter (whose slugs like
-    # "anthropic/claude-fable-5" are model ids whose first segment is a
-    # vendor, not a Hermes provider). When the caller supplied no explicit
-    # provider, the parsed prefix ALSO propagates into the provider-aware
-    # lookup (step 5f) — without it the leftover bare id keeps its "qwen"
-    # substring, which matches the generic DEFAULT_CONTEXT_LENGTHS entry
-    # before the real per-model lookup scores: the bare-vs-prefixed
-    # divergence in #47782 (1,000,000 vs 131,072). An explicitly supplied
-    # provider always wins over the parsed one, and an endpoint-URL
-    # inference wins over both.
+    # provider in the prefix: strip it when the prefix names a BUNDLED
+    # provider and the caller is not on an OpenRouter endpoint (which makes
+    # the whole id an OR slug like "anthropic/claude-fable-5" — the first
+    # segment is a vendor, not a Hermes provider). The bundled-only check
+    # keeps the rewrite stable across installs: the provider registry is
+    # extended by user plugins under $HERMES_HOME, and a user-only
+    # registration must not change how server-side ids resolve. When the
+    # caller supplied no explicit provider, the parsed prefix ALSO
+    # propagates into the provider-aware lookup (step 5f) — without it the
+    # leftover bare id keeps its "qwen" substring, which matches the
+    # generic DEFAULT_CONTEXT_LENGTHS entry before the real per-model
+    # lookup scores: the bare-vs-prefixed divergence in #47782 (1,000,000
+    # vs 131,072). An explicitly supplied provider always wins over the
+    # parsed one, and an endpoint-URL inference wins over both.
     parsed_provider = ""
     if not (provider or "").strip() and "/" in model:
-        prefix, rest = model.split("/", 1)
-        prefix = prefix.strip().lower()
-        if rest.strip() and prefix:
-            # Only when the caller supplied NO provider, and only for a
-            # prefix that names a REGISTERED provider, treat the id as the
-            # provider/model convention: strip it and propagate the parsed
-            # provider into the provider-aware lookup. Every other slash
-            # form stays whole — explicit-provider ids are server-side
-            # spellings (local/custom endpoints know "NousResearch/Hermes-…"
-            # org-qualified names; NVIDIA NIM uses "deepseek-ai/…"; OpenRouter
-            # slugs use "anthropic/…"), and stripping those breaks the
-            # downstream catalog/cache lookups.
-            try:
-                from providers import get_provider_profile
+        on_openrouter = bool(base_url) and (
+            _infer_provider_from_url(base_url) == "openrouter"
+        )
+        if not on_openrouter:
+            prefix, rest = model.split("/", 1)
+            prefix = prefix.strip().lower()
+            if rest.strip() and prefix:
+                # Only when the caller supplied NO provider, is not on an
+                # OpenRouter endpoint, and the prefix names a BUNDLED
+                # provider, treat the id as the provider/model convention:
+                # strip it and propagate the parsed provider into the
+                # provider-aware lookup. Every other slash form stays
+                # whole — explicit-provider ids are server-side spellings
+                # (local/custom endpoints know "NousResearch/Hermes-…"
+                # org-qualified names; NVIDIA NIM uses "deepseek-ai/…";
+                # OpenRouter slugs use "anthropic/…"), and stripping those
+                # breaks the downstream catalog/cache lookups.
+                try:
+                    from providers import is_bundled_provider
 
-                if get_provider_profile(prefix) is not None:
-                    parsed_provider = prefix
-                    model = rest.strip()
-            except Exception:
-                pass
+                    if is_bundled_provider(prefix):
+                        parsed_provider = prefix
+                        model = rest.strip()
+                except Exception:
+                    pass
     model = _strip_provider_prefix(model)
 
     # Endpoint-scoped provider metadata. Keep this ahead of the persistent
@@ -3323,9 +3331,10 @@ def get_model_context_length(
     if (
         not effective_provider
         or effective_provider in {"openrouter", "custom"}
-        # A provider parsed off the model id is the weakest signal — an
-        # endpoint URL inference is more authoritative and overrides it.
-        or (parsed_provider and not (provider or "").strip())
+        # A provider parsed off the model id is the weakest signal (it is
+        # only ever set when the caller supplied no provider) — an endpoint
+        # URL inference is more authoritative and overrides it.
+        or parsed_provider
     ):
         if base_url:
             inferred = _infer_provider_from_url(base_url)

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -46,6 +46,10 @@ _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
+# Canonical names + aliases contributed by repo-bundled sources only
+# (bundled plugin dirs + legacy ``providers/*.py`` modules). Populated once
+# during ``_discover_providers``; ``None`` until then.
+_BUNDLED_NAMES: frozenset[str] | None = None
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -76,6 +80,25 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
         _discover_providers()
     canonical = _ALIASES.get(name, name)
     return _REGISTRY.get(canonical)
+
+
+def _known_names() -> frozenset[str]:
+    """All registered canonical names + aliases, from any source."""
+    return frozenset(_REGISTRY) | frozenset(_ALIASES)
+
+
+def is_bundled_provider(name: str) -> bool:
+    """True when ``name`` (canonical or alias) was contributed by a bundled source.
+
+    Only bundled plugin dirs and legacy ``providers/*.py`` modules count:
+    names registered later by user plugins (``$HERMES_HOME``) or pip
+    entry-points resolve through ``get_provider_profile`` but return False
+    here. Use this when a heuristic must not change with the user's
+    installed plugins (e.g. stripping a provider prefix off a model id).
+    """
+    if not _discovered:
+        _discover_providers()
+    return name in (_BUNDLED_NAMES or frozenset())
 
 
 def list_providers() -> list[ProviderProfile]:
@@ -300,12 +323,18 @@ def _discover_providers() -> None:
     #    genuinely new providers.
     _discover_entry_point_providers()
 
+    # Snapshot the name space around the bundled sources (step 1 + step 3)
+    # so ``is_bundled_provider`` can tell repo-bundled names apart from
+    # user-plugin / pip-installed ones regardless of override collisions.
+    _names_pre_bundled = _known_names()
+
     # 1. Bundled plugins — shipped with hermes-agent.
     if _BUNDLED_PLUGINS_DIR.is_dir():
         for child in sorted(_BUNDLED_PLUGINS_DIR.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             _import_plugin_dir(child, "bundled")
+    _names_post_bundled = _known_names()
 
     # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
     #    These can override any bundled profile of the same name (last-writer-wins
@@ -316,6 +345,7 @@ def _discover_providers() -> None:
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             _import_plugin_dir(child, "user")
+    _names_pre_legacy = _known_names()
 
     # 3. Legacy single-file profiles at providers/<name>.py. Kept for
     #    back-compat — if someone drops a ``providers/foo.py`` into an
@@ -336,6 +366,10 @@ def _discover_providers() -> None:
                 )
     except Exception:
         pass
+    global _BUNDLED_NAMES
+    _BUNDLED_NAMES = (_names_post_bundled - _names_pre_bundled) | (
+        _known_names() - _names_pre_legacy
+    )
 
     # (Pip entry-point providers are discovered in step 0, before the
     # filesystem plugins, so first-party profiles always win on name

--- a/tests/agent/test_context_length_slash_provider.py
+++ b/tests/agent/test_context_length_slash_provider.py
@@ -1,0 +1,127 @@
+"""Regression tests for slash-qualified model ids in context-length lookup (#47782).
+
+``get_model_context_length`` returned different windows for the same model
+depending on spelling: ``"qwen3.7-plus"`` with ``provider="opencode-go"``
+resolved via the provider-aware models.dev lookup (1,000,000), while
+``"opencode-go/qwen3.7-plus"`` kept the prefixed id, whose ``qwen``
+substring matched the generic hardcoded ``DEFAULT_CONTEXT_LENGTHS`` entry
+(131,072) before the per-model lookup scored. The fix parses the
+slash prefix once — but only when the caller supplied no explicit provider —
+strips it from the model id, and propagates it into the provider-aware
+lookup. OpenRouter slug handling and explicitly-supplied providers are
+untouched.
+"""
+
+from unittest.mock import patch
+
+import agent.model_metadata as mm
+
+
+def _with_models_dev(monkeypatch, entries):
+    """Point lookup_models_dev_context at a fake catalog keyed (provider, model)."""
+    calls = []
+
+    def fake_lookup(provider, model):
+        calls.append((provider, model))
+        return entries.get((provider, model))
+
+    monkeypatch.setattr(
+        "agent.models_dev.lookup_models_dev_context", fake_lookup, raising=True
+    )
+    return calls
+
+
+class TestSlashQualifiedResolution:
+    def test_prefixed_and_bare_with_provider_agree(self, monkeypatch):
+        calls = _with_models_dev(
+            monkeypatch, {("opencode-go", "qwen3.7-plus"): 1_000_000}
+        )
+        monkeypatch.setattr(
+            mm, "get_model_context_length_async", mm.get_model_context_length
+        )
+
+        via_bare = mm.get_model_context_length(
+            "qwen3.7-plus", provider="opencode-go"
+        )
+        via_prefixed = mm.get_model_context_length("opencode-go/qwen3.7-plus")
+
+        assert via_prefixed == via_bare == 1_000_000
+        assert ("opencode-go", "qwen3.7-plus") in calls, (
+            "the parsed prefix must reach the provider-aware lookup (#47782)"
+        )
+
+    def test_parsed_provider_beats_generic_substring_default(self, monkeypatch):
+        # The generic {"qwen": 131072} entry must NOT win when the slash
+        # prefix resolves to a real provider with a per-model entry.
+        _with_models_dev(
+            monkeypatch, {("opencode-go", "qwen3.5-plus"): 262_144}
+        )
+        assert (
+            mm.get_model_context_length("opencode-go/qwen3.5-plus") == 262_144
+        )
+
+    def test_explicit_provider_leaves_server_side_spelling_whole(
+        self, monkeypatch
+    ):
+        # With an explicit provider the id is a server-side spelling and is
+        # NOT rewritten: local/custom endpoints know org-qualified names
+        # like "NousResearch/Hermes-…" verbatim, and NVIDIA NIM uses
+        # "deepseek-ai/…" vendor ids. The strip only happens when the
+        # caller supplied no provider at all.
+        calls = _with_models_dev(
+            monkeypatch, {("custom-provider", "NousResearch/Hermes-3-70B"): 65_536}
+        )
+        assert (
+            mm.get_model_context_length(
+                "NousResearch/Hermes-3-70B", provider="custom-provider"
+            )
+            == 65_536
+        )
+        assert ("custom-provider", "NousResearch/Hermes-3-70B") in calls
+
+    def test_unknown_prefix_left_untouched(self, monkeypatch):
+        # A slash prefix that is NOT a registered provider is left as part
+        # of the model id (existing consumers of qualified forms keep
+        # working; the fallback path is unchanged).
+        calls = _with_models_dev(monkeypatch, {})
+        with patch.dict(mm.DEFAULT_CONTEXT_LENGTHS, {"notaprovider/odd-model": 777}):
+            assert mm.get_model_context_length("notaprovider/odd-model") == 777
+
+    def test_openrouter_slug_not_stripped_with_explicit_provider(
+        self, monkeypatch
+    ):
+        # OR slugs ("anthropic/claude-fable-5") are model ids, not
+        # provider prefixes: with an explicit OpenRouter provider the id
+        # must reach the OR catalog verbatim. Pin via a fake OR metadata
+        # entry keyed by the full slug — if the prefix were stripped the
+        # lookup would miss and fall through to a different value.
+        monkeypatch.setattr(
+            mm,
+            "fetch_model_metadata",
+            lambda: {"anthropic/claude-fable-5": {"context_length": 999_999}},
+        )
+        assert (
+            mm.get_model_context_length(
+                "anthropic/claude-fable-5", provider="openrouter"
+            )
+            == 999_999
+        )
+
+    def test_url_inference_still_beats_parsed_prefix(self, monkeypatch):
+        calls = _with_models_dev(
+            monkeypatch, {("from-url", "m1"): 123_456}
+        )
+        # A provider inferred from the endpoint URL is more authoritative
+        # than one parsed off the model id (opencode-go is registered, so
+        # the parse succeeds and would otherwise claim the lookup).
+        with patch.object(
+            mm, "_infer_provider_from_url", return_value="from-url"
+        ):
+            assert (
+                mm.get_model_context_length(
+                    "opencode-go/m1", base_url="https://api.example/v1"
+                )
+                == 123_456
+            )
+        assert ("from-url", "m1") in calls
+        assert ("opencode-go", "m1") not in calls

--- a/tests/agent/test_context_length_slash_provider.py
+++ b/tests/agent/test_context_length_slash_provider.py
@@ -125,3 +125,36 @@ class TestSlashQualifiedResolution:
             )
         assert ("from-url", "m1") in calls
         assert ("opencode-go", "m1") not in calls
+
+    def test_openrouter_endpoint_keeps_slug_whole(self, monkeypatch):
+        # Same OR-slug protection as the explicit-provider test above, but
+        # for the caller that supplied NO provider and only the OpenRouter
+        # base URL: the endpoint makes the whole id an OR slug, and the
+        # first segment ("anthropic") names a bundled provider, so without
+        # the endpoint guard the strip would rewrite the id to
+        # ("anthropic", "claude-fable-5") and miss the OR catalog entry.
+        monkeypatch.setattr(
+            mm,
+            "fetch_model_metadata",
+            lambda: {"anthropic/claude-fable-5": {"context_length": 999_999}},
+        )
+        assert (
+            mm.get_model_context_length(
+                "anthropic/claude-fable-5",
+                base_url="https://openrouter.ai/api/v1",
+            )
+            == 999_999
+        )
+
+    def test_user_plugin_prefix_not_stripped(self, monkeypatch):
+        # The strip must key off BUNDLED provider names only: the registry
+        # is extended by user plugins, and a user-only registration must
+        # not change how a slash-qualified id resolves. "anthropic" is
+        # bundled, "acme-inference" is not.
+        calls = _with_models_dev(monkeypatch, {})
+        monkeypatch.setattr(
+            "providers.is_bundled_provider", lambda name: name == "anthropic"
+        )
+        with patch.dict(mm.DEFAULT_CONTEXT_LENGTHS, {"acme-inference/m9": 555}):
+            assert mm.get_model_context_length("acme-inference/m9") == 555
+        assert not calls

--- a/tests/providers/test_provider_registry.py
+++ b/tests/providers/test_provider_registry.py
@@ -64,3 +64,23 @@ def test_list_providers_dedupes_aliases_in_cached_snapshot():
 
     assert providers.get_provider_profile("moonshot") is profile
     assert providers.list_providers() == [profile]
+
+
+def test_is_bundled_provider_covers_bundled_names():
+    # Bundled plugin profiles resolve through the registry AND report as
+    # bundled, so name-based rewrites (e.g. stripping a provider prefix off
+    # a model id) stay stable across installs.
+    assert providers.is_bundled_provider("anthropic")
+    assert providers.is_bundled_provider("openrouter")
+
+
+def test_is_bundled_provider_false_for_user_only_names():
+    # A name registered only outside discovery (the user-plugin /
+    # register_provider path) must NOT count as bundled even though the
+    # registry resolves it.
+    _reset_registry()
+    providers.register_provider(_profile("acme-only", "acme"))
+
+    assert providers.get_provider_profile("acme-only") is not None
+    assert not providers.is_bundled_provider("acme-only")
+    assert not providers.is_bundled_provider("acme")


### PR DESCRIPTION
## What does this PR do?

`get_model_context_length` returned different context windows for the same model depending on spelling: `"qwen3.7-plus"` with `provider="opencode-go"` resolved through the provider-aware models.dev lookup (1,000,000), while the equivalent `"opencode-go/qwen3.7-plus"` kept the prefixed id — whose generic `qwen` substring matched the hardcoded `DEFAULT_CONTEXT_LENGTHS` entry (131,072) before any per-model entry scored. The divergence is user-facing (boot banner under-reports; the pre-flight context-budget check compresses prematurely or rejects runnable sessions), and on the Bedrock path the wrong value gets persisted (confirmed independently in the issue thread, 2026-08-26). Three earlier PRs (#47783/#47810/#47881) were closed without merging; the AI triage review identified #47810's shape — separate both provider and model, propagating the parsed provider — as the strongest reference.

This implements that shape at the top of the resolution chain: when the caller supplied **no** provider and the slash prefix names a **registered** provider, strip the prefix and propagate the parsed provider into the provider-aware lookup (step 5f). Explicit-provider ids are deliberately left whole — they are server-side spellings whose full form the downstream catalogs and caches are keyed on (local/custom endpoints know `"NousResearch/Hermes-…"` org-qualified names; NVIDIA NIM uses `"deepseek-ai/…"`; OpenRouter slugs use `"anthropic/…"`). An endpoint-URL provider inference still outranks the parsed prefix, and an explicitly supplied provider outranks both.

## Related Issue

Fixes #47782

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — in `get_model_context_length`, parse the slash prefix once before the resolution steps: strip + propagate when no explicit provider was given and the prefix is a registered provider; seed `effective_provider` with the parsed prefix (overridable by URL inference); explicit-provider and vendor-slug spellings pass through untouched.
- `tests/agent/test_context_length_slash_provider.py` — six regression tests: prefixed and bare+provider spellings agree through the same catalog entry; the parsed provider beats the generic substring default; explicit-provider org-qualified ids stay whole; unregistered prefixes stay whole; OpenRouter slug lookup is untouched; URL inference outranks the parsed prefix.

## How to Test

1. `.venv/bin/python -m pytest tests/agent -k slash_provider -v` — should pass (6 passed).
2. Adjacent suites stay green: `.venv/bin/python -m pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py tests/agent/test_model_metadata_ssl.py tests/agent/test_bedrock_1m_context.py -q` — should pass (152 passed; the local-endpoint suite pins that `"NousResearch/Hermes-3-Llama-3.1-70B"` under an explicit provider reaches the cache verbatim, which this PR preserves).
3. Fail-on-main control: `git checkout HEAD~1 -- agent/model_metadata.py` and rerun the new file — should fail (3 failed: the agreement, generic-default, and URL-inference tests), then restore. Observed result: `3 failed, 3 passed` pre-fix (the explicit-provider and unregistered-prefix pass-through tests pass on both sides by design), `6 passed` post-fix.
4. Live check from the report's repro: `get_model_context_length("qwen3.7-plus", provider="opencode-go")` and `get_model_context_length("opencode-go/qwen3.7-plus")` should both return 1,000,000.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#47783/#47810/#47881 all target this issue and are closed unmerged; none is open, and the 2026-08-26 confirmation in the issue shows the bug is live on main)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in the inline comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python string parsing, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
