### PR TITLE
feat: add Volcengine Ark provider (火山方舟)

### DIFF
--- a/plugins/model-providers/volcengine-ark/README.md
+++ b/plugins/model-providers/volcengine-ark/README.md
@@ -1,0 +1,62 @@
+# Volcengine Ark Provider (火山方舟)
+
+This provider adds support for [Volcengine Ark](https://www.volcengine.com/product/ark), ByteDance's AI model platform.
+
+## Features
+
+- **Agent Plan Support**: Subscription-based access with dedicated endpoint (`/api/plan/v3`)
+- **Multiple Models**: Doubao (豆包), DeepSeek-V3.2, GLM-5.1, Kimi-K2.6, MiniMax-M2.7, and more
+- **OpenAI Compatible**: Full compatibility with OpenAI SDK and tool calling
+
+## Setup
+
+### 1. Get API Key
+
+1. Sign up at [Volcengine](https://www.volcengine.com/)
+2. Complete real-name authentication (实名认证)
+3. Subscribe to [Agent Plan](https://console.volcengine.com/ark/agent-plan)
+4. Create API Key at: 控制台 → API 密钥管理 → 创建 API Key
+
+### 2. Configure Hermes
+
+```bash
+# Set API key
+export VOLCENGINE_ARK_API_KEY="ark-your-key-here"
+
+# Or use hermes config
+hermes config set model.provider volcengine-ark
+hermes config set model.api_key "ark-your-key-here"
+hermes config set model.default "doubao-seed-1.6"  # or other model ID
+```
+
+### 3. Available Models
+
+Common model IDs (check your console for exact IDs):
+- `doubao-seed-1.6` - Doubao latest
+- `deepseek-v4-pro` - DeepSeek V4 Pro
+- `glm-5.2` - GLM 5.2 (latest)
+- `kimi-k2.6` - Kimi K2.6
+- `minimax-m2.7` - MiniMax M2.7
+
+## Agent Plan vs API
+
+- **Agent Plan**: Subscription-based, uses `/api/plan/v3` endpoint, AFP credit billing
+- **API**: Pay-per-use, uses `/api/v3` endpoint, token-based billing
+
+This provider defaults to Agent Plan endpoint. For API usage, override base_url:
+
+```bash
+hermes config set model.base_url "https://ark.cn-beijing.volces.com/api/v3"
+```
+
+## Troubleshooting
+
+- **Model not found**: Use exact model ID from your console (e.g., `ark-code-latest`)
+- **Authentication failed**: Verify API key starts with `ark-`
+- **Endpoint mismatch**: Agent Plan uses `/api/plan/v3`, not `/api/v3`
+
+## Links
+
+- [Product Page](https://www.volcengine.com/product/ark)
+- [Documentation](https://www.volcengine.com/docs/82379/1330310)
+- [API Reference](https://www.volcengine.com/docs/82379/1511946)

--- a/plugins/model-providers/volcengine-ark/__init__.py
+++ b/plugins/model-providers/volcengine-ark/__init__.py
@@ -1,0 +1,21 @@
+"""Volcengine Ark (火山方舟) provider profile.
+
+Supports both Agent Plan and API usage modes. Agent Plan uses a dedicated
+endpoint (/api/plan/v3) with subscription-based billing (AFP credits).
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+volcengine_ark = ProviderProfile(
+    name="volcengine-ark",
+    aliases=("volc-ark", "ark", "huoshan-ark", "doubao"),
+    display_name="Volcengine Ark (火山方舟)",
+    description="Volcengine Ark - Agent Plan & API access (Doubao, DeepSeek, GLM, Kimi, MiniMax)",
+    signup_url="https://www.volcengine.com/product/ark",
+    env_vars=("VOLCENGINE_ARK_API_KEY", "ARK_API_KEY"),
+    base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+    auth_type="api_key",
+)
+
+register_provider(volcengine_ark)


### PR DESCRIPTION
## Summary

This PR adds support for Volcengine Ark (火山方舟), ByteDance's AI model platform, as a built-in provider.

## Changes

- Added `plugins/model-providers/volcengine-ark/` with provider profile and README
- Supports both Agent Plan (subscription-based) and API (pay-per-use) modes
- OpenAI-compatible endpoint for full tool calling support
- Multiple models: Doubao, DeepSeek-V4, GLM-5.2, Kimi-K2.6, MiniMax-M2.7
- Environment variables: VOLCENGINE_ARK_API_KEY, ARK_API_KEY
- Aliases: volc-ark, ark, huoshan-ark, doubao

## Configuration

Users can configure via:

```bash
hermes config set model.provider volcengine-ark
hermes config set model.api_key "ark-your-key"
hermes config set model.default "doubao-seed-1.6"
```

## Testing

- Provider follows the same pattern as existing providers (alibaba, deepseek, etc.)
- Uses ProviderProfile from providers.base
- Registered via register_provider()

## Motivation

Volcengine Ark is a major Chinese AI platform offering multiple frontier models with subscription-based Agent Plan. Adding native support makes it easier for Chinese users to integrate without manual custom provider configuration.