### PR TITLE
fix(update): gate macOS TCC notice on in-scope variable

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7018,7 +7018,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # shows ON while macOS re-prompts on every capture, and the modern prompt
         # has no Allow button, so users loop. One line of guidance after update
         # tells affected users how to complete the one-time re-grant.
-        if sys.platform == "darwin" and has_desktop_app:
+        if sys.platform == "darwin" and had_desktop_app_before_update:
             print()
             print(
                 "  ℹ macOS: if Hermes re-prompts for permissions you already "

--- a/tests/hermes_cli/test_update_macos_tcc_gate.py
+++ b/tests/hermes_cli/test_update_macos_tcc_gate.py
@@ -1,0 +1,71 @@
+"""Regression guard: the macOS TCC stale-grant notice gate must reference
+only names resolvable in ``_cmd_update_impl``'s scope (#95309).
+
+Commit 36c1755065 added the TCC stale-grant notice to the post-update path
+of ``_cmd_update_impl`` but gated it on ``has_desktop_app`` — a local of
+``_rebuild_desktop_after_update``, never defined in ``_cmd_update_impl``'s
+scope. On macOS every ``hermes update`` crashed with
+``NameError: name 'has_desktop_app' is not defined`` right after printing
+``✓ Code updated!``, skipping the remaining post-update steps (state.db
+integrity check, model-catalog seed, bundled-skills sync).
+
+The guard asserts the runtime-resolution invariant rather than the exact
+variable name, so it survives a future rename: whatever identifier gates
+the darwin TCC notice must be a local/parameter of ``_cmd_update_impl``,
+a module global, or a builtin — otherwise the update crashes with
+NameError at runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import inspect
+import re
+import types
+
+import hermes_cli.update_cmd as update_cmd
+
+_DARWIN_TCC_GATE = re.compile(r'if sys\.platform == "darwin" and (\w+):')
+
+
+def _gate_name() -> str:
+    """Return the identifier gating the darwin TCC stale-grant notice."""
+    src = inspect.getsource(update_cmd._cmd_update_impl)
+    assert "tccutil reset ScreenCapture" in src, "TCC stale-grant notice missing"
+    m = _DARWIN_TCC_GATE.search(src)
+    assert m, "darwin TCC notice gate not found in _cmd_update_impl"
+    return m.group(1)
+
+
+def _resolves_in_update_scope(name: str) -> bool:
+    """True if ``name`` resolves at runtime where the gate executes.
+
+    Mirrors CPython's own resolution for the function body: a name is
+    local/parameter (in the function's ``co_varnames``), or looked up as
+    a global/builtin (``update_cmd`` module namespace or builtins). A name
+    defined only in another function (the #95309 bug) matches neither —
+    it would raise NameError exactly like the real runtime did.
+    """
+    func_src = inspect.getsource(update_cmd._cmd_update_impl)
+    code = compile(ast.parse(func_src), "<update-scope-check>", "exec")
+    fcode = next(
+        c
+        for c in code.co_consts
+        if isinstance(c, types.CodeType) and c.co_name == "_cmd_update_impl"
+    )
+    if name in fcode.co_varnames:
+        return True
+    return name in dir(update_cmd) or name in dir(builtins)
+
+
+def test_tcc_notice_gate_references_resolvable_name():
+    """FAIL-BEFORE: gate used ``has_desktop_app`` (a local of
+    ``_rebuild_desktop_after_update``) → NameError on every macOS update.
+    """
+    name = _gate_name()
+    assert _resolves_in_update_scope(name), (
+        f"TCC notice gate references {name!r}, which is not a local of "
+        "_cmd_update_impl and not a module global/builtin — update would "
+        "crash with NameError on macOS (#95309)"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a guaranteed `NameError` crash at the end of every `hermes update` on macOS, introduced by `36c1755065` (fix(macos): detect stale TCC grants and guide one-time re-grant).

The new TCC stale-grant notice in `_cmd_update_impl` was gated on `has_desktop_app` — a **local of `_rebuild_desktop_after_update`**, not a variable in `_cmd_update_impl`'s scope. Since the gate is unconditional on darwin, every successful macOS update printed `✓ Code updated!` and then crashed:

```
File ".../hermes_cli/update_cmd.py", line 7021, in _cmd_update_impl
    if sys.platform == "darwin" and has_desktop_app:
                                    ^^^^^^^^^^^^^^^
NameError: name 'has_desktop_app' is not defined
```

This skips all post-update steps (state.db integrity check + auto-restore, model-catalog cache seed, bundled-skills sync) and returns a non-zero exit code, so a bot-gateway-driven update reports failure even though the code update itself succeeded.

## Related Issue

Fixes #95309

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py:7021` — gate the darwin TCC notice on `had_desktop_app_before_update`, which is in scope (defined at the top of the update flow) and carries the intended meaning ("a desktop app was installed before this update"). One line.
- `tests/hermes_cli/test_update_macos_tcc_gate.py` — regression guard. It does not pin the variable name; it extracts whatever identifier gates the darwin TCC notice and asserts it resolves in `_cmd_update_impl`'s runtime scope (function local/parameter via `co_varnames`, module global, or builtin) — mirroring CPython's own name resolution. Verified: fails on the pre-fix tree with the exact `has_desktop_app` diagnostic, passes on this branch.

## How to Test

1. Repro (pre-fix): macOS, git install, `git pull` to `36c1755065` or later, run `hermes update` → `NameError` traceback after `✓ Code updated!` (see issue #95309).
2. `pytest tests/hermes_cli/test_update_macos_tcc_gate.py -q` → passes on this branch; fails on base (verified: `FAILED ... TCC notice gate references 'has_desktop_app' ...`).
3. `pytest tests/hermes_cli/test_update_macos_tcc_gate.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_*.py tests/hermes_cli/test_lazy_refresh_venv_repair.py -q` → 164 passed; 10 failures that reproduce identically on unmodified base (environment-related: test-internal managed-uv binary install fails on this macOS host, e.g. `test_update_non_interactive_runs_safe_config_migrations`) — no new failures from this change.
4. `ruff check` (repo config, 0.15.10) → clean. `ty check` → base has 13 diagnostics in update_cmd.py, this branch has 12 (the removed one is exactly `unresolved-reference: Name 'has_desktop_app' used when not defined` at line 7021; zero new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full update-related subset instead (see How to Test #3); the 10 pre-existing environment failures reproduce on unmodified base
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.1 (Apple Silicon), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is darwin-gated; other platforms never enter the block
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

Pre-fix (base `c0b5a8e15d`), `ty check` on `hermes_cli/update_cmd.py`:

```
"description": "unresolved-reference: Name `has_desktop_app` used when not defined",
"severity": "major",
"line": 7021
```

Same command on this branch: diagnostic gone, no new ones.
