### PR TITLE
fix(telegram): handle inbound rich-only messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -252,6 +252,25 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".gif": "image/gif",
 }
 
+
+def _telegram_message_has_rich_text(message: Any) -> bool:
+    """Return whether PTB preserved an inbound Bot API rich-message body.
+
+    Bot API rich messages are currently exposed by PTB as unknown fields in
+    ``Message.api_kwargs`` rather than as ``Message.text``. Consequently the
+    stock ``filters.TEXT`` filter does not match them.
+    """
+    try:
+        api_kwargs = getattr(message, "api_kwargs", None)
+        getter = getattr(api_kwargs, "get", None)
+        if not callable(getter):
+            return False
+        rich_message = getter("rich_message")
+        rich_getter = getattr(rich_message, "get", None)
+        return callable(rich_getter) and isinstance(rich_getter("blocks"), list)
+    except Exception:
+        return False
+
 def _coerce_duration_seconds(value: Any) -> Optional[int]:
     """Round a raw length to whole positive seconds, or None if unusable."""
     try:
@@ -4341,8 +4360,13 @@ class TelegramAdapter(BasePlatformAdapter):
         the ``gateway_platform_event`` observer (group 99) in lockstep with the
         core handlers.
         """
+        class _InboundRichTextFilter(filters.MessageFilter):
+            def filter(self, message: Message) -> bool:
+                return _telegram_message_has_rich_text(message)
+
+        inbound_text = filters.TEXT | _InboundRichTextFilter()
         app.add_handler(TelegramMessageHandler(
-            filters.TEXT & ~filters.COMMAND,
+            inbound_text & ~filters.COMMAND,
             self._handle_text_message
         ))
         app.add_handler(TelegramMessageHandler(
@@ -9666,7 +9690,10 @@ class TelegramAdapter(BasePlatformAdapter):
         them into a single MessageEvent before dispatching.
         """
         msg = self._effective_update_message(update)
-        if not msg or not msg.text:
+        if not msg:
+            return
+        inbound_text = self._extract_inbound_message_text(msg)
+        if not inbound_text:
             return
         # Early user-level auth check: reject unauthorized users before any
         # text batching, observe-buffer persistence, event building, or response
@@ -9686,6 +9713,7 @@ class TelegramAdapter(BasePlatformAdapter):
         await self._ensure_forum_commands(update.message)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        event.text = inbound_text
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
@@ -10513,6 +10541,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 lines.extend(text.splitlines())
 
         return "\n".join(line.rstrip() for line in lines if line)
+
+    @classmethod
+    def _extract_inbound_message_text(cls, message: Any) -> str:
+        """Extract normal or Bot API rich text from an inbound message."""
+        text = getattr(message, "text", None)
+        if text:
+            return text
+        try:
+            api_kwargs = getattr(message, "api_kwargs", None)
+            getter = getattr(api_kwargs, "get", None)
+            if not callable(getter):
+                return ""
+            rich_message = getter("rich_message")
+            rich_getter = getattr(rich_message, "get", None)
+            if not callable(rich_getter):
+                return ""
+            return cls._flatten_rich_blocks(rich_getter("blocks")).strip()
+        except Exception:
+            return ""
 
     @classmethod
     def _extract_rich_reply_text(cls, reply_to_message: Any) -> Optional[str]:

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -7,7 +7,7 @@ from the same session and aggregate them before dispatching.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -63,6 +63,70 @@ def _make_event(text: str, chat_id: str = "12345") -> MessageEvent:
 
 
 class TestTextBatching:
+    @staticmethod
+    def _rich_message():
+        return SimpleNamespace(
+            text=None,
+            api_kwargs={
+                "rich_message": {
+                    "blocks": [
+                        {"type": "paragraph", "text": "Production path:"},
+                        {
+                            "type": "list",
+                            "items": [
+                                {
+                                    "label": "1.",
+                                    "blocks": [
+                                        {"type": "paragraph", "text": "Try normal PageIndex."}
+                                    ],
+                                },
+                                {
+                                    "label": "2.",
+                                    "blocks": [
+                                        {"type": "paragraph", "text": "Fall back to AnyDoc."}
+                                    ],
+                                },
+                            ],
+                        },
+                    ]
+                }
+            },
+        )
+
+    def test_registered_text_handler_accepts_inbound_rich_message(self):
+        """PTB's TEXT filter misses rich-only updates; Hermes must match them."""
+        adapter = _make_adapter()
+        app = SimpleNamespace(handlers=[], add_handler=lambda handler, **_: app.handlers.append(handler))
+
+        adapter._register_handlers(app)
+
+        update = SimpleNamespace(effective_message=self._rich_message())
+        assert app.handlers[0].check_update(update)
+
+    @pytest.mark.asyncio
+    async def test_inbound_rich_message_is_flattened_and_enqueued(self):
+        """A rich-only paste reaches the ordinary batching pipeline as text."""
+        adapter = _make_adapter()
+        message = self._rich_message()
+        adapter._is_user_authorized_from_message = lambda _: True
+        adapter._should_process_message = lambda _: True
+        adapter._ensure_forum_commands = AsyncMock()
+        adapter._build_message_event = lambda *_, **__: _make_event("")
+        adapter._clean_bot_trigger_text = lambda text: text
+        adapter._cache_replied_media = AsyncMock()
+        adapter._apply_telegram_group_observe_attribution = lambda event: event
+        adapter._enqueue_text_event = MagicMock()
+        update = SimpleNamespace(effective_message=message, message=message, update_id=77)
+
+        await adapter._handle_text_message(update, None)
+
+        event = adapter._enqueue_text_event.call_args.args[0]
+        assert event.text == (
+            "Production path:\n"
+            "1. Try normal PageIndex.\n"
+            "2. Fall back to AnyDoc."
+        )
+
     @pytest.mark.asyncio
     async def test_single_message_dispatched_after_delay(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

- match inbound Telegram messages whose body is present only in `Message.api_kwargs.rich_message`
- flatten rich paragraphs and lists to plain text before the existing authorization, session-routing, and batching pipeline
- add behavioral regression coverage for both handler matching and end-to-end enqueueing

## Problem

`python-telegram-bot` preserves Bot API rich-message bodies in `Message.api_kwargs`, leaving `Message.text` empty. Hermes registered only `filters.TEXT` and `_handle_text_message` returned immediately when `.text` was empty. Telegram therefore acknowledged these updates while Hermes silently discarded them.

## Testing

```text
scripts/run_tests.sh \
  tests/gateway/test_telegram_text_batching.py \
  tests/gateway/test_telegram_rich_messages.py \
  tests/gateway/test_gateway_platform_event_hook.py \
  tests/gateway/test_telegram_group_gating.py
```

117 passed, 0 failed.