### PR TITLE
macOS computer-use permissions survive every build — daemon launches as CuaDriver.app with fail-closed signature checks (salvage #76433 + #95099)

### DIFF
--- a/contributors/emails/projetsjsl@gmail.com
+++ b/contributors/emails/projetsjsl@gmail.com
@@ -1,0 +1,1 @@
+projetsjsl

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3646,6 +3646,12 @@ DEFAULT_CONFIG = {
         # flags when it launches the runtime. See
         # https://cua.ai/docs/reference/cua-driver/permission-modes
         "capability_manifest": "",
+        # macOS only: allow launching an UNSIGNED (ad-hoc / TeamIdentifier
+        # not set) CuaDriver.app for the private-session daemon. The default
+        # (false) fails closed unless the bundle is signed with the official
+        # cua-driver identity (com.trycua.driver / team 4YEC26S9KF). Enable
+        # only when developing the driver locally from source.
+        "allow_unsigned_driver": False,
         # Pre-authorize existing-profile browser attachment in standard mode
         # (cua-driver's trusted-launcher `--grant existing-profile`). When
         # true, the agent can attach to your already-running, signed-in

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1535,7 +1535,8 @@ class TestCaptureAppFilterNoMatch:
              "structuredContent": None},
         ]
 
-        backend.capture(mode="ax")
+        with patch("tools.computer_use.cua_backend.sys.platform", "linux"):
+            backend.capture(mode="ax")
 
         assert backend._active_pid == 200
         assert backend._active_window_id == 2

--- a/tests/tools/test_computer_use_browser_authorization.py
+++ b/tests/tools/test_computer_use_browser_authorization.py
@@ -248,6 +248,43 @@ def test_schema_does_not_expose_approval_token():
 # ── bounded embedded daemon ─────────────────────────────────────────────
 
 
+def test_macos_embedded_daemon_launches_through_cuadriver_app():
+    command = cb._embedded_daemon_spawn_command(
+        "/tmp/cua-driver",
+        ["serve", "--embedded", "--socket", "/tmp/private.sock"],
+        platform="darwin",
+        app_path="/Applications/CuaDriver.app",
+    )
+
+    assert command == [
+        "/usr/bin/open",
+        "-n",
+        "-a",
+        "/Applications/CuaDriver.app",
+        "--args",
+        "serve",
+        "--embedded",
+        "--socket",
+        "/tmp/private.sock",
+    ]
+
+
+def test_non_macos_embedded_daemon_keeps_direct_binary_launch():
+    command = cb._embedded_daemon_spawn_command(
+        "/tmp/cua-driver",
+        ["serve", "--embedded", "--socket", "/tmp/private.sock"],
+        platform="linux",
+    )
+
+    assert command == [
+        "/tmp/cua-driver",
+        "serve",
+        "--embedded",
+        "--socket",
+        "/tmp/private.sock",
+    ]
+
+
 def test_bounded_daemon_requires_a_manifest():
     with pytest.raises(ValueError, match="capability_manifest"):
         _EmbeddedCuaDaemon("cua-driver", "bounded")

--- a/tests/tools/test_computer_use_browser_authorization.py
+++ b/tests/tools/test_computer_use_browser_authorization.py
@@ -248,7 +248,9 @@ def test_schema_does_not_expose_approval_token():
 # ── bounded embedded daemon ─────────────────────────────────────────────
 
 
-def test_macos_embedded_daemon_launches_through_cuadriver_app():
+def test_macos_embedded_daemon_launches_through_cuadriver_app(monkeypatch):
+    validated = []
+    monkeypatch.setattr(cb, "_validate_cua_driver_app_signature", lambda app: validated.append(app))
     command = cb._embedded_daemon_spawn_command(
         "/tmp/cua-driver",
         ["serve", "--embedded", "--socket", "/tmp/private.sock"],
@@ -256,9 +258,12 @@ def test_macos_embedded_daemon_launches_through_cuadriver_app():
         app_path="/Applications/CuaDriver.app",
     )
 
