### PR TITLE
fix(telegram): recover inbound rich_message bodies silently dropped by filters.TEXT

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4333,6 +4333,14 @@ class TelegramAdapter(BasePlatformAdapter):
             },
         }
 
+    @staticmethod
+    def _is_rich_message_inbound(message: Any) -> bool:
+        """Return whether a Message carries a rich-only inbound body."""
+        if getattr(message, "text", None) or getattr(message, "caption", None):
+            return False
+        api_kwargs = getattr(message, "api_kwargs", None) or {}
+        return isinstance(api_kwargs.get("rich_message"), dict)
+
     def _register_handlers(self, app) -> None:
         """Register every PTB handler on ``app``.
 
@@ -4350,10 +4358,7 @@ class TelegramAdapter(BasePlatformAdapter):
             """Match Bot API 10.x rich_message bodies with no plain text."""
 
             def filter(self, message):
-                if getattr(message, "text", None) or getattr(message, "caption", None):
-                    return False
-                kw = getattr(message, "api_kwargs", None) or {}
-                return isinstance(kw.get("rich_message"), dict)
+                return TelegramAdapter._is_rich_message_inbound(message)
 
         # Bot API 10.x premium/formatted clients deliver long texts as
         # message.rich_message WITHOUT msg.text, so filters.TEXT never
@@ -8980,7 +8985,13 @@ class TelegramAdapter(BasePlatformAdapter):
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
 
     @classmethod
-    def _extract_bot_mention_usernames(cls, message: Message, self_username: str = "") -> set[str]:
+    def _extract_bot_mention_usernames(
+        cls,
+        message: Message,
+        self_username: str = "",
+        *,
+        text_override: Optional[str] = None,
+    ) -> set[str]:
         """Extract explicit Telegram bot usernames mentioned in text/captions.
 
         Foreign handles are only treated as bot mentions when they look
@@ -9005,7 +9016,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(cls._FOREIGN_BOT_HANDLE_RE.fullmatch(handle))
 
         def _iter_sources():
-            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
+            message_text = getattr(message, "text", None) or ""
+            if text_override is not None:
+                # rich_message is rendered locally, so Telegram's entity offsets
+                # cannot be trusted against the normalized replacement text.
+                text_entities = (
+                    (getattr(message, "entities", None) or [])
+                    if text_override == message_text
+                    else []
+                )
+                yield text_override, text_entities
+            else:
+                yield message_text, getattr(message, "entities", None) or []
             yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
 
         for source_text, entities in _iter_sources():
@@ -9062,7 +9084,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except UnicodeDecodeError:
             return ""
 
-    def _message_mentions_bot(self, message: Message) -> bool:
+    def _message_mentions_bot(self, message: Message, *, text_override: Optional[str] = None) -> bool:
         if not self._bot:
             return False
 
@@ -9071,7 +9093,18 @@ class TelegramAdapter(BasePlatformAdapter):
         expected = f"@{bot_username}" if bot_username else None
 
         def _iter_sources():
-            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
+            message_text = getattr(message, "text", None) or ""
+            if text_override is not None:
+                # See _extract_bot_mention_usernames: rendered rich_message text
+                # has no reliable one-to-one mapping to Telegram entity offsets.
+                text_entities = (
+                    (getattr(message, "entities", None) or [])
+                    if text_override == message_text
+                    else []
+                )
+                yield text_override, text_entities
+            else:
+                yield message_text, getattr(message, "entities", None) or []
             yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
 
         # Telegram parses mentions server-side and emits MessageEntity objects
@@ -9115,7 +9148,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     if command_text[at_index:].strip().lower() == expected:
                         return True
         if bot_username:
-            return bot_username in self._extract_bot_mention_usernames(message, bot_username)
+            return bot_username in self._extract_bot_mention_usernames(
+                message,
+                bot_username,
+                text_override=text_override,
+            )
         return False
 
     def _schedule_bot_identity_recheck(self) -> None:
@@ -9145,7 +9182,12 @@ class TelegramAdapter(BasePlatformAdapter):
             tracked.add(task)
             task.add_done_callback(tracked.discard)
 
