### PR TITLE
fix(desktop): keep Routines rows usable in narrow panes (salvage #91625 + #89557)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -10982,12 +10982,12 @@ function RoutineRow({ job, onOpen, owner }) {
 
   return jsxs('div', {
     className: cn(
-      'group grid gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
+      'group grid min-w-0 gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
       'hover:border-(--ui-stroke-primary, var(--ui-stroke-secondary))'
     ),
     children: [
       jsxs('div', {
-        className: 'flex items-center gap-2',
+        className: 'flex min-w-0 items-center gap-2',
         children: [
           // The row's own button, not a click handler on the card: the switch
           // and delete control are siblings, so opening the details can never
@@ -11019,7 +11019,7 @@ function RoutineRow({ job, onOpen, owner }) {
               type: 'button',
               disabled: busy,
               className:
-                'flex size-5 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
+                'flex size-5 shrink-0 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
               onClick: () => act('remove'),
               children: jsx(Codicon, { name: 'trash', className: 'text-[0.75rem]' })
             })
@@ -11027,7 +11027,7 @@ function RoutineRow({ job, onOpen, owner }) {
         ]
       }),
       jsxs('div', {
-        className: 'flex items-center justify-between gap-2 pl-3.5',
+        className: 'flex min-w-0 items-center justify-between gap-2 pl-3.5',
         children: [
           jsxs('span', {
             className:
@@ -11043,7 +11043,7 @@ function RoutineRow({ job, onOpen, owner }) {
       legacyUnsafe
         ? jsx('div', {
             className:
-              'rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
+              'min-w-0 rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
             children: 'Paused for security: delete and recreate this legacy cronjob before running it again.'
           })
         : null

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -10953,6 +10953,7 @@ function RoutineRow({ job, onOpen, owner }) {
   const legacyUnsafe = isLegacyDelegatedRoutine(job)
   const serverActive = !legacyUnsafe && job.enabled !== false && job.state !== 'paused'
   const active = pendingActive === null ? serverActive : pendingActive
+  const displaySchedule = scheduleLabel(job.schedule)
 
   if (pendingActive !== null && pendingActive === serverActive) {
     setPendingActive(null) // server caught up
@@ -11031,11 +11032,19 @@ function RoutineRow({ job, onOpen, owner }) {
         children: [
           jsxs('span', {
             className:
-              'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
-            children: [jsx(Codicon, { name: 'calendar', className: 'text-[0.7rem]' }), scheduleLabel(job.schedule)]
+              'inline-flex min-w-0 max-w-full flex-1 items-center gap-1 rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
+            children: [
+              jsx(Codicon, { name: 'calendar', className: 'shrink-0 text-[0.7rem]' }),
+              jsx('span', {
+                className: 'min-w-0 truncate',
+                title: displaySchedule,
+                children: displaySchedule
+              })
+            ]
           }),
           jsx('span', {
-            className: 'ml-auto shrink-0 whitespace-nowrap text-[0.65rem] text-(--ui-text-quaternary)',
+            className:
+              'ml-auto max-w-full shrink-0 truncate whitespace-nowrap text-[0.65rem] text-(--ui-text-quaternary)',
             children: active && job.next_run_at ? `next ${relativeTime(new Date(job.next_run_at).getTime())}` : 'paused'
           })
         ]

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11027,15 +11027,15 @@ function RoutineRow({ job, onOpen, owner }) {
         ]
       }),
       jsxs('div', {
-        className: 'flex min-w-0 items-center justify-between gap-2 pl-3.5',
+        className: 'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 pl-3.5',
         children: [
           jsxs('span', {
             className:
-              'inline-flex items-center gap-1 rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
+              'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
             children: [jsx(Codicon, { name: 'calendar', className: 'text-[0.7rem]' }), scheduleLabel(job.schedule)]
           }),
           jsx('span', {
-            className: 'truncate text-[0.65rem] text-(--ui-text-quaternary)',
+            className: 'ml-auto shrink-0 whitespace-nowrap text-[0.65rem] text-(--ui-text-quaternary)',
             children: active && job.next_run_at ? `next ${relativeTime(new Date(job.next_run_at).getTime())}` : 'paused'
           })
         ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
@@ -1,55 +1,21 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import test from 'node:test'
-import vm from 'node:vm'
+import { JOB, collect, findRow, hasAll, renderRoutineRow } from './routine-row-test-harness.mjs'
 
-const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
-const start = source.indexOf('function RoutineRow(')
-const end = source.indexOf('// Structured schedule picker:', start)
+test('metadata keeps next-run visible and gives schedule the truncation budget', () => {
+  const elements = collect(renderRoutineRow(JOB, { relativeTime: () => 'in 4 days' }))
+  const metadata = findRow(elements, 'flex', 'flex-wrap', 'pl-3.5')
+  const schedule = findRow(elements, 'inline-flex', 'flex-1', 'rounded-full')
+  const scheduleText = elements.find(
+    element => element.type === 'span' && hasAll(element, 'truncate') && element.props?.title === 'Daily'
+  )
+  const nextRun = elements.find(element => element.props?.children === 'next in 4 days')
 
-assert.ok(start >= 0 && end > start, 'RoutineRow must remain extractable')
-
-function renderRoutineRow() {
-  const context = {
-    Codicon: 'Codicon',
-    Switch: 'Switch',
-    Tip: 'Tip',
-    cn: (...values) => values.filter(Boolean).join(' '),
-    host: { request: async () => undefined, notifyError: () => undefined },
-    invalidateRoutineOwner: async () => undefined,
-    isLegacyDelegatedRoutine: () => false,
-    jsx: (type, props) => ({ type, props }),
-    jsxs: (type, props) => ({ type, props }),
-    relativeTime: () => 'in 4 days',
-    routineTitle: () => 'Daily digest',
-    scheduleLabel: () => 'Every day',
-    useState: initial => [initial, () => undefined]
-  }
-
-  vm.createContext(context)
-  vm.runInContext(`${source.slice(start, end)}\nglobalThis.__RoutineRow = RoutineRow`, context)
-
-  return context.__RoutineRow({
-    job: {
-      enabled: true,
-      job_id: 'daily-digest',
-      next_run_at: '2026-08-23T09:00:00Z',
-      schedule: '0 9 * * *'
-    },
-    profile: 'default'
-  })
-}
-
-test('routine metadata wraps without truncating the schedule or next-run time', () => {
-  const row = renderRoutineRow()
-  const metadata = row.props.children[1]
-  const [schedule, nextRun] = metadata.props.children
-
-  assert.match(metadata.props.className, /\bflex-wrap\b/)
-  assert.match(schedule.props.className, /\bshrink-0\b/)
-  assert.match(schedule.props.className, /\bwhitespace-nowrap\b/)
-  assert.match(nextRun.props.className, /\bshrink-0\b/)
-  assert.match(nextRun.props.className, /\bwhitespace-nowrap\b/)
-  assert.doesNotMatch(nextRun.props.className, /\btruncate\b/)
-  assert.equal(nextRun.props.children, 'next in 4 days')
+  assert.ok(metadata, 'metadata line must render')
+  assert.ok(hasAll(metadata, 'min-w-0'), 'metadata line must stay bounded')
+  assert.ok(schedule, 'schedule pill must render')
+  assert.ok(hasAll(schedule, 'min-w-0', 'max-w-full'), 'schedule must own the flexible width budget')
+  assert.ok(scheduleText, 'schedule text must truncate and preserve its full tooltip')
+  assert.ok(nextRun, 'next-run label must render')
+  assert.ok(hasAll(nextRun, 'shrink-0', 'whitespace-nowrap', 'max-w-full', 'truncate'))
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
@@ -19,3 +19,11 @@ test('metadata keeps next-run visible and gives schedule the truncation budget',
   assert.ok(nextRun, 'next-run label must render')
   assert.ok(hasAll(nextRun, 'shrink-0', 'whitespace-nowrap', 'max-w-full', 'truncate'))
 })
+
+test('paused jobs keep the same bounded timing slot', () => {
+  const elements = collect(renderRoutineRow({ ...JOB, enabled: false, next_run_at: null }))
+  const paused = elements.find(element => element.props?.children === 'paused')
+
+  assert.ok(paused, 'paused timing label must render')
+  assert.ok(hasAll(paused, 'shrink-0', 'whitespace-nowrap', 'max-w-full', 'truncate'))
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const start = source.indexOf('function RoutineRow(')
+const end = source.indexOf('// Structured schedule picker:', start)
+
+assert.ok(start >= 0 && end > start, 'RoutineRow must remain extractable')
+
+function renderRoutineRow() {
+  const context = {
+    Codicon: 'Codicon',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    cn: (...values) => values.filter(Boolean).join(' '),
+    host: { request: async () => undefined, notifyError: () => undefined },
+    invalidateRoutineOwner: async () => undefined,
+    isLegacyDelegatedRoutine: () => false,
+    jsx: (type, props) => ({ type, props }),
+    jsxs: (type, props) => ({ type, props }),
+    relativeTime: () => 'in 4 days',
+    routineTitle: () => 'Daily digest',
+    scheduleLabel: () => 'Every day',
+    useState: initial => [initial, () => undefined]
+  }
+
+  vm.createContext(context)
+  vm.runInContext(`${source.slice(start, end)}\nglobalThis.__RoutineRow = RoutineRow`, context)
+
+  return context.__RoutineRow({
+    job: {
+      enabled: true,
+      job_id: 'daily-digest',
+      next_run_at: '2026-08-23T09:00:00Z',
+      schedule: '0 9 * * *'
+    },
+    profile: 'default'
+  })
+}
+
+test('routine metadata wraps without truncating the schedule or next-run time', () => {
+  const row = renderRoutineRow()
+  const metadata = row.props.children[1]
+  const [schedule, nextRun] = metadata.props.children
+
+  assert.match(metadata.props.className, /\bflex-wrap\b/)
+  assert.match(schedule.props.className, /\bshrink-0\b/)
+  assert.match(schedule.props.className, /\bwhitespace-nowrap\b/)
+  assert.match(nextRun.props.className, /\bshrink-0\b/)
+  assert.match(nextRun.props.className, /\bwhitespace-nowrap\b/)
+  assert.doesNotMatch(nextRun.props.className, /\btruncate\b/)
+  assert.equal(nextRun.props.children, 'next in 4 days')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,141 +1,55 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import test from 'node:test'
-import vm from 'node:vm'
+import { JOB, collect, findRow, hasAll, renderRoutineRow } from './routine-row-test-harness.mjs'
 
-// RoutineRow narrow-pane layout contract (#91623):
-// The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
-// display:grid node inside the pane's grid list; grid items default to
-// min-width:auto, so the row could not shrink below its min-content width.
-// A nowrap job title pinned the row at ~284px inside the 250px pane, the
-// overflow-hidden ScrollArea clipped the right edge, and the enable/disable
-// Switch + delete button became invisible (title truncation also never
-// engaged). Every grid/flex node in the row's width chain must carry
-// min-w-0 so the title and metadata can actually shrink.
-//
-// These tests render the real RoutineRow (extracted from plugin.js, with
-// the React runtime and SDK components stubbed) and assert the contract on
-// the resulting JSX tree — not on source formatting. Tailwind class order,
-// cn() composition, or whitespace can change freely without false reds; a
-// real regression in the width chain (dropped min-w-0 / shrink-0) fails.
-
-const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
-
-function slice(from, to) {
-  const start = source.indexOf(from)
-  const end = source.indexOf(to, start)
-  assert.ok(start >= 0 && end > start, `slice ${JSON.stringify(from)} must remain extractable`)
-  return source.slice(start, end)
-}
-
-function renderRoutineRow(job) {
-  // Real helper logic rides along with the row; only the React runtime,
-  // SDK components, and host bridge are stubbed.
-  const helpers = slice('const BOT_TAG_RE = ', '\nasync function loadRoutines(')
-  const scheduleLabel = slice('function scheduleLabel(', '\nfunction RoutineRow(')
-  const row = slice('function RoutineRow(', '\n// Structured schedule picker')
-
-  const context = {
-    jsx: (type, props) => ({ type, props: props || {} }),
-    jsxs: (type, props) => ({ type, props: props || {} }),
-    useState: initial => [initial, () => {}],
-    cn: (...parts) => parts.filter(Boolean).join(' '),
-    relativeTime: () => 'now',
-    Switch: 'Switch',
-    Tip: 'Tip',
-    Codicon: 'Codicon',
-    host: { request: async () => ({}), notifyError: () => {} },
-    invalidateRoutineOwner: async () => {}
-  }
-  vm.runInNewContext(
-    `${helpers}\n${scheduleLabel}\n${row}\nglobalThis.__row = RoutineRow;`,
-    context
-  )
-  // RoutineRow takes { job, owner } since the bot-owner routing rework;
-  // the width-chain contract does not depend on the owner value.
-  return context.__row({ job, owner: undefined })
-}
-
-// Flatten the JSX tree into nodes. Nodes with a className get
-// { type, tokens } (tokens = the cn()-joined class set); classless nodes
-// (Switch etc.) are still listed so their presence can be asserted.
-function collect(node, acc = []) {
-  if (!node || typeof node !== 'object') {
-    return acc
-  }
-  const { props } = node
-  const entry = { type: node.type }
-  if (typeof props?.className === 'string') {
-    entry.tokens = new Set(props.className.split(/\s+/))
-  }
-  acc.push(entry)
-  const children = props?.children
-  if (Array.isArray(children)) {
-    for (const child of children) {
-      collect(child, acc)
-    }
-  } else {
-    collect(children, acc)
-  }
-  return acc
-}
-
-const hasAll = (el, ...tokens) => !!el.tokens && tokens.every(t => el.tokens.has(t))
-const findRow = (els, ...tokens) => els.find(el => hasAll(el, ...tokens))
-
-const JOB = {
-  job_id: 'j1',
-  name: '[bot:researcher] Daily digest',
-  schedule: 'every 60m',
-  enabled: true,
-  state: 'active',
-  next_run_at: '2026-08-23T00:00:00Z'
-}
+// RoutineRow narrow-pane layout contract (#91623): the Routines pane docks
+// at 250px. Every grid/flex node in the width chain must carry min-w-0 so
+// the title and metadata shrink rather than pushing controls past the clip.
 
 test('row root grid carries min-w-0 so the row can shrink inside the pane', () => {
-  const els = collect(renderRoutineRow(JOB))
-  const root = findRow(els, 'grid')
+  const elements = collect(renderRoutineRow(JOB))
+  const root = findRow(elements, 'grid')
   assert.ok(root, 'row root must be a grid')
   assert.ok(hasAll(root, 'min-w-0'), 'row root grid must be min-w-0')
 })
 
-test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
-  const els = collect(renderRoutineRow(JOB))
-  // The title line is the first flex row; the metadata line also uses
-  // justify-between, so require its absence to pin the right line.
-  const line = els.find(el => hasAll(el, 'flex', 'gap-2') && !hasAll(el, 'justify-between'))
+test('title/controls line shrinks while Switch remains visible', () => {
+  const elements = collect(renderRoutineRow(JOB))
+  const line = elements.find(element => hasAll(element, 'flex', 'gap-2') && !hasAll(element, 'flex-wrap'))
   assert.ok(line, 'title/controls line must be a flex row')
   assert.ok(hasAll(line, 'min-w-0'), 'title/controls line must be min-w-0')
 
-  const title = findRow(els, 'flex-1', 'truncate')
-  assert.ok(title, 'job title span must be flex-1 truncate')
-  assert.ok(hasAll(title, 'min-w-0'), 'title must carry min-w-0 for truncation to engage')
-
-  assert.ok(els.some(el => el.type === 'Switch'), 'enable/disable Switch must render')
+  const title = findRow(elements, 'flex-1', 'truncate')
+  assert.ok(title, 'job title must be flex-1 truncate')
+  assert.ok(hasAll(title, 'min-w-0'), 'title must carry min-w-0')
+  assert.ok(
+    elements.some(element => element.type === 'Switch'),
+    'Switch must render'
+  )
 })
 
-test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
-  const els = collect(renderRoutineRow(JOB))
-  const meta = findRow(els, 'flex', 'justify-between', 'pl-3.5')
-  assert.ok(meta, 'metadata line must be a flex row')
-  assert.ok(hasAll(meta, 'min-w-0'), 'metadata line must be min-w-0')
+test('metadata line carries min-w-0 so wrapped timing stays inside the pane', () => {
+  const elements = collect(renderRoutineRow(JOB))
+  const metadata = findRow(elements, 'flex', 'flex-wrap', 'pl-3.5')
+  assert.ok(metadata, 'metadata line must be a flex row')
+  assert.ok(hasAll(metadata, 'min-w-0'), 'metadata line must be min-w-0')
 })
 
-test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
-  const els = collect(renderRoutineRow(JOB))
-  const del = findRow(els, 'size-5')
-  assert.ok(del, 'delete button must render')
-  assert.ok(hasAll(del, 'shrink-0'), 'delete button must be shrink-0')
+test('delete button is shrink-0 so its icon is never crushed', () => {
+  const elements = collect(renderRoutineRow(JOB))
+  const remove = findRow(elements, 'size-5')
+  assert.ok(remove, 'delete button must render')
+  assert.ok(hasAll(remove, 'shrink-0'), 'delete button must be shrink-0')
 })
 
-test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
+test('legacy warning strip carries min-w-0', () => {
   const legacyJob = {
     ...JOB,
     prompt_preview:
       'You are running the scheduled routine "Daily digest" for agent \'researcher\'. Execute it AS that agent...'
   }
-  const els = collect(renderRoutineRow(legacyJob))
-  const strip = findRow(els, 'px-2', 'py-1.5')
-  assert.ok(strip, 'legacy warning strip must render for legacy jobs')
+  const elements = collect(renderRoutineRow(legacyJob))
+  const strip = findRow(elements, 'px-2', 'py-1.5')
+  assert.ok(strip, 'legacy warning strip must render')
   assert.ok(hasAll(strip, 'min-w-0'), 'legacy warning strip must be min-w-0')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import vm from 'node:vm'
 
 // RoutineRow narrow-pane layout contract (#91623):
 // The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
@@ -11,27 +12,130 @@ import test from 'node:test'
 // Switch + delete button became invisible (title truncation also never
 // engaged). Every grid/flex node in the row's width chain must carry
 // min-w-0 so the title and metadata can actually shrink.
+//
+// These tests render the real RoutineRow (extracted from plugin.js, with
+// the React runtime and SDK components stubbed) and assert the contract on
+// the resulting JSX tree — not on source formatting. Tailwind class order,
+// cn() composition, or whitespace can change freely without false reds; a
+// real regression in the width chain (dropped min-w-0 / shrink-0) fails.
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
-  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+function slice(from, to) {
+  const start = source.indexOf(from)
+  const end = source.indexOf(to, start)
+  assert.ok(start >= 0 && end > start, `slice ${JSON.stringify(from)} must remain extractable`)
+  return source.slice(start, end)
+}
+
+function renderRoutineRow(job) {
+  // Real helper logic rides along with the row; only the React runtime,
+  // SDK components, and host bridge are stubbed.
+  const helpers = slice('const BOT_TAG_RE = ', '\nasync function loadRoutines(')
+  const scheduleLabel = slice('function scheduleLabel(', '\nfunction RoutineRow(')
+  const row = slice('function RoutineRow(', '\n// Structured schedule picker')
+
+  const context = {
+    jsx: (type, props) => ({ type, props: props || {} }),
+    jsxs: (type, props) => ({ type, props: props || {} }),
+    useState: initial => [initial, () => {}],
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    relativeTime: () => 'now',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    Codicon: 'Codicon',
+    host: { request: async () => ({}), notifyError: () => {} },
+    invalidateRoutineOwner: async () => {}
+  }
+  vm.runInNewContext(
+    `${helpers}\n${scheduleLabel}\n${row}\nglobalThis.__row = RoutineRow;`,
+    context
+  )
+  // RoutineRow takes { job, owner } since the bot-owner routing rework;
+  // the width-chain contract does not depend on the owner value.
+  return context.__row({ job, owner: undefined })
+}
+
+// Flatten the JSX tree into nodes. Nodes with a className get
+// { type, tokens } (tokens = the cn()-joined class set); classless nodes
+// (Switch etc.) are still listed so their presence can be asserted.
+function collect(node, acc = []) {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  const { props } = node
+  const entry = { type: node.type }
+  if (typeof props?.className === 'string') {
+    entry.tokens = new Set(props.className.split(/\s+/))
+  }
+  acc.push(entry)
+  const children = props?.children
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collect(child, acc)
+    }
+  } else {
+    collect(children, acc)
+  }
+  return acc
+}
+
+const hasAll = (el, ...tokens) => !!el.tokens && tokens.every(t => el.tokens.has(t))
+const findRow = (els, ...tokens) => els.find(el => hasAll(el, ...tokens))
+
+const JOB = {
+  job_id: 'j1',
+  name: '[bot:researcher] Daily digest',
+  schedule: 'every 60m',
+  enabled: true,
+  state: 'active',
+  next_run_at: '2026-08-23T00:00:00Z'
+}
+
+test('row root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  const els = collect(renderRoutineRow(JOB))
+  const root = findRow(els, 'grid')
+  assert.ok(root, 'row root must be a grid')
+  assert.ok(hasAll(root, 'min-w-0'), 'row root grid must be min-w-0')
 })
 
 test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
-  // The old pinned-width form must not come back.
-  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+  const els = collect(renderRoutineRow(JOB))
+  // The title line is the first flex row; the metadata line also uses
+  // justify-between, so require its absence to pin the right line.
+  const line = els.find(el => hasAll(el, 'flex', 'gap-2') && !hasAll(el, 'justify-between'))
+  assert.ok(line, 'title/controls line must be a flex row')
+  assert.ok(hasAll(line, 'min-w-0'), 'title/controls line must be min-w-0')
+
+  const title = findRow(els, 'flex-1', 'truncate')
+  assert.ok(title, 'job title span must be flex-1 truncate')
+  assert.ok(hasAll(title, 'min-w-0'), 'title must carry min-w-0 for truncation to engage')
+
+  assert.ok(els.some(el => el.type === 'Switch'), 'enable/disable Switch must render')
 })
 
 test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+  const els = collect(renderRoutineRow(JOB))
+  const meta = findRow(els, 'flex', 'justify-between', 'pl-3.5')
+  assert.ok(meta, 'metadata line must be a flex row')
+  assert.ok(hasAll(meta, 'min-w-0'), 'metadata line must be min-w-0')
 })
 
 test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
-  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+  const els = collect(renderRoutineRow(JOB))
+  const del = findRow(els, 'size-5')
+  assert.ok(del, 'delete button must render')
+  assert.ok(hasAll(del, 'shrink-0'), 'delete button must be shrink-0')
 })
 
 test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
-  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+  const legacyJob = {
+    ...JOB,
+    prompt_preview:
+      'You are running the scheduled routine "Daily digest" for agent \'researcher\'. Execute it AS that agent...'
+  }
+  const els = collect(renderRoutineRow(legacyJob))
+  const strip = findRow(els, 'px-2', 'py-1.5')
+  assert.ok(strip, 'legacy warning strip must render for legacy jobs')
+  assert.ok(hasAll(strip, 'min-w-0'), 'legacy warning strip must be min-w-0')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// RoutineRow narrow-pane layout contract (#91623):
+// The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
+// display:grid node inside the pane's grid list; grid items default to
+// min-width:auto, so the row could not shrink below its min-content width.
+// A nowrap job title pinned the row at ~284px inside the 250px pane, the
+// overflow-hidden ScrollArea clipped the right edge, and the enable/disable
+// Switch + delete button became invisible (title truncation also never
+// engaged). Every grid/flex node in the row's width chain must carry
+// min-w-0 so the title and metadata can actually shrink.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+})
+
+test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
+  // The old pinned-width form must not come back.
+  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+})
+
+test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+})
+
+test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
+  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+})
+
+test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
+  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-test-harness.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-test-harness.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function slice(from, to) {
+  const start = source.indexOf(from)
+  const end = source.indexOf(to, start)
+  assert.ok(start >= 0 && end > start, `slice ${JSON.stringify(from)} must remain extractable`)
+  return source.slice(start, end)
+}
+
+export function renderRoutineRow(job, { relativeTime = () => 'now' } = {}) {
+  const helpers = slice('const BOT_TAG_RE = ', '\nasync function loadRoutines(')
+  const scheduleLabel = slice('function scheduleLabel(', '\nfunction RoutineRow(')
+  const row = slice('function RoutineRow(', '\n// Structured schedule picker')
+  const context = {
+    jsx: (type, props) => ({ type, props: props || {} }),
+    jsxs: (type, props) => ({ type, props: props || {} }),
+    useState: initial => [initial, () => {}],
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    relativeTime,
+    Switch: 'Switch',
+    Tip: 'Tip',
+    Codicon: 'Codicon',
+    host: { request: async () => ({}), notifyError: () => {} },
+    invalidateRoutineOwner: async () => {}
+  }
+  vm.runInNewContext(`${helpers}\n${scheduleLabel}\n${row}\nglobalThis.__row = RoutineRow;`, context)
+
+  return context.__row({ job, owner: undefined })
+}
+
+export function collect(node, acc = []) {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  const { props } = node
+  const entry = { type: node.type, props }
+  if (typeof props?.className === 'string') {
+    entry.tokens = new Set(props.className.split(/\s+/))
+  }
+  acc.push(entry)
+  const children = props?.children
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collect(child, acc)
+    }
+  } else {
+    collect(children, acc)
+  }
+  return acc
+}
+
+export const hasAll = (element, ...tokens) =>
+  Boolean(element.tokens) && tokens.every(token => element.tokens.has(token))
+
+export const findRow = (elements, ...tokens) => elements.find(element => hasAll(element, ...tokens))
+
+export const JOB = {
+  job_id: 'j1',
+  name: '[bot:researcher] Daily digest',
+  schedule: 'every 1440m',
+  enabled: true,
+  state: 'active',
+  next_run_at: '2026-08-23T00:00:00Z'
+}


### PR DESCRIPTION
## What does this PR do?

Routines rows still exceed the right-docked pane's width on current `main`. With a long job title and schedule, the 250 px pane renders a 511 px row, so the Switch, delete button, schedule, and next-run value are clipped outside the visible pane.

This salvage PR combines rebased versions of the two existing fixes as one layout-class repair:

- #91625 by @MicroWearld breaks the grid/flex min-content chain and keeps controls from shrinking away.
- #89557 by @worlldz preserves the next-run value and lets timing metadata adapt in narrow panes.
- A small reconciliation keeps the schedule flexible and ellipsized, preserves its full value in a tooltip, and keeps the next-run value fully visible.

The original contributions were rebased with authorship preserved, plus one reconciliation commit. Both original PRs remain open and overlap on the same metadata row; this salvage can yield if either author resumes their branch or maintainers prefer a different composition.

## Related Issue

Fixes #91623

Fixes #89534

Salvages #91625 and #89557 with original authorship preserved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Add `min-w-0` through the RoutineRow grid/flex width chain.
- Keep the Switch and delete affordance non-shrinking.
- Let metadata wrap while keeping the row bounded to the pane.
- Give the schedule the flexible/truncation budget and preserve its full label as a tooltip.
- Keep next-run time non-shrinking and fully readable, with a bounded truncation fallback for extreme strings.
- Preserve both contributors' rendered-JSX behavior tests and reconcile their assertions around the combined contract.

The schedule uses a native `title` tooltip intentionally. `Tip` wraps interactive controls such as Delete; wrapping passive truncating text would add another node to the flex-width chain this fix is repairing.

## How to Test

1. Run the two focused rendered-JSX tests:
   `cd apps/desktop && node --test src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs src/plugins/hermes-bots/tests/routine-row-layout.test.mjs`
2. Run the full Bot plugin suite:
   `node --test src/plugins/hermes-bots/tests/*.test.mjs`
3. Run Desktop typecheck and production build:
   `npm run typecheck && npm run build`
4. Render a long title, long schedule, active Switch, delete control, and next-run value at 250 px and 200 px in light and dark mode.

Validated on macOS arm64 at head `5ecc594886`:

| Variant | Pane | Row | Controls | Timing |
|---|---:|---:|---|---|
| current main | 250 px | 511 px | clipped | clipped |
| #89557 alone | 250 px | 511 px | clipped | clipped |
| #91625 alone | 250 px | 250 px | visible | next-run truncates with a long schedule |
| combined salvage | 250 px | 250 px | visible | schedule ellipsizes, next-run visible |
| combined salvage | 200 px | 200 px | visible | schedule ellipsizes, next-run visible |

Automated checks:

- Focused RoutineRow behavior: 7 passed.
- Full Bot plugin suite: 575 passed.
- Desktop typecheck: passed.
- Desktop production build: passed.
- `git diff --check`: passed.

## Checklist

### Code

- [x] I read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched current source plus open, closed, and merged PRs for this layout class
- [x] The PR contains only the Routines row layout repair
- [ ] `pytest tests/ -q` passes in full (not run; no Python changed and CI selects the frontend lane)
- [x] Tests cover the new behavior
- [x] Tested on macOS arm64

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: CSS/renderer-only change; Windows CI remains required
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

The A/B below uses the exact built Desktop CSS at the real 250 px dock width. On main, the row expands past the clip boundary; the salvage keeps every control inside while preserving the next-run value.

![Routine row on main versus the combined salvage](https://github.com/user-attachments/assets/42afa4ac-a503-4a40-a7eb-8e6dfa2bd0ab)

The packaged app captures below use an isolated mock provider, profile, and cron store. They show the real Bot Chat plus the right-docked Cronjobs pane, with no personal gateway or session data.

| Light | Dark |
|---|---|
| ![Real app, light mode](https://github.com/user-attachments/assets/dd40b9dd-9aea-412b-a692-d619d15aefe0) | ![Real app, dark mode](https://github.com/user-attachments/assets/a86e5827-a55c-4820-8264-b214073afa92) |


