### PR TITLE
fix(desktop): bound getConnection()/resolveGatewayWsUrl() on every remaining route

### DIFF
--- a/apps/desktop/src/api/plugins.test.ts
+++ b/apps/desktop/src/api/plugins.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from '@/hermes'
+
+import { activeConnection } from './plugins'
+
+// desktop.getConnection/getConnectionFor are IPC round-trips into the main
+// process with no timeout of their own (#93454). A wedged main-process
+// round-trip must reject instead of hanging pluginSocket's connect() forever.
+describe('activeConnection connection timeout (#93454)', () => {
+  afterEach(() => {
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.useRealTimers()
+  })
+
+  it('rejects instead of hanging forever when getConnection() wedges', async () => {
+    vi.useFakeTimers()
+    setApiRequestProfile('coder')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { getConnection: vi.fn(() => new Promise(() => undefined)) }
+    })
+
+    const pending = expect(activeConnection()).rejects.toThrow('Timed out connecting to profile "coder"')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+
+  it('rejects instead of hanging forever when getConnectionFor() wedges', async () => {
+    vi.useFakeTimers()
+    setApiRequestConnection('gw-tailscale')
+    setApiRequestProfile('research')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getConnection: vi.fn(() => new Promise(() => undefined)),
+        getConnectionFor: vi.fn(() => new Promise(() => undefined))
+      }
+    })
+
+    const pending = expect(activeConnection()).rejects.toThrow('Timed out connecting to profile "research"')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+})

--- a/apps/desktop/src/api/plugins.ts
+++ b/apps/desktop/src/api/plugins.ts
@@ -1,5 +1,6 @@
 import type { HermesConnection } from '@/global'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 
 import { getApiRequestConnection, getApiRequestProfile, hermesApi, profileScoped } from './client'
 
@@ -8,16 +9,33 @@ import { getApiRequestConnection, getApiRequestProfile, hermesApi, profileScoped
  *  registry agent's descriptor comes from getConnectionFor (its SOURCE
  *  connection), everything else from the profile-keyed local pool. The
  *  getConnectionFor bridge is optional (older Desktop mains); without it the
