### PR TITLE
fix(update): skip the elevating autostart repair on unattended cua-driver refresh

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1940,8 +1940,25 @@ def _run_cua_driver_installer(
                     logger.debug("cua-driver installer output:\n%s", result.stdout)
         installed_binary = _resolved_cua_driver_cmd()
         if result.returncode == 0 and installed_binary:
-            if is_windows and not _repair_cua_driver_autostart_windows(
-                installed_binary, verbose=verbose
+            # Unattended refreshes (installer_timeout set) pass -NoAutoStart
+            # above specifically to skip install.ps1's self-elevating
+            # Register-CuaDriverAutostart branch (#87703) — but
+            # _repair_cua_driver_autostart_windows has its OWN independent
+            # self-elevating branch (Start-Process ... -Verb RunAs -Wait, up
+            # to 300s) that fires whenever the task isn't ALREADY registered,
+            # regardless of installer_timeout. -NoAutoStart guarantees it
+            # won't be registered on a first-time unattended install, so this
+            # call would reopen the exact hidden-UAC-prompt hang -NoAutoStart
+            # was added to avoid. Skip it here too when unattended, same
+            # tradeoff -NoAutoStart already accepts: an unregistered task
+            # stays unregistered until the next interactive
+            # `computer-use install --upgrade` re-registers it.
+            if (
+                is_windows
+                and installer_timeout is None
+                and not _repair_cua_driver_autostart_windows(
+                    installed_binary, verbose=verbose
+                )
             ):
                 _print_warning(
                     "    cua-driver installed, but auto-start was not registered."

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1586,6 +1586,50 @@ class TestWindowsAutostartRepair:
         )
 
     @pytest.mark.windows_only
+    def test_unattended_refresh_skips_autostart_repair_to_avoid_uac(self):
+        """``windows_only``: an unattended refresh (installer_timeout set,
+        e.g. ``hermes update``'s confirmed-upgrade path) passes -NoAutoStart
+        specifically so install.ps1 never self-elevates (#87703) — but
+        ``_repair_cua_driver_autostart_windows`` has its OWN independent
+        elevating branch (Start-Process ... -Verb RunAs -Wait) that used to
+        run unconditionally after ANY successful install, including this one,
+        whenever the scheduled task wasn't already registered (guaranteed by
+        -NoAutoStart on a first-time unattended install). Confirm it's now
+        skipped for installer_timeout is not None, matching the -NoAutoStart
+        tradeoff: the task stays unregistered until the next interactive
+        `computer-use install --upgrade`, instead of popping a hidden UAC
+        prompt inside `hermes update`.
+        """
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+
+        def fake_which(name: str):
+            if name == "cua-driver":
+                return r"C:\Users\Ha Trung\AppData\Local\Programs\Cua\cua-driver\bin\cua-driver.exe"
+            return None
+
+        with patch.object(tools_config.shutil, "which", side_effect=fake_which), \
+             patch("subprocess.Popen", return_value=fake_proc), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_cua_install_lock_held", return_value=False), \
+             patch.object(tools_config, "_cua_release_endpoint_reachable", return_value=True), \
+             patch.object(tools_config, "_repair_cua_driver_autostart_windows", return_value=True) as repair, \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False, installer_timeout=120
+            )
+
+        assert ok is True
+        repair.assert_not_called()
+
+    @pytest.mark.windows_only
     def test_autostart_repair_quotes_username_space_path_via_file_path(self):
         """``windows_only``: same early return off Windows — the elevated
         PowerShell command string is only built on a real Windows host.


### PR DESCRIPTION
## What does this PR do?

`23c3f5086e` (merged today via #95129) made `hermes update`'s Windows cua-driver refresh unattended-safe by passing `-NoAutoStart` to `install.ps1`, specifically to skip its self-elevating `Register-CuaDriverAutostart` branch (#87703 — the hidden UAC prompt an automatic, non-interactive update can't answer). Its own comment describes `-NoAutoStart` as skipping "the ONLY branch that self-elevates."

That's not quite right. `_repair_cua_driver_autostart_windows` (`hermes_cli/tools_config.py`) has its own, independent self-elevating branch:

```python
ps_cmd = (
    f"$exe = {_ps_single_quote(binary)}; "
    "$proc = Start-Process -FilePath $exe "
    "-ArgumentList @('autostart','enable') "
    "-Verb RunAs -Wait -PassThru -ErrorAction Stop; "
    "exit $proc.ExitCode"
)
```

`_run_cua_driver_installer` calls this **unconditionally** after any successful install/refresh, regardless of `installer_timeout` (the exact flag that already gates the lock/network preflights a few lines above it for unattended runs). `-NoAutoStart` guarantees the scheduled task is **not** registered on a first-time unattended install — so this call reliably falls into the `-Verb RunAs -Wait` branch, reopening the exact hidden-UAC-prompt hang class `-NoAutoStart` was added to avoid, just from a second, sibling call site the same commit's own description missed.

The routine-confirmed-upgrade code path this feeds (`install_cua_driver(upgrade=True, require_confirmed_update=True)`, used by `hermes update`) has an existing comment that states the intended contract directly: *"Windows routine upgrades run UNATTENDED-SAFE rather than deferring... Only contract repairs and fresh installs stay interactive-only... those are the paths where upstream legitimately needs a human (first-time autostart elevation, SmartScreen)."* The unconditional repair call violates that stated contract.

## Fix

Skip `_repair_cua_driver_autostart_windows` when `installer_timeout is not None` (the unattended-refresh signal), matching the same tradeoff `-NoAutoStart` itself already accepts: an unregistered scheduled task stays unregistered until the next interactive `hermes computer-use install --upgrade` re-registers it, instead of popping a blocking UAC prompt inside a background `hermes update` run. Explicit/interactive installs (`installer_timeout=None`) are unaffected — a human is present there, same as before.

The other call site of `_repair_cua_driver_autostart_windows` (in the "already installed and compatible" fast path) is only reached with `upgrade=False`, which `hermes update` never passes (it always passes `upgrade=True` — see that path's own docstring) — so it's already interactive-only and needed no change.

## Test plan

- Added `test_unattended_refresh_skips_autostart_repair_to_avoid_uac` alongside the existing `test_windows_installer_runs_autostart_repair_after_success`, confirming the repair call is skipped when `installer_timeout` is set and still runs (no regression) when it isn't.
- Both this new test and the existing sibling are `windows_only`-marked and skip on this (non-Windows) host, consistent with every other Windows-native test in this file. Since the code path here is pure Python control flow around mocked `subprocess`/`shutil.which` calls (no genuine Windows syscalls needed to exercise the branch), I verified empirically rather than only by reading the code: invoked both test methods directly with `platform.system()` forced to `"Windows"` (bypassing the marker skip) — both pass with the fix.
- Mutation-verified: stashed the production fix (kept the test forcing setup), re-ran the same forced-Windows repro — confirmed `_repair_cua_driver_autostart_windows` **is** called without the fix (bug reproduces), then restored the fix and confirmed it's skipped again.
- Full suite: `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_install_cua_driver.py tests/hermes_cli/test_tools_config.py -q` — 98 passed, 31 skipped (all `windows_only`), no regressions.