### PR TITLE
fix(mcp): correct inverted return value in _stdio_children_dead

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,9 +2994,8 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            return False  # alive — at least one child still running
+        return True  # all children have exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
Fix logic inversion bug introduced in commit 786f37071a where `_stdio_children_dead()` returned `True` when a child process was alive (meaning "all dead"), causing ALL stdio MCP servers to fail-fast falsely.

**Bug:** When `psutil.pid_exists(pid)` returns `True` (process is alive), the function incorrectly returned `True` (meaning "all children have exited"), which is the opposite of the documented behavior.

**Fix:** Return `False` when a live PID is found (not all dead), matching the docstring "True when every stdio child we spawned has exited." Also removed the unreachable dead-code line.

Fixes #95270