+    # Signature validation is mandatory before any launch command is built.
+    assert validated == ["/Applications/CuaDriver.app"]
     assert command == [
         "/usr/bin/open",
         "-n",
+        "-g",
         "-a",
         "/Applications/CuaDriver.app",
         "--args",
@@ -267,6 +272,83 @@ def test_macos_embedded_daemon_launches_through_cuadriver_app():
         "--socket",
         "/tmp/private.sock",
     ]
+
+
+def _codesign_proc(returncode=0, stderr=""):
+    import subprocess as _sp
+
+    return _sp.CompletedProcess(["codesign"], returncode, stdout="", stderr=stderr)
+
+
+def _patch_codesign(monkeypatch, proc):
+    monkeypatch.setattr(cb.shutil, "which", lambda name: "/usr/bin/codesign")
+    monkeypatch.setattr(cb.subprocess, "run", lambda *a, **kw: proc)
+
+
+def test_driver_signature_valid_official_identity(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(stderr="Identifier=com.trycua.driver\nTeamIdentifier=4YEC26S9KF\n"),
+    )
+    cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")  # no raise
+
+
+def test_driver_signature_rejects_suffixed_identifier(monkeypatch):
+    import pytest
+
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(stderr="Identifier=com.trycua.driver.evil\nTeamIdentifier=4YEC26S9KF\n"),
+    )
+    with pytest.raises(RuntimeError, match="identifier"):
+        cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_rejects_wrong_team(monkeypatch):
+    import pytest
+
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(stderr="Identifier=com.trycua.driver\nTeamIdentifier=EVIL000000\n"),
+    )
+    with pytest.raises(RuntimeError, match="team"):
+        cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_unsigned_rejected_by_default(monkeypatch):
+    import pytest
+
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(stderr="Identifier=com.trycua.driver\nTeamIdentifier=not set\n"),
+    )
+    monkeypatch.setattr(cb, "_computer_use_cfg", lambda: {})
+    with pytest.raises(RuntimeError, match="team"):
+        cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_driver_signature_unsigned_allowed_by_config_opt_in(monkeypatch):
+    _patch_codesign(
+        monkeypatch,
+        _codesign_proc(stderr="Identifier=com.trycua.driver\nTeamIdentifier=not set\n"),
+    )
+    monkeypatch.setattr(cb, "_computer_use_cfg", lambda: {"allow_unsigned_driver": True})
+    cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")  # no raise
+
+
+def test_driver_signature_rejects_unsigned_bundle(monkeypatch):
+    import pytest
+
+    _patch_codesign(monkeypatch, _codesign_proc(returncode=1, stderr="code object is not signed at all"))
+    with pytest.raises(RuntimeError, match="not code-signed"):
+        cb._validate_cua_driver_app_signature("/Applications/CuaDriver.app")
+
+
+def test_resolve_app_path_has_no_applications_fallback(tmp_path):
+    # A driver binary OUTSIDE any .app bundle must resolve to None — the old
+    # /Applications fallback could launch a DIFFERENT install than the
+    # resolved driver.
+    assert cb._resolve_cua_driver_app_path(str(tmp_path / "cua-driver")) is None
 
 
 def test_non_macos_embedded_daemon_keeps_direct_binary_launch():

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -174,7 +174,7 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
     stopped = SimpleNamespace(returncode=0, stdout="", stderr="")
 
     daemon = cua_backend._EmbeddedCuaDaemon("cua-driver", "unrestricted")
