### PR TITLE
fix(cron): preserve hashes within shell words

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -397,6 +397,69 @@ def _budget_exhausted(what: str, depth: int) -> bool:
 
 # --- shell tokenization -----------------------------------------------------------------------
 
+def _mask_shell_comments(text: str) -> str:
+    """Blank shell comments while preserving quoted and word-internal hashes.
+
+    The quote dialect intentionally matches :func:`_split_logical_lines`: it
+    models POSIX single and double quotes, not ANSI-C ``$'...'`` or locale
+    ``$\"...\"`` strings.  Keeping the two state machines aligned preserves
+    the conservative tokenization fallback for unsupported quote forms.
+
+    This is deliberately a conservative comment model rather than exact shell
+    emulation.  In particular, redirects are not treated as word boundaries,
+    so text after a redirect-adjacent ``#`` remains visible to the guard.
+    """
+    masked = list(text)
+    in_single = False
+    in_double = False
+    escaped = False
+    comment = False
+    word_start = True
+
+    for index, char in enumerate(text):
+        if comment:
+            if char == "\n":
+                comment = False
+                word_start = True
+            else:
+                masked[index] = " "
+            continue
+        if in_single:
+            if char == "'":
+                in_single = False
+            continue
+        if escaped:
+            escaped = False
+            word_start = False
+            continue
+        if char == "\\":
+            escaped = True
+            word_start = False
+            continue
+        if in_double:
+            if char == '"':
+                in_double = False
+            continue
+        if char == "'":
+            in_single = True
+            word_start = False
+            continue
+        if char == '"':
+            in_double = True
+            word_start = False
+            continue
+        if char == "#" and word_start:
+            masked[index] = " "
+            comment = True
+            continue
+        if char == "\n" or char.isspace() or char in _CONTROL_CHARS:
+            word_start = True
+        else:
+            word_start = False
+
+    return "".join(masked)
+
+
 def _split_logical_lines(text: str) -> list[str]:
     """Split on newlines outside quotes (a quoted newline is data, not a separator); honors
     escapes."""
@@ -422,11 +485,11 @@ def _split_logical_lines(text: str) -> list[str]:
     return lines
 
 
-def _shlex_tokens(line: str) -> list[str]:
+def _shlex_tokens(line: str, *, comments: bool = True) -> list[str]:
     """POSIX-tokenize one shell line, honoring quotes and `#` comments; raises ValueError."""
     lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|()")
     lexer.whitespace_split = True
-    lexer.commenters = "#"
+    lexer.commenters = "#" if comments else ""
     return list(lexer)
 
 
@@ -450,13 +513,14 @@ def _split_segments(tokens: list[str], *, keep_controls: bool = False) -> Iterat
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments per logical line; a line shlex rejects (unbalanced
     quotes) falls back to per-physical-line tokenization."""
-    for line in _split_logical_lines(command.replace("\\\n", "")):
+    normalized = _mask_shell_comments(command.replace("\\\n", ""))
+    for line in _split_logical_lines(normalized):
         try:
-            tokens = _shlex_tokens(line)
+            tokens = _shlex_tokens(line, comments=False)
         except ValueError:
             for physical_line in line.splitlines():
                 try:
-                    yield from _split_segments(_shlex_tokens(physical_line))
+                    yield from _split_segments(_shlex_tokens(physical_line, comments=False))
                 except ValueError:
                     continue
             continue

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1484,6 +1484,45 @@ class TestLifecycleGuardModule:
         # Must not raise; relative script cannot resolve without a home.
         check_gateway_lifecycle("daily ops", "relative-script.sh")
 
+    @pytest.mark.skipif(os.name != "posix", reason="os.mkfifo is POSIX-only")
+    def test_hash_inside_word_is_literal_in_multiline_single_quote(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        fifo = tmp_path / "public" / "app.js"
+        fifo.parent.mkdir()
+        os.mkfifo(fifo)
+        command = f"runner tag#literal 'first line\n{fifo}\nlast line'"
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ) is False
+
+    def test_real_comment_hides_referenced_script_path(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"runner ok # sh {script}", cwd=str(tmp_path)
+        ) is False
+
+    def test_command_after_comment_remains_visible(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n", encoding="utf-8")
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"runner ok # ignored\nsh {script}", cwd=str(tmp_path)
+        ) is True
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path


### PR DESCRIPTION
## What does this PR do?

Preserves literal `#` characters inside shell words while keeping real shell comments inert during lifecycle command segmentation.

Python's `shlex` treats `#` as a comment wherever it appears when `lexer.commenters = "#"`. POSIX shells only start a comment when `#` begins a word. The broader behavior could discard the rest of a line after `tag#literal`, lose a following opening quote, and promote a multiline data path into command position, causing false lifecycle blocks.

This redesign adds a quote/escape-aware comment masker, then tokenizes with `shlex` comment handling disabled. It deliberately preserves upstream's existing quote-aware logical-line behavior; unlike the earlier branch version, it does not split multiline double-quoted data into standalone commands.

## Related Issue

Narrow follow-up to #81721.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Mask comments only when `#` appears at a shell word boundary.
- Preserve `#` inside words, assignments, escaped words, and quoted text.
- Keep comments inert without hiding real commands on following lines.
- Add regressions for word-internal hashes, comment-hidden script references, and commands after comments.
- Preserve existing multiline double-quoted argument boundaries.

## How to Test

```bash
pytest -q tests/hermes_cli/test_gateway_restart_loop.py
ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py
```

Verified on Ubuntu 24.04: **300 passed**; Ruff, `py_compile`, and `git diff --check` passed. Independent exact-range review confirmed the earlier multiline-double-quote false-positive blocker is removed.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional commit
- [x] Searched for duplicate work
- [x] Focused one-commit scope
- [ ] Complete repository suite run
- [x] Regression tests added
- [x] Tested on Ubuntu 24.04
- [x] Documentation/config/schema changes are N/A
