### PR TITLE
feat(mcp): add mainland China catalog integrations

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -277,6 +277,18 @@ def _parse_manifest(path: Path) -> CatalogEntry:
                 f"'{_required_key}' (the key the Authorization header references)"
             )
 
+    if t_type == "stdio":
+        # Process arguments are visible to same-host process inspection and may
+        # be captured by launcher diagnostics. Secrets must be delivered via
+        # transport.env instead of interpolated into argv.
+        for spec in env_list:
+            placeholder = "${" + spec.name + "}"
+            if spec.secret and any(placeholder in arg for arg in transport.args):
+                raise CatalogError(
+                    f"{path}: secret auth env '{spec.name}' must not appear in "
+                    "transport.args; pass it through transport.env"
+                )
+
     tools_raw = data.get("tools") or {}
     if not isinstance(tools_raw, dict):
         raise CatalogError(f"{path}: 'tools' must be a mapping")

--- a/optional-mcps/alibaba-cloud-openapi/manifest.yaml
+++ b/optional-mcps/alibaba-cloud-openapi/manifest.yaml
@@ -1,0 +1,70 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: alibaba-cloud-openapi
+description: Alibaba Cloud API discovery and documentation through the official OpenAPI MCP proxy.
+source: https://github.com/aliyun/alibabacloud-api-mcp-server
+
+# Official local stdio proxy to Alibaba Cloud's account-specific Streamable
+# HTTP service. v0.2.17 was released on 2026-08-07. The upstream-enforced
+# allowlist intentionally omits every execution, script, IaC, task, and
+# presigned-URL tool.
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - "alibabacloud.mcp-proxy==0.2.17"
+    - --site-type
+    - CN
+    - --allow-tools
+    - "AlibabaCloud___ListProducts,AlibabaCloud___ListApis,AlibabaCloud___GetApiDefinition,AlibabaCloud___SearchApis,AlibabaCloud___ListProductRegions,AlibabaCloud___GenerateCLICommand,AlibabaCloud___SearchDocuments,AlibabaCloud___GetDocument,AlibabaCloud___GetDocumentTree,AlibabaCloud___GrepDocuments"
+  version: "0.2.17"
+  env:
+    ALIBABA_CLOUD_ACCESS_KEY_ID: "${ALIBABA_CLOUD_ACCESS_KEY_ID}"
+    ALIBABA_CLOUD_ACCESS_KEY_SECRET: "${ALIBABA_CLOUD_ACCESS_KEY_SECRET}"
+
+auth:
+  type: api_key
+  env:
+    - name: ALIBABA_CLOUD_ACCESS_KEY_ID
+      prompt: "Alibaba Cloud RAM AccessKey ID"
+      required: true
+      secret: true
+    - name: ALIBABA_CLOUD_ACCESS_KEY_SECRET
+      prompt: "Alibaba Cloud RAM AccessKey Secret"
+      required: true
+      secret: true
+
+tools:
+  default_enabled:
+    - AlibabaCloud___ListProducts
+    - AlibabaCloud___ListApis
+    - AlibabaCloud___GetApiDefinition
+    - AlibabaCloud___SearchApis
+    - AlibabaCloud___ListProductRegions
+    - AlibabaCloud___GenerateCLICommand
+    - AlibabaCloud___SearchDocuments
+    - AlibabaCloud___GetDocument
+    - AlibabaCloud___GetDocumentTree
+    - AlibabaCloud___GrepDocuments
+
+suggest:
+  keywords:
+    - alibaba cloud
+    - aliyun
+    - 阿里云
+  hosts:
+    - aliyun.com
+    - alibabacloud.com
+
+post_install: |
+  Use a dedicated least-privilege RAM identity — never an Alibaba Cloud account
+  or root AccessKey. Initially attach only
+  `AliyunOpenAPIMCPServerStaticCredentialAccess`; business-product permissions
+  are unnecessary for this catalog entry's discovery/documentation surface.
+
+  This entry deliberately excludes CallCLI, RunScript, RunIaC, GetTask, and
+  GetPresignedUrl at the proxy itself. Create a separately reviewed advanced
+  configuration with RAM, safety, and boundary policies if execution is ever
+  required. The current Alibaba Cloud integration guide requires Python 3.13+.

