### PR TITLE
fix(security): apply the sensitive-file guard to the fs preview endpoints

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3004,6 +3004,12 @@ async def fs_list(path: str):
 @app.get("/api/fs/read-text")
 async def fs_read_text(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    # Same #57505 sensitive-file guard as /api/fs/download three routes
+    # below: this is a read surface (full text of any resolvable path), and
+    # without the check an authenticated dashboard session can exfiltrate
+    # every credential store the guard exists to protect (#95303).
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     bytes_to_read = min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES)
@@ -3075,6 +3081,11 @@ async def fs_write_text(payload: FsWriteText):
 @app.get("/api/fs/read-data-url")
 async def fs_read_data_url(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    # Same #57505 guard as download/read-text: the data-URL form returns the
+    # WHOLE file base64-encoded (bypassing even the text-preview cap), so an
+    # unguarded route here is the strongest exfil surface of the three (#95303).
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     if st.st_size > _FS_DATA_URL_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     try:

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -77,6 +77,51 @@ def test_fs_download_rejects_sensitive_files(client, tmp_path):
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize("route", ["read-text", "read-data-url"])
+@pytest.mark.parametrize(
+    "sensitive_name", [".env", "auth.json", "config.yaml"]
+)
+def test_fs_read_previews_reject_sensitive_files(
+    client, tmp_path, route, sensitive_name
+):
+    """The two preview endpoints must enforce the same #57505 guard as
+    download — without it an authenticated session reads every credential
+    store as text or a whole-file base64 data URL (#95303)."""
+    target = tmp_path / sensitive_name
+    target.write_text("SECRET=1")
+
+    response = client.get(f"/api/fs/{route}", params={"path": str(target)})
+
+    assert response.status_code == 403
+
+
+def test_fs_read_previews_reject_credential_directory(client, tmp_path):
+    """Paths inside a credential directory (mcp-tokens) are sensitive by
+    component, not basename — both preview routes must 403."""
+    cred_dir = tmp_path / "mcp-tokens"
+    cred_dir.mkdir()
+    target = cred_dir / "server.json"
+    target.write_text("{}")
+
+    for route in ("read-text", "read-data-url"):
+        response = client.get(f"/api/fs/{route}", params={"path": str(target)})
+        assert response.status_code == 403, route
+
+
+def test_fs_read_previews_serve_ordinary_files(client, tmp_path):
+    """The guard must not block the normal spot-editor flow."""
+    target = tmp_path / "notes.md"
+    target.write_text("hello")
+
+    text_response = client.get("/api/fs/read-text", params={"path": str(target)})
+    url_response = client.get("/api/fs/read-data-url", params={"path": str(target)})
+
+    assert text_response.status_code == 200
+    assert text_response.json()["text"] == "hello"
+    assert url_response.status_code == 200
+    assert "aGVsbG8=" in url_response.json()["dataUrl"]
+
+
 def test_fs_endpoints_require_auth(tmp_path):
     client = TestClient(web_server.app)
     target = tmp_path / "secret.txt"

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -93,6 +93,10 @@ def test_fs_read_previews_reject_sensitive_files(
     response = client.get(f"/api/fs/{route}", params={"path": str(target)})
 
     assert response.status_code == 403
+    # Pin that the 403 comes from the sensitive-path guard itself, so a
+    # future refactor raising a different 403 (e.g. from _fs_path) can't
+    # silently pass this test.
+    assert "sensitive" in response.json()["detail"]
 
 
 def test_fs_read_previews_reject_credential_directory(client, tmp_path):


### PR DESCRIPTION
## What does this PR do?

`/api/fs/read-text` and `/api/fs/read-data-url` resolved any path through `_fs_path()` (any absolute path or `file://` URL) and returned its contents **without** the `_is_sensitive_path()` check their sibling `/api/fs/download` — introduced in the same file-surface family — enforces (#95303). The guard's own documented contract at `web_server.py` says these files "must never be listed, read, or downloaded through the … API", but only one of the three read surfaces checked. An authenticated dashboard session could read every credential store the guard exists to protect:

```
GET /api/fs/read-text?path=/home/u/.hermes/.env          → every API key as text
GET /api/fs/read-data-url?path=/home/u/.hermes/auth.json → whole OAuth store, base64
```

`read-data-url` is the strongest exfil surface of the three — it returns the whole file base64-encoded, bypassing even the text-preview cap. With the dashboard's supported OAuth-gated non-loopback bind, this turns a leaked browser-history entry or an XSS'd session token into full credential exfiltration. The report also notes the asymmetry is provably an oversight: the existing test suite asserts `.env` → 403 for `download` only, with no equivalent for either preview endpoint.

The fix routes both previews through the same `_is_sensitive_path()` guard exactly like `download`, and pins all three read surfaces with 403 tests (parametrized over `.env` / `auth.json` / `config.yaml` for both routes, the `mcp-tokens` credential-directory component case, and an ordinary-file pass-through so the spot-editor flow is unaffected) so the surfaces cannot drift apart again.

## Related Issue

Fixes #95303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `fs_read_text()` and `fs_read_data_url()` now raise 403 via `_is_sensitive_path(target)` right after `_fs_regular_file()` resolution, mirroring `fs_download()`; comments document the #57505 contract and the data-URL bypass rationale.
- `tests/hermes_cli/test_web_server_fs.py` — added `test_fs_read_previews_reject_sensitive_files` (2 routes × 3 sensitive basenames parametrized 403 pins), `test_fs_read_previews_reject_credential_directory` (mcp-tokens component case on both routes), and `test_fs_read_previews_serve_ordinary_files` (ordinary text file 200s on both routes, spot-editor flow intact).

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_web_server_fs.py -v` — should pass (13 passed).
2. Fail-on-main control: `git checkout HEAD~1 -- hermes_cli/web_server.py` and rerun the file — should fail (7 failed: all new 403 pins; the pre-existing tests including the download 403 pass on both sides), then restore. Observed result: `7 failed, 6 passed` pre-fix, `13 passed` post-fix.
3. Live check from the report: with an authenticated dashboard session, `GET /api/fs/read-text?path=<home>/.hermes/.env` and `GET /api/fs/read-data-url?path=<home>/.hermes/auth.json` should both return 403 "Access to sensitive files is not allowed", while an ordinary workspace text file still previews on both routes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open sensitive-path PRs cover managed-files writes, path-separator collapsing, symlink resolution, and ACP guards — none touch these two read endpoints)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the guard's docstring already documents the read-surface contract; the inline comments tie the endpoints to it)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is case-insensitive by basename and platform-agnostic on path components
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (HTTP route behavior only)
