### PR TITLE
fix(macos): keep TCC anchor aliases bootable

### DIFF
--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -174,16 +174,18 @@ def _anchor_marker(venv_bin: Path) -> Path:
     return venv_bin / _MARKER_NAME
 
 
-def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
-    """Re-point uv alias symlinks at the stable anchor.
+def _repoint_aliases(venv_bin: Path, source_file: Path) -> None:
+    """Point Python aliases at the original executable uv-store binary.
 
-    ``python3`` / ``python3.11`` inside the venv bin dir currently resolve into
-    the versioned store; anything spawned through them would still churn TCC.
-    Only symlinks that resolve into the uv store are touched.
+    A stable real-file TCC anchor works when invoked as ``python``.  CPython
+    loses the venv prefix, however, when an alias such as ``python3`` resolves
+    through that copied executable.  Keep aliases on the source binary so
+    launchers that invoke ``python3`` remain bootable.
     """
     # Union of the running interpreter's expected aliases and every versioned
     # alias actually on disk — a store built by a different Python minor than
     # the one running this code must still get its aliases repointed.
+    anchor = venv_bin / "python"
     names = set(_sibling_names())
     try:
         names.update(p.name for p in venv_bin.glob("python3.*") if p.is_symlink())
@@ -194,11 +196,15 @@ def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
         try:
             if not alias.is_symlink():
                 continue
-            if not _is_uv_macos_store(str(alias.resolve(strict=False))):
+            resolved = alias.resolve(strict=False)
+            if not (
+                _is_uv_macos_store(str(resolved))
+                or resolved == anchor
+            ):
                 continue
             tmp = venv_bin / f".{name}.tcc-tmp"
             try:
-                os.symlink(anchor.name, tmp)
+                os.symlink(str(source_file), tmp)
                 os.replace(tmp, alias)
             except OSError:
                 try:
@@ -227,7 +233,7 @@ def _install_anchor(venv_dir: Path, source_file: Path) -> None:
         os.chmod(tmp_path, source_file.stat().st_mode | 0o111)
         os.replace(tmp_path, venv_py)
         _anchor_marker(venv_bin).write_text(str(source_file), encoding="utf-8")
-        _repoint_aliases(venv_bin, venv_py)
+        _repoint_aliases(venv_bin, source_file)
     except Exception:
         try:
             tmp_path.unlink(missing_ok=True)
@@ -266,6 +272,7 @@ def ensure_tcc_anchor(project_root: Path | None = None) -> Path | None:
             if marker.is_file() and marker.read_text(encoding="utf-8").strip() == str(
                 source_file
             ):
+                _repoint_aliases(venv_py.parent, source_file)
                 return venv_py
         except OSError:
             pass

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -136,9 +136,12 @@ class TestEnsureTccAnchor:
         assert marker.read_text(encoding="utf-8").strip() == str(
             store_bin / "python3.11"
         )
-        # Alias symlinks no longer resolve into the versioned store.
+        # A copied macOS interpreter can boot as ``python`` but not through a
+        # ``python3`` alias pointing at that copy: CPython then loses the venv
+        # prefix and looks for stdlib under its build-time /install prefix.
+        # Keep aliases on the original, executable uv-store interpreter.
         alias = venv_py.parent / "python3"
-        assert not tcc._is_uv_macos_store(str(alias.resolve(strict=False)))
+        assert alias.resolve(strict=False) == store_bin / "python3.11"
 
     def test_idempotent(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)
@@ -153,6 +156,21 @@ class TestEnsureTccAnchor:
         assert anchored == venv_py
         assert venv_py.is_file() and not venv_py.is_symlink()
         assert marker.read_text(encoding="utf-8") == before
+
+    def test_repairs_aliases_left_by_predecessor_anchor(self, tmp_path, monkeypatch):
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path)
+        root = _build_checkout(tmp_path, store_bin=store_bin, anchored=True)
+        venv_bin = root / ".venv" / "bin"
+
+        # The preceding implementation anchored ``python`` and left the
+        # aliases pointing to that copied executable.  This is the on-disk
+        # shape that makes Desktop's ``python3`` updater fail to boot.
+        assert (venv_bin / "python3").resolve(strict=False) == venv_bin / "python"
+
+        tcc.ensure_tcc_anchor(root)
+
+        assert (venv_bin / "python3").resolve(strict=False) == store_bin / "python3.11"
 
     def test_reanchors_after_patch_bump(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)


### PR DESCRIPTION
## Summary
- Keep the stable real-file TCC anchor on `venv/bin/python`.
- Point `python3` and versioned aliases at the executable uv-store interpreter instead of the copied anchor.
- Repair aliases left by the previous anchor implementation on idempotent runs.

This prevents Desktop Update All Instances from failing at Python startup with `ModuleNotFoundError: encodings` and `/install` as the resolved prefix.

## Validation
- `uv run python -m pytest tests/hermes_cli/test_macos_tcc_anchor.py -q` — 21 passed
- Actual macOS venv smoke tests: `python`, `python3`, and `python3.11` each imported `encodings` and resolved the venv prefix successfully.
- `git diff --check`