-    def _explicit_bot_mentions_exclude_self(self, message: Message) -> bool:
+    def _explicit_bot_mentions_exclude_self(
+        self,
+        message: Message,
+        *,
+        text_override: Optional[str] = None,
+    ) -> bool:
         """Return True when explicit bot handles target other bots, not this one.
 
         Telegram groups can contain several Hermes bot profiles. A message like
@@ -9167,7 +9209,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if not bot_username:
             return False
 
-        mentioned_bot_usernames = self._extract_bot_mention_usernames(message, bot_username)
+        mentioned_bot_usernames = self._extract_bot_mention_usernames(
+            message,
+            bot_username,
+            text_override=text_override,
+        )
         excludes_self = bool(mentioned_bot_usernames) and bot_username not in mentioned_bot_usernames
         if excludes_self:
             # Either the message really is for another bot, or our cached
@@ -9177,10 +9223,16 @@ class TelegramAdapter(BasePlatformAdapter):
             self._schedule_bot_identity_recheck()
         return excludes_self
 
-    def _message_matches_mention_patterns(self, message: Message) -> bool:
+    def _message_matches_mention_patterns(
+        self,
+        message: Message,
+        *,
+        text_override: Optional[str] = None,
+    ) -> bool:
         if not self._mention_patterns:
             return False
-        for candidate in (getattr(message, "text", None), getattr(message, "caption", None)):
+        text = text_override if text_override is not None else getattr(message, "text", None)
+        for candidate in (text, getattr(message, "caption", None)):
             if not candidate:
                 continue
             for pattern in self._mention_patterns:
@@ -9188,13 +9240,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     return True
         return False
 
-    def _is_guest_mention(self, message: Message) -> bool:
+    def _is_guest_mention(self, message: Message, *, text_override: Optional[str] = None) -> bool:
         """Return True for the narrow guest-mode bypass: explicit bot mention.
 
         The caller (:meth:`_should_process_message`) has already verified
         the message is a group chat, so that check is not repeated here.
         """
-        return self._telegram_guest_mode() and self._message_mentions_bot(message)
+        return self._telegram_guest_mode() and self._message_mentions_bot(
+            message,
+            text_override=text_override,
+        )
 
     def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
         bot_username = self._current_bot_username()
@@ -9204,7 +9259,12 @@ class TelegramAdapter(BasePlatformAdapter):
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 
-    def _should_observe_unmentioned_group_message(self, message: Message) -> bool:
+    def _should_observe_unmentioned_group_message(
+        self,
+        message: Message,
+        *,
+        text_override: Optional[str] = None,
+    ) -> bool:
         """Return True when a group message should be stored but not dispatched."""
         if self._is_own_message(message):
             return False
@@ -9228,7 +9288,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
-        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(
+            message,
+            text_override=text_override,
+        ):
             return False
 
         allowed = self._telegram_observe_allowed_chats()
@@ -9251,9 +9314,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if self._is_reply_to_bot(message):
             return False
-        if self._message_mentions_bot(message):
+        if self._message_mentions_bot(message, text_override=text_override):
             return False
-        if self._message_matches_mention_patterns(message):
+        if self._message_matches_mention_patterns(message, text_override=text_override):
             return False
         return True
 
@@ -9547,7 +9610,13 @@ class TelegramAdapter(BasePlatformAdapter):
         user_id = getattr(from_user, "id", None)
         return bot_id is not None and user_id is not None and bot_id == user_id
 
-    def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
+    def _should_process_message(
+        self,
+        message: Message,
+        *,
+        is_command: bool = False,
+        text_override: Optional[str] = None,
+    ) -> bool:
         """Apply Telegram group trigger rules.
 
         DMs remain unrestricted. Group/supergroup messages are accepted when:
@@ -9611,12 +9680,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
 
-        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(
+            message,
+            text_override=text_override,
+        ):
             return False
 
         # Resolve guest-mode mention bypass once so _message_mentions_bot
         # is not called redundantly in the normal flow below.
