### PR TITLE
fix(memory): score HRR probe/related/reason by structural presence, not residual comparison

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -115,6 +115,22 @@ def similarity(a: "np.ndarray", b: "np.ndarray") -> float:
     return float(np.mean(np.cos(a - b)))
 
 
+def presence(fact_vector: "np.ndarray", key: "np.ndarray") -> float:
+    """Structural-presence score: how strongly ``key`` participates in ``fact_vector``.
+
+    Unbinding a component that was bound into the vector leaves a zero-phase
+    (identity) DC spike in the residual — mean cosine ~0.5+ per binding at
+    practical bundle widths — while an unrelated key leaves zero-mean noise.
+    Reading the residual's DC term measures presence directly; comparing the
+    residual against any other vector (content bundle, role atom) cannot
+    recover this signal and returns noise regardless of presence.
+
+    Range [-1, 1]; clamp at 0 before using as a score multiplier.
+    """
+    _require_numpy()
+    return float(np.mean(np.cos(unbind(fact_vector, key))))
+
+
 def encode_text(text: str, dim: int = 1024) -> "np.ndarray":
     """Bag-of-words: bundle of atom vectors for each token.
 

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -129,9 +129,11 @@ class FactRetriever:
     ) -> list[dict]:
         """Compositional entity query using HRR algebra.
 
