### PR TITLE
fix(tools): DaemonThreadPoolExecutor compatibility with Python 3.14

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,12 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Compatible with CPython 3.8–3.14.
+        # CPython 3.14 removed the ``_initializer``/``_initargs`` instance
+        # attributes and changed ``_worker`` to take a pre-built worker context
+        # object (``self._create_worker_context()``) instead of the positional
+        # ``(work_queue, initializer, initargs)`` triple. Detect which API the
+        # running interpreter expects so the same source works on every version.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +53,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14+: _worker(executor_ref, worker_context, work_queue)
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # Python 3.8–3.13: _worker(executor_ref, work_queue, initializer, initargs)
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Summary
- CPython 3.14 removed the `_initializer`/`_initargs` instance attributes from `ThreadPoolExecutor` and changed `concurrent.futures.thread._worker` to accept a pre-built worker context (`self._create_worker_context()`) instead of the `(work_queue, initializer, initargs)` triple.
- The hardcoded `self._initializer` access in `DaemonThreadPoolExecutor._adjust_thread_count` made **every tool call** crash on Python 3.14 with:
  ```
  'DaemonThreadPoolExecutor' object has no attribute '_initializer'
  ```
- Branch on `hasattr(self, "_create_worker_context")` so the same source works on 3.8–3.14. 3.14 takes the new context-based `_worker` signature; older versions keep the original positional one.

## Test plan
- [x] On CPython 3.14.6: instantiate + `submit(...)` + `result()` succeeds, no `_initializer` error.
- [x] No change to 3.8–3.13 behavior (only the else-branch is reached there).

## Linked issue
Fixes https://github.com/NousResearch/hermes-agent/issues/58596