### PR TITLE
fix(vision): remove kimi-coding from _PROVIDERS_WITHOUT_VISION deny-list

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1037,14 +1037,11 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
 # it must skip straight to the aggregator chain instead of returning a client
 # that will 404 on every vision request.
 #
-# kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
-# api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
-# describe as having no image_in capability. Vision lives on the separate
-# Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
-_PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
-    "kimi-coding",
-    "kimi-coding-cn",
-})
+# kimi-coding / kimi-coding-cn were removed in #18990 because Kimi Coding
+# now supports vision upstream.  The set is kept (empty) so that future
+# providers without vision can be added here without touching the resolve
+# logic.
+_PROVIDERS_WITHOUT_VISION: frozenset = frozenset()
 
 # OpenRouter app attribution headers (base — always sent).
 # `X-Title` is the canonical attribution header OpenRouter's dashboard
@@ -7441,19 +7438,6 @@ def resolve_vision_provider_client(
                         main_provider, default_model or resolved_model or main_model,
                     )
                     return _finalize(main_provider, sync_client, default_model)
-            elif main_provider in _PROVIDERS_WITHOUT_VISION:
-                # Kimi Coding Plan's /coding endpoint (Anthropic Messages wire)
-                # does not accept image input — Kimi's own docs say "Current
-                # model does not support image input, switch to a model with
-                # image_in capability" and vision lives on the separate Kimi
-                # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
-                # client that will 404 on every vision request (#17076).
-                logger.debug(
-                    "Vision auto-detect: skipping main provider %s (no "
-                    "vision support) — falling through to aggregator chain",
-                    main_provider,
-                )
             elif not _main_model_supports_vision(main_provider, vision_model):
                 # The main model is known to be text-only (e.g. DeepSeek V4,
                 # gpt-oss-120b without vision). Building a client and sending


### PR DESCRIPTION
## Summary

Supersedes #95200 (closed when branch was force-updated). Same fix, rebased onto current `main`.

Removes `kimi-coding` from the `_PROVIDERS_WITHOUT_VISION` deny-list in `agent/auxiliary_client.py`. Kimi Coding now supports vision — the stale deny-list entry caused `resolve_vision_provider_client()` to skip it and return `None` instead of attempting the vision call.

## Changes

- Empty `_PROVIDERS_WITHOUT_VISION` frozenset (both `kimi-coding` and `kimi-coding-cn` entries removed)
- Remove the dead `elif main_provider in _PROVIDERS_WITHOUT_VISION:` branch (now unreachable with empty set)
- Add comment noting the set is empty and when to repopulate

Closes #18990