### PR TITLE
fix(desktop): preserve bot profile model on new chats

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3244,6 +3244,55 @@ describe('openNewSessionTile workspace target', () => {
 
     expect(createParams).not.toHaveProperty('cwd')
   })
+
+  it('uses the Bot profile default instead of leaking the ambient composer model', async () => {
+    setCurrentModel('ambient-model')
+    setCurrentProvider('ambient-provider')
+
+    let createParams: Record<string, unknown> | undefined
+
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method, params) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: { cwd: '', model: 'profile-default-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-bot-tile'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    const route = {
+      connectionId: 'local',
+      mode: 'local' as const,
+      profile: 'writer',
+      targetProfile: 'writer'
+    }
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', {
+        listed: false,
+        route,
+        workspaceScope: {
+          ownerRoute: route,
+          workspaceMode: 'bots',
+          workspaceOwnerKey: 'bot:local::writer'
+        }
+      })
+    })
+
+    expect(createParams).toMatchObject({ hidden: true, profile: 'writer' })
+    expect(createParams).not.toHaveProperty('model')
+    expect(createParams).not.toHaveProperty('provider')
+  })
 })
 describe('selectSidebarItem', () => {
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -213,7 +213,8 @@ function reconcileAuthoritativeMessages(
 // never the profile default (that lives in Settings → Model).
 async function desktopSessionCreateParams(
   cwd: string,
-  capturedRoute = $newChatRoute.get()
+  capturedRoute = $newChatRoute.get(),
+  includeComposerModel = true
 ): Promise<Record<string, unknown>> {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
@@ -239,7 +240,7 @@ async function desktopSessionCreateParams(
     source: 'desktop',
     ...(cwd && { cwd }),
     ...(profile ? { profile: capturedRoute?.targetProfile || profile } : {}),
-    ...(selection.model
+    ...(includeComposerModel && selection.model
       ? { model: selection.model, ...(selection.provider ? { provider: selection.provider } : {}) }
       : {}),
     ...(selection.effort ? { reasoning_effort: selection.effort } : {}),
@@ -613,8 +614,13 @@ export function useSessionActions({
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
+        // Bot-workspace tabs target an agent profile without switching the
+        // window's ambient composer. Do not leak that unrelated session's
+        // model/provider into the Bot chat; omitting both lets the selected
+        // profile supply its configured default. Ordinary Sessions tiles keep
+        // the sticky composer override.
         const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
+          ...(await desktopSessionCreateParams(cwd, capturedRoute, workspaceScope.workspaceMode !== 'bots')),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
 


### PR DESCRIPTION
## Summary

- prevent Bot-workspace new chats from inheriting the Desktop window's ambient composer model/provider
- let the selected Bot profile resolve its configured default model/provider
- preserve sticky composer-model overrides for ordinary Sessions-mode chats and primary sends
- add a focused regression test for the Bot-scoped session-creation payload

## Root cause

The Bots pane targets another profile without switching the window's ambient composer state. `openNewSessionTile()` reused `desktopSessionCreateParams()`, which always copied `$currentModel` and `$currentProvider` into `session.create`. Those session overrides superseded the selected Bot profile's defaults.

## Fix

`desktopSessionCreateParams()` now accepts a narrow `includeComposerModel` flag that defaults to `true`. Bot-workspace tile creation passes `false`; all existing Sessions and primary-send callers retain the default behavior.

## Verification

- `npm test -- --run src/app/session/hooks/use-session-actions.test.tsx` → 68 passed
- `npm run typecheck` → passed
- `hermes desktop --build-only --force-build` → packaged macOS app built successfully

Fixes #95264
