### PR TITLE
fix(cron): deliver finite bot-chat jobs without false ownership loss

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6617,11 +6617,12 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     claim = job.get("fire_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
     if not owner:
-        return run(None)
+        return run(None, None)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
     lost_ownership = threading.Event()
+    side_effect_fenced = threading.Event()
     heartbeat_context = contextvars.copy_context()
 
     def _finish_unstarted(error: str) -> None:
@@ -6663,6 +6664,14 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
                 if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                    if side_effect_fenced.is_set():
+                        # save/delivery holds this owner's per-job fence. The
+                        # heartbeat cannot acquire that same lock from another
+                        # thread, but no replacement owner can acquire it
+                        # either, so contention here is proof of protection,
+                        # not ownership loss.
+                        last_confirmed = time.monotonic()
+                        continue
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",
@@ -6709,7 +6718,7 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         return True
 
     try:
-        return run(lost_ownership)
+        return run(lost_ownership, side_effect_fenced)
     finally:
         stop.set()
         heartbeat_thread.join(timeout=1.0)
@@ -6755,7 +6764,7 @@ def run_one_job(
     try:
         return _run_with_fire_claim_heartbeat(
             job,
-            lambda lost_ownership: _run_one_job_body(
+            lambda lost_ownership, side_effect_fenced: _run_one_job_body(
                 job,
                 adapters=adapters,
                 loop=loop,
@@ -6766,6 +6775,7 @@ def run_one_job(
                     if cancel_event is not None
                     else lost_ownership
                 ),
+                fire_claim_fenced=side_effect_fenced,
                 execution_token=execution_token,
             ),
         )
@@ -6786,6 +6796,7 @@ def _run_one_job_body(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
+    fire_claim_fenced: Optional[threading.Event] = None,
     execution_token: Optional[object] = None,
 ) -> bool:
     claim = job.get("fire_claim")
@@ -6797,7 +6808,23 @@ def _run_one_job_body(
     def _side_effect_fence():
         if fire_owner is None:
             return contextlib.nullcontext(True)
-        return fire_claim_fence(job["id"], expected_owner=fire_owner)
+
+        @contextlib.contextmanager
+        def _owned_fence():
+            try:
+                with fire_claim_fence(
+                    job["id"], expected_owner=fire_owner
+                ) as owns_claim:
+                    if owns_claim and fire_claim_fenced is not None:
+                        fire_claim_fenced.set()
+                    yield owns_claim
+            finally:
+                # Clear only after fire_claim_fence releases the lock. Until
+                # then heartbeat contention remains safe and expected.
+                if fire_claim_fenced is not None:
+                    fire_claim_fenced.clear()
+
+        return _owned_fence()
 
     def _fire_claim_ownership_lost() -> bool:
         if fire_claim_lost is not None and fire_claim_lost.is_set():

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -578,3 +578,66 @@ def test_terminal_owner_cas_failure_marks_ledger_ownership_lost(monkeypatch):
         success=False,
         error="Fire claim ownership lost before terminal completion.",
     )
+
+
+def test_finite_bot_chat_delivery_does_not_report_its_own_claim_lock_as_lost(
+    monkeypatch,
+):
+    """A long Bot Chat delivery owns the fence, so lock contention is safe."""
+    import cron.scheduler as scheduler
+
+    delivery_active = threading.Event()
+    heartbeat_contended = threading.Event()
+    finish = MagicMock()
+
+    def heartbeat(*_args, **_kwargs):
+        if delivery_active.is_set():
+            heartbeat_contended.set()
+            return False
+        return True
+
+    @contextlib.contextmanager
+    def owned_fence(*_args, **_kwargs):
+        yield True
+
+    def deliver(*_args, **_kwargs):
+        delivery_active.set()
+        assert heartbeat_contended.wait(timeout=1)
+        delivery_active.clear()
+        return None
+
+    job = {
+        "id": "long-fenced-delivery",
+        "execution_id": "execution-long-delivery",
+        "name": "long-fenced-delivery",
+        "deliver": "bot-chat,telegram:1",
+        "schedule": {"kind": "once"},
+        "repeat": {"times": 1, "completed": 0},
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_args: None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "output", "response", None),
+    )
+    monkeypatch.setattr(scheduler, "fire_claim_fence", owned_fence)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(job) is True
+
+    finish.assert_called_once_with(
+        "execution-long-delivery",
+        success=True,
+        error=None,
+        delivery_outcome="delivered",
+    )

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -412,7 +412,7 @@ class TestCombinedCancelEvent:
         with patch.object(
             sched,
             "_run_with_fire_claim_heartbeat",
-            side_effect=lambda job_arg, run: run(threading.Event()),
+            side_effect=lambda job_arg, run: run(threading.Event(), threading.Event()),
         ), patch.object(sched, "_run_one_job_body", return_value=True) as body:
             assert sched.run_one_job(job, cancel_event=external) is True
 


### PR DESCRIPTION
## What does this PR do?

Finite cron jobs that deliver to Bot Chat can finish the agent turn successfully and still be recorded as interrupted before the result reaches Bot Chat or another configured target. This change keeps the fire-claim heartbeat from treating the current owner's long-held delivery fence as ownership loss while preserving stale-owner fencing.

### Symptom

A once or repeat-limited job with `bot-chat` in its delivery targets can end with `Fire claim ownership lost; stale result was discarded.` even though the agent turn completed successfully.

### Impact

The completed result is discarded and none of the configured delivery targets receive it. The reported reproductions affect Desktop-triggered finite jobs with Bot Chat delivery; the broader blast radius is unknown.

### Bug Cause

**Trigger:** `cron/scheduler.py` / `_run_with_fire_claim_heartbeat()` while `_run_one_job_body()` holds the per-job fire fence around a long delivery.

**Causal chain:**
1. Bot Chat delivery runs a full child agent turn while the current fire owner holds the per-job side-effect fence.
2. The heartbeat thread tries to acquire that same per-job lock and a timed-out acquisition returns `False`.
3. The wrapper interprets lock contention as a replaced claim, sets the ownership-lost event, and records the completed run as interrupted instead of finalizing its successful result.

**Why it is wrong:** The side-effect fence excludes every replacement owner while it is held. A heartbeat that cannot acquire that same fence during the protected side effect has not proven ownership loss.

**Working sibling / contrast:** Local and ordinary platform delivery paths usually finish before the heartbeat contends with the fence, so they proceed to terminal bookkeeping normally.

**Ruled out:** The regression test forces heartbeat contention while the original owner still holds the fence, then confirms the claim is usable immediately after the fence releases. No replacement owner is involved.

### Fix

Track when the running owner is inside its side-effect fence. Heartbeat lock contention during that interval renews the local confirmation window instead of raising ownership loss; once the fence releases, normal owner validation resumes. A regression test covers a finite one-shot with combined Bot Chat and Telegram targets and verifies successful ledger finalization.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` - distinguish owner-protected fence contention from actual fire-claim loss.
- `tests/cron/test_script_claim_heartbeat.py` - reproduce a finite multi-target Bot Chat delivery spanning a heartbeat.
- `tests/cron/test_shutdown_interrupt.py` - adapt the cancellation forwarding test to the heartbeat callback state.

## How to Test

1. Run the focused cron claim, delivery, and shutdown tests:

```bash
scripts/run_tests.sh tests/cron/test_script_claim_heartbeat.py tests/cron/test_shutdown_interrupt.py tests/cron/test_claim_job_for_fire.py tests/cron/test_cron_bot_chat_delivery.py tests/cron/test_run_one_job.py -q
```

2. Confirm all 81 selected tests pass (with one platform-specific skip on Windows).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant cron tests and all selected tests pass
- [x] I've added a regression test for the bug
- [x] I've tested the deterministic scheduler regression on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the user-facing contract is unchanged
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the synchronization change uses `threading.Event` and existing lock abstractions
- [x] Tool description/schema updates are N/A; no model tool contract changed

## Screenshots / Logs

The focused regression failed before the fix with `Interrupted by shutdown before terminal completion.` after the heartbeat reported ownership loss. The focused five-file suite passes: 81 passed, 1 skipped.