### PR TITLE
fix(desktop): stall-window guard for never-reconciled sessions

### DIFF
--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -225,4 +225,112 @@ describe('SessionStateCache', () => {
       expect(cache.get('working')).toBe(working)
     })
   })
+
+  describe('stalled session eviction (#95276)', () => {
+    function busy(storedSessionId: string, text = storedSessionId): ClientSessionState {
+      return { ...settled(storedSessionId, text), busy: true }
+    }
+
+    it('evicts entries gone silent past the stall window even under no size pressure', () => {
+      let nowMs = 0
+      const evicted: string[] = []
+
+      const cache = new SessionStateCache(
+        { isReferenced: () => false, onEvict: runtimeId => evicted.push(runtimeId) },
+        // No count/byte pressure at all: only the stall guard can bound these.
+        {
+          maxBytes: Number.POSITIVE_INFINITY,
+          maxCount: Number.POSITIVE_INFINITY,
+          stalledMs: 10_000,
+          now: () => nowMs
+        }
+      )
+
+      // Mid-turn orphans: committed as busy, then no further events, ever.
+      for (const id of ['a', 'b', 'c']) {
+        cache.set(`runtime-${id}`, busy(`stored-${id}`, 'x'.repeat(2048)))
+      }
+
+      cache.prune()
+      expect(cache.size).toBe(3)
+
+      nowMs += 10_001
+      cache.prune()
+
+      // Pre-fix this stays 3 forever: busy transcripts are invisible to the LRU.
+      expect(cache.size).toBe(0)
+      expect([...evicted].sort()).toEqual(['runtime-a', 'runtime-b', 'runtime-c'])
+    })
+
+    it.each([
+      ['busy', (state: ClientSessionState) => ({ ...state, busy: true }), true],
+      ['awaiting response', (state: ClientSessionState) => ({ ...state, awaitingResponse: true }), true],
+      ['needs input', (state: ClientSessionState) => ({ ...state, needsInput: true }), false]
+    ])('%s past the stall window is evictable exactly when the wait is not on the user', (_label, decorate, stalls) => {
+      let nowMs = 0
+      const evicted: string[] = []
+
+      const cache = new SessionStateCache(
+        { isReferenced: () => false, onEvict: runtimeId => evicted.push(runtimeId) },
+        { stalledMs: 5_000, now: () => nowMs }
+      )
+
+      cache.set('runtime', decorate(settled('stored')))
+      nowMs += 5_001
+      cache.prune()
+
+      expect(cache.has('runtime')).toBe(!stalls)
+      expect(evicted).toEqual(stalls ? ['runtime'] : [])
+    })
+
+    it('keeps a busy transcript alive while events keep arriving and evicts only after silence', () => {
+      let nowMs = 0
+      const evicted: string[] = []
+
+      const cache = new SessionStateCache(
+        { isReferenced: () => false, onEvict: runtimeId => evicted.push(runtimeId) },
+        { stalledMs: 10_000, now: () => nowMs }
+      )
+
+      cache.set('runtime', busy('stored', 'chunk-0'))
+
+      // A healthy long turn keeps mutating state; each event resets the window.
+      for (let tick = 1; tick <= 4; tick += 1) {
+        nowMs += 8_000
+        cache.set('runtime', busy('stored', `chunk-${tick}`))
+        cache.prune()
+        expect(cache.has('runtime')).toBe(true)
+      }
+
+      // Events stop; silence outlasts the window.
+      nowMs += 10_001
+      cache.prune()
+
+      expect(cache.has('runtime')).toBe(false)
+      expect(evicted).toEqual(['runtime'])
+    })
+
+    it('never stall-evicts drafts, in-flight messages, or referenced states', () => {
+      let nowMs = 0
+
+      const cache = new SessionStateCache(
+        { isReferenced: runtimeId => runtimeId === 'referenced', onEvict: () => undefined },
+        { stalledMs: 1, now: () => nowMs }
+      )
+
+      const pending = busy('stored-pending')
+      pending.messages = [{ id: 'pending-assistant', role: 'assistant', parts: [], pending: true }]
+      const draft = { ...createClientSessionState(null), messages: transcript('draft'), busy: true }
+
+      cache.set('pending', pending)
+      cache.set('draft', draft)
+      cache.set('referenced', busy('stored-referenced'))
+      nowMs += 2
+      cache.prune()
+
+      expect(cache.has('pending')).toBe(true)
+      expect(cache.has('draft')).toBe(true)
+      expect(cache.has('referenced')).toBe(true)
+    })
+  })
 })

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -3,9 +3,24 @@ import type { ClientSessionState } from '../types'
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_COUNT = 24
 export const DEFAULT_WARM_SESSION_TRANSCRIPT_BYTES = 32 * 1024 * 1024
 
