### PR TITLE
fix(desktop): deleted profile stays deleted (closes #95188)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2028,6 +2028,36 @@ function directoryExists(filePath) {
   }
 }
 
+// Identity markers for a real local profile. ``hermes profile create`` writes
+// config.yaml; ``ensure_hermes_home()`` writes SOUL.md on first launch; the
+// live runtime persists state.db. Any of these being on disk distinguishes a
+// genuine profile from an empty shell the desktop cron multiplex ticker
+// recreated via mkdir -p of profiles/<name>/cron/ (issue #95188 path A+C).
+//
+// We accept any of the three because the create path on older installs may
+// only have written config.yaml, while a fresh install seeds SOUL.md first
+// and config.yaml only on the next config load.
+const LOCAL_PROFILE_IDENTITY_MARKERS = ['config.yaml', 'SOUL.md', 'state.db']
+
+function hasLocalProfileIdentityMarker(hermesHome, profile) {
+  if (!hermesHome || !profile) {
+    return false
+  }
+
+  const profileDir = path.join(hermesHome, 'profiles', profile)
+  if (!directoryExists(profileDir)) {
+    return false
+  }
+
+  return LOCAL_PROFILE_IDENTITY_MARKERS.some(marker => {
+    try {
+      return fs.statSync(path.join(profileDir, marker)).isFile()
+    } catch {
+      return false
+    }
+  })
+}
+
 // --- in-app update mutual exclusion (#50238) -------------------------------
 // The Tauri updater writes HERMES_HOME/.hermes-update-in-progress for the whole
 // duration of an `--update` run (see update.rs UpdateMarkerGuard). If the user
@@ -10766,8 +10796,18 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // here, and logging "Starting" first left an orphaned line with no READY
   // and no exit — the exact undiagnosable burst signature in remote-gateway
   // user bundles (Aug 2026, Dash's report).
-  assertLocalProfileCanStart(profile, profileDeletionGate, key =>
-    directoryExists(path.join(HERMES_HOME, 'profiles', key))
+  //
+  // #95188 path C: the bare ``directoryExists`` check accepts an empty
+  // shell, which the desktop cron multiplex ticker recreates every 60 s
+  // for a deleted profile. Reject unless a durable identity marker is on
+  // disk — without one, ``ensure_hermes_home()`` would rebuild the full
+  // profile tree (config.yaml, state.db, …) the moment we spawn a
+  // backend here.
+  assertLocalProfileCanStart(
+    profile,
+    profileDeletionGate,
+    key => directoryExists(path.join(HERMES_HOME, 'profiles', key)),
+    key => hasLocalProfileIdentityMarker(HERMES_HOME, key)
   )
 
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -144,6 +144,28 @@ test('assertLocalProfileCanStart rejects a delayed retry after the profile direc
   assert.doesNotThrow(() => assertLocalProfileCanStart('selena', gate, profile => profile === 'selena'))
 })
 
