### PR TITLE
fix(gateway): report unlimited startup budget

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,7 +65,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
     compression_made_progress,
 )
-from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
+from hermes_cli.config import TURN_LIMIT_UNLIMITED, _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -2166,6 +2166,21 @@ def _current_max_iterations() -> int:
     _reload_runtime_env_preserving_config_authority()
     from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
     return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
+
+
+def _format_agent_budget(max_iterations: int) -> str:
+    """Format the resolved turn-limit sentinel for operator diagnostics."""
+    if max_iterations == TURN_LIMIT_UNLIMITED:
+        return "unlimited"
+    return str(max_iterations)
+
+
+def _log_agent_budget() -> None:
+    """Log the runtime-resolved agent budget for startup diagnostics."""
+    logger.info(
+        "Agent budget: max_iterations=%s (resolved through runtime turn-limit chain)",
+        _format_agent_budget(_current_max_iterations()),
+    )
 
 
 from contextlib import contextmanager as _contextmanager
@@ -12573,12 +12588,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # config.yaml → env bridge did the right thing at a glance (instead
         # of silently running at a stale .env value for weeks).
         try:
-            _effective_max_iter = int(os.getenv("HERMES_MAX_ITERATIONS", "500"))
-            logger.info(
-                "Agent budget: max_iterations=%d (agent.max_turns from config.yaml, "
-                "or HERMES_MAX_ITERATIONS from .env, or default 500)",
-                _effective_max_iter,
-            )
+            _log_agent_budget()
         except Exception:
             pass
         # Redaction status: ON by default (#17691). Surface a prominent

--- a/tests/gateway/test_agent_budget_diagnostic.py
+++ b/tests/gateway/test_agent_budget_diagnostic.py
@@ -1,0 +1,50 @@
+"""Regression tests for the gateway startup turn-budget diagnostic."""
+
+import logging
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway import run as gateway_run
+
+
+def _isolate_turn_limit_resolution(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run, "_reload_runtime_env_preserving_config_authority", lambda: None
+    )
+
+
+def test_agent_budget_diagnostic_reports_unlimited(monkeypatch, caplog):
+    _isolate_turn_limit_resolution(monkeypatch)
+    monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        gateway_run._log_agent_budget()
+
+    assert "max_iterations=unlimited" in caplog.text
+    assert "default 500" not in caplog.text
+
+
+def test_agent_budget_diagnostic_reports_finite_limit(monkeypatch, caplog):
+    _isolate_turn_limit_resolution(monkeypatch)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "25")
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        gateway_run._log_agent_budget()
+
+    assert "max_iterations=25" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_gateway_start_uses_runtime_budget_diagnostic(monkeypatch, tmp_path):
+    """The production startup path must call the resolver-backed diagnostic."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+    monkeypatch.setattr(gateway_run, "_log_agent_budget", lambda: calls.append(True))
+    runner = gateway_run.GatewayRunner(
+        GatewayConfig(platforms={}, sessions_dir=tmp_path / "sessions")
+    )
+
+    await runner.start()
+
+    assert calls == [True]


### PR DESCRIPTION
## Summary

- resolve the gateway startup budget diagnostic through the same `resolve_turn_limit` path used by runtime turns
- display the unlimited sentinel as `unlimited` instead of claiming a stale default of 500
- cover both unlimited and finite limits, plus the real `GatewayRunner.start()` call site

## Duplicate scope

Setup default drift remains with #72284. I added current-main evidence there that `DEFAULT_CONFIG.agent.max_turns` is now `None` and that first-time Quick/Full Setup still overwrite it with 150. This PR intentionally does not touch setup or Blank Slate.

## Tests

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_agent_budget_diagnostic.py tests/gateway/test_runtime_env_reload_config_authority.py tests/hermes_cli/test_resolve_turn_limit.py -q` (55 passed)
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_agent_budget_diagnostic.py`
- `.venv/bin/python -m compileall -q gateway/run.py tests/gateway/test_agent_budget_diagnostic.py`
- mutation check: restoring the old inline startup diagnostic fails `test_gateway_start_uses_runtime_budget_diagnostic`

## Risk

Low. This changes startup logging only; runtime budget resolution is unchanged.