### PR TITLE
feat(desktop): Settings toggle to expand file-edit diffs by default

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
+import { $expandFileEditsByDefault, setExpandFileEditsByDefault } from '@/store/file-edit-expansion'
 import { $introSplash, setIntroSplash } from '@/store/intro-splash'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
@@ -345,6 +346,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const expandFileEditsByDefault = useStore($expandFileEditsByDefault)
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
   const sessionListDensity = useStore($sessionListDensity)
   const tabStripDefault = useStore($tabStripDefault)
@@ -805,6 +807,28 @@ export function AppearanceSettings() {
             }
             description={a.reasoningCollapsedDesc}
             title={a.reasoningCollapsedTitle}
+          />
+
+          {/* Same disclosure family as the thinking toggle: it sets what NEW
+              rows do at mount (#74302). A row the user already toggled keeps
+              its own choice — $toolDisclosureOpen outranks this default. */}
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setExpandFileEditsByDefault(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={expandFileEditsByDefault ? 'on' : 'off'}
+              />
+            }
+            description={a.expandFileEditsDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.fileEdits)}
+            title={a.expandFileEditsTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -13,6 +13,7 @@ export type CredentialSettingsView = 'settings' | 'tools'
 export const APPEARANCE_SETTING_IDS = {
   backdrop: 'appearance.backdrop',
   embeds: 'appearance.embeds',
+  fileEdits: 'appearance.file-edits',
   introSplash: 'appearance.intro-splash',
   language: 'appearance.language',
   theme: 'appearance.theme',

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -41,6 +41,7 @@ import { AlertCircle, CheckCircle2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import { $expandFileEditsByDefault } from '@/store/file-edit-expansion'
 import { recordPreviewArtifact } from '@/store/preview-status'
 import { sessionApprovalRequest } from '@/store/prompts'
 import { $toolInlineDiff } from '@/store/tool-diffs'
@@ -369,7 +370,14 @@ function ToolEntry({ part }: ToolEntryProps) {
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
   const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
   const isFileEdit = isFileEditTool(toolName)
-  const defaultOpen = Boolean(inlineDiff)
+  // File-edit diffs follow the Appearance preference (#74302): users review
+  // edits differently — some want diffs visible as they land, others prefer
+  // a compact transcript — so a diff mounts expanded only for tools outside
+  // the file-edit family, or when the user opted in. Clicking still expands
+  // a folded row, and a manual toggle persists over either default
+  // ($toolDisclosureOpen wins whenever the row has been touched before).
+  const expandFileEdits = useStore($expandFileEditsByDefault)
+  const defaultOpen = Boolean(inlineDiff) && (!isFileEdit || expandFileEdits)
   const open = useDisclosureOpen(disclosureId, defaultOpen)
   const canDismiss = !isPending && !embedded
   // Only animate entries that mount while their message is actively

--- a/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $displayTimestamps } from '@/store/display-timestamps'
+import { $expandFileEditsByDefault } from '@/store/file-edit-expansion'
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 import { clearDismissedToolRows } from '@/store/tool-dismiss'
@@ -429,8 +430,18 @@ describe('settled tool run', () => {
 
 // A diff is what the user reviews, so it is never what gets summarized away.
 // It stays on screen at the point in the turn where it happened, with the
-// activity either side of it collapsing around it.
+// activity either side of it collapsing around it. How much of it shows at
+// mount is the Appearance preference (#74302): folded until opened unless the
+// user opted into expanding file edits by default.
 describe('a file edit among ordinary activity', () => {
+  beforeEach(() => {
+    $expandFileEditsByDefault.set(false)
+  })
+
+  afterEach(() => {
+    $expandFileEditsByDefault.set(false)
+  })
+
   it('stays visible between the two runs it interrupted', async () => {
     const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
 
@@ -443,12 +454,37 @@ describe('a file edit among ordinary activity', () => {
     expect(shape).toEqual(['summary', 'row', 'summary'])
   })
 
-  it('keeps the diff itself on screen rather than behind the summary', async () => {
+  it('starts its diff folded behind the summary and expands on click', async () => {
+    const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
+
+    const row = await waitFor(() => {
+      const candidate = container.querySelector('[data-tool-row]')
+
+      expect(candidate).not.toBeNull()
+
+      return candidate as HTMLElement
+    })
+
+    expect(row.hasAttribute('data-file-edit')).toBe(false)
+    expect(row.hasAttribute('data-tool-open')).toBe(false)
+    expect(container.querySelector('[data-slot="file-diff-panel"]')).toBeNull()
+
+    fireEvent.click(row.querySelector('button[aria-expanded]') as HTMLButtonElement)
+
+    expect(row.hasAttribute('data-file-edit')).toBe(true)
+    expect(row.hasAttribute('data-tool-open')).toBe(true)
+    expect(container.querySelector('[data-slot="file-diff-panel"]')).not.toBeNull()
+  })
+
+  it('mounts with the diff expanded when expanding file edits is enabled', async () => {
+    $expandFileEditsByDefault.set(true)
+
     const { container } = render(<GroupHarness message={editBetweenRunsMessage()} />)
 
     await waitFor(() => {
       expect(container.querySelector('[data-tool-row][data-file-edit]')).not.toBeNull()
     })
+    expect(container.querySelector('[data-tool-row][data-tool-open]')).not.toBeNull()
   })
 })
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -444,6 +444,9 @@ export const ar = defineLocale({
       toolViewDesc: 'تحكم في كيفية عرض نشاط الأدوات داخل المحادثة.',
       reasoningCollapsedTitle: 'طي التفكير افتراضيًا',
       reasoningCollapsedDesc: 'أبقِ التفكير المتدفق متاحًا دون توسيعه حتى تفتحه.',
+      expandFileEditsTitle: 'توسيع تعديلات الملفات افتراضيًا',
+      expandFileEditsDesc:
+        'افتح الفرق المضمّن عند تنفيذ write_file أو patch. عند الإيقاف يبقى صف الملخص المضغوط حتى تفتحه.',
       translucencyTitle: 'شفافية النافذة',
       translucencyDesc: 'إظهار سطح المكتب من خلال النافذة بالكامل، بما في ذلك النص.',
       translucencyGlassDesc: 'زجاج غير لامع: يظهر سطح المكتب كضبابية ناعمة بينما يبقى النص واضحًا.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -543,6 +543,9 @@ export const en: Translations = {
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
       reasoningCollapsedTitle: 'Collapse thinking by default',
       reasoningCollapsedDesc: 'Keep streamed reasoning available without expanding it until you open it.',
+      expandFileEditsTitle: 'Expand file edits by default',
+      expandFileEditsDesc:
+        'Open the inline diff when write_file or patch lands. Off keeps the compact summary row until you open it.',
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -366,6 +366,9 @@ export const ja = defineLocale({
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
       reasoningCollapsedTitle: '思考ブロックをデフォルトで折りたたむ',
       reasoningCollapsedDesc: 'ストリーミング中の推論を、開くまで折りたたんだまま利用できるようにします。',
+      expandFileEditsTitle: 'ファイル編集をデフォルトで展開',
+      expandFileEditsDesc:
+        'write_file や patch の実行時にインライン diff を自動で開きます。オフの場合は要約行のみ表示され、クリックで開けます。',
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -436,6 +436,8 @@ export interface Translations {
       toolViewDesc: string
       reasoningCollapsedTitle: string
       reasoningCollapsedDesc: string
+      expandFileEditsTitle: string
+      expandFileEditsDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
       sessionDensityTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -356,6 +356,8 @@ export const zhHant = defineLocale({
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
       reasoningCollapsedTitle: '預設摺疊推理過程',
       reasoningCollapsedDesc: '保留串流推理內容，但在您開啟前維持摺疊。',
+      expandFileEditsTitle: '預設展開檔案編輯',
+      expandFileEditsDesc: 'write_file 或 patch 完成時自動展開內聯 diff。關閉時僅保留精簡摘要列，點擊後才展開。',
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -530,6 +530,8 @@ export const zh: Translations = {
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
       reasoningCollapsedTitle: '默认折叠推理过程',
       reasoningCollapsedDesc: '保留流式推理内容，但在您打开前保持折叠。',
+      expandFileEditsTitle: '默认展开文件编辑',
+      expandFileEditsDesc: 'write_file 或 patch 落地时自动展开内联 diff。关闭时仅保留紧凑摘要行，点击后才展开。',
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,

--- a/apps/desktop/src/store/file-edit-expansion.ts
+++ b/apps/desktop/src/store/file-edit-expansion.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether a new file-edit tool row mounts with its inline diff expanded.
+ *
+ * Settings → Appearance owns the lever (#74302): users review edits
+ * differently — some want every diff visible as it lands, others prefer a
+ * compact transcript they expand on demand. Off (the shipped default) keeps
+ * each settled row at its one-line summary; a manual toggle on a specific row
+ * still wins over this default via `$toolDisclosureOpen`.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const EXPAND_FILE_EDITS_STORAGE_KEY = 'hermes.desktop.fileEdits.expandedByDefault'
+
+/** Desktop-local presentation preference; shared backend config must not be changed by a single window. */
+export const $expandFileEditsByDefault = atom(storedBoolean(EXPAND_FILE_EDITS_STORAGE_KEY, false))
+
+$expandFileEditsByDefault.subscribe(value => persistBoolean(EXPAND_FILE_EDITS_STORAGE_KEY, value))
+
+export function setExpandFileEditsByDefault(value: boolean) {
+  $expandFileEditsByDefault.set(value)
+}


### PR DESCRIPTION
## What does this PR do?

Implements the persisted Desktop preference asked for in #74302: **Settings → Appearance → "Expand file edits by default"**.

The inline diff of a file-edit tool row (`write_file`, `patch`, …) previously mounted expanded whenever a diff existed — hardcoded in `fallback.tsx` (`defaultOpen = Boolean(inlineDiff)`), so edit-heavy runs buried the transcript and #74302's motivation ("some users want diffs visible, others prefer compact progress") had no lever. This PR replaces that hardcode with a real preference:

- **Off (shipped default):** a settled edit row stays at its one-line summary — file name, status glyph, `+N −N` counts — until clicked.
- **On:** preserves today's expand-on-arrival behavior for users who review diffs live.
- **Per-row choices still win:** `useDisclosureOpen` resolves `$toolDisclosureOpen(disclosureId) ?? defaultOpen`, so any row the user has manually toggled keeps its own state (#74302's "explicit per-row user choices take precedence").

## Changes

- `apps/desktop/src/store/file-edit-expansion.ts` *(new)* — `$expandFileEditsByDefault` nanostores atom, persisted device-local via `persistBoolean`/`storedBoolean` under `hermes.desktop.fileEdits.expandedByDefault` (same pattern as the reasoning-disclosure preference; desktop-local presentation state, never shared backend config).
- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx` — the hardcoded default becomes `Boolean(inlineDiff) && (!isFileEdit || expandFileEdits)`; non-file-edit tools keep their existing default untouched.
- `apps/desktop/src/app/settings/appearance-settings.tsx` — new Appearance row (segmented Off/On, haptic feedback) next to "Collapse thinking by default", registered as `appearance.file-edits` for settings search / deep-link highlighting.
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar,types}.ts` — copy for the new row in all five locales.
- `apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx` — replaces the expanded-by-default assertion with three tests: diff starts folded behind the summary and expands on click (no `data-tool-open`/`data-file-edit`, no mounted `[data-slot="file-diff-panel"]` until clicked); mounts expanded when the preference is on; run shape unchanged. CSS needed no change — an *open* edit is what carries `data-file-edit`.

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui src/components/assistant-ui/tool src/i18n
npm run typecheck
```

Local results:

- Focused UI suites (tool + i18n): 11 files / 122 tests passed.
- `npm run typecheck` (renderer + electron + e2e tsconfigs): clean.
- Focused ESLint on all touched files: 0 errors. Prettier: clean.

Resolves #74302

Supersedes the approach in my earlier #95301 (a hardcoded flip of the same default), which I am closing: a one-way flip can't satisfy both camps in #74302 — this preference can.
