### PR TITLE
fix(relay): restore voice-note STT — wire media[] MIMEs, message_type "voice", and a User-Agent for CDN downloads

### DIFF
--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1167,8 +1167,10 @@ class RelayAdapter(BasePlatformAdapter):
                     # lanes); a dead re-host reference does not.
                     localized.append((url, mime))
             event.media_urls = [u for u, _ in localized]
-            if types:
-                event.media_types = [m for _, m in localized]
+            # Keep the parallel-array invariant: one mime slot per surviving
+            # url, always. A short/stale media_types would shift entries onto
+            # the wrong url the moment anything indexes or merges them.
+            event.media_types = [m for _, m in localized]
         except Exception:  # noqa: BLE001 - media localization must never break inbound
             logger.debug("relay inbound media localization failed", exc_info=True)
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1138,25 +1138,37 @@ class RelayAdapter(BasePlatformAdapter):
             urls = list(getattr(event, "media_urls", None) or [])
             if not urls:
                 return
+            # media_types is INDEXED IN PARALLEL with media_urls by every
+            # downstream classifier (_event_media_type_at). Any URL we drop or
+            # rewrite here must carry its MIME with it, or the surviving
+            # attachments inherit a neighbour's type and get mis-routed (an
+            # image classified by a PDF's mime is not treated as an image).
+            # Carry (url, mime) as PAIRS through the whole loop.
+            types = list(getattr(event, "media_types", None) or [])
+            pairs = [
+                (u, types[i] if i < len(types) else "") for i, u in enumerate(urls)
+            ]
             client = self._get_media_client()
-            localized: list[str] = []
-            for url in urls:
+            localized: list[tuple[str, str]] = []
+            for url, mime in pairs:
                 if not isinstance(url, str) or not url:
                     continue
                 if client is None:
                     # No authenticated client: keep public URLs, drop re-hosts.
                     if "/relay/media/" not in url:
-                        localized.append(url)
+                        localized.append((url, mime))
                     continue
                 path = await client.download(url)
                 if path:
-                    localized.append(path)
+                    localized.append((path, mime))
                 elif "/relay/media/" not in url:
                     # A public URL that failed to download still has value as
                     # a URL (native adapters pass URLs to vision in some
                     # lanes); a dead re-host reference does not.
-                    localized.append(url)
-            event.media_urls = localized
+                    localized.append((url, mime))
+            event.media_urls = [u for u, _ in localized]
+            if types:
+                event.media_types = [m for _, m in localized]
         except Exception:  # noqa: BLE001 - media localization must never break inbound
             logger.debug("relay inbound media localization failed", exc_info=True)
 

--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -68,6 +68,14 @@ def media_base_url(relay_dial_url: str) -> str:
     return raw
 
 
+# Discord's CDN (and other public hosts) reject urllib's default
+# ``Python-urllib/x.y`` User-Agent with HTTP 403 — which silently killed EVERY
+# Discord CDN pass-through download (voice notes, images, documents): the
+# localizer kept the raw URL and downstream consumers then tried to open a URL
+# as a file path. Always send a descriptive UA.
+_MEDIA_USER_AGENT = "HermesAgent-Relay/1.0 (+https://github.com/NousResearch/hermes-agent)"
+
+
 class RelayMediaClient:
     """Authenticated client for the connector's ``/relay/media`` routes."""
 
