### PR TITLE
chore(agent): remove twelve orphaned private helpers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5932,26 +5932,6 @@ def _try_main_fallback_chain(
         )
     return None, None, ""
 
-
-def _resolve_single_provider(
-    provider: str,
-    model: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[Any]:
-    """Resolve a single provider entry from fallback_chain to an OpenAI client.
-
-    Uses the existing provider resolution infrastructure where possible.
-    """
-    # Reuse resolve_provider_client which handles provider→client mapping.
-    client, resolved_model = resolve_provider_client(
-        provider=provider,
-        model=model,
-        explicit_base_url=base_url,
-        explicit_api_key=api_key,
-    )
-    return client
-
 def _resolve_auto_route(
     main_runtime: Optional[Dict[str, Any]] = None,
     task: Optional[str] = None,
@@ -9043,19 +9023,6 @@ def _client_streams_internally(client: Any) -> bool:
         AnthropicAuxiliaryClient,
         BedrockAuxiliaryClient,
     ))
-
-
-def _is_streaming_rejected_error(exc: Exception) -> bool:
-    """Provider explicitly refused a streamed chat.completions request."""
-    err = str(exc).lower()
-    if "stream_options" in err:
-        return True
-    return "stream" in err and (
-        "not supported" in err
-        or "unsupported" in err
-        or "not allowed" in err
-        or "disabled" in err
-    )
 
 
 def _provider_requires_stream(provider: str, base_url: Optional[str]) -> bool:

--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -608,22 +608,6 @@ def build_summary(payload: dict[str, Any]) -> list[str]:
     return lines
 
 
