### PR TITLE
fix(desktop): don't resolve sys.executable when writing Linux desktop entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,7 +78,12 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # NOTE: do NOT .resolve() sys.executable here. In venvs whose
+            # python is a symlink to a base interpreter (uv-managed Pythons),
+            # resolve() escapes the venv and the written Exec= loses
+            # site-packages (#hermes-desktop-entry-symlink) — the DE launch
+            # then dies on the first third-party import.
+            argv = [str(Path(sys.executable)), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,10 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # sys.executable must stay UNRESOLVED: resolving it follows venv-python
+    # symlinks (uv-managed interpreters) and escapes the venv, producing an
+    # Exec= that can't import hermes_cli.
+    interpreter = str(Path(sys.executable))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")


### PR DESCRIPTION
## Problem

On Linux, the `hermes.desktop` entry is regenerated on every `hermes desktop` launch by `resolve_exec_command()`. When Hermes runs from a venv whose `python` is a **symlink to a base interpreter** — the norm for uv-managed Pythons (`uv python install`), which the installer itself sets up — `Path(sys.executable).resolve()` follows the symlink and escapes the venv.

The generated `Exec=` then points at the bare base interpreter, which has no `site-packages`. Every launch from the apps menu dies silently on the first third-party import (`ModuleNotFoundError`, invisible because `Terminal=false`), and since the entry is rewritten on each launch, manual edits to `.desktop` never stick. This is the same failure class as #90292, reached via a different path.

Observed on Arch + Hyprland with a uv-managed CPython 3.11: `Exec=/home/<u>/.local/share/uv/python/cpython-3.11.../bin/python3.11 ...` → silent crash; after the fix, `Exec=/home/<u>/.hermes/hermes-agent/venv/bin/python ...` → launches correctly.

## Fix

Keep `sys.executable` unresolved in `_needs_interpreter`'s caller branch. It already points at the venv interpreter that's actually running Hermes — resolving it only ever *loses* information here.

Note `_needs_interpreter` itself still uses `.resolve().parent` for its substring check; that comparison remains correct (it compares resolved dirs against a resolved shebang string) and I left it untouched deliberately.

## Testing

- Reproduced: bare uv interpreter fails with `No module named 'yaml'` / `hermes_cli` when used for `Exec=`.
- After patch: regenerated entry points at the venv python; `gtk-launch hermes` (the same code path DE menus use) launches the Electron app; process tree confirmed.
- Existing tests: `pytest tests/hermes_cli/test_linux_desktop_entry.py` passes.