@@ -128,6 +136,7 @@ class RelayMediaClient:
             or "application/octet-stream"
         )
         headers = {
+            "User-Agent": _MEDIA_USER_AGENT,
             "Authorization": f"Bearer {self._bearer()}",
             "Content-Type": content_type,
             "X-Media-Filename": (filename or path.name)[:255],
@@ -164,7 +173,7 @@ class RelayMediaClient:
         needs_auth = self.is_relay_media_url(url)
         if needs_auth and not self.enabled:
             return None
-        headers = {}
+        headers = {"User-Agent": _MEDIA_USER_AGENT}
         if needs_auth:
             headers["Authorization"] = f"Bearer {self._bearer()}"
 

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -212,35 +212,36 @@ def _normalize_slack_parent_command(
 def _media_types_from_wire(raw: Dict[str, Any]) -> list[str]:
     """Per-attachment MIME types, aligned to ``media_urls`` BY URL.
 
-    ``media_urls`` (legacy, flat) and ``media`` (rich, Phase 2) are separate
-    wire fields, and consumers index them by the same ``i``
-    (``_event_media_type_at``). Deriving the MIME list positionally is unsafe:
-    the two fields can disagree in order, and a length check alone accepts a
-    reordered pair — attaching one attachment's MIME to another's URL, which
-    silently MIS-ROUTES it (an image classified by a PDF's mime is not treated
-    as an image at all).
+    INVARIANT: the returned list is ALWAYS the same length as ``media_urls``
+    (padded with ``""``), or empty when there are no urls. Consumers index the
+    two lists by the same ``i`` (``_event_media_type_at``) AND concatenate them
+    pairwise (``merge_pending_message_event`` extends both), so a short
+    ``media_types`` is not a harmless absence — on a merge it shifts every
+    subsequent entry onto the wrong url.
 
-    So resolve each URL's MIME by LOOKUP, never by position: build
-    ``url -> mime`` from ``media[]`` and map it over ``media_urls``. Any URL
-    with no matching entry keeps its slot as ``""`` and falls back to
-    message-level classification, which is the safe degradation.
+    Resolution is BY URL LOOKUP, never by position: ``media_urls`` (legacy,
+    flat) and ``media`` (rich, Phase 2) are independent wire fields that may
+    disagree in order, and a length check alone accepts a reordered pair —
+    attaching one attachment's MIME to another's url, which silently
+    mis-routes it. A url with no matching ``media[]`` entry keeps its slot as
+    ``""`` and falls back to message-level classification.
     """
-    media = raw.get("media")
     urls = raw.get("media_urls")
-    if not isinstance(media, list) or not media:
-        return []
     if not isinstance(urls, list) or not urls:
-        # No URL list to align to — the MIME list has no meaningful indices.
         return []
+    media = raw.get("media")
     mime_by_url: dict[str, str] = {}
-    for m in media:
-        if isinstance(m, dict):
-            url = m.get("url")
-            if isinstance(url, str) and url:
-                mime_by_url[url] = m.get("mime") or ""
+    if isinstance(media, list):
+        for m in media:
+            if isinstance(m, dict):
+                url = m.get("url")
+                if isinstance(url, str) and url:
+                    mime_by_url[url] = m.get("mime") or ""
+    # One slot per url, ALWAYS — even with no media[] at all (all ""), so the
+    # parallel-array invariant holds for every consumer.
     types = [mime_by_url.get(u, "") if isinstance(u, str) else "" for u in urls]
     missing = sum(1 for t in types if not t)
-    if missing:
+    if missing and mime_by_url:
         logger.debug(
             "relay inbound: %d/%d media_urls had no matching media[] mime",
             missing,

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -210,33 +210,43 @@ def _normalize_slack_parent_command(
 
 
 def _media_types_from_wire(raw: Dict[str, Any]) -> list[str]:
-    """Per-attachment MIME types, positionally aligned with ``media_urls``.
+    """Per-attachment MIME types, aligned to ``media_urls`` BY URL.
 
     ``media_urls`` (legacy, flat) and ``media`` (rich, Phase 2) are separate
-    wire fields. The connector builds both from one list, so they agree — but
-    the gateway must not ASSUME that: consumers index the two lists by the
-    same ``i`` (``_event_media_type_at``), so a length disagreement would
-    attach one attachment's MIME to another's URL and mis-route it. That is
-    strictly worse than having no MIME, where classification safely falls
-    back to the message-level type.
+    wire fields, and consumers index them by the same ``i``
+    (``_event_media_type_at``). Deriving the MIME list positionally is unsafe:
+    the two fields can disagree in order, and a length check alone accepts a
+    reordered pair — attaching one attachment's MIME to another's URL, which
+    silently MIS-ROUTES it (an image classified by a PDF's mime is not treated
+    as an image at all).
 
-    Fail safe: map only when the lengths agree; otherwise return ``[]``.
-    A missing per-entry ``mime`` keeps its slot as ``""``.
+    So resolve each URL's MIME by LOOKUP, never by position: build
+    ``url -> mime`` from ``media[]`` and map it over ``media_urls``. Any URL
+    with no matching entry keeps its slot as ``""`` and falls back to
+    message-level classification, which is the safe degradation.
     """
     media = raw.get("media")
+    urls = raw.get("media_urls")
     if not isinstance(media, list) or not media:
         return []
-    urls = raw.get("media_urls")
-    if isinstance(urls, list) and len(urls) != len(media):
-        # Disagreeing producer — refuse to guess the pairing.
-        logger.warning(
-            "relay inbound media/media_urls length mismatch (%d vs %d); "
-            "dropping per-attachment MIME types for this event",
-            len(media),
-            len(urls),
-        )
+    if not isinstance(urls, list) or not urls:
+        # No URL list to align to — the MIME list has no meaningful indices.
         return []
-    return [(m.get("mime") or "") if isinstance(m, dict) else "" for m in media]
+    mime_by_url: dict[str, str] = {}
+    for m in media:
+        if isinstance(m, dict):
+            url = m.get("url")
+            if isinstance(url, str) and url:
+                mime_by_url[url] = m.get("mime") or ""
+    types = [mime_by_url.get(u, "") if isinstance(u, str) else "" for u in urls]
+    missing = sum(1 for t in types if not t)
+    if missing:
+        logger.debug(
+            "relay inbound: %d/%d media_urls had no matching media[] mime",
+            missing,
+            len(types),
+        )
+    return types
 
 
 def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -209,6 +209,36 @@ def _normalize_slack_parent_command(
     return normalized, normalized_type
 
 
+def _media_types_from_wire(raw: Dict[str, Any]) -> list[str]:
+    """Per-attachment MIME types, positionally aligned with ``media_urls``.
+
+    ``media_urls`` (legacy, flat) and ``media`` (rich, Phase 2) are separate
+    wire fields. The connector builds both from one list, so they agree — but
+    the gateway must not ASSUME that: consumers index the two lists by the
+    same ``i`` (``_event_media_type_at``), so a length disagreement would
+    attach one attachment's MIME to another's URL and mis-route it. That is
+    strictly worse than having no MIME, where classification safely falls
+    back to the message-level type.
+
+    Fail safe: map only when the lengths agree; otherwise return ``[]``.
+    A missing per-entry ``mime`` keeps its slot as ``""``.
+    """
+    media = raw.get("media")
+    if not isinstance(media, list) or not media:
+        return []
+    urls = raw.get("media_urls")
+    if isinstance(urls, list) and len(urls) != len(media):
+        # Disagreeing producer — refuse to guess the pairing.
+        logger.warning(
+            "relay inbound media/media_urls length mismatch (%d vs %d); "
+            "dropping per-attachment MIME types for this event",
+            len(media),
+            len(urls),
+        )
+        return []
+    return [(m.get("mime") or "") if isinstance(m, dict) else "" for m in media]
+
+
 def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
     """Rebuild a MessageEvent from the connector's normalized inbound payload.
 
@@ -314,10 +344,15 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         # like its native-adapter equivalent (and what makes a kind:"voice"
         # attachment STT-eligible). Entries without a mime keep positional
         # alignment with an empty string.
-        media_types=[
-            (m.get("mime") or "") if isinstance(m, dict) else ""
-            for m in (raw.get("media") or [])
-        ],
+        #
+        # media_urls and media[] are independent wire fields. Today's
+        # connector builds both from the same list, but a malformed or
+        # future producer could disagree — and a LENGTH MISMATCH would
+        # silently misassociate a MIME with the wrong URL (worse than no
+        # MIME at all: it mis-routes an attachment). Fail safe: map only
+        # when the two agree, otherwise leave media_types empty and let the
+        # message-level type drive classification (pre-fix behaviour).
+        media_types=_media_types_from_wire(raw),
         # Surrounding channel/group CONTEXT the connector attached for this
         # addressed turn (design relay-channel-context): a read-only, oldest→
         # newest list of nearby non-addressed messages (Model A pull / Model B

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -306,6 +306,18 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         reply_to_author_name=(raw.get("reply_to") or {}).get("author"),
         reply_to_is_own_message=bool((raw.get("reply_to") or {}).get("is_own", False)),
         media_urls=raw.get("media_urls") or [],
+        # Per-attachment MIME types, parallel to media_urls, from the
+        # connector's rich media[] array. run.py's per-attachment classifiers
+        # (_event_media_type_at) consult media_types[i] FIRST and only fall
+        # back to the message-level type when it's empty — so this mapping is
+        # what lets a relayed image/document/audio attachment route exactly
+        # like its native-adapter equivalent (and what makes a kind:"voice"
+        # attachment STT-eligible). Entries without a mime keep positional
+        # alignment with an empty string.
+        media_types=[
+            (m.get("mime") or "") if isinstance(m, dict) else ""
+            for m in (raw.get("media") or [])
+        ],
         # Surrounding channel/group CONTEXT the connector attached for this
         # addressed turn (design relay-channel-context): a read-only, oldest→
         # newest list of nearby non-addressed messages (Model A pull / Model B

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -176,3 +176,56 @@ async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     empty = tmp_path / "empty.bin"
     empty.write_bytes(b"")
     assert await c.upload(str(empty)) is None
+
+@pytest.mark.asyncio
+async def test_download_sends_a_user_agent_on_every_request():
+    """Discord's CDN 403s the default ``Python-urllib/x.y`` User-Agent.
+
+    Live-verified on staging 2026-08-26: every Discord CDN pass-through
+    download failed with ``HTTP Error 403: Forbidden``, the localizer then kept
+    the raw URL, and the transcriber tried to open a URL as a file path
+    ("Audio file not found") — so voice notes, images and documents were ALL
+    silently dead on the Discord relay lane. Reproduced from a clean shell:
+    urllib with no UA → 403; the same URL with any descriptive UA → 200.
+
+    Assert the header on BOTH url classes (public pass-through and
+    bearer-authenticated re-host), because they take different header paths.
+    """
+    seen: list[dict] = []
+
+    class _Resp:
+        headers = {"Content-Type": "audio/ogg", "Content-Length": "4"}
+
+        def read(self, *_a):
+            return b"OggS"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):  # noqa: ARG001
+        seen.append(dict(req.headers))
+        return _Resp()
+
+    import urllib.request as _ur
+
+    orig = _ur.urlopen
+    _ur.urlopen = _fake_urlopen  # type: ignore[assignment]
+    try:
+        c = RelayMediaClient("https://conn.example", "gw1", "sec")
+        assert await c.download("https://cdn.discordapp.com/attachments/1/2/v.ogg")
+        assert await c.download("https://conn.example/relay/media/deadbeef")
+    finally:
+        _ur.urlopen = orig  # type: ignore[assignment]
+
+    assert len(seen) == 2
+    for headers in seen:
+        # urllib title-cases header keys on Request.
+        ua = headers.get("User-agent") or headers.get("User-Agent")
+        assert ua, f"no User-Agent sent; urllib would default to Python-urllib (403s on Discord CDN): {headers}"
+        assert "python-urllib" not in ua.lower()
+    # The re-host request must still carry its bearer (no regression).
+    rehost_headers = seen[1]
+    assert (rehost_headers.get("Authorization") or "").startswith("Bearer ")

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -100,11 +100,11 @@ class TestMediaTypesMapping:
         ev = _event_from_wire(_wire_event("text"))
         assert ev.media_types == []
 
-    def test_length_mismatch_drops_mimes_rather_than_misaligning(self):
+    def test_length_mismatch_resolves_by_url_without_misaligning(self):
         """media_urls and media[] are independent wire fields; consumers index
-        BOTH by the same i. A disagreeing producer must not cause a MIME to be
-        attached to the wrong URL (mis-routing) — fail safe to no MIMEs, which
-        degrades to message-level classification."""
+        BOTH by the same i. Resolution is BY URL, so a length disagreement can
+        no longer misalign anything: each surviving URL keeps its own mime and
+        an unmatched URL degrades to "" (message-level classification)."""
         media = [
             {"url": "https://x/a.png", "kind": "image", "mime": "image/png"},
             {"url": "https://x/b.pdf", "kind": "document", "mime": "application/pdf"},
@@ -112,8 +112,8 @@ class TestMediaTypesMapping:
         ev = _event_from_wire(
             _wire_event("image", media=media, media_urls=["https://x/a.png"])
         )
-        assert ev.media_types == []
         assert ev.media_urls == ["https://x/a.png"]
+        assert ev.media_types == ["image/png"]
 
 
 class TestSttGate:
@@ -174,3 +174,85 @@ class TestSttGate:
             )
         )
         assert _event_media_is_stt_input(ev, 0) is False
+
+class TestUrlMimePairingThroughLocalization:
+    """The end-to-end invariant my unit tests originally missed.
+
+    media_urls and media_types are indexed BY POSITION by every downstream
+    classifier. _localize_inbound_media drops entries (a dead connector
+    re-host) as a NORMAL best-effort path — so if it filters URLs without
+    filtering MIMEs in lockstep, every surviving attachment inherits a
+    neighbour's type. Drive the REAL path: wire parse -> localization ->
+    run.py classifier."""
+
+    def _adapter(self):
+        from gateway.relay.adapter import RelayAdapter
+
+        return RelayAdapter.__new__(RelayAdapter)
+
+    def test_dropped_first_attachment_does_not_shift_the_second_mime(self):
+        import asyncio
+
+        from gateway.run import _event_media_is_image, _event_media_type_at
+
+        rehost = "https://conn.example/relay/media/dead"
+        kept = "https://cdn.discordapp.com/attachments/1/2/kept.png"
+        ev = _event_from_wire(
+            _wire_event(
+                "document",
+                media=[
+                    {"url": rehost, "kind": "document", "mime": "application/pdf"},
+                    {"url": kept, "kind": "image", "mime": "image/png"},
+                ],
+                media_urls=[rehost, kept],
+            )
+        )
+        assert ev.media_types == ["application/pdf", "image/png"]
+
+        adapter = self._adapter()
+        adapter._media_client = None
+        adapter._get_media_client = lambda: None  # type: ignore[method-assign]
+        asyncio.run(adapter._localize_inbound_media(ev))
+
+        # The dead re-host is dropped; the PNG must keep ITS OWN mime.
+        assert ev.media_urls == [kept]
+        assert ev.media_types == ["image/png"]
+        assert _event_media_type_at(ev, 0) == "image/png"
+        assert _event_media_is_image(ev, 0) is True
+
+    def test_reordered_media_vs_media_urls_resolves_by_url_not_position(self):
+        """Equal-length but differently-ordered wire fields must not pair up
+        positionally — resolve each URL's mime by lookup."""
+        png = "https://x/a.png"
+        pdf = "https://x/b.pdf"
+        ev = _event_from_wire(
+            _wire_event(
+                "image",
+                media=[
+                    {"url": pdf, "mime": "application/pdf"},
+                    {"url": png, "mime": "image/png"},
+                ],
+                media_urls=[png, pdf],
+            )
+        )
+        assert ev.media_types == ["image/png", "application/pdf"]
+
+    def test_url_with_no_matching_media_entry_gets_empty_mime(self):
+        known = "https://x/a.png"
+        orphan = "https://x/unknown.bin"
+        ev = _event_from_wire(
+            _wire_event(
+                "image",
+                media=[{"url": known, "mime": "image/png"}],
+                media_urls=[known, orphan],
+            )
+        )
+        assert ev.media_types == ["image/png", ""]
+
+    def test_media_without_media_urls_yields_no_types(self):
+        """No URL list to align to ⇒ the indices are meaningless."""
+        ev = _event_from_wire(
+            _wire_event("image", media=[{"url": "https://x/a.png", "mime": "image/png"}])
+        )
+        assert ev.media_urls == []
+        assert ev.media_types == []

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -148,7 +148,9 @@ class TestSttGate:
         ev = _event_from_wire(
             _wire_event("voice", media_urls=["https://gw/relay/media/x"])
         )
-        assert ev.media_types == []
+        # No media[] ⇒ no per-attachment mime, but the slot still exists so the
+        # parallel-array invariant holds (see TestParallelArrayLengthInvariant).
+        assert ev.media_types == [""]
         assert _event_media_is_stt_input(ev, 0) is True
 
     def test_legacy_audio_typed_voice_note_stays_out_of_stt(self):
@@ -256,3 +258,91 @@ class TestUrlMimePairingThroughLocalization:
         )
         assert ev.media_urls == []
         assert ev.media_types == []
+
+class TestParallelArrayLengthInvariant:
+    """media_types must ALWAYS have one slot per media_url.
+
+    Not merely an indexing nicety: ``merge_pending_message_event``
+    (gateway/platforms/base.py) EXTENDS both lists when a second media message
+    is merged into a pending one. If a media_types-less event merges with a
+    typed one, extend() concatenates lists of different lengths and shifts
+    every later mime onto the wrong url. Found by self-review after two
+    rounds of external review flagged this same bug class in adjacent seams."""
+
+    def test_media_urls_without_media_still_get_one_empty_slot_each(self):
+        """An older connector sends media_urls with no media[]. Padding keeps
+        the invariant instead of emitting a length-0 media_types."""
+        ev = _event_from_wire(
+            _wire_event("image", media_urls=["https://x/a.png", "https://x/b.png"])
+        )
+        assert ev.media_types == ["", ""]
+        assert len(ev.media_types) == len(ev.media_urls)
+
+    def test_merging_an_untyped_event_with_a_typed_one_keeps_mimes_on_their_urls(self):
+        from gateway.platforms.base import merge_pending_message_event
+        from gateway.run import _event_media_type_at
+
+        untyped = _event_from_wire(
+            _wire_event("image", media_urls=["https://x/old1.png", "https://x/old2.png"])
+        )
+        typed = _event_from_wire(
+            _wire_event(
+                "document",
+                media=[{"url": "https://x/new.pdf", "mime": "application/pdf"}],
+                media_urls=["https://x/new.pdf"],
+            )
+        )
+        pending = {"k": untyped}
+        merge_pending_message_event(pending, "k", typed)
+        merged = pending["k"]
+
+        assert len(merged.media_types) == len(merged.media_urls)
+        # The PDF's mime must stay on the PDF, not slide onto old1.png.
+        assert _event_media_type_at(merged, 0) == ""
+        assert _event_media_type_at(merged, 1) == ""
+        assert _event_media_type_at(merged, 2) == "application/pdf"
+
+    def test_localization_preserves_the_invariant_when_it_drops_entries(self):
+        import asyncio
+
+        from gateway.relay.adapter import RelayAdapter
+
+        rehost = "https://conn.example/relay/media/dead"
+        kept = "https://x/kept.png"
+        ev = _event_from_wire(
+            _wire_event("image", media_urls=[rehost, kept])  # no media[] at all
+        )
+        assert ev.media_types == ["", ""]
+
+        adapter = RelayAdapter.__new__(RelayAdapter)
+        adapter._media_client = None
+        adapter._get_media_client = lambda: None  # type: ignore[method-assign]
+        asyncio.run(adapter._localize_inbound_media(ev))
+
+        assert ev.media_urls == [kept]
+        assert len(ev.media_types) == len(ev.media_urls)
+
+    def test_localization_normalizes_a_short_media_types_from_any_source(self):
+        """Defence in depth: an event that reaches the localizer with a SHORT
+        media_types (not produced by _event_from_wire — e.g. a synthetic or
+        replayed event) must come out with one slot per surviving url, not
+        with the short list passed through."""
+        import asyncio
+
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.relay.adapter import RelayAdapter
+
+        ev = MessageEvent(text="", message_type=MessageType.PHOTO)
+        ev.media_urls = ["https://x/a.png", "https://x/b.png"]
+        ev.media_types = []  # empty, while urls exist — the shape that must
+        # NOT be passed through: consumers would index/merge against a
+        # zero-length mime list and shift every later entry.
+
+        adapter = RelayAdapter.__new__(RelayAdapter)
+        adapter._media_client = None
+        adapter._get_media_client = lambda: None  # type: ignore[method-assign]
+        asyncio.run(adapter._localize_inbound_media(ev))
+
+        assert ev.media_urls == ["https://x/a.png", "https://x/b.png"]
+        assert ev.media_types == ["", ""]
+        assert len(ev.media_types) == len(ev.media_urls)

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -99,3 +99,78 @@ class TestMediaTypesMapping:
         """Older connectors (no media[]) — byte-identical to pre-fix."""
         ev = _event_from_wire(_wire_event("text"))
         assert ev.media_types == []
+
+    def test_length_mismatch_drops_mimes_rather_than_misaligning(self):
+        """media_urls and media[] are independent wire fields; consumers index
+        BOTH by the same i. A disagreeing producer must not cause a MIME to be
+        attached to the wrong URL (mis-routing) — fail safe to no MIMEs, which
+        degrades to message-level classification."""
+        media = [
+            {"url": "https://x/a.png", "kind": "image", "mime": "image/png"},
+            {"url": "https://x/b.pdf", "kind": "document", "mime": "application/pdf"},
+        ]
+        ev = _event_from_wire(
+            _wire_event("image", media=media, media_urls=["https://x/a.png"])
+        )
+        assert ev.media_types == []
+        assert ev.media_urls == ["https://x/a.png"]
+
+
+class TestSttGate:
+    """Direct assertions on run.py's STT gate against REAL wire-parsed
+    events. The PR's acceptance criterion is STT routing, not object
+    construction — pin the user-visible invariant here.
+
+    Note the deployment-ordering consequence: MessageType.VOICE parses on
+    ANY gateway (the enum predates this PR) and the gate accepts VOICE with
+    empty media_types, so a NEW connector + OLD gateway already fires STT
+    for voice notes. Desirable — but it means the gate's behaviour is part
+    of the wire contract, and it must not silently change."""
+
+    def test_new_connector_voice_event_is_stt_eligible(self):
+        from gateway.run import _event_media_is_stt_input
+
+        ev = _event_from_wire(
+            _wire_event(
+                "voice",
+                media=[{"url": "https://gw/relay/media/x", "kind": "voice", "mime": "audio/ogg"}],
+                media_urls=["https://gw/relay/media/x"],
+            )
+        )
+        assert _event_media_is_stt_input(ev, 0) is True
+
+    def test_voice_event_stt_eligible_even_without_media_types(self):
+        """A new-connector/old-gateway-shaped event — voice type, no
+        media[] — still fires STT (the gate's VOICE branch doesn't consult
+        media_types). Pins the rollout behaviour, not just the new one."""
+        from gateway.run import _event_media_is_stt_input
+
+        ev = _event_from_wire(
+            _wire_event("voice", media_urls=["https://gw/relay/media/x"])
+        )
+        assert ev.media_types == []
+        assert _event_media_is_stt_input(ev, 0) is True
+
+    def test_legacy_audio_typed_voice_note_stays_out_of_stt(self):
+        from gateway.run import _event_media_is_stt_input
+
+        ev = _event_from_wire(
+            _wire_event(
+                "audio",
+                media=[{"url": "https://gw/relay/media/x", "kind": "voice", "mime": "audio/ogg"}],
+                media_urls=["https://gw/relay/media/x"],
+            )
+        )
+        assert _event_media_is_stt_input(ev, 0) is False
+
+    def test_music_upload_is_never_stt_eligible(self):
+        from gateway.run import _event_media_is_stt_input
+
+        ev = _event_from_wire(
+            _wire_event(
+                "audio",
+                media=[{"url": "https://cdn/x/song.mp3", "kind": "audio", "mime": "audio/mpeg"}],
+                media_urls=["https://cdn/x/song.mp3"],
+            )
+        )
+        assert _event_media_is_stt_input(ev, 0) is False

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -1,0 +1,101 @@
+"""Unit tests for relay voice-note + per-attachment media-type mapping.
+
+The relay contract gained ``message_type: "voice"`` (connector PR: voice
+notes on Discord/Telegram/WhatsApp classify distinctly from audio-file
+uploads). The gateway side has two obligations:
+
+1. ``MessageType("voice")`` must parse — it already does, since the enum
+   predates the wire value — and
+2. the connector's rich ``media[]`` array (each entry carries the
+   per-attachment ``mime``) must land on ``event.media_types`` so run.py's
+   per-attachment classifiers (``_event_media_is_stt_input``, image vs
+   document routing) work for relayed events, not just native adapters.
+
+Live-verified failure (staging 2026-08-26): a voice note arrived as
+``MessageType.AUDIO`` with ``media_types == []`` — STT never fired and the
+agent got a "the user sent an audio file attachment" note instead.
+
+Pure unit tests: no socket, no websockets dependency.
+"""
+
+from __future__ import annotations
+
+from gateway.platforms.base import MessageType
+from gateway.relay.ws_transport import _event_from_wire
+
+
+def _wire_event(message_type: str, **extra):
+    src = {
+        "platform": "discord",
+        "chat_id": "chan-1",
+        "chat_type": "dm",
+        "user_id": "u-1",
+        "user_name": "ben",
+    }
+    return {
+        "text": "",
+        "message_type": message_type,
+        "source": src,
+        **extra,
+    }
+
+
+class TestVoiceMessageType:
+
+    def test_wire_voice_parses_to_message_type_voice(self):
+        ev = _event_from_wire(_wire_event("voice"))
+        assert ev.message_type == MessageType.VOICE
+
+    def test_wire_audio_still_parses_to_message_type_audio(self):
+        """Music files keep the non-STT type — the connector must not have
+        collapsed them (it doesn't), and the gateway must not either."""
+        ev = _event_from_wire(_wire_event("audio"))
+        assert ev.message_type == MessageType.AUDIO
+
+
+class TestMediaTypesMapping:
+
+    def test_media_mimes_land_on_event_media_types(self):
+        media = [
+            {
+                "url": "https://cdn.discordapp.com/attachments/1/2/voice-message.ogg",
+                "kind": "audio",
+                "mime": "audio/ogg",
+                "size": 19197,
+                "filename": "voice-message.ogg",
+            },
+        ]
+        ev = _event_from_wire(
+            _wire_event("voice", media=media, media_urls=[m["url"] for m in media])
+        )
+        assert ev.media_types == ["audio/ogg"]
+        # media_urls must remain the parallel legacy field (unchanged).
+        assert ev.media_urls == [media[0]["url"]]
+
+    def test_media_types_parallel_to_media_urls_for_multiple_attachments(self):
+        media = [
+            {"url": "https://x/photo.png", "kind": "image", "mime": "image/png"},
+            {"url": "https://x/doc.pdf", "kind": "document", "mime": "application/pdf"},
+        ]
+        ev = _event_from_wire(
+            _wire_event("image", media=media, media_urls=[m["url"] for m in media])
+        )
+        assert ev.media_types == ["image/png", "application/pdf"]
+        assert len(ev.media_types) == len(ev.media_urls)
+
+    def test_missing_mime_gives_empty_string_at_that_index(self):
+        """A media entry without a mime must not shift the alignment between
+        media_urls[i] and media_types[i] — run.py indexes both by position."""
+        media = [
+            {"url": "https://x/photo.png", "kind": "image", "mime": "image/png"},
+            {"url": "https://x/blob", "kind": "document"},  # no mime
+        ]
+        ev = _event_from_wire(
+            _wire_event("image", media=media, media_urls=[m["url"] for m in media])
+        )
+        assert ev.media_types == ["image/png", ""]
+
+    def test_no_media_field_means_empty_media_types(self):
+        """Older connectors (no media[]) — byte-identical to pre-fix."""
+        ev = _event_from_wire(_wire_event("text"))
+        assert ev.media_types == []


### PR DESCRIPTION
## Three wire-boundary fixes for relayed media

Pairs with **gateway-gateway #228** (merged, live on staging — puts `"voice"` on the wire). Together these restore voice-note transcription over the relay, and fix all relayed Discord media as a side effect.

### 1. `media[]` MIMEs were dropped → per-attachment routing broken

The connector's rich `media[]` array (per-attachment `mime`/`kind`/`size`/`filename`) was discarded at `_event_from_wire` — only `media_urls` survived — so `event.media_types` was always `[]` and every per-attachment classifier in `run.py` fell back to the message-level type. Now mapped, positionally aligned.

**Pairing is by URL, and survives localization** (both hardened after review — the first version of this PR got it wrong):

- `_media_types_from_wire()` resolves each `media_urls[i]`'s MIME via a `url -> mime` lookup over `media[]`, never by position. A length check alone was not alignment: equal-length-but-reordered wire fields paired wrongly, and an absent `media_urls` skipped the check entirely. An unmatched URL degrades to `""` (message-level classification).
- **`media_types` is always `len(media_urls)`**, padded with `""`. Not cosmetic: `merge_pending_message_event` (`gateway/platforms/base.py:2725`) *extends* both lists when a second media message merges into a pending one, so a populated `media_urls` with an empty `media_types` (older connector: urls but no `media[]`) concatenated lists of different lengths and shifted every later MIME onto the wrong url.
- `_localize_inbound_media()` now carries `(url, mime)` as **pairs**, and rewrites the MIME list unconditionally (no `if types:` short-circuit leaving a stale list). It previously filtered `media_urls` — dropping a dead connector re-host is a *normal* best-effort path — without filtering `media_types`, so every surviving attachment inherited its neighbour's MIME:

```
before  urls  [.../relay/media/dead, .../kept.png]
        types [application/pdf, image/png]
after   urls  [.../kept.png]
        types [application/pdf, image/png]      <-- the PNG reads as a PDF
_event_media_is_image(ev, 0) -> False
```

### 2. `"voice"` → `MessageType.VOICE`

Parsed by the pre-existing enum branch; pinned by test so a refactor can't collapse the voice/music distinction again. No `run.py` change needed — the existing STT gate works once the inputs arrive intact.

### 3. Discord CDN downloads 403'd — no User-Agent (found during live validation)

`RelayMediaClient` never set a User-Agent, and Discord's CDN rejects urllib's default `Python-urllib/x.y` with **HTTP 403**. `_localize_inbound_media` then kept the raw URL, and the consumer tried to open a URL as a file path:

```
WARNING gateway.relay.media: relay media download failed for
  https://cdn.discordapp.com/...voice-message.ogg: HTTP Error 403: Forbidden
INFO gateway.run: Voice transcription failed for https://cdn.discordapp.com/...
  : Audio file not found: https://cdn.discordapp.com/...
```

This killed **all** Discord relay inbound media — images and documents too, not just voice. Telegram/WhatsApp were unaffected because their media is connector-re-hosted (`/relay/media/{id}`, fetched from our own host) and localizes to real `/tmp` paths.

Reproduced from a clean shell against a live CDN URL:

| client | result |
|---|---|
| `curl` (sends its own UA) | 200 |
| `urllib`, no UA | **403 Forbidden** |
| `urllib` + descriptive UA | 200, 14583 bytes, `OggS` magic |

## Live validation on staging

Not just unit-green — the whole chain was exercised on `hermes-agent-stg-test-6698`:

1. gg #228 merged → staging auto-deployed `cc02e6f6d`; a paired Discord+Telegram voice probe confirmed the wire flipped to `message_type:"voice"` on both lanes, `admitted_instances:1`.
2. STT was invoked **for the first time** (previously no transcription log lines existed at all) — proving the routing fix works end-to-end.
3. It then failed on a *pre-existing* instance issue: `stt.provider` was unset, so autodetect chose local faster-whisper, which couldn't download its 145 MB model onto a 98%-full volume. Switched that instance to the managed provider (`stt.provider: nous`) — an instance config matter, not a code one.
4. Telegram + WhatsApp then transcribed successfully; Discord still failed → root-caused to the 403 above, hot-patched on the instance, and **Ben confirmed the Discord voice note transcribed**. Zero new 403s and zero new transcription failures after the patch.

## Rollout (accurate — corrected during review)

`MessageType.VOICE` **predates this PR** (`gateway/platforms/base.py:2285`) and the STT gate's VOICE branch doesn't consult `media_types`, so a new connector against an *old* gateway already fires STT — an old gateway does **not** squash the value.

| Connector | Gateway | Result |
|---|---|---|
| old | old | voice stays `AUDIO`; no auto-STT |
| old | new | still `AUDIO`; no auto-STT — unchanged |
| new (live now) | old | `"voice"` → existing `VOICE`; **STT fires**, but Discord media still 403s |
| new | new | **STT fires**, MIMEs correct, Discord media downloads |

Music uploads (`message_type:"audio"`, `audio/mpeg`) are never STT-eligible in any combination — asserted directly.

## Tests

`tests/gateway/relay/test_wire_voice_media.py` (11) + `test_relay_media.py` (+1):

- **RED-first (4):** the three `media_types` mapping assertions (failed with `[]` on main) and the User-Agent assertion (failed with `{}` — no header at all).
- **Characterization (3):** `voice`/`audio` enum parse + no-media case — pass on main by design; they pin behaviour a refactor could break.
- **STT gate (4):** `_event_media_is_stt_input` asserted directly on real wire-parsed events — the actual acceptance criterion.
- **URL↔MIME pairing + length invariant (9):** resolution by URL (incl. reordered and length-mismatched wire fields, unmatched URL, absent `media_urls`) plus the end-to-end case — wire parse → `_localize_inbound_media` dropping the first attachment → `run.py` classifier — proving the retained attachment keeps its own MIME. The pre-existing localization test could not catch this: it builds events without `media_types`.

**Mutation-verified** (all six): deleting the gate's `VOICE` branch turns the STT tests RED; removing the UA from `download()` fails the media test while its five siblings stay green; reinstating the URL-only filter in localization fails 1; reverting to positional MIME resolution fails 3; removing the length padding fails 4; restoring the `if types:` guard fails 1.

Regression: relay suite **262 passed**; gateway media/voice/stt/audio selection **689 passed**; ruff clean; cross-repo integration payload re-verified after the rework.


