### PR TITLE
fix(cron): mirror continuable-cron briefs for origin-fallback and opted-in explicit targets (salvage #89329)

### DIFF
--- a/contributors/emails/kshitijkapoorr@gmail.com
+++ b/contributors/emails/kshitijkapoorr@gmail.com
@@ -1,0 +1,1 @@
+kshitijk4poor

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3212,6 +3212,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # the attach_to_session/mirror opt-in.
         origin_user_id = origin.get("user_id") if origin_target else None
 
+        # DM shape of this target, needed by BOTH the in_channel flatten gate
+        # below and the seed/_seed_cron_channel_session chat_type further down:
+        # a 1:1 DM keys as ``dm`` (Slack DM channel ids start with "D"; or the
+        # origin says so), everything else as ``group``.
+        origin_chat_type = str(origin.get("chat_type") or "").lower()
+        is_dm_target = origin_chat_type == "dm" or (
+            not origin_chat_type and str(chat_id).startswith("D")
+        )
+
+        # Shared continuable-target gate for the in_channel surface. The
+        # thread-flatten and the flat-session seed MUST use the SAME gate —
+        # if they drift, the brief and its continuation session land in
+        # different places (the split-surface bug the flatten exists to
+        # prevent). Origin targets qualify unconditionally (independent of the
+        # attach_to_session / mirror opt-in — see 3c52d3589f); non-origin
+        # mirror-eligible targets (origin_fallback / opted-in explicit)
+        # qualify only when the seed can actually create a resolvable session
+        # (_inchannel_seed_allowed: DM-shaped, or a known user_id for
+        # user-isolated group keys).
+        inchannel_continuable = origin_target or (
+            mirror_this_target
+            and _inchannel_seed_allowed(is_dm=is_dm_target, user_id=origin_user_id)
+        )
+
         # Built-in names resolve to their enum member; plugin platform names
         # create dynamic members via Platform._missing_().
         try:
@@ -3311,7 +3335,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 )
                 in_channel_surface = False
 
-        if in_channel_surface and origin_target and live_adapter_ready:
+        if in_channel_surface and inchannel_continuable and live_adapter_ready:
             # Force flat delivery (D2): the continuable-channel target must
             # ignore any inherited origin/target thread_id, or the flat
             # continuable session seeded below (thread_id=None, via
@@ -3320,8 +3344,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # reads `thread_id` and would otherwise route into the origin
             # thread instead of flat into the channel.
             #
-            # Gated on `origin_target`, NOT `mirror_this_target`: the seed
-            # below fires on origin-match alone (in_channel is the
+            # Gated on `inchannel_continuable` (the SAME gate as the seed
+            # below), NOT `mirror_this_target` alone: for origin targets the
+            # seed fires on origin-match alone (in_channel is the
             # continuation surface, independent of the attach_to_session /
             # mirror opt-in), so the flatten must use the SAME gate — with
             # the default knobs off, a mirror-gated flatten kept delivering
@@ -3349,15 +3374,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # For an in_channel delivery the flat continuation session is created
         # explicitly below (the shipped mirror only APPENDS to an existing
         # session, and the flat channel row is otherwise absent for a
-        # chat_postMessage delivery). ``is_dm`` selects the session chat_type so
-        # the seeded key matches the inbound reply's key: a 1:1 DM keys as
-        # ``dm`` (Slack DM channel ids start with "D"; or the origin says so),
-        # everything else as ``group`` (shared channel). ``inchannel_seeded``
-        # suppresses the generic mirror below so the brief is not double-written.
-        origin_chat_type = str(origin.get("chat_type") or "").lower()
-        is_dm_target = origin_chat_type == "dm" or (
-            not origin_chat_type and str(chat_id).startswith("D")
-        )
+        # chat_postMessage delivery). ``is_dm_target`` (computed above with
+        # origin_user_id) selects the session chat_type so the seeded key
+        # matches the inbound reply's key. ``inchannel_seeded`` suppresses the
+        # generic mirror below so the brief is not double-written.
         inchannel_seeded = False
 
         # Continuable cron (thread-preferred): when mirroring is enabled for the
@@ -3678,28 +3698,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     # session (the shipped mirror only appends to an existing
                     # session — the flat row is otherwise absent for a
                     # chat_postMessage delivery, so the brief would be lost).
