### PR TITLE
fix(xai): alias reserved tool_search bridge on the wire

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -59,6 +59,13 @@ def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
 # (Firecrawl / Tavily / …). Mapped back to ``web_search`` in normalize_response.
 _XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
 
+# Wire-name used when Hermes's Tool Search bridge is on the xAI wire.
+# Grok reserves the literal ``tool_search`` for its native server-side Tool
+# Search and rejects the client declaration with HTTP 400 (#95003). Alias
+# on the wire; map back to ``tool_search`` in normalize_response so Hermes
+# dispatch is unchanged. ``tool_describe`` / ``tool_call`` are not reserved.
+_XAI_CLIENT_TOOL_SEARCH_ALIAS = "hermes_tool_search"
+
 # OpenCode's /v1/responses endpoints (Zen and Go, including custom providers
 # pointing at opencode.ai) reserve certain function names server-side and
 # reject client tools that use them with HTTP 400 ("custom function name
@@ -142,6 +149,19 @@ def _rename_client_web_search_for_xai(response_tools: List[Dict[str, Any]]) -> L
         if isinstance(tool, dict) and tool.get("name") == "web_search":
             aliased = dict(tool)
             aliased["name"] = _XAI_CLIENT_WEB_SEARCH_ALIAS
+            rewritten.append(aliased)
+        else:
+            rewritten.append(tool)
+    return rewritten
+
+
+def _rename_client_tool_search_for_xai(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Rename client ``tool_search`` → alias so xAI won't reject the request."""
+    rewritten: List[Dict[str, Any]] = []
+    for tool in response_tools:
+        if isinstance(tool, dict) and tool.get("name") == "tool_search":
+            aliased = dict(tool)
+            aliased["name"] = _XAI_CLIENT_TOOL_SEARCH_ALIAS
             rewritten.append(aliased)
         else:
             rewritten.append(tool)
@@ -553,6 +573,12 @@ class ResponsesApiTransport(ProviderTransport):
                 else:
                     response_tools = _rename_client_web_search_for_xai(response_tools)
 
+            # Always alias the Tool Search bridge name — xAI's native
+            # ``tool_search`` is a different feature (server-side discovery
+            # of *xAI's* tools), not a substitute for Hermes's deferred
+            # MCP/plugin catalog. Do not swap to ``{"type": "tool_search"}``.
+            response_tools = _rename_client_tool_search_for_xai(response_tools)
+
         # OpenCode Responses backends reserve web_search / search_files as
         # function names (HTTP 400 "custom function name 'X' is reserved",
         # #85589). Alias them on the wire; normalize_response maps them back.
@@ -799,6 +825,10 @@ class ResponsesApiTransport(ProviderTransport):
                 # the real ``web_search`` tool (Firecrawl / etc.).
                 if name == _XAI_CLIENT_WEB_SEARCH_ALIAS:
                     name = "web_search"
+                # Undo the xAI Tool Search bridge alias so Hermes dispatches
+                # the real ``tool_search`` handler (#95003).
+                elif name == _XAI_CLIENT_TOOL_SEARCH_ALIAS:
+                    name = "tool_search"
                 # Undo the OpenCode reserved-name wire aliases the same way
                 # (hermes_web_search / hermes_search_files, #85589).
                 elif name in _RESERVED_ALIAS_TO_NAME:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -821,6 +821,110 @@ class TestCodexBuildKwargs:
             assert "reasoning" not in kw, f"{model} must not receive reasoning"
 
 
+class TestXaiToolSearchBridgeAlias:
+    """xAI reserves the function name ``tool_search`` for Grok's native
+    server-side Tool Search (HTTP 400, #95003). The transport aliases the
+    Hermes bridge on the wire and maps it back on dispatch."""
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    _TOOLS = [
+        {"type": "function", "function": {
+            "name": "tool_search", "description": "Search deferred tools.",
+            "parameters": {"type": "object",
+                           "properties": {"query": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "tool_describe", "description": "Describe a deferred tool.",
+            "parameters": {"type": "object",
+                           "properties": {"name": {"type": "string"}}}}},
+        {"type": "function", "function": {
+            "name": "read_file", "description": "Read a file.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}}}},
+    ]
+
+    def _names(self, kw):
+        return [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
+
+    def test_xai_aliases_tool_search_bridge(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_xai_responses=True,
+        )
+        names = self._names(kw)
+        assert "hermes_tool_search" in names
+        assert "tool_search" not in names
+        assert "tool_describe" in names  # not reserved by xAI
+        assert "read_file" in names
+
+    def test_xai_does_not_emit_native_tool_search_type(self, transport):
+        """Hermes must not swap the bridge for xAI's native tool_search."""
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_xai_responses=True,
+        )
+        assert not any(t.get("type") == "tool_search" for t in kw.get("tools", []))
+
+    def test_non_xai_path_keeps_canonical_tool_search_name(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=list(self._TOOLS),
+            is_xai_responses=False,
+        )
+        names = self._names(kw)
+        assert "tool_search" in names
+        assert "hermes_tool_search" not in names
+
+    def test_xai_rename_does_not_mutate_input_tools(self, transport):
+        tools = list(self._TOOLS)
+        transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            is_xai_responses=True,
+        )
+        assert tools[0]["function"]["name"] == "tool_search"
+
+    def test_normalize_maps_tool_search_alias_back(self, transport, monkeypatch):
+        import agent.transports.codex as codex_mod
+
+        msg = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id="call_1",
+                    response_item_id="fc_1",
+                    function=SimpleNamespace(
+                        name=codex_mod._XAI_CLIENT_TOOL_SEARCH_ALIAS,
+                        arguments='{"query":"browser"}',
+                    ),
+                )
+            ],
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            reasoning_details=None,
+        )
+        response = SimpleNamespace(output=[], status="completed")
+        monkeypatch.setattr(
+            "agent.codex_responses_adapter._normalize_codex_response",
+            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+        )
+        normalized = transport.normalize_response(response)
+        assert normalized.tool_calls is not None
+        assert len(normalized.tool_calls) == 1
+        assert normalized.tool_calls[0].name == "tool_search"
+
+
 class TestOpencodeReservedToolAliases:
     """OpenCode /v1/responses reserves web_search / search_files as function
     names (HTTP 400 "custom function name 'X' is reserved", #85589). The


### PR DESCRIPTION
## What does this PR do?

xAI's Responses API (`xai` / `xai-oauth`, default for Grok) reserves the function name `tool_search` for Grok's native server-side Tool Search and rejects any client function with that literal:

```
HTTP 400: {"code":"invalid-argument","error":"The function name tool_search is reserved for the tool_search tool"}
```

Hermes's progressive-disclosure bridge registers exactly that name (`TOOL_SEARCH_NAME = "tool_search"` in `tools/tool_search.py`). With the default `tools.tool_search.enabled: auto`, every grok-4.6 turn fails once the catalog activates.

This aliases the bridge on the wire to `hermes_tool_search` for `is_xai_responses`, then maps it back in `normalize_response` so Hermes dispatch is unchanged. Same treatment as the existing xAI `web_search` collision. `tool_describe` / `tool_call` are not reserved by xAI and are left alone.

We do **not** swap to native `{"type": "tool_search"}` — that is xAI's server-side discovery of *xAI's* tools, not Hermes's deferred MCP/plugin catalog.

Related open PRs for the same class of bug: #95019 (Responses alias), #95011 (chat_completions path), #95219 (collision-safe follow-up), #83126 (OpenAI Codex namespace). This one is the default `xai-oauth` Responses path with regression tests matching the existing `web_search` alias tests.

## Related Issue

Fixes #95003

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex.py` — add `_XAI_CLIENT_TOOL_SEARCH_ALIAS = "hermes_tool_search"` and `_rename_client_tool_search_for_xai()`; apply it for `is_xai_responses`; map the alias back in `normalize_response`.
- `tests/agent/transports/test_codex_transport.py` — `TestXaiToolSearchBridgeAlias`: wire rename, siblings untouched, non-xAI path unchanged, input not mutated, alias round-trips to `tool_search`.

## How to Test

1. `pytest tests/agent/transports/test_codex_transport.py::TestXaiToolSearchBridgeAlias tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs tests/agent/transports/test_codex_transport.py::TestOpencodeReservedToolAliases -q`
2. Live: `xai-oauth` / `grok-4.6` with `tools.tool_search: auto` and enough deferrable plugin/MCP tools to activate the bridge. The request should be accepted (no reserved-name 400). If the model calls `hermes_tool_search`, Hermes dispatches `tool_search`.
3. Workaround control (pre-fix): the same payload with a client function named `tool_search` is rejected by `https://api.x.ai/v1`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (xai-oauth / grok-4.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduced on Windows 11, hermes-agent 0.20.5, `provider=xai-oauth`, `model=grok-4.6`:

```
agent.conversation_loop: API call failed error_type=BadRequestError provider=xai-oauth base_url=https://api.x.ai/v1 model=grok-4.6 summary=HTTP 400: {"code":"invalid-argument","error":"The function name tool_search is reserved for the tool_search tool"}
```