### PR TITLE
fix(desktop): list named profiles from native Windows SSH remotes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14872,7 +14872,7 @@ async function probeSshProfileInventory(connection) {
 
   try {
     await ssh.open()
-    const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
+    const profiles = await remoteLifecycle.listSshRemoteHermesProfiles(ssh, sshConfig.remoteHermesPath)
 
     if (profiles.length > 0) {
       sshRosterCache.set(connection.id, profiles)

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -270,7 +270,7 @@ test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
 test('listSshRemoteHermesProfiles keeps the POSIX listing on Linux/macOS remotes', async () => {
   const ssh = fakeSsh([
     [/uname/, 'Linux\nx86_64\n'],
-    [/HERMES_HOME/, '/Users/z\.hermes\n'],
+    [/HERMES_HOME/, '/Users/z/.hermes\n'],
     [/ls -1/, 'bob\ndixie\n']
   ])
 

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
   isForwardBindCollision,
   isLockfileSkew,
   listRemoteHermesProfiles,
+  listSshRemoteHermesProfiles,
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,
@@ -264,6 +265,66 @@ test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
     ssh.calls.some(cmd => cmd.includes('ls -1')),
     false
   )
+})
+
+test('listSshRemoteHermesProfiles keeps the POSIX listing on Linux/macOS remotes', async () => {
+  const ssh = fakeSsh([
+    [/uname/, 'Linux\nx86_64\n'],
+    [/HERMES_HOME/, '/Users/z\.hermes\n'],
+    [/ls -1/, 'bob\ndixie\n']
+  ])
+
+  assert.deepEqual(await listSshRemoteHermesProfiles(ssh), ['default', 'bob', 'dixie'])
+  // POSIX path safety is untouched: the shell home check still gates the ls.
+  assert.equal(ssh.calls.some(cmd => cmd.includes('Unsafe')), false)
+})
+
+test('listRemoteHermesProfiles still rejects a hostile POSIX HERMES_HOME through the dispatcher', async () => {
+  const ssh = fakeSsh([
+    [/uname/, 'Darwin\narm64\n'],
+    [/HERMES_HOME/, '/tmp/x; echo pwned\n']
+  ])
+
+  await assert.rejects(
+    () => listSshRemoteHermesProfiles(ssh),
+    (err: any) => err.kind === 'unsafe-path'
+  )
+})
+
+test('listSshRemoteHermesProfiles routes native Windows hosts through the runtime helper', async () => {
+  // A native Windows host answers neither uname probe; its drive-letter
+  // HERMES_HOME used to die in the POSIX safety check ("Unsafe remote Hermes
+  // home.") and every named profile vanished from the roster.
+  const probe = JSON.stringify({
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\Users\\me\\AppData\\Local\\hermes',
+    hermesPath: 'C:\\h\\hermes-agent\\venv\\Scripts\\hermes.exe',
+    python: 'C:\\h\\venv\\Scripts\\python.exe'
+  })
+  let helperCall = 0
+
+  const ssh = fakeSsh([
+    [/uname/, new Error("'uname' is not recognized as an internal or external command")],
+    [
+      /EncodedCommand/,
+      () => {
+        helperCall += 1
+
+        if (helperCall === 1) {
+          return probe
+        }
+
+        return JSON.stringify({ profiles: ['work', 'gaming'] })
+      }
+    ]
+  ])
+
+  assert.deepEqual(await listSshRemoteHermesProfiles(ssh), ['default', 'gaming', 'work'])
+  // The Windows branch never runs the POSIX echo/ls inventory...
+  assert.equal(ssh.calls.some(cmd => cmd.includes('HERMES_HOME') || cmd.includes('ls -1')), false)
+  // ...and never spawns a remote dashboard for inventory.
+  assert.equal(ssh.calls.some(cmd => cmd.includes('serve')), false)
 })
 
 test('locateHermes prefers the explicit profile path when executable', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -29,6 +29,7 @@ import crypto from 'node:crypto'
 
 import { parseRemoteProfileListing } from './connection-registry'
 import { assertBootstrapNotSuperseded } from './ssh-connection'
+import { detectRemotePlatform, listWindowsRemoteProfiles } from './windows-remote-lifecycle'
 
 const LOCKFILE_SCHEMA_VERSION = 2
 // Bumped when the desktop<->dashboard reuse contract changes in a way that makes
@@ -384,6 +385,23 @@ async function listRemoteHermesProfiles(ssh) {
   }
 
   return parseRemoteProfileListing(listing)
+}
+
+// Platform-aware roster inventory. SSH connect accepts Linux, macOS, and
+// native Windows remotes, but listRemoteHermesProfiles above is POSIX-only:
+// its home check rejects drive-letter HERMES_HOME values
+// (%LOCALAPPDATA%\hermes), so Windows hosts logged "Unsafe remote Hermes
+// home." and every named profile vanished from the roster. Route by platform —
+// the same detection connect uses — so Windows answers through the canonical
+// remote runtime helper while POSIX path safety is unchanged.
+async function listSshRemoteHermesProfiles(ssh, explicitHermesPath = '') {
+  const platform = await detectRemotePlatform(ssh, explicitHermesPath)
+
+  if (platform.os === 'Windows') {
+    return listWindowsRemoteProfiles(ssh, explicitHermesPath)
+  }
+
+  return listRemoteHermesProfiles(ssh)
 }
 
 function assertSafeRemoteHome(home) {
@@ -1650,6 +1668,7 @@ export {
   isForwardBindCollision,
   isLockfileSkew,
   listRemoteHermesProfiles,
+  listSshRemoteHermesProfiles,
   locateHermes,
   LOCKFILE_SCHEMA_VERSION,
   lockfilePath,

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   detectRemotePlatform,
   encodedPowerShell,
   helperCommand,
+  listWindowsRemoteProfiles,
   powerShellCommand,
   probeWindowsRemote,
   psLiteral,
@@ -306,16 +307,12 @@ test('managed update drain preserves a Windows owner when creation time does not
     hermesPath: 'C:\\h\\hermes.exe',
     hermesHome: 'C:\\h'
   }
-
   const operations: string[] = []
-
   const ssh = sshWith(async command => {
     const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
     operations.push(script)
-
     return JSON.stringify(lock)
   })
-
   await assert.rejects(
     terminateOwnedWindowsDashboardForUpdate(
       ssh,
@@ -333,7 +330,6 @@ test('managed update drain preserves a Windows owner when creation time does not
     false
   )
 })
-
 test('managed update drain rechecks Windows PID/create-time ownership before exact terminate', async () => {
   const lock = {
     schemaVersion: 2,
@@ -348,26 +344,19 @@ test('managed update drain rechecks Windows PID/create-time ownership before exa
     hermesPath: 'C:\\h\\hermes.exe',
     hermesHome: 'C:\\h'
   }
-
   const operations: string[] = []
-
   const ssh = sshWith(async command => {
     const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
     operations.push(script)
-
     if (script.includes("'read-lock'")) {
       return JSON.stringify(lock)
     }
-
     if (script.includes("'process-state'")) {
       return JSON.stringify({ alive: true, owned: true, indeterminate: false })
     }
-
     return JSON.stringify({ ok: true })
   })
-
   const result = await terminateOwnedWindowsDashboardForUpdate(ssh, { python: 'C:\\h\\python.exe' }, lock)
-
   assert.equal(result.terminated, true)
   assert.equal(operations.filter(operation => operation.includes("'read-lock'")).length, 2)
   assert.equal(operations.filter(operation => operation.includes("'process-state'")).length, 2)
@@ -376,4 +365,70 @@ test('managed update drain rechecks Windows PID/create-time ownership before exa
     operations.some(operation => operation.includes("'remove-lock'")),
     false
   )
+
+test('listWindowsRemoteProfiles inventories named profiles via the canonical runtime helper', async () => {
+  const probe = JSON.stringify({
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\Users\\me\\AppData\\Local\\hermes',
+    hermesPath: 'C:\\h\\hermes-agent\\venv\\Scripts\\hermes.exe',
+    python: 'C:\\h\\venv\\Scripts\\python.exe'
+  })
+  // The helper answers with the canonical roster; junk that a hand-made
+  // profiles dir could contain is filtered exactly like the POSIX listing.
+  const listing = JSON.stringify({
+    home: 'C:\\Users\\me\\AppData\\Local\\hermes',
+    profiles: ['work', 'default', 'bob.rollback-old', '.junk', 'UPPER', 7, null]
+  })
+  let step = 0
+  const calls: string[] = []
+  const ssh = sshWith(async command => {
+    calls.push(command)
+    step += 1
+    if (step === 1) {
+      return probe
+    }
+    return listing
+  })
+  assert.deepEqual(await listWindowsRemoteProfiles(ssh), ['default', 'UPPER', 'work'])
+  assert.equal(calls.length, 2)
+  // Inventory only: the second hop targets the runtime helper, not a spawn.
+  // (The desktop sanitizer is case-tolerant; the remote registry itself
+  // only ever emits lowercase ids.)
+  const helperScript = Buffer.from(calls[1].split(' ').pop()!, 'base64').toString('utf16le')
+  assert.match(helperScript, /-m' 'hermes_cli\.windows_ssh_runtime' 'list-profiles'/)
+  assert.equal(calls.some(cmd => cmd.includes('--isolated')), false)
+})
+test('listWindowsRemoteProfiles surfaces a malformed helper answer as a failure', async () => {
+  const probe = JSON.stringify({
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\h',
+    hermesPath: 'C:\\h\\hermes.exe',
+    python: 'C:\\h\\python.exe'
+  })
+  let step = 0
+  const ssh = sshWith(async () => {
+    step += 1
+    if (step === 1) {
+      return probe
+    }
+    return 'not json at all'
+  })
+  await assert.rejects(() => listWindowsRemoteProfiles(ssh))
+})
+test('listWindowsRemoteProfiles still reports default when only canonical exists', async () => {
+  const probe = JSON.stringify({
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\h',
+    hermesPath: 'C:\\h\\hermes.exe',
+    python: 'C:\\h\\python.exe'
+  })
+  let step = 0
+  const ssh = sshWith(async () => {
+    step += 1
+    return step === 1 ? probe : JSON.stringify({ profiles: [] })
+  })
+  assert.deepEqual(await listWindowsRemoteProfiles(ssh), ['default'])
 })

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -366,6 +366,7 @@ test('managed update drain rechecks Windows PID/create-time ownership before exa
     false
   )
 
+})
 test('listWindowsRemoteProfiles inventories named profiles via the canonical runtime helper', async () => {
   const probe = JSON.stringify({
     os: 'Windows',

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 
+import { parseRemoteProfileListing } from './connection-registry'
 import { assertBootstrapNotSuperseded, redactSecrets, SSH_ERROR } from './ssh-connection'
 
 const LOCKFILE_SCHEMA_VERSION = 2
@@ -750,6 +751,21 @@ async function connectWindowsRemote(deps) {
   }
 }
 
+// Roster inventory for a native Windows host: ask the canonical remote runtime
+// helper which profiles this installation would serve. Pure inventory — never
+// spawns or touches an existing backend.
+async function listWindowsRemoteProfiles(ssh, explicitHermesPath = '') {
+  const runtime = await probeWindowsRemote(ssh, explicitHermesPath)
+  const result = await helper(ssh, runtime, 'list-profiles')
+  const names = Array.isArray(result?.profiles)
+    ? result.profiles.filter(name => typeof name === 'string')
+    : []
+
+  // Reuse the POSIX roster sanitizer so both platforms apply identical name
+  // rules: `default` first, rollback snapshots/junk dropped, sorted.
+  return parseRemoteProfileListing(names.join('\n'))
+}
+
 function buildWindowsInteractiveCommand(remoteCwd = '') {
   const cwd = String(remoteCwd || '').trim()
   const script = ['$ErrorActionPreference="Stop"']
@@ -774,6 +790,7 @@ export {
   encodedPowerShell,
   helper,
   helperCommand,
+  listWindowsRemoteProfiles,
   powerShellCommand,
   probeWindowsRemote,
   psLiteral,

--- a/contributors/emails/Finn763@users.noreply.github.com
+++ b/contributors/emails/Finn763@users.noreply.github.com
@@ -1,1 +1,2 @@
 Finn763
+# PR #95360 salvage

--- a/hermes_cli/windows_ssh_runtime.py
+++ b/hermes_cli/windows_ssh_runtime.py
@@ -450,6 +450,18 @@ def inspect_hermes(hermes_path: str) -> dict[str, Any]:
     }
 
 
+def list_profiles() -> dict[str, Any]:
+    """Inventory Hermes profiles on this host without spawning any backend.
+
+    Delegates to the canonical profile registry so the roster Desktop sees is
+    exactly what this installation serves: canonical ``default`` plus every
+    valid named profile directory under the Hermes root.
+    """
+    from hermes_cli.profiles import list_profile_names
+
+    return {"profiles": list_profile_names()}
+
+
 def dispatch(argv: list[str]) -> Any:
     if not argv:
         raise ValueError("missing operation")
@@ -457,6 +469,8 @@ def dispatch(argv: list[str]) -> Any:
     if operation == "probe":
         import platform
         return {"os": "Windows", "arch": platform.machine(), "hermesHome": str(get_default_hermes_root()), "python": sys.executable}
+    if operation == "list-profiles" and len(argv) == 1:
+        return list_profiles()
     if operation == "upload-token" and len(argv) == 3:
         return upload_token(argv[1], argv[2], sys.stdin.buffer.read(65))
     if operation == "read-lock" and len(argv) == 2:

--- a/tests/hermes_cli/test_windows_ssh_runtime_list_profiles.py
+++ b/tests/hermes_cli/test_windows_ssh_runtime_list_profiles.py
@@ -1,0 +1,72 @@
+"""list-profiles operation of the Windows SSH runtime helper.
+
+Desktop SSH roster inventory asks a native Windows host which Hermes profiles
+it would serve via `python -m hermes_cli.windows_ssh_runtime list-profiles`.
+The operation must stay spawn-free and answer from the canonical profile
+registry (`default` plus every valid named profile directory).
+"""
+
+import json
+
+import pytest
+
+from hermes_cli import windows_ssh_runtime
+
+
+def _make_install(root, profiles=()):
+    """Lay out a Hermes install under *root*: profiles dir + junk entries."""
+    profiles_dir = root / "profiles"
+    profiles_dir.mkdir(parents=True)
+    for name in profiles:
+        (profiles_dir / name).mkdir()
+    return root
+
+
+def test_list_profiles_returns_canonical_default_when_no_profiles_exist(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    (tmp_path / "hermes-home").mkdir()
+
+    assert windows_ssh_runtime.dispatch(["list-profiles"]) == {"profiles": ["default"]}
+
+
+def test_list_profiles_invents_default_plus_valid_named_dirs(tmp_path, monkeypatch):
+    home = _make_install(
+        tmp_path / "hermes-home",
+        ["work", "coder-2", ".hidden", "Bad Name", "bob.rollback-old", "UPPER"],
+    )
+    # A plain file must not be mistaken for a profile.
+    (home / "profiles" / "notes.txt").write_text("not a profile")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert windows_ssh_runtime.dispatch(["list-profiles"]) == {"profiles": ["default", "coder-2", "work"]}
+
+
+def test_list_profiles_anchors_profile_mode_hermes_home_to_the_root(tmp_path, monkeypatch):
+    # HERMES_HOME pointing INTO a profile (<root>/profiles/coder) must still
+    # inventory the whole installation — same anchoring get_default_hermes_root
+    # applies everywhere else.
+    root = tmp_path / "docker-root"
+    _make_install(root, ["coder", "ops"])
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "coder"))
+
+    assert windows_ssh_runtime.dispatch(["list-profiles"]) == {"profiles": ["default", "coder", "ops"]}
+
+
+def test_list_profiles_rejects_extra_arguments():
+    with pytest.raises(ValueError):
+        windows_ssh_runtime.dispatch(["list-profiles", "extra"])
+
+
+def test_list_profiles_main_emits_single_line_json(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    (tmp_path / "hermes-home").mkdir()
+
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["windows_ssh_runtime.py", "list-profiles"])
+    windows_ssh_runtime.main()
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"profiles": ["default"]}


### PR DESCRIPTION
## Summary

SSH roster inventory on Desktop always ran the POSIX-only `listRemoteHermesProfiles`, whose home check (`/^(\/|~\/)[A-Za-z0-9._/+-]+$/`) rejects drive-letter `HERMES_HOME` values. A native Windows SSH host (standard install, `%LOCALAPPDATA%\hermes`) therefore logged `profile inventory failed … Unsafe remote Hermes home.` and its canonical + named profiles never appeared in the Bot roster — even though SSH *connect* already supports Windows.

Inventory is now platform-aware, using the same platform detection connect uses:

- **Linux/macOS remotes**: the existing POSIX `echo`/`ls` listing, byte-for-byte unchanged (hostile-home rejection still enforced).
- **Native Windows remotes**: a new `list-profiles` operation in `hermes_cli.windows_ssh_runtime` delegates to the canonical profile registry (`hermes_cli.profiles.list_profile_names`), so the desktop sees exactly what the installation would serve — no one-off Windows path parser, no dashboard spawn. It honors `HERMES_HOME`/profile-mode anchoring via `get_default_hermes_root`. The desktop side reuses the existing `parseRemoteProfileListing` sanitizer so both platforms apply identical name rules (`default` first, rollback snapshots/junk dropped, sorted).

## Test plan

- [x] `apps/desktop/electron/windows-remote-lifecycle.test.ts`: 3 new tests — canonical-helper inventory (junk filtered, helper command shape, no `--isolated` spawn), malformed helper answer surfaces as failure, default-only roster.
- [x] `apps/desktop/electron/remote-lifecycle.test.ts`: 3 new tests — POSIX listing preserved on Linux/macOS, hostile POSIX `HERMES_HOME` still rejected through the dispatcher, native Windows host routed through the runtime helper without touching the POSIX echo/ls path.
- [x] New `tests/hermes_cli/test_windows_ssh_runtime_list_profiles.py`: default-only installs, junk profile dirs excluded, profile-mode `HERMES_HOME` anchored to root, argv validation, single-line JSON output.
- [x] vitest `--project electron` for remote-lifecycle / windows-remote-lifecycle / connection-registry / desktop-remote-route: **174 passed, 1 skipped**.
- [x] `tsc --noEmit` clean on all three desktop tsconfig projects (app, electron, e2e).
- [x] pytest new file: **5 passed**.

Closes #95319

Compat note: inventory on a Windows remote requires an install current enough to ship `windows_ssh_runtime list-profiles`; older installs degrade to today's behavior (a logged inventory failure), which is strictly no worse than status quo.
