### PR TITLE
fix(mcp): harden stdio transport recovery

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -110,6 +110,7 @@ class TestKeepaliveProbe:
 
     async def test_keepalive_uses_ping_for_prompt_only_server(self):
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.invalid/mcp"}
         task.initialize_result = _caps(prompts=SimpleNamespace())
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),
@@ -126,6 +127,7 @@ class TestKeepaliveProbe:
     async def test_keepalive_uses_ping_legacy_fallback(self):
         """No captured capabilities → still pings (no spurious list_tools)."""
         task = MCPServerTask("test")
+        task._config = {"url": "https://example.invalid/mcp"}
         assert task.initialize_result is None
         task.session = SimpleNamespace(
             list_tools=AsyncMock(),

--- a/tests/tools/test_mcp_failure_classification.py
+++ b/tests/tools/test_mcp_failure_classification.py
@@ -85,7 +85,10 @@ def test_keepalive_failure_logs_root_cause(monkeypatch, tmp_path, caplog):
             raise _group(BrokenPipeError())
 
     task = _Task("pipey")
-    task._config = {"keepalive_interval": 0.01}
+    task._config = {
+        "url": "https://example.invalid/mcp",
+        "keepalive_interval": 0.01,
+    }
     task.session = object()
 
     monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)

--- a/tests/tools/test_mcp_stdio_child_liveness.py
+++ b/tests/tools/test_mcp_stdio_child_liveness.py
@@ -1,0 +1,74 @@
+"""Regression tests for MCP stdio child liveness races."""
+
+import asyncio
+import json
+from collections.abc import Awaitable
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tools import mcp_tool
+
+
+class _TextBlock:
+    type = "text"
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _ToolResult:
+    isError = False
+    structuredContent = None
+    meta = None
+
+    def __init__(self, text: str):
+        self.content = [_TextBlock(text)]
+
+
+def _run_in_fresh_loop(coro_or_factory, timeout=30):
+    candidate = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    coro = cast(Awaitable[Any], candidate)
+    loop = asyncio.new_event_loop()
+    try:
+        async def install_lock_and_run():
+            for server in list(mcp_tool._servers.values()):
+                if getattr(server, "_rpc_lock", None) is None:
+                    server._rpc_lock = asyncio.Lock()
+            return await coro
+
+        return loop.run_until_complete(
+            install_lock_and_run()
+        )
+    finally:
+        loop.close()
+
+
+def test_tool_call_constructs_one_child_watcher_awaitable():
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=_ToolResult("ok"))
+    watcher_calls = 0
+
+    def watch_children():
+        nonlocal watcher_calls
+        watcher_calls += 1
+
+        async def wait_forever():
+            await asyncio.Event().wait()
+
+        return wait_forever()
+
+    server = SimpleNamespace(
+        session=session,
+        _rpc_lock=None,
+        _watch_stdio_children=watch_children,
+    )
+    with (
+        patch.dict(mcp_tool._servers, {"stdio-liveness": server}),
+        patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_in_fresh_loop),
+    ):
+        handler = mcp_tool._make_tool_handler("stdio-liveness", "read_only", 30.0)
+        result = json.loads(handler({}))
+
+    assert result == {"result": "ok"}
+    assert watcher_calls == 1

--- a/tests/tools/test_mcp_stdio_child_liveness.py
+++ b/tests/tools/test_mcp_stdio_child_liveness.py
@@ -177,3 +177,26 @@ def test_parallel_stdio_spawn_capture_keeps_each_server_pid_owned(monkeypatch):
     asyncio.run(run_both())
 
     assert captured == {101: {101}, 202: {202}}