-                    # Gated on ORIGIN-match without requiring the mirror
-                    # opt-in: in_channel IS the continuation surface — a
-                    # continuable flat cron without its seed is a brief the
+                    # Gated on `inchannel_continuable` — the SHARED gate with
+                    # the thread-flatten above (they must not drift, or the
+                    # brief and its continuation session land in different
+                    # places). Origin targets seed without requiring the
+                    # mirror opt-in: in_channel IS the continuation surface —
+                    # a continuable flat cron without its seed is a brief the
                     # next reply can't see (the bug Victor hit live
                     # 2026-08-19: agent had "no idea about the delivery
-                    # message"). attach_to_session remains the knob for the
-                    # SEPARATE thread/default-surface mirror behavior; it must
-                    # not be required for origin targets.
-                    # Mirror-eligible NON-origin targets (origin_fallback /
-                    # opted-in explicit — see _target_mirror_eligible) also
-                    # seed, guarded by _inchannel_seed_allowed: group-channel
+                    # message"). Mirror-eligible NON-origin targets
+                    # (origin_fallback / opted-in explicit — see
+                    # _target_mirror_eligible) also seed, guarded by
+                    # _inchannel_seed_allowed inside the gate: group-channel
                     # keys are user-isolated, so a seed without a user_id
                     # (origin-less managed cron into a shared channel) would
                     # create an orphan session no reply resolves to — those
                     # fall back to the plain mirror instead.
-                    _seed_this_target = origin_target or (
-                        mirror_this_target
-                        and _inchannel_seed_allowed(
-                            is_dm=is_dm_target, user_id=origin_user_id,
-                        )
-                    )
-                    if in_channel_surface and _seed_this_target and not thread_seeded:
+                    if in_channel_surface and inchannel_continuable and not thread_seeded:
                         inchannel_seeded = _seed_cron_channel_session(
                             job, runtime_adapter, platform_name, chat_id,
                             mirror_text, is_dm=is_dm_target,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1787,7 +1787,13 @@ _MIRROR_PROVENANCE_RANK = {
 }
 
 
-def _target_mirror_eligible(job: dict, target: dict, *, global_mirror: bool) -> bool:
+def _target_mirror_eligible(
+    job: dict,
+    target: dict,
+    *,
+    global_mirror: bool,
+    origin_match: Optional[bool] = None,
+) -> bool:
     """Whether a resolved delivery target may receive the transcript mirror.
 
     The June origin-scoping refactor gated mirroring on target == origin,
@@ -1810,17 +1816,28 @@ def _target_mirror_eligible(job: dict, target: dict, *, global_mirror: bool) -> 
 
     Broadcast expansions (``all``, bare-platform home targets) carry no
     provenance tag and are never eligible — unchanged invariant.
+
+    ``origin_match`` lets the caller pass a precomputed
+    ``_target_matches_origin`` result (``_deliver_result`` already computes it
+    for the same target); when ``None`` it is computed here so tests and
+    future callers stay self-contained.
     """
-    origin = _resolve_origin(job) or {}
-    if _target_matches_origin(
-        origin, target.get("platform", ""), target.get("chat_id", ""),
-        target.get("thread_id"),
-    ):
+    if origin_match is None:
+        origin = _resolve_origin(job) or {}
+        origin_match = _target_matches_origin(
+            origin, target.get("platform", ""), target.get("chat_id", ""),
+            target.get("thread_id"),
+        )
+    if origin_match:
         return True
     resolved_from = target.get("_resolved_from")
     if resolved_from == "origin_fallback":
         # Same activation rules as an origin target: per-job attach wins,
-        # else the global flag.
+        # else the global flag. This deliberately restates the precedence
+        # _cron_mirror_delivery_enabled encodes (keep the two in sync): the
+        # sole production caller pre-merges it into `global_mirror`, but the
+        # helper must stay correct standalone — a per-job False must beat a
+        # raw global True for any caller that does not pre-merge.
         per_job = job.get("attach_to_session")
         if isinstance(per_job, bool):
             return per_job
@@ -3203,7 +3220,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # Broadcast/fan-out targets are never mirrored (_target_mirror_eligible).
         origin_target = _target_matches_origin(origin, platform_name, chat_id, thread_id)
         mirror_this_target = mirror_enabled and _target_mirror_eligible(
-            job, target, global_mirror=mirror_enabled,
+            job, target, global_mirror=mirror_enabled, origin_match=origin_target,
         )
         # Pass the origin's user_id so a per-user-isolated group chat resolves to
         # the exact member who scheduled the job — parity with send_message.
@@ -3744,11 +3761,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 is_dm=is_dm_target,
                                 scope_id=origin.get("scope_id"),
                             )