-        guest_mention = self._is_guest_mention(message)
+        guest_mention = self._is_guest_mention(message, text_override=text_override)
 
         # allowed_chats check (whitelist). When set, group messages from chats
         # outside the whitelist are ignored unless guest_mode permits this
@@ -9637,9 +9709,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         # When guest_mode is True, _is_guest_mention already called
         # _message_mentions_bot above — skip the redundant second call.
-        if not self._telegram_guest_mode() and self._message_mentions_bot(message):
+        if not self._telegram_guest_mode() and self._message_mentions_bot(
+            message,
+            text_override=text_override,
+        ):
             return True
-        return self._message_matches_mention_patterns(message)
+        return self._message_matches_mention_patterns(message, text_override=text_override)
 
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
@@ -9718,7 +9793,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                     )
                                 elif label:
                                     lines.append(f"{indent}{label}")
-                        continue
+                        # Fall through so a future list block carrying its own
+                        # text or sibling blocks does not silently lose content.
                     text = block.get("text")
                     if isinstance(text, str) and text.strip():
                         lines.append(indent + text)
@@ -9739,30 +9815,10 @@ class TelegramAdapter(BasePlatformAdapter):
         them into a single MessageEvent before dispatching.
         """
         msg = self._effective_update_message(update)
-        if not msg or not msg.text:
-            if msg is not None:
-                rich_text = self._recover_rich_message_inbound_text(msg)
-                if rich_text:
-                    try:
-                        # PTB freezes TelegramObject attributes; bypass the
-                        # frozen __setattr__ to attach the rendered body.
-                        object.__setattr__(msg, "text", rich_text)
-                    except Exception:
-                        logger.warning(
-                            "rich_message recovery could not attach text",
-                            exc_info=True,
-                        )
-                        return
-                    logger.info(
-                        "[Telegram] Recovered rich_message inbound text (%d chars)",
-                        len(rich_text),
-                    )
-            if not msg or not msg.text:
-                return
-        # Early user-level auth check: reject unauthorized users before any
-        # text batching, observe-buffer persistence, event building, or response
-        # generation. This prevents removed/blocked users from injecting prompts
-        # into the agent path or the observed transcript context (#40863).
+        if not msg:
+            return
+        # Reject unauthorized users before rich_message recovery, batching,
+        # observed-context persistence, event building, or response generation.
         if not self._is_user_authorized_from_message(msg):
             logger.warning(
                 "[Telegram] Blocked unauthorized user %s in chat %s",
@@ -9770,13 +9826,41 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(msg):
-            if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
-            return
-        await self._ensure_forum_commands(update.message)
 
-        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        # Keep the raw PTB Message truthful: rich_message has no msg.text.
+        # The recovered body belongs in Hermes' normalized MessageEvent instead.
+        effective_text = msg.text or self._recover_rich_message_inbound_text(msg)
+        if not effective_text:
+            return
+        if not msg.text:
+            logger.info(
+                "[Telegram] Recovered rich_message inbound text (%d chars)",
+                len(effective_text),
+            )
+
+        if not self._should_process_message(msg, text_override=effective_text):
+            if self._should_observe_unmentioned_group_message(msg, text_override=effective_text):
+                observed_event = self._build_message_event(
+                    msg,
+                    MessageType.TEXT,
+                    update_id=update.update_id,
+                    text_override=effective_text,
+                )
+                self._observe_unmentioned_group_message(
+                    msg,
+                    MessageType.TEXT,
+                    update_id=update.update_id,
+                    event=observed_event,
+                )
+            return
+        await self._ensure_forum_commands(msg)
+
+        event = self._build_message_event(
+            msg,
+            MessageType.TEXT,
+            update_id=update.update_id,
+            text_override=effective_text,
+        )
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
@@ -10627,6 +10711,8 @@ class TelegramAdapter(BasePlatformAdapter):
         message: Message,
         msg_type: MessageType,
         update_id: Optional[int] = None,
+        *,
+        text_override: Optional[str] = None,
     ) -> MessageEvent:
         """Build a MessageEvent from a Telegram message.
 