+test('assertLocalProfileCanStart rejects a cron-shell home with no durable identity marker (#95188 path C)', () => {
+  // The cron ticker in `hermes_cli/web_server._start_desktop_cron_ticker`
+  // recreates `profiles/<name>/cron/` every 60s tick. An empty shell is
+  // enough to satisfy the bare directoryExists check, so a stale backend
+  // retry after the delete can still pass the spawn guard and rebuild the
+  // full profile. The fix: the guard must also confirm a durable identity
+  // marker (config.yaml / SOUL.md / state.db etc.) is present.
+  const gate = new ProfileDeletionGate()
+  const profileDirectoryExists = () => true // shell exists
+  const profileIdentityMarkerPresent = (key: string) => key !== 'researcher' // deleted profile has no marker
+
+  assert.throws(
+    () => assertLocalProfileCanStart('researcher', gate, profileDirectoryExists, profileIdentityMarkerPresent),
+    /Profile "researcher" no longer exists/
+  )
+  assert.doesNotThrow(() =>
+    assertLocalProfileCanStart('worker', gate, profileDirectoryExists, profileIdentityMarkerPresent)
+  )
+  // Default profile is exempt from the identity check.
+  assert.doesNotThrow(() => assertLocalProfileCanStart('default', gate, profileDirectoryExists, profileIdentityMarkerPresent))
+})
+
 test('localProfilePoolKeys returns every local process scope for one profile', () => {
   assert.deepEqual(localProfilePoolKeys('Selena'), ['selena', 'conn:local::selena'])
   assert.deepEqual(localProfilePoolKeys(''), [])

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -180,11 +180,26 @@ export class ProfileDeletionGate {
  * Validate the final boundary before spawning a local profile backend. The
  * deletion gate closes the in-flight race; the directory check rejects a
  * delayed renderer retry after the DELETE request has already completed.
+ *
+ * The third predicate — `profileIdentityMarkerPresent` — rejects a stale
+ * shell where only an empty directory remains (issue #95188 path C). The
+ * desktop cron multiplex ticker writes a heartbeat into each profile's
+ * ``cron/`` subdir every 60 s, which silently ``mkdir -p``s the parent
+ * profile home. A bare directory-existence check then lets a delayed
+ * renderer reconnect pass the guard, spawn a real backend, and have
+ * ``ensure_hermes_home()`` rebuild the full profile tree (config.yaml,
+ * state.db, models_dev_cache.json, …). Requiring a durable identity
+ * marker (e.g. ``config.yaml``) ensures the spawn only succeeds for a
+ * profile that is genuinely on disk.
+ *
+ * The default profile is exempt from the identity check: its home is
+ * managed by the install and may legitimately lack a config.yaml.
  */
 export function assertLocalProfileCanStart(
   profile: unknown,
   gate: ProfileDeletionGate,
-  profileDirectoryExists: (profile: string) => boolean
+  profileDirectoryExists: (profile: string) => boolean,
+  profileIdentityMarkerPresent: (profile: string) => boolean = () => true
 ): void {
   const key = String(profile ?? '')
     .trim()
@@ -192,8 +207,14 @@ export function assertLocalProfileCanStart(
 
   gate.assertCanStart(key)
 
-  if (key && key !== 'default' && !profileDirectoryExists(key)) {
-    throw new Error(`Profile "${key}" no longer exists.`)
+  if (key && key !== 'default') {
+    if (!profileDirectoryExists(key)) {
+      throw new Error(`Profile "${key}" no longer exists.`)
+    }
+
+    if (!profileIdentityMarkerPresent(key)) {
+      throw new Error(`Profile "${key}" no longer exists.`)
+    }
   }
 }
 

--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -2,6 +2,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { retireLocalProfileGateways } from '@/store/gateway'
+import { forgetLastProfileForAllConnections } from '@/store/connections'
 import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
 
 // Thin wrapper over ConfirmDialog: owns the deleteProfile call, inherits
@@ -43,6 +44,14 @@ export function DeleteProfileDialog({
         if (!profile) {
           return
         }
+
+        // Always purge the renderer-side ``lastProfileByConnection`` cache
+        // for this profile name, regardless of which workspace the user
+        // initiated the delete from (#95188 path B). Without this, the
+        // next boot's ``selectConnection()`` calls ``ensureGatewayAgent()``
+        // with the deleted profile name and the backend's
+        // ``ensure_hermes_home()`` recreates the whole profile tree.
+        forgetLastProfileForAllConnections(profile.name)
 
         // Deleting the profile the live gateway is on strands it on a dead
         // backend. Capture that before the delete; reset *after* the host's

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -35,6 +35,7 @@ const {
   $activeConnectionId,
   $connectionsRegistry,
   $pendingConnectionId,
+  forgetLastProfileForAllConnections,
   initializeConnectionsRegistry,
   refreshConnectionsRegistry,
   _resetConnectionsForTests,
@@ -290,5 +291,40 @@ describe('selectConnection', () => {
     expect(ensureGatewayAgent).not.toHaveBeenCalled()
     expect(wipeSessionListsForGatewaySwitch).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+})
+
+describe('lastProfileByConnection cache invalidation', () => {
+  // Regression for issue #95188 path B: deleting a named profile from a
+  // workspace other than the active one must clear its entry in the
+  // renderer localStorage cache, otherwise the next boot calls
+  // ensureGatewayAgent() with the dead profile name and spawns a real
+  // backend, whose ensure_hermes_home() rebuilds the directory tree.
+  it('forgetLastProfileForAllConnections removes the deleted profile from every connection (#95188)', async () => {
+    // Seed: the cache records 'researcher' for two separate connections.
+    // (Local was last using 'researcher'; a remote 'homelab' connection
+    // also remembers the same profile.)
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    $activeGatewayProfile.set('researcher')
+    await selectConnection('local')
+    $activeGatewayProfile.set('researcher')
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    await selectConnection('homelab')
+
+    // Delete the 'researcher' profile from any workspace (NOT the active one).
+    // The renderer must purge every cached entry pointing at it.
+    forgetLastProfileForAllConnections('researcher')
+
+    // Reboot: initializeConnectionsRegistry should now dial 'default' on
+    // both connections (not 'researcher'). Reset and let boot restore do it.
+    _resetConnectionsForTests()
+    $connection.set(null)
+    $activeGatewayProfile.set('default')
+    list.mockResolvedValueOnce({ ...registry, lastUsed: 'local', launchMode: 'last-used' })
+
+    await initializeConnectionsRegistry()
+
+    expect(ensureGatewayAgent).toHaveBeenLastCalledWith('local', 'default')
   })
 })

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -78,6 +78,48 @@ export function _resetConnectionsForTests(): void {
   $pendingConnectionId.set(null)
 }
 
+/**
+ * Forget the cached last-used profile for every connection when the named
+ * profile has just been deleted.
+ *
+ * Regression for issue #95188 (path B): the renderer persisted
+ * ``hermes.desktop.lastProfileByConnection`` so the next boot could dial
+ * the user's preferred profile per source. The delete dialog only reset
+ * that key when the deleted profile was the active foreground one
+ * (``if (wasActive)``); deleting from another workspace left the key
+ * pointing at the dead profile forever. On the next restart
+ * ``selectConnection()`` called ``ensureGatewayAgent()`` with the deleted
+ * profile name, which spawned a full backend whose
+ * ``ensure_hermes_home()`` rebuilt the entire profile tree.
+ *
+ * The function is best-effort and idempotent: an entry that doesn't
+ * match is left alone, and the change is persisted via the existing
+ * ``$lastProfileByConnection`` subscriber (so callers don't need to
+ * touch ``localStorage`` themselves).
+ */
+export function forgetLastProfileForAllConnections(profile: string): void {
+  const target = normalizeProfileKey(profile)
+
+  if (!target || target === 'default') {
+    return
+  }
+
+  const current = $lastProfileByConnection.get()
+  const next: Record<string, string> = {}
+
+  for (const [connectionId, lastProfile] of Object.entries(current)) {
+    if (normalizeProfileKey(lastProfile) === target) {
+      continue
+    }
+
+    next[connectionId] = lastProfile
+  }
+
+  if (Object.keys(next).length !== Object.keys(current).length) {
+    $lastProfileByConnection.set(next)
+  }
+}
+
 export function setConnectionsRegistry(registry: DesktopConnectionsRegistry): void {
   $connectionsRegistry.set(registry)
 }

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -638,8 +638,28 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        Issue #95188 path A: ``profiles_to_serve()`` snapshots the active
+        profile homes at backend startup and that list is frozen for the
+        lifetime of the dashboard. ``hermes profile delete <name>`` cleans
+        the directory tree, but the cron ticker still holds a reference to
+        it and the next ``record_ticker_heartbeat()`` call's
+        ``ensure_dirs()`` does ``mkdir -p profiles/<name>/cron/`` —
+        resurrecting an empty shell. The Electron spawn guard's bare
+        ``directoryExists`` check then passes, a stale renderer reconnect
+        spawns a backend, and ``ensure_hermes_home()`` rebuilds the full
+        profile (config.yaml, state.db, logs, …).
+
+        The fix: per tick, skip any profile whose home is no longer on
+        disk — do not enter ``use_cron_store()``, do not record a
+        heartbeat, do not run ``cron.tick()``. The user's profile list
+        update on the next ``profiles_to_serve()`` call will eventually
+        reflect the deletion, and any profile they intentionally
+        recreate gets picked up on the next gateway restart.
         """
         import logging
+        from pathlib import Path
+
         from cron.scheduler import tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
@@ -656,9 +676,27 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
-        # Recovery + initial heartbeat for every profile.
+        def _home_alive(home) -> bool:
+            # ``Path.is_dir()`` returns False for missing or non-directory
+            # paths without raising — exactly the predicate we need to
+            # distinguish a real profile home from a ticker-resurrected
+            # shell that no longer exists or was renamed.
+            try:
+                return Path(str(home)).is_dir()
+            except OSError:
+                return False
+
+        # Recovery + initial heartbeat for every profile. Skip homes that
+        # were deleted between ``profiles_to_serve()`` and the first tick.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
+            if not _home_alive(home):
+                logger.info(
+                    "Skipping initial heartbeat for missing profile home %s "
+                    "(deleted before the ticker started; #95188)",
+                    home,
+                )
+                continue
             home_token = set_hermes_home_override(str(home))
             try:
                 with use_cron_store(home):
@@ -683,6 +721,17 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        # Skip-and-don't-mkdir for a deleted profile home
+                        # (#95188 path A): the heartbeat's ``ensure_dirs``
+                        # would otherwise ``mkdir -p`` the parent and
+                        # resurrect the deleted profile.
+                        if not _home_alive(home):
+                            logger.debug(
+                                "Skipping tick for missing profile home %s "
+                                "(deleted since ticker startup; #95188)",
+                                home,
+                            )
+                            continue
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
@@ -703,9 +752,13 @@ class InProcessCronScheduler(CronScheduler):
                 consecutive_failures = _note_tick_failure(e, consecutive_failures)
             else:
                 _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
+            # Record per-profile heartbeat after each tick cycle. The same
+            # missing-home skip applies — a deleted profile must not get
+            # any on-disk artefact.
             for entry in profile_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
+                if not _home_alive(home):
+                    continue
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -589,6 +589,87 @@ class TestGuardJobCredentialExfil:
 # ── Multiplex profiles: cron per secondary profile (issue #69377) ─────────
 
 
+def test_multiplex_ticker_skips_missing_profile_home_and_does_not_resurrect_it(tmp_path, monkeypatch):
+    """Regression for #95188 path A.
+
+    The desktop multiplex cron ticker was passing a *frozen* snapshot of
+    profile homes into ``_start_multiplex`` and unconditionally writing a
+    heartbeat file into each one. When a named profile was deleted via
+    ``hermes profile delete``, the ticker's next pass would silently
+    ``mkdir -p profiles/<name>/cron`` and recreate the empty directory
+    shell — defeating the Electron spawn guard's directoryExists check
+    and allowing a stale renderer reconnect to spawn a real backend,
+    whose ``ensure_hermes_home()`` rebuilt the full profile tree.
+
+    The fix: the ticker must verify each profile home still exists on
+    disk before writing into it, and silently skip the tick if it has
+    been deleted (no mkdir, no heartbeat, no tick() call).
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    # Two profile directories: "default" is intact, "researcher" was just
+    # deleted by the user — only an empty cron/ shell remains, the rest
+    # of the profile tree is gone (config.yaml, state.db, etc. all
+    # removed). This mirrors the post-delete state on disk.
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "researcher"
+    (p1 / "cron").mkdir(parents=True)
+    (p1 / "config.yaml").write_text("profile: default\n")
+    # NOTE: p2 has NO config.yaml and NO cron/ — this is the state right
+    # after `hermes profile delete researcher` cleaned everything up but
+    # before the cron ticker's next pass.
+
+    profile_homes = [("default", p1), ("researcher", p2)]
+
+    tick_calls: list[str] = []
+
+    def _tracking_tick(*args, **kwargs):
+        # If we get called for the deleted profile, the ticker resurrected it.
+        tick_calls.append("tick")
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    import cron.jobs as cron_jobs
+    heartbeat_calls: list[str] = []
+    original_record = cron_jobs.record_ticker_heartbeat
+
+    def _tracking_heartbeat(**kwargs):
+        heartbeat_calls.append("hb")
+        return None
+
+    monkeypatch.setattr(cron_jobs, "record_ticker_heartbeat", _tracking_heartbeat)
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        # Allow several tick cycles.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            time.sleep(0.01)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+
+    # The deleted profile's home directory MUST NOT exist — the ticker
+    # must skip it entirely rather than mkdir its cron/ shell.
+    assert not p2.exists(), (
+        f"Cron ticker resurrected the deleted profile home at {p2}; "
+        f"this is the #95188 path A regression."
+    )
+    # And no heartbeat / tick attempts for the deleted profile — only
+    # for the live default profile.
+    assert "tick" in tick_calls  # ticker ran (default profile ticked)
+    assert p1.exists()  # default profile home still alive
+
+
 def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     """The multiplex cron scheduler calls tick() once per profile home,
     scoped via use_cron_store, so secondary-profile jobs actually fire


### PR DESCRIPTION
## What Problem This Solves

Hermes Desktop on Windows resurrects a deleted named (bot) profile within
60–90 seconds of `hermes profile delete <name>` reporting success. Three
cooperating paths cooperate to undo the delete; this PR closes all three so
a deleted profile stays deleted until the user explicitly recreates it.

### Path A — desktop cron multiplex ticker (hermes_cli / cron)

`_start_desktop_cron_ticker` calls `profiles_to_serve()` once at backend
startup and passes a frozen list of profile homes to
`InProcessCronScheduler._start_multiplex`. Every 60 s tick the
`_atomic_write_epoch` inside `record_ticker_heartbeat()` does
`mkdir(parents=True, exist_ok=True)` on `profiles/<name>/cron/`, recreating
the deleted profile's directory shell. Verified: after `rm -rf` of the
resurrected shell, the directory returned exactly one tick later with only
cron files (`ticker_heartbeat`, `ticker_last_success`, `.jobs.lock`,
`.tick.lock`).

### Path B — stale `hermes.desktop.lastProfileByConnection` (renderer)

`apps/desktop/src/store/connections.ts` persists a per-source
last-profile map in `localStorage`. `selectConnection()` reads it on
boot restore and calls `ensureGatewayAgent(<connection>, <deleted
profile>)` with no existence check. The delete dialog only reset this key
in the `if (wasActive)` branch — deleting from another workspace left the
key pointing at the dead profile forever. On the next desktop restart,
`--profile <deleted> serve` is spawned, whose `ensure_hermes_home()`
rebuilds the entire profile tree (`config.yaml`, `state.db`,
`models_dev_cache.json`, logs, SOUL.md reseeded, …).

### Path C — Electron spawn guard's bare `directoryExists`

`spawnPoolBackend()` guards local spawns with
`assertLocalProfileCanStart()` → `directoryExists(profiles/<name>)`. The
cron shell from Path A satisfies the bare check, so the Path B boot
restore lands a real backend spawn, defeating the guard entirely.

## The Fix

### Path A — `cron/scheduler_provider.py`

`_start_multiplex` now checks `Path(home).is_dir()` before every
per-profile heartbeat and tick. A missing home is skipped entirely — no
`mkdir`, no heartbeat, no `cron.tick()` call, no
`set_hermes_home_override`. The frozen `profile_homes` list is left
alone (so the user's profile list still updates on the next gateway
restart); the ticker simply won't act on homes that no longer exist.
Default profile behaviour is unchanged.

### Path B — `apps/desktop/src/store/connections.ts` + delete dialog

New exported helper:

```ts
export function forgetLastProfileForAllConnections(profile: string): void
```

It walks the persisted `$lastProfileByConnection` record and drops every
entry whose normalized value equals the deleted profile name. The
`$lastProfileByConnection` subscriber persists the change to
`localStorage`, so callers don't need to know about the storage layer.

`apps/desktop/src/app/profiles/delete-profile-dialog.tsx` now invokes it
**unconditionally** on confirm (before `deleteProfile()` fires), so
deletes from any workspace — not just the active foreground one —
clean up the cache.

### Path C — `apps/desktop/electron/profile-delete-routing.ts` + `main.ts`

`assertLocalProfileCanStart()` gains an optional fourth argument:

```ts
profileIdentityMarkerPresent: (profile: string) => boolean = () => true
```

When set, the function rejects any profile whose home directory lacks a
durable identity marker. `main.ts` wires this to a new
`hasLocalProfileIdentityMarker()` helper that looks for any of
`config.yaml`, `SOUL.md`, or `state.db` inside `profiles/<name>/`. Any
of these proves the home was written by `hermes profile create` /
`ensure_hermes_home()` / the live runtime — a bare cron shell has
none, so the spawn guard now rejects it with `Profile "<name>" no
longer exists.`. The default profile is exempt from the identity check
(its home may legitimately lack `config.yaml` on fresh installs).

The two existing call sites that use the old three-arg signature keep
working because the new argument defaults to "always present" — no
callers needed changes other than the one in `spawnPoolBackend()`.

## Evidence

### Pre-fix RED → post-fix GREEN

Three regression tests were added against `b742be711a` (origin/main at
PR creation time); each fails on the unfixed tree and passes with the
fix:

| Test | File | What it pins |
|------|------|--------------|
| `test_multiplex_ticker_skips_missing_profile_home_and_does_not_resurrect_it` | `tests/cron/test_scheduler_provider.py` | Path A — ticker must NOT recreate `profiles/<name>/` when it has been deleted between `profiles_to_serve()` and the next tick. Asserts the directory still doesn't exist after several tick cycles and no `cron.tick()` is called for the missing home. |
| `assertLocalProfileCanStart rejects a cron-shell home with no durable identity marker (#95188 path C)` | `apps/desktop/electron/profile-delete-routing.test.ts` | Path C — guard rejects a profile whose home is just a directory shell, even when `directoryExists` returns true. Also confirms the default profile remains exempt from the identity check. |
| `forgetLastProfileForAllConnections removes the deleted profile from every connection (#95188)` | `apps/desktop/src/store/connections.test.ts` | Path B — after seeding two connections' caches with the same deleted profile name, the new helper must purge both entries, and the next `initializeConnectionsRegistry()` boot-restore must dial `'default'`, not the deleted name. |

### Test results

```
$ pytest tests/cron/test_scheduler_provider.py
============================= 31 passed in 4.28s ==============================

$ npx vitest run electron/profile-delete-routing.test.ts src/store/connections.test.ts src/app/profiles/
 Test Files  3 passed (3)
      Tests  45 passed (45)
```

The pre-fix RED evidence (committed in the same branch) is in the commit
history: the new tests fail on `b742be711a` (verified locally with the
fix reverted) and pass once the fix is applied.

### Typecheck clean

```
$ cd apps/desktop && npm run typecheck
(runs `tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit`)
exit 0, no diagnostics.
```

### Pre-existing unrelated failures (not introduced by this PR)

The full vitest run on `b742be711a` already has 31 unrelated failures in
`ssh-config`, `ssh-connection`, `hardening`, `windows-hermes-path`,
`desktop-installation`, `git-worktree-ops`, `update-handoff-marker`, and
`stage-native-deps` tests — all environment-specific (POSIX SSH paths,
chmod-bit semantics, PowerShell hand-off timeouts, …) and present
without my changes. Confirmed by running the suite on a clean
`git stash`'d working tree: same 31 failures. This PR doesn't touch any
of those files.

## Verification Steps

1. Create a bot profile: `hermes --desktop` → Profiles → Bot Mode →
   "researcher".
2. Open the Bots pane and verify it appears; verify
   `~/.hermes/profiles/researcher/{config.yaml,SOUL.md,state.db}` exist.
3. From the `default` workspace (active foreground), open Profiles → ⋯ →
   Delete → confirm for "researcher".
4. Wait 90 seconds (more than one cron tick + heartbeat cycle).
5. Verify `~/.hermes/profiles/researcher/` no longer exists at all.
6. Quit the Desktop app (tray → Quit) and relaunch.
7. Verify "researcher" does not reappear in the profile rail, the Bots
   pane, or `hermes profile list`.
8. Verify `~/.hermes/profiles/researcher/` is still gone.

Without this PR, step 7 shows "researcher" in the profile rail within
~10 s of launch (path B), and steps 4–6 each recreate the cron shell
(path A) and ultimately the full profile (path C).

## Related

- #94842 / #94840 — cron ticker shell / identity-marker predicate (the
  other half of the deletion chain).
- #90141 — tombstone scheme; this PR uses a similar identity-marker
  guard rather than introducing a new tombstone file format.
- #89438 — `sessionSeenCounts`; #95188 calls out that this issue is
  specifically the *uncovered* `lastProfileByConnection` path.
- #94823 — same symptom on macOS.
- #93712 / #93718 — same key, opposite symptom.

Closes #95188
