### PR TITLE
Add excel_line — Excel-backed long-term memory provider to plugin index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "0b9d51f171c676a49783f183ed54995549ec9cec",
+      "ref": "8f710da17ea3e223797a5414e50adb0b6b8a0a80",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "ea29d565d98f71d7768c79ef84efd560b2678e43",
+      "ref": "fa176759adf240a43e39fe87cdbc4ae86023a6b9",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -6,11 +6,20 @@
       "name": "hermes-media-studio",
       "description": "Media Studio — generative media workspace plugin for Hermes Desktop (fal + Krea, durable job queue, library).",
       "author": "NousResearch",
-      "tags": ["media", "image-gen", "video-gen", "dashboard", "desktop"],
+      "tags": [
+        "media",
+        "image-gen",
+        "video-gen",
+        "dashboard",
+        "desktop"
+      ],
       "repo": "NousResearch/hermes-media-studio",
       "ref": "e8d59971d2b7901405b39dac7b03bdd616272d0d",
       "homepage": "https://github.com/NousResearch/hermes-media-studio",
-      "capabilities": ["tools", "dashboard"],
+      "capabilities": [
+        "tools",
+        "dashboard"
+      ],
       "api_version": 1,
       "added_at": "2026-08-12"
     },
@@ -18,11 +27,18 @@
       "name": "hermes-telegram-business",
       "description": "Observe-with-approval Telegram Business Mode (secretary bot) plugin — every drafted reply requires owner approval before it reaches the customer.",
       "author": "NousResearch",
-      "tags": ["telegram", "gateway", "approvals", "messaging"],
+      "tags": [
+        "telegram",
+        "gateway",
+        "approvals",
+        "messaging"
+      ],
       "repo": "NousResearch/hermes-telegram-business",
       "ref": "e905f3bc5eeaa5a9dab9bc5155601b3ebec75757",
       "homepage": "https://github.com/NousResearch/hermes-telegram-business",
-      "capabilities": ["platform"],
+      "capabilities": [
+        "platform"
+      ],
       "api_version": 1,
       "added_at": "2026-08-12"
     },
@@ -30,12 +46,20 @@
       "name": "plugin-llm-example",
       "description": "Reference plugin showing host-owned structured LLM access via ctx.llm.complete_structured(). Registers a /receipt-extract slash command.",
       "author": "NousResearch",
-      "tags": ["example", "llm", "reference", "slash-command"],
+      "tags": [
+        "example",
+        "llm",
+        "reference",
+        "slash-command"
+      ],
       "repo": "NousResearch/hermes-example-plugins",
       "subdir": "plugin-llm-example",
       "ref": "38fe0fb53eff98d477f807432e965429e665ca33",
       "homepage": "https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-example",
-      "capabilities": ["commands", "llm"],
+      "capabilities": [
+        "commands",
+        "llm"
+      ],
       "api_version": 1,
       "added_at": "2026-08-12"
     },
@@ -43,12 +67,20 @@
       "name": "plugin-llm-async-example",
       "description": "Reference plugin demonstrating async host-owned LLM access from plugin code — the asyncio counterpart to plugin-llm-example.",
       "author": "NousResearch",
-      "tags": ["example", "llm", "async", "reference"],
+      "tags": [
+        "example",
+        "llm",
+        "async",
+        "reference"
+      ],
       "repo": "NousResearch/hermes-example-plugins",
       "subdir": "plugin-llm-async-example",
       "ref": "38fe0fb53eff98d477f807432e965429e665ca33",
       "homepage": "https://github.com/NousResearch/hermes-example-plugins/tree/main/plugin-llm-async-example",
-      "capabilities": ["commands", "llm"],
+      "capabilities": [
+        "commands",
+        "llm"
+      ],
       "api_version": 1,
       "added_at": "2026-08-12"
     },
@@ -56,13 +88,40 @@
       "name": "hermes-plugin-chrome-profiles",
       "description": "Switch Hermes browser tools between Chrome profiles via CDP.",
       "author": "anpicasso",
-      "tags": ["browser", "chrome", "cdp", "tools"],
+      "tags": [
+        "browser",
+        "chrome",
+        "cdp",
+        "tools"
+      ],
       "repo": "anpicasso/hermes-plugin-chrome-profiles",
       "ref": "5b9c3257b464c0f926d4355149a8aed9c8f307b4",
       "homepage": "https://github.com/anpicasso/hermes-plugin-chrome-profiles",