-                    elif in_channel_surface and not origin_target:
+                    elif in_channel_surface and not inchannel_continuable:
                         logger.warning(
-                            "Job '%s': in_channel delivery to %s:%s is not the "
-                            "origin conversation (origin=%s:%s thread=%s) — seed "
-                            "skipped, brief not continuable here",
+                            "Job '%s': in_channel delivery to %s:%s is not a "
+                            "continuable target (origin=%s:%s thread=%s; not the "
+                            "origin conversation, and not a mirror-eligible "
+                            "fallback/opted-in target the seed can key) — seed "
+                            "skipped; the plain mirror below may still apply",
                             job["id"], platform_name, chat_id,
                             origin.get("platform"), origin.get("chat_id"),
                             origin.get("thread_id"),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1776,6 +1776,75 @@ def _target_matches_origin(origin: dict, platform_name: str, chat_id: str,
     return True
 
 
+# Resolution-provenance ranking for the dedup OR-merge in
+# _resolve_delivery_targets: higher rank = stronger mirror claim. Broadcast
+# expansions rank 0 so "origin,all"/"all,origin" hitting the same chat keeps
+# the origin(-fallback) tag regardless of token order.
+_MIRROR_PROVENANCE_RANK = {
+    "origin": 3,
+    "origin_fallback": 2,
+    "explicit": 1,
+}
+
+
+def _target_mirror_eligible(job: dict, target: dict, *, global_mirror: bool) -> bool:
+    """Whether a resolved delivery target may receive the transcript mirror.
+
+    The June origin-scoping refactor gated mirroring on target == origin,
+    which correctly excluded broadcasts but also silenced two legitimate
+    conversation shapes — both hit by script-provisioned ("managed") crons,
+    which never capture an origin (``_origin_from_env`` only fires for jobs
+    created from a live gateway chat):
+
+    - ``origin_fallback``: ``deliver=origin`` with no captured origin resolves
+      to the home channel — the user's primary conversation standing in for
+      the origin, not a broadcast. Eligible under the same flags as a true
+      origin target. (Field report 2026-08-17: brief delivered to the Slack
+      DM, mirror silently skipped, reply hit a context-less session.)
+    - ``explicit``: a ``platform:chat_id`` target is eligible ONLY when the
+      job itself opts in via ``attach_to_session: true`` — the job author
+      declaring this target a conversation (managed per-user DM briefings).
+      The global ``cron.mirror_delivery`` flag never activates explicit
+      targets: it must not start writing transcript entries into arbitrary
+      explicitly-addressed chats (shared channels, other users' DMs).
+
+    Broadcast expansions (``all``, bare-platform home targets) carry no
+    provenance tag and are never eligible — unchanged invariant.
+    """
+    origin = _resolve_origin(job) or {}
+    if _target_matches_origin(
+        origin, target.get("platform", ""), target.get("chat_id", ""),
+        target.get("thread_id"),
+    ):
+        return True
+    resolved_from = target.get("_resolved_from")
+    if resolved_from == "origin_fallback":
+        # Same activation rules as an origin target: per-job attach wins,
+        # else the global flag.
+        per_job = job.get("attach_to_session")
+        if isinstance(per_job, bool):
+            return per_job
+        return bool(global_mirror)
+    if resolved_from == "explicit":
+        return job.get("attach_to_session") is True
+    return False
+
+
+def _inchannel_seed_allowed(*, is_dm: bool, user_id: Optional[str]) -> bool:
+    """Whether the flat in_channel session seed may run for a target.
+
+    Group-channel session keys are user-isolated
+    (``…:group:<chat_id>:<user_id>`` — see _seed_cron_channel_session); a
+    seed without a real user_id would create an orphan session that no
+    inbound reply ever resolves to, which is worse than no seed (the plain
+    mirror can still land if a session exists). DM keys don't embed
+    user_id, so DM targets are always seedable. Origin-captured jobs carry
+    the scheduler's user_id; origin-less managed jobs typically don't, and
+    their group-channel targets must fall back to the plain mirror.
+    """
+    return bool(is_dm or user_id)
+
+
 def _maybe_mirror_cron_delivery(
     job: dict,
     platform_name: str,
@@ -2430,6 +2499,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": _origin_delivery_thread(origin),
+                # Resolution provenance for mirror eligibility (see
+                # _target_mirror_eligible): this IS the origin conversation.
+                "_resolved_from": "origin",
             }
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
@@ -2445,6 +2517,11 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                     "platform": platform_name,
                     "chat_id": chat_id,
                     "thread_id": _get_home_target_thread_id(platform_name),
+                    # The fallback stands in for the user's primary
+                    # conversation (NOT a broadcast) — mirror-eligible so
+                    # continuable crons work for script-provisioned jobs
+                    # that never captured an origin.
+                    "_resolved_from": "origin_fallback",
                 }
         return None
 
@@ -2489,6 +2566,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
+            # Explicit platform:chat target — mirror-eligible only under the
+            # job's own attach_to_session opt-in (see _target_mirror_eligible).
+            "_resolved_from": "explicit",
         }
 
     platform_name = deliver_value