-        Unbinds entity from memory bank to extract associated content.
-        This is NOT keyword search — it uses algebraic structure to find facts
-        where the entity plays a structural role.
+        Scores each fact by the structural presence of bind(entity,
+        ROLE_ENTITY): unbinding a bound-in component leaves an identity
+        (zero-phase) DC spike in the residual, while an unrelated key leaves
+        zero-mean noise. This is NOT keyword search — it finds facts where
+        the entity plays a structural role.
 
         Falls back to FTS5 search if numpy unavailable.
         """
@@ -145,21 +147,6 @@ class FactRetriever:
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
         probe_key = hrr.bind(entity_vec, role_entity)
-
-        # Try category-specific bank first, then all facts
-        if category:
-            bank_name = f"cat:{category}"
-            bank_row = conn.execute(
-                "SELECT vector FROM memory_banks WHERE bank_name = ?",
-                (bank_name,),
-            ).fetchone()
-            if bank_row:
-                bank_vec = hrr.bytes_to_phases(bank_row["vector"], dim=self.hrr_dim)
-                extracted = hrr.unbind(bank_vec, probe_key)
-                # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
-                    extracted, category=category, limit=limit
-                )
 
         # Score against individual fact vectors directly
         where = "WHERE hrr_vector IS NOT NULL"
@@ -183,19 +170,15 @@ class FactRetriever:
             # Final fallback: keyword search
             return self.search(entity, category=category, limit=limit)
 
-        # role_content is loop-invariant — encode it once (deterministic
-        # SHA-256-based atom) instead of once per fact row.
-        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-            # Unbind probe key from fact to see if entity is structurally present
-            residual = hrr.unbind(fact_vec, probe_key)
-            # Compare residual against content signal
-            content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
-            sim = hrr.similarity(residual, content_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            # Structural presence of bind(entity, ROLE_ENTITY) in the fact:
+            # unbinding a bound-in component leaves an identity DC spike;
+            # unrelated keys leave zero-mean noise.
+            sim = max(0.0, hrr.presence(fact_vec, probe_key))
+            fact["score"] = sim * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -250,22 +233,24 @@ class FactRetriever:
         # (deterministic SHA-256-based atoms) instead of twice per fact row.
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
         role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+        # Bare-atom key catches content words; role-bound key catches linked entities.
+        bare_key = entity_vec
+        bound_key = hrr.bind(entity_vec, role_entity)
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
 
-            # Check structural similarity: unbind entity from fact
-            residual = hrr.unbind(fact_vec, entity_vec)
-            # A high-similarity residual to ANY known role vector means this entity
-            # plays a structural role in the fact
+            # Structural presence via identity DC spike: a component that was
+            # bound into the fact leaves a zero-phase spike when unbound;
+            # unrelated keys leave zero-mean noise. Check both roles — the
+            # entity may be a linked entity (ROLE_ENTITY) or a content word
+            # (ROLE_CONTENT).
+            entity_presence = hrr.presence(fact_vec, bound_key)
+            word_presence = hrr.presence(fact_vec, hrr.bind(bare_key, role_content))
+            best_sim = max(entity_presence, word_presence)
 
-            entity_role_sim = hrr.similarity(residual, role_entity)
-            content_role_sim = hrr.similarity(residual, role_content)
-            # Take the max — entity could appear in either role
-            best_sim = max(entity_role_sim, content_role_sim)
-
-            fact["score"] = (best_sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = max(0.0, best_sim) * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -329,21 +314,19 @@ class FactRetriever:
         # Score each fact by how much EACH entity is structurally present.
         # A fact scores high only if ALL entities have structural presence
         # (AND semantics via min, vs OR which would use mean/max).
-        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
 
-            entity_scores = []
-            for probe_key in entity_residuals:
-                residual = hrr.unbind(fact_vec, probe_key)
-                sim = hrr.similarity(residual, role_content)
-                entity_scores.append(sim)
-
+            # Presence via identity DC spike (see probe/related). min() keeps
+            # AND semantics: every queried entity must have been bound in.
+            entity_scores = [
+                max(0.0, hrr.presence(fact_vec, probe_key))
+                for probe_key in entity_residuals
+            ]
             min_sim = min(entity_scores)
-            fact["score"] = (min_sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = min_sim * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -454,43 +437,6 @@ class FactRetriever:
 
         contradictions.sort(key=lambda x: x["contradiction_score"], reverse=True)
         return contradictions[:limit]
-
-    def _score_facts_by_vector(
-        self,
-        target_vec: "np.ndarray",
-        category: str | None = None,
-        limit: int = 10,
-    ) -> list[dict]:
-        """Score facts by similarity to a target vector."""
-        conn = self.store._conn
-
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-
-        rows = conn.execute(
-            f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
-            {where}
-            """,
-            params,
-        ).fetchall()
-
-        scored = []
-        for row in rows:
-            fact = dict(row)
-            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-            sim = hrr.similarity(target_vec, fact_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
-
-        scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
 
     def _fts_candidates(
         self,

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -211,15 +211,90 @@ def test_related_encodes_role_atoms_once(hoisted_retriever, monkeypatch):
     )
 
 
-def test_probe_encodes_role_atom_once(hoisted_retriever, monkeypatch):
+def test_probe_never_encodes_role_content(hoisted_retriever, monkeypatch):
+    """probe() scores presence of bind(entity, ROLE_ENTITY) via the identity
+    DC spike; it has no use for the content-role atom at all."""
     calls = _counting_spy(monkeypatch, "encode_atom")
     results = hoisted_retriever.probe("entity_1")
     assert results
     role_content_calls = [a for a in calls
                           if a and a[0] == "__hrr_role_content__"]
-    assert len(role_content_calls) == 1, (
-        f"role_content atom encoded {len(role_content_calls)}x in one "
-        "probe() — loop-invariant hoist regressed"
+    assert role_content_calls == [], (
+        f"probe() encoded __hrr_role_content__ {len(role_content_calls)}x — "
+        "stale comparison path resurfaced"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral ranking: probe/related/reason must rank facts containing the
+# queried structure ABOVE facts that don't. The pre-fix implementations
+# compared unbind residuals against unrelated vectors, which returned pure
+# noise regardless of structural presence.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ranked_retriever(tmp_path):
+    """Facts where specific entities/words clearly separate relevant from not."""
+    store = MemoryStore(str(tmp_path / "rank_store.db"))
+    # DASH-linked facts (quoted -> entity extraction links them)
+    store.add_fact(content='Quitting employment unlocks "DASH" trading.',
+                   category="project")
+    store.add_fact(content='No "DASH" buys until October. Next vest in November.',
+                   category="project")
+    # Facts WITHOUT any DASH connection
+    store.add_fact(content="Badminton twice a week keeps the resting heart rate down.",
+                   category="general")
+    store.add_fact(content="The Thursday deployment rollback failed on stale migration state.",
+                   category="project")
+    retriever = FactRetriever(store=store)
+    yield retriever
+    store.close()
+
+
+def test_probe_ranks_linked_facts_first(ranked_retriever):
+    results = ranked_retriever.probe("DASH", limit=4)
+    assert len(results) >= 2
+    top_two = [r["content"].lower() for r in results[:2]]
+    assert all("dash" in c for c in top_two), (
+        f"probe() top-2 not DASH facts: {top_two}"
+    )
+
+
+def test_related_ranks_structural_matches_first(ranked_retriever):
+    results = ranked_retriever.related("badminton", limit=4)
+    assert results
+    assert "badminton" in results[0]["content"].lower(), (
+        f"related() top hit misses the queried word: {results[0]['content']!r}"
+    )
+
+
+def test_reason_requires_all_entities(ranked_retriever):
+    store = ranked_retriever.store
+    store.add_fact(content='"Manan" drafted the "RNOR" relocation tax plan.',
+                   category="project")
+    hits = ranked_retriever.reason(["Manan", "RNOR"], limit=5)
+    assert hits
+    assert "manan" in hits[0]["content"].lower()
+    assert "rnor" in hits[0]["content"].lower()
+
+
+def test_presence_separates_bound_from_unbound():
+    """Unit contract for hrr.presence(): a key bound into a vector must score
+    far above an unrelated key."""
+    rng_key = hrr.encode_atom("dash", 1024)
+    other_key = hrr.encode_atom("totally-unrelated-atom", 1024)
+    role = hrr.encode_atom("__hrr_role_entity__", 1024)
+    fact_vec = hrr.encode_fact(
+        "plain content words here", entities=["dash"], dim=1024,
+    )
+    bound_score = hrr.presence(fact_vec, hrr.bind(rng_key, role))
+    noise_floor = max(
+        abs(hrr.presence(fact_vec, hrr.bind(other_key, role))),
+        0.05,  # empirical noise ceiling at this bundle width
+    )
+    assert bound_score > 3 * noise_floor, (
+        f"bound={bound_score:.4f} vs noise floor {noise_floor:.4f} — "
+        "presence() lost the DC signal"
     )
 
 


### PR DESCRIPTION
## Summary

`probe()`, `related()`, and `reason()` in the holographic memory plugin unbind a probe key from each fact vector, then compare the residual against an **unrelated vector** — the content bundle bound to `ROLE_CONTENT` (probe, reason) or the raw role atoms (`related()`). An unbind residual of a phase vector is zero-mean noise unless compared against the identity, so these scores never reflected whether the queried entity was actually present. Every compositional query returned effectively arbitrary rankings at a ~0.4 score floor (from the `(sim+1)/2 * trust` mapping).

The signal was there all along: unbinding a component that **was** bound into the fact leaves a zero-phase (identity) DC spike in the residual — mean cosine 0.5+ at practical bundle widths — while an unrelated key leaves noise around 0.

## Changes

- Add `hrr.presence(fact_vector, key)` reading the identity/DC term of the unbind residual directly
- `probe`: presence of `bind(entity, ROLE_ENTITY)` per fact; category memory-bank detour removed (it fed `_score_facts_by_vector`, which had the same flaw — now dead code and removed)
- `related`: max presence over the role-bound key and the bare key under `ROLE_CONTENT` (keeps both linked-entity and content-word matching)
- `reason`: min presence across entities (AND semantics preserved)
- Scores clamped at 0, so absent-structure facts rank at/near zero instead of getting the old ≥0.5·trust floor from noise

`memory_banks` remains maintained by the store for future consumers; this only removes the read path that couldn't work.

## Test plan

- [x] Replaced the `encode_atom`-count pin on `probe()` (which asserted exactly the stale encode being removed) with behavioral ranking tests that fail on pre-fix code:
  - `test_probe_ranks_linked_facts_first` — top-2 must be entity-linked facts
  - `test_related_ranks_structural_matches_first`
  - `test_reason_requires_all_entities`
  - `test_presence_separates_bound_from_unbound` — unit contract for the DC signal
- [x] Kept `test_related_encodes_role_atoms_once` hoist-count test (still passes — related() still encodes each role atom once)
- [x] Full holographic suite green on current `main`: `57 passed`
- [x] Also validated on a live production store (~36 real facts): before the fix, all 36 facts scored ~0.40 regardless of relevance; after, entity-linked facts score 0.4–0.6 while unrelated ones stay ≤0.05