### PR TITLE
fix(desktop): let guarded model choices complete instead of silently reverting

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -1,9 +1,10 @@
 import { QueryClient } from '@tanstack/react-query'
-import { cleanup, render, renderHook } from '@testing-library/react'
+import { cleanup, render, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelInfo } from '@/hermes'
 import { modelOptionsQueryKey } from '@/lib/model-options'
+import { $confirmRequest, settleConfirm } from '@/store/confirm'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -81,6 +82,7 @@ describe('useModelControls', () => {
   })
 
   afterEach(() => {
+    settleConfirm(false)
     cleanup()
     vi.restoreAllMocks()
     $activeGatewayProfile.set('default')
@@ -299,6 +301,63 @@ describe('useModelControls', () => {
     await controls.selectModel({ model: 'grok-4.5', provider: 'xai' })
 
     expect(invalidate).toHaveBeenCalled()
+  })
+
+  it('confirms and retries a guarded live-session model switch', async () => {
+    $activeSessionId.set('session-1')
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_message: 'This tier trains on your prompts.',
+        confirm_required: true,
+        value: 'muse-spark-1.2-contributor'
+      })
+      .mockResolvedValueOnce({
+        confirm_required: false,
+        scope: 'global',
+        value: 'muse-spark-1.2-contributor'
+      })
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    const pending = controls.selectModel({ model: 'muse-spark-1.2-contributor', provider: 'opencode-go' })
+
+    await waitFor(() => expect($confirmRequest.get()?.description).toBe('This tier trains on your prompts.'))
+    settleConfirm(true)
+
+    await expect(pending).resolves.toBe(true)
+    expect(requestGateway).toHaveBeenNthCalledWith(2, 'config.set', {
+      confirm_expensive_model: true,
+      session_id: 'session-1',
+      key: 'model',
+      value: 'muse-spark-1.2-contributor --provider opencode-go --global'
+    })
+  })
+
+  it('rolls back a guarded live-session model switch when confirmation is cancelled', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('fable-5')
+    setCurrentProvider('nous')
+    const requestGateway = vi.fn().mockResolvedValue({
+      confirm_message: 'This tier trains on your prompts.',
+      confirm_required: true,
+      value: 'muse-spark-1.2-contributor'
+    })
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    const pending = controls.selectModel({ model: 'muse-spark-1.2-contributor', provider: 'opencode-go' })
+
+    await waitFor(() => expect($confirmRequest.get()).not.toBeNull())
+    settleConfirm(false)
+
+    await expect(pending).resolves.toBe(false)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect($currentModel.get()).toBe('fable-5')
+    expect($currentProvider.get()).toBe('nous')
+    expect(notifyError).not.toHaveBeenCalled()
   })
 
   it('keeps the pick when an OLDER gateway refuses a mid-turn switch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -6,6 +6,7 @@ import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
+import { requestConfirmedModelSwitch } from '@/lib/model-switch-confirmation'
 import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -235,11 +236,37 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
         const scope = persistsAsDefault ? '--global' : '--session'
 
-        const result = await requestGateway<{ deferred?: boolean }>('config.set', {
+        const outcome = await requestConfirmedModelSwitch(requestGateway, {
           session_id: liveSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} ${scope}`
         })
+
+        if (outcome.status === 'cancelled') {
+          if (touchesPrimary) {
+            setCurrentModel(prevModel)
+            setCurrentProvider(prevProvider)
+            setCurrentModelSource(prevSource)
+          } else {
+            sessionTileDelegate()?.updateSession(liveSessionId, state => ({
+              ...state,
+              model: prevModel,
+              provider: prevProvider
+            }))
+          }
+
+          updateModelOptionsCache(
+            liveSessionId,
+            prevProvider,
+            prevModel,
+            touchesPrimary && !liveSessionId,
+            liveGatewayProfile
+          )
+
+          return false
+        }
+
+        const { result } = outcome
 
         // A pick made DURING a turn is queued by the gateway and applied at the
         // next turn start (`deferred`). Re-fetching now would answer with the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -9,6 +9,7 @@ import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
+import { $confirmRequest, settleConfirm } from '@/store/confirm'
 import { requestGatewayForAgent } from '@/store/gateway'
 import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
@@ -1688,6 +1689,7 @@ describe('usePromptActions desktop slash pickers', () => {
   })
 
   afterEach(() => {
+    settleConfirm(false)
     cleanup()
     vi.useRealTimers()
     vi.restoreAllMocks()
@@ -1710,6 +1712,45 @@ describe('usePromptActions desktop slash pickers', () => {
     await handle!.submitText('/resume 20260610_130000_123abc')
 
     expect(resumeStoredSession).toHaveBeenCalledWith('20260610_130000_123abc')
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('confirms and retries a guarded typed /model switch through config.set', async () => {
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_message: 'This tier trains on your prompts.',
+        confirm_required: true,
+        value: 'muse-spark-1.2-contributor'
+      })
+      .mockResolvedValueOnce({
+        confirm_required: false,
+        scope: 'session',
+        value: 'muse-spark-1.2-contributor'
+      })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    const pending = handle!.submitText('/model muse-spark-1.2-contributor --provider opencode-go')
+
+    await waitFor(() => expect($confirmRequest.get()?.description).toBe('This tier trains on your prompts.'))
+    settleConfirm(true)
+    await pending
+
+    expect(requestGateway).toHaveBeenNthCalledWith(1, 'config.set', {
+      session_id: RUNTIME_SESSION_ID,
+      key: 'model',
+      value: 'muse-spark-1.2-contributor --provider opencode-go'
+    })
+    expect(requestGateway).toHaveBeenNthCalledWith(2, 'config.set', {
+      confirm_expensive_model: true,
+      session_id: RUNTIME_SESSION_ID,
+      key: 'model',
+      value: 'muse-spark-1.2-contributor --provider opencode-go'
+    })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -15,6 +15,7 @@ import {
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
+import { requestConfirmedModelSwitch } from '@/lib/model-switch-confirmation'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
@@ -1013,8 +1014,36 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          // Power users can still type `/model <name>` — run it on the backend.
-          await runExec(ctx)
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          try {
+            const outcome = await requestConfirmedModelSwitch(requestGateway, {
+              session_id: resolved.sessionId,
+              key: 'model',
+              value: ctx.arg.trim()
+            })
+
+            if (outcome.status === 'cancelled') {
+              resolved.render('model switch cancelled')
+
+              return
+            }
+
+            const { result } = outcome
+            if (!result.value) {
+              resolved.render('error: invalid response: model switch')
+
+              return
+            }
+
+            resolved.render(result.deferred ? `model → ${result.value} (applies next turn)` : `model → ${result.value}`)
+          } catch (error) {
+            resolved.render(`error: ${error instanceof Error ? error.message : String(error)}`)
+          }
 
           return
         }

--- a/apps/desktop/src/lib/model-switch-confirmation.ts
+++ b/apps/desktop/src/lib/model-switch-confirmation.ts
@@ -1,0 +1,56 @@
+import { confirm } from '@/store/confirm'
+
+export interface ConfigSetModelResponse {
+  confirm_message?: string
+  confirm_required?: boolean
+  deferred?: boolean
+  scope?: string
+  value?: string
+  warning?: string
+}
+
+export interface AppliedModelSwitch {
+  result: ConfigSetModelResponse
+  status: 'applied'
+}
+
+export interface CancelledModelSwitch {
+  status: 'cancelled'
+}
+
+export type ModelSwitchOutcome = AppliedModelSwitch | CancelledModelSwitch
+
+type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+
+export async function requestConfirmedModelSwitch(
+  requestGateway: GatewayRequest,
+  params: { session_id: string; key: 'model'; value: string }
+): Promise<ModelSwitchOutcome> {
+  const request = (confirmed = false) =>
+    requestGateway<ConfigSetModelResponse>('config.set', {
+      ...(confirmed ? { confirm_expensive_model: true } : {}),
+      ...params
+    })
+
+  let result = await request()
+
+  if (result.confirm_required) {
+    const accepted = await confirm({
+      confirmLabel: 'Switch anyway',
+      description: result.confirm_message || result.warning || 'This model requires confirmation.',
+      destructive: true,
+      title: 'Confirm model switch'
+    })
+
+    if (!accepted) {
+      return { status: 'cancelled' }
+    }
+
+    result = await request(true)
+    if (result.confirm_required) {
+      throw new Error(result.confirm_message || result.warning || 'Model switch confirmation was not accepted.')
+    }
+  }
+
+  return { result, status: 'applied' }
+}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13323,6 +13323,38 @@ def test_config_set_model_defers_while_running(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_config_set_guarded_model_confirms_before_deferring_while_running():
+    server._sessions["sid"] = _session(running=True)
+    params = {
+        "session_id": "sid",
+        "key": "model",
+        "value": "muse-spark-1.2-contributor --provider opencode-go",
+    }
+    try:
+        unconfirmed = server.handle_request(
+            {"id": "1", "method": "config.set", "params": params}
+        )
+
+        assert unconfirmed["result"]["confirm_required"] is True
+        assert "TRAINS ON YOUR DATA" in unconfirmed["result"]["confirm_message"]
+        assert "pending_model_switch" not in server._sessions["sid"]
+
+        confirmed = server.handle_request(
+            {
+                "id": "2",
+                "method": "config.set",
+                "params": {**params, "confirm_expensive_model": True},
+            }
+        )
+
+        assert confirmed["result"]["confirm_required"] is False
+        assert confirmed["result"]["deferred"] is True
+        pending = server._sessions["sid"]["pending_model_switch"]
+        assert pending["confirm_expensive_model"] is True
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_apply_pending_model_switch_runs_queued_pick(monkeypatch):
     """The queued pick is consumed once, on the turn thread, via
     _apply_model_switch — and cleared so it can't re-fire next turn."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12689,11 +12689,36 @@ def _(rid, params: dict) -> dict:
                         pending_model = parsed.model_input
                     except Exception:
                         pending_model = str(value)
+                    confirmed = bool(params.get("confirm_expensive_model", False))
+                    if not confirmed:
+                        try:
+                            from hermes_cli.model_selection_guards import (
+                                combined_selection_warning,
+                            )
+
+                            warning = combined_selection_warning(
+                                pending_model,
+                                provider=(
+                                    getattr(parsed, "explicit_provider", "") or ""
+                                ).strip(),
+                            )
+                        except Exception:
+                            warning = None
+                        if warning is not None:
+                            return _ok(
+                                rid,
+                                {
+                                    "key": key,
+                                    "value": pending_model,
+                                    "warning": warning.message,
+                                    "confirm_required": True,
+                                    "confirm_message": warning.message,
+                                    "scope": "session",
+                                },
+                            )
                     session["pending_model_switch"] = {
                         "raw": value,
-                        "confirm_expensive_model": bool(
-                            params.get("confirm_expensive_model", False)
-                        ),
+                        "confirm_expensive_model": confirmed,
                         # The resolved model/provider the next turn will run on.
                         # _session_info reports these while the switch is pending
                         # so the end-of-turn settle keeps showing the user's pick


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now completes the gateway confirmation handshake when a selected model requires explicit consent. Picker and typed `/model` switches show the gateway warning, retry the same `config.set` request only after approval, and roll back optimistic picker state when the user cancels. Busy sessions now return the confirmation before queuing the switch, so the approved choice still applies on the next turn instead of being dropped later.

### Symptom

Selecting a contributor-tier model in Desktop appears to succeed, but the next turn still uses the previous model and no confirmation dialog appears. The same failure affects a typed `/model` command.

### Impact

Desktop users cannot select models protected by the data-policy or cost confirmation guard. The silent optimistic UI makes the old runtime model look like a random fallback instead of a rejected switch.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-model-controls.ts:238` when `config.set` returns `confirm_required`, plus the typed model path in `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`.

**Causal chain:**
1. A user selects a guarded model and the gateway returns `confirm_required` without mutating runtime state.
2. Desktop reads only `deferred`, treats the structured response as success, and leaves its optimistic model selection painted.
3. No confirmed retry reaches the gateway, so later turns continue on the previous model.

**Why it is wrong:** `confirm_required` is a protocol state, not a successful model mutation. The client must ask the user and repeat the same request with `confirm_expensive_model: true` before it can commit the selection.

**Working sibling / contrast:** The TUI already handles the same `config.set` response by opening a confirmation overlay and retrying with the confirmation flag.

**Ruled out:** Provider resolution is not the failure. The gateway resolves the target model before returning the guard response, and existing idle confirmation tests prove the confirmed switch path can apply it.

### Fix

- Add one Desktop confirmation helper that owns the `config.set` confirm-and-retry protocol.
- Use it from both picker/tile model controls and typed `/model` commands.
- Roll back optimistic picker and cache state on cancellation without showing an error toast.
- Evaluate model-selection guards before deferring a busy-session switch, then queue only the confirmed request.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/model-switch-confirmation.ts` - centralize the guarded model confirmation and retry handshake.
- `apps/desktop/src/app/session/hooks/use-model-controls.ts` - confirm picker/tile switches and restore prior state on cancellation.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` - route typed `/model` through the same structured protocol.
- `tui_gateway/server.py` - return guard confirmation before a busy-session switch is deferred.
- Focused Desktop and gateway tests cover approval, retry payloads, cancellation, slash routing, and deferred state.

## How to Test

1. In Desktop, select a contributor-tier model from a live session and verify the warning dialog appears.
2. Cancel and verify the previous model remains selected; repeat, approve, and verify the switch applies (or reports that it applies next turn while busy).
3. Repeat with `/model muse-spark-1.2-contributor --provider opencode-go`.
4. Run the automated checks:

```bash
cd apps/desktop
npx vitest run src/app/session/hooks/use-model-controls.test.tsx src/app/session/hooks/use-prompt-actions/index.test.tsx
npm run typecheck
npm run lint -- --quiet

cd ../..
scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'config_set_model' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop and gateway test entries and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the implementation and focused checks on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; this restores the existing model-switch protocol
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the change is renderer and gateway protocol logic
- [x] Tool description and schema updates are N/A; no model tool behavior changed