- *  profile-scoped pool lookup is the best available answer. */
-async function activeConnection(): Promise<HermesConnection> {
+ *  profile-scoped pool lookup is the best available answer.
+ *
+ *  Both branches are IPC round-trips into the main process with no timeout of
+ *  their own (#93454) — a wedged main-process round-trip otherwise hangs
+ *  pluginSocket's connect() forever instead of falling back to the polling
+ *  fallback every consumer already has. Bound the same way store/gateway's
+ *  openSecondary bounds the same *For/plain pair.
+ *
+ *  Exported for tests. */
+export async function activeConnection(): Promise<HermesConnection> {
   const getConnectionFor = window.hermesDesktop.getConnectionFor
   const connectionId = getApiRequestConnection()
+  const profile = getApiRequestProfile()
 
   if (connectionId && getConnectionFor) {
-    return getConnectionFor({ connectionId, profile: getApiRequestProfile() })
+    return withTimeout(
+      getConnectionFor({ connectionId, profile }),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out connecting to profile "${profile}"`
+    )
   }
 
-  return window.hermesDesktop.getConnection(getApiRequestProfile())
+  return withTimeout(
+    window.hermesDesktop.getConnection(profile),
+    RECONNECT_ATTEMPT_TIMEOUT_MS,
+    `Timed out connecting to profile "${profile}"`
+  )
 }
 
 /** Options for a plugin REST call — mirrors the app's own `hermesDesktop.api`

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { withTimeout } from '@/lib/with-timeout'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -104,18 +104,12 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
-// desktop.revalidateConnection() / getConnection() / resolveGatewayWsUrl() are
-// IPC round-trips into the main process with no timeout of their own (#93454).
-// A remote backend that looks alive to a fresh probe but leaves the
-// main-process reconnect path stuck (e.g. a wedged revalidation after a
-// liveness-probe trip) hangs these awaits forever. While any is pending,
-// `reconnecting` never clears, so scheduleReconnect()/attemptReconnect()
-// early-return permanently and the backoff loop is latched — the UI stays
-// "reconnecting" until the app is restarted even though the gateway is
-// reachable again. Bound all three so a stall rejects instead, letting the
-// existing catch/finally clear the guard and resume backoff. gateway.connect()
-// already has its own connect timeout.
-const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
+// While any of the RECONNECT_ATTEMPT_TIMEOUT_MS-bounded awaits below is
+// pending, `reconnecting` never clears, so scheduleReconnect()/
+// attemptReconnect() early-return permanently and the backoff loop is
+// latched — the UI stays "reconnecting" until the app is restarted even
+// though the gateway is reachable again. gateway.connect() already has its
+// own connect timeout.
 
 /** Registry identity whose runtimes died with the primary connection. */
 export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'connectionId' | 'mode'>): null | string {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
 import { $gateway } from '@/store/gateway'
@@ -10,6 +10,8 @@ const fakeGateway = { connectionState: 'open' } as unknown as HermesGateway
 
 afterEach(() => {
   $gateway.set(null)
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  vi.useRealTimers()
 })
 
 describe('useGatewayRequest', () => {
@@ -35,5 +37,35 @@ describe('useGatewayRequest', () => {
     act(() => $gateway.set(fakeGateway))
 
     expect(result.current.gateway).toBe(fakeGateway)
+  })
+
+  it('rejects instead of hanging forever when the reconnect getConnection() wedges (#93454)', async () => {
+    // Repro: a request lands on a dropped socket, the "not connected" catch
+    // kicks off a reconnect, and the IPC round-trip into main
+    // (desktop.getConnection) never settles — e.g. a wedged revalidation after
+    // a liveness-probe trip. Without an internal timeout on that await,
+    // reconnectingRef never clears and requestGateway hangs forever instead of
+    // surfacing the original transport error.
+    vi.useFakeTimers()
+
+    const dropped = {
+      connectionState: 'closed',
+      request: vi.fn().mockRejectedValue(new Error('connection closed'))
+    } as unknown as HermesGateway
+    const getConnection = vi.fn(() => new Promise(() => undefined))
+
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { getConnection }
+    $gateway.set(dropped)
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    const pending = expect(result.current.requestGateway('some.method')).rejects.toThrow('connection closed')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // getConnection() await must reject so the reconnect gives up and the
+    // original transport error surfaces, instead of requestGateway() never
+    // settling.
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { HermesGateway } from '@/hermes'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gateway'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
@@ -72,8 +73,17 @@ export function useGatewayRequest() {
       try {
         // Reconnect to whichever profile the gateway is currently routed to (not
         // always the primary), so a sleep/wake reconnect keeps the user on the
-        // profile they were chatting in.
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        // profile they were chatting in. Both awaits below are IPC round-trips
+        // into the main process with no timeout of their own (#93454) — a
+        // wedged main-process round-trip otherwise hangs this await forever,
+        // latching reconnectingRef.current so every later requestGateway() call
+        // returns the same never-settling promise. Bound the same way
+        // use-gateway-boot.ts bounds the primary boot/soft-switch equivalents.
+        const conn = await withTimeout(
+          desktop.getConnection($activeGatewayProfile.get()),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
         connectionRef.current = conn
         setConnection(conn)
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
@@ -82,7 +92,11 @@ export function useGatewayRequest() {
         // auth rejection becomes a reauth error; transport failures remain
         // retryable. Stash only the former so requestGateway can show the
         // actionable "sign in again" message.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out re-minting the gateway WebSocket URL'
+        )
         await existing.connect(wsUrl)
 
         return existing

--- a/apps/desktop/src/lib/voice-playback.routing.test.ts
+++ b/apps/desktop/src/lib/voice-playback.routing.test.ts
@@ -41,6 +41,7 @@ describe('resolveSpeakStreamUrl', () => {
     setApiRequestConnection(null)
     setApiRequestProfile(null)
     Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.useRealTimers()
   })
 
   it('resolves through the registry (connection, profile) bridges when a registry connection is active', async () => {
@@ -101,5 +102,21 @@ describe('resolveSpeakStreamUrl', () => {
     // descriptor's own wsUrl (no cross-scope re-mint).
     expect(url).toContain('/api/audio/speak-stream')
     expect(getConnection).toHaveBeenCalledWith('research')
+  })
+
+  it('resolves to null instead of hanging forever when getConnection() wedges (#93454)', async () => {
+    // desktop.getConnection/getConnectionFor/resolveGatewayWsUrl are IPC
+    // round-trips into the main process with no timeout of their own. A
+    // wedged main-process round-trip otherwise hangs voice mode's "speaking"
+    // state forever instead of falling back to playSpeechText.
+    vi.useFakeTimers()
+    setApiRequestProfile('coder')
+    getConnection.mockImplementation(() => new Promise(() => undefined))
+
+    const pending = resolveSpeakStreamUrl()
+
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    await expect(pending).resolves.toBeNull()
   })
 })

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -7,6 +7,7 @@ import {
   type DirectTtsConfig,
   synthesizeSpeechClientDirect
 } from '@/lib/voice-client-direct'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $voicePlayback,
   setVoicePlaybackState,
@@ -125,10 +126,23 @@ export async function resolveSpeakStreamUrl(): Promise<null | string> {
     const profile = getApiRequestProfile()
     const connectionId = getApiRequestConnection()
 
+    // Both awaits below are IPC round-trips into the main process with no
+    // timeout of their own (#93454) — a wedged main-process round-trip
+    // otherwise hangs voice mode's "speaking" state forever instead of
+    // falling back to playSpeechText. Bound the same way
+    // store/gateway's openSecondary bounds the same *For/plain pair.
     const conn =
       connectionId && desktop.getConnectionFor
-        ? await desktop.getConnectionFor({ connectionId, profile })
-        : await desktop.getConnection(profile)
+        ? await withTimeout(
+            desktop.getConnectionFor({ connectionId, profile }),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${profile}"`
+          )
+        : await withTimeout(
+            desktop.getConnection(profile),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${profile}"`
+          )
 
     const wsDeps =
       connectionId && desktop.getGatewayWsUrlFor
@@ -137,7 +151,11 @@ export async function resolveSpeakStreamUrl(): Promise<null | string> {
           ? {}
           : desktop
 
-    const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
+    const wsUrl = await withTimeout(
+      resolveGatewayWsUrl(wsDeps, conn),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out re-minting the gateway WebSocket URL for profile "${profile}"`
+    )
     const url = new URL(wsUrl)
 
     if (!url.pathname.endsWith('/api/ws')) {

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -1,3 +1,10 @@
+// desktop.getConnection() / getConnectionFor() / revalidateConnection() /
+// resolveGatewayWsUrl() are IPC round-trips into the main process with no
+// timeout of their own (#93454). A wedged main-process round-trip (e.g. a
+// stuck revalidation after a liveness-probe trip) otherwise hangs an awaiting
+// caller forever. Every caller of these bounds them with this shared budget.
+export const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
+
 /** Rejection raised by withTimeout. The bounded work is NOT cancelled — the
  * caller decides what a straggler that settles later means. */
 export class TimeoutError extends Error {

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -178,3 +178,75 @@ describe('ensureGatewayForProfile — secondary connect failure surfaces (#81094
     expect(activeGateway()).toBe(gatewayMocks.instances[0])
   })
 })
+
+describe('secondary connection timeout (#93454)', () => {
+  it("rejects instead of hanging forever when openSecondary's getConnection() wedges", async () => {
+    // Repro: desktop.getConnection is an IPC round-trip into the main process
+    // with no timeout of its own. A wedged main-process round-trip (e.g. a
+    // stuck revalidation) hangs this await forever, latching
+    // entry.connectPromise so every routed action against this secondary
+    // (SSH terminal, messaging DELETE, session send, …) never settles either.
+    vi.useFakeTimers()
+
+    let callCount = 0
+    const getConnection = vi.fn(({ profile }: { profile: string }) => {
+      callCount += 1
+
+      // First call is sharedPrimaryRoute's probe — resolves fast, not the
+      // shared primary. Every call after (openSecondary's actual dial) wedges.
+      if (callCount === 1) {
+        return Promise.resolve({ sharedPrimary: false })
+      }
+
+      return new Promise(() => undefined)
+    })
+
+    installDesktop({ getConnection })
+
+    const pending = expect(ensureGatewayForProfile('work')).rejects.toThrow('Timed out connecting to profile "work"')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // await must reject instead of hanging forever.
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+  })
+
+  it('does not let a wedged shared-primary-route probe block the secondary dial forever', async () => {
+    // Same unbounded-IPC hazard as above, but for sharedPrimaryRoute's own
+    // getConnection() probe, which runs BEFORE openSecondary on every route —
+    // a wedge there must resolve to "not the shared primary" and fall through
+    // to the ordinary secondary dial instead of hanging the whole route
+    // decision forever.
+    vi.useFakeTimers()
+
+    let callCount = 0
+    const getConnection = vi.fn(({ profile }: { profile: string }) => {
+      callCount += 1
+
+      if (callCount === 1) {
+        return new Promise(() => undefined)
+      }
+
+      return Promise.resolve({
+        authMode: 'token',
+        baseUrl: `https://${profile}.invalid`,
+        mode: 'local',
+        profile,
+        token: 'fake-test-token',
+        wsUrl: `wss://${profile}.invalid/ws`
+      })
+    })
+
+    installDesktop({ getConnection })
+
+    const pending = ensureGatewayForProfile('work')
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await pending
+
+    // The probe's own bound (not just openSecondary's) is what let this
+    // resolve after a single 20s timeout instead of two stacked ones.
+    expect(callCount).toBe(2)
+    expect(activeGateway()).toBe(gatewayMocks.instances[0])
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -4,6 +4,7 @@ import { atom } from 'nanostores'
 import type { HermesConnection } from '@/global'
 import { HermesGateway, setApiRequestConnection } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
 
@@ -409,11 +410,25 @@ async function openSecondary(entry: Secondary): Promise<void> {
     }
 
     // Registry-scoped entries dial through getConnectionFor when the bridge has
-    // it. Local/legacy entries retain the existing getConnection path.
+    // it. Local/legacy entries retain the existing getConnection path. Both are
+    // IPC round-trips into the main process with no timeout of their own
+    // (#93454) — a wedged main-process round-trip otherwise hangs this await
+    // forever, latching entry.connectPromise so every routed action against
+    // this secondary (SSH terminal, messaging DELETE, session send, …) never
+    // settles either. Bound the same way use-gateway-boot.ts bounds the
+    // primary's equivalent awaits.
     const conn =
       entry.connectionId && desktop.getConnectionFor
-        ? await desktop.getConnectionFor({ connectionId: entry.connectionId, profile: entry.profile })
-        : await desktop.getConnection(entry.profile)
+        ? await withTimeout(
+            desktop.getConnectionFor({ connectionId: entry.connectionId, profile: entry.profile }),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${entry.profile}"`
+          )
+        : await withTimeout(
+            desktop.getConnection(entry.profile),
+            RECONNECT_ATTEMPT_TIMEOUT_MS,
+            `Timed out connecting to profile "${entry.profile}"`
+          )
 
     entry.connection = conn
 
@@ -427,7 +442,11 @@ async function openSecondary(entry: Secondary): Promise<void> {
           ? {}
           : desktop
 
-    const wsUrl = await resolveGatewayWsUrl(wsDeps, conn)
+    const wsUrl = await withTimeout(
+      resolveGatewayWsUrl(wsDeps, conn),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out re-minting the gateway WebSocket URL for profile "${entry.profile}"`
+    )
 
     try {
       await entry.gateway.connect(wsUrl)
@@ -617,7 +636,15 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   }
 
   try {
-    const conn = await desktop.getConnection(profile)
+    // Unbounded IPC round-trip into main (#93454) — a wedge here must reject
+    // like any other failure, not hang the route decision forever, since
+    // every caller (gatewayForProfile → requestGatewayForProfile/Agent) awaits
+    // this before it can fall back to dialing a secondary.
+    const conn = await withTimeout(
+      desktop.getConnection(profile),
+      RECONNECT_ATTEMPT_TIMEOUT_MS,
+      `Timed out resolving the shared-primary route for profile "${profile}"`
+    )
 
     return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {


### PR DESCRIPTION
## What does this PR do?

#93454/#93662 identified that `desktop.getConnection()`/`resolveGatewayWsUrl()` (and `revalidateConnection()`) are IPC round-trips into the Electron main process with no timeout of their own — a wedged main-process round-trip (e.g. a stuck revalidation after a liveness-probe trip) hangs the awaiting caller forever instead of surfacing a failure. That fix bounded all three with a 20s `withTimeout()`, but only on the `boot()` and soft-switch paths in `use-gateway-boot.ts`.

Every other production call site of the same IPC pair was still unbounded:

- **`store/gateway.ts`'s `openSecondary()`** — the actual connection-establishment underneath `requestGatewayForProfile`/`requestGatewayForAgent`, `ensureGatewayForProfile`/`ensureGatewayForAgent`, `retainGatewayForAgent`, `retainGatewayForSessionTurn`, and every other exported routing entry point that opens a non-primary profile's socket. This is the mechanism the recent SSH-routing / messaging-DELETE / registry-ownership fix series routes through — a wedge here hangs every one of those routed actions with no timeout, no retry, no user-visible error.
- **`store/gateway.ts`'s `sharedPrimaryRoute()`** — the probe that runs *before* `openSecondary` on every non-primary route decision. Its `try/catch` already returns `false` on any failure, but with no timeout a wedge here blocks the whole route decision forever (the `catch` never fires because nothing ever rejects).
- **`use-gateway-request.ts`'s on-demand reconnect** — the primary gateway's "not connected" retry path, hit by any RPC that lands on a dropped socket.
- **`voice-playback.ts`'s `resolveSpeakStreamUrl()`** — voice mode's streaming-TTS connection resolver.
- **`api/plugins.ts`'s `activeConnection()`** — `pluginSocket`'s connect step.

## Changes

- Extracted `RECONNECT_ATTEMPT_TIMEOUT_MS` into the shared `lib/with-timeout.ts` (previously a local constant in `use-gateway-boot.ts`) so every call site shares one budget instead of duplicating the constant. `use-gateway-boot.ts` now imports it instead of redeclaring it — no behavior change there.
- Wrapped every remaining unbounded `getConnection()`/`getConnectionFor()`/`resolveGatewayWsUrl()` call in the five files above with the existing `withTimeout()` helper, using the same 20s budget and the same message style as the already-merged fix.
- Each fix site already has existing rejection handling (`try/catch`, `.catch(() => null)`, or a `finally` that clears a guard flag) — the timeout rejection flows through the same paths a genuine connection failure already used, so no new error-handling was needed, only the missing bound.

## Test plan

- Added 6 regression tests mirroring the existing `use-gateway-boot.test.tsx` hang-repro pattern: wedge `getConnection()`/`getConnectionFor()` with a never-resolving promise, advance fake timers past the 20s bound, assert the caller settles (rejects/resolves-null as appropriate) instead of hanging.
  - `store/gateway.test.ts`: `openSecondary`'s dial, and `sharedPrimaryRoute`'s probe (isolated from each other via call-count-based mocking, since the probe runs first on every route).
  - `use-gateway-request.test.ts`: the on-demand reconnect path.
  - `voice-playback.routing.test.ts`: `resolveSpeakStreamUrl`.
  - `api/plugins.test.ts` (new file): `activeConnection`, exported for testing (mirrors how `voice-playback.ts` already exports `resolveSpeakStreamUrl` "for tests" for the same reason), covering both the `getConnectionFor` and plain `getConnection` branches.
- Mutation-verified: `git stash`'d the production fix (kept the tests), confirmed all 6 new tests fail — 4 by genuinely timing out at the vitest level (proving they really hang without the fix, not just asserting a message), 2 by `TypeError`/type error on the not-yet-exported `activeConnection`. Restored the fix and confirmed all tests pass again.
- Full regression sweep: `vitest run src/store/gateway.test.ts src/store/gateway-switch.test.ts src/app/gateway src/lib/voice-playback.routing.test.ts src/api/plugins.test.ts` — 70 passed, no regressions (includes the 24 pre-existing `use-gateway-boot.test.tsx` tests, confirming the `RECONNECT_ATTEMPT_TIMEOUT_MS` extraction didn't change its behavior).
- `tsc -p . --noEmit` on the desktop workspace — clean.