### PR TITLE
fix(kanban): allow same-card correction with existing PR

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9438,6 +9438,10 @@ def check_respawn_guard(
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        A later ``changes_requested`` event is the exception: the reviewer
+        deliberately returned that same PR to its recorded implementer, so
+        the existing PR is the artifact to repair rather than duplicate-work
+        evidence.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9518,7 +9522,8 @@ def check_respawn_guard(
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed', "
+            "             'changes_requested') "
             "LIMIT 1",
             (task_id, completed_at),
         ).fetchone()
@@ -9526,12 +9531,30 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A reviewer-requested correction after that comment deliberately
+    #    requeues the original implementer to repair the same PR, so it must
+    #    not be treated as a duplicate-work signal.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    has_recent_pr = False
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? ORDER BY created_at DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            has_recent_pr = True
+            break
+    if has_recent_pr:
+        latest_review_phase = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? "
+            "AND kind IN ('review_requested', 'changes_requested') "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if (
+            latest_review_phase is None
+            or latest_review_phase["kind"] != "changes_requested"
+        ):
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -475,6 +475,61 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+def test_active_pr_guard_allows_same_card_changes_requested_requeue(
+    kanban_home: Path,
+) -> None:
+    """A reviewer correction must return to the original PR owner.
+
+    The fresh PR is the artifact being repaired after ``request_changes``;
+    treating it as duplicate-work evidence strands the same card in ``ready``.
+    """
+    pr_comment = "Opened https://github.com/example/repo/pull/123 for review."
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="repair same PR", assignee="builder")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        kb.add_comment(conn, task_id, author="builder", body=pr_comment)
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="PR ready",
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+
+        review = kb.claim_review_task(conn, task_id, claimer="reviewer:1")
+        assert review is not None
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason="Fix the single-root wiring.",
+            expected_run_id=review.current_run_id,
+        )
+        # The implementer may update the existing PR/result before a crash.
+        # That same-PR comment must not erase the active correction phase.
+        kb.add_comment(
+            conn,
+            task_id,
+            author="builder",
+            body="Updated https://github.com/example/repo/pull/123 after review.",
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_comments SET created_at = "
+                "(SELECT MAX(created_at) + 1 FROM task_events "
+                " WHERE task_id = ? AND kind = 'changes_requested') "
+                "WHERE id = (SELECT MAX(id) FROM task_comments WHERE task_id = ?)",
+                (task_id, task_id),
+            )
+
+        rework = kb.get_task(conn, task_id)
+        assert rework is not None
+        assert rework.status == "ready"
+        assert rework.assignee == "builder"
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- allow the original Kanban implementer to resume the same card after a reviewer requests changes, even when that card already has a PR
- treat the existing PR as the artifact to repair during the active `changes_requested` phase rather than duplicate-work evidence
- keep review lifecycle state authoritative even when the implementer posts a newer PR update comment before a later worker crash
- add a regression covering same-card correction and the updated-comment ordering edge case

## Why

The fresh-PR respawn guard correctly prevents duplicate implementation after a worker has already opened a PR. It also blocked the intended correction path: `request_changes` returned the same card to its original owner, but the existing PR caused the replacement worker to be suppressed. That left an actionable correction card ready with no owner process.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py` — 72 passed, 1 skipped
- `.venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py`
- `.venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py`
- `git diff --check`

## Scope

This changes only the respawn guard's interpretation of an existing PR during the native same-card correction phase. Normal fresh-PR duplicate suppression remains unchanged.
