### PR TITLE
fix(cli): reference in-scope desktop-presence flag in macOS update TCC notice (#95309)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7018,7 +7018,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # shows ON while macOS re-prompts on every capture, and the modern prompt
         # has no Allow button, so users loop. One line of guidance after update
         # tells affected users how to complete the one-time re-grant.
-        if sys.platform == "darwin" and has_desktop_app:
+        if sys.platform == "darwin" and had_desktop_app_before_update:
             print()
             print(
                 "  ℹ macOS: if Hermes re-prompts for permissions you already "

--- a/tests/hermes_cli/test_update_darwin_tcc_notice_scope.py
+++ b/tests/hermes_cli/test_update_darwin_tcc_notice_scope.py
@@ -1,0 +1,47 @@
+"""Regression guard for #95309: the macOS TCC stale-grant notice must use an
+in-scope variable.
+
+``hermes update`` crashed at the very end of a *successful* macOS update with
+``NameError: name 'has_desktop_app' is not defined``. The update itself
+completed (``✓ Code updated!`` was printed) but the command then exited via
+traceback, silently skipping every post-update step (state.db integrity check,
+model-catalog cache seed, bundled-skills sync).
+
+Root cause: ``has_desktop_app`` is a *local* of ``_rebuild_desktop_after_update``;
+the macOS TCC-notice block in ``_cmd_update_impl`` referenced it out of scope.
+The intended variable, ``had_desktop_app_before_update``, is a genuine local of
+``_cmd_update_impl`` (and is exactly the flag the notice needs — "a desktop app
+was present before the update, so its re-signed bundle may hold a stale grant").
+
+These are bytecode-scope invariants rather than a full drive of the update
+pipeline: the crashing line only runs after git-pull + web/desktop rebuild on
+darwin, which is impractical to stub end-to-end, whereas the defect is purely a
+name-resolution boundary that ``co_names`` / ``co_varnames`` pin exactly.
+"""
+
+import hermes_cli.update_cmd as update_mod
+
+
+def test_cmd_update_impl_never_references_out_of_scope_has_desktop_app():
+    """``has_desktop_app`` is defined only inside the rebuild helper. If it
+    appears in ``_cmd_update_impl``'s ``co_names`` it is being looked up as a
+    global/free name — an unavoidable ``NameError`` on the darwin path."""
+    code = update_mod._cmd_update_impl.__code__
+    assert "has_desktop_app" not in code.co_names, (
+        "_cmd_update_impl references `has_desktop_app`, a local of "
+        "_rebuild_desktop_after_update; use `had_desktop_app_before_update` "
+        "(an actual local of _cmd_update_impl). See #95309."
+    )
+
+
+def test_cmd_update_impl_owns_the_intended_presence_flag():
+    """The correct, in-scope flag must be a real local of the update command."""
+    code = update_mod._cmd_update_impl.__code__
+    assert "had_desktop_app_before_update" in code.co_varnames
+
+
+def test_rebuild_helper_still_owns_has_desktop_app():
+    """Sanity: ``has_desktop_app`` legitimately lives in the rebuild helper, so
+    the guard above asserts a real scoping boundary, not a renamed symbol."""
+    code = update_mod._rebuild_desktop_after_update.__code__
+    assert "has_desktop_app" in code.co_varnames


### PR DESCRIPTION
## What

Fixes #95309 — `hermes update` crashed at the very end of a **successful** macOS update with:

```
NameError: name 'has_desktop_app' is not defined
```

The update finished (`✓ Code updated!` printed) but then exited via traceback, silently skipping the post-update steps (state.db integrity check, model-catalog cache seed, bundled-skills sync). Reproducible on every darwin update because the failing line is unconditional on darwin.

## Root cause

`has_desktop_app` is a **local of `_rebuild_desktop_after_update()`** (`hermes_cli/update_cmd.py:5772`). The macOS TCC stale-grant notice in `_cmd_update_impl` referenced it out of scope:

```python
if sys.platform == "darwin" and has_desktop_app:   # NameError
```

Introduced by `36c1755065`.

## Fix

Use `had_desktop_app_before_update` — a genuine local of `_cmd_update_impl` (`:6108`) that already gates the desktop rebuild call a few lines above. It is exactly the condition the notice needs: a desktop bundle was present before the update, so its re-signed bundle may carry a stale TCC grant.

```python
if sys.platform == "darwin" and had_desktop_app_before_update:
```

One line; behavior on non-desktop and non-darwin installs is unchanged.

## Tests

`tests/hermes_cli/test_update_darwin_tcc_notice_scope.py` adds bytecode-scope guards:

- `_cmd_update_impl` must not reference `has_desktop_app` as a free/global name (`co_names`) — the exact NameError signature.
- `had_desktop_app_before_update` must be a real local of `_cmd_update_impl`.
- `has_desktop_app` still belongs to `_rebuild_desktop_after_update` (asserts a real scoping boundary, not a rename).

I verified these fail against `upstream/main` (pre-fix: `_cmd_update_impl` references `has_desktop_app`, never assigns it) and pass with the fix. The full drive to the crashing line runs only after git-pull + web/desktop rebuild on darwin, which is impractical to stub end-to-end; the defect is purely a name-resolution boundary, which the bytecode invariants pin exactly. Existing `test_update_*` suites remain green.
