### PR TITLE
fix(matrix): stop the ephemeral sender revoking the live gateway session

### DIFF
--- a/tests/tools/test_matrix_ephemeral_device_isolation.py
+++ b/tests/tools/test_matrix_ephemeral_device_isolation.py
@@ -1,0 +1,98 @@
+"""Regression tests for the ephemeral Matrix sender's device isolation (#95253).
+
+The standalone fallback in ``_send_matrix_via_adapter`` constructs a
+throwaway ``MatrixAdapter`` and logs in with password auth. When it
+resolved the SAME device id as the live gateway adapter
+(``MATRIX_DEVICE_ID`` / ``extra.device_id``), matrix.org's
+one-token-per-device policy revoked the live session on the ephemeral
+login — the live adapter then failed every sync with ``M_UNKNOWN_TOKEN``
+until a gateway restart. The fix drops the configured device id on the
+ephemeral instance (only when it would have to password-login), so the
+homeserver issues a fresh device for the throwaway connection and the
+persistent adapter's stable E2EE identity is untouched.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+class _StubEphemeralAdapter:
+    """Captures the device-id state the fix must adjust."""
+
+    instances = []
+
+    def __init__(self, pconfig):
+        self.pconfig = pconfig
+        self._access_token = getattr(pconfig, "token", "") or ""
+        # Mirror the real constructor: fixed device id from config/env.
+        self._device_id = (
+            (pconfig.extra or {}).get("device_id", "") or "FIXEDDEVICE"
+        )
+        self.connected = False
+        self.disconnected = False
+        _StubEphemeralAdapter.instances.append(self)
+
+    async def connect(self):
+        self.connected = True
+        return True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def send(self, chat_id, message, metadata=None):
+        return SimpleNamespace(
+            success=True, error=None, message_id="$stub-event"
+        )
+
+
+def _pconfig(token=""):
+    return SimpleNamespace(
+        enabled=True,
+        token=token,
+        extra={"homeserver": "https://matrix.example.com", "device_id": "LIVEDEVICE"},
+    )
+
+
+async def _run(pconfig):
+    from tools.send_message_tool import _send_matrix_via_adapter
+
+    _StubEphemeralAdapter.instances = []
+    with patch(
+        "gateway.run._gateway_runner_ref",
+        side_effect=ImportError("no gateway in standalone context"),
+    ), patch(
+        "plugins.platforms.matrix.adapter.MatrixAdapter", _StubEphemeralAdapter
+    ):
+        return await _send_matrix_via_adapter(
+            pconfig, "!room:example.com", "hello"
+        )
+
+
+class TestEphemeralDeviceIsolation:
+    @pytest.mark.asyncio
+    async def test_password_login_ephemeral_drops_configured_device(self):
+        """The throwaway adapter must not login on the live gateway's
+        device — a shared device id revokes the live session on
+        one-token-per-device homeservers (#95253)."""
+        result = await _run(_pconfig(token=""))
+        assert result.get("success") is True
+        (instance,) = _StubEphemeralAdapter.instances
+        assert instance._device_id == "", (
+            "the ephemeral password-login path must let the homeserver issue "
+            "a fresh device instead of reusing the live adapter's"
+        )
+        assert instance.disconnected is True
+
+    @pytest.mark.asyncio
+    async def test_access_token_ephemeral_keeps_device_resolution(self):
+        """Token-authenticated sends never login, so the device id is
+        resolved from the token itself (whoami) and must not be blanked."""
+        result = await _run(_pconfig(token="syt_tok"))
+        assert result.get("success") is True
+        (instance,) = _StubEphemeralAdapter.instances
+        assert instance._device_id == "LIVEDEVICE", (
+            "access-token ephemeral sends keep the configured device id — "
+            "no login happens, so no revocation is possible"
+        )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2022,6 +2022,17 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
 
     adapter = MatrixAdapter(pconfig)
+    # An ephemeral password login must never run on the live gateway's
+    # device: matrix.org (and any one-token-per-device homeserver) revokes
+    # the existing session when a second login lands on the same device_id,
+    # leaving the live adapter deaf with M_UNKNOWN_TOKEN until restart
+    # (#95253). With no access token this sender has to login, so drop the
+    # configured device id and let the homeserver issue a fresh device for
+    # this throwaway connection; the persistent adapter's stable E2EE
+    # identity (MATRIX_DEVICE_ID) is untouched. Token-authenticated sends
+    # never login, so their device resolution stays as-is.
+    if not getattr(adapter, "_access_token", ""):
+        adapter._device_id = ""
     try:
         connected = await adapter.connect()
         if not connected:


### PR DESCRIPTION
## What does this PR do?

A Matrix message sent through the standalone/ephemeral path (standalone cron, `hermes send` CLI — anywhere the gateway's in-process adapter is not reachable) silently revoked the live gateway adapter's session. Both the persistent gateway adapter and the throwaway sender in `_send_matrix_via_adapter` resolved the same `device_id` from configuration (`MATRIX_DEVICE_ID` / `extra.device_id`), and matrix.org enforces **one active access token per device** — the ephemeral login invalidated the live token, leaving the bot deaf with `Matrix: sync error: Token is not active — retrying in 5s` until a gateway restart (#95253; the report's timing makes the mechanism unambiguous: live adapter syncs cleanly, ephemeral send logs in on the same device, and within seconds the live session is dead).

The fix drops the configured device id on the ephemeral adapter instance **only when it would have to password-login** (no access token configured), so the homeserver issues a fresh device for the throwaway connection. Token-authenticated sends never login, so their device resolution (from `whoami`) is untouched. The persistent adapter's stable E2EE identity — the reason `MATRIX_DEVICE_ID` exists — is preserved verbatim.

## Related Issue

Fixes #95253

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py` — in `_send_matrix_via_adapter`'s ephemeral branch, after constructing the throwaway adapter: when no access token is configured, blank `_device_id` so the password login creates a fresh device instead of colliding with the live adapter's.
- `tests/tools/test_matrix_ephemeral_device_isolation.py` — two regression tests: a password-login ephemeral send drops the configured device id (and still connects/disconnects cleanly); an access-token ephemeral send keeps the configured device id (no login happens, no revocation is possible).

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_matrix_ephemeral_device_isolation.py -v` — should pass (2 passed).
2. Fail-on-main control: `git checkout HEAD~1 -- tools/send_message_tool.py` and rerun the new file — should fail (1 failed: the password-login device-drop pin; the access-token pass-through test passes on both sides by design), then restore. Observed result: `1 failed, 1 passed` pre-fix, `2 passed` post-fix.
3. Live check from the report's setup: run the gateway with password login and a fixed `MATRIX_DEVICE_ID`, trigger a standalone-context send (e.g. `hermes send` outside the gateway), and confirm the live adapter keeps syncing without `M_UNKNOWN_TOKEN` — on matrix.org the account's device list shows a second, distinct device for the ephemeral sender.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open Matrix PRs cover E2EE deps split, tool splitting, MAS refresh tokens, password-without-token, status reporting, mention placeholders, MAS re-auth, metadata — none touch the ephemeral sender's device identity; the MAS re-auth fix explicitly does not separate it, per the report)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism documented in the inline comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python attribute adjustment, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (wire behavior unchanged for token-authenticated sends)