@@ -10777,7 +10863,7 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
         return MessageEvent(
-            text=message.text or "",
+            text=text_override if text_override is not None else (message.text or ""),
             message_type=msg_type,
             source=source,
             raw_message=message,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4345,6 +4345,24 @@ class TelegramAdapter(BasePlatformAdapter):
             filters.TEXT & ~filters.COMMAND,
             self._handle_text_message
         ))
+
+        class _RichMessageInboundFilter(filters.MessageFilter):
+            """Match Bot API 10.x rich_message bodies with no plain text."""
+
+            def filter(self, message):
+                if getattr(message, "text", None) or getattr(message, "caption", None):
+                    return False
+                kw = getattr(message, "api_kwargs", None) or {}
+                return isinstance(kw.get("rich_message"), dict)
+
+        # Bot API 10.x premium/formatted clients deliver long texts as
+        # message.rich_message WITHOUT msg.text, so filters.TEXT never
+        # matches them and they are silently dropped before reaching
+        # _handle_text_message. Route them through the same pipeline.
+        app.add_handler(TelegramMessageHandler(
+            _RichMessageInboundFilter() & ~filters.COMMAND,
+            self._handle_text_message
+        ))
         app.add_handler(TelegramMessageHandler(
             filters.COMMAND,
             self._handle_command
@@ -9658,6 +9676,61 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    @staticmethod
+    def _recover_rich_message_inbound_text(message: "Message") -> Optional[str]:
+        """Render an inbound Bot API 10.x rich_message body to plain text.
+
+        Premium/formatted clients deliver long texts as
+        ``message.rich_message`` with NO ``text`` field; PTB does not model
+        that field but preserves it in ``Message.api_kwargs``. Returns None
+        unless the message carries only a rich_message body.
+        """
+        try:
+            if getattr(message, "text", None) or getattr(message, "caption", None):
+                return None
+            api_kwargs = getattr(message, "api_kwargs", None) or {}
+            rich = api_kwargs.get("rich_message")
+            if not isinstance(rich, dict):
+                return None
+
+            def _render(blocks: Any, depth: int = 0) -> List[str]:
+                lines: List[str] = []
+                if not isinstance(blocks, list):
+                    return lines
+                indent = "  " * max(depth - 1, 0)
+                for block in blocks:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = str(block.get("type", "")).lower()
+                    if btype == "list":
+                        items = block.get("items")
+                        if isinstance(items, list):
+                            for item in items:
+                                if not isinstance(item, dict):
+                                    continue
+                                label = str(item.get("label") or "").strip()
+                                body = _render(item.get("blocks"), depth + 1)
+                                if body:
+                                    child_indent = indent + "  "
+                                    lines.append(f"{indent}{label} {body[0]}".strip())
+                                    lines.extend(
+                                        f"{child_indent}{line}" for line in body[1:]
+                                    )
+                                elif label:
+                                    lines.append(f"{indent}{label}")
+                        continue
+                    text = block.get("text")
+                    if isinstance(text, str) and text.strip():
+                        lines.append(indent + text)
+                    lines.extend(_render(block.get("blocks"), depth + 1))
+                return lines
+
+            rendered = "\n".join(_render(rich.get("blocks"))).strip()
+            return rendered or None
+        except Exception:
+            logger.warning("rich_message inbound recovery failed", exc_info=True)
+            return None
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -9667,7 +9740,25 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
-            return
+            if msg is not None:
+                rich_text = self._recover_rich_message_inbound_text(msg)
+                if rich_text:
+                    try:
+                        # PTB freezes TelegramObject attributes; bypass the
+                        # frozen __setattr__ to attach the rendered body.
+                        object.__setattr__(msg, "text", rich_text)
+                    except Exception:
+                        logger.warning(
+                            "rich_message recovery could not attach text",
+                            exc_info=True,
+                        )
+                        return
+                    logger.info(
+                        "[Telegram] Recovered rich_message inbound text (%d chars)",
+                        len(rich_text),
+                    )
+            if not msg or not msg.text:
+                return
         # Early user-level auth check: reject unauthorized users before any
         # text batching, observe-buffer persistence, event building, or response
         # generation. This prevents removed/blocked users from injecting prompts

--- a/tests/test_telegram_inbound_rich_message.py
+++ b/tests/test_telegram_inbound_rich_message.py
@@ -9,7 +9,9 @@ dropped. These tests lock in both halves of the fix:
 2. ``_RichMessageInboundFilter`` matches only rich_message-only updates.
 """
 
+import asyncio
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -41,9 +43,7 @@ def _load_real_ptb():
             pytest.skip("real python-telegram-bot unavailable")
         # Keep the real package alive under a private name and restore whatever
         # the conftest had installed so other suites are unaffected.
-        ext = importlib.import_module("telegram.ext")
         sys.modules["_real_telegram_for_rich_tests"] = mod
-        sys.modules["_real_telegram_for_rich_tests_ext"] = ext
         return mod
     finally:
         for k, v in saved.items():
@@ -51,9 +51,9 @@ def _load_real_ptb():
 
 
 _real_telegram = _load_real_ptb()
-_real_telegram_ext = sys.modules["_real_telegram_for_rich_tests_ext"]
 Message = _real_telegram.Message  # noqa: E402
 Update = _real_telegram.Update  # noqa: E402
+Chat = _real_telegram.Chat  # noqa: E402
 
 
 RICH_BLOCKS = {
@@ -94,6 +94,15 @@ def _rich_message(**kwargs):
         chat={"id": 12345, "type": "private"},
         api_kwargs={"rich_message": RICH_BLOCKS},
     )
+
+
+def _event_adapter():
+    """Build the narrow adapter fixture needed by _build_message_event."""
+    adapter = _make_adapter()
+    adapter.config = SimpleNamespace(extra={})
+    adapter.build_source = lambda **_kwargs: SimpleNamespace()
+    adapter._effective_message_thread_id = lambda _message: None
+    return adapter
 
 
 class TestRecoverRichMessageInboundText:
@@ -153,53 +162,107 @@ class TestRecoverRichMessageInboundText:
         assert "- first line" in out
         assert "\n  second line" in out
 
-
-class TestAttachRecoveredText:
-    def test_object_setattr_attaches_to_frozen_message(self):
-        # PTB freezes Message attributes; the handler must bypass via
-        # object.__setattr__ so downstream code can read msg.text.
-        msg = _rich_message()
+    def test_list_keeps_own_text_and_sibling_blocks(self):
         adapter = _make_adapter()
-        text = adapter._recover_rich_message_inbound_text(msg)
-        object.__setattr__(msg, "text", text)
-        assert msg.text == text
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"},
+                      api_kwargs={"rich_message": {"blocks": [
+                          {"type": "list", "text": "list title", "blocks": [
+                              {"type": "paragraph", "text": "sibling block"}],
+                           "items": [{"label": "-", "blocks": [
+                               {"type": "paragraph", "text": "list item"}]}]},
+                      ]}})
+        out = adapter._recover_rich_message_inbound_text(msg)
+        assert out == "- list item\nlist title\nsibling block"
+
+
+class TestRecoveredTextNormalisation:
+    def test_build_event_uses_override_and_preserves_raw_message(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = _event_adapter()
+        msg = Message(
+            message_id=1,
+            date=0,
+            chat=Chat(id=12345, type="private"),
+            api_kwargs={"rich_message": RICH_BLOCKS},
+        )
+        recovered = adapter._recover_rich_message_inbound_text(msg)
+        event = adapter._build_message_event(msg, MessageType.TEXT, text_override=recovered)
+
+        assert recovered is not None
+        assert msg.text is None
+        assert event.raw_message is msg
+        assert event.text == recovered
+
+    def test_handler_enqueues_recovered_text_without_mutating_raw_message(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = _event_adapter()
+        msg = Message(
+            message_id=1,
+            date=0,
+            chat=Chat(id=12345, type="private"),
+            api_kwargs={"rich_message": RICH_BLOCKS},
+        )
+        update = Update(update_id=1, message=msg)
+        queued = []
+        seen = {}
+
+        adapter._is_user_authorized_from_message = lambda _message: True
+        adapter._should_process_message = lambda _message, **kwargs: seen.update(kwargs) or True
+        adapter._clean_bot_trigger_text = lambda text: text
+        adapter._apply_telegram_group_observe_attribution = lambda event: event
+        adapter._enqueue_text_event = queued.append
+
+        async def _noop(*_args, **_kwargs):
+            return None
+
+        adapter._ensure_forum_commands = _noop
+        adapter._cache_replied_media = _noop
+
+        asyncio.run(adapter._handle_text_message(update, None))
+
+        assert seen["text_override"] == adapter._recover_rich_message_inbound_text(msg)
+        assert len(queued) == 1
+        assert queued[0].message_type == MessageType.TEXT
+        assert queued[0].text == seen["text_override"]
+        assert queued[0].raw_message is msg
+        assert msg.text is None
+
+    def test_recovered_text_participates_in_bot_mention_detection(self):
+        adapter = _make_adapter()
+        adapter._bot = SimpleNamespace(id=7)
+        adapter._current_bot_username = lambda: "hermesbot"
+        msg = _rich_message()
+
+        assert adapter._message_mentions_bot(msg, text_override="@hermesbot hello")
 
 
 class TestRichMessageInboundFilter:
     def _filter(self):
-        # Re-create the filter class exactly as registered, using the REAL
-        # PTB filters module (sys.modules["telegram"] may be a conftest mock).
-        filters = _real_telegram_ext.filters
+        # The nested registration filter delegates to this production predicate;
+        # testing it directly prevents a copied test-only implementation drifting.
+        from plugins.platforms.telegram.adapter import TelegramAdapter
 
-        class _RichMessageInboundFilter(filters.MessageFilter):
-            def filter(self, message):
-                if getattr(message, "text", None) or getattr(message, "caption", None):
-                    return False
-                kw = getattr(message, "api_kwargs", None) or {}
-                return isinstance(kw.get("rich_message"), dict)
-
-        return _RichMessageInboundFilter()
-
-    def _update(self, msg):
-        return Update(update_id=1, message=msg)
+        return TelegramAdapter._is_rich_message_inbound
 
     def test_matches_rich_only_update(self):
         f = self._filter()
-        assert f.check_update(self._update(_rich_message())) == 1
+        assert f(_rich_message()) is True
 
     def test_ignores_plain_text_update(self):
         f = self._filter()
         msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
         object.__setattr__(msg, "text", "hello")
-        assert not f.check_update(self._update(msg))
+        assert f(msg) is False
 
     def test_ignores_caption_update(self):
         f = self._filter()
         msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
         object.__setattr__(msg, "caption", "cap")
-        assert not f.check_update(self._update(msg))
+        assert f(msg) is False
 
     def test_ignores_message_without_anything(self):
         f = self._filter()
         msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
-        assert not f.check_update(self._update(msg))
+        assert f(msg) is False

--- a/tests/test_telegram_inbound_rich_message.py
+++ b/tests/test_telegram_inbound_rich_message.py
@@ -1,0 +1,205 @@
+"""Tests for inbound Bot API 10.x rich_message recovery.
+
+Premium/formatted Telegram clients deliver long texts as
+``message.rich_message`` with NO plain ``text`` field. Before the fix,
+``filters.TEXT`` never matched those updates and they were silently
+dropped. These tests lock in both halves of the fix:
+
+1. ``_recover_rich_message_inbound_text`` renders the block tree to text.
+2. ``_RichMessageInboundFilter`` matches only rich_message-only updates.
+"""
+
+import sys
+
+import pytest
+
+def _load_real_ptb():
+    """Return real PTB classes even when another conftest mocked ``telegram``.
+
+    ``tests/gateway/conftest.py`` installs a MagicMock ``telegram`` package at
+    collection time. When both gateway and root files are collected in one
+    pytest session, that mock replaces the real library in ``sys.modules``
+    before this module imports. Re-import the real distribution directly so
+    these tests always exercise actual PTB behaviour.
+    """
+    import importlib
+    import importlib.util
+
+    existing = sys.modules.get("telegram")
+    if existing is not None and getattr(existing, "__file__", None):
+        return existing
+
+    saved = {k: v for k, v in sys.modules.items() if k == "telegram" or k.startswith("telegram.")}
+    for k in saved:
+        del sys.modules[k]
+    try:
+        spec = importlib.util.find_spec("telegram")
+        if spec is None or spec.loader is None:
+            pytest.skip("python-telegram-bot not installed")
+        mod = importlib.import_module("telegram")
+        if getattr(mod, "__file__", None) is None:
+            pytest.skip("real python-telegram-bot unavailable")
+        # Keep the real package alive under a private name and restore whatever
+        # the conftest had installed so other suites are unaffected.
+        ext = importlib.import_module("telegram.ext")
+        sys.modules["_real_telegram_for_rich_tests"] = mod
+        sys.modules["_real_telegram_for_rich_tests_ext"] = ext
+        return mod
+    finally:
+        for k, v in saved.items():
+            sys.modules[k] = v
+
+
+_real_telegram = _load_real_ptb()
+_real_telegram_ext = sys.modules["_real_telegram_for_rich_tests_ext"]
+Message = _real_telegram.Message  # noqa: E402
+Update = _real_telegram.Update  # noqa: E402
+
+
+RICH_BLOCKS = {
+    "blocks": [
+        {"type": "paragraph", "text": "Here is the full answer you asked for."},
+        {"type": "paragraph", "text": ""},
+        {"type": "paragraph", "text": "These are the main findings:"},
+        {"type": "list", "items": [
+            {"label": "1.", "blocks": [
+                {"type": "paragraph", "text": "The first finding is documented here"}],
+             "type": "1", "value": 1},
+            {"label": "2.", "blocks": [
+                {"type": "paragraph", "text": "The second finding is measured"}],
+             "type": "1", "value": 2},
+        ]},
+        {"type": "paragraph", "text": "The system includes:"},
+        {"type": "list", "items": [
+            {"label": "-", "blocks": [
+                {"type": "paragraph", "text": "First limitation described here"}]},
+            {"label": "-", "blocks": [
+                {"type": "paragraph", "text": "Second limitation described here"}]},
+        ]},
+    ]
+}
+
+
+def _make_adapter():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    return object.__new__(TelegramAdapter)
+
+
+def _rich_message(**kwargs):
+    """Build a PTB Message carrying only a rich_message body (api_kwargs)."""
+    return Message(
+        message_id=kwargs.get("message_id", 1),
+        date=0,
+        chat={"id": 12345, "type": "private"},
+        api_kwargs={"rich_message": RICH_BLOCKS},
+    )
+
+
+class TestRecoverRichMessageInboundText:
+    def test_renders_paragraphs_and_lists(self):
+        adapter = _make_adapter()
+        out = adapter._recover_rich_message_inbound_text(_rich_message())
+        assert out is not None
+        lines = out.splitlines()
+        assert lines[0] == "Here is the full answer you asked for."
+        assert "These are the main findings:" in out
+        assert "1. The first finding is documented here" in out
+        assert "2. The second finding is measured" in out
+        assert "First limitation described here" in out
+
+    def test_empty_blocks_yield_none(self):
+        adapter = _make_adapter()
+        msg = Message(message_id=1, date=0,
+                      chat={"id": 1, "type": "private"},
+                      api_kwargs={"rich_message": {"blocks": []}})
+        assert adapter._recover_rich_message_inbound_text(msg) is None
+
+    def test_plain_text_message_untouched(self):
+        adapter = _make_adapter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        object.__setattr__(msg, "text", "normal message")
+        assert adapter._recover_rich_message_inbound_text(msg) is None
+
+    def test_caption_message_untouched(self):
+        adapter = _make_adapter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        object.__setattr__(msg, "caption", "photo caption")
+        assert adapter._recover_rich_message_inbound_text(msg) is None
+
+    def test_no_api_kwargs_is_none(self):
+        adapter = _make_adapter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        assert adapter._recover_rich_message_inbound_text(msg) is None
+
+    def test_garbage_shapes_are_none(self):
+        adapter = _make_adapter()
+        for kw in ({}, {"rich_message": None}, {"rich_message": "x"},
+                   {"rich_message": {}}, {"rich_message": {"blocks": "no"}}):
+            msg = Message(message_id=1, date=0,
+                          chat={"id": 1, "type": "private"}, api_kwargs=kw)
+            assert adapter._recover_rich_message_inbound_text(msg) is None
+
+    def test_list_item_first_line_gets_label_rest_indented(self):
+        adapter = _make_adapter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"},
+                      api_kwargs={"rich_message": {"blocks": [
+                          {"type": "list", "items": [
+                              {"label": "-", "blocks": [
+                                  {"type": "paragraph", "text": "first line"},
+                                  {"type": "paragraph", "text": "second line"}]},
+                          ]}]}})
+        out = adapter._recover_rich_message_inbound_text(msg)
+        assert "- first line" in out
+        assert "\n  second line" in out
+
+
+class TestAttachRecoveredText:
+    def test_object_setattr_attaches_to_frozen_message(self):
+        # PTB freezes Message attributes; the handler must bypass via
+        # object.__setattr__ so downstream code can read msg.text.
+        msg = _rich_message()
+        adapter = _make_adapter()
+        text = adapter._recover_rich_message_inbound_text(msg)
+        object.__setattr__(msg, "text", text)
+        assert msg.text == text
+
+
+class TestRichMessageInboundFilter:
+    def _filter(self):
+        # Re-create the filter class exactly as registered, using the REAL
+        # PTB filters module (sys.modules["telegram"] may be a conftest mock).
+        filters = _real_telegram_ext.filters
+
+        class _RichMessageInboundFilter(filters.MessageFilter):
+            def filter(self, message):
+                if getattr(message, "text", None) or getattr(message, "caption", None):
+                    return False
+                kw = getattr(message, "api_kwargs", None) or {}
+                return isinstance(kw.get("rich_message"), dict)
+
+        return _RichMessageInboundFilter()
+
+    def _update(self, msg):
+        return Update(update_id=1, message=msg)
+
+    def test_matches_rich_only_update(self):
+        f = self._filter()
+        assert f.check_update(self._update(_rich_message())) == 1
+
+    def test_ignores_plain_text_update(self):
+        f = self._filter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        object.__setattr__(msg, "text", "hello")
+        assert not f.check_update(self._update(msg))
+
+    def test_ignores_caption_update(self):
+        f = self._filter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        object.__setattr__(msg, "caption", "cap")
+        assert not f.check_update(self._update(msg))
+
+    def test_ignores_message_without_anything(self):
+        f = self._filter()
+        msg = Message(message_id=1, date=0, chat={"id": 1, "type": "private"})
+        assert not f.check_update(self._update(msg))


### PR DESCRIPTION
## Symptom

With Bot API 10.x clients (Telegram Premium / formatted senders), long inbound texts arrive as `message.rich_message` **without a plain `text` field**. PTB does not model this field but preserves it in `Message.api_kwargs`. Since the inbound handler registers `filters.TEXT & ~filters.COMMAND`, such updates match no handler and are **dropped silently** — the agent never sees the message and nothing is logged.

## Root cause

`_handle_text_message` early-returns on `if not msg or not msg.text`, and the update never reaches it because `filters.TEXT` requires `msg.text`.

## Fix (two layers)

1. New `_RichMessageInboundFilter` matches updates whose Message has no `text`/`caption` but carries a dict-shaped `api_kwargs["rich_message"]`; registered alongside the text handler so those updates enter the same pipeline.
2. `_recover_rich_message_inbound_text()` renders the rich block tree (paragraphs, nested lists) to plain text and attaches it via `object.__setattr__` (PTB freezes `TelegramObject` attributes) so batching, auth checks and replies work unchanged.

## Verification

Reproduced against a live gateway: a 5k+ char rich_message was recovered, logged and delivered where current `main` drops it. 12 new tests cover rendering, malformed payloads, filter behavior, and frozen-message attachment; existing Telegram suites pass unchanged.