### PR TITLE
fix(kanban): worker self-holds its claim on iteration-budget exhaustion (#95212)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -67,9 +67,16 @@ def _record_kanban_budget_exhausted(
     exhausted its iteration budget.
 
     This is a bounded fallback (#87096): the CAS invariant in ``_end_run``
-    (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
-    already closed the run this is a no-op — so it is safe to call from
-    multiple exit paths.
+    (``WHERE ended_at IS NULL``) plus the self-hold open-run guard guarantee
+    idempotence — if another path already recorded the failure this is a
+    no-op — so it is safe to call from multiple exit paths.
+
+    Since #95212 this runs INSIDE the still-live worker, so it records the
+    failure with ``hold_claim=True``: the unified counter ticks and the run
+    closes ``timed_out``, but the claim is deliberately kept — the task
+    stays ``running`` (undispatchable) until this process actually exits,
+    after which the dispatcher's reclaim chain releases it without spawning
+    a duplicate worker or re-counting the failure.
     """
     try:
         from hermes_cli import kanban_db as _kb
@@ -85,7 +92,8 @@ def _record_kanban_budget_exhausted(
                     "iterations"
                 ),
                 outcome="timed_out",
-                release_claim=True,
+                release_claim=False,
+                hold_claim=True,
                 end_run=True,
                 event_payload_extra={
                     "budget_used": api_call_count,

--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #95318 attribution

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8849,6 +8849,15 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def _run_metadata_flag(metadata_json: Optional[str], key: str) -> bool:
+    """True when a JSON-encoded ``task_runs.metadata`` carries truthy ``key``."""
+    try:
+        data = json.loads(metadata_json) if metadata_json else {}
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(data, dict) and bool(data.get(key))
+
+
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -8914,6 +8923,56 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 continue
 
             pid = int(row["worker_pid"])
+
+            # Budget-exhaustion self-hold (#95212): the worker accounted its
+            # own terminal failure and deliberately kept status='running'
+            # with the claim intact while it finished teardown. Its latest
+            # ended run carries the ``claim_hold`` marker. Releasing now is
+            # pure paperwork: restore the source phase WITHOUT re-accounting
+            # the failure (the unified counter already ticked when the
+            # worker held) and WITHOUT classifying the exit as a crash or a
+            # clean-exit protocol violation.
+            held_run = conn.execute(
+                "SELECT id, metadata FROM task_runs "
+                "WHERE task_id = ? AND ended_at IS NOT NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (row["id"],),
+            ).fetchone()
+            if held_run is not None and _run_metadata_flag(
+                held_run["metadata"], "claim_hold",
+            ):
+                held_retry_status = _retry_status_for_run(conn, row["id"])
+                cur = conn.execute(
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL "
+                    "WHERE id = ? AND status = 'running' "
+                    "  AND worker_pid = ? AND claim_lock IS ?",
+                    (held_retry_status, row["id"], pid, row["claim_lock"]),
+                )
+                if cur.rowcount == 1:
+                    _append_event(
+                        conn, row["id"], "budget_hold_reclaimed",
+                        {
+                            "pid": pid,
+                            "claimer": row["claim_lock"],
+                            "retry_status": held_retry_status,
+                            "prior_run_id": int(held_run["id"]),
+                            "prior_outcome": "timed_out",
+                        },
+                        run_id=int(held_run["id"]),
+                    )
+                    exited_hook_payloads.append({
+                        "task_id": row["id"],
+                        "assignee": row["assignee"],
+                        "run_id": int(held_run["id"]),
+                        "worker_pid": pid,
+                        "exit_kind": "budget_hold",
+                        "exit_code": None,
+                        "outcome": "timed_out",
+                        "retry_status": held_retry_status,
+                    })
+                continue
+
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
@@ -9158,6 +9217,7 @@ def _record_task_failure(
     failure_limit: int = None,
     force_trip: bool = False,
     release_claim: bool = False,
+    hold_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
@@ -9185,6 +9245,19 @@ def _record_task_failure(
       counter; if the breaker trips, the task is re-transitioned
       into ``blocked`` and a ``gave_up`` event is emitted.
 
+    * ``hold_claim=True`` — worker self-hold path (#95212). Caller is
+      the live worker itself recording ITS OWN terminal failure
+      (iteration-budget exhaustion). The failure is accounted exactly
+      like every other path (counter tick, run closed with
+      ``outcome``, breaker may trip to ``blocked``), but below
+      threshold the task STAYS ``running`` with its claim intact:
+      releasing your own claim from inside the process that holds it
+      re-advertises the task to the dispatcher while you are still
+      running, which spawns a duplicate worker beside you.
+      ``detect_crashed_workers`` releases the held claim once the pid
+      is actually gone (``budget_hold_reclaimed`` event), without
+      re-counting the failure.
+
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
     context (e.g. pid on crash, elapsed on timeout).
@@ -9206,6 +9279,12 @@ def _record_task_failure(
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
+    if release_claim and hold_claim:
+        raise ValueError(
+            "release_claim and hold_claim are mutually exclusive: "
+            "release hands the task back to its source phase now; "
+            "hold keeps it claimed until the worker's pid is gone"
+        )
     blocked = False
     with write_txn(conn):
         row = conn.execute(
@@ -9214,9 +9293,22 @@ def _record_task_failure(
         ).fetchone()
         if row is None:
             return False
+        if hold_claim and not conn.execute(
+            "SELECT 1 FROM tasks t JOIN task_runs r "
+            "ON r.id = t.current_run_id "
+            "WHERE t.id = ? AND t.status = 'running' "
+            "  AND r.ended_at IS NULL",
+            (task_id,),
+        ).fetchone():
+            # Self-hold idempotence (#95212): several exit paths can call
+            # this while the worker winds down, and unlike the spawn path
+            # the task STAYS ``running`` after the first call. Only a
+            # caller that still sees an open run accounts the failure;
+            # later callers must not tick ``consecutive_failures`` again.
+            return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
-            if release_claim
+            if (release_claim or hold_claim)
             else ("review" if row["status"] == "review" else "ready")
         )
         failures = int(row["consecutive_failures"]) + 1
@@ -9235,8 +9327,11 @@ def _record_task_failure(
 
         if force_trip or failures >= effective_limit:
             # Trip the breaker.
-            if release_claim:
-                # Spawn path: still running, also clear claim state.
+            if release_claim or hold_claim:
+                # Claimed-task exit (spawn failure, or the worker's own
+                # budget-exhaustion report): flip to blocked and clear the
+                # claim state. Blocked tasks are never dispatched, so
+                # clearing worker_pid here cannot spawn a duplicate.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
@@ -9294,6 +9389,31 @@ def _record_task_failure(
                     "WHERE id = ? AND status = 'running'",
                     (retry_status, failures, error[:500], task_id),
                 )
+            elif hold_claim:
+                # Self-hold (#95212): account the failure but keep the task
+                # running with its claim untouched — the caller IS the live
+                # worker, and clearing its own claim from inside its own
+                # process is what let the dispatcher spawn a duplicate
+                # beside it. Extend the claim window so TTL staleness can't
+                # fire mid-teardown; detect_crashed_workers releases the
+                # claim once the pid is actually gone (without re-counting
+                # this failure — see ``budget_hold_reclaimed``).
+                grace_expires = int(time.time()) + RECLAIM_DEFER_GRACE_SECONDS
+                conn.execute(
+                    "UPDATE tasks SET consecutive_failures = ?, "
+                    "last_failure_error = ?, claim_expires = ? "
+                    "WHERE id = ? AND status = 'running'",
+                    (failures, error[:500], grace_expires, task_id),
+                )
+                held_run = conn.execute(
+                    "SELECT current_run_id FROM tasks WHERE id = ?",
+                    (task_id,),
+                ).fetchone()
+                if held_run is not None and held_run["current_run_id"]:
+                    conn.execute(
+                        "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
+                        (grace_expires, int(held_run["current_run_id"])),
+                    )
             else:
                 # Timeout/crash path: caller already restored the source phase.
                 conn.execute(
@@ -9302,23 +9422,31 @@ def _record_task_failure(
                     (failures, error[:500], task_id),
                 )
             if end_run:
-                # Spawn path: close the open run with outcome.
+                # Spawn / self-hold path: close the open run with outcome.
+                run_meta = {
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if hold_claim:
+                    # Durable marker (#95212): tells detect_crashed_workers
+                    # that this run's failure is already accounted and the
+                    # leftover running claim is paperwork-only — release it
+                    # once the pid is gone, never re-account it.
+                    run_meta["claim_hold"] = True
+                    event_payload["claim_hold"] = True
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_meta,
                 )
                 _append_event(
-                    conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    conn, task_id, outcome, event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -1,5 +1,7 @@
 """Regression tests for iteration-limit exit normalization (#61631)."""
 
+import logging
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -190,7 +192,8 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
             "within the allowed iterations"
         ),
         outcome="timed_out",
-        release_claim=True,
+        release_claim=False,
+        hold_claim=True,
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
     )
@@ -271,7 +274,8 @@ def test_bounded_fallback_records_kanban_failure_when_interrupted(monkeypatch):
     args, kwargs = record.call_args
     assert args[1] == "task-456"
     assert kwargs["outcome"] == "timed_out"
-    assert kwargs["release_claim"] is True
+    assert kwargs["release_claim"] is False
+    assert kwargs["hold_claim"] is True
     assert kwargs["end_run"] is True
     assert kwargs["event_payload_extra"]["budget_used"] == 60
     assert kwargs["event_payload_extra"]["budget_max"] == 60
@@ -371,5 +375,61 @@ def test_bounded_fallback_does_not_fire_when_budget_not_exhausted(monkeypatch):
     )
 
     record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #95212 regression: the budget-exhaustion fallback runs INSIDE the still-
+# live worker. It must not release the worker's own claim (the old
+# ``release_claim=True`` spawn-failure mode flipped the task back to ready
+# and nulled worker_pid while the process kept running, so the dispatcher
+# spawned a duplicate worker beside it). End-to-end against a real DB.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB (mirrors test_kanban_db)."""
+    from hermes_cli import kanban_db as _kb
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _kb.init_db()
+    return home
+
+
+def test_budget_exhausted_finalizer_holds_live_workers_claim(kanban_home):
+    """While the worker process is alive, recording its own iteration-budget
+    exhaustion must leave the task running + claimed — NOT re-dispatchable."""
+    from agent.turn_finalizer import _record_kanban_budget_exhausted
+    from hermes_cli import kanban_db as _kb
+
+    with _kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = _kb.create_task(conn, title="budget-race", assignee="a")
+        assert _kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        _kb._set_worker_pid(conn, tid, os.getpid())  # live pid: our process
+
+    # Exactly what finalize_turn does when the iteration budget runs out.
+    _record_kanban_budget_exhausted(tid, 8, 8, logging.getLogger("test"))
+
+    with _kb.connect() as conn:
+        row = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "consecutive_failures FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "running", (
+            "pre-fix (#95212) this self-released to 'ready' while the "
+            f"worker was still alive; got {row['status']}"
+        )
+        assert row["claim_lock"] == f"{host}:worker"
+        assert row["claim_expires"] is not None
+        assert row["worker_pid"] == os.getpid()
+        # The failure itself is still accounted (#87096 taxonomy).
+        assert row["consecutive_failures"] == 1
+        # The dispatcher cannot spawn a duplicate for a running task.
+        assert _kb.claim_task(conn, tid) is None
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1792,3 +1792,49 @@ def test_detect_crashed_workers_releases_held_claim_without_recounting(
         assert "budget_hold_reclaimed" in kinds
         assert "crashed" not in kinds
         assert "protocol_violation" not in kinds
+
+
+def test_detect_crashed_workers_leaves_held_claim_while_pid_alive(
+    kanban_home, monkeypatch,
+):
+    """Direct counterpart to the release test: while the held worker's pid is
+    still ALIVE, ``detect_crashed_workers`` must not act on the held claim at
+    all — status/claim/pid stay exactly as the worker left them and no reclaim
+    event of any kind is appended."""
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="budget-hold-alive", assignee="a")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, tid, 424242)
+
+        kb._record_task_failure(conn, tid, **_hold_failure_kwargs())
+        held = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert held["status"] == "running"
+
+        crashed = kb.detect_crashed_workers(conn)
+
+        assert crashed == []
+        assert getattr(kb.detect_crashed_workers, "_last_rate_limited", []) == []
+        row = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "running"
+        assert row["claim_lock"] == f"{host}:worker"
+        assert row["claim_expires"] is not None
+        assert row["worker_pid"] == 424242
+        kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
+            ).fetchall()
+        ]
+        assert "budget_hold_reclaimed" not in kinds
+        assert "crashed" not in kinds
+        assert "protocol_violation" not in kinds

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1614,3 +1614,181 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Iteration-budget self-release race (#95212)
+#
+# The turn finalizer runs INSIDE the still-live worker. It used to record the
+# budget-exhaustion failure with ``release_claim=True`` — the spawn-failure
+# mode, only correct when NO process exists — nulling claim_lock /
+# claim_expires / worker_pid and flipping the task back to ``ready`` while its
+# own process kept running, so the dispatcher could spawn a duplicate worker
+# beside it. Now the worker SELF-HOLDS: the failure is accounted immediately
+# (#87096 taxonomy preserved), but status stays ``running`` with the claim
+# intact until the pid is actually gone; ``detect_crashed_workers`` then
+# releases the held claim WITHOUT re-counting the failure.
+# ---------------------------------------------------------------------------
+
+
+def _hold_failure_kwargs():
+    """Kwargs the turn finalizer passes for a budget-exhausted worker."""
+    return dict(
+        error=(
+            "Iteration budget exhausted (8/8) — task could not complete "
+            "within the allowed iterations"
+        ),
+        outcome="timed_out",
+        release_claim=False,
+        hold_claim=True,
+        end_run=True,
+    )
+
+
+def test_budget_self_hold_keeps_running_claim_intact(kanban_home):
+    """Hold mode accounts the failure but must NOT touch the claim: the task
+    stays running / undispatchable while the worker process is still alive."""
+    import json
+
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="budget-hold", assignee="a")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, tid, os.getpid())  # any live pid
+
+        blocked = kb._record_task_failure(conn, tid, **_hold_failure_kwargs())
+
+        row = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "consecutive_failures, last_failure_error "
+            "FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        # Claim preserved — nothing for the dispatcher to spawn onto.
+        assert row["status"] == "running", (
+            f"pre-fix this was 'ready' (self-released): {row['status']}"
+        )
+        assert row["claim_lock"] == f"{host}:worker"
+        assert row["claim_expires"] is not None
+        assert row["worker_pid"] == os.getpid()
+        # Failure accounted exactly once; run closed as timed_out.
+        assert row["consecutive_failures"] == 1
+        assert "Iteration budget exhausted" in (row["last_failure_error"] or "")
+        assert blocked is False
+        run = conn.execute(
+            "SELECT outcome, metadata FROM task_runs WHERE task_id = ?",
+            (tid,),
+        ).fetchone()
+        assert run["outcome"] == "timed_out"
+        assert json.loads(run["metadata"]).get("claim_hold") is True
+        # And a dispatcher tick cannot claim a running task.
+        assert kb.claim_task(conn, tid) is None
+
+
+def test_budget_self_hold_trips_breaker_to_blocked(kanban_home):
+    """When the unified counter reaches the limit, hold mode trips straight to
+    ``blocked`` — parked, undispatchable, no duplicate-worker window."""
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="budget-trip", assignee="a")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, tid, os.getpid())
+
+        blocked = kb._record_task_failure(
+            conn, tid, **_hold_failure_kwargs(), failure_limit=1,
+        )
+
+        assert blocked is True
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "blocked"
+        assert row["claim_lock"] is None
+        assert row["worker_pid"] is None
+
+
+def test_budget_self_hold_is_idempotent_across_exit_paths(kanban_home):
+    """Several exit paths can invoke the finalizer fallback while the worker
+    winds down; only the FIRST one may tick the failure counter."""
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="budget-idempotent", assignee="a")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, tid, os.getpid())
+
+        for _ in range(2):
+            kb._record_task_failure(conn, tid, **_hold_failure_kwargs())
+
+        row = conn.execute(
+            "SELECT consecutive_failures FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["consecutive_failures"] == 1
+        timed_out_events = conn.execute(
+            "SELECT kind FROM task_events "
+            "WHERE task_id = ? AND kind = 'timed_out'",
+            (tid,),
+        ).fetchall()
+        assert len(timed_out_events) == 1
+
+
+def test_hold_claim_and_release_claim_are_mutually_exclusive(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="mutex", assignee="a")
+        with pytest.raises(ValueError):
+            kb._record_task_failure(
+                conn, tid, error="x", outcome="crashed",
+                release_claim=True, hold_claim=True,
+            )
+
+
+def test_detect_crashed_workers_releases_held_claim_without_recounting(
+    kanban_home, monkeypatch,
+):
+    """Once the held worker's pid is actually gone, the reclaim chain restores
+    the source phase WITHOUT ticking ``consecutive_failures`` again (the
+    worker already accounted the failure) and without misclassifying the exit
+    as a crashed run or a clean-exit protocol violation."""
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    alive = {"value": True}
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: alive["value"])
+
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="budget-reclaim", assignee="a")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:worker") is not None
+        kb._set_worker_pid(conn, tid, 424242)
+
+        kb._record_task_failure(conn, tid, **_hold_failure_kwargs())
+        held = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert held["status"] == "running"
+
+        # The worker finishes teardown and exits.
+        alive["value"] = False
+        crashed = kb.detect_crashed_workers(conn)
+
+        assert crashed == []
+        assert getattr(kb.detect_crashed_workers, "_last_rate_limited", []) == []
+        row = conn.execute(
+            "SELECT status, claim_lock, claim_expires, worker_pid, "
+            "consecutive_failures FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "ready"
+        assert row["claim_lock"] is None
+        assert row["claim_expires"] is None
+        assert row["worker_pid"] is None
+        assert row["consecutive_failures"] == 1, (
+            "releasing a self-held claim must NOT double-count the failure"
+        )
+        kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
+            ).fetchall()
+        ]
+        assert "budget_hold_reclaimed" in kinds
+        assert "crashed" not in kinds
+        assert "protocol_violation" not in kinds

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4563,6 +4563,11 @@ class TestRunConversation:
         ``failure_limit`` breaker eventually trips. The legacy
         ``kanban_block`` call was replaced because blocked-outcome runs
         bypass the failure counter.
