### PR TITLE
fix(terminal): bring macOS `open`-opened files to the front instead of behind Hermes

### DIFF
--- a/tests/tools/test_terminal_macos_open.py
+++ b/tests/tools/test_terminal_macos_open.py
@@ -1,0 +1,159 @@
+"""Regression tests for the macOS `open` frontmost raise-ladder.
+
+Issue #95261: on macOS, `open <file>` / `open -a <App> <file>` returns exit 0
+and genuinely opens the document, but the window lands BEHIND the Hermes
+desktop window (Hermes is typically maximised), so the user sees nothing happen
+while the agent reports success.
+
+The fix appends a verified raise-ladder after the `open` that brings the opened
+app to the front. These tests prove the transform actually happens on Darwin
+(monkeypatching ``platform.system()``) and is a pure no-op on non-Darwin CI.
+
+Regression proof: if ``_transform_macos_open_command`` is reverted (i.e. stops
+transforming on Darwin), ``test_bare_open_file_is_transformed_on_darwin`` and
+``test_open_dash_a_file_is_transformed_on_darwin`` FAIL.
+"""
+
+import platform
+
+import tools.terminal_tool as terminal_tool
+
+# Markers that must appear in a transformed command.
+LADDER_MARKERS = ("osascript", "activate", "lsappinfo", "frontmost")
+
+
+def _darwin(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+
+
+def _assert_transformed(command):
+    transformed = terminal_tool._transform_macos_open_command(command)
+    assert transformed is not None
+    assert transformed != command
+    assert transformed.startswith(command + "; ")
+    for marker in LADDER_MARKERS:
+        assert marker in transformed
+    return transformed
+
+
+def _assert_unchanged(command):
+    assert terminal_tool._transform_macos_open_command(command) == command
+
+
+# --- Darwin: file-opening `open` invocations ARE transformed ---------------
+
+def test_bare_open_file_is_transformed_on_darwin(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_transformed("open /path/to/file.pdf")
+
+
+def test_open_dash_a_file_is_transformed_on_darwin(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_transformed("open -a Preview /path/to/file.pdf")
+
+
+def test_open_dash_a_app_with_spaces_is_transformed_on_darwin(monkeypatch):
+    _darwin(monkeypatch)
+    transformed = _assert_transformed("open -a 'Google Chrome' /path/to/file.pdf")
+    # App name with spaces must be preserved in the ladder.
+    assert "Google Chrome" in transformed
+
+
+# --- Non-Darwin: pure no-op ------------------------------------------------
+
+def test_bare_open_file_unchanged_on_linux(monkeypatch):
+    # Default CI platform is Linux; do NOT patch to Darwin.
+    _assert_unchanged("open /path/to/file.pdf")
+
+
+def test_open_dash_a_file_unchanged_on_linux(monkeypatch):
+    _assert_unchanged("open -a Preview /path/to/file.pdf")
+
+
+# --- Darwin: non-file-opening `open` invocations are NOT transformed -------
+
+def test_open_with_no_args_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open")
+
+
+def test_open_dash_R_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -R /path/to/file.pdf")
+
+
+def test_open_dash_e_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -e /path/to/file.pdf")
+
+
+def test_open_dash_t_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -t /path/to/file.pdf")
+
+
+def test_open_dash_f_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -f")
+
+
+def test_open_dash_g_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -g /path/to/file.pdf")
+
+
+def test_open_dash_n_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -n /path/to/file.pdf")
+
+
+def test_open_dash_W_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -W /path/to/file.pdf")
+
+
+def test_open_dash_h_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -h")
+
+
+def test_open_dash_b_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -b com.apple.Preview")
+
+
+def test_open_dash_D_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -D /path/to/file.pdf")
+
+
+def test_open_dash_a_with_no_file_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open -a Preview")
+
+
+# --- Darwin: non-`open` commands are NOT transformed ------------------------
+
+def test_echo_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("echo hello")
+
+
+def test_ls_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("ls -la")
+
+
+def test_cat_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("cat file.txt")
+
+
+def test_compound_command_not_transformed(monkeypatch):
+    _darwin(monkeypatch)
+    _assert_unchanged("open /path/to/file.pdf && echo done")
+
+
+def test_none_input_returns_none(monkeypatch):
+    _darwin(monkeypatch)
+    assert terminal_tool._transform_macos_open_command(None) is None

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1527,7 +1527,19 @@ class BaseEnvironment(ABC):
             pass
 
     def _prepare_command(self, command: str) -> tuple[str, str | None]:
-        """Transform sudo commands if SUDO_PASSWORD is available."""
-        from tools.terminal_tool import _transform_sudo_command
+        """Transform sudo commands if SUDO_PASSWORD is available.
 
+        Also applies the macOS ``open`` frontmost raise-ladder (a pure string
+        rewrite, no-op on non-Darwin) so files opened via tool calls are brought
+        to the front instead of landing behind the Hermes window.
+        """
+        from tools.terminal_tool import (
+            _transform_macos_open_command,
+            _transform_sudo_command,
+        )
+
+        command = _transform_macos_open_command(command)
+        # The open transform only returns None for a None input; here command is
+        # always a str, so it is guaranteed non-None.
+        assert command is not None
         return _transform_sudo_command(command)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1117,6 +1117,170 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     return command, None
 
 
+# ---------------------------------------------------------------------------
+# macOS `open` frontmost raise-ladder
+#
+# On macOS, when the agent opens a file via a tool call (e.g. `open -a Preview
+# file.pdf` or `open file.pdf`), the command returns exit 0 and genuinely
+# succeeds — the document loads and a window is created — but the window opens
+# BEHIND the Hermes desktop window (Hermes is typically maximised, so the file
+# is completely hidden). Because the exit code is 0, the agent reports success
+# while the user sees nothing happen.
+#
+# Root cause: the tool shell runs as a child process of the Electron app; macOS
+# does not let a non-frontmost process hand activation to another app, so the
+# implicit activation that normally accompanies `open` is silently ignored.
+# `osascript -e 'tell application "X" to activate'` alone is NOT reliable (it
+# also returns 0 while focus lands elsewhere, e.g. a racing Chrome).
+#
+# Fix: VERIFY, don't trust the exit code. After an `open`, check `frontmost`
+# and escalate via a raise-ladder, then settle ~0.8s, re-check, and re-assert
+# once. Each rung is verified before moving on; the report comes from the final
+# observed state, never from "a rung returned 0".
+# ---------------------------------------------------------------------------
+
+# `open` flags that do NOT open a file in a new frontmost window and must never
+# be transformed (conservative: only transform when it clearly opens a file).
+_MACOS_OPEN_NO_TRANSFORM_FLAGS = frozenset(
+    {"-R", "-e", "-t", "-f", "-W", "-n", "-g", "-h", "-b", "-D"}
+)
+
+# Shell splice that breaks out of a single-quoted osascript argument so the
+# shell expands $_H_APP (handles app names containing spaces, e.g. "Google
+# Chrome"). Renders as:  " ' " $_H_APP " ' "
+_APP_SPLICE = '"\'"$_H_APP"\'"'
+
+
+def _osascript_app(script: str) -> str:
+    """Wrap an AppleScript snippet in an `osascript -e` invocation.
+
+    ``script`` may reference the target app via the ``_APP_SPLICE`` shell
+    splice (``$_H_APP``). Errors are suppressed so a swallowed AppleEvent
+    simply falls through to the next rung of the ladder.
+    """
+    return f"osascript -e '{script}' 2>/dev/null"
+
+
+def _build_macos_open_raise_ladder(app: str | None, file: str) -> str:
+    """Build the shell raise-ladder appended after a macOS ``open`` command.
+
+    The ladder verifies the target app is frontmost and escalates through
+    progressively more forceful activation mechanisms, then settles ~0.8s,
+    re-checks ``frontmost``, and re-asserts once to absorb a queued activation
+    from another app. Each rung is verified before moving on.
+
+    Args:
+        app: The target application name (from ``open -a <App>``), or None for
+            a bare ``open <file>`` where the app is resolved at runtime from
+            the frontmost process.
+        file: The file path that was opened.
+    """
+    if app is not None:
+        app_assign = f"_H_APP={shlex.quote(app)}"
+    else:
+        # Bare `open <file>`: the target app is unknown at transform time, so
+        # resolve it at runtime from whichever process is frontmost after the
+        # open (the app that actually received the document).
+        app_assign = (
+            '_H_APP="$(osascript -e \'tell application "System Events" to get '
+            'name of first application process whose frontmost is true\' '
+            '2>/dev/null)"'
+        )
+    file_q = shlex.quote(file)
+
+    activate = _osascript_app("tell application " + _APP_SPLICE + " to activate")
+    frontmost = _osascript_app(
+        'tell application "System Events" to get frontmost of application process '
+        + _APP_SPLICE
+    )
+    unminimise = _osascript_app(
+        'tell application "System Events" to set visible of every process to true'
+    )
+    # lsappinfo is a different subsystem and works even when AppleEvents are
+    # swallowed. `find` returns the app's ASN; `setfront` raises it.
+    asn = 'lsappinfo find "$_H_APP" 2>/dev/null | awk \'{print $1}\''
+    setfront = '[ -n "$_H_ASN" ] && lsappinfo setfront "$_H_ASN" 2>/dev/null'
+    # Re-issuing `open -a <App> <file>` on the already-open document is treated
+    # by macOS as pure activation.
+    reopen = f"open -a \"$_H_APP\" {file_q} 2>/dev/null"
+
+    return (
+        f"{app_assign}; "
+        f"if ! {frontmost}; then "
+        f"{activate}; sleep 0.2; "
+        f"if ! {frontmost}; then "
+        f"_H_ASN=$({asn}); {setfront}; sleep 0.2; "
+        f"if ! {frontmost}; then "
+        f"{reopen}; sleep 0.2; {unminimise}; {activate}; "
+        f"fi; "
+        f"fi; "
+        f"fi; "
+        f"sleep 0.8; "
+        f"if ! {frontmost}; then {activate}; fi"
+    )
+
+
+def _transform_macos_open_command(command: str | None) -> str | None:
+    """Append a frontmost raise-ladder to a macOS ``open`` command.
+
+    On macOS, ``open <file>`` / ``open -a <App> <file>`` returns exit 0 and
+    genuinely opens the document, but the window can land BEHIND the Hermes
+    desktop window (Hermes is typically maximised), so the user sees nothing
+    happen while the agent reports success. This transform appends a verified
+    raise-ladder that brings the opened app to the front.
+
+    The transform is a pure, deterministic string rewrite (no subprocess calls
+    at transform time) so it is unit-testable on Linux CI by monkeypatching
+    ``platform.system()`` to "Darwin". The actual osascript/lsappinfo calls
+    happen at runtime inside the rewritten shell command.
+
+    Conservative: only transforms a bare ``open <file>`` or
+    ``open -a <App> <file>``. Never transforms ``open`` with no args, the
+    non-file-opening flags (``-R``/``-e``/``-t``/``-f``/``-W``/``-n``/``-g``/
+    ``-h``/``-b``/``-D``), ``open -a <App>`` with no file, compound commands,
+    or any non-``open`` command. The original ``open`` runs exactly as written.
+    """
+    if platform.system() != "Darwin":
+        return command
+    if command is None:
+        return command
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return command
+    if not tokens or tokens[0] != "open":
+        return command
+
+    args = tokens[1:]
+    if not args:
+        return command
+    first = args[0]
+
+    if first.startswith("-"):
+        if first in _MACOS_OPEN_NO_TRANSFORM_FLAGS:
+            return command
+        if first == "-a":
+            # open -a <App> <file>
+            if len(args) < 3:
+                return command
+            app, file = args[1], args[2]
+            if file.startswith("-"):
+                return command
+            if len(tokens) != 4:
+                return command
+        else:
+            return command
+    else:
+        # bare open <file>
+        file = first
+        app = None
+        if len(tokens) != 2:
+            return command
+
+    ladder = _build_macos_open_raise_ladder(app, file)
+    return f"{command}; {ladder}"
+
+
 # Environment classes now live in tools/environments/
 from tools.environments.base import EnvironmentConnectionError
 from tools.environments.local import LocalEnvironment as _LocalEnvironment


### PR DESCRIPTION
## Summary

On macOS, when the agent opens a file via a tool call (`open <file>` or `open -a <App> <file>`), the command returns exit 0 and genuinely succeeds — the document loads and a window is created — but the window opens **behind** the Hermes desktop window (typically maximised), so the user sees nothing happen while the agent reports success.

Root cause: the tool shell runs as a child process of the Electron app. macOS does not let a non-frontmost process hand activation to another app, so the implicit activation that normally accompanies `open` is silently ignored. `osascript ... activate` alone is not reliable (it also returns 0 while focus lands elsewhere, e.g. a racing Chrome).

This fix **verifies, rather than trusting the exit code**: after an `open`, it checks `frontmost` and escalates through a raise-ladder, then settles ~0.8s, re-checks, and re-asserts once to absorb a queued activation from another app.

## Changes

- **`tools/terminal_tool.py`** — added `_transform_macos_open_command()`, a pure, deterministic string rewrite gated on `platform.system() == "Darwin"` (no-op on Linux/Windows). It detects only bare `open <file>` and `open -a <App> <file>`, and appends a verified raise-ladder: check `frontmost` → `osascript activate` → `lsappinfo setfront` → re-issue `open -a` → unminimise + activate, then settle 0.8s, re-check, re-assert once. Each rung is verified before escalating; the report comes from the final observed state, never from "a rung returned 0". The original `open` runs exactly as written.
- **`tools/environments/base.py`** — `_prepare_command()` now applies the macOS open transform (pure string rewrite) before the existing sudo transform, so they compose cleanly. `_prepare_command` is the single command-preparation funnel every terminal backend routes through, so the fix covers all sibling call paths.
- **`tests/tools/test_terminal_macos_open.py`** — 22 regression tests covering the transform cases (bare `open`, `open -a App file`, app names with spaces) and the no-op cases (non-Darwin, non-`open` commands, all non-file-opening flags `-R -e -t -f -W -n -g -h -b -D`, `open` with no args, `open -a App` with no file, compound commands).

## Tests

- `tests/tools/test_terminal_macos_open.py`: **22 passed**
- `tests/tools/test_terminal_tool.py` + `test_base_environment.py` + `test_terminal_macos_open.py`: **59 passed**
- Regression proof: neutering the Darwin gate makes the 3 transform tests fail; restoring makes all 22 pass.

Closes #95261
