### PR TITLE
fix(desktop): Bot Mode model picker always settles and stops remount churn (#95279)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8614,6 +8614,34 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
 
 // ── model picker (provider/model dropdowns via model.options) ───────────────
 
+// #95279: the picker's catalog read rides the BOT's own socket — a lazily
+// dialed second backend that can wedge (cold pool spawn, dropped remote hop)
+// without the primary socket ever noticing. An unbounded RPC there left the
+// query pending forever and the picker spinning ("never settles"). Bound every
+// attempt: past the budget the query rejects and ModelPicker falls back to its
+// free-text inputs instead of an eternal GlyphSpinner.
+const MODEL_OPTIONS_SETTLE_MS = 20000
+
+function boundedModelOptionsFetch(fetch, settleMs = MODEL_OPTIONS_SETTLE_MS) {
+  // window.setTimeout (not bare setTimeout): bare vm test harnesses expose
+  // timers only through the window shim. With no scheduler at all, degrade to
+  // the old unbounded behavior rather than not fetching.
+  const scope = typeof window === 'undefined' ? null : window
+
+  if (!scope || typeof scope.setTimeout !== 'function') {
+    return fetch
+  }
+
+  let timerId = null
+  const deadline = new Promise((_, reject) => {
+    timerId = scope.setTimeout(() => {
+      reject(new Error(`model.options did not answer within ${Math.round(settleMs / 1000)}s (#95279 settle guard)`))
+    }, settleMs)
+  })
+
+  return Promise.race([fetch, deadline]).finally(() => scope.clearTimeout(timerId))
+}
+
 function useModelOptions(bot = null) {
   // Hook body runs during render: an orphaned row must paint the picker
   // disabled/erroring, not throw into the pane's error boundary.
@@ -8623,11 +8651,18 @@ function useModelOptions(bot = null) {
 
   return useQuery({
     queryKey: [ID, 'model-options', route ? botRouteKey(route) : 'active'],
-    queryFn: () => requestForBot(bot, 'model.options', {
-      include_unconfigured: true,
-      explicit_only: false,
-      refresh: true
-    }),
+    // No forced `refresh`: forcing a network read on EVERY mount bypassed the
+    // staleTime cache, so each Bots view remount (tab re-front, dialog reopen,
+    // pane visibility flip) knocked the picker back into its loading state and
+    // discarded the user's staged selection mid-edit (#95279). The cached read
+    // still refreshes per staleTime like every other surface's catalog.
+    queryFn: () =>
+      boundedModelOptionsFetch(
+        requestForBot(bot, 'model.options', {
+          include_unconfigured: true,
+          explicit_only: false
+        })
+      ),
     enabled: !orphaned,
     staleTime: 120000,
     retry: false

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
@@ -222,6 +222,9 @@ test('Edit Profile model options use the captured non-identity Bot route', async
     'profile',
     remoteBot.route,
     'model.options',
-    { include_unconfigured: true, explicit_only: false, refresh: true }
+    // No `refresh`: the picker's catalog read participates in the staleTime
+    // cache — a forced network read on every mount re-entered the spinner and
+    // wiped staged selections on Bots view remounts (#95279).
+    { include_unconfigured: true, explicit_only: false }
   ]])
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/model-picker-settle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/model-picker-settle.test.mjs
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #95279 regression: the Bot Mode model picker's catalog read must always
+// SETTLE and must not churn the network on every surface remount.
+//
+// The picker's query rides the BOT's own socket (a second, lazily dialed pool
+// backend — exactly the Bots-only context of #95279). Two defects there left
+// the picker unusable while Bots was active:
+//
+//   1. The RPC promise had NO deadline. A wedged dial left it pending forever
+//      → the spinner never settled and the picker was dead ("model picker
+//      never settles").
+//   2. Every fetch forced `refresh: true`, bypassing react-query's cache, so
+//      each Bots view remount (tab re-front, dialog reopen, pane visibility
+//      flip) knocked the picker back into its loading state and discarded the
+//      staged selection mid-edit.
+//
+// These tests pin the contract: bounded settlement (reject → free-text
+// fallback) and a cached, unforced catalog read.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadPickerHarness({ requestProfile } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => values.set(slot, value),
+      listen: () => undefined
+    }
+    values.set(slot, initial)
+    return slot
+  }
+  const jsx = (type, props = {}) => ({ type, props })
+  const routed = []
+  let query
+  const stateValues = [true, false, '']
+  const context = {
+    atom,
+    Checkbox: 'Checkbox',
+    GlyphSpinner: 'GlyphSpinner',
+    Input: 'Input',
+    ScrollArea: 'ScrollArea',
+    Textarea: 'Textarea',
+    document: { createElement: () => ({}), getElementById: () => null, head: { appendChild: () => undefined } },
+    host: {
+      getGateway: () => 'ambient-gateway',
+      requestProfile: async (...args) => {
+        routed.push(args)
+
+        return requestProfile ? requestProfile(...args) : new Promise(() => {})
+      },
+      request: async (...args) => {
+        routed.push(['ambient', ...args])
+
+        return requestProfile ? requestProfile(...args) : new Promise(() => {})
+      },
+      state: {
+        gateway: { get: () => 'open', listen: () => undefined },
+        profile: { get: () => 'default', listen: () => undefined }
+      }
+    },
+    jsx,
+    jsxs: jsx,
+    queryClient: { invalidateQueries: () => undefined },
+    sdk: {},
+    useQuery: options => {
+      query = options
+
+      return { data: undefined, isLoading: false, error: null }
+    },
+    useState: initial => [stateValues.length ? stateValues.shift() : initial, () => undefined],
+    window: { setTimeout, clearTimeout }
+  }
+  const code = source
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__useModelOptions = useModelOptions;')
+  vm.runInNewContext(code, context, { filename: 'plugin.js' })
+
+  return { context, query: () => query, routed }
+}
+
+const remoteBot = {
+  connectionId: 'remote-a',
+  name: 'default',
+  remoteSource: true,
+  route: {
+    connectionId: 'remote-a',
+    mode: 'remote',
+    profile: 'default',
+    targetProfile: 'backend-default'
+  },
+  sourceScoped: true,
+  targetProfile: 'backend-default'
+}
+
+test('#95279: the picker catalog query settles when the bot gateway never answers', async t => {
+  // Fake clocks: tick past the settle budget without waiting real time. The
+  // harness captured the mocked setTimeout above (enable runs first).
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+
+  const runtime = loadPickerHarness({ requestProfile: () => new Promise(() => {}) })
+  runtime.context.__useModelOptions(remoteBot)
+  const query = runtime.query()
+
+  assert.equal(typeof query.queryFn, 'function')
+
+  let settled = false
+
+  query.queryFn().then(
+    () => {
+      settled = 'resolved'
+    },
+    () => {
+      settled = 'rejected'
+    }
+  )
+
+  // Past the settle budget the bounded fetch must have rejected (the picker
+  // then renders its free-text fallback). A macrotask boundary drains every
+  // microtask hop of the rejection chain before we look.
+  t.mock.timers.tick(30_000)
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(settled, 'rejected')
+})
+
+test('#95279: the picker catalog read is cached, not force-refreshed on every mount', async () => {
+  const runtime = loadPickerHarness({
+    requestProfile: async () => ({ providers: [{ models: ['m1'], name: 'Prov', slug: 'prov' }] })
+  })
+  runtime.context.__useModelOptions(remoteBot)
+  const query = runtime.query()
+
+  // Same bot + route ⇒ one stable cache key, so Bots view remounts reuse the
+  // fetched catalog instead of knocking the picker back into its spinner.
+  assert.deepEqual(query.queryKey[1], 'model-options')
+  assert.deepEqual(query.queryKey[2], 'remote-a::default')
+
+  const data = await query.queryFn()
+
+  assert.deepEqual(JSON.parse(JSON.stringify(data)), {
+    providers: [{ models: ['m1'], name: 'Prov', slug: 'prov' }]
+  })
+
+  // No forced refresh: the read participates in the staleTime cache. A forced
+  // refresh here is what made every remount re-enter the loading state and
+  // wipe the user's in-progress pick (#95279).
+  assert.deepEqual(JSON.parse(JSON.stringify(runtime.routed)), [
+    [remoteBot.route, 'model.options', { include_unconfigured: true, explicit_only: false }]
+  ])
+})
+
+test('#95279: picker query stays disabled for orphaned rows and keyed active for local bots', () => {
+  const runtime = loadPickerHarness()
+
+  // An orphaned row must not dispatch at all (renders free-text fallback).
+  runtime.context.__useModelOptions({ name: 'ghost', remoteSource: true })
+  const orphanQuery = runtime.query()
+  assert.equal(orphanQuery.enabled, false)
+
+  // A local (non source-scoped) bot reads the ambient gateway under the
+  // stable 'active' key.
+  runtime.context.__useModelOptions({ name: 'default' })
+  const localQuery = runtime.query()
+  assert.equal(localQuery.enabled, true)
+  assert.deepEqual(localQuery.queryKey[2], 'active')
+})


