### PR TITLE
feat(memory): add PLUR bundled memory provider — local-first engram memory with BM25+embedding retrieval

### DIFF
--- a/plugins/memory/plur/README.md
+++ b/plugins/memory/plur/README.md
@@ -1,0 +1,75 @@
+# PLUR Memory Provider
+
+Local-first persistent memory via the PLUR engram system. Corrections, preferences, and patterns survive across sessions, tools, and machines — stored as plain YAML on disk, searched with BM25 + BGE embeddings (Reciprocal Rank Fusion), synced via git. Zero API calls, zero cloud required.
+
+## Requirements
+
+**CLI** (required):
+```bash
+npm install -g @plur-ai/cli
+# or: npx @plur-ai/cli --version (to verify)
+```
+
+**Python package** (installed automatically by `hermes memory setup`):
+```bash
+pip install 'plur-hermes>=0.18.1'
+```
+
+## Setup
+
+```bash
+hermes memory setup    # select "plur" from the picker
+```
+
+Or manually:
+```bash
+hermes config set memory.provider plur
+```
+
+## Config
+
+| Env Var | Required | Default | Description |
+|---------|----------|---------|-------------|
+| `PLUR_PATH` | No | `~/.plur` | Path to your engram store |
+| `PLUR_INJECT_MODE` | No | `fast` | `fast` (BM25-only) or `hybrid` (BM25+embeddings) |
+| `PLUR_INJECTION_FEEDBACK` | No | `true` | Auto-send relevance feedback after each turn |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `plur_learn` | Create a new engram — store a correction, preference, or pattern |
+| `plur_recall` | Search engrams by topic (BM25 or hybrid) |
+| `plur_inject` | Get relevant engrams for a task (three-tier output) |
+| `plur_list` | List all engrams with optional filtering |
+| `plur_forget` | Retire an engram by ID or search query |
+| `plur_feedback` | Rate an engram (positive/negative/neutral) |
+| `plur_capture` | Record an episode to the timeline |
+| `plur_timeline` | Query the episodic timeline |
+| `plur_status` | Check PLUR system health and engram count |
+| `plur_sync` | Cross-device sync via git |
+| `plur_ingest` | Extract and save engrams from text or conversation logs |
+| `plur_packs_list` | List installed engram packs |
+| `plur_packs_install` | Install an engram pack |
+| `plur_packs_export` | Export engrams as a shareable pack |
+| `plur_promote` | Increase an engram's activation and priority |
+| `plur_stores_add` | Add a knowledge store path |
+| `plur_stores_list` | List configured knowledge stores |
+| `plur_similarity_search` | Search by cosine similarity with scores |
+
+## How it works
+
+PLUR implements the full Hermes MemoryProvider lifecycle:
+
+- **`prefetch(query)`** — injects relevant engrams before each turn using the fast BM25 path (switch to hybrid with `PLUR_INJECT_MODE=hybrid`)
+- **`sync_turn(user, assistant)`** — auto-extracts learnings from self-reported corrections; sends relevance feedback for injected engrams
+- **`on_session_end(messages)`** — captures the session as an episode at real session boundaries (not per-turn)
+- **`system_prompt_block()`** — adds a brief "N engrams active" status line to the system prompt
+
+Engram activation follows the ACT-R model: frequently recalled and recently used engrams surface first; irrelevant ones decay over time.
+
+## Links
+
+- [PLUR on GitHub](https://github.com/plur-ai/plur)
+- [PyPI: plur-hermes](https://pypi.org/project/plur-hermes/)
+- [npm: @plur-ai/cli](https://www.npmjs.com/package/@plur-ai/cli)

--- a/plugins/memory/plur/__init__.py
+++ b/plugins/memory/plur/__init__.py
@@ -1,0 +1,109 @@
+"""PLUR memory plugin — bundled MemoryProvider interface.
+
+Local-first persistent memory via the PLUR engram system. Stores knowledge
+as typed engrams on disk (plain YAML), searches with BM25 + BGE embeddings
+(Reciprocal Rank Fusion), and syncs across machines via git. Zero API calls,
+zero cloud required.
+
+Requires: ``plur-hermes>=0.18.1`` (pip) + ``plur`` CLI (npm install -g @plur-ai/cli).
+
+Config via environment variables:
+  PLUR_PATH          — path to engram store (default: ~/.plur)
+  PLUR_INJECT_MODE   — "fast" (BM25-only, default) or "hybrid" (BM25+embeddings)
+  PLUR_INJECTION_FEEDBACK — "true" (default) to send relevance feedback after each turn
+
+Config via config.yaml:
+  memory:
+    provider: plur
+    plur:
+      plur_path: ""        # override PLUR_PATH
+      plur_inject_mode: fast  # "fast" or "hybrid"
+
+Tools exposed to the model: plur_learn, plur_recall, plur_inject, plur_list,
+plur_forget, plur_feedback, plur_capture, plur_timeline, plur_status,
+plur_sync, plur_ingest, plur_packs_list, plur_packs_install, plur_packs_export,
+plur_promote, plur_stores_add, plur_stores_list, plur_similarity_search (18 total).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+try:
+    from plur_hermes.memory_provider import PlurMemoryProvider as _PlurMemoryProvider
+    _PLUR_HERMES_AVAILABLE = True
+except ImportError:
+    _PLUR_HERMES_AVAILABLE = False
+    _PlurMemoryProvider = None  # type: ignore[assignment,misc]
+
+
+class PlurProvider(MemoryProvider):
+    """Bundled PLUR memory provider for Hermes.
+
+    Thin wrapper around ``plur_hermes.memory_provider.PlurMemoryProvider``
+    that satisfies the Hermes bundled-plugin discovery contract.  The full
+    implementation lives in plur-hermes so it is shared between this bundled
+    path and the pip entry-point path (``hermes_agent.memory_providers``).
+
+    When ``plur-hermes`` is installed alongside this plugin, both paths are
+    mutually compatible and may run in the same process.  The bundled path
+    takes precedence (bundled > user > project > entry-point per the memory
+    plugin discovery order), so users who install plur-hermes separately will
+    land here when this provider is selected via config.
+    """
+
+    name = "plur"
+
+    def __init__(self) -> None:
+        if not _PLUR_HERMES_AVAILABLE:
+            raise ImportError(
+                "plur-hermes is not installed. "
+                "Run: pip install 'plur-hermes>=0.18.1'"
+            )
+        self._impl: _PlurMemoryProvider = _PlurMemoryProvider()  # type: ignore[misc]
+
+    # -- Delegation to PlurMemoryProvider ------------------------------------
+
+    def is_available(self) -> bool:
+        return self._impl.is_available()
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._impl.initialize(session_id, **kwargs)
+
+    def system_prompt_block(self) -> str:
+        return self._impl.system_prompt_block()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        return self._impl.prefetch(query, session_id=session_id)
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._impl.sync_turn(
+            user_content,
+            assistant_content,
+            session_id=session_id,
+            messages=messages,
+        )
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        self._impl.on_session_end(messages)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return self._impl.get_tool_schemas()
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        return self._impl.handle_tool_call(tool_name, args, **kwargs)
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return self._impl.get_config_schema()
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        self._impl.save_config(values, hermes_home)

--- a/plugins/memory/plur/plugin.yaml
+++ b/plugins/memory/plur/plugin.yaml
@@ -1,0 +1,9 @@
+name: plur
+version: 0.18.1
+description: "PLUR — local-first persistent memory with engrams, BM25+embedding retrieval, and cross-device git sync."
+pip_dependencies:
+  - plur-hermes>=0.18.1
+external_dependencies:
+  - name: plur CLI
+    install: "npm install -g @plur-ai/cli"
+    check: "plur --version"


### PR DESCRIPTION
## Summary

Adds PLUR as a bundled Hermes memory provider under `plugins/memory/plur/`.

PLUR is a local-first persistent memory system for AI agents — no API keys, no cloud, no external services. Knowledge is stored as **engrams** (plain YAML on disk), retrieved via BM25 + BGE-small-en-v1.5 embeddings (RRF fusion), and synced across machines via git. Activation follows the ACT-R cognitive model: frequently used engrams surface first; irrelevant ones decay.

```bash
hermes memory setup          # select "plur" from the picker
# or
hermes config set memory.provider plur
```

## What's in this PR

| File | Purpose |
|------|---------|
| `plugins/memory/plur/plugin.yaml` | Plugin declaration — version, pip/CLI deps |
| `plugins/memory/plur/__init__.py` | `PlurProvider` — thin wrapper delegating to `plur_hermes.memory_provider.PlurMemoryProvider` |
| `plugins/memory/plur/README.md` | Setup, config, tool reference |

### Why a thin wrapper?

The full MemoryProvider implementation lives in [`plur-hermes`](https://pypi.org/project/plur-hermes/) (`PlurMemoryProvider`) so it is shared between:
1. **This bundled path** — discovered by plugin scanner, activated via `memory.provider: plur`
2. **The pip entry-point path** — `hermes_agent.memory_providers` entry point, auto-registers when `plur-hermes` is installed

Both paths are mutually compatible. The bundled path takes precedence (per memory plugin discovery order).

## MemoryProvider lifecycle

| Hook | Behaviour |
|------|-----------|
| `prefetch(query)` | BM25-fast engram injection before each turn; switches to hybrid (BM25+embeddings) via `PLUR_INJECT_MODE=hybrid` |
| `sync_turn(user, asst)` | Auto-extracts learnings from self-reported corrections; sends positive/negative relevance feedback for injected engrams |
| `on_session_end(messages)` | Captures session episode at real session boundary (not per-turn) |
| `system_prompt_block()` | Brief "N engrams active — use plur_recall / plur_learn" status line |
| `get_tool_schemas()` | 18 PLUR tools exposed to MemoryManager |
| `handle_tool_call(name, args)` | Dispatches to PlurBridge methods |

## Tools exposed to the model (18)

`plur_learn`, `plur_recall`, `plur_inject`, `plur_list`, `plur_forget`, `plur_feedback`, `plur_capture`, `plur_timeline`, `plur_status`, `plur_sync`, `plur_ingest`, `plur_packs_list`, `plur_packs_install`, `plur_packs_export`, `plur_promote`, `plur_stores_add`, `plur_stores_list`, `plur_similarity_search`

## Config

| Env Var | Default | Description |
|---------|---------|-------------|
| `PLUR_PATH` | `~/.plur` | Engram store location |
| `PLUR_INJECT_MODE` | `fast` | `fast` (BM25) or `hybrid` (BM25+embeddings, ~2s) |
| `PLUR_INJECTION_FEEDBACK` | `true` | Auto-send relevance feedback per turn |

## Requirements

- **pip**: `plur-hermes>=0.18.1` (listed in `pip_dependencies` — `hermes memory setup` installs automatically)
- **CLI**: `npm install -g @plur-ai/cli` (local search engine + sync)

## Testing

The plur-hermes test suite covers the MemoryProvider ABC contract (40+ tests): [packages/hermes/test/test_memory_provider.py](https://github.com/plur-ai/plur/blob/feat/measured-under-869/packages/hermes/test/test_memory_provider.py)

Bundled plugin smoke test:
```python
from plugins.memory.plur import PlurProvider
p = PlurProvider()
assert p.name == "plur"
assert isinstance(p.get_tool_schemas(), list)
assert len(p.get_tool_schemas()) == 18
```

## Links

- plur-ai/plur PR (v0.18.1): https://github.com/plur-ai/plur/pull/981
- PyPI: https://pypi.org/project/plur-hermes/
- GitHub: https://github.com/plur-ai/plur