+
+
+def test_stdio_lifecycle_uses_process_liveness_without_protocol_ping(monkeypatch):
+    server = mcp_tool.MCPServerTask("stdio-no-ping")
+    session = MagicMock()
+    session.send_ping = AsyncMock()
+    server.session = session
+    server._config = {"command": "fake", "keepalive_interval": 0.01}
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(
+        mcp_tool.MCPServerTask,
+        "_stdio_children_dead",
+        lambda _self: False,
+    )
+
+    async def scenario():
+        waiter = asyncio.create_task(server._wait_for_lifecycle_event())
+        await asyncio.sleep(0.04)
+        server._shutdown_event.set()
+        return await waiter
+
+    assert asyncio.run(scenario()) == "shutdown"
+    assert session.send_ping.await_count == 0

--- a/tests/tools/test_mcp_stdio_child_liveness.py
+++ b/tests/tools/test_mcp_stdio_child_liveness.py
@@ -72,3 +72,108 @@ def test_tool_call_constructs_one_child_watcher_awaitable():
 
     assert result == {"result": "ok"}
     assert watcher_calls == 1
+
+
+def test_dead_child_pre_call_retires_session_and_next_call_uses_fresh_session(
+    monkeypatch,
+):
+    old_session = MagicMock()
+    old_session.call_tool = AsyncMock(return_value=_ToolResult("stale"))
+    server = mcp_tool.MCPServerTask("stdio-recovery")
+    server.session = old_session
+    cast(Any, server)._rpc_lock = None
+    server._stdio_child_pids = {101}
+    monkeypatch.setattr("psutil.pid_exists", lambda _pid: False)
+
+    with (
+        patch.dict(mcp_tool._servers, {"stdio-recovery": server}),
+        patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_in_fresh_loop),
+    ):
+        handler = mcp_tool._make_tool_handler("stdio-recovery", "read_only", 30.0)
+        first = json.loads(handler({}))
+
+        assert "exited" in first["error"]
+        assert server.session is None
+        assert server._reconnect_event.is_set()
+        assert old_session.call_tool.await_count == 0
+
+        fresh_session = MagicMock()
+        fresh_session.call_tool = AsyncMock(return_value=_ToolResult("fresh"))
+        server.session = fresh_session
+        server._stdio_child_pids = set()
+        server._reconnect_event.clear()
+        server._ready.set()
+
+        second = json.loads(handler({}))
+
+    assert second == {"result": "fresh"}
+    assert fresh_session.call_tool.await_count == 1
+    assert old_session.call_tool.await_count == 0
+
+
+def test_dead_child_mid_call_retires_session_and_requests_reconnect(monkeypatch):
+    async def never_finishes():
+        await asyncio.Event().wait()
+
+    session = MagicMock()
+    session.call_tool = MagicMock(side_effect=lambda *_args, **_kwargs: never_finishes())
+    server = mcp_tool.MCPServerTask("stdio-mid-call")
+    server.session = session
+    cast(Any, server)._rpc_lock = None
+    states = iter((False, True))
+    monkeypatch.setattr(
+        mcp_tool.MCPServerTask,
+        "_stdio_children_dead",
+        lambda _self: next(states, True),
+    )
+
+    with (
+        patch.dict(mcp_tool._servers, {"stdio-mid-call": server}),
+        patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_in_fresh_loop),
+    ):
+        handler = mcp_tool._make_tool_handler("stdio-mid-call", "read_only", 30.0)
+        result = json.loads(handler({}))
+
+    assert "exited mid-call" in result["error"]
+    assert server.session is None
+    assert server._reconnect_event.is_set()
+    assert session.call_tool.call_count == 1
+
+
+def test_parallel_stdio_spawn_capture_keeps_each_server_pid_owned(monkeypatch):
+    active_pids: set[int] = set()
+    captured: dict[int, set[int]] = {}
+
+    class FakeStdioClient:
+        def __init__(self, pid: int):
+            self.pid = pid
+
+        async def __aenter__(self):
+            active_pids.add(self.pid)
+            await asyncio.sleep(0.02)
+            return (object(), object())
+
+        async def __aexit__(self, *_exc):
+            active_pids.discard(self.pid)
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "_snapshot_child_pids",
+        lambda: set(active_pids),
+    )
+    monkeypatch.setattr(mcp_tool, "_filter_mcp_children", lambda pids: pids)
+
+    async def capture(pid: int):
+        async with mcp_tool._tracked_stdio_spawn(FakeStdioClient(pid)) as (
+            _streams,
+            owned_pids,
+        ):
+            captured[pid] = owned_pids
+            await asyncio.sleep(0.04)
+
+    async def run_both():
+        await asyncio.gather(capture(101), capture(202))
+
+    asyncio.run(run_both())
+
+    assert captured == {101: {101}, 202: {202}}

