### PR TITLE
macOS updater can no longer orphan saved logins — keychain item untouched, fallback re-sign strictly verified (salvage #90961)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7628,6 +7628,43 @@ def _desktop_macos_has_valid_real_signature(app: Path) -> bool:
         return False
 
 
+def _desktop_macos_update_keychain_acl(app: Path) -> None:
+    """Update the 'Hermes Safe Storage' keychain item's ACL after re-signing.
+
+    Electron's ``safeStorage`` stores its encryption key in a Keychain item
+    named ``<productName> Safe Storage`` (here: "Hermes Safe Storage").  macOS
+    ties each keychain item's Access Control List to the Designated Requirement
+    of the app that created it.  When the self-updater rebuilds and re-signs
+    the bundle (ad-hoc or with a different identity), the new DR no longer
+    matches the stored ACL, so macOS re-prompts on every launch.
+
+    After re-signing, delete the existing keychain item so Electron recreates
+    it with the correct ACL for the newly-signed app on next launch.  The
+    trade-off: previously encrypted tokens become unreadable (the user
+    re-enters the gateway token once), but the keychain prompt stops appearing
+    on every launch.
+
+    If the item doesn't exist yet (first launch), this is a no-op.
+
+    Best-effort: never raises.
+    """
+    security = shutil.which("security")
+    if not security:
+        return
+    service_name = "Hermes Safe Storage"
+    # Chromium/Electron safeStorage uses "<appName> Key" as the account name.
+    account_name = "Hermes Key"
+    try:
+        result = subprocess.run(
+            [security, "delete-generic-password", "-s", service_name, "-a", account_name],
+            check=False, capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            print("  → Reset Hermes Safe Storage keychain entry for new signing identity")
+    except Exception:
+        pass  # Best-effort; the prompt is annoying but not fatal.
+
+
 def _desktop_macos_local_codesign(
     app: Path, *, desktop_dir: Path, identity: str = "-"
 ) -> bool:
@@ -7778,6 +7815,7 @@ def _desktop_macos_relaunchable_fixup(
         if _desktop_macos_local_codesign(app, desktop_dir=desktop_dir, identity=identity):
             label = "keychain identity" if identity != "-" else "stable ad-hoc identity"
             print(f"  → macOS desktop signed with {label}; TCC grants persist across rebuilds")
+            _desktop_macos_update_keychain_acl(app)
             return True
     except Exception as exc:
         if identity != "-":
@@ -7788,6 +7826,7 @@ def _desktop_macos_relaunchable_fixup(
         print(f"  (warning: stable macOS signing failed ({exc}); using legacy ad-hoc sign)")
     try:
         subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
+        _desktop_macos_update_keychain_acl(app)
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
     return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7628,21 +7628,31 @@ def _desktop_macos_has_valid_real_signature(app: Path) -> bool:
         return False
 
 
-def _desktop_macos_update_keychain_acl(app: Path) -> None:
-    """Update the 'Hermes Safe Storage' keychain item's ACL after re-signing.
+def _desktop_macos_reset_keychain_safe_storage(app: Path) -> None:
+    """Delete the 'Hermes Safe Storage' keychain item after an ad-hoc re-sign.
+
+    NOTE: this does NOT update the item's ACL — it deletes the item, which
+    permanently orphans every credential encrypted under it. It is only safe
+    on the LEGACY AD-HOC fallback path, where every rebuild produces a new
+    cdhash so the keychain ACL can never match and the alternative is a
+    recurring prompt. It MUST NOT be called on the stable signing path: there
+    the designated requirement is certificate-anchored and stable, so after
+    the first launch under the new identity the ACL already matches and
+    deleting the item only destroys credentials that were working fine.
 
     Electron's ``safeStorage`` stores its encryption key in a Keychain item
     named ``<productName> Safe Storage`` (here: "Hermes Safe Storage").  macOS
-    ties each keychain item's Access Control List to the Designated Requirement
-    of the app that created it.  When the self-updater rebuilds and re-signs
-    the bundle (ad-hoc or with a different identity), the new DR no longer
-    matches the stored ACL, so macOS re-prompts on every launch.
+    ties each keychain item's Access Control List to the code signature of
+    the app that created it.  When the self-updater rebuilds and re-signs the
+    bundle ad-hoc, the new cdhash no longer matches the stored ACL, so macOS
+    re-prompts on every launch.
 
-    After re-signing, delete the existing keychain item so Electron recreates
-    it with the correct ACL for the newly-signed app on next launch.  The
-    trade-off: previously encrypted tokens become unreadable (the user
-    re-enters the gateway token once), but the keychain prompt stops appearing
-    on every launch.
+    Deleting the item makes Electron recreate it with the correct ACL for the
+    newly-signed app on next launch.  The trade-off: previously encrypted
+    tokens become unreadable (the user re-enters the gateway token once), but
+    the keychain prompt stops appearing on every launch.  The durable fix is
+    a stable signing identity (``desktop.macos_signing_identity``), which
+    makes this path unreachable.
 
     If the item doesn't exist yet (first launch), this is a no-op.
 
@@ -7815,7 +7825,6 @@ def _desktop_macos_relaunchable_fixup(
         if _desktop_macos_local_codesign(app, desktop_dir=desktop_dir, identity=identity):
             label = "keychain identity" if identity != "-" else "stable ad-hoc identity"
             print(f"  → macOS desktop signed with {label}; TCC grants persist across rebuilds")
-            _desktop_macos_update_keychain_acl(app)
             return True
     except Exception as exc:
         if identity != "-":
@@ -7826,7 +7835,13 @@ def _desktop_macos_relaunchable_fixup(
         print(f"  (warning: stable macOS signing failed ({exc}); using legacy ad-hoc sign)")
     try:
         subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
-        _desktop_macos_update_keychain_acl(app)
+        # Legacy ad-hoc fallback only: every rebuild produces a new cdhash, so
+        # the keychain ACL can never match and the alternative is a recurring
+        # prompt. This deletes the item (credentials are re-entered once per
+        # update); it is intentionally NOT called on the stable identity path
+        # above, where the cert-anchored DR is stable and the deletion would
+        # destroy working credentials on every update.
+        _desktop_macos_reset_keychain_safe_storage(app)
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
     return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7818,6 +7818,7 @@ def _desktop_macos_relaunchable_fixup(
             )
             return False
         print("  → macOS desktop re-signed (legacy ad-hoc); safeStorage keychain item left untouched")
+        return True
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
     return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7628,53 +7628,6 @@ def _desktop_macos_has_valid_real_signature(app: Path) -> bool:
         return False
 
 
-def _desktop_macos_reset_keychain_safe_storage(app: Path) -> None:
-    """Delete the 'Hermes Safe Storage' keychain item after an ad-hoc re-sign.
-
-    NOTE: this does NOT update the item's ACL — it deletes the item, which
-    permanently orphans every credential encrypted under it. It is only safe
-    on the LEGACY AD-HOC fallback path, where every rebuild produces a new
-    cdhash so the keychain ACL can never match and the alternative is a
-    recurring prompt. It MUST NOT be called on the stable signing path: there
-    the designated requirement is certificate-anchored and stable, so after
-    the first launch under the new identity the ACL already matches and
-    deleting the item only destroys credentials that were working fine.
-
-    Electron's ``safeStorage`` stores its encryption key in a Keychain item
-    named ``<productName> Safe Storage`` (here: "Hermes Safe Storage").  macOS
-    ties each keychain item's Access Control List to the code signature of
-    the app that created it.  When the self-updater rebuilds and re-signs the
-    bundle ad-hoc, the new cdhash no longer matches the stored ACL, so macOS
-    re-prompts on every launch.
-
-    Deleting the item makes Electron recreate it with the correct ACL for the
-    newly-signed app on next launch.  The trade-off: previously encrypted
-    tokens become unreadable (the user re-enters the gateway token once), but
-    the keychain prompt stops appearing on every launch.  The durable fix is
-    a stable signing identity (``desktop.macos_signing_identity``), which
-    makes this path unreachable.
-
-    If the item doesn't exist yet (first launch), this is a no-op.
-
-    Best-effort: never raises.
-    """
-    security = shutil.which("security")
-    if not security:
-        return
-    service_name = "Hermes Safe Storage"
-    # Chromium/Electron safeStorage uses "<appName> Key" as the account name.
-    account_name = "Hermes Key"
-    try:
-        result = subprocess.run(
-            [security, "delete-generic-password", "-s", service_name, "-a", account_name],
-            check=False, capture_output=True, text=True,
-        )
-        if result.returncode == 0:
-            print("  → Reset Hermes Safe Storage keychain entry for new signing identity")
-    except Exception:
-        pass  # Best-effort; the prompt is annoying but not fatal.
-
-
 def _desktop_macos_local_codesign(
     app: Path, *, desktop_dir: Path, identity: str = "-"
 ) -> bool:
@@ -7834,14 +7787,37 @@ def _desktop_macos_relaunchable_fixup(
             )
         print(f"  (warning: stable macOS signing failed ({exc}); using legacy ad-hoc sign)")
     try:
-        subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
-        # Legacy ad-hoc fallback only: every rebuild produces a new cdhash, so
-        # the keychain ACL can never match and the alternative is a recurring
-        # prompt. This deletes the item (credentials are re-entered once per
-        # update); it is intentionally NOT called on the stable identity path
-        # above, where the cert-anchored DR is stable and the deletion would
-        # destroy working credentials on every update.
-        _desktop_macos_reset_keychain_safe_storage(app)
+        # Legacy ad-hoc fallback: re-sign, but NEVER delete the safeStorage
+        # keychain item. Deleting it would permanently orphan every
+        # credential encrypted under it (gateway token, native OAuth access/
+        # refresh tokens) — and this path is reached exactly when the
+        # entitlement-preserving signer failed, so there is no verified
+        # successor identity to hand the key to. The keychain prompt macOS
+        # shows instead is recoverable ("Always Allow" updates the item's ACL
+        # partition list and preserves the key); deletion is not. The real
+        # fix (proof-carrying rotation/migration) belongs in Electron, where
+        # safeStorage can read the old key. Tracked as follow-up.
+        result = subprocess.run(
+            [codesign, "--force", "--deep", "--sign", "-", str(app)],
+            check=False, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            print(
+                f"  (warning: legacy ad-hoc re-sign failed (exit {result.returncode}); "
+                "leaving safeStorage keychain item untouched)"
+            )
+            return False
+        verify = subprocess.run(
+            [codesign, "--verify", "--deep", "--strict", str(app)],
+            check=False, capture_output=True, text=True,
+        )
+        if verify.returncode != 0:
+            print(
+                f"  (warning: legacy ad-hoc re-sign did not pass strict verification; "
+                "leaving safeStorage keychain item untouched)"
+            )
+            return False
+        print("  → macOS desktop re-signed (legacy ad-hoc); safeStorage keychain item left untouched")
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")
     return False

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -744,50 +744,15 @@ def test_cmd_gui_setup_tcc_identity_exits_before_build(tmp_path, monkeypatch):
 
 
 @pytest.mark.macos_only
-def test_relaunchable_fixup_stable_identity_skips_keychain_reset(tmp_path, monkeypatch):
+def test_relaunchable_fixup_stable_identity_never_touches_keychain(tmp_path, monkeypatch):
     """A successful stable-identity re-sign must NOT delete the safeStorage item.
 
-    Regression for review feedback on #90961: the keychain reset deletes the
-    item, permanently orphaning every safeStorage-backed credential (gateway
-    token, native OAuth access/refresh tokens — see electron/main.ts). On the
-    stable path the cert-anchored designated requirement is stable across
-    rebuilds, so after the first launch the keychain ACL already matches and
-    deleting the item would destroy working credentials on every update.
-
-    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
-    the subject is codesign against a real ``.app`` bundle layout.
-    """
-    root = _make_desktop_tree(tmp_path)
-    desktop_dir = root / "apps" / "desktop"
-    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
-    monkeypatch.delenv("CSC_LINK", raising=False)
-    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
-    exe = _make_packaged_executable(root, monkeypatch)
-    app = exe.parents[2]
-
-    resets: list[Path] = []
-    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
-    monkeypatch.setattr(
-        cli_main, "_desktop_macos_local_signing_identity", lambda: "Developer ID Application: Example"
-    )
-    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", lambda app, **kw: True)
-    monkeypatch.setattr(
-        cli_main, "_desktop_macos_reset_keychain_safe_storage", lambda app: resets.append(app)
-    )
-
-    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
-    assert resets == []
-
-
-@pytest.mark.macos_only
-def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, monkeypatch):
-    """The legacy ad-hoc fallback keeps the keychain reset (documented trade-off).
-
-    On the ad-hoc path every rebuild produces a new cdhash, so the keychain
-    ACL can never match and the alternative is a recurring prompt. The reset
-    is the documented trade-off there (re-enter credentials once per update);
-    the durable fix is a stable signing identity, which makes this path
-    unreachable.
+    Regression for review feedback on #90961: deleting the keychain item
+    permanently orphans every safeStorage-backed credential (gateway token,
+    native OAuth access/refresh tokens — see electron/main.ts). On the stable
+    path the cert-anchored designated requirement is stable across rebuilds,
+    so after the first launch the keychain ACL already matches and deleting
+    the item would destroy working credentials on every update.
 
     ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
     the subject is codesign against a real ``.app`` bundle layout.
@@ -801,7 +766,124 @@ def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, mo
     app = exe.parents[2]
 
     calls: list[list[str]] = []
-    resets: list[Path] = []
+    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
+    monkeypatch.setattr(
+        cli_main, "_desktop_macos_local_signing_identity", lambda: "Developer ID Application: Example"
+    )
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", lambda app, **kw: True)
+    monkeypatch.setattr(
+        cli_main.subprocess, "run",
+        lambda cmd, **kw: calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0),
+    )
+
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
+    assert not any("delete-generic-password" in c for c in calls)
+
+
+@pytest.mark.macos_only
+def test_relaunchable_fixup_default_noconfig_success_never_touches_keychain(tmp_path, monkeypatch):
+    """Default no-config path (identity == '-') must not delete the keychain item.
+
+    Witness for the default ad-hoc success path: with no
+    ``desktop.macos_signing_identity`` configured, the fixup signs ad-hoc with
+    identifier-pinned requirements and must leave the safeStorage item alone.
+
+    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
+    the subject is codesign against a real ``.app`` bundle layout.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_signing_identity", lambda: None)
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", lambda app, **kw: True)
+    monkeypatch.setattr(
+        cli_main.subprocess, "run",
+        lambda cmd, **kw: calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0),
+    )
+
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
+    assert not any("delete-generic-password" in c for c in calls)
+
+
+@pytest.mark.macos_only
+def test_relaunchable_fixup_legacy_adhoc_failure_never_touches_keychain(tmp_path, monkeypatch):
+    """A failed fallback re-sign must preserve the keychain item (no deletion).
+
+    Regression for review feedback on #90961: the fallback previously deleted
+    the safeStorage item unconditionally, even when ``codesign`` failed
+    (``check=False`` result was ignored). A failed recovery can permanently
+    orphan gateway and native OAuth credentials without producing a verified
+    successor app/key identity. The fixup must check the codesign result,
+    run strict verification, and leave the keychain untouched on failure.
+
+    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
+    the subject is codesign against a real ``.app`` bundle layout.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        # First subprocess call is the xattr clear (exit 0); the deep sign
+        # fails with a non-zero exit.
+        if cmd[:2] == ["/usr/bin/codesign", "--force"]:
+            return subprocess.CompletedProcess(cmd, 1)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(
+        cli_main.shutil, "which", lambda name: "/usr/bin/codesign" if name == "codesign" else None
+    )
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_signing_identity", lambda: None)
+
+    def boom(*a, **kw):
+        raise subprocess.CalledProcessError(1, ["codesign"])
+
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", boom)
+
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
+    assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
+    assert not any("--verify" in c for c in calls)
+    assert not any("delete-generic-password" in c for c in calls)
+
+
+@pytest.mark.macos_only
+def test_relaunchable_fixup_legacy_adhoc_success_still_verifies_and_never_deletes(tmp_path, monkeypatch):
+    """A successful fallback re-sign runs strict verification, no deletion.
+
+    The legacy ad-hoc fallback signs, verifies with
+    ``codesign --verify --deep --strict``, and leaves the safeStorage keychain
+    item untouched. The keychain prompt macOS shows instead is recoverable
+    ("Always Allow" updates the ACL partition list and preserves the key);
+    deletion is not.
+
+    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
+    the subject is codesign against a real ``.app`` bundle layout.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
@@ -818,13 +900,11 @@ def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, mo
         raise subprocess.CalledProcessError(1, ["codesign"])
 
     monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", boom)
-    monkeypatch.setattr(
-        cli_main, "_desktop_macos_reset_keychain_safe_storage", lambda app: resets.append(app)
-    )
 
     assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
     assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
-    assert resets == [app]
+    assert ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)] in calls
+    assert not any("delete-generic-password" in c for c in calls)
 
 
 # --- desktop.* launch options (config.yaml) -------------------------------

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -458,6 +458,10 @@ def test_desktop_macos_local_codesign_signs_native_binaries(tmp_path, monkeypatc
 def test_relaunchable_fixup_falls_back_to_legacy_adhoc_on_failure(tmp_path, monkeypatch, capsys):
     """A failing stable sign must still leave a launchable (deep ad-hoc) bundle.
 
+    The stable signer raising routes into the legacy deep ad-hoc fallback;
+    with the fallback sign and strict verification succeeding, the fixup
+    reports ``True`` per its documented contract.
+
     ``macos_only``: the subject is ``codesign`` against a real ``.app`` bundle
     layout (``exe.parents[2]``), which only the macOS packaged tree produces.
     """
@@ -487,7 +491,7 @@ def test_relaunchable_fixup_falls_back_to_legacy_adhoc_on_failure(tmp_path, monk
 
     monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", boom)
 
-    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
     assert ["xattr", "-cr", str(app)] in calls
     assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
 
@@ -901,7 +905,7 @@ def test_relaunchable_fixup_legacy_adhoc_success_still_verifies_and_never_delete
 
     monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", boom)
 
-    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
     assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
     assert ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app)] in calls
     assert not any("delete-generic-password" in c for c in calls)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -741,6 +741,82 @@ def test_cmd_gui_setup_tcc_identity_exits_before_build(tmp_path, monkeypatch):
     mock_install.assert_not_called()
 
 
+def test_relaunchable_fixup_stable_identity_skips_keychain_reset(tmp_path, monkeypatch):
+    """A successful stable-identity re-sign must NOT delete the safeStorage item.
+
+    Regression for review feedback on #90961: the keychain reset deletes the
+    item, permanently orphaning every safeStorage-backed credential (gateway
+    token, native OAuth access/refresh tokens — see electron/main.ts). On the
+    stable path the cert-anchored designated requirement is stable across
+    rebuilds, so after the first launch the keychain ACL already matches and
+    deleting the item would destroy working credentials on every update.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    resets: list[Path] = []
+    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
+    monkeypatch.setattr(
+        cli_main, "_desktop_macos_local_signing_identity", lambda: "Developer ID Application: Example"
+    )
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", lambda app, **kw: True)
+    monkeypatch.setattr(
+        cli_main, "_desktop_macos_reset_keychain_safe_storage", lambda app: resets.append(app)
+    )
+
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is True
+    assert resets == []
+
+
+def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, monkeypatch):
+    """The legacy ad-hoc fallback keeps the keychain reset (documented trade-off).
+
+    On the ad-hoc path every rebuild produces a new cdhash, so the keychain
+    ACL can never match and the alternative is a recurring prompt. The reset
+    is the documented trade-off there (re-enter credentials once per update);
+    the durable fix is a stable signing identity, which makes this path
+    unreachable.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("APPLE_SIGNING_IDENTITY", raising=False)
+    exe = _make_packaged_executable(root, monkeypatch)
+    app = exe.parents[2]
+
+    calls: list[list[str]] = []
+    resets: list[Path] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(
+        cli_main.shutil, "which", lambda name: "/usr/bin/codesign" if name == "codesign" else None
+    )
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli_main, "_desktop_macos_has_valid_real_signature", lambda a: False)
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_signing_identity", lambda: None)
+
+    def boom(*a, **kw):
+        raise subprocess.CalledProcessError(1, ["codesign"])
+
+    monkeypatch.setattr(cli_main, "_desktop_macos_local_codesign", boom)
+    monkeypatch.setattr(
+        cli_main, "_desktop_macos_reset_keychain_safe_storage", lambda app: resets.append(app)
+    )
+
+    assert cli_main._desktop_macos_relaunchable_fixup(desktop_dir) is False
+    assert ["/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app)] in calls
+    assert resets == [app]
+
+
 # --- desktop.* launch options (config.yaml) -------------------------------
 
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -741,6 +741,9 @@ def test_cmd_gui_setup_tcc_identity_exits_before_build(tmp_path, monkeypatch):
     mock_install.assert_not_called()
 
 
+
+
+@pytest.mark.macos_only
 def test_relaunchable_fixup_stable_identity_skips_keychain_reset(tmp_path, monkeypatch):
     """A successful stable-identity re-sign must NOT delete the safeStorage item.
 
@@ -750,6 +753,9 @@ def test_relaunchable_fixup_stable_identity_skips_keychain_reset(tmp_path, monke
     stable path the cert-anchored designated requirement is stable across
     rebuilds, so after the first launch the keychain ACL already matches and
     deleting the item would destroy working credentials on every update.
+
+    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
+    the subject is codesign against a real ``.app`` bundle layout.
     """
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"
@@ -773,6 +779,7 @@ def test_relaunchable_fixup_stable_identity_skips_keychain_reset(tmp_path, monke
     assert resets == []
 
 
+@pytest.mark.macos_only
 def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, monkeypatch):
     """The legacy ad-hoc fallback keeps the keychain reset (documented trade-off).
 
@@ -781,6 +788,9 @@ def test_relaunchable_fixup_legacy_adhoc_still_resets_keychain_item(tmp_path, mo
     is the documented trade-off there (re-enter credentials once per update);
     the durable fix is a stable signing identity, which makes this path
     unreachable.
+
+    ``macos_only``: the fixup no-ops on non-macOS (sys.platform guard), and
+    the subject is codesign against a real ``.app`` bundle layout.
     """
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"


### PR DESCRIPTION
## Summary
The macOS updater can no longer destroy saved logins: the desktop re-sign path never touches the "Hermes Safe Storage" keychain item, and the legacy ad-hoc codesign fallback now checks its own result and runs strict verification instead of silently reporting success. Salvage of #90961 by @DavidMetcalfe (all commits cherry-picked, authorship preserved — the branch history walks through and then removes an earlier deletion-based approach; the final tree contains zero keychain-touching code).

Context: since keychain encryption became opt-in (#95015), this protects opted-in users — for them the keychain item is the only key to their gateway token + native OAuth ciphertext, and deleting it (the earlier draft's approach, blocked twice in review) would orphan those credentials unrecoverably. The residual re-prompt for opted-in users is tracked in the re-scoped #91115 (ACL is cdhash-bound; proof-carrying rotation is the durable fix).

## Changes
- `hermes_cli/main.py` (@DavidMetcalfe): `_desktop_macos_relaunchable_fixup` fallback path — replaces the blind `codesign --force --deep --sign - (check=False)` with result check → `codesign --verify --deep --strict` gate → `return True` only on verified success; warn + `return False` otherwise. Never touches the keychain on any path.
- `tests/hermes_cli/test_gui_command.py` (@DavidMetcalfe): 4 mutation-verified macos_only witnesses (stable path never deletes, default no-config success never deletes, failed fallback never deletes/verifies, successful fallback verifies strictly) + flips the pre-existing fallback test to the new contract.
- Conflict resolution (ours): the PR's test section and #95091's TCC-identity tests insert at the same anchor — both kept.

## Validation
| | Before | After |
|---|---|---|
| Failed fallback codesign | ignored (check=False), reported success | warns, returns False, keychain untouched |
| Successful fallback | unverified | `--verify --deep --strict` gated |

- `tests/hermes_cli/test_gui_command.py`: 41 passed, 9 skipped (macos_only witnesses platform-gated)
- **Live repro:** premise verified on current main (fallback still `check=False` with no verification); the reviewer thread on #90961 carries 4 rounds of review with mutation-verified witnesses and exact-head green CI at the salvaged revision.

Credit: @DavidMetcalfe (author), @andrexibiza (review rounds that caught the deletion hazard). Closes #90961. Refs #90959, #91115.

## Infographic

![The updater can no longer destroy your saved logins](https://v3b.fal.media/files/b/0aa7d9c8/ZCZgetn-eEPUoiyH30wL0_5qmLPYDe.png)