--- a/optional-mcps/amap/manifest.yaml
+++ b/optional-mcps/amap/manifest.yaml
@@ -1,0 +1,59 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: amap
+description: Mainland China geocoding, POI search, weather, distance, and route planning with Amap (Gaode).
+source: https://lbs.amap.com/api/mcp-server/gettingstarted
+
+# Official vendor-hosted Streamable HTTP endpoint. Amap retired its legacy
+# SSE endpoint in March 2026. The Web Service key is required as a query
+# parameter; the ${...} placeholder keeps the literal secret out of config.
+transport:
+  type: http
+  url: "https://mcp.amap.com/mcp?key=${MCP_AMAP_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: MCP_AMAP_API_KEY
+      prompt: "Amap Web Service API key"
+      required: true
+      secret: true
+
+tools:
+  # The three maps_schema_* tools create Amap app handoff/deep links. Keep the
+  # default surface to data queries and route calculations; users can opt into
+  # navigation, taxi, and personal-map links with `hermes mcp configure amap`.
+  default_enabled:
+    - maps_direction_bicycling
+    - maps_direction_driving
+    - maps_direction_transit_integrated
+    - maps_direction_walking
+    - maps_distance
+    - maps_geo
+    - maps_regeocode
+    - maps_ip_location
+    - maps_around_search
+    - maps_search_detail
+    - maps_text_search
+    - maps_weather
+
+suggest:
+  keywords:
+    - amap
+    - gaode
+    - 高德
+    - 高德地图
+  hosts:
+    - amap.com
+
+post_install: |
+  Create an application in the Amap Open Platform and add a Key whose service
+  platform is "Web 服务" (Web Service), then provide that Key when prompted.
+  The credential is stored in the Hermes profile .env; config.yaml retains
+  only its placeholder.
+
+  Navigation, taxi, and personal-map handoff tools are disabled by default.
+  Enable them later with `hermes mcp configure amap` if needed, then start a
+  new Hermes session so the selected tools load.

--- a/optional-mcps/baidu-maps/manifest.yaml
+++ b/optional-mcps/baidu-maps/manifest.yaml
@@ -1,0 +1,53 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: baidu-maps
+description: Mainland China geocoding, POI search, routing, weather, and live traffic with Baidu Maps.
+source: https://lbsyun.baidu.com/faq/api?title=mcpserver/quickstart
+
+# Official vendor-hosted Streamable HTTP endpoint. The older /sse transport is
+# legacy. Baidu requires a server-side AK in the `ak` query parameter.
+transport:
+  type: http
+  url: "https://mcp.map.baidu.com/mcp?ak=${MCP_BAIDU_MAPS_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: MCP_BAIDU_MAPS_API_KEY
+      prompt: "Baidu Maps server-side AK"
+      required: true
+      secret: true
+
+tools:
+  # IP location is privacy-sensitive when called without an explicit IP, and
+  # POI extraction sends free-form text and requires an advanced-service
+  # entitlement. Both remain available through the tool picker.
+  default_enabled:
+    - map_geocode
+    - map_reverse_geocode
+    - map_search_places
+    - map_place_details
+    - map_directions_matrix
+    - map_directions
+    - map_weather
+    - map_road_traffic
+
+suggest:
+  keywords:
+    - baidu maps
+    - 百度地图
+  hosts:
+    - baidu.com
+    - map.baidu.com
+
+post_install: |
+  Create a server-side AK in the Baidu Maps Open Platform console, then provide
+  it when prompted. The credential is stored in the Hermes profile .env;
+  config.yaml retains only its placeholder.
+
+  `map_ip_location` and `map_poi_extract` are disabled by default for privacy
+  and entitlement reasons. Enable them with `hermes mcp configure baidu-maps`
+  if needed. Baidu's server uses BD-09 coordinates; do not mix them directly
+  with Amap's GCJ-02 coordinates.

