### PR TITLE
fix(tui): stop named keys leaking as literal text via CSI-u/modifyOtherKeys

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event-noleak.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event-noleak.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { INITIAL_STATE, parseMultipleKeypresses } from '../parse-keypress.js'
+
+import { InputEvent } from './input-event.js'
+
+/** Feed one raw sequence through the full tokenizer → InputEvent pipeline. */
+const inputForSequence = (sequence: string): string => {
+  const [keys] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+
+  expect(keys).toHaveLength(1)
+
+  return new InputEvent(keys[0]!).input
+}
+
+describe('modifyOtherKeys named keys produce no text', () => {
+  // Regression: Alt+Backspace on Ghostty arrives as ESC[27;3;127~. The old
+  // inputForSpecialSequence fell through to `name`, so once the input line was
+  // empty the literal word "backspace" leaked into the prompt.
+  it('Alt+Backspace via modifyOtherKeys leaks no text', () => {
+    expect(inputForSequence('\x1b[27;3;127~')).toBe('')
+  })
+
+  it('Ctrl+Backspace via modifyOtherKeys leaks no text', () => {
+    expect(inputForSequence('\x1b[27;5;127~')).toBe('')
+  })
+
+  it('Alt+Backspace via kitty CSI-u leaks no text', () => {
+    expect(inputForSequence('\x1b[127;3u')).toBe('')
+  })
+
+  it('plain Backspace still parses without text', () => {
+    expect(inputForSequence('\x7f')).toBe('')
+  })
+})
+
+describe('printable special-sequence forms are preserved', () => {
+  it('Alt+a via modifyOtherKeys still types "a"', () => {
+    expect(inputForSequence('\x1b[27;3;97~')).toBe('a')
+  })
+
+  it('Ctrl+Space via CSI-u still types a space', () => {
+    expect(inputForSequence('\x1b[32;5u')).toBe(' ')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -2,8 +2,20 @@ import { nonAlphanumericKeys, type ParsedKey } from '../parse-keypress.js'
 
 import { Event } from './event.js'
 
-const inputForSpecialSequence = (name: string): string =>
-  name === 'space' ? ' ' : name === 'return' || name === 'escape' ? '' : name
+// Only names that are themselves a printable character ('space' → ' ', or a
+// single letter/digit like Alt+a via modifyOtherKeys) have a text form. Every
+// multi-character named key arriving via CSI u / modifyOtherKeys (backspace,
+// delete, tab, return, escape, F-keys…) must produce NO text. The previous
+// version enumerated the empty-string keys and fell through to `name` for
+// everything else, so Alt+Backspace on Ghostty (ESC[27;3;127~) leaked the
+// literal word "backspace" into the prompt once the input line was empty and
+// no backspace branch consumed the event first. Length-checking the name
+// fails safe for any future named key.
+const inputForSpecialSequence = (name: string): string => {
+  if (name === 'space') return ' '
+  if (name.length === 1) return name
+  return ''
+}
 
 export type Key = {
   upArrow: boolean


### PR DESCRIPTION
## Summary

- `inputForSpecialSequence()` in hermes-ink's `input-event.ts` fell through to the key's own **name** for anything that wasn't `space`/`return`/`escape`. Multi-character names like `'backspace'` therefore became printable input text.
- On Ghostty, Alt+Backspace arrives as the modifyOtherKeys sequence `ESC[27;3;127~` (the TUI enables modifyOtherKeys=2; kitty protocol is deliberately skipped for Ghostty). The name decodes correctly to `'backspace'`, but the conversion helper turned it into the literal six characters `"backspace"`.
- Once the composer line is empty, no backspace branch in `textInput.tsx` consumes the event (`k.backspace && c > 0` fails), so it falls through to the printable-insert path — and the word "backspace" lands in the prompt. Reproduces every time on Ghostty.
- The special-sequence paths set `processedAsSpecialSequence = true`, which skips the `nonAlphanumericKeys` cleanup that would otherwise have caught this. So the conversion helper itself must never return a multi-character name.

## Fix

Rule is now length-based and fails safe:

```ts
const inputForSpecialSequence = (name: string): string => {
  if (name === 'space') return ' '
  if (name.length === 1) return name   // Alt+a still types "a"
  return ''                            // backspace, delete, tab, F-keys… → no text
}
```

This fixes the whole class at the conversion layer rather than special-casing each key — same bug family as the earlier ctrl+space / ctrl+escape leaks noted in comments in `parse-keypress.ts`.

## Test plan

- New regression suite `input-event-noleak.test.ts` (6 tests): Alt/Ctrl+Backspace via both modifyOtherKeys and kitty CSI-u produce no text; plain Backspace unchanged; Alt+a via modifyOtherKeys still types `"a"`; Ctrl+Space still types a space.
- Focused suites pass: `parse-keypress.test.ts`, `parse-keypress-noregress.test.ts`, `parse-keypress-drop-probe.test.ts` (47 tests) plus the new suite.
- Full `packages/hermes-ink` vitest run: 233 passed; the single failure (`ink-backpressure.test.ts`) also fails on clean `main` without this change (pre-existing timing flake).
- `tsc --noEmit -p .` clean on `packages/hermes-ink`.
- Manually verified end-to-end in `hermes --tui` under Ghostty: Alt+Backspace on an empty line is now a no-op.
