### PR TITLE
fix(desktop): start inline-diff tool rows collapsed by default

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -369,8 +369,13 @@ function ToolEntry({ part }: ToolEntryProps) {
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
   const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
   const isFileEdit = isFileEditTool(toolName)
-  const defaultOpen = Boolean(inlineDiff)
-  const open = useDisclosureOpen(disclosureId, defaultOpen)
+
+  // Diff-bearing rows start collapsed (#95248): expanded-by-default diffs
+  // buried the transcript during edit-heavy sessions. The one-line summary —
+  // file name, status, +/- counts — is all a settled row shows until opened;
+  // clicking still expands, and a manual toggle persists over this default
+  // ($toolDisclosureOpen wins whenever the row has been touched before).
+  const open = useDisclosureOpen(disclosureId)
   const canDismiss = !isPending && !embedded
   // Only animate entries that mount while their message is actively
   // streaming — historical sessions mount with `messageRunning === false`,

--- a/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
@@ -429,7 +429,10 @@ describe('settled tool run', () => {
 
 // A diff is what the user reviews, so it is never what gets summarized away.
 // It stays on screen at the point in the turn where it happened, with the
-// activity either side of it collapsing around it.
+// activity either side of it collapsing around it. The row itself starts
+// collapsed (#95248) — file name and +/- counts ride the summary line while
+// the full diff waits one click away — and opening it restores the
+// expanded-edit chrome.
 describe('a file edit among ordinary activity', () => {
   it('stays visible between the two runs it interrupted', async () => {
     const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
@@ -443,12 +446,31 @@ describe('a file edit among ordinary activity', () => {
     expect(shape).toEqual(['summary', 'row', 'summary'])
   })
 
-  it('keeps the diff itself on screen rather than behind the summary', async () => {
+  it('starts its row collapsed, with no diff panel mounted', async () => {
     const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
+
+    await screen.findByText('Explored 2 files')
+
+    expect(container.querySelector('[data-tool-row][data-tool-open]')).toBeNull()
+    // The expanded-edit marker rides on open state — styles.css keeps an
+    // expanded edit at full strength and lets a collapsed one fade like any
+    // other row — so it must be absent while collapsed.
+    expect(container.querySelector('[data-file-edit]')).toBeNull()
+    expect(container.querySelector('[data-slot="file-diff-panel"]')).toBeNull()
+  })
+
+  it('expands on click to show the diff behind its expanded-edit marker', async () => {
+    const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
+
+    await screen.findByText('Explored 2 files')
+
+    fireEvent.click(container.querySelector('[data-tool-row] button[aria-expanded="false"]') as Element)
 
     await waitFor(() => {
       expect(container.querySelector('[data-tool-row][data-file-edit]')).not.toBeNull()
     })
+
+    expect(container.querySelector('[data-slot="file-diff-panel"]')).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Diff-bearing tool rows (`write_file`, `patch`, other file-edit tools) were hardcoded to mount **expanded**: `fallback.tsx` set `defaultOpen = Boolean(inlineDiff)`, so every new edit dumped its full diff into the transcript and buried the conversation during edit-heavy sessions.

This PR flips the default to **collapsed**, matching the compact-transcript UX intent of #95248:

- A diff row now starts as its one-line summary — file name, status glyph, `+N −N` diff counts.
- Click still expands the row to show the diff (`DisclosureRow` + persisted per-row state unchanged).
- A manual toggle persists over the new default via the existing `hermes.desktop.toolDisclosure.v1` store (`$toolDisclosureOpen` wins whenever the user has touched the row before), capped at 240 entries as before.
- Pending approvals are unaffected: `PendingToolApproval` renders outside the disclosure body.
- CSS needed no change — `styles.css` already treats a *collapsed* edit like any other fading row (`data-file-edit` only rides an open row) and gives an expanded edit full strength/margins.

## Changes

- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx`
  - Drop `defaultOpen = Boolean(inlineDiff)`; rows start collapsed (`useDisclosureOpen(disclosureId)` falls back to closed).
  - Comment explains the rationale and persistence interplay.
- `apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx`
  - Replace the expanded-by-default assertion with two tests: a diff row starts collapsed (no `data-tool-open`, no `data-file-edit`, no mounted `[data-slot="file-diff-panel"]`) and expands on click (marker restored, diff panel mounts).
  - The run-shape assertion (`summary / row / summary`) still holds — the card stays in place, just folded.

## Test plan

- `npx vitest run --project ui src/components/assistant-ui/tool` — 7 files / 94 tests green.
- `npx vitest run --project ui` — 5798/5808 tests; the 10 failures were 15–30s timeout/empty-render flakes in unrelated settings/messaging/markdown files while `npm run typecheck` ran concurrently on the same machine. All five affected files re-ran green in isolation immediately after (46/46).
- `npm run typecheck` (renderer + electron + e2e tsconfigs) — clean.

Closes #95248