-      "capabilities": ["tools"],
+      "capabilities": [
+        "tools"
+      ],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "excel_line",
+      "description": "Excel-backed long-term memory provider for Hermes. Keeps durable, human-auditable knowledge in Excel workbooks alongside built-in MEMORY.md/USER.md; mirrors the built-in write path, injects indexed memories via prefetch() every session, and exposes search/read tools. Direct-store mode writes straight to the store with no LLM dependency; auto-extract falls back to a raw-text backup so memory is never silently lost.",
+      "author": "kalice-vi",
+      "tags": [
+        "memory",
+        "excel",
+        "knowledge",
+        "long-term-memory",
+        "provider"
+      ],
+      "repo": "kalice-vi/hermes-excel-line",
+      "ref": "d960fbbc90f012d23f966c6840086bccc01a0667",
+      "homepage": "https://github.com/kalice-vi/hermes-excel-line",
+      "capabilities": [
+        "memory"
+      ],
+      "api_version": 1,
+      "added_at": "2026-08-26"
     }
   ]
 }

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "9e9a5fee1bb46716953d2d3bb5c610874828cafd",
+      "ref": "0b9d51f171c676a49783f183ed54995549ec9cec",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "8f710da17ea3e223797a5414e50adb0b6b8a0a80",
+      "ref": "57f20ec34a30791595f15b1749988496a1a7f370",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "9089c8747b4049bee109bd30a110beb69ad962e7",
+      "ref": "9e9a5fee1bb46716953d2d3bb5c610874828cafd",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "57f20ec34a30791595f15b1749988496a1a7f370",
+      "ref": "ea29d565d98f71d7768c79ef84efd560b2678e43",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "provider"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "d960fbbc90f012d23f966c6840086bccc01a0667",
+      "ref": "9089c8747b4049bee109bd30a110beb69ad962e7",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "001abff1f9f7f7eae9d322bd3d8d17a62febf1dc",
+      "ref": "2b687352f525db78f7df494c3dce500c90d4351e",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "f0a42fe31e0f09a5be62db6fbe9249e7bdf559bc",
+      "ref": "001abff1f9f7f7eae9d322bd3d8d17a62febf1dc",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "2b687352f525db78f7df494c3dce500c90d4351e",
+      "ref": "5b3416b6e5719abfc8ff13d84c58292ec5796cb4",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "5b3416b6e5719abfc8ff13d84c58292ec5796cb4",
+      "ref": "2b3268489875c1713a64f8cbb57372a028f4f490",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -115,7 +115,7 @@
         "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "6a01333ea39e5856fec4e5b3b0355ecd9ed1104f",
+      "ref": "f0a42fe31e0f09a5be62db6fbe9249e7bdf559bc",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -105,17 +105,17 @@
     },
     {
       "name": "excel_line",
-      "description": "Excel-backed long-term memory provider for Hermes. Keeps durable, human-auditable knowledge in Excel workbooks alongside built-in MEMORY.md/USER.md; mirrors the built-in write path, injects indexed memories via prefetch() every session, and exposes search/read tools. Direct-store mode writes straight to the store with no LLM dependency; auto-extract falls back to a raw-text backup so memory is never silently lost.",
+      "description": "Excel-backed long-term memory tree for Hermes Agent (v2 tree architecture, 10-row cap per file, dynamic branching, leaf pointers, keyless model rotation).",
       "author": "kalice-vi",
       "tags": [
         "memory",
         "excel",
-        "knowledge",
         "long-term-memory",
-        "provider"
+        "hierarchical",
+        "tree"
       ],
       "repo": "kalice-vi/hermes-excel-line",
-      "ref": "fa176759adf240a43e39fe87cdbc4ae86023a6b9",
+      "ref": "6a01333ea39e5856fec4e5b3b0355ecd9ed1104f",
       "homepage": "https://github.com/kalice-vi/hermes-excel-line",
       "capabilities": [
         "memory"


### PR DESCRIPTION
## Summary
Add `excel_line` to the community plugin index. It is a Hermes memory provider plugin that keeps durable, human-auditable knowledge in Excel workbooks alongside the built-in MEMORY.md / USER.md.

- Mirrors the built-in memory write path (on_memory_write) so agent-authored and auto-extracted memories persist.
- prefetch() injects indexed memories into every session (auto-retrieve, like built-in memory).
- Exposes search / read tools for on-demand retrieval.
- Direct-store mode writes straight to the Excel store with NO LLM dependency — fixes the original bug where memory was logged but never retrievable.
- on_session_end auto-extract falls back to a raw-text backup, so memory is never silently lost.

## Entry added
name: excel_line | repo: kalice-vi/hermes-excel-line | ref: f68ef7fd85af344eb554c94f6998317a5895bd69

## Verification
- `hermes plugins doctor .` -> OK: runtime discovery, manifest parsing, import, and registration passed.
- 33-test QA suite (tests/test_excel_line.py) all green.
- No user data shipped (.gitignore excludes *.xlsx, logs/).

## Install
`hermes plugins install kalice-vi/hermes-excel-line`