@@ -2766,15 +2846,24 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     for raw in raw_parts:
         parts.extend(_expand_routing_tokens(raw))
 
-    seen = set()
+    seen = {}
     targets = []
     for part in parts:
         target = _resolve_single_delivery_target(job, part)
         if target:
             key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))
             if key not in seen:
-                seen.add(key)
+                seen[key] = target
                 targets.append(target)
+            else:
+                # OR-merge resolution provenance on dedup: "origin,all" (either
+                # order) resolving to the same chat must keep the
+                # origin/origin_fallback tag — a mirror-eligible token must not
+                # lose eligibility to token order (see _target_mirror_eligible).
+                kept = seen[key]
+                if _MIRROR_PROVENANCE_RANK.get(str(target.get("_resolved_from") or ""), 0) > \
+                        _MIRROR_PROVENANCE_RANK.get(str(kept.get("_resolved_from") or ""), 0):
+                    kept["_resolved_from"] = target.get("_resolved_from")
     return targets
 
 
@@ -3107,11 +3196,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 job["id"], platform_name, chat_id, thread_id,
             )
 
-        # Mirror is scoped to the ORIGIN conversation only. A fan-out / broadcast
-        # / home-channel-fallback target is never mirrored (it is not the
-        # conversation the job was created in, and may have no session at all).
+        # Mirror scope: the origin conversation, the home-channel FALLBACK for
+        # an origin-less deliver=origin job (a script-provisioned managed cron
+        # standing in for the user's primary conversation — not a broadcast),
+        # or an explicit target the job opted into via attach_to_session.
+        # Broadcast/fan-out targets are never mirrored (_target_mirror_eligible).
         origin_target = _target_matches_origin(origin, platform_name, chat_id, thread_id)
-        mirror_this_target = mirror_enabled and origin_target
+        mirror_this_target = mirror_enabled and _target_mirror_eligible(
+            job, target, global_mirror=mirror_enabled,
+        )
         # Pass the origin's user_id so a per-user-isolated group chat resolves to
         # the exact member who scheduled the job — parity with send_message.
         # Resolved for ANY origin-matching target (not just mirror-enabled):
@@ -3585,14 +3678,28 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     # session (the shipped mirror only appends to an existing
                     # session — the flat row is otherwise absent for a
                     # chat_postMessage delivery, so the brief would be lost).
-                    # Gated on ORIGIN-match only, NOT on the mirror opt-in:
-                    # in_channel IS the continuation surface — a continuable
-                    # flat cron without its seed is a brief the next reply
-                    # can't see (the bug Victor hit live 2026-08-19: agent had
-                    # "no idea about the delivery message"). attach_to_session
-                    # remains the knob for the SEPARATE thread/default-surface
-                    # mirror behavior; it must not be required here.
-                    if in_channel_surface and origin_target and not thread_seeded:
+                    # Gated on ORIGIN-match without requiring the mirror
+                    # opt-in: in_channel IS the continuation surface — a
+                    # continuable flat cron without its seed is a brief the
+                    # next reply can't see (the bug Victor hit live
+                    # 2026-08-19: agent had "no idea about the delivery
+                    # message"). attach_to_session remains the knob for the
+                    # SEPARATE thread/default-surface mirror behavior; it must
+                    # not be required for origin targets.
+                    # Mirror-eligible NON-origin targets (origin_fallback /
+                    # opted-in explicit — see _target_mirror_eligible) also
+                    # seed, guarded by _inchannel_seed_allowed: group-channel
+                    # keys are user-isolated, so a seed without a user_id
+                    # (origin-less managed cron into a shared channel) would
+                    # create an orphan session no reply resolves to — those
+                    # fall back to the plain mirror instead.
+                    _seed_this_target = origin_target or (
+                        mirror_this_target
+                        and _inchannel_seed_allowed(
+                            is_dm=is_dm_target, user_id=origin_user_id,
+                        )
+                    )
+                    if in_channel_surface and _seed_this_target and not thread_seeded:
                         inchannel_seeded = _seed_cron_channel_session(
                             job, runtime_adapter, platform_name, chat_id,
                             mirror_text, is_dm=is_dm_target,

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -46,7 +46,7 @@ class TestOriginThreadStaleGuard:
                           "thread_id": SYNTH}}
         target = _resolve_single_delivery_target(job, "origin")
         assert target == {"platform": "slack", "chat_id": "D0BJTDCSR7C",
-                          "thread_id": None}
+                          "thread_id": None, "_resolved_from": "origin"}
 
     def test_origin_thread_kept_when_chat_not_home(self, monkeypatch):
         """A non-home Slack origin thread may be a genuine working thread: keep it."""

