### PR TITLE
fix(cron): scan executable interpreter heredocs

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -266,7 +266,10 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     # restart" inside such a body is documentation, not a command this shell will execute.
     from tools.shell_heredoc import strip_inert_heredoc_bodies
 
-    text = strip_inert_heredoc_bodies(text)
+    # Interpreter heredocs are inert to the outer shell but not to the
+    # interpreter: Python/AppleScript source can launch this exact lifecycle
+    # command. Only mask true data-sink bodies for this semantic scanner.
+    text = strip_inert_heredoc_bodies(text, data_sinks_only=True)
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
     if _GATEWAY_LIFECYCLE_PATTERN.search(normalized):
         return True

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -274,6 +274,16 @@ class TestGatewayLifecyclePattern:
         """Quoted source is inert to the shell, not to its interpreter."""
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
+    def test_interpreter_heredoc_prose_fails_closed(self):
+        """Keep interpreter source visible even when it only prints prose.
+
+        This deliberately accepts a false positive: Python source can execute
+        commands, so deciding whether a string is merely prose would require
+        interpreting the program rather than conservatively scanning it.
+        """
+        text = "python3 - <<'PY'\nprint('hermes gateway restart')\nPY"
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
     @pytest.mark.parametrize("text", [
         # Executable heredoc (shell consumer) must stay blocked.
         "bash <<EOF\nhermes gateway restart\nEOF",

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -259,6 +259,22 @@ class TestGatewayLifecyclePattern:
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
     @pytest.mark.parametrize("text", [
+        (
+            "python3 - <<'PY'\n"
+            'import os; os.system("hermes gateway restart")\n'
+            "PY"
+        ),
+        (
+            "osascript <<'APPLESCRIPT'\n"
+            'do shell script "hermes gateway restart"\n'
+            "APPLESCRIPT"
+        ),
+    ])
+    def test_executable_interpreter_heredoc_body_still_scanned(self, text):
+        """Quoted source is inert to the shell, not to its interpreter."""
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
         # Executable heredoc (shell consumer) must stay blocked.
         "bash <<EOF\nhermes gateway restart\nEOF",
         # Unquoted delimiter = expansion-capable = fail open to scanning.

--- a/tools/shell_heredoc.py
+++ b/tools/shell_heredoc.py
@@ -19,6 +19,12 @@ _INERT_HEREDOC_CONSUMER_RE = re.compile(
     re.IGNORECASE)
 
 
+# Unlike interpreters, cat only consumes stdin as data during this command.
+_INERT_DATA_SINK_HEREDOC_CONSUMER_RE = re.compile(
+    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:env\s+)?(?:[A-Za-z0-9_./-]+/)?"
+    r"cat(?=\s|$)", re.IGNORECASE)
+
+
 def _span_end(command: str, cursor: int, closer: str) -> int:
     """Index just past the backslash-aware span opened at ``cursor``."""
     end = cursor + 1
@@ -159,11 +165,15 @@ def _find_heredoc_close(
         cursor = after
 
 
-def strip_inert_heredoc_bodies(command: str) -> str:
-    """Mask heredoc bodies that are provably inert data (see module docstring)."""
+def strip_inert_heredoc_bodies(command: str, *, data_sinks_only: bool = False) -> str:
+    """Mask inert outer-shell data; ``data_sinks_only`` keeps interpreter source visible."""
     # Runs on every terminal call: skip the state machine when no '<<' exists; stop past the last.
     if "<<" not in command:
         return command
+    consumer_re = (
+        _INERT_DATA_SINK_HEREDOC_CONSUMER_RE
+        if data_sinks_only else _INERT_HEREDOC_CONSUMER_RE
+    )
     last_opener_index = command.rfind("<<")
     ranges: list[tuple[int, int]] = []
     command_start = 0
@@ -190,7 +200,7 @@ def strip_inert_heredoc_bodies(command: str) -> str:
         if all(quoted for _delimiter, _strip_tabs, quoted in specs) and not has_list_operator:
             masked_opener = _mask_simple_quotes(command[command_start:command_end])
             if (not any(m in masked_opener for m in ("$(", "`", "<(", ">("))
-                    and _INERT_HEREDOC_CONSUMER_RE.search(masked_opener)):
+                    and consumer_re.search(masked_opener)):
                 ranges.extend(body_ranges)
         command_start = body_cursor
     # Single-pass rebuild (ranges are sorted and non-overlapping), bodies -> their newlines only.

--- a/tools/shell_heredoc.py
+++ b/tools/shell_heredoc.py
@@ -11,17 +11,22 @@ from __future__ import annotations
 
 import re
 
+# Shared opener prefix prevents drift between scanner policies.
+_HEREDOC_CONSUMER_PREFIX = (
+    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:env\s+)?(?:[A-Za-z0-9_./-]+/)?"
+)
+
 # Non-shell interpreters whose quoted heredoc bodies are data for THAT interpreter; optional
 # VAR=... assignments, ``env`` and a path prefix allowed. Narrow on purpose: unmatched = visible.
 _INERT_HEREDOC_CONSUMER_RE = re.compile(
-    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:env\s+)?(?:[A-Za-z0-9_./-]+/)?"
+    _HEREDOC_CONSUMER_PREFIX +
     r"(?:python(?:3(?:\.\d+)*)?|osascript|cat)(?=\s|$)",
     re.IGNORECASE)
 
 
 # Unlike interpreters, cat only consumes stdin as data during this command.
 _INERT_DATA_SINK_HEREDOC_CONSUMER_RE = re.compile(
-    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:env\s+)?(?:[A-Za-z0-9_./-]+/)?"
+    _HEREDOC_CONSUMER_PREFIX +
     r"cat(?=\s|$)", re.IGNORECASE)
 
 


### PR DESCRIPTION
## What does this PR do?

Keeps executable interpreter heredoc bodies visible to the gateway lifecycle scanner.

The shared heredoc masker correctly treats quoted Python and AppleScript bodies as inert to the **outer shell**. They are not inert to their interpreters, however: both can execute a literal `hermes gateway restart`. The lifecycle scanner was using the generic masking mode and therefore missed those commands.

This follow-up adds a narrow `data_sinks_only` mode to the shared helper. The lifecycle scanner uses it so true data sinks such as `cat` retain the merged runbook-prose exemption, while Python and AppleScript source remains visible. Other shell scanners keep the existing default behavior unchanged.

## Related Issue

Narrow follow-up to #81721 and the heredoc handling merged in #93340.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add an opt-in data-sink-only mode to `tools.shell_heredoc.strip_inert_heredoc_bodies()`.
- Use that mode only in `cron.lifecycle_guard.contains_gateway_lifecycle_command()`.
- Add regressions for Python and AppleScript source that executes a literal gateway lifecycle command.
- Preserve the existing quoted-`cat` runbook exemption and terminal background-guard behavior.

## How to Test

```bash
pytest -q tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal_heredoc_background_guard.py
ruff check cron/lifecycle_guard.py tools/shell_heredoc.py tests/hermes_cli/test_gateway_restart_loop.py
```

Verified on Ubuntu 24.04: **329 passed**; Ruff, `py_compile`, and `git diff --check` passed. Independent exact-range security review found no blocker.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched existing PRs to avoid a duplicate
- [x] This PR contains only the focused fix and regressions
- [ ] I've run the complete repository test suite
- [x] I've added tests for the bug
- [x] Tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior is documented in code/docstrings
- [x] Config-example changes are N/A
- [x] Architecture/workflow documentation changes are N/A
- [x] Cross-platform impact considered; implementation uses shared Python parsing only
- [x] Tool schema changes are N/A
