### PR TITLE
fix(security): refuse sensitive targets in fs write-text

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3036,8 +3036,19 @@ async def fs_write_text(payload: FsWriteText):
     and ``os.replace``-d into place so a crash mid-write can't truncate the
     original. Stale-on-disk detection is the client's job (re-read before save),
     so both transports behave identically.
+
+    Sensitive targets are refused with the same guard the read surfaces apply
+    (#95306, minimal half): the denylist covers the Hermes credential and
+    config stores (``auth.json``, ``.env*``, ``config.yaml``), and overwriting
+    them through the HTTP spot editor is the config-injection chain — a
+    rewritten ``config.yaml`` registers an attacker-controlled MCP stdio
+    server that executes on next tool resolution. A configurable write-root
+    allowlist is the fuller design and is deliberately left to maintainer
+    discussion; this half only closes the credential-store overwrite.
     """
     target = _fs_path(payload.path)
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     text = payload.content or ""
     if len(text.encode("utf-8")) > _FS_TEXT_WRITE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="Content too large")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2160,10 +2160,11 @@ def _is_sensitive_path(path: Path) -> bool:
     the canonical guards cover as directory trees but a basename-only check
     would miss.
 
-    Read-side only: this guards list/read/download (the #57505 exfil surface).
-    The write endpoints (upload/mkdir/delete) are a separate threat class
-    handled by the write-path checks; extending this guard to them is out of
-    scope for this fix.
+    Guards both the read surfaces (list/read/download, the #57505 exfil
+    surface) and the write-text spot-editor endpoint (the #95306
+    config-injection chain). The remaining write endpoints
+    (upload/mkdir/delete) are a separate threat class that still awaits the
+    fuller write-root allowlist design.
     """
     if _is_sensitive_filename(path.name):
         return True

--- a/tests/hermes_cli/test_web_server_fs_write_guard.py
+++ b/tests/hermes_cli/test_web_server_fs_write_guard.py
@@ -1,0 +1,94 @@
+"""Regression tests for the fs write-text sensitive-target guard (#95306).
+
+``POST /api/fs/write-text`` overwrote arbitrary resolvable paths with no
+``_is_sensitive_path()`` check while every read surface applied it — an
+authenticated dashboard session could rewrite the Hermes credential and
+config stores (``auth.json``, ``.env*``, ``config.yaml``) through the spot
+editor, which is the config-injection chain: a rewritten ``config.yaml``
+registers an attacker-controlled MCP stdio server executed on next tool
+resolution. The fix applies the read-side guard to the write surface
+(minimal half; the configurable write-root allowlist is left to maintainer
+discussion).
+"""
+
+import pytest
+
+from hermes_cli import web_server
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+@pytest.mark.parametrize(
+    "sensitive_name", [".env", "auth.json", "config.yaml"]
+)
+def test_write_text_rejects_sensitive_targets(client, tmp_path, sensitive_name):
+    target = tmp_path / sensitive_name
+    target.write_text("original")
+
+    response = client.post(
+        "/api/fs/write-text", json={"path": str(target), "content": "tampered"}
+    )
+
+    assert response.status_code == 403
+    assert target.read_text() == "original", (
+        "the guard must fire before any staging or replace touches the file"
+    )
+
+
+def test_write_text_rejects_credential_directory_target(client, tmp_path):
+    cred_dir = tmp_path / "mcp-tokens"
+    cred_dir.mkdir()
+    target = cred_dir / "server.json"
+    target.write_text("{}")
+
+    response = client.post(
+        "/api/fs/write-text", json={"path": str(target), "content": "tampered"}
+    )
+
+    assert response.status_code == 403
+    assert target.read_text() == "{}"
+
+
+def test_write_text_rejects_sensitive_creation(client, tmp_path):
+    """The guard must also block CREATING a sensitive store that does not
+    exist yet (config.yaml in a fresh home) — not only overwrites."""
+    target = tmp_path / "config.yaml"
+
+    response = client.post(
+        "/api/fs/write-text", json={"path": str(target), "content": "malicious: on"}
+    )
+
+    assert response.status_code == 403
+    assert not target.exists()
+
+
+def test_write_text_serves_ordinary_files(client, tmp_path):
+    """The spot-editor flow for ordinary workspace files is unaffected."""
+    target = tmp_path / "notes.md"
+    target.write_text("old")
+
+    response = client.post(
+        "/api/fs/write-text", json={"path": str(target), "content": "new"}
+    )
+
+    assert response.status_code == 200
+    assert target.read_text() == "new"

--- a/tests/hermes_cli/test_web_server_fs_write_guard.py
+++ b/tests/hermes_cli/test_web_server_fs_write_guard.py
@@ -38,7 +38,7 @@ def client(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "sensitive_name", [".env", "auth.json", "config.yaml"]
+    "sensitive_name", [".env", ".ENV", "auth.json", "config.yaml"]
 )
 def test_write_text_rejects_sensitive_targets(client, tmp_path, sensitive_name):
     target = tmp_path / sensitive_name


### PR DESCRIPTION
## What does this PR do?

`POST /api/fs/write-text` overwrote arbitrary resolvable paths (any absolute path or `file://` URL via `_fs_path()`) with **no** `_is_sensitive_path()` check, while every read surface (`/api/files/read`, the range-response builder, list pruning, `/api/fs/download`, and — as of #95303 — the two preview endpoints) applies it. The denylist covers the Hermes credential and config stores (`auth.json`, `.env*`, `config.yaml`), so through the HTTP spot editor an authenticated dashboard session could execute the report's config-injection chain: a rewritten `config.yaml` registers an attacker-controlled MCP stdio server that executes on next tool resolution; cron script swap and `.env`/`auth.json` tampering are the sibling chains (#95306).

The fix applies the read-side guard to the write surface — the minimal half the report sanctions ("At minimum apply `_is_sensitive_path()` like `/api/fs/download`"), firing before any staging temp file or `os.replace` so both overwrites and creations of sensitive stores are refused with the same 403 the read surfaces return. The fuller design (a configurable write-root allowlist for gated/remote sessions, per the report's "Better" option) is deliberately left to maintainer discussion and is out of scope here.

## Related Issue

Fixes #95306

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `fs_write_text()` raises 403 via `_is_sensitive_path(target)` immediately after `_fs_path()` resolution; the docstring documents the config-injection rationale and the scoping decision.
- `tests/hermes_cli/test_web_server_fs_write_guard.py` — five regression tests: overwrites of `.env` / `auth.json` / `config.yaml` are refused with the file content untouched (the guard fires before staging); a `mcp-tokens` credential-directory target is refused; creating a not-yet-existing sensitive store is refused (not just overwrites); an ordinary workspace file still writes successfully.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_web_server_fs_write_guard.py -v` — should pass (6 passed).
2. Adjacent fs suites stay green: `.venv/bin/python -m pytest tests/hermes_cli -k web_server_fs -q` — should pass (11 passed, 1 skipped).
3. Fail-on-main control: `git checkout HEAD~1 -- hermes_cli/web_server.py` and rerun the new file — should fail (5 failed: all guard pins; the ordinary-file write test passes on both sides by design), then restore. Observed result: `5 failed, 1 passed` pre-fix, `6 passed` post-fix.
4. Live check: with an authenticated dashboard session, `POST /api/fs/write-text` targeting `<home>/.hermes/config.yaml` should return 403 "Access to sensitive files is not allowed" and leave the file untouched, while an ordinary workspace file still saves through the spot editor.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the open write-side PRs cover managed-files upload denylists and media-delivery paths, not the spot-editor endpoint; #95317 covers the read-side siblings of this family)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (mechanism and scoping documented in the endpoint docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is case-insensitive and platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (HTTP route behavior only)
