### PR TITLE
chore(tools): remove two orphaned private helpers

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2061,12 +2061,6 @@ def _read_shell_word(command: str, pos: int) -> tuple[int, int, str]:
     return (start, i, command[start:i])
 
 
-def _strip_optional_shell_quotes(word: str) -> str:
-    if len(word) >= 2 and word[0] == word[-1] and word[0] in ("'", '"'):
-        return word[1:-1]
-    return word
-
-
 def _is_simple_shell_literal(value: str) -> bool:
     return bool(value and _SIMPLE_SHELL_LITERAL_RE.fullmatch(value))
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -324,14 +324,6 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
-def _note_delivery_attempt(delegation_id: str) -> None:
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            "UPDATE async_delegations SET delivery_attempts=delivery_attempts+1, updated_at=? WHERE delegation_id=?",
-            (time.time(), delegation_id),
-        )
-
-
 def recover_abandoned_delegations() -> int:
     """Classify records whose owning process disappeared as outcome unknown."""
     try:


### PR DESCRIPTION
## What

Removes two module-private helpers that have no callers anywhere in the tree:

| Symbol | File | Orphaned since |
|---|---|---|
| `_strip_optional_shell_quotes` | `tools/approval.py:2064` | #36846 (2026-07-01) |
| `_note_delivery_attempt` | `tools/async_delegation.py:327` | durable-delivery hardening (2026-07-12) |

## Why this is safe

`_note_delivery_attempt` was the only *orphaned* writer of `delivery_attempts`. The column keeps its live writer at `async_delegation.py:471`, so the counter still increments and the reader at `:506` is unaffected — no behaviour change.

## How the candidates were found and filtered

Located with `code-review-graph dead-code`, but a static call graph is not sufficient evidence on its own: it reports thread targets, callback arguments, re-exports and string-dispatched names as dead. **34 of 38 sampled "dead" symbols in `tools/` were false positives** (`threading.Thread(target=get_input)`, `args=(_heartbeat_loop,)`, `from .schema import get_computer_use_schema`, …).

Every symbol here was confirmed orphaned with a repo-wide `git grep` across *all* file types before removal.

Two candidates were deliberately **kept**:

- `_adjust_thread_count` (`tools/daemon_pool.py`) overrides a `ThreadPoolExecutor` internal that CPython calls from `submit()`.
- `_cli_skill_text` (`tools/browser_use_cli.py`) is documented as intentionally retained for external importers.

## Testing

`tests/acp/ tests/test_delegate_cascade_49148.py`: **34 failed, 108 passed** — byte-identical to the same run on pristine `origin/main` (verified by stashing the change and re-running). No new failures. Both edited modules pass `py_compile`.