--- a/optional-mcps/feishu/manifest.yaml
+++ b/optional-mcps/feishu/manifest.yaml
@@ -1,0 +1,76 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: feishu
+description: Feishu/Lark messages, documents, Base, contacts, and Wiki through the official OpenAPI MCP server.
+source: https://github.com/larksuite/lark-openapi-mcp
+
+# Official stdio package. v0.5.1 was released on 2025-08-06 and requires
+# Node.js 20+. Application identity is the conservative default; upstream's
+# interactive user OAuth mode is still marked beta.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - -y
+    - "@larksuiteoapi/lark-mcp@0.5.1"
+    - mcp
+    - --tools
+    - preset.light
+    - --tool-name-case
+    - snake
+    - --token-mode
+    - tenant_access_token
+  version: "0.5.1"
+  env:
+    APP_ID: "${APP_ID}"
+    APP_SECRET: "${APP_SECRET}"
+    LARK_DOMAIN: "${LARK_DOMAIN}"
+
+auth:
+  type: api_key
+  env:
+    - name: APP_ID
+      prompt: "Feishu/Lark application App ID"
+      required: true
+      secret: false
+    - name: APP_SECRET
+      prompt: "Feishu/Lark application App Secret"
+      required: true
+      secret: true
+    - name: LARK_DOMAIN
+      prompt: "Open Platform domain"
+      default: "https://open.feishu.cn"
+      required: true
+      secret: false
+
+tools:
+  # preset.light exposes three mutations (record creation, message sending,
+  # document import). Keep the default surface read-only.
+  default_enabled:
+    - bitable_v1_appTableRecord_search
+    - contact_v3_user_batchGetId
+    - docx_v1_document_rawContent
+    - im_v1_chat_search
+    - im_v1_message_list
+    - wiki_v2_space_getNode
+
+suggest:
+  keywords:
+    - feishu
+    - lark
+    - 飞书
+  hosts:
+    - feishu.cn
+    - larksuite.com
+
+post_install: |
+  Requires Node.js 20 or newer. Create the application in the platform matching
+  the configured domain: https://open.feishu.cn for mainland-China Feishu, or
+  https://open.larksuite.com for global Lark. Grant only the OpenAPI permissions
+  required by the enabled tools and publish/enable the app for the tenant.
+
+  The default uses tenant application identity and excludes record creation,
+  message sending, and document import. Enable write tools only deliberately
+  with `hermes mcp configure feishu`, then start a new Hermes session.