--- a/tests/cron/test_mirror_origin_fallback.py
+++ b/tests/cron/test_mirror_origin_fallback.py
@@ -1,0 +1,240 @@
+"""Mirror eligibility for origin-fallback and explicit cron delivery targets.
+
+Field report (enterprise, 2026-08-17): `cron.mirror_delivery: true` with
+`deliver: origin` delivered the brief to Slack but never appended it to the
+reply-facing gateway session, so a user reply hit a session with no context.
+
+Root cause: the job was created by a provisioning script, so it carries no
+captured origin. `deliver: origin` falls back to the home channel — the
+user's actual conversation — but `_target_matches_origin` returns False for
+an empty origin, so the mirror and the in_channel seed never fire. The June
+origin-scoping refactor (c06ceb3232) correctly excluded broadcasts, but the
+origin-FALLBACK target is not a broadcast: it is the best available stand-in
+for the user's primary conversation.
+
+Design under test:
+- Delivery targets carry a `mirror_eligibility` tag set at resolution time:
+  * origin match            -> eligible (unchanged)
+  * origin-fallback (deliver=origin, no origin) -> eligible (NEW)
+  * explicit platform:chat  -> eligible ONLY with per-job attach_to_session
+    (NEW, opt-in; the global flag never activates explicit targets)
+  * `all` / bare-platform expansion -> never eligible (unchanged invariant)
+- Dedup across tokens (e.g. "origin,all" hitting the same chat) OR-merges
+  eligibility so token order cannot strip it.
+- The in_channel flat-session seed requires a DM-shaped target or a known
+  user_id: group-channel session keys are user-isolated, and a seed without
+  user_id would create an orphan session no reply ever resolves to.
+"""
+
+import pytest
+
+from cron.scheduler import (
+    _deliver_result,
+    _resolve_delivery_targets,
+    _target_mirror_eligible,
+)
+
+
+@pytest.fixture(autouse=True)
+def _home_channel(monkeypatch):
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "D0HOME")
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+
+class TestMirrorEligibilityResolution:
+    def test_origin_target_is_eligible(self):
+        job = {
+            "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "D0AAA", "chat_type": "dm"},
+        }
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert _target_mirror_eligible(job, targets[0], global_mirror=True)
+
+    def test_origin_fallback_target_is_eligible(self):
+        """deliver=origin with no captured origin: the home-channel fallback
+        is the user's conversation, not a broadcast — mirror it."""
+        job = {"deliver": "origin", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert targets[0]["chat_id"] == "D0HOME"
+        assert _target_mirror_eligible(job, targets[0], global_mirror=True)
+
+    def test_all_expansion_is_never_eligible(self):
+        """Broadcast targets stay unmirrored even with the global flag on."""
+        job = {"deliver": "all", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        assert targets, "home channel should expand from 'all'"
+        for t in targets:
+            assert not _target_mirror_eligible(job, t, global_mirror=True)
+
+    def test_bare_platform_target_is_not_eligible(self):
+        job = {"deliver": "slack", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert not _target_mirror_eligible(job, targets[0], global_mirror=True)
+
+    def test_explicit_target_not_eligible_under_global_flag(self):
+        """Global mirror_delivery must not write sessions into arbitrary
+        explicitly-addressed chats."""
+        job = {"deliver": "slack:D0EXPL", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert not _target_mirror_eligible(job, targets[0], global_mirror=True)
+
+    def test_explicit_target_eligible_with_per_job_attach(self):
+        """attach_to_session=true on the job is the author declaring the
+        explicit target a conversation — managed per-user DM crons."""
+        job = {
+            "deliver": "slack:D0EXPL",
+            "origin": None,
+            "attach_to_session": True,
+        }
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert _target_mirror_eligible(job, targets[0], global_mirror=False)
+
+    def test_origin_and_all_dedup_keeps_eligibility(self):
+        """'origin,all' resolving to the same home chat must not lose the
+        fallback's eligibility to dedup order."""
+        job = {"deliver": "origin,all", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        # Home channel deduped to one target.
+        slack_targets = [t for t in targets if t["platform"].lower() == "slack"]
+        assert len(slack_targets) == 1
+        assert _target_mirror_eligible(job, slack_targets[0], global_mirror=True)
+
+    def test_all_and_origin_reversed_order_keeps_eligibility(self):
+        job = {"deliver": "all,origin", "origin": None}
+        targets = _resolve_delivery_targets(job)
+        slack_targets = [t for t in targets if t["platform"].lower() == "slack"]
+        assert len(slack_targets) == 1
+        assert _target_mirror_eligible(job, slack_targets[0], global_mirror=True)
+
+    def test_explicit_other_chat_with_origin_not_eligible(self):
+        """An explicit target that is NOT the origin stays unmirrored under
+        the global flag even when the job has an origin elsewhere."""
+        job = {
+            "deliver": "slack:D0OTHER",
+            "origin": {"platform": "slack", "chat_id": "D0AAA", "chat_type": "dm"},
+        }
+        targets = _resolve_delivery_targets(job)
+        assert len(targets) == 1
+        assert not _target_mirror_eligible(job, targets[0], global_mirror=True)
+
+
+class TestFallbackMirrorEndToEnd:
+    """Drive _deliver_result with a stubbed sender + mirror recorder."""
+
+    @pytest.fixture()
+    def slack_env(self, monkeypatch, tmp_path):
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "cron:\n  mirror_delivery: true\n"
+            "platforms:\n  slack:\n    enabled: true\n    token: xoxb-test\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        send_calls = []
+
+        async def fake_sender(pconfig, chat_id, message, *, thread_id=None,
+                              media_files=None, force_document=False, caption=None):
+            send_calls.append({"chat_id": chat_id, "thread_id": thread_id})
+            return {"success": True, "chat_id": chat_id, "message_id": "1.2"}
+
+        import gateway.platform_registry as reg
+        import hermes_cli.plugins as hp
+
+        entry = reg.platform_registry.get("slack")
+        if entry is None:
+            hp.discover_plugins()
+            entry = reg.platform_registry.get("slack")
+        if entry is None:
+            pytest.skip("slack platform entry not registered")
+        monkeypatch.setattr(entry, "standalone_sender_fn", fake_sender)
+        monkeypatch.setattr(hp, "discover_plugins", lambda *a, **k: None)
+
+        mirror_calls = []
+
+        import cron.scheduler as sched
+
+        def fake_mirror(platform, chat_id, text, source_label="cli",
+                        thread_id=None, user_id=None, role="assistant"):
+            mirror_calls.append({
+                "platform": platform, "chat_id": chat_id,
+                "thread_id": thread_id, "user_id": user_id, "role": role,
+            })
+            return True
+
+        import gateway.mirror as mirror_mod
+
+        monkeypatch.setattr(mirror_mod, "mirror_to_session", fake_mirror)
+        return {"send": send_calls, "mirror": mirror_calls}
+
+    def test_origin_fallback_job_mirrors_brief(self, slack_env):
+        """The field repro: managed cron, deliver=origin, no origin captured.
+        The brief must be mirrored into the home-channel session."""
+        job = {"id": "j1", "name": "brief", "deliver": "origin", "origin": None}
+        err = _deliver_result(job, "Risk-off close brief", adapters=None, loop=None)
+        assert err is None
+        assert len(slack_env["send"]) == 1
+        assert len(slack_env["mirror"]) == 1, (
+            "origin-fallback delivery must mirror the brief into the "
+            "home-channel session (the reply-continuity bug)"
+        )
+        assert slack_env["mirror"][0]["chat_id"] == "D0HOME"
+        assert slack_env["mirror"][0]["role"] == "user"
+
+    def test_all_broadcast_does_not_mirror(self, slack_env):
+        job = {"id": "j2", "name": "cast", "deliver": "all", "origin": None}
+        err = _deliver_result(job, "broadcast text", adapters=None, loop=None)
+        assert err is None
+        assert len(slack_env["send"]) == 1
+        assert len(slack_env["mirror"]) == 0
+
+    def test_explicit_target_with_attach_mirrors(self, slack_env):
+        job = {
+            "id": "j3", "name": "managed-dm", "deliver": "slack:D0USER7",
+            "origin": None, "attach_to_session": True,
+        }
+        err = _deliver_result(job, "managed brief", adapters=None, loop=None)
+        assert err is None
+        assert len(slack_env["mirror"]) == 1
+        assert slack_env["mirror"][0]["chat_id"] == "D0USER7"
+
+    def test_explicit_target_without_attach_does_not_mirror(self, slack_env):
+        job = {
+            "id": "j4", "name": "plain-explicit", "deliver": "slack:D0USER8",
+            "origin": None,
+        }
+        err = _deliver_result(job, "plain text", adapters=None, loop=None)
+        assert err is None
+        assert len(slack_env["mirror"]) == 0
+
+    def test_origin_job_still_mirrors_unchanged(self, slack_env):
+        """Regression control: the June origin-scoped behavior is untouched."""
+        job = {
+            "id": "j5", "name": "origin-job", "deliver": "origin",
+            "origin": {"platform": "slack", "chat_id": "D0AAA", "chat_type": "dm"},
+        }
+        err = _deliver_result(job, "origin brief", adapters=None, loop=None)
+        assert err is None
+        assert len(slack_env["mirror"]) == 1
+        assert slack_env["mirror"][0]["chat_id"] == "D0AAA"
+
+
+class TestInChannelSeedUserIdGuard:
+    """Group-channel seeds are user-keyed; a seed with no user_id would create
+    an orphan session. DM targets are safe (key has no user_id)."""
+
+    def test_seed_requires_dm_or_user_id(self):
+        from cron.scheduler import _inchannel_seed_allowed
+
+        # DM-shaped chat, no user_id: allowed (DM keys don't embed user).
+        assert _inchannel_seed_allowed(is_dm=True, user_id=None)
+        # Group chat with known user: allowed.
+        assert _inchannel_seed_allowed(is_dm=False, user_id="U123")
+        # Group chat, no user: refused — would orphan the session.
+        assert not _inchannel_seed_allowed(is_dm=False, user_id=None)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -194,6 +194,7 @@ class TestResolveDeliveryTarget:
             "platform": "telegram",
             "chat_id": "-1001",
             "thread_id": "17585",
+            "_resolved_from": "origin",
         }
 
 
@@ -238,6 +239,7 @@ class TestResolveDeliveryTarget:
             "platform": "telegram",
             "chat_id": "-1003724596514",
             "thread_id": "17",
+            "_resolved_from": "explicit",
         }
 
 
@@ -254,6 +256,7 @@ class TestResolveDeliveryTarget:
             "platform": "whatsapp",
             "chat_id": "12345678901234@lid",
             "thread_id": None,
+            "_resolved_from": "explicit",
         }
 
 
@@ -269,6 +272,7 @@ class TestResolveDeliveryTarget:
             "platform": "whatsapp",
             "chat_id": "12345@lid",
             "thread_id": None,
+            "_resolved_from": "explicit",
         }
 
     def test_unresolved_target_still_delivered_as_written(self):
@@ -287,6 +291,7 @@ class TestResolveDeliveryTarget:
             "platform": "telegram",
             "chat_id": "ops-room",
             "thread_id": None,
+            "_resolved_from": "explicit",
         }
 
 

