### PR TITLE
feat(desktop): auto-grow Bot group composer

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -12245,7 +12245,12 @@ function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputPr
         // Input whose form submitted on every Enter — newlines were
         // impossible. Enter (no Shift) still submits via onSubmitDraft;
         // Shift+Enter falls through to the textarea's native newline.
-        className: cn('max-h-40 min-h-9 resize-none', inputProps.className),
+        // Grow with wrapped text/newlines so long briefs remain reviewable,
+        // then scroll internally before the composer takes over the room.
+        className: cn(
+          'field-sizing-content max-h-[min(50vh,24rem)] min-h-9 overflow-y-auto resize-none',
+          inputProps.className
+        ),
         onChange: event => {
           onChange(event.target.value)
           refreshToken(event.target)

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -31,6 +31,23 @@ test('room composer is a textarea with Enter=submit, Shift+Enter=newline (#89884
   assert.match(component, /insert\(options\[active\]\.handle\)/)
 })
 
+test('room composer grows with long prompts while preserving a bounded transcript', () => {
+  const start = source.indexOf('function GroupMentionInput')
+  const nextFn = source.indexOf('\nfunction ', start + 1)
+  const component = source.slice(start, nextFn)
+
+  // Start as one row, then let Chromium size the textarea from its content.
+  // A viewport-relative cap keeps the transcript usable; content beyond it
+  // scrolls inside the textarea rather than taking over the whole room.
+  const composerClass = /className: cn\(\s*'([^']*)',\s*inputProps\.className\s*\)/.exec(component)?.[1]
+
+  assert.ok(composerClass, 'composer class contract is present')
+  assert.match(component, /rows: 1/)
+  assert.match(composerClass, /field-sizing-content/)
+  assert.match(composerClass, /max-h-\[min\(50vh,24rem\)\]/)
+  assert.match(composerClass, /overflow-y-auto/)
+})
+
 test('room composer swallows IME composition Enters before submit/mention (#93528)', () => {
   // macOS Chinese IME: Enter that confirms a candidate word fires a keydown
   // the composer mistook for a send — the message went out mid-composition.


### PR DESCRIPTION
## What does this PR do?

Makes the Bot Mode group-room composer grow automatically as a prompt wraps or gains newlines, so longer briefs can be written and reviewed without scrolling through a one-row field.

The empty composer stays compact. Growth is bounded at `min(50vh, 24rem)`; longer content scrolls inside the textarea so the room transcript remains usable. The shared `GroupMentionInput` means this applies consistently to both new-thread and reply-in-thread composers.

Existing Enter-to-send, Shift+Enter newline, IME guards, @mention completion, attachments, and draft persistence are unchanged.

## Related Issue

Fixes #95300

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add content-based sizing to the shared Bot group composer.
- Cap the composer at half the viewport or 24rem and explicitly scroll overflow.
- Add a regression contract for the compact row, content sizing, bounded height, and overflow behavior.

## How to Test

1. Open Bots and enter a group room.
2. Type or paste a long, wrapped brief; confirm the composer grows beyond one row.
3. Add enough content to reach the cap; confirm the textarea scrolls internally and the transcript remains visible.
4. Confirm Enter sends, Shift+Enter inserts a newline, and repeat in a thread reply.

Automated verification:

```bash
cd apps/desktop
node --test src/plugins/hermes-bots/tests/group-room-ux.test.mjs
npm run check:test:plugins
npm run check:lint
npm run build
```

Results on Windows 11:

- Targeted group-room tests: 8/8 passed
- Desktop plugin suite: 568/568 passed
- TypeScript + ESLint: passed with existing warning baseline only
- Production desktop build: passed
- Generated production CSS contains the `field-sizing: content` and bounded max-height rules
- Independent pre-commit review: passed; no security or logic findings

## Checklist

### Code

- [x] I have read the Contributing Guide and repository Agent Rules
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I have run `pytest tests/ -q` (N/A: desktop-only renderer change)
- [x] I have added tests for my changes
- [x] I have tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; no public API or setting changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: standard CSS and existing Tailwind utility; no platform-specific code
- [x] Tool descriptions/schemas: N/A; no tool behavior changed

## Screenshots / Logs

No screenshot included. The production build and generated CSS were verified locally; CI can exercise the repository gates.