### PR TITLE
fix(agent): heal credential-pool last_status after a successful served request

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4025,6 +4025,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         def _relay_final_response() -> dict[str, Any]:
             tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
+            # Heal the pool entry after a successful served request (#95166)
+            pool = getattr(agent, "_credential_pool", None)
+            if pool is not None:
+                api_key = getattr(agent, "api_key", None)
+                if api_key:
+                    from agent.credential_pool import STATUS_EXHAUSTED, STATUS_DEAD
+                    for entry in pool.entries():
+                        if entry.runtime_api_key == api_key and entry.last_status in (STATUS_EXHAUSTED, STATUS_DEAD):
+                            pool._mark_healthy(entry)
             return {
                 "model": model_name,
                 "choices": [

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -915,6 +915,24 @@ class CredentialPool:
             self._persist()
         return updated
 
+    def _mark_healthy(self, entry: PooledCredential, *, persist: bool = True) -> PooledCredential:
+        """Clear a stale exhausted/dead verdict after a served request succeeds (#95166)."""
+        if entry.last_status is None:
+            return entry
+        updated = replace(
+            entry,
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+        self._replace_entry(entry, updated)
+        if persist:
+            self._persist()
+        return updated
+
     def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,48 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+class TestMarkHealthy:
+    """_mark_healthy clears a transient failure verdict (#95166)."""
+
+    def test_clears_exhausted_status(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED, STATUS_OK
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="env", access_token="sk-test",
+            last_status=STATUS_EXHAUSTED, last_status_at=1000.0,
+            last_error_code=429, last_error_reason="rate_limit",
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+        assert healed.last_status_at is None
+        assert healed.last_error_code is None
+
+    def test_skips_already_healthy_entry(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_OK
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="env", access_token="sk-test",
+            last_status=STATUS_OK,
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+
+    def test_clears_dead_status(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_OK, STATUS_DEAD
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="test", access_token="sk-test",
+            last_status=STATUS_DEAD, last_status_at=1000.0,
+            last_error_code=401, last_error_reason="token_invalidated",
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+        assert healed.last_error_code is None


### PR DESCRIPTION
## Summary

Fixes gap 2 of #95166: a credential-pool entry marked `STATUS_EXHAUSTED` by a transient wall stays exhausted after the wall lifts, making every subsequent pool reader see a false wall.

## Approach

- **`_mark_healthy()`** (agent/credential_pool.py) — symmetric to `_mark_exhausted()`: resets `last_status` to `STATUS_OK` and clears error fields. No-op when the entry already has `last_status=None`.
- **`_relay_final_response()`** (agent/chat_completion_helpers.py) — the unified success exit for chat-completions mode: after a successful served request, heals the active credential-pool entry if it still carries a stale exhausted/dead verdict.
- Only chat-completions mode is covered by the success-side heal; other API modes (responses, streaming-only) are not yet wired — the issue's reported probe path uses chat-completions, so this closes the gap for the primary case.

## Test Plan

- 3 new tests in `test_credential_pool.py`: `TestMarkHealthy` — clears exhausted status, skips already-healthy entry, clears dead status.
- Full file: 62/62 pass (3 new, 59 existing). `ruff check` clean. Windows footgun lint clean.

## Risk / Exclusions

- `_mark_healthy` is provider-agnostic and only touches the shared credential pool.
- `_relay_final_response` only runs for chat-completions mode; other API modes (responses, streaming-only) are unaffected.
- No prompt-cache or message-alternation impact (the heal runs after the response is fully constructed).

References #95166