### PR TITLE
fix(desktop): honor fnmatch globs in the MCP Tools panel's include/exclude

### DIFF
--- a/apps/desktop/src/lib/mcp-tool-filter.test.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.test.ts
@@ -31,6 +31,38 @@ describe('isToolEnabled', () => {
     expect(isToolEnabled(server, 'a')).toBe(true)
     expect(isToolEnabled(server, 'b')).toBe(false)
   })
+
+  it('exclude glob disables matching tools, mirroring the backend fnmatch', () => {
+    // Real catalog manifest shape: optional-mcps/betterstack excludes
+    // "*instructions*" — the backend's matches_name_filter blocks
+    // get_instructions/read_instructions_now/etc; the panel must too.
+    const server = { tools: { exclude: ['remove_dashboard', '*instructions*'] } }
+    expect(isToolEnabled(server, 'get_instructions')).toBe(false)
+    expect(isToolEnabled(server, 'read_instructions_now')).toBe(false)
+    expect(isToolEnabled(server, 'remove_dashboard')).toBe(false)
+    expect(isToolEnabled(server, 'list_dashboards')).toBe(true)
+  })
+
+  it('include glob only enables matching tools', () => {
+    const server = { tools: { include: ['agento11y_*'] } }
+    expect(isToolEnabled(server, 'agento11y_query')).toBe(true)
+    expect(isToolEnabled(server, 'agento11y_export')).toBe(true)
+    expect(isToolEnabled(server, 'other_tool')).toBe(false)
+  })
+
+  it('glob is case-sensitive and anchored, like fnmatchcase', () => {
+    const server = { tools: { exclude: ['get_*'] } }
+    expect(isToolEnabled(server, 'GET_secrets')).toBe(true)
+    expect(isToolEnabled(server, 'x_get_secrets')).toBe(true)
+    expect(isToolEnabled(server, 'get_secrets')).toBe(false)
+  })
+
+  it('supports fnmatch character classes', () => {
+    const server = { tools: { exclude: ['tool_[abc]'] } }
+    expect(isToolEnabled(server, 'tool_a')).toBe(false)
+    expect(isToolEnabled(server, 'tool_b')).toBe(false)
+    expect(isToolEnabled(server, 'tool_d')).toBe(true)
+  })
 })
 
 describe('toggleToolInServer', () => {
@@ -70,5 +102,10 @@ describe('countEnabledTools', () => {
   it('counts enabled tools out of a discovered list', () => {
     const server = { tools: { exclude: ['b'] } }
     expect(countEnabledTools(server, ['a', 'b', 'c'])).toBe(2)
+  })
+
+  it('counts a glob exclude against every matching discovered tool', () => {
+    const server = { tools: { exclude: ['*instructions*'] } }
+    expect(countEnabledTools(server, ['get_instructions', 'read_instructions_now', 'list_dashboards'])).toBe(1)
   })
 })

--- a/apps/desktop/src/lib/mcp-tool-filter.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.ts
@@ -1,7 +1,12 @@
 // Per-tool MCP gating. A server's optional `tools.include` (whitelist) /
 // `tools.exclude` (denylist) decide which discovered tools the agent registers
-// — `include` wins, no filter means all. Mirrors `_register_server_tools` in
-// `tools/mcp_tool.py`.
+// — `include` wins, no filter means all. Entries may be exact tool names or
+// fnmatch-style globs (`*`, `?`, `[seq]`) — mirrors `_register_server_tools` /
+// `matches_name_filter` in `tools/mcp_tool.py`, including glob support: a
+// catalog manifest's `default_excluded: ["*instructions*"]` must gate the
+// same tools here that the backend actually blocks, or this panel shows the
+// wrong checkbox state and enabled-count for any server whose filter uses a
+// glob (several curated catalog entries do).
 
 export interface McpToolsFilter {
   exclude?: string[]
@@ -9,6 +14,8 @@ export interface McpToolsFilter {
 }
 
 type ServerConfig = Record<string, unknown>
+
+const GLOB_METACHARS = /[*?[]/
 
 const asNames = (value: unknown): string[] | undefined =>
   Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : undefined
@@ -25,10 +32,79 @@ export function readToolsFilter(server: ServerConfig | null | undefined): McpToo
   return { exclude: asNames(tools.exclude), include: asNames(tools.include) }
 }
 
+// Translate one fnmatch-style pattern into a case-sensitive RegExp, mirroring
+// Python's fnmatch.translate: `*` → any run (incl. empty), `?` → any one
+// char, `[seq]`/`[!seq]` → a (negated) character class, everything else
+// literal. An unterminated `[` (no closing `]`) falls back to a literal `[`,
+// same as CPython's translate.
+function fnmatchToRegExp(pattern: string): RegExp {
+  let source = ''
+  let i = 0
+
+  while (i < pattern.length) {
+    const char = pattern[i]
+
+    i += 1
+
+    if (char === '*') {
+      source += '.*'
+    } else if (char === '?') {
+      source += '.'
+    } else if (char === '[') {
+      let j = i
+
+      if (pattern[j] === '!') {
+        j += 1
+      }
+
+      if (pattern[j] === ']') {
+        j += 1
+      }
+
+      while (j < pattern.length && pattern[j] !== ']') {
+        j += 1
+      }
+
+      if (j >= pattern.length) {
+        source += '\\['
+      } else {
+        let charClass = pattern.slice(i, j).replace(/\\/g, '\\\\')
+
+        if (charClass.startsWith('!')) {
+          charClass = `^${charClass.slice(1)}`
+        }
+
+        source += `[${charClass}]`
+        i = j + 1
+      }
+    } else {
+      source += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    }
+  }
+
+  return new RegExp(`^${source}$`)
+}
+
+// True if `name` matches any entry in `patterns` — exact names match
+// literally; entries containing a glob metacharacter match as a
+// case-sensitive fnmatch pattern. Exact membership is checked first, same as
+// the backend's matches_name_filter.
+function matchesNameFilter(name: string, patterns: string[]): boolean {
+  if (!patterns.length) {
+    return false
+  }
+
+  if (patterns.includes(name)) {
+    return true
+  }
+
+  return patterns.some(pattern => GLOB_METACHARS.test(pattern) && fnmatchToRegExp(pattern).test(name))
+}
+
 export function isToolEnabled(server: ServerConfig | null | undefined, name: string): boolean {
   const { exclude, include } = readToolsFilter(server)
 
-  return include?.length ? include.includes(name) : !exclude?.includes(name)
+  return include?.length ? matchesNameFilter(name, include) : !matchesNameFilter(name, exclude ?? [])
 }
 
 // Toggle one tool, preserving the config's mode (include if present, else an


### PR DESCRIPTION
## What does this PR do?

`apps/desktop/src/lib/mcp-tool-filter.ts` — the helper behind the MCP Tools panel's per-tool checkboxes and "N of M enabled" count — is documented as mirroring `_register_server_tools` in `tools/mcp_tool.py`. It checked `tools.include`/`tools.exclude` membership with plain array `.includes()`, but the backend it mirrors also matches **fnmatch-style globs** (`*`, `?`, `[seq]`) via `matches_name_filter`:

```python
def matches_name_filter(tool_name: str, patterns: set[str]) -> bool:
    if tool_name in patterns:
        return True
    return any(
        fnmatch.fnmatchcase(tool_name, p)
        for p in patterns
        if "*" in p or "?" in p or "[" in p
    )
```

Glob support isn't theoretical — the curated MCP catalog ships it, e.g. `optional-mcps/betterstack/manifest.yaml`'s `default_excluded: ["*instructions*"]` and Grafana's `"agento11y_*"`.

## The bug

For any server configured with a glob filter, the desktop panel showed the **wrong checkbox state** and the **wrong enabled count** for every tool the glob covers. Example: with `tools: { exclude: ["remove_dashboard", "*instructions*"] }`, `isToolEnabled(server, "get_instructions")` returned `true` (shown enabled/checked) even though the backend's `matches_name_filter` blocks it at dispatch time. Not a security bypass — actual tool gating at dispatch time is unaffected, and `toggleToolInServer` already preserves glob entries verbatim on toggle (no data loss) — but a real trust/correctness bug: a user reviewing "what's actually reachable" in the panel gets a wrong answer.

## Fix

Added `fnmatchToRegExp` + `matchesNameFilter` to the TS helper, translating the same glob syntax (`*`, `?`, `[seq]`, `[!seq]`) the same way Python's `fnmatch.translate` does — exact names still match literally first (cheap, and matches the backend's own "exact membership checked first" comment). Used by `isToolEnabled` (and therefore `countEnabledTools`). `toggleToolInServer` is unchanged.

Cross-checked the translator's actual output against Python's `fnmatch.fnmatchcase` for every pattern shape exercised in the new tests (plain glob, anchoring/case-sensitivity, character class, negated character class, unterminated bracket) — all matched exactly.

Leaves one adjacent, out-of-scope thing untouched: `asNames`' scalar-string coercion (a bare `tools.include: "foo"` is currently dropped as absent) is a separate, complementary gap already covered by open PR #58142 — not duplicated here.

## Test plan

- Added regression tests to `mcp-tool-filter.test.ts`: exclude-glob (mirroring the real betterstack manifest shape), include-glob, case-sensitivity/anchoring, character-class support, and a `countEnabledTools` case showing the count bug directly.
- Mutation-verified: reverted the production fix (kept the tests), confirmed all 5 new tests fail (2 pre-existing behaviors, 3 new assertions) with the exact wrong values the bug produces; restored the fix and confirmed all 17 tests in the file pass.
- `tsc -p . --noEmit` on the desktop workspace — clean.