### PR DESCRIPTION
Partial: addresses the picker-settle half of #95279; the window-reload loop reported in the issue is a separate main-process defect and remains open

## What Problem This Solves

In the Bots section the model picker's provider/model catalog read (`useModelOptions` → `model.options`) had two defects that together made the picker unusable there while the Sessions chat stayed fine:

1. **The RPC promise could pend forever ("picker never settles").** The read rides the *bot's own* socket — a lazily dialed second backend that can wedge (cold pool spawn, dropped remote hop) without the primary socket noticing. Nothing bounded the call: no timeout on the gateway RPC, `retry: false`, so a wedged dial left `isLoading` true indefinitely and the picker spun forever.
2. **Every fetch forced `refresh: true`.** That bypasses react-query's `staleTime` cache entirely, so every Bots view remount — tab re-front (a close + re-open that REMOUNTS the whole Bots view), Edit/New dialog reopen, pane visibility flip, window focus churn — knocked the picker back into its loading state and discarded the user's staged provider/model selection mid-edit. The reporter already observed the symptom persist after trying exactly this removal locally; this change lands it together with the settle guarantee so the picker both settles once and stays settled.

## Evidence

- New regression suite `apps/desktop/src/plugins/hermes-bots/tests/model-picker-settle.test.mjs`, run against the unpatched plugin:
  - `#95279: the picker catalog query settles when the bot gateway never answers` — **failed pre-fix** (the query promise was still pending after the settle budget), passes post-fix (rejects through the new guard, so `ModelPicker` renders its free-text fallback instead of an eternal spinner).
  - `#95279: the picker catalog read is cached, not force-refreshed on every mount` — **failed pre-fix** (`refresh: true` still sent), passes post-fix (`{ include_unconfigured: true, explicit_only: false }`, stable `[ID, 'model-options', route]` cache key).
- `embed-skills-view.test.mjs` updated to pin the new cached-read params.
- Full plugin test suite (`npm run check:test:plugins`): **573 passed, 0 failed**.
- Related vitest suites (`model-menu-panel`, `model-catalog-menu`, `use-model-controls`): **42 passed, 0 failed**.
- `npm run typecheck`: **clean** (renderer, electron, e2e projects).

The fix keeps the orphaned-row behavior untouched (query stays disabled, free-text fallback) and degrades to the old unbounded behavior only when no timer scheduler exists (bare vm harnesses).
