### PR TITLE
fix(computer-use): Linux X11 desktops no longer wedge behind a stuck overlay window (salvage #88242)

### DIFF
--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -1,9 +1,10 @@
 """Tests for the cua-driver --no-overlay policy.
 
 cua-driver's cursor overlay rendering loop can consume CPU indefinitely when
-idle (#28152, #47032). Hermes passes ``--no-overlay`` to suppress it when the
-``computer_use.no_overlay`` config is enabled (or auto-detected on macOS and
-headless Linux / WSL2).
+idle (#28152, #47032), and on Linux/X11 its fullscreen always-on-top overlay
+window can wedge the desktop when a session ends uncleanly. Hermes passes
+``--no-overlay`` to suppress it when the ``computer_use.no_overlay`` config is
+enabled (or auto-detected on macOS, headless Linux / WSL2, and Linux X11).
 
 These assert the behavior contract (auto-detect, explicit override, version
 probe), not specific config snapshots.
@@ -51,6 +52,52 @@ class TestNoOverlayFlag:
         with patch("hermes_cli.config.load_config",
                    side_effect=RuntimeError("boom")):
             assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_x11_auto_detects_off(self, monkeypatch):
+        """X11 desktop (DISPLAY set, no Wayland) defaults the overlay off.
+
+        The X11 overlay is a fullscreen always-on-top all-workspaces window
+        that can get stuck over every workspace after an unclean session end,
+        wedging desktop input until the app restarts. Config must not need to
+        opt out per-machine.
+        """
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_x11_explicit_session_type_also_off(self, monkeypatch):
+        """XDG_SESSION_TYPE=x11 without Wayland env is still X11."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.linux_only
+    def test_linux_wayland_keeps_overlay(self, monkeypatch):
+        """Wayland desktop keeps the overlay: the compositor owns the
+        overlay surface lifecycle, so it cannot get stuck above every
+        workspace the way an X11 window can."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+        monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is False
+
+    @pytest.mark.linux_only
+    def test_linux_x11_explicit_false_overrides_auto_detect(self, monkeypatch):
+        """An explicit ``no_overlay: false`` must restore the cursor even on
+        X11 — auto-detection is the default, never a hard lock."""
+        monkeypatch.setenv("DISPLAY", ":0")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        with patch("hermes_cli.config.load_config",
+                   return_value={"computer_use": {"no_overlay": False}}):
+            assert cua_backend._cua_no_overlay() is False
 
 
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -235,10 +235,12 @@ def _cua_no_overlay() -> bool:
     """True when Hermes should pass ``--no-overlay`` to cua-driver.
 
     Reads ``computer_use.no_overlay``. Default ``None`` (auto-detect):
-    disable the overlay where idle CPU burn is a known failure mode —
-    macOS (cursor-overlay vImage redraw loop, #28152/#47032), headless
-    Linux / WSL2 / containers — and keep it on Windows / desktop Linux
-    with a display. Explicit ``True`` / ``False`` overrides auto-detection.
+    disable the overlay where idle CPU burn or an X11 desktop wedge is a
+    known failure mode — macOS (cursor-overlay vImage redraw loop,
+    #28152/#47032), headless Linux / WSL2 / containers, and Linux X11
+    (fullscreen always-on-top overlay window that can get stuck over every
+    workspace after an unclean session end) — and keep it on Windows and
+    Linux Wayland. Explicit ``True`` / ``False`` overrides auto-detection.
     """
     val = _computer_use_cfg().get("no_overlay")
     if val is not None:
@@ -258,6 +260,17 @@ def _cua_no_overlay() -> bool:
                 return True
     except Exception:
         pass
+    # Linux/X11: the cursor overlay is a fullscreen, always-on-top,
+    # all-workspaces X11 window (save-unders path). An unclean session end
+    # (agent interrupted mid-capture, stale target window) can leave it stuck
+    # above every app on every workspace, wedging desktop input until the app
+    # restarts — the same failure class as the HUD window on Mutter/X11
+    # (#83473). There is no compositor-owned surface to tear down with the
+    # client connection, so default the overlay off on X11 too; set
+    # computer_use.no_overlay: false to keep the cursor. Wayland keeps it: the
+    # compositor owns the overlay surface lifecycle there.
+    if os.environ.get("XDG_SESSION_TYPE") != "wayland" and not os.environ.get("WAYLAND_DISPLAY"):
+        return True
     return False
 
 
@@ -818,9 +831,9 @@ def _resolve_mcp_invocation(
     expose ``manifest``, or any indeterminate failure — the wrapper must
     not refuse to start just because the discovery hop failed.
 
-    When ``computer_use.no_overlay`` is enabled (or auto-detected on
-    Linux), ``--no-overlay`` is appended to suppress the cursor overlay
-    rendering loop that can consume CPU indefinitely when idle
+    When ``computer_use.no_overlay`` is enabled (or auto-detected — macOS,
+    headless/WSL2/X11 Linux), ``--no-overlay`` is appended to suppress the
+    cursor overlay rendering loop that can consume CPU indefinitely when idle
     (#28152, #47032).  Older drivers that don't recognise the flag will
     reject it; callers should fall back to the no-overlay invocation on
     spawn failure.

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -217,6 +217,15 @@ Hermes run declares a public cua-driver **session name** (something like
 concurrent runs and subagents get distinct cursors. The MCP transport owns the
 private lifecycle session inside the runtime; the public name does not.
 
+The overlay cursor is cosmetic — captures, clicks, and typing all work
+without it. Hermes disables it automatically where it is a known failure
+mode: macOS (idle CPU burn), headless Linux / WSL2 / containers, and
+**Linux X11 desktops** (the overlay is a fullscreen always-on-top window
+that can get stuck over every workspace after an unclean session end,
+wedging desktop input). Linux Wayland and Windows keep the overlay. Set
+`computer_use.no_overlay: false` in `config.yaml` to force the cursor on
+(or `true` to force it off) on any platform.
+
 Tune the cursor with `cua-driver`'s CLI flags or the runtime
 `set_agent_cursor_style` MCP tool — see
 [cua.ai/docs/how-to-guides/driver/personalize-cursor](https://cua.ai/docs/how-to-guides/driver/personalize-cursor)


### PR DESCRIPTION
## Summary
Computer use on Linux X11 desktops no longer wedges the desktop: the agent-cursor overlay now defaults OFF there, the same auto-detect treatment macOS and headless/WSL2 Linux already get. Salvage of #88242 by @alkaiyali.

Root cause: on X11 the overlay is a fullscreen, always-on-top, all-workspaces window with no compositor-owned lifecycle — an unclean session end (interrupted capture, stale target, driver error) leaves it stuck above every app, eating all clicks until the process is killed. This is the freeze reported on Linux Mint 22.3 / Cinnamon in the support thread (mouse moves, nothing responds), which `computer_use.no_overlay: true` manually resolved.

## Changes
- `tools/computer_use/cua_backend.py`: `_cua_no_overlay()` auto-detect returns True on Linux X11 (no Wayland env); Wayland and Windows keep the overlay. Explicit `no_overlay: false` still restores the cursor anywhere.
- `tests/computer_use/test_cua_no_overlay.py`: 4 new contract tests (X11 off, `XDG_SESSION_TYPE=x11` off, Wayland on, explicit-false override wins).
- `website/docs/user-guide/features/computer-use.md`: document the auto-detect matrix and the `computer_use.no_overlay` override (previously undocumented).

## Validation
| | Before | After |
|---|---|---|
| Linux X11, config unset | overlay on → stuck-window desktop wedge possible | overlay off |
| Linux Wayland / Windows | overlay on | overlay on (unchanged) |
| `no_overlay: false` on X11 | overlay on | overlay on (override wins) |

`tests/computer_use/test_cua_no_overlay.py`: 13 passed, 1 skipped (macos-only). Real-import E2E across X11 / explicit-x11 / Wayland / headless / explicit-false: all 5 as expected.

**Live repro:** community-confirmed — the Mint 22.3/Cinnamon freeze in the support thread fired on default config and was cleared by manually setting `computer_use.no_overlay: true` (this PR's new default); Wayland box here doesn't fire, matching the auto-detect split.

Companion: the embedded YOLO daemon overlay gap is handled separately (salvage of #78601).

## Infographic

![Cursor overlay off by default on Linux X11](https://v3b.fal.media/files/b/0aa7d9e3/xDWHV7OOS61_Jbfs-mJRG_pZMlIFvD.png)
