### PR TITLE
fix(computer_use): YOLO runs no longer ignore computer_use.no_overlay (#78599, salvage #78601)

### DIFF
--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -11,7 +11,7 @@ probe), not specific config snapshots.
 """
 
 import os
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -223,3 +223,30 @@ class TestMcpArgsOverlayFlag:
             result = cua_backend._mcp_args_with_overlay_flag(original)
             assert "--no-overlay" in result
             assert "--no-overlay" not in original
+
+
+class TestEmbeddedDaemonOverlayFlag:
+    def test_serve_process_disables_overlay_when_policy_requires_it(self):
+        daemon = cua_backend._EmbeddedCuaDaemon("/usr/bin/cua-driver", "unrestricted")
+        process = MagicMock()
+        process.poll.return_value = None
+        status = MagicMock(returncode=0)
+
+        with patch.object(
+            cua_backend,
+            "_resolve_mcp_invocation",
+            return_value=("/usr/bin/cua-driver", ["mcp"]),
+        ), patch.object(
+            cua_backend, "_cua_no_overlay", return_value=True,
+        ), patch.object(
+            cua_backend, "_cua_driver_supports_no_overlay", return_value=True,
+        ), patch.object(
+            cua_backend.subprocess, "Popen", return_value=process,
+        ) as popen, patch.object(
+            cua_backend.subprocess, "run", return_value=status,
+        ), patch.object(cua_backend.threading, "Thread"):
+            daemon.start()
+
+        command = popen.call_args.args[0]
+        assert command[:2] == ["/usr/bin/cua-driver", "serve"]
+        assert "--no-overlay" in command

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -178,6 +178,12 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
         cua_backend,
         "_resolve_mcp_invocation",
         return_value=("/opt/cua-driver", ["mcp"]),
+    ), patch.object(
+        # This test pins the socket/ack contract, not overlay policy. Pin the
+        # policy off so the environment-dependent auto-detect (headless CI vs
+        # Wayland dev box) can't add a `--help` capability-probe subprocess.run
+        # call that the fixed two-entry side_effect below doesn't budget for.
+        cua_backend, "_cua_no_overlay", return_value=False,
     ), patch.object(cua_backend.subprocess, "Popen", return_value=process) as popen, patch.object(
         cua_backend.subprocess, "run", side_effect=[status, stopped]
     ):

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -728,6 +728,10 @@ class _EmbeddedCuaDaemon:
                     "--approve-capability-manifest",
                 ]
             )
+        # The private daemon owns the platform cursor overlay. Applying the
+        # policy only to its MCP proxy leaves this long-lived serve process
+        # free to create a full-screen overlay before session tuning runs.
+        command = _mcp_args_with_overlay_flag(command, driver_cmd=self._command)
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
`computer_use.no_overlay` is now honored on YOLO/unrestricted runs: the private embedded `cua-driver serve` daemon those runs spawn gets `--no-overlay` at process start. Salvage of #78601 by @cvillarroel2 (fixes #78599).

Root cause: unrestricted/bounded sessions bypass the machine-wide daemon and launch their own `serve --embedded` process, which owns the platform cursor overlay — but only the MCP proxy invocation got the overlay flag. On Linux X11 the result was the desktop-wedging overlay window appearing even with `no_overlay: true` set ("I enabled the fix and it froze anyway" in the support thread).

## Changes
- `tools/computer_use/cua_backend.py`: `_EmbeddedCuaDaemon.start()` routes its serve command through the existing `_mcp_args_with_overlay_flag()` (policy + driver-capability probe) before `Popen`. Drivers without `--no-overlay` support are unchanged.
- `tests/computer_use/test_cua_no_overlay.py`: regression test asserting the spawned serve command carries `--no-overlay` when policy and support are on (updated during salvage to main's current `start()` shape — `--socket`/`--permission-mode`/status-probe args landed since the PR branched).

## Validation
| | Before | After |
|---|---|---|
| YOLO serve daemon cmdline, `no_overlay: true` | no `--no-overlay` → overlay spawns, X11 wedge possible | `serve --embedded ... --dangerously-bypass-approvals --no-overlay` |
| Driver without flag support | unchanged | unchanged (capability probe gates) |

`tests/computer_use/test_cua_no_overlay.py`: 10 passed, 1 skipped. Real E2E (no mocked Popen): fake driver binary advertising `--no-overlay`, real `_EmbeddedCuaDaemon("unrestricted").start()` — logged argv shows `serve --embedded --socket ... --permission-mode unrestricted --dangerously-bypass-approvals --no-overlay`; startup probe and stop both clean.

**Live repro:** community-confirmed — third freeze in the support thread fired with `no_overlay: true` already enabled, specifically on a YOLO run through the embedded daemon; the contributor's Hyprland process probe verified the fixed cmdline live.

Companion: #95284 defaults the overlay off on Linux X11 (salvage of #88242); this PR makes that default reach unrestricted runs too.

## Infographic

![YOLO daemon now honors no_overlay](https://v3b.fal.media/files/b/0aa7d9f6/gKWaexbqRG12TLxm3dRwR_iqnge95B.png)