--- a/tests/tools/test_send_message_plugin_extensibility.py
+++ b/tests/tools/test_send_message_plugin_extensibility.py
@@ -184,6 +184,7 @@ def test_cli_and_cron_share_plugin_target_normalization(plugin_platform, monkeyp
         "platform": name,
         "chat_id": "@alice@example.com",
         "thread_id": None,
+        "_resolved_from": "explicit",
     }
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1903,7 +1903,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "attach_to_session": {
                 "type": "boolean",
-                "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the origin DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts."
+                "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts. Scope: the job's own conversation only — the origin chat, the home-channel fallback when deliver='origin' captured no origin (script-created jobs), or the job's single explicit platform:chat target (this flag is the only way to attach an explicit target). Broadcast targets are never attached; no effect when deliver='local'."
             },
         },
         "required": ["action"]

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -478,7 +478,7 @@ cron:
   mirror_delivery: false   # set true to make cron deliveries continuable
 ```
 
-Behaviour is **thread-preferred**, scoped to the job's origin chat:
+Behaviour is **thread-preferred**, scoped to the job's own conversation:
 
 - **Thread-capable platforms** (Telegram topics, Discord/Slack threads): each
   delivery opens its own dedicated thread and the brief is seeded into that
@@ -489,8 +489,19 @@ Behaviour is **thread-preferred**, scoped to the job's origin chat:
   is mirrored into the origin DM session instead — the DM itself is the
   continuation surface.
 
-Only the origin chat is ever touched: fan-out / broadcast targets (`all`,
-explicit other-chat deliveries) are never made continuable. The mirror is
+Only the job's **own conversation** is ever touched:
+
+- the **origin chat** the job was created in;
+- the **home-channel fallback** when `deliver: origin` captured no origin (jobs
+  created by scripts or the API rather than from a live gateway chat) — the
+  user's primary conversation standing in for the origin;
+- a job's **single explicit `platform:chat` target**, but only when the job
+  itself opts in with `attach_to_session: true` — the job author declares that
+  target a conversation. The global `mirror_delivery` flag alone never makes an
+  explicitly-addressed chat continuable.
+
+Broadcast / fan-out targets (`all`, bare-platform home channels) are never made
+continuable. The mirror is
 written as a labelled user turn (`[Cron delivery: <task name>]`), which keeps
 the conversation history alternation-safe across all model providers.
 


### PR DESCRIPTION
## Summary

Salvage of #89329 by @victor-kyriazakos onto current `main` — continuable-cron mirroring now works for script-provisioned (origin-less) jobs: the home-channel fallback of `deliver: origin` is mirror-eligible under the same activation rules as a true origin, and explicit `platform:chat` targets can opt in per job via `attach_to_session: true`. Broadcast targets remain excluded.

Root cause: jobs created outside a live gateway chat never capture an `origin`, so `deliver: origin` falls back to the home channel and the text delivers — but mirror eligibility was gated on `_target_matches_origin`, which is False with no origin. The transcript mirror and the `in_channel` seed silently skipped, so replying to the brief hit a context-less session.

## Changes

- `cron/scheduler.py`:
  - Delivery targets carry a `_resolved_from` provenance tag (`origin` / `origin_fallback` / `explicit`; broadcast expansions untagged).
  - `_target_mirror_eligible` replaces the bare origin check at the mirror gate. `origin_fallback` follows origin activation rules (per-job `attach_to_session` wins, else global `cron.mirror_delivery`); `explicit` requires per-job `attach_to_session: true` — the global flag alone never mirrors into explicitly-addressed chats.
  - Dedup in `_resolve_delivery_targets` OR-merges provenance so `origin,all` in either token order keeps eligibility.
  - `_inchannel_seed_allowed` guards the flat-session seed for non-origin targets (group keys are user-isolated; a seed without `user_id` would orphan).
- `tools/cronjob_tools.py`: `attach_to_session` schema text updated to describe the widened attach scope.
- Tests: new `tests/cron/test_mirror_origin_fallback.py` (15 tests); exact-shape assertions extended for the provenance field.

## Salvage notes (conflicts vs main)

Two conflicts against commits that landed after the PR branched, both resolved as main + the PR's intent:

1. `3c52d3589f` made the origin-target `in_channel` seed independent of the mirror opt-in. The salvaged gate composes both behaviors: `origin_target or (mirror_this_target and _inchannel_seed_allowed(...))` — origin targets keep seeding unconditionally (main's fix preserved), while newly mirror-eligible fallback/explicit targets seed under the PR's user-id guard.
2. Follow-up commit: `tests/cron/test_cron_relay_delivery_guards.py` (landed on main after the PR) gained the `_resolved_from: origin` field in its one exact-dict assertion — same contract growth the PR already applied to 6 sibling assertions.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/cron/` (77 files) | 969 passed; 5 pre-existing `test_monitor_kind.py` failures reproduce identically on unmodified `origin/main` |
| New suite + touched suites (`test_mirror_origin_fallback`, `test_scheduler`, `test_cron_relay_delivery_guards`, `test_cronjob_tools`, `test_send_message_plugin_extensibility`) | all green |
| E2E (real imports): fallback eligibility on/off via global flag and per-job override, explicit opt-in only, broadcast never eligible, dedup provenance stable in both token orders, origin-bearing regression control | all pass |
| ruff on changed files | clean |

## Credit

Cherry-picked from #89329 with @victor-kyriazakos's authorship preserved; conflict resolution + test-assertion follow-up by @kshitijk4poor.

Closes #89329.