--- a/tests/tools/test_mcp_stdio_child_liveness.py
+++ b/tests/tools/test_mcp_stdio_child_liveness.py
@@ -175,7 +175,12 @@ def test_parallel_stdio_spawn_capture_keeps_each_server_pid_owned(monkeypatch):
         await asyncio.gather(capture(101), capture(202))
 
     asyncio.run(run_both())
+    assert captured == {101: {101}, 202: {202}}
 
+    # Hermes tears down and recreates its MCP event loop. The spawn guard must
+    # remain usable after the loop that first contended on it has closed.
+    captured.clear()
+    asyncio.run(run_both())
     assert captured == {101: {101}, 202: {202}}
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6225,7 +6225,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_awaitable = None
                     if asyncio.iscoroutine(_call_coro) and callable(_watch_children):
                         candidate = _watch_children()
-                        if inspect.isawaitable(candidate):
+                        if asyncio.iscoroutine(candidate):
                             _watch_awaitable = candidate
                     if _watch_awaitable is None:
                         # Stubbed sessions (MagicMock in tests) return a

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5412,15 +5412,21 @@ _orphan_stdio_pid_servers: Dict[int, str] = {}
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 
-# Only the stdio process-spawn window is serialized. Sessions run concurrently
-# after their direct child PID has been attributed to the owning server.
-_stdio_spawn_lock = asyncio.Lock()
+# Only the stdio process-spawn window is serialized. A threading lock remains
+# valid when Hermes tears down and recreates the MCP asyncio event loop.
+_stdio_spawn_lock = threading.Lock()
+
+
+async def _acquire_stdio_spawn_lock() -> None:
+    """Acquire the loop-neutral spawn lock without blocking an event loop."""
+    while not _stdio_spawn_lock.acquire(blocking=False):
+        await asyncio.sleep(0.01)
 
 
 @asynccontextmanager
 async def _tracked_stdio_spawn(client_context):
     """Enter one stdio client and attribute only its own child processes."""
-    await _stdio_spawn_lock.acquire()
+    await _acquire_stdio_spawn_lock()
     try:
         pids_before = _snapshot_child_pids()
         streams = await client_context.__aenter__()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3043,11 +3043,11 @@ class MCPServerTask:
 
         Shutdown takes precedence if both events are set simultaneously.
 
