### PR TITLE
fix(cron): forward attach_to_session through cronjob handler (salvage #84829)

### DIFF
--- a/contributors/emails/kshitijkapoorr@gmail.com
+++ b/contributors/emails/kshitijkapoorr@gmail.com
@@ -1,0 +1,1 @@
+kshitijk4poor

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -553,6 +553,12 @@ class TestRegisteredHandlerForwardsAttachToSession:
         stored = get_job(created["job_id"])
         assert stored is not None
         assert "attach_to_session" not in stored
+        # And the formatted list output must not invent the field either.
+        listed = json.loads(registry.dispatch("cronjob", {"action": "list"}))
+        formatted = next(
+            j for j in listed["jobs"] if j["job_id"] == created["job_id"]
+        )
+        assert "attach_to_session" not in formatted
 
 
 class TestLocalDeliveryNotice:

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -444,6 +444,117 @@ class TestAgentCannotSetModelPin:
         assert stored["name"] == "renamed"
 
 
+class TestRegisteredHandlerForwardsAttachToSession:
+    """#84802 — schema + cronjob() already accept attach_to_session, but the
+    registry adapter must forward it or create silently drops the field and
+    update returns "No updates provided." """
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    def test_create_persists_attach_to_session(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "name": "Continuable cron canary",
+                    "schedule": "1h",
+                    "repeat": 1,
+                    "deliver": "origin",
+                    "attach_to_session": True,
+                    "prompt": "Reply exactly: canary",
+                },
+            )
+        )
+        assert created["success"] is True
+        assert created.get("job", {}).get("attach_to_session") is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is True
+        listing = json.loads(registry.dispatch("cronjob", {"action": "list"}))
+        listed = next(j for j in listing["jobs"] if j["job_id"] == created["job_id"])
+        assert listed.get("attach_to_session") is True
+
+    def test_update_persists_attach_to_session(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "name": "plain",
+                    "schedule": "1h",
+                    "prompt": "Reply exactly: canary",
+                },
+            )
+        )
+        assert created["success"] is True
+        assert "attach_to_session" not in (get_job(created["job_id"]) or {})
+
+        updated = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "update",
+                    "job_id": created["job_id"],
+                    "attach_to_session": True,
+                },
+            )
+        )
+        assert updated["success"] is True, updated
+        assert updated.get("job", {}).get("attach_to_session") is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is True
+
+        disabled = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "update",
+                    "job_id": created["job_id"],
+                    "attach_to_session": False,
+                },
+            )
+        )
+        assert disabled["success"] is True, disabled
+        assert disabled.get("job", {}).get("attach_to_session") is False
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored.get("attach_to_session") is False
+        listing = json.loads(registry.dispatch("cronjob", {"action": "list"}))
+        listed = next(j for j in listing["jobs"] if j["job_id"] == created["job_id"])
+        assert listed.get("attach_to_session") is False
+
+    def test_omitted_create_leaves_field_absent(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "schedule": "1h",
+                    "prompt": "fire and forget",
+                },
+            )
+        )
+        assert created["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert "attach_to_session" not in stored
+
+
 class TestLocalDeliveryNotice:
     """#51568 — TUI/CLI cron jobs are local-only; surface that at create time
     so the agent doesn't promise a delivery that never happens."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -804,6 +804,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     ]
     if external_refs:
         result["context_from"] = external_refs
+    if isinstance(job.get("attach_to_session"), bool):
+        result["attach_to_session"] = job["attach_to_session"]
     return result
 
 
@@ -1970,6 +1972,7 @@ def _cronjob_handler(args, **kw):
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=_mon_script,
         monitor_url=_mon_url,
         task_id=kw.get("task_id"),


### PR DESCRIPTION
## Summary

Salvage of #84829 by @StanleyStetson onto current `main` — the `cronjob` tool's registered handler now forwards `attach_to_session`, so create/update actually persist the documented per-job continuable flag, and `_format_job` surfaces the stored bool (explicit `false` included) in create/update/list responses.

Root cause: the registry adapter lambda never passed `attach_to_session` into `cronjob()`, so create silently dropped it and an update touching only that field returned `No updates provided.` (#84802).

## Changes

- `tools/cronjob_tools.py`: forward `attach_to_session=args.get("attach_to_session")` in the registered handler; include `attach_to_session` in `_format_job` when stored as a bool.
- `tests/tools/test_cronjob_tools.py`: registry-dispatch round-trip against a real job store (`True` on create, flip to `False` on update, surfaced in list).

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_cronjob_tools.py` | 71/71 passed |
| `scripts/run_tests.sh tests/cron/` | 955 passed; 5 pre-existing failures in `test_monitor_kind.py` reproduce identically on unmodified `origin/main` |
| E2E (real imports, temp HERMES_HOME, real jobs.json) | create persists `true`, update flips to `false`, list surfaces explicit `false` |
| ruff on changed files | clean |

Cherry-pick conflict vs main was cosmetic (`_format_job` gained `context_from`/`continuity` formatting since the PR branched); resolved in favor of main + the PR's addition.

## Credit

Cherry-picked from #84829 with @StanleyStetson's authorship preserved. Duplicate cluster fixing the same handler hole: #57556, #90813, #92537, #93854, #84833 (superset w/ warning notice), #69647 (mixed unrelated files). This PR was selected for its `isinstance(..., bool)` `_format_job` guard (explicit `false` visible) plus real-store round-trip tests.

Closes #84829. Fixes #84802.