+
+        As of #95212 the worker records the failure in self-hold mode
+        (``hold_claim=True``): the counter still ticks, but the claim stays
+        held while the process finishes teardown instead of being released
+        from inside a still-running worker.
         """
         self._setup_agent(agent)
         agent.max_iterations = 2
@@ -4610,7 +4615,8 @@ class TestRunConversation:
         # Positional: (conn, task_id, ...)
         assert call.args[1] == "t_test_task_123"
         assert call.kwargs.get("outcome") == "timed_out"
-        assert call.kwargs.get("release_claim") is True
+        assert call.kwargs.get("release_claim") is False
+        assert call.kwargs.get("hold_claim") is True
         assert call.kwargs.get("end_run") is True
         assert "Iteration budget exhausted" in call.kwargs.get("error", "")
 


### PR DESCRIPTION
## Fix

A kanban worker that exhausted its iteration budget used to release **its own
claim** from inside its own still-running process: the turn finalizer called
`_record_task_failure(..., release_claim=True)` — the spawn-failure mode, which
is only correct when *no* process exists. That nulled `claim_lock`,
`claim_expires`, and `worker_pid` and flipped the task back to its source
phase while the worker kept executing (summary call, output, teardown), so the
dispatcher saw a legitimately free task and could spawn a duplicate worker on
the same task + workspace.

The reclaim paths got liveness protection in #21183 (`_worker_survived_termination`
→ `_defer_reclaim_for_live_worker`), but the self-release path never did — and
no termination is attempted there because the worker would have to stop itself.

### Approach: self-hold (account now, release only after pid death)

Preserving `worker_pid` alone (issue Option 1) does not close the window: the
spawn selector gates only on `status = 'ready' AND claim_lock IS NULL`
(`_dispatch_once_locked`, `claim_task`) and never consults `worker_pid`; the
pid-liveness machinery lives exclusively on the reclaim paths, which act on
`status = 'running'` rows. So the claim has to stay *held*:

- `_record_task_failure()` gains a `hold_claim=True` mode. The failure is
  accounted immediately — unified `consecutive_failures` counter ticks, the run
  closes with `outcome="timed_out"`, the breaker may trip straight to
  `blocked` (#87096 taxonomy preserved) — but below threshold the task stays
  `running` with its claim intact, hence undispatchable. The claim window is
  extended by `RECLAIM_DEFER_GRACE_SECONDS` so TTL staleness can't fire
  mid-teardown. Mutually exclusive with `release_claim` (raises `ValueError`);
  an open-run guard makes repeated calls from multiple exit paths idempotent.
- `detect_crashed_workers()` recognizes the held state via a durable
  `claim_hold` marker in the ended run's metadata and releases it once
  `_pid_alive(worker_pid)` is false — restoring the source phase with a
  `budget_hold_reclaimed` event **without** re-counting the failure and
  without misclassifying the exit as a crash or clean-exit protocol violation.
  This keeps the two retry budgets independent, as flagged in the issue thread.
- `agent/turn_finalizer.py` now records budget exhaustion with
  `release_claim=False, hold_claim=True`.

### Tests

Regression tests written red-first against unfixed `main` (the end-to-end one
reproduces the bug verbatim: `self-released to 'ready' while the worker was
still alive; got ready`):

- `tests/hermes_cli/test_kanban_db.py`: hold keeps a live worker's running
  claim intact (+ dispatcher cannot claim); breaker trip goes to `blocked`;
  idempotence across exit paths (counter ticks exactly once); `hold_claim` +
  `release_claim` mutual exclusion; `detect_crashed_workers` releases the held
  claim after pid death without double-counting or protocol-violation
  misclassification; and a direct counterpart asserting that while
  `_pid_alive(worker_pid)` is still True, `detect_crashed_workers` takes **no
  action** on the held claim — status/claim/pid untouched, no reclaim event of
  any kind appended.
- `tests/agent/test_turn_finalizer_iteration_limit_exit.py`: end-to-end test
  driving the real finalizer against a real DB; mock-contract assertions
  updated to the new kwargs.
- `tests/run_agent/test_run_agent.py::test_kanban_block_called_on_iteration_exhaustion`:
  updated from pinning `release_claim=True` (the bug) to the self-hold
  contract, keeping its original invariant that the failure counter advances.

Related suites (`pytest tests/hermes_cli/test_kanban*.py tests/gateway/test_kanban_reconcile_orphans.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/run_agent/test_run_agent.py`):
574 passed, 1 skipped on the local Windows worktree — every #95212
self-hold/release assertion passes; the remaining local failures are
pre-existing environment artifacts of this host (Unix-only reap-registry
wait-status encoding, the Windows `hermes.EXE` argv shim, worktree
materialization paths) and sit outside the self-hold path. No production
code changed since the reviewed revision, and CI on the current head is
fully green (check-attribution, common-ancestor, Python lints, Python tests
incl. Windows-only, e2e).

Canonical issue: #71175 ("[Bug]: iteration-budget exhaustion un-claims a LIVE
goal-mode Kanban worker; the dispatcher then spawns a second writer onto the
same worktree") is the root of this duplicate chain; #95212 was filed as its
duplicate and is kept below so both close with the fix.

Closes #71175
Closes #95212