-def _merge_runs(cells: Iterable[Run]) -> Row:
-    out: Row = []
-    for run in cells:
-        text, style, alpha = run[0], run[1], (run[2] if len(run) > 2 else 1.0)
-        hex_override = run[3] if len(run) > 3 else None
-        prev_hex = out[-1][3] if out and len(out[-1]) > 3 else None
-        if out and out[-1][1] == style and abs(out[-1][2] - alpha) < 1e-6 and prev_hex == hex_override:
-            out[-1][0] += text
-        else:
-            merged: Run = [text, style, alpha]
-            if hex_override:
-                merged.append(hex_override)
-            out.append(merged)
-    return out
-
-
 def render_frames(payload: dict[str, Any], *, cols: int = 80, rows: int = 16, frames: int = 48) -> dict[str, Any]:
     """Pre-render a full play-through (reveal 0→1) plus static legend/summary."""
     frames = max(2, min(frames, 240))

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -854,10 +854,6 @@ def _root_rust(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(file_path, workspace, ["Cargo.toml", "Cargo.lock"])
 
 
-def _root_ruby(file_path: str, workspace: str) -> Optional[str]:
-    return _root_or_workspace(file_path, workspace, ["Gemfile"])
-
-
 def _root_clangd(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(
         file_path,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2748,19 +2748,6 @@ def _fetch_codex_oauth_context_lengths_with_source(
     return result, True
 
 
-def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
-    """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
-
-    Codex OAuth imposes its own context limits that differ from the direct
-    OpenAI API (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex). The
-    `context_window` field in each model entry is the authoritative source.
-
-    Returns a ``{slug: context_window}`` dict. Empty on failure.
-    """
-    result, _fresh = _fetch_codex_oauth_context_lengths_with_source(access_token)
-    return result
-
-
 def _resolve_codex_oauth_context_length_with_source(
     model: str, access_token: str = ""
 ) -> Tuple[Optional[int], str]:
@@ -3711,17 +3698,6 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
         else:
             shadow[k] = v
     return shadow
-
-
-def _estimate_message_chars(msg: Dict[str, Any]) -> int:
-    """Char count for token estimation, excluding base64 image data.
-
-    Base64 images are counted via `_count_image_tokens` instead; including
-    their raw chars here would massively overestimate token usage.
-    """
-    if not isinstance(msg, dict):
-        return len(str(msg))
-    return len(str(_wire_message_shadow(msg)))
 
 
 def _estimate_message_tokens_without_images(msg: Dict[str, Any]) -> int:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -120,15 +120,6 @@ class ModelInfo:
     def supports_audio_input(self) -> bool:
         return "audio" in self.input_modalities
 
-    def format_cost(self) -> str:
-        """Human-readable cost string, e.g. '$3.00/M in, $15.00/M out'."""
-        if not self.has_cost_data():
-            return "unknown"
-        parts = [f"${self.cost_input:.2f}/M in", f"${self.cost_output:.2f}/M out"]
-        if self.cost_cache_read is not None:
-            parts.append(f"cache read ${self.cost_cache_read:.2f}/M")
-        return ", ".join(parts)
-
     def format_capabilities(self) -> str:
         """Human-readable capabilities, e.g. 'reasoning, tools, vision, PDF'."""
         caps = []

--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -23,7 +23,6 @@ from OpenAI's ``hatch-pet`` skill (openai/skills, Apache-2.0).
 
 from __future__ import annotations
 
-import io
 import logging
 import math
 from pathlib import Path
@@ -1066,13 +1065,6 @@ def compose_atlas(frames_by_state: dict[str, list]):
                 cell = _fit_to_cell(cell)
             atlas.alpha_composite(cell, (col * CELL_WIDTH, row * CELL_HEIGHT))
     return _clear_transparent_rgb(atlas)
-
-
-def atlas_to_webp_bytes(atlas) -> bytes:
-    """Encode an atlas image to lossless WebP bytes (the on-disk pet format)."""
-    buf = io.BytesIO()
-    atlas.save(buf, format="WEBP", lossless=True, quality=100, method=6, exact=True)
-    return buf.getvalue()
 
 
 def validate_atlas(atlas) -> dict:

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -2376,13 +2376,6 @@ def get_status() -> ProxyStatus:
     return status
 
 
-def _read_tunnel_port_from_config() -> Optional[int]:
-    listen = _read_http_listen_from_config()
-    if listen is None:
-        return None
-    return listen[1]
-
-
 def _read_http_listen_from_config() -> Optional[Tuple[str, int]]:
     """Return ``(host, port)`` of the configured sandbox-facing listener.
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -719,15 +719,6 @@ def redact_cdp_url(value: object) -> str:
     return text
 
 
-def _redact_http_request_target_query_params(text: str) -> str:
-    """Redact sensitive query params in HTTP access-log request targets."""
-    def _sub(m: re.Match) -> str:
-        prefix = m.group(1)
-        query = _redact_query_string(m.group(2))
-        return f"{prefix}?{query}"
-    return _HTTP_REQUEST_TARGET_QUERY_RE.sub(_sub, text)
-
-
 def _redact_form_body(text: str) -> str:
     """Redact sensitive values in a form-urlencoded body.
 
@@ -1408,12 +1399,6 @@ _HTTP_METHOD_SUBSTRINGS = (
     "TRACE ",
     "CONNECT ",
 )
-
-
-def _has_http_method_substring(text: str) -> bool:
-    """Cheap pre-check before scanning for access-log request targets."""
-    upper = text.upper()
-    return any(method in upper for method in _HTTP_METHOD_SUBSTRINGS)
 
 
 class RedactingFormatter(logging.Formatter):

--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -266,16 +266,6 @@ def _canonical_tokens(canonical: str) -> list[str]:
         return []
 
 
-def _find_subsequence(tokens: list[str], needle: list[str]) -> Optional[int]:
-    if not tokens or not needle or len(needle) > len(tokens):
-        return None
-    cleaned = [_clean_token(t) for t in tokens]
-    for idx in range(0, len(cleaned) - len(needle) + 1):
-        if cleaned[idx:idx + len(needle)] == needle:
-            return idx
-    return None
-
-
 def _strip_command_prefix(tokens: list[str]) -> list[str]:
     """Remove harmless command prefixes before matching canonical commands."""
     remaining = list(tokens)


### PR DESCRIPTION
## What

Twelve unreachable symbols in `agent/` — no callers anywhere in the tree, in any file type. Pure deletion: **126 lines removed, 0 added**, across 9 files.

| Symbol | File |
|---|---|
| `_resolve_single_provider` | `agent/auxiliary_client.py` |
| `_is_streaming_rejected_error` | `agent/auxiliary_client.py` |
| `_merge_runs` | `agent/learning_graph_render.py` |
| `_root_ruby` | `agent/lsp/servers.py` |
| `_fetch_codex_oauth_context_lengths` | `agent/model_metadata.py` |
| `_estimate_message_chars` | `agent/model_metadata.py` |
| `_read_tunnel_port_from_config` | `agent/proxy_sources/iron_proxy.py` |
| `_redact_http_request_target_query_params` | `agent/redact.py` |
| `_has_http_method_substring` | `agent/redact.py` |
| `_find_subsequence` | `agent/verification_evidence.py` |
| `atlas_to_webp_bytes` | `agent/pet/generate/atlas.py` |
| `ModelInfo.format_cost` | `agent/models_dev.py` |

## How the candidates were filtered

Located with `code-review-graph`, but a static call graph is **not sufficient evidence on its own**: it reports thread targets, callback arguments, re-exports and string-dispatched names as dead. Of 379 non-dunder "dead" functions in `agent/`, **362 were reachable** — a 95% false-positive rate. Every symbol here was confirmed orphaned with a repo-wide `git grep` across all file types.

The last two were initially **kept** on the assumption that they were public surface, then removed after direct evidence:

- `atlas_to_webp_bytes` — `orchestrate.py` module-qualifies eight helpers from `atlas.py` (`compose_atlas`, `validate_atlas`, `mirror_frames`, `normalize_cells`, `single_frame`, `extract_strip_frames`, `remove_background`, `_clear_transparent_rgb`) and never this one. Removing it also orphaned `import io`, dropped here too.
- `ModelInfo.format_cost` — the only grep hits were the unrelated `format_cost_label` in `usage_pricing.py`. Every sibling accessor (`has_cost_data`, `supports_vision`, `supports_pdf`, `supports_audio_input`) is reached through `format_capabilities`, which `cli.py` calls at two sites; `format_cost` is reached from nowhere.

## Seven candidates deliberately kept

- `get_accounting_context`, `get_friendly_tool_labels` — paired getters whose setters have 4 live call sites each.
- `unregister_session_initializer` — its `register_` half is called by `hermes_cli/observability/relay_shared_metrics.py:1282`; removing one half breaks a symmetric API.
- `get_async_text_auxiliary_client` — async twin of `get_text_auxiliary_client` (4 call sites).
- `coding_system_blocks` — 4 of 5 siblings in that module are imported by `system_prompt.py` / `conversation_loop.py`.

## Testing

`tests/agent/ -k "models_dev or atlas or pet or model_metadata"` — **239 passed, 18 skipped, 0 failed**.

Full `tests/agent/` for the first commit: **243 failed, 5146 passed, 40 skipped** both with and without the change — baseline captured by stashing the deletion and re-running on pristine `origin/main`, byte-identical counts. All nine edited modules pass `py_compile`.