-        Periodically sends a lightweight keepalive (``ping``, with a
-        ``list_tools`` fallback for servers that don't implement the optional
-        ping utility — see :meth:`_keepalive_probe`) to prevent TCP/session
-        state from going stale during idle periods (#17003). If the keepalive
-        fails, triggers a reconnect.
+        HTTP/SSE sessions periodically send a lightweight keepalive (``ping``,
+        with a ``list_tools`` fallback for servers that do not implement the
+        optional ping utility). Stdio sessions use owned-process liveness
+        instead because local transports have no remote session TTL and some
+        otherwise-valid servers close on the optional ping method.
 
         The cadence is ``keepalive_interval`` from server config (default
         :data:`_DEFAULT_KEEPALIVE_INTERVAL`, floored at
@@ -3094,11 +3094,25 @@ class MCPServerTask:
                     self._mark_stdio_recycled(recycle_reason)
                     return "recycle"
 
-                # Timeout — no lifecycle event fired.  Probe the connection
-                # to detect stale/expired sessions — but NEVER while an RPC
-                # is in flight (#48069): the stdio session is a single
-                # JSON-RPC stream and a concurrent ping/list_tools can wedge
-                # the in-flight request. A busy server is provably alive.
+                # Local stdio servers have no remote session TTL and several
+                # valid SDK servers close their transport when sent the optional
+                # MCP ping utility. Process liveness is the safe idle probe;
+                # protocol health is proved by real tool calls. HTTP/SSE keeps
+                # the protocol ping/list_tools keepalive below.
+                if not self._is_http():
+                    if self._stdio_children_dead():
+                        self.mark_suspect("stdio subprocess exited while idle")
+                        self.session = None
+                        self._ready.clear()
+                        self._reconnect_event.set()
+                        break
+                    continue
+
+                # Timeout — no lifecycle event fired. Probe the remote
+                # connection to detect stale/expired sessions — but NEVER while
+                # an RPC is in flight (#48069): concurrent JSON-RPC liveness
+                # probes can wedge an in-flight request. A busy server is
+                # already provably alive.
                 if self.session:
                     if self._rpc_lock.locked() or any(
                         not t.done() for t in self._inflight_tasks

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6172,12 +6172,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
-                    _watch_ok = (
-                        _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
-                        and asyncio.iscoroutine(_call_coro)
-                    )
-                    if not _watch_ok:
+                    _watch_awaitable = None
+                    if asyncio.iscoroutine(_call_coro) and callable(_watch_children):
+                        candidate = _watch_children()
+                        if inspect.isawaitable(candidate):
+                            _watch_awaitable = candidate
+                    if _watch_awaitable is None:
                         # Stubbed sessions (MagicMock in tests) return a
                         # non-awaitable, or there is no child-watcher to race
                         # against: plain await is exactly the pre-#81995
@@ -6193,7 +6193,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # the call immediately instead of riding out the full
                         # tool timeout.
                         rpc_task = asyncio.ensure_future(_call_coro)
-                        watch_task = asyncio.ensure_future(_watch_children())
+                        watch_task = asyncio.ensure_future(_watch_awaitable)
                         try:
                             done, _pending = await asyncio.wait(
                                 {rpc_task, watch_task},

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3020,6 +3020,13 @@ class MCPServerTask:
                 return
             await asyncio.sleep(0.25)
 
+    def _retire_dead_stdio_transport(self, reason: str) -> None:
+        """Drop a dead stdio session and wake the transport rebuild loop."""
+        self.mark_suspect(reason)
+        self.session = None
+        self._ready.clear()
+        self._reconnect_event.set()
+
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.
 
@@ -3277,8 +3284,6 @@ class MCPServerTask:
         # exist, which would otherwise stall the shared MCP event loop.
         await asyncio.to_thread(_kill_orphaned_mcp_children)
 
-        # Snapshot child PIDs before spawning so we can track the new one.
-        pids_before = _snapshot_child_pids()
         new_pids: set = set()
         # Redirect subprocess stderr into a shared log file so MCP servers
         # (FastMCP banners, slack-mcp startup JSON, etc.) don't dump onto
@@ -3287,20 +3292,12 @@ class MCPServerTask:
         _write_stderr_log_header(self.name)
         _errlog = _get_mcp_stderr_log()
         try:
-            async with stdio_client(server_params, errlog=_errlog) as (
-                read_stream,
-                write_stream,
-            ):
-                # Capture the newly spawned subprocess PID for force-kill cleanup.
-                # Filter out non-MCP children that race into the snapshot window:
-                # slash_worker and LSP servers (jdtls/pyright/yaml-ls) are spawned
-                # directly by the gateway without start_new_session, so their pgid
-                # equals the TUI parent PID. If they leak into _stdio_pgids, the
-                # shutdown sweep's killpg() kills the TUI parent itself.
-                # See agent/lsp/client.py for the complementary start_new_session fix.
-                new_pids = _filter_mcp_children(
-                    _snapshot_child_pids() - pids_before
-                )
+            async with _tracked_stdio_spawn(
+                stdio_client(server_params, errlog=_errlog)
+            ) as ((read_stream, write_stream), owned_pids):
+                # The spawn guard serializes only process creation and PID
+                # attribution. The session itself remains fully concurrent.
+                new_pids = set(owned_pids)
                 if new_pids:
                     # Capture pgid while the child is alive — once it exits we
                     # can no longer call ``os.getpgid`` on it, and the cleanup
@@ -5401,6 +5398,36 @@ _orphan_stdio_pid_servers: Dict[int, str] = {}
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 
+# Only the stdio process-spawn window is serialized. Sessions run concurrently
+# after their direct child PID has been attributed to the owning server.
+_stdio_spawn_lock = asyncio.Lock()
+
+
+@asynccontextmanager
+async def _tracked_stdio_spawn(client_context):
+    """Enter one stdio client and attribute only its own child processes."""
+    await _stdio_spawn_lock.acquire()
+    try:
+        pids_before = _snapshot_child_pids()
+        streams = await client_context.__aenter__()
+        try:
+            owned_pids = _filter_mcp_children(
+                _snapshot_child_pids() - pids_before
+            )
+        except BaseException:
+            await client_context.__aexit__(*sys.exc_info())
+            raise
+    finally:
+        _stdio_spawn_lock.release()
+
+    try:
+        yield streams, owned_pids
+    except BaseException:
+        if not await client_context.__aexit__(*sys.exc_info()):
+            raise
+    else:
+        await client_context.__aexit__(None, None, None)
+
 
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
@@ -6165,6 +6192,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         and isinstance(_stdio_dead_result := _stdio_dead(), bool)
                         and _stdio_dead_result
                     ):
+                        server._retire_dead_stdio_transport(
+                            f"stdio subprocess exited before tools/call {tool_name}"
+                        )
                         raise TimeoutError(
                             f"MCP stdio subprocess for '{server_name}' has "
                             f"exited; failing the call fast instead of "
@@ -6201,6 +6231,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             )
                             if watch_task in done and not rpc_task.done():
                                 rpc_task.cancel()
+                                server._retire_dead_stdio_transport(
+                                    f"stdio subprocess exited during tools/call {tool_name}"
+                                )
                                 raise TimeoutError(
                                     f"MCP stdio subprocess for '{server_name}' "
                                     f"exited mid-call; failing the call fast "


### PR DESCRIPTION
## Summary

Harden stdio MCP lifecycle handling so dead children trigger a fresh transport without coroutine leaks, PID cross-contamination, event-loop restart failures, or optional-ping reconnect churn.

Slack deduplication is intentionally split into focused PR #95124.

## Changes

- Retire stale stdio sessions and signal reconnect on pre-call or mid-call child death without replaying potentially non-idempotent tools.
- Serialize only stdio spawn/PID attribution with a loop-neutral guard while leaving established sessions concurrent.
- Use owned-process liveness for local stdio idle checks; retain protocol ping/list-tools keepalive for HTTP/SSE.
- Keep the child watcher coroutine-specific and construct it exactly once.
- Add regressions for pre-call death, mid-call death, fresh-session retry, overlapping server spawns, event-loop recreation, and stdio no-ping behavior.

## Keepalive rationale

Local stdio transports have no remote session TTL, and observed otherwise-valid SDK servers close when sent the optional MCP `ping`. Stdio therefore defaults to owned-process liveness at idle and proves protocol health through bounded real calls. HTTP/SSE retains protocol keepalive because remote session expiry cannot be inferred from a local process. An opt-in stdio protocol-probe mode can be considered separately without restoring a default known to churn valid servers.

## Verification

- `pytest tests/tools/test_mcp*.py` → 591 passed
- Ruff on all changed files → passed
- `git diff --check origin/main...HEAD` → passed

## Risk / rollback

Scoped to MCP transport lifecycle and tests. Revert the six PR commits to restore prior behavior.