+/**
+ * A busy/awaiting entry whose state has not changed for this long is an
+ * orphaned mid-turn session (#95276): while the authoritative store still
+ * claims work for its runtime id, its frozen flags fail #isWarmSettled
+ * forever, pinning its transcript outside both LRU bounds. Chosen far beyond
+ * the five-minute session watchdog so legitimate quiet stretches (long tool
+ * runs stream no events) never trip it, while still bounding how long a dead
+ * turn can hold memory.
+ */
+export const DEFAULT_STALLED_SESSION_MS = 30 * 60 * 1000
+
 interface SessionStateCacheLimits {
   maxBytes?: number
   maxCount?: number
+  /** Silence past which a busy/awaiting entry becomes an eviction candidate. */
+  stalledMs?: number
+  /** Injectable clock for deterministic tests. */
+  now?: () => number
 }
 
 interface SessionStateCacheCallbacks {
@@ -44,7 +59,13 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   readonly #callbacks: SessionStateCacheCallbacks
   readonly #maxBytes: number
   readonly #maxCount: number
+  readonly #stalledMs: number
+  readonly #now: () => number
   readonly #recency = new Map<string, number>()
+  // Last time each entry's state was replaced via set(). updateSessionState
+  // skips writes for unchanged states, so this is "last event activity" —
+  // reads must not count, or polling would keep dead sessions fresh forever.
+  readonly #mutations = new Map<string, number>()
   #clock = 0
 
   constructor(callbacks: SessionStateCacheCallbacks, limits: SessionStateCacheLimits = {}) {
@@ -52,6 +73,8 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
     this.#callbacks = callbacks
     this.#maxBytes = limits.maxBytes ?? DEFAULT_WARM_SESSION_TRANSCRIPT_BYTES
     this.#maxCount = limits.maxCount ?? DEFAULT_WARM_SESSION_TRANSCRIPT_COUNT
+    this.#stalledMs = limits.stalledMs ?? DEFAULT_STALLED_SESSION_MS
+    this.#now = limits.now ?? (() => Date.now())
   }
 
   override get(runtimeId: string): ClientSessionState | undefined {
@@ -67,22 +90,27 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   override set(runtimeId: string, state: ClientSessionState): this {
     super.set(runtimeId, state)
     this.#touch(runtimeId)
+    this.#mutations.set(runtimeId, this.#now())
 
     return this
   }
 
   override delete(runtimeId: string): boolean {
     this.#recency.delete(runtimeId)
+    this.#mutations.delete(runtimeId)
 
     return super.delete(runtimeId)
   }
 
   override clear(): void {
     this.#recency.clear()
+    this.#mutations.clear()
     super.clear()
   }
 
   prune(): void {
+    this.#evictStalled()
+
     const candidates: Array<{ bytes: number; runtimeId: string; state: ClientSessionState; touched: number }> = []
     let bytes = 0
 
@@ -122,6 +150,53 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
       bytes -= candidate.bytes
       this.#callbacks.onEvict(candidate.runtimeId, candidate.state)
     }
+  }
+
+  /**
+   * Orphaned mid-turn entries never satisfy #isWarmSettled, so they are
+   * invisible to the weighted LRU and would pin their transcripts forever.
+   * Unlike that sweep this one is unconditional — it exists to bound memory,
+   * not to serve it — but it keeps every protection that makes eviction safe:
+   * persisted sessions only, no drafts or in-flight messages, waits that are
+   * on the user rather than on a dead turn, and live references win.
+   */
+  #evictStalled(): void {
+    const stalled: Array<{ runtimeId: string; state: ClientSessionState }> = []
+
+    for (const [runtimeId, state] of this.entries()) {
+      if (this.#isStalled(runtimeId, state)) {
+        stalled.push({ runtimeId, state })
+      }
+    }
+
+    for (const candidate of stalled) {
+      // References and activity can change between detection and eviction.
+      const current = super.get(candidate.runtimeId)
+
+      if (current !== candidate.state || !this.#isStalled(candidate.runtimeId, current)) {
+        continue
+      }
+
+      super.delete(candidate.runtimeId)
+      this.#recency.delete(candidate.runtimeId)
+      this.#mutations.delete(candidate.runtimeId)
+      this.#callbacks.onEvict(candidate.runtimeId, candidate.state)
+    }
+  }
+
+  #isStalled(runtimeId: string, state: ClientSessionState): boolean {
+    const mutatedAt = this.#mutations.get(runtimeId)
+
+    return (
+      Boolean(state.storedSessionId) &&
+      (state.busy || state.awaitingResponse) &&
+      // A blocking prompt is waiting on a human, not on a dead turn.
+      !state.needsInput &&
+      !hasDraftOrInFlightMessage(state) &&
+      mutatedAt !== undefined &&
+      this.#now() - mutatedAt >= this.#stalledMs &&
+      !this.#callbacks.isReferenced(runtimeId, state)
+    )
   }
 
   #isWarmSettled(runtimeId: string, state: ClientSessionState): boolean {


