### PR TITLE
fix(mcp): swapped return values in _stdio_children_dead() breaking stdio fast-fail

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -921,6 +921,47 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_stdio_children_dead_false_when_a_tracked_pid_is_alive(self):
+        """Regression test (#81995 fast-fail): a live tracked child must NOT
+        be reported as dead.
+
+        A prior refactor accidentally swapped the return values here — a
+        live PID made this return True ("dead"), which caused every
+        subsequent tools/call RPC on a perfectly healthy stdio server to
+        fail immediately with "MCP stdio subprocess has exited" (visible
+        e.g. against n8n-mcp, whose deeper watchdog->npm->node process
+        chain reliably populates _stdio_child_pids, unlike shallower-spawn
+        servers that happened to dodge the bug).
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("srv")
+        server._config = {"command": "npx"}
+        server._stdio_child_pids = {12345}
+
+        with patch("psutil.pid_exists", return_value=True):
+            assert server._stdio_children_dead() is False
+
+    def test_stdio_children_dead_true_when_all_tracked_pids_are_gone(self):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("srv")
+        server._config = {"command": "npx"}
+        server._stdio_child_pids = {12345, 67890}
+
+        with patch("psutil.pid_exists", return_value=False):
+            assert server._stdio_children_dead() is True
+
+    def test_stdio_children_dead_false_when_no_pids_tracked(self):
+        """Best-effort: unknown liveness must never trigger a false fast-fail."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("srv")
+        server._config = {"command": "npx"}
+        server._stdio_child_pids = set()
+
+        assert server._stdio_children_dead() is False
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,8 +2994,7 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
+            return False  # alive (signal permission irrelevant for liveness)
         return True
 
     async def _watch_stdio_children(self) -> None:


### PR DESCRIPTION
## Bug

`_stdio_children_dead()` (added in the #81995 fast-fail work, landed in d1627d513) has its two return values swapped:

```python
for pid in pids:
    import psutil
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True  # alive (signal permission irrelevant for liveness)
    return False  # at least one child alive   <-- unreachable dead code
return True
```

A **live** tracked PID makes this return `True` ("dead"), the opposite of the docstring ("True when every stdio child we spawned has exited") and the opposite of what the inline comment on that exact line says (`# alive`). The correct `return False` sits right below as unreachable dead code — a clean tell that a refactor swapped the two lines.

## Impact

This function gates the fast-fail check in `_call()` that runs before every `tools/call` RPC on a stdio MCP server (the #81995 machinery, meant to fail fast when a stdio subprocess has actually died instead of hanging for the full tool timeout). With the bug inverted, it does the opposite: a **healthy, alive** stdio server immediately fails every real tool call with:

```
MCP stdio subprocess for '<name>' has exited; failing the call fast instead of waiting <N>s
```

Reproduced and confirmed live against `n8n-mcp`: the subprocess was answering keepalive `PingRequest`s every ~2.5 minutes for 20+ minutes straight (fully healthy per its own logs), and `psutil.pid_exists()` confirmed the tracked PIDs were genuinely alive — yet every `tools/call` still hit the fast-fail path and errored immediately.

Why this doesn't affect every stdio server equally: `_stdio_child_pids` is only populated when `_snapshot_child_pids() - pids_before` process-tree diffing at spawn time actually yields new PIDs. Servers with a deeper spawn chain (n8n-mcp: watchdog → `npm exec` → `node`) reliably populate it; shallower/faster spawns may not, so they never hit this code path. Server *discovery* (`tools/list`) is unaffected since it's a different code path — which is why an affected server still shows up correctly in tool listings while being completely unusable for real calls, making this a confusing bug to diagnose (looks like a connectivity/timeout issue, isn't one).

## Fix

Single `return False` when a live PID is found among the tracked children, matching both the docstring and the existing inline comment.

## Tests

Added `TestMCPServerTask`:
- `test_stdio_children_dead_false_when_a_tracked_pid_is_alive` — regression test for this exact bug; fails against the pre-fix code, passes after
- `test_stdio_children_dead_true_when_all_tracked_pids_are_gone`
- `test_stdio_children_dead_false_when_no_pids_tracked` — best-effort/unknown case per the existing docstring

Verified locally: reverted just the two-line fix, confirmed the new regression test fails against the buggy code (`assert True is False`), restored the fix, confirmed all 3 new tests + the full `tests/tools/test_mcp_tool.py` suite (101 tests) pass.