### PR TITLE
feat(approvals): per-tool allow/ask/deny policy — non-shell tools finally gated (Perplexity Computer-inspired, #35357)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -664,6 +664,30 @@ def _run_agent_tool_execution_middleware(
                 else authorization_gate.run(_resolve_pre_tool_block)
             )
 
+        # User-defined per-tool approval policy (approvals.tools in
+        # config.yaml) — inspired by Perplexity Computer's per-connector
+        # Allow / Always ask / Deny permission controls (Aug 2026). This is
+        # the single funnel both the sequential and concurrent paths run
+        # through, so gating here covers every tool the agent loop can
+        # invoke (built-in, MCP, plugin). Direct handle_function_call
+        # callers outside the loop run the same check there, keyed off the
+        # same skip_pre_tool_call_hook single-fire contract as plugin hooks.
+        if block_message is None:
+            try:
+                from tools.approval import check_tool_policy
+
+                _policy_result = check_tool_policy(function_name)
+            except Exception:
+                _policy_result = None
+            if _policy_result is not None and not _policy_result.get(
+                "approved", True
+            ):
+                block_message = _policy_result.get("message") or (
+                    f"BLOCKED: tool '{function_name}' was not approved by "
+                    "the user's per-tool approval policy."
+                )
+                block_error_type = "tool_policy_block"
+
         guardrail_decision = None
         if block_message is None:
             guardrail_decision = agent._tool_guardrails.before_call(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2455,6 +2455,25 @@ DEFAULT_CONFIG = {
         #     - "git push --force*"
         #     - "*curl*|*sh*"
         "deny": [],
+        # Per-tool approval policy — inspired by Perplexity Computer's
+        # per-connector permission controls (Allow / Always ask / Deny,
+        # Aug 2026). Maps tool names (fnmatch globs allowed, e.g.
+        # "mcp_github_*") to one of:
+        #   allow (default) — tool runs normally
+        #   ask             — human approval required before every run;
+        #                     [o]nce/[s]ession/[a]lways persistence per
+        #                     tool; honored on CLI and gateway; cron jobs
+        #                     follow approvals.cron_mode; fails closed
+        #                     when nobody can answer
+        #   deny            — tool is blocked unconditionally, BEFORE the
+        #                     --yolo / /yolo / mode=off bypass (like
+        #                     approvals.deny command globs)
+        # Example:
+        #   tools:
+        #     send_message: ask
+        #     "mcp_gmail_*": ask
+        #     browser_exec: deny
+        "tools": {},
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/model_tools.py
+++ b/model_tools.py
@@ -1382,6 +1382,41 @@ def handle_function_call(
         # the hook on that same pass. When skip=True, the caller already
         # fired it — do nothing here.
         if not skip_pre_tool_call_hook:
+            # User-defined per-tool approval policy (approvals.tools) —
+            # same single-fire contract as the plugin pre_tool_call hook:
+            # the agent loop runs this check in tool_executor and passes
+            # skip=True here, so direct callers (execute_code sandbox
+            # bridge, scripts, tests) get exactly one policy evaluation.
+            try:
+                from tools.approval import check_tool_policy
+
+                _policy_result = check_tool_policy(function_name)
+            except Exception:
+                _policy_result = None
+            if _policy_result is not None and not _policy_result.get(
+                "approved", True
+            ):
+                _policy_message = _policy_result.get("message") or (
+                    f"BLOCKED: tool '{function_name}' was not approved by "
+                    "the user's per-tool approval policy."
+                )
+                result = tool_error(_policy_message)
+                _emit_post_tool_call_hook(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status="blocked",
+                    error_type="tool_policy_block",
+                    error_message=_policy_message,
+                    middleware_trace=list(_tool_middleware_trace),
+                )
+                return result
+
             block_message: Optional[str] = None
             try:
                 from hermes_cli.plugins import _dispatch_pre_tool_call_hooks

--- a/tests/tools/test_tool_policy.py
+++ b/tests/tools/test_tool_policy.py
@@ -1,0 +1,202 @@
+"""Tests for the per-tool approval policy (``approvals.tools``).
+
+Inspired by Perplexity Computer's per-connector Allow / Always ask / Deny
+permission controls (Aug 2026). The policy is enforced at the tool
+dispatcher so it covers built-in, MCP, and plugin tools alike.
+"""
+
+import json
+from unittest.mock import patch
+
+
+from tools import approval as approval_mod
+from tools.approval import (
+    _resolve_tool_policy,
+    check_tool_policy,
+)
+
+
+def _with_policy(policy):
+    """Patch the approvals config to carry the given tools policy map."""
+    return patch.object(
+        approval_mod, "_get_approval_config", return_value={"tools": policy}
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_tool_policy — matching semantics
+# ---------------------------------------------------------------------------
+
+class TestResolveToolPolicy:
+    def test_empty_policy_returns_none(self):
+        with _with_policy({}):
+            assert _resolve_tool_policy("send_message") is None
+
+    def test_missing_key_returns_none(self):
+        with patch.object(approval_mod, "_get_approval_config", return_value={}):
+            assert _resolve_tool_policy("send_message") is None
+
+    def test_malformed_policy_returns_none(self):
+        with patch.object(
+            approval_mod, "_get_approval_config",
+            return_value={"tools": ["send_message"]},
+        ):
+            assert _resolve_tool_policy("send_message") is None
+
+    def test_config_read_failure_fails_open(self):
+        with patch.object(
+            approval_mod, "_get_approval_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _resolve_tool_policy("send_message") is None
+
+    def test_exact_match(self):
+        with _with_policy({"send_message": "ask"}):
+            assert _resolve_tool_policy("send_message") == "ask"
+
+    def test_exact_match_case_insensitive(self):
+        with _with_policy({"Send_Message": "deny"}):
+            assert _resolve_tool_policy("send_message") == "deny"
+
+    def test_glob_match(self):
+        with _with_policy({"mcp_gmail_*": "ask"}):
+            assert _resolve_tool_policy("mcp_gmail_send_email") == "ask"
+            assert _resolve_tool_policy("mcp_github_create_issue") is None
+
+    def test_exact_beats_glob(self):
+        with _with_policy({"mcp_gmail_*": "deny", "mcp_gmail_read": "allow"}):
+            assert _resolve_tool_policy("mcp_gmail_read") == "allow"
+            assert _resolve_tool_policy("mcp_gmail_send") == "deny"
+
+    def test_verb_aliases(self):
+        for raw, expected in [
+            ("allow", "allow"), ("auto", "allow"),
+            ("ask", "ask"), ("always", "ask"), ("always_ask", "ask"),
+            ("always-ask", "ask"),
+            ("deny", "deny"), ("never", "deny"), ("block", "deny"),
+            ("ASK", "ask"), (" deny ", "deny"),
+        ]:
+            with _with_policy({"send_message": raw}):
+                assert _resolve_tool_policy("send_message") == expected, raw
+
+    def test_unknown_verb_ignored(self):
+        with _with_policy({"send_message": "maybe"}):
+            assert _resolve_tool_policy("send_message") is None
+
+    def test_non_string_entries_ignored(self):
+        with _with_policy({"send_message": 1, 2: "deny", None: "ask"}):
+            assert _resolve_tool_policy("send_message") is None
+
+
+# ---------------------------------------------------------------------------
+# check_tool_policy — verb behavior
+# ---------------------------------------------------------------------------
+
+class TestCheckToolPolicy:
+    def test_no_policy_is_noop(self):
+        with _with_policy({}):
+            assert check_tool_policy("send_message") is None
+
+    def test_allow_is_noop(self):
+        with _with_policy({"send_message": "allow"}):
+            assert check_tool_policy("send_message") is None
+
+    def test_deny_blocks(self):
+        with _with_policy({"send_message": "deny"}):
+            result = check_tool_policy("send_message")
+        assert result is not None
+        assert result["approved"] is False
+        assert "approvals.tools" in result["message"]
+        assert "send_message" in result["message"]
+
+    def test_deny_beats_yolo(self):
+        with _with_policy({"send_message": "deny"}), \
+             patch.object(approval_mod, "_YOLO_MODE_FROZEN", True):
+            result = check_tool_policy("send_message")
+        assert result is not None and result["approved"] is False
+
+    def test_ask_routes_through_shared_gate(self):
+        captured = {}
+
+        def _fake_gate(**kwargs):
+            captured.update(kwargs)
+            return {"approved": True, "message": None}
+
+        with _with_policy({"send_message": "ask"}), \
+             patch.object(approval_mod, "_run_approval_gate", _fake_gate):
+            result = check_tool_policy("send_message")
+        assert result == {"approved": True, "message": None}
+        # Per-tool allowlist grain: [a]lways on one tool must never blanket
+        # other tools.
+        assert captured["pattern_key"] == "plugin_rule:tool_policy:send_message"
+        # Explicit ask rules override the yolo bypass.
+        assert captured["honor_yolo_bypass"] is False
+        # An ask rule demands a human — no silent fall-through.
+        assert captured["fail_closed_when_no_human"] is True
+
+    def test_ask_fires_under_yolo(self):
+        """An explicit ask rule must still prompt when yolo is active."""
+        gate_calls = []
+
+        def _fake_gate(**kwargs):
+            gate_calls.append(kwargs)
+            return {"approved": False, "message": "BLOCKED: denied by user"}
+
+        with _with_policy({"send_message": "ask"}), \
+             patch.object(approval_mod, "_YOLO_MODE_FROZEN", True), \
+             patch.object(approval_mod, "_run_approval_gate", _fake_gate):
+            result = check_tool_policy("send_message")
+        assert gate_calls, "gate must be invoked even under yolo"
+        assert result["approved"] is False
+
+    def test_gate_yolo_param_actually_bypasses_when_honored(self):
+        """Sanity: honor_yolo_bypass=True still short-circuits under yolo
+        (the dangerous-command path's historical behavior is unchanged)."""
+        with patch.object(approval_mod, "_YOLO_MODE_FROZEN", True):
+            result = approval_mod._run_approval_gate(
+                pattern_key="x", description="d", display_target="t",
+                cron_deny_message="c", single_query_deny_message="s",
+                autoapprove_log_prefix="p",
+            )
+        assert result == {"approved": True, "message": None}
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration (model_tools.handle_function_call)
+# ---------------------------------------------------------------------------
+
+class TestDispatcherIntegration:
+    def test_denied_tool_blocked_at_dispatch(self):
+        import model_tools
+
+        with _with_policy({"vision_analyze": "deny"}):
+            result = model_tools.handle_function_call(
+                "vision_analyze", {"image_url": "x"}
+            )
+        payload = json.loads(result)
+        assert "error" in payload
+        assert "approvals.tools" in payload["error"]
+
+    def test_skip_pre_tool_call_hook_skips_policy(self):
+        """The agent loop passes skip=True after running the policy itself —
+        the dispatcher must not double-fire the gate."""
+        import model_tools
+
+        with _with_policy({"nonexistent_tool_xyz": "deny"}):
+            result = model_tools.handle_function_call(
+                "nonexistent_tool_xyz", {}, skip_pre_tool_call_hook=True
+            )
+        payload = json.loads(result)
+        # Blocked message must be the unknown-tool error, NOT the policy
+        # block (the policy path was skipped).
+        assert "approvals.tools" not in payload.get("error", "")
+
+    def test_unlisted_tool_unaffected(self):
+        import model_tools
+
+        with _with_policy({"vision_analyze": "deny"}):
+            result = model_tools.handle_function_call(
+                "definitely_not_a_real_tool", {}
+            )
+        payload = json.loads(result)
+        assert "approvals.tools" not in payload.get("error", "")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3628,6 +3628,7 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    honor_yolo_bypass: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3673,8 +3674,13 @@ def _run_approval_gate(
     """
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
-    # here only skips the recoverable approval layer.
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    # here only skips the recoverable approval layer. Callers that carry
+    # an EXPLICIT user instruction to ask (approvals.tools: ask — the user
+    # named this tool in their policy) pass honor_yolo_bypass=False so the
+    # named rule beats the blanket bypass.
+    if honor_yolo_bypass and (
+        _YOLO_MODE_FROZEN or is_current_session_yolo_enabled()
+    ):
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
@@ -4008,6 +4014,7 @@ def request_tool_approval(
     *,
     rule_key: str = "",
     approval_callback=None,
+    honor_yolo_bypass: bool = True,
 ) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
@@ -4093,6 +4100,134 @@ def request_tool_approval(
             "but no interactive user or gateway is present to approve it. "
             "A plugin flagged this action for human confirmation."
         ),
+        honor_yolo_bypass=honor_yolo_bypass,
+    )
+
+
+# =========================================================================
+# Per-tool approval policy (approvals.tools in config.yaml)
+# =========================================================================
+# Inspired by Perplexity Computer's per-connector permission controls
+# (Aug 2026: every connected tool can be set to Allow / Always ask / Deny,
+# with one-off approvals, thread-level grants, and recurring runs
+# inheriting grants). Hermes' equivalent: a user-defined mapping of tool
+# names (fnmatch globs allowed) to a policy verb, enforced at the tool
+# dispatcher — the choke point every tool call funnels through — so it
+# covers built-in tools, MCP tools, and plugin tools alike.
+# Also addresses issue #35357 (approval gate does not cover non-shell
+# tools such as send_message / write_file).
+
+# Accepted policy verbs and their aliases (issue #35357 used always/auto).
+_TOOL_POLICY_ALIASES = {
+    "allow": "allow",
+    "auto": "allow",
+    "ask": "ask",
+    "always_ask": "ask",
+    "always-ask": "ask",
+    "always": "ask",
+    "deny": "deny",
+    "never": "deny",
+    "block": "deny",
+}
+
+
+def _get_tool_policy_map() -> dict:
+    """Read ``approvals.tools`` — a mapping of tool-name globs to verbs.
+
+    Returns an empty dict when unset or malformed (policy is opt-in).
+    """
+    try:
+        raw = _get_approval_config().get("tools") or {}
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _resolve_tool_policy(tool_name: str) -> str | None:
+    """Return the normalized policy verb for *tool_name*, or None.
+
+    Resolution order: an exact (case-insensitive) key match wins over glob
+    patterns; globs are checked in declaration order (YAML mappings
+    preserve order). Unknown verbs are ignored with a debug log rather
+    than guessed at.
+    """
+    policy_map = _get_tool_policy_map()
+    if not policy_map:
+        return None
+    name_lower = tool_name.lower()
+    glob_entries: list[tuple[str, str]] = []
+    for key, value in policy_map.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        key_norm = key.strip().lower()
+        verb = _TOOL_POLICY_ALIASES.get(value.strip().lower())
+        if not key_norm:
+            continue
+        if verb is None:
+            logger.debug(
+                "approvals.tools: unknown policy %r for %r — ignored",
+                value, key,
+            )
+            continue
+        if key_norm == name_lower:
+            return verb
+        glob_entries.append((key_norm, verb))
+    for pattern, verb in glob_entries:
+        if fnmatch.fnmatchcase(name_lower, pattern):
+            return verb
+    return None
+
+
+def check_tool_policy(tool_name: str, approval_callback=None) -> Optional[dict]:
+    """Evaluate the user's per-tool approval policy for a tool call.
+
+    Returns:
+        ``None`` when no policy applies (or policy is ``allow``) — the
+        call proceeds through the normal pipeline.
+        A ``check_dangerous_command``-shaped dict otherwise:
+        ``{"approved": False, "message": ...}`` for a deny match or a
+        declined/blocked ask, or ``{"approved": True, "message": None}``
+        when the user approved an ask (callers may treat this the same
+        as ``None``).
+
+    Semantics (mirrors ``approvals.deny`` / the plugin escalation gate):
+
+    - ``deny`` blocks unconditionally — BEFORE the --yolo / /yolo /
+      ``approvals.mode: off`` bypass, like ``approvals.deny`` command
+      globs. "Never let the agent use this tool."
+    - ``ask`` routes through the shared human-approval gate
+      (:func:`request_tool_approval`): [o]nce / [s]ession / [a]lways
+      persistence per tool, gateway button prompts, ``cron_mode``
+      honored, fail-closed when no human can answer. An ask rule is an
+      EXPLICIT user instruction naming this tool, so it fires even under
+      --yolo / /yolo (``honor_yolo_bypass=False``) — "run everything
+      unattended, but always ask before this one" is the whole point.
+    - ``allow`` / no match: no-op.
+    """
+    verb = _resolve_tool_policy(tool_name)
+    if verb is None or verb == "allow":
+        return None
+    if verb == "deny":
+        return {
+            "approved": False,
+            "user_deny": True,
+            "message": (
+                f"BLOCKED: the '{tool_name}' tool is set to 'deny' in the "
+                "user's per-tool approval policy (approvals.tools in "
+                "config.yaml). It cannot be used — not even with --yolo, "
+                "/yolo, or approvals.mode=off. Do NOT retry this tool; "
+                "the user has explicitly forbidden it."
+            ),
+        }
+    # verb == "ask" — reuse the shared gate; the per-tool rule_key gives
+    # each tool its own [a]lways / [s]ession allowlist grain.
+    return request_tool_approval(
+        tool_name,
+        f"Your approval policy requires confirmation before the "
+        f"'{tool_name}' tool runs (approvals.tools: ask)",
+        rule_key=f"tool_policy:{tool_name}",
+        approval_callback=approval_callback,
+        honor_yolo_bypass=False,
     )
 
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -139,6 +139,27 @@ Like the rest of the approval config, changes take effect immediately (the confi
 Deny rules are a guardrail against an honest-but-wrong agent, the same threat model as the dangerous-pattern detector. They are not a sandbox against a deliberately adversarial process — for that, use an isolated backend (Docker, Modal) or an egress-restricted environment.
 :::
 
+### Per-Tool Approval Policy (`approvals.tools`)
+
+Command globs cover the terminal, but the agent has many other tools — `send_message`, `write_file`, browser automation, every connected MCP tool. `approvals.tools` lets you set a per-tool permission level, the same three-way control Perplexity Computer ships for its connectors: **allow** (default), **ask** (pause for your approval before every run), or **deny** (never).
+
+```yaml
+approvals:
+  tools:
+    send_message: ask       # always confirm before messages leave your account
+    "mcp_gmail_*": ask      # globs work — gate a whole MCP connector at once
+    browser_exec: deny      # never allow, even under yolo
+```
+
+Details:
+
+- Keys are tool names or [fnmatch](https://docs.python.org/3/library/fnmatch.html) globs, matched case-insensitively. An exact name beats a glob; globs are checked in the order they appear.
+- Accepted values: `allow` (aliases `auto`), `ask` (aliases `always`, `always_ask`), `deny` (aliases `never`, `block`). Unknown values are ignored.
+- **`ask`** routes through the same approval gate as dangerous commands: interactive prompt on the CLI, native buttons on gateway platforms, with `[o]nce / [s]ession / [a]lways / [d]eny` persistence per tool. Answering "always" for `send_message` never auto-approves any other tool.
+- Because an ask rule is an explicit instruction naming that tool, it fires **even under `--yolo` / `/yolo`** — "run everything unattended, but always ask before this one" is the intended pattern. `deny` likewise beats every bypass.
+- Recurring/unattended contexts: cron jobs follow `approvals.cron_mode` (default `deny`), single-query `-q` runs follow `approvals.single_query_mode`, and a context with no human to answer fails closed.
+- Enforcement happens at the tool dispatcher — the choke point every tool call funnels through — so built-in tools, MCP tools, and plugin tools are all covered. Note the terminal tool has its own richer command-level pipeline; use `approvals.deny` / the dangerous-pattern gate for command granularity, and `terminal: ask` only if you want every shell command gated.
+
 ### Approval Timeout
 
 When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).


### PR DESCRIPTION
## Summary

Hermes users can now set a per-tool permission level — **allow / ask / deny** — for any tool the agent has, including MCP connectors and plugin tools. "Run everything unattended, but always ask before send_message" is now a two-line config change; previously only terminal commands had user-editable approval control, and non-shell tools ran silently (#35357).

## Perplexity Computer inspiration

Perplexity Computer rolled out granular per-connector permissions (~Aug 20 2026): every connected tool can be set to **Allow** (autonomous), **Always ask** (explicit approval per use), or **Deny** (blocked), with one-off vs thread-level grants and recurring runs inheriting grants. Sources: [changelog 08/24](https://www.perplexity.ai/changelog/computer-in-email-gpt-5-6-terra-luna-and-grok-4-6) ("Connector approvals: pause actions before they run").

## Ours vs theirs (before this PR)

| Dimension | Perplexity Computer | Hermes (before) |
|---|---|---|
| Per-tool 3-way policy | Allow / Always ask / Deny per connector tool | Only terminal commands: `approvals.deny` globs + dangerous-pattern prompts; all other tools ungated (#35357) |
| Grant persistence | Once / rest-of-thread; recurring runs inherit | once/session/always existed — but only for command patterns and plugin-escalated rules |
| Unattended runs | inherit thread grants | `cron_mode` / `single_query_mode` (kept as-is) |

## Changes

- `tools/approval.py`: `approvals.tools` policy map (`_resolve_tool_policy`, `check_tool_policy`) — exact match beats glob, case-insensitive fnmatch, verb aliases (`always`→ask, `never`→deny). `deny` fires before the yolo/mode=off bypass like `approvals.deny`. `ask` reuses the shared `_run_approval_gate` via `request_tool_approval` with a per-tool `rule_key` (an "always" on one tool never blankets another) and a new `honor_yolo_bypass=False` — an explicit named ask rule beats the blanket yolo bypass. Fail-closed when no human can answer; cron honors `cron_mode`.
- `agent/tool_executor.py`: policy enforced in the shared execution funnel both sequential and concurrent paths run through (covers built-in + MCP + plugin tools).
- `model_tools.py`: same check for direct `handle_function_call` callers, on the existing `skip_pre_tool_call_hook` single-fire contract (no double prompts from the agent loop).
- `hermes_cli/config_defaults.py`: `approvals.tools: {}` default + commented example.
- `website/docs/user-guide/security.md`: new "Per-Tool Approval Policy" section.
- `tests/tools/test_tool_policy.py`: 21 tests — matcher semantics, alias table, deny-beats-yolo, ask-fires-under-yolo, per-tool grant grain, dispatcher integration, single-fire skip contract.

## Validation

| | Result |
|---|---|
| `tests/tools/test_tool_policy.py` | 21/21 pass |
| `test_approval.py` + `test_request_tool_approval.py` + `test_approval_deny_rules.py` | same 10 pre-existing failures as clean `origin/main` (verified) — zero new |

Related: closes the gap reported in #35357; complements PR #92437 (command-glob ask rules) — this PR covers the tool axis, that one the command axis; both reuse the same gate.

## Infographic

![Per-tool approval policy](https://v3b.fal.media/files/b/0aa7d845/J_6vgZqxwUIEc12rWMRFB_kAqWh5bB.png)