### PR DESCRIPTION
## What Problem This Solves

Closes #95276 (the retention half).

**Scope narrowed per review** ([Halldrix's comment](https://github.com/NousResearch/hermes-agent/pull/95302#issuecomment-5425072474)): upstream #95495 (merged as `b455abe0b331`, commit `06be6cffbc`) has landed the deterministic orphan release for this cache — `SessionStateCache` now takes an optional `isAuthoritativelyActive` probe wired to `$sessionStates` by `use-session-state-cache`, so a mid-turn snapshot whose authoritative record settles or is retired stops pinning its transcript. This PR therefore **strips its overlapping orphan criterion** (`#evictOrphans` / `isPublishedRuntimeId` and its tests) instead of stacking a second eviction mechanism onto the same file.

What remains is the mechanism the probe does not cover: the **30-minute stall window** (`#evictStalled` + mutation-clock plumbing). Snapshots that are still busy/awaiting **and still published** keep failing `#isWarmSettled` forever — the probe returns true because the authoritative store keeps claiming work for their runtime id, yet no event will ever reach them:

- reconnect-reconcile leftovers that reconcile skipped by scope,
- turns that died before any reconnect ever ran,
- neighbors preserved through reconcile (e.g. alongside a `needsInput` row) whose runtime is never touched again.

`prune()` sweeps such entries first: still busy/awaiting whose state has not been replaced via `set()` past a conservative window (default 30 min, far beyond the five-minute session watchdog) become unconditional eviction candidates. Every existing safety property is preserved:

- persisted sessions only (`storedSessionId` required — eviction stays recoverable via server reload),
- unsaved drafts and in-flight (`pending`) messages are never touched,
- `needsInput` waits stay protected indefinitely (waiting on a human, not on a dead turn),
- live references (active session, selected session, open tiles) win over staleness,
- eviction re-validates state identity and staleness immediately before deleting (same race discipline as the LRU path), never throws, and routes through the same `onEvict` callback so ownership cleanup and `releaseSessionTranscript` run unchanged.

Activity is measured as "state replaced via `set()`" — `updateSessionState` skips writes when nothing changed, so heartbeats/polling cannot keep a dead entry fresh, while any real event (stream chunk, tool transition) resets the window and keeps legitimate long-running turns alive. The sweep is orthogonal to and composes cleanly with upstream's probe: unpublished orphans release deterministically at zero threshold; published-but-silent snapshots wait out the stall window.

## Evidence

- Rebased onto current `main` (`86ae906e88`, includes #95495). Red → green re-verified on that base: reverting only `session-state-cache.ts` while keeping the tests → **4 failed / 17 passed** (all four new stall-window bound tests fail, every pre-existing and upstream-probe test holds); restoring the fix → **21/21 passed**.
- Related session-state suites on the rebased head all green: `session-state-cache`, `use-session-state-cache`, and the six `store/session-states*` suites → **8 files / 126 tests passed**.
- Coverage pinned by the retained tests: silence past the window evicts even under no size pressure (pre-fix the cache keeps the entries forever); `busy`/`awaitingResponse` past the window evict while `needsInput` does not; a live turn survives repeated prunes while events keep arriving (each event resets the window) and is evicted only once silence outlasts it; drafts, pending messages, and referenced states survive even a zero-length window.
- `npm run typecheck` (renderer + electron + e2e projects) exits clean; eslint exits clean on the touched files (0 errors).
