### PR TITLE
fix(kimi-coding-cn): route sk-kimi- keys to coding endpoint, honor KIMI_CN_BASE_URL

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3066,7 +3066,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             continue
         active_sources.add(source)
         base_url = env_url or pconfig.inference_base_url
-        if provider == "kimi-coding":
+        if provider in ("kimi-coding", "kimi-coding-cn"):
             base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
         elif provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -338,6 +338,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url="https://api.moonshot.cn/v1",
         api_key_env_vars=("KIMI_CN_API_KEY",),
+        base_url_env_var="KIMI_CN_BASE_URL",
     ),
     "stepfun": ProviderConfig(
         id="stepfun",


### PR DESCRIPTION
## Problem

`kimi-coding-cn` provider always resolved its base URL to the default `https://api.moonshot.cn/v1`, regardless of API key prefix:

1. `agent/credential_pool.py` — `_seed_from_env()` only ran `_resolve_kimi_base_url()` for `provider == "kimi-coding"`, missing `"kimi-coding-cn"`
2. `hermes_cli/auth.py` — the `kimi-coding-cn` `ProviderConfig` lacked `base_url_env_var`, so `KIMI_CN_BASE_URL` was never read

Users on the Kimi Coding plan (China) set `KIMI_CN_API_KEY` with an `sk-kimi-` prefixed key. Those keys are only valid on `https://api.kimi.com/coding`; the legacy Moonshot endpoint rejects them with **HTTP 401 Invalid Authentication**, which silently triggers fallback to the next provider in the chain. The sibling resolution path in `auth.py` (`resolve_provider_api_key`, line ~7372) already covers both providers via `_resolve_kimi_base_url()` — the credential pool seeding was simply left behind.

## Reproduction

```
hermes chat -q "hi" -m kimi-k3 --provider kimi-coding-cn -v
# → OpenAI client created ... provider=kimi-coding-cn base_url=https://api.moonshot.cn/v1
# → openai.AuthenticationError: 401 Invalid Authentication
# → Fallback activated: kimi-k3 → <next provider>
```

## Fix

- `agent/credential_pool.py`: `if provider == "kimi-coding"` → `if provider in ("kimi-coding", "kimi-coding-cn")`
- `hermes_cli/auth.py`: add `base_url_env_var="KIMI_CN_BASE_URL"` to the `kimi-coding-cn` `ProviderConfig`, matching `kimi-coding`'s `KIMI_BASE_URL` handling

## Verification

After the fix:

```
hermes chat -q "hi" -m kimi-k3 --provider kimi-coding-cn -v
# → provider=kimi-coding-cn base_url=https://api.kimi.com/coding  ✓
# → request succeeds, no fallback
```