### PR TITLE
fix(commandcode): forward DeepSeek reasoning controls through the wire

### DIFF
--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -97,6 +97,32 @@ class CommandCodeProfile(ProviderProfile):
         """Fetch from the public CommandCode /models endpoint."""
         return _fetch_commandcode_models(timeout=timeout, base_url=base_url)
 
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict, dict]:
+        """Apply the native DeepSeek reasoning controls for DeepSeek-family ids.
+
+        CommandCode fronts DeepSeek with vendor-prefixed ids
+        (``deepseek/deepseek-v4-flash``). DeepSeek V4+ defaults to thinking
+        mode when the ``thinking`` field is omitted, so without an explicit
+        wire control a Hermes ``/reasoning none`` changes the session state
+        but not the actual request — the turn sits in
+        ``reflecting.../brainstorming...`` for minutes (#95232). Strip the
+        vendor prefix and delegate to the native DeepSeek profile's logic
+        (extra_body.thinking + reasoning_effort mapping); other CommandCode
+        model families keep the base no-op behavior.
+        """
+        m = (model or "").strip()
+        if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
+            return {}, {}
+        from plugins.model_providers.deepseek import deepseek as _deepseek_profile
+
+        return _deepseek_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model=m.split("/", 1)[1],
+            **context,
+        )
+
 
 commandcode = CommandCodeProfile(
     name="commandcode",

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -115,8 +115,19 @@ class CommandCodeProfile(ProviderProfile):
         m = (model or "").strip()
         if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
             return {}, {}
-        from plugins.model_providers.deepseek import deepseek as _deepseek_profile
-
+        try:
+            from plugins.model_providers.deepseek import deepseek as _deepseek_profile
+        except ImportError:
+            # The bundled-plugin loader tolerates a plugin failing to load
+            # (it pops the half-registered module and continues), so the
+            # shim may be absent. Degrade to the pre-fix no-op instead of
+            # crashing every DeepSeek-routed CommandCode turn.
+            logger.warning(
+                "DeepSeek provider plugin unavailable; CommandCode cannot "
+                "forward reasoning controls (#95232)",
+                exc_info=True,
+            )
+            return {}, {}
         return _deepseek_profile.build_api_kwargs_extras(
             reasoning_config=reasoning_config,
             model=m.split("/", 1)[1],

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -86,28 +86,64 @@ class TestCommandCodeProfileIdentity:
 
 
 class TestCommandCodeProfileNoThinkingInterference:
-    """Chat completions profile is a no-op for thinking config — it delegates
-    to the underlying model's provider (DeepSeek, Qwen, etc.) for wire format.
+    """Reasoning wire controls for the chat-completions profile.
+
+    DeepSeek-family ids get the native DeepSeek controls (DeepSeek V4+
+    defaults to thinking when the field is omitted, so an explicit wire
+    control is required for ``/reasoning none`` to reach the request,
+    #95232); every other CommandCode model family keeps the base no-op.
     """
 
-    def test_passthrough_no_reasoning_config(self, commandcode_profile):
+    def test_deepseek_disabled_reasoning_sends_thinking_disabled(
+        self, commandcode_profile
+    ):
         extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config=None, model="deepseek/deepseek-v4-pro"
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v4-flash",
         )
-        # Chat completions profile doesn't inject thinking params — that's
-        # the DeepSeek provider's job when routed through DeepSeek's own profile.
-        # When routed through CommandCode, the underlying model API handles it.
-        assert isinstance(extra_body, dict)
-        assert isinstance(top_level, dict)
-        # Default ProviderProfile returns ({}, {}).
+        assert extra_body.get("thinking") == {"type": "disabled"}
+        assert top_level == {}
 
-    def test_passthrough_with_reasoning_config(self, commandcode_profile):
+    def test_deepseek_enabled_reasoning_maps_effort(self, commandcode_profile):
         extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="deepseek/deepseek-v4-pro",
         )
-        assert isinstance(extra_body, dict)
-        assert isinstance(top_level, dict)
+        assert extra_body.get("thinking") == {"type": "enabled"}
+        assert top_level.get("reasoning_effort") == "high"
+
+    def test_deepseek_no_config_defaults_to_enabled(self, commandcode_profile):
+        # Matches DeepSeek's API default, applied explicitly so the field is
+        # never omitted for thinking-capable models.
+        extra_body, _ = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="deepseek/deepseek-v4-flash"
+        )
+        assert extra_body.get("thinking") == {"type": "enabled"}
+
+    def test_deepseek_v3_stays_noop(self, commandcode_profile):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v3",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_passthrough_non_deepseek_family(self, commandcode_profile):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="Qwen/Qwen3.7-Max",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_passthrough_no_reasoning_config_non_deepseek(
+        self, commandcode_profile
+    ):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="gpt-5.5"
+        )
+        assert extra_body == {}
+        assert top_level == {}
 
 
 # ── Anthropic Messages profile ────────────────────────────────────────────────

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -145,6 +145,23 @@ class TestCommandCodeProfileNoThinkingInterference:
         assert extra_body == {}
         assert top_level == {}
 
+    def test_missing_deepseek_plugin_degrades_to_noop(
+        self, commandcode_profile, monkeypatch, caplog
+    ):
+        # The bundled-plugin loader pops half-registered modules when a
+        # plugin fails to load, so the deepseek shim can be absent at
+        # runtime; the delegation must degrade to the pre-fix no-op
+        # instead of crashing every DeepSeek-routed CommandCode turn.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "plugins.model_providers.deepseek", None)
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
 
 # ── Anthropic Messages profile ────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

CommandCode fronts DeepSeek with vendor-prefixed ids (`deepseek/deepseek-v4-flash`), and DeepSeek V4+ defaults to thinking mode when the `thinking` field is omitted. `CommandCodeProfile` did not override `build_api_kwargs_extras()`, so a Hermes `/reasoning none` changed the TUI/session state but not the actual wire request — the turn sat in `reflecting.../brainstorming...` for minutes with no visible response, while the same model and API key worked fine against the CommandCode OpenAI-compatible endpoint directly (#95232; the report verifies the endpoint, key, network path, and model id are all healthy).

The fix strips the `deepseek/` vendor prefix for DeepSeek-family ids and delegates to the native `DeepSeekProfile.build_api_kwargs_extras()` — the same `extra_body.thinking` enable/disable control and `reasoning_effort` mapping the native provider already ships. Other CommandCode model families (Qwen, Kimi, GLM, GPT, …) keep the base no-op behavior. The two prior no-op tests codified the bug (the report calls this out) and are rewritten to pin the new contract.

## Related Issue

Fixes #95232

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/commandcode/__init__.py` — `CommandCodeProfile.build_api_kwargs_extras()` strips the `deepseek/` prefix and delegates to the native DeepSeek profile's implementation for DeepSeek-family ids; non-DeepSeek families return the base no-op.
- `tests/plugins/model_providers/test_commandcode_profile.py` — `TestCommandCodeProfileNoThinkingInterference` rewritten: disabled reasoning sends `thinking: disabled`; enabled reasoning maps effort to `reasoning_effort`; no config defaults to explicitly enabled (never omitted for thinking-capable models); DeepSeek V3 stays no-op; non-DeepSeek families stay no-op with and without reasoning config.

## How to Test

1. `.venv/bin/python -m pytest tests/plugins/model_providers -k commandcode -v` — should pass (38 passed).
2. Full provider suite stays green: `.venv/bin/python -m pytest tests/plugins/model_providers -q` — should pass (239 passed).
3. Fail-on-main control: `git checkout HEAD~1 -- plugins/model-providers/commandcode` and rerun the commandcode tests — should fail (3 failed: the disabled/enabled/default-enabled pins; the V3 and non-DeepSeek pass-through tests pass on both sides by design), then restore. Observed result: `3 failed, 35 passed` pre-fix, `38 passed` post-fix.
4. Live check from the report: `/reasoning none` then `/model deepseek/deepseek-v4-flash --provider commandcode` with a trivial prompt — the turn should return promptly instead of hanging in a thinking state, and the request body should carry `"thinking": {"type": "disabled"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open CommandCode PRs cover doctor vendor slugs, /usage limits, and a CLI skill — none touch reasoning wire controls)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in the method docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python provider logic, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
