### PR TITLE
fix(tui): preserve text selection while streaming

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -811,6 +811,7 @@ export default class Ink {
       terminalWidth,
       terminalRows,
       altScreen: this.altScreenActive,
+      freezeScrollFollow: this.altScreenActive && (this.selection.isDragging || hasSelection(this.selection)),
       prevFrameContaminated: this.prevFrameContaminated
     })
 

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -443,6 +443,7 @@ function renderNodeToOutput(
     prevScreen,
     skipSelfBlit = false,
     inheritedBackgroundColor,
+    freezeScrollFollow = false,
     visibleX1 = 0,
     visibleX2 = output.width,
     visibleY1 = 0,
@@ -458,6 +459,7 @@ function renderNodeToOutput(
     // opaque descendants' narrower rects are safe to blit.
     skipSelfBlit?: boolean
     inheritedBackgroundColor?: Color
+    freezeScrollFollow?: boolean
     visibleX1?: number
     visibleX2?: number
     visibleY1?: number
@@ -896,7 +898,7 @@ function renderNodeToOutput(
           node.pendingScrollDelta = undefined
         }
 
-        const atBottom = sticky || (grew && scrollTopBeforeCompensation >= prevMaxScroll)
+        const atBottom = !freezeScrollFollow && (sticky || (grew && scrollTopBeforeCompensation >= prevMaxScroll))
 
         if (atBottom && (node.pendingScrollDelta ?? 0) >= 0) {
           node.scrollTop = maxScroll
@@ -1194,6 +1196,7 @@ function renderNodeToOutput(
                 edgeTop - contentY,
                 edgeBottom - contentY,
                 boxBackgroundColor,
+                freezeScrollFollow,
                 true,
                 repairX,
                 repairX + repairWidth,
@@ -1347,6 +1350,7 @@ function renderNodeToOutput(
                     offsetY: contentY,
                     prevScreen: undefined,
                     inheritedBackgroundColor: boxBackgroundColor,
+                    freezeScrollFollow,
                     visibleX1: repairChildX,
                     visibleX2: repairChildRight,
                     visibleY1: repairChildTop,
@@ -1407,6 +1411,7 @@ function renderNodeToOutput(
                 shiftedTop - contentY,
                 shiftedBottom - contentY,
                 boxBackgroundColor,
+                freezeScrollFollow,
                 true,
                 repairOverlayX,
                 repairOverlayRight,
@@ -1456,6 +1461,7 @@ function renderNodeToOutput(
               scrollTop,
               scrollTop + innerHeight,
               boxBackgroundColor,
+              freezeScrollFollow,
               false,
               childVisibleX1,
               childVisibleX2,
@@ -1526,6 +1532,7 @@ function renderNodeToOutput(
           // on re-render → /permissions body blanked on Down arrow, #25436).
           ownBackgroundColor || node.style.opaque ? undefined : prevScreen,
           boxBackgroundColor,
+          freezeScrollFollow,
           childVisibleX1,
           childVisibleX2,
           childVisibleY1,
@@ -1550,6 +1557,7 @@ function renderNodeToOutput(
         hasRemovedChild,
         prevScreen,
         inheritedBackgroundColor,
+        freezeScrollFollow,
         activeVisibleX1,
         activeVisibleX2,
         activeVisibleY1,
@@ -1605,6 +1613,7 @@ function renderChildren(
   hasRemovedChild: boolean,
   prevScreen: Screen | undefined,
   inheritedBackgroundColor: Color | undefined,
+  freezeScrollFollow: boolean,
   visibleX1: number,
   visibleX2: number,
   visibleY1: number,
@@ -1627,6 +1636,7 @@ function renderChildren(
       skipSelfBlit:
         seenDirtyClipped && isAbsolute && !childElem.style.opaque && childElem.style.backgroundColor === undefined,
       inheritedBackgroundColor,
+      freezeScrollFollow,
       visibleX1,
       visibleX2,
       visibleY1,
@@ -1777,6 +1787,7 @@ function renderScrolledChildren(
   scrollTopY: number,
   scrollBottomY: number,
   inheritedBackgroundColor: Color | undefined,
+  freezeScrollFollow: boolean,
   // When true (DECSTBM fast path), culled children keep their cache —
   // the blit+shift put stable rows in next.screen so stale cache is
   // never read. Avoids walking O(total_children * subtree_depth) per frame.
@@ -1860,6 +1871,7 @@ function renderScrolledChildren(
       offsetY,
       prevScreen: hasRemovedChild || seenDirtyChild ? undefined : prevScreen,
       inheritedBackgroundColor,
+      freezeScrollFollow,
       visibleX1,
       visibleX2,
       visibleY1: Math.max(visibleY1, offsetY + scrollTopY),

--- a/ui-tui/packages/hermes-ink/src/ink/renderer.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/renderer.ts
@@ -21,6 +21,10 @@ export type RenderOptions = {
   terminalWidth: number
   terminalRows: number
   altScreen: boolean
+  // Keep sticky scrollboxes fixed while the user is selecting text. Without
+  // this, streaming output moves the selection off-screen before it can be
+  // copied.
+  freezeScrollFollow: boolean
   // True when the previous frame's screen buffer was mutated post-render
   // (selection overlay), reset to blank (alt-screen enter/resize/SIGCONT),
   // or reset to 0×0 (forceRedraw). Blitting from such a prevScreen would
@@ -120,6 +124,7 @@ export default function createRenderer(node: DOMElement, stylePool: StylePool): 
     // Normal-flow removals don't paint cross-subtree and are fine.
     const absoluteRemoved = consumeAbsoluteRemovedFlag()
     renderNodeToOutput(node, output, {
+      freezeScrollFollow: options.freezeScrollFollow,
       prevScreen: absoluteRemoved || options.prevFrameContaminated ? undefined : prevScreen
     })
 

--- a/ui-tui/packages/hermes-ink/src/ink/selection-streaming.test.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/selection-streaming.test.tsx
@@ -1,0 +1,79 @@
+import { PassThrough } from 'stream'
+
+import React, { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Box from './components/Box.js'
+import ScrollBox, { type ScrollBoxHandle } from './components/ScrollBox.js'
+import Text from './components/Text.js'
+import Ink from './ink.js'
+import { finishSelection, startSelection, updateSelection } from './selection.js'
+
+const makeStream = (columns = 40, rows = 8) => {
+  const stream = new PassThrough()
+
+  Object.assign(stream, { columns, isTTY: false, rows })
+  stream.on('data', () => {})
+
+  return stream
+}
+
+const transcript = (count: number, scrollRef: React.RefObject<ScrollBoxHandle | null>) => (
+  <Box flexDirection="column" height={8}>
+    <ScrollBox flexDirection="column" height={4} ref={scrollRef} stickyScroll>
+      {Array.from({ length: count }, (_, index) => (
+        <Text key={index}>line-{index}</Text>
+      ))}
+    </ScrollBox>
+  </Box>
+)
+
+describe('streaming while text is selected', () => {
+  it('pauses transcript following until the text selection is cleared', () => {
+    const stdout = makeStream()
+    const stdin = makeStream()
+    const stderr = makeStream()
+    const scrollRef = createRef<ScrollBoxHandle>()
+
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    })
+
+    try {
+      ink.setAltScreenActive(true, 'all')
+      ink.render(transcript(8, scrollRef))
+      ink.onRender()
+
+      const scrollTop = scrollRef.current!.getScrollTop()
+
+      startSelection(ink.selection, 0, 2)
+      updateSelection(ink.selection, 5, 2)
+      finishSelection(ink.selection)
+      ink.onRender()
+
+      const selectedText = ink.getTextSelectionText()
+
+      expect(selectedText).toBe('line-6')
+
+      ink.render(transcript(14, scrollRef))
+      ink.onRender()
+
+      expect(scrollRef.current!.getScrollTop()).toBe(scrollTop)
+      expect(ink.hasTextSelection()).toBe(true)
+      expect(ink.getTextSelectionText()).toBe(selectedText)
+
+      ink.clearTextSelection()
+      ink.onRender()
+
+      expect(scrollRef.current!.getScrollTop()).toBe(
+        scrollRef.current!.getScrollHeight() - scrollRef.current!.getViewportHeight()
+      )
+    } finally {
+      ink.unmount()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- keep selected TUI text visible and copyable while agent output is streaming
- pause sticky transcript following while a text selection is active
- resume following the live tail as soon as the selection is cleared
- add a renderer-level regression test for selection across transcript growth

## Root cause

Sticky `ScrollBox` following continued to advance the transcript whenever streaming output increased its height. The selection endpoints were shifted with that follow movement and could be moved off-screen and cleared before the user copied them.

The renderer now suppresses sticky following only while the alt-screen selection is being dragged or remains active. Rendering continues normally, and clearing the selection restores live-tail following.

## Testing

- `npm test --workspace ui-tui -- selection-streaming.test.tsx scrollBoxRendererBounds.test.ts virtualHistoryOffsetCache.test.ts --run` — 22 passed
- `npx --prefix ui-tui vitest run ui-tui/packages/hermes-ink/src/ink --exclude ui-tui/packages/hermes-ink/src/ink/ink-backpressure.test.ts` — 220 passed
- `npm run typecheck --workspace ui-tui`
- `npm run build --workspace ui-tui`
- ESLint on all four changed files
- `hermes --tui --dev` launch/exit smoke test