--- a/optional-mcps/tencent-cloudbase/manifest.yaml
+++ b/optional-mcps/tencent-cloudbase/manifest.yaml
@@ -1,0 +1,77 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: tencent-cloudbase
+description: Tencent CloudBase environments, databases, functions, storage, hosting, auth, and logs.
+source: https://github.com/TencentCloudBase/CloudBase-AI-Toolkit
+
+# Official stdio package. v2.26.0 was published on 2026-08-10 and is the newest
+# release satisfying the catalog's two-week stabilization floor on 2026-08-26.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - -y
+    - "@cloudbase/cloudbase-mcp@2.26.0"
+  version: "2.26.0"
+  env:
+    CLOUDBASE_API_KEY: "${CLOUDBASE_API_KEY}"
+    CLOUDBASE_ENV_ID: "${CLOUDBASE_ENV_ID}"
+    TCB_REGION: ap-shanghai
+
+auth:
+  type: api_key
+  env:
+    - name: CLOUDBASE_API_KEY
+      prompt: "CloudBase environment API key"
+      required: true
+      secret: true
+    - name: CLOUDBASE_ENV_ID
+      prompt: "CloudBase environment ID"
+      required: true
+      secret: false
+
+tools:
+  # Exact tools marked readOnlyHint=true by the pinned server. Read-only does
+  # not mean non-sensitive: database rows, logs, permissions, and object lists
+  # may still expose production data, so users should prune further as needed.
+  default_enabled:
+    - queryEnv
+    - readNoSqlDatabaseStructure
+    - readNoSqlDatabaseContent
+    - manageDataModel
+    - queryPgDatabase
+    - queryPgStorage
+    - queryMysqlDatabase
+    - queryFunctions
+    - queryHosting
+    - queryStorage
+    - searchKnowledgeBase
+    - queryCloudRun
+    - queryGateway
+    - queryAppAuth
+    - queryApps
+    - queryPermissions
+    - queryLogs
+    - queryAgents
+
+suggest:
+  keywords:
+    - cloudbase
+    - 云开发
+    - 腾讯云开发
+  hosts:
+    - cloud.tencent.com
+    - cloudbase.net
+
+post_install: |
+  Use a CloudBase environment-level API key and the matching environment ID.
+  The catalog defaults to the mainland-China `ap-shanghai` region and enables
+  only tools the pinned server labels read-only. Those tools may still reveal
+  sensitive database content, logs, identities, permissions, and object names;
+  narrow the selection with `hermes mcp configure tencent-cloudbase` for
+  production environments.
+
+  All mutating manage/write tools and the general `callCloudApi` escape hatch
+  are disabled by default. Start a new Hermes session after installation.

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -221,6 +221,32 @@ class TestManifestParsing:
         with pytest.raises(CatalogError, match="MCP_DEMO_API_KEY"):
             _parse_manifest(path)
 
+    def test_stdio_secret_placeholder_rejected_in_args(self, catalog_dir):
+        """Secrets must reach stdio servers through env, never process argv."""
+        body = _basic_manifest(
+            transport={
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "demo-mcp@1.0.0", "--secret", "${DEMO_SECRET}"],
+                "env": {"DEMO_SECRET": "${DEMO_SECRET}"},
+            },
+            auth={
+                "type": "api_key",
+                "env": [
+                    {
+                        "name": "DEMO_SECRET",
+                        "prompt": "secret",
+                        "secret": True,
+                    }
+                ],
+            },
+        )
+        path = _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import CatalogError, _parse_manifest
+
+        with pytest.raises(CatalogError, match="secret.*transport.args"):
+            _parse_manifest(path)
+
 
 
 


### PR DESCRIPTION
## Summary

- add official MCP catalog entries for Amap, Baidu Maps, Feishu/Lark, Alibaba Cloud OpenAPI, and Tencent CloudBase
- default each integration to a conservative read-only or discovery-only tool surface
- pin every local launcher to an exact release older than the catalog's two-week stabilization floor
- reject secret placeholders in stdio process arguments so credentials must flow through `transport.env`

## Security

- Feishu App Secret is passed only through the upstream-supported `APP_SECRET` environment variable, never argv
- Alibaba Cloud execution, script, IaC, task, and presigned-URL tools are blocked at the upstream proxy allowlist
- CloudBase mutating tools and the generic `callCloudApi` escape hatch are disabled by default
- Amap deep-link actions and Baidu privacy-sensitive/advanced tools are opt-in

## Verification

- `tests/hermes_cli/test_mcp_catalog.py`: 36 passed
- installed all five manifests end-to-end against an isolated `HERMES_HOME`
- live MCP tool discovery: Feishu 0.5.1 (9 tools), CloudBase 2.26.0 (39 tools)
- executed Alibaba Cloud proxy 0.2.17 and verified its allowlist CLI
- verified npm package versions and integrity metadata
- independent pre-commit security review passed with no findings

## Notes

WPS 365 and DingTalk were researched but intentionally not included: WPS lacks a generic catalog-ready endpoint/auth flow, while the current DingTalk package logs credential-bearing request data to stderr and is not reproducible from its public repository.