-    with patch.object(
+    with patch.object(cua_backend.sys, "platform", "linux"), patch.object(
         cua_backend,
         "_resolve_mcp_invocation",
         return_value=("/opt/cua-driver", ["mcp"]),

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -593,23 +593,88 @@ def _wsl_windows_path_to_posix(path: str) -> str:
 
 
 def _resolve_cua_driver_app_path(driver_cmd: str) -> Optional[str]:
-    """Return the installed CuaDriver.app carrying *driver_cmd*, if present."""
+    """Return the CuaDriver.app bundle that CARRIES *driver_cmd*, if any.
+
+    Deliberately derived from the resolved driver binary path only — no
+    /Applications or ~/Applications fallback. A fallback candidate can be a
+    DIFFERENT install than the driver the manifest resolved (stale copy,
+    side-by-side version), and launching it would run code the resolution
+    chain never validated. If the resolved driver does not live inside an
+    app bundle, the caller fails closed with install guidance.
+    """
     marker = ".app/Contents/MacOS/"
-    candidates: List[str] = []
     marker_index = driver_cmd.find(marker)
-    if marker_index >= 0:
-        candidates.append(driver_cmd[: marker_index + len(".app")])
-    candidates.extend(
-        [
-            "/Applications/CuaDriver.app",
-            os.path.expanduser("~/Applications/CuaDriver.app"),
-        ]
-    )
-    for candidate in candidates:
-        executable = os.path.join(candidate, "Contents", "MacOS", "cua-driver")
-        if os.path.isfile(executable) and os.access(executable, os.X_OK):
-            return candidate
+    if marker_index < 0:
+        return None
+    candidate = driver_cmd[: marker_index + len(".app")]
+    executable = os.path.join(candidate, "Contents", "MacOS", "cua-driver")
+    if os.path.isfile(executable) and os.access(executable, os.X_OK):
+        return candidate
     return None
+
+
+# The only bundle identity the private daemon may launch through, and the
+# team that signs official cua-driver releases. Exact matches only: a
+# suffixed identifier ("com.trycua.driver.evil") or a different non-empty
+# team is an impostor bundle, not a variant.
+_CUA_DRIVER_BUNDLE_ID = "com.trycua.driver"
+_CUA_DRIVER_TEAM_ID = "4YEC26S9KF"
+
+
+def _validate_cua_driver_app_signature(app_path: str) -> None:
+    """Fail closed unless *app_path* is the genuinely-signed CuaDriver.app.
+
+    Launching via ``/usr/bin/open`` hands LaunchServices whatever bundle sits
+    at the path, so the TCC-identity fix must not become a launcher for
+    arbitrary apps: require ``codesign -dv`` to report EXACTLY
+    ``Identifier=com.trycua.driver`` and the expected TeamIdentifier.
+    ``TeamIdentifier=not set`` (unsigned/ad-hoc dev builds) is allowed only
+    when ``computer_use.allow_unsigned_driver: true`` is set in config.yaml —
+    the escape hatch for local driver development, never the default. Raises
+    RuntimeError on any mismatch or when codesign is unavailable/fails.
+    """
+    codesign = shutil.which("codesign")
+    if not codesign:
+        raise RuntimeError(
+            "codesign is required to verify CuaDriver.app before launching it."
+        )
+    try:
+        proc = subprocess.run(
+            [codesign, "-dv", app_path],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"could not verify CuaDriver.app signature: {exc}") from exc
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"CuaDriver.app at {app_path} is not code-signed; refusing to launch it "
+            f"({(proc.stderr or '').strip()})"
+        )
+    # codesign -dv reports on stderr.
+    fields = {}
+    for line in (proc.stderr or "").splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            fields.setdefault(key.strip(), value.strip())
+    identifier = fields.get("Identifier", "")
+    team = fields.get("TeamIdentifier", "")
+    if identifier != _CUA_DRIVER_BUNDLE_ID:
+        raise RuntimeError(
+            f"CuaDriver.app at {app_path} has identifier {identifier!r}, "
+            f"expected {_CUA_DRIVER_BUNDLE_ID!r}; refusing to launch it."
+        )
+    if team == _CUA_DRIVER_TEAM_ID:
+        return
+    if team in ("", "not set") and _computer_use_cfg().get("allow_unsigned_driver") is True:
+        return
+    raise RuntimeError(
+        f"CuaDriver.app at {app_path} is signed by team {team!r}, expected "
+        f"{_CUA_DRIVER_TEAM_ID!r}; refusing to launch it. (Set "
+        "computer_use.allow_unsigned_driver: true in config.yaml only for "
+        "local unsigned driver builds.)"
+    )
 
 
 def _embedded_daemon_spawn_command(
@@ -628,9 +693,11 @@ def _embedded_daemon_spawn_command(
             "CuaDriver.app is required for private computer-use sessions on macOS. "
             "Run `hermes computer-use install` to restore it."
         )
+    _validate_cua_driver_app_signature(resolved_app)
     return [
         "/usr/bin/open",
         "-n",
+        "-g",
         "-a",
         resolved_app,
         "--args",

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -592,13 +592,61 @@ def _wsl_windows_path_to_posix(path: str) -> str:
     return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
 
 
+def _resolve_cua_driver_app_path(driver_cmd: str) -> Optional[str]:
+    """Return the installed CuaDriver.app carrying *driver_cmd*, if present."""
+    marker = ".app/Contents/MacOS/"
+    candidates: List[str] = []
+    marker_index = driver_cmd.find(marker)
+    if marker_index >= 0:
+        candidates.append(driver_cmd[: marker_index + len(".app")])
+    candidates.extend(
+        [
+            "/Applications/CuaDriver.app",
+            os.path.expanduser("~/Applications/CuaDriver.app"),
+        ]
+    )
+    for candidate in candidates:
+        executable = os.path.join(candidate, "Contents", "MacOS", "cua-driver")
+        if os.path.isfile(executable) and os.access(executable, os.X_OK):
+            return candidate
+    return None
+
+
+def _embedded_daemon_spawn_command(
+    driver_cmd: str,
+    serve_args: List[str],
+    *,
+    platform: str,
+    app_path: Optional[str] = None,
+) -> List[str]:
+    """Build the private-daemon launch while preserving macOS TCC identity."""
+    if platform != "darwin":
+        return [driver_cmd, *serve_args]
+    resolved_app = app_path or _resolve_cua_driver_app_path(driver_cmd)
+    if not resolved_app:
+        raise RuntimeError(
+            "CuaDriver.app is required for private computer-use sessions on macOS. "
+            "Run `hermes computer-use install` to restore it."
+        )
+    return [
+        "/usr/bin/open",
+        "-n",
+        "-a",
+        resolved_app,
+        "--args",
+        *serve_args,
+    ]
+
+
 class _EmbeddedCuaDaemon:
-    """Private host-owned daemon for a non-standard permission mode.
+    """Private daemon for a non-standard permission mode.
 
     Cua Driver permission mode is immutable after daemon startup.  Reusing the
     machine-wide daemon would therefore let one Hermes session's YOLO choice
     affect another session.  A private embedded daemon gives the requesting
-    session its own socket, process, and launch-time authorization:
+    session its own socket, runtime, and launch-time authorization. On macOS
+    the runtime is launched through CuaDriver.app so TCC remains attached to
+    ``com.trycua.driver`` instead of the embedding host's ad-hoc signature:
 
     * ``unrestricted`` — explicit Hermes YOLO; launch-time risk
       acknowledgement via ``--dangerously-bypass-approvals``.
@@ -661,6 +709,9 @@ class _EmbeddedCuaDaemon:
         self._command = driver_cmd
         self._mcp_args: List[str] = list(_CUA_DRIVER_ARGS)
         self._process: Any = None
+        self._owns_runtime = False
+        self._running = False
+        self._launch_via_app = False
         self._stderr_tail: deque[str] = deque(maxlen=20)
         self._stderr_thread: Optional[threading.Thread] = None
         token = uuid.uuid4().hex[:12]
@@ -692,7 +743,7 @@ class _EmbeddedCuaDaemon:
             pass
 
     def start(self) -> None:
-        if self._process is not None and self._process.poll() is None:
+        if self._running:
             return
         from tools.environments.local import _sanitize_subprocess_env
 
@@ -702,8 +753,7 @@ class _EmbeddedCuaDaemon:
             raise RuntimeError(cua_driver_install_hint())
         self._command, self._mcp_args = _resolve_mcp_invocation(self._driver_cmd)
         env = _sanitize_subprocess_env(self.child_env())
-        command = [
-            self._command,
+        serve_args = [
             "serve",
             "--embedded",
             "--socket",
@@ -713,7 +763,7 @@ class _EmbeddedCuaDaemon:
             self.permission_mode,
         ]
         if self.permission_mode == "unrestricted":
-            command.append("--dangerously-bypass-approvals")
+            serve_args.append("--dangerously-bypass-approvals")
         # A v3 manifest is a ceiling, not a mode: cua-driver accepts it
         # alongside any permission mode and it "can narrow a profile but never
         # widen it". Attaching it to unrestricted is what bounds an
@@ -721,7 +771,7 @@ class _EmbeddedCuaDaemon:
         # applies — not only for bounded, which used to drop it for every
         # other mode.
         if self.manifest_applies:
-            command.extend(
+            serve_args.extend(
                 [
                     "--capability-manifest",
                     str(self.capability_manifest),
@@ -731,7 +781,15 @@ class _EmbeddedCuaDaemon:
         # The private daemon owns the platform cursor overlay. Applying the
         # policy only to its MCP proxy leaves this long-lived serve process
         # free to create a full-screen overlay before session tuning runs.
-        command = _mcp_args_with_overlay_flag(command, driver_cmd=self._command)
+        # Must be appended BEFORE the macOS app-launch wrapping so the flag
+        # travels inside `open ... --args` with the rest of the serve args.
+        serve_args = _mcp_args_with_overlay_flag(serve_args, driver_cmd=self._command)
+        self._launch_via_app = sys.platform == "darwin"
+        command = _embedded_daemon_spawn_command(
+            self._command,
+            serve_args,
+            platform=sys.platform,
+        )
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,
@@ -740,6 +798,7 @@ class _EmbeddedCuaDaemon:
             text=True,
             env=env,
         )
+        self._owns_runtime = True
         self._stderr_thread = threading.Thread(
             target=self._drain_stderr,
             args=(self._process,),
@@ -750,7 +809,10 @@ class _EmbeddedCuaDaemon:
 
         deadline = time.monotonic() + self._START_TIMEOUT_SECONDS
         while time.monotonic() < deadline:
-            if self._process.poll() is not None:
+            return_code = self._process.poll()
+            if return_code is not None and (
+                not self._launch_via_app or return_code != 0
+            ):
                 detail = "; ".join(self._stderr_tail) or "no diagnostic output"
                 raise RuntimeError(
                     f"embedded cua-driver exited during startup: {detail}"
@@ -767,6 +829,7 @@ class _EmbeddedCuaDaemon:
             except (OSError, subprocess.SubprocessError):
                 probe = None
             if probe is not None and probe.returncode == 0:
+                self._running = True
                 return
             time.sleep(0.1)
 
@@ -775,7 +838,7 @@ class _EmbeddedCuaDaemon:
         raise RuntimeError(f"embedded cua-driver startup timed out: {detail}")
 
     def proxy_invocation(self) -> Tuple[str, List[str]]:
-        if self._process is None or self._process.poll() is not None:
+        if not self._running:
             raise RuntimeError("embedded cua-driver daemon is not running")
         return self._command, [
             *self._mcp_args,
@@ -787,7 +850,10 @@ class _EmbeddedCuaDaemon:
     def stop(self) -> None:
         process = self._process
         self._process = None
-        if process is not None and process.poll() is None:
+        owns_runtime = self._owns_runtime
+        self._owns_runtime = False
+        self._running = False
+        if owns_runtime:
             from tools.environments.local import _sanitize_subprocess_env
 
             try:
@@ -801,6 +867,7 @@ class _EmbeddedCuaDaemon:
                 )
             except (OSError, subprocess.SubprocessError):
                 pass
+        if process is not None:
             try:
                 process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -149,6 +149,19 @@ the manifest fails closed inside cua-driver. A missing or unreadable manifest
 fails loudly at session start rather than silently downgrading. Session YOLO
 still overrides bounded for that one session.
 
+On macOS, private-session daemons launch through the installed
+`CuaDriver.app` bundle (so permission grants attribute to the driver's own
+identity instead of resetting with every Hermes build), and Hermes verifies
+the bundle's code signature — exact `com.trycua.driver` identifier and the
+official signing team — before launching it. If you build cua-driver from
+source (unsigned), opt in explicitly:
+
+```yaml
+# config.yaml
+computer_use:
+  allow_unsigned_driver: true   # local driver development only
+```
+
 Each MCP transport owns a private lifecycle session inside its runtime. A
 public session name is only a label for cursor identity and session-scoped
 state. It does not select, share, or keep a runtime alive. Turning `/yolo` off,


### PR DESCRIPTION
## Summary
macOS computer-use private sessions stop losing (and re-prompting for) Screen Recording and Accessibility permissions on every Hermes build: the embedded cua-driver daemon now launches through the installed `CuaDriver.app` bundle via LaunchServices, so TCC attributes grants to `com.trycua.driver` — a stable, signed identity — instead of the bundle-less Hermes host process whose ad-hoc cdhash churns per build. Fixes #84033 and #90647 (two symptoms of the same defect).

Salvage of #95099 (@projetsjsl — app-bundle launch, socket-based readiness, `_running`/`_owns_runtime` lifecycle so `proxy_invocation()`/`stop()` don't key off `process.poll()` of the short-lived `open`), which is a derivative of #76433 (@Chadmc9889 — first submitter, original diagnosis and mechanism; the rebase lost his git authorship, restored here via Co-authored-by).

## Changes
- `tools/computer_use/cua_backend.py` (@projetsjsl base, cherry-picked): `_embedded_daemon_spawn_command` + `_resolve_cua_driver_app_path` pure helpers; darwin launches `open -n -a CuaDriver.app --args serve ...`; readiness by socket probe.
- Hardening commit (ours, grafting #76433's review direction, Co-authored-by @Chadmc9889):
  - **fail-closed signature validation** — `codesign -dv` must report EXACT `Identifier=com.trycua.driver` + the official team ID before LaunchServices gets the bundle; suffixed identifiers and wrong teams rejected (the launch fix must not double as an arbitrary-app launcher). Unsigned dev builds only via `computer_use.allow_unsigned_driver: true` (config.yaml, default false).
  - **no /Applications fallback** — the bundle is derived only from the resolved driver binary; a fallback could launch a different install than the manifest validated.
  - **`open -g`** — daemon launch no longer activates/steals focus (restored from #76433).
  - dropped #95099's empty rebase-marker commit.
- Rebase resolution: main's new overlay-flag hunk now applies to `serve_args` BEFORE app-launch wrapping so `--no-overlay` rides inside `open ... --args`.
- Docs: computer-use page documents the bundle launch + signature gate + `allow_unsigned_driver`.

## Validation
| | Before | After |
|---|---|---|
| Daemon TCC client | raw child of bundle-less host (cdhash churn) | signed `com.trycua.driver` bundle |
| Bundle trust | any CuaDriver.app at known paths | exact identifier+team or fail closed |
| Tests | 162 | 169 passed (7 new, exact-match assertions sabotage-verified) |

**Live repro (premise):** current main's `_EmbeddedCuaDaemon.start()` verified to spawn the daemon as a raw `subprocess.Popen` child. TCC attribution itself is macOS-only; the readiness/lifecycle behavior is pinned by mocked tests and the reporter evidence in #84033/#90647 — real-Mac E2E flagged for verification.

Credits: @Chadmc9889 (first submitter, mechanism + fail-closed direction — Co-authored-by), @projetsjsl (rebase + lifecycle hardening), reporters @orion-nebula-dev (#84033) and @ai2070 (#90647). Closes #76433, #95099. Fixes #84033, #90647.

## Infographic

![Computer use stops asking for screen permission every build](https://v3b.fal.media/files/b/0aa7dcb1/iAPpgeWFOQDPfKVL-v-A5_mCtpiax2.png)
