### PR TITLE
fix(cron): recover stale Discord origin DMs by exact user

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3307,6 +3307,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
 
+            # Discord DM channel ids are not durable authorities: an old DM
+            # channel can become inaccessible even though the exact scheduling
+            # user is still valid.  Preserve the origin identity only for an
+            # origin-matching 1:1 DM so the adapter may safely recreate that
+            # user's channel.  Never stamp fan-out, guild, or group targets.
+            if (
+                platform == Platform.DISCORD
+                and origin_target
+                and origin_chat_type == "dm"
+                and origin_user_id
+            ):
+                route_metadata["_cron_origin_dm_user_id"] = str(origin_user_id)
+
             # Relay egress needs a tenant discriminator on the frame: the
             # connector's fail-closed guard resolves the workspace/guild from
             # metadata.scope_id, and after a gateway restart the RelayAdapter's

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -138,6 +138,20 @@ except ImportError:
     Intents = Any
     commands = None
 
+def _is_discord_channel_lookup_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` is Discord's inaccessible-channel response.
+
+    Resolve the optional Discord exception classes at call time. Besides
+    keeping the adapter importable without the messaging extra, this avoids
+    freezing an empty exception tuple when another test imports the optional
+    adapter before discord.py is available.
+    """
+    for error_name in ("Forbidden", "NotFound"):
+        error_type = getattr(discord, error_name, None)
+        if isinstance(error_type, type) and isinstance(exc, error_type):
+            return True
+    return False
+
 import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
@@ -3433,6 +3447,55 @@ class DiscordAdapter(BasePlatformAdapter):
         kept.append(notice)
         return kept
 
+    async def _resolve_exact_origin_dm_channel(
+        self,
+        metadata: Optional[Dict[str, Any]],
+        *,
+        stale_channel: Optional[Any] = None,
+    ) -> Optional[Any]:
+        """Resolve or create the exact user's DM channel for origin delivery.
+
+        This is deliberately narrower than a generic channel fallback: only a
+        caller-authenticated origin DM carrying an exact user id is eligible.
+        Guild, group, thread, and fan-out delivery must continue to fail closed.
+        """
+        if not self._client or not metadata:
+            return None
+        user_id = metadata.get("_cron_origin_dm_user_id")
+        if user_id is None:
+            return None
+        try:
+            discord_user_id = int(user_id)
+        except (TypeError, ValueError):
+            return None
+
+        user = self._client.get_user(discord_user_id)
+        if user is None:
+            user = await self._client.fetch_user(discord_user_id)
+        if user is None:
+            return None
+        channel = getattr(user, "dm_channel", None)
+        if channel is not None and stale_channel is not None:
+            channel_id = getattr(channel, "id", None)
+            stale_channel_id = getattr(stale_channel, "id", None)
+            same_cached_channel = channel is stale_channel or (
+                channel_id is not None and channel_id == stale_channel_id
+            )
+            if same_cached_channel:
+                state = getattr(user, "_state", None)
+                remove_private_channel = getattr(
+                    state,
+                    "_remove_private_channel",
+                    None,
+                )
+                if not callable(remove_private_channel):
+                    return None
+                remove_private_channel(channel)
+                channel = None
+        if channel is None:
+            channel = await user.create_dm()
+        return channel
+
     async def send(
         self,
         chat_id: str,
@@ -3493,7 +3556,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Get the parent channel
                 channel = self._client.get_channel(int(chat_id))
                 if not channel:
-                    channel = await self._client.fetch_channel(int(chat_id))
+                    try:
+                        channel = await self._client.fetch_channel(int(chat_id))
+                    except Exception as exc:
+                        if not _is_discord_channel_lookup_error(exc):
+                            raise
+                        channel = await self._resolve_exact_origin_dm_channel(metadata)
+                        if channel is None:
+                            raise
+                if not channel:
+                    channel = await self._resolve_exact_origin_dm_channel(metadata)
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
@@ -3531,7 +3603,24 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                 except Exception as e:
                     err_text = str(e)
-                    if (
+                    if not message_ids and _is_discord_channel_lookup_error(e):
+                        recovered_channel = await self._resolve_exact_origin_dm_channel(
+                            metadata,
+                            stale_channel=channel,
+                        )
+                        if recovered_channel is None:
+                            raise
+                        channel = recovered_channel
+                        reference = self._reply_reference_for_send(reply_to, channel)
+                        if self._reply_to_mode == "all":
+                            chunk_reference = reference
+                        else:
+                            chunk_reference = reference if i == 0 else None
+                        msg = await channel.send(
+                            content=chunk,
+                            reference=chunk_reference,
+                        )
+                    elif (
                         chunk_reference is not None
                         and (
                             (

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -452,6 +452,69 @@ class TestDeliverResultWrapping:
         standalone_send.assert_not_awaited()
 
 
+    def test_discord_origin_dm_passes_exact_user_identity_to_live_adapter(self):
+        """Cron origin delivery gives Discord enough identity to refresh a stale DM."""
+        from concurrent.futures import Future
+
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="msg-1")
+        adapter.supports_inchannel_continuable = False
+        adapter.supports_inchannel_continuable_for_platform = None
+        config = GatewayConfig(
+            platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+        )
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        job = {
+            "id": "discord-origin-dm",
+            "name": "Merge ready",
+            "deliver": "origin,discord:999",
+            "origin": {
+                "platform": "discord",
+                "chat_id": "555",
+                "chat_type": "dm",
+                "user_id": "42",
+            },
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+        ):
+            result = _deliver_result(
+                job,
+                "Merge-ready packet",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        assert adapter.send.await_count == 2
+        sends_by_chat = {
+            call.args[0]: call.kwargs["metadata"]
+            for call in adapter.send.await_args_list
+        }
+        origin_metadata = sends_by_chat["555"]
+        assert origin_metadata["_cron_origin_dm_user_id"] == "42"
+        assert "user_id" not in origin_metadata
+        assert "chat_type" not in origin_metadata
+        assert "_cron_origin_dm_user_id" not in sends_by_chat["999"]
+
+
     def test_live_adapter_sends_media_as_attachments(self, tmp_path, monkeypatch):
         """When a live adapter is available, MEDIA files should be sent as native
         platform attachments (e.g., Discord voice, Telegram audio) rather than

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -43,8 +43,20 @@ def _ensure_discord_mock():
 
 
 _ensure_discord_mock()
+_DISCORD_DEPENDENCY = sys.modules["discord"]
 
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+@pytest.fixture(autouse=True)
+def _restore_discord_dependency(monkeypatch):
+    """Keep send tests independent of optional-import tests collected first."""
+    adapter_module = sys.modules["plugins.platforms.discord.adapter"]
+    monkeypatch.setattr(adapter_module, "discord", _DISCORD_DEPENDENCY)
+    monkeypatch.setitem(
+        DiscordAdapter.send.__globals__,
+        "discord",
+        _DISCORD_DEPENDENCY,
+    )
 
 
 @pytest.mark.asyncio
@@ -149,6 +161,135 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     assert send_calls[0]["reference"] is _discord_mod.MessageReference.return_value
     assert send_calls[1]["reference"] is None
     assert send_calls[2]["reference"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_recreates_stale_origin_dm_channel_from_exact_user(monkeypatch):
+    """A stale cron-origin DM channel can be recreated for that exact user."""
+    class Forbidden(Exception):
+        pass
+
+    class NotFound(Exception):
+        pass
+
+    monkeypatch.setitem(
+        DiscordAdapter.send.__globals__,
+        "discord",
+        SimpleNamespace(Forbidden=Forbidden, NotFound=NotFound),
+    )
+
+    sent = SimpleNamespace(id=7001)
+    dm_channel = SimpleNamespace(send=AsyncMock(return_value=sent))
+    user = SimpleNamespace(dm_channel=None, create_dm=AsyncMock(return_value=dm_channel))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    client = SimpleNamespace(
+        get_channel=MagicMock(return_value=None),
+        fetch_channel=AsyncMock(side_effect=Forbidden("Missing Access")),
+        get_user=MagicMock(return_value=None),
+        fetch_user=AsyncMock(return_value=user),
+    )
+    adapter._client = client
+
+    result = await adapter.send(
+        "555",
+        "Merge-ready packet",
+        metadata={"_cron_origin_dm_user_id": "42"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "7001"
+    client.get_user.assert_called_once_with(42)
+    client.fetch_user.assert_awaited_once_with(42)
+    user.create_dm.assert_awaited_once()
+    dm_channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_recovers_when_cached_origin_channel_is_inaccessible(monkeypatch):
+    """A cached stale channel must not bypass exact-user DM recovery."""
+    class Forbidden(Exception):
+        pass
+
+    class NotFound(Exception):
+        pass
+
+    monkeypatch.setitem(
+        DiscordAdapter.send.__globals__,
+        "discord",
+        SimpleNamespace(Forbidden=Forbidden, NotFound=NotFound),
+    )
+
+    sent = SimpleNamespace(id=7002)
+    stale_channel = SimpleNamespace(
+        id=555,
+        send=AsyncMock(side_effect=Forbidden("Missing Access")),
+    )
+    dm_channel = SimpleNamespace(send=AsyncMock(return_value=sent))
+    state = SimpleNamespace(_remove_private_channel=MagicMock())
+    user = SimpleNamespace(
+        dm_channel=stale_channel,
+        create_dm=AsyncMock(return_value=dm_channel),
+        _state=state,
+    )
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    client = SimpleNamespace(
+        get_channel=MagicMock(return_value=stale_channel),
+        fetch_channel=AsyncMock(),
+        get_user=MagicMock(return_value=user),
+        fetch_user=AsyncMock(),
+    )
+    adapter._client = client
+
+    result = await adapter.send(
+        "555",
+        "Merge-ready packet",
+        metadata={"_cron_origin_dm_user_id": "42"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "7002"
+    stale_channel.send.assert_awaited_once()
+    client.fetch_channel.assert_not_awaited()
+    client.get_user.assert_called_once_with(42)
+    client.fetch_user.assert_not_awaited()
+    state._remove_private_channel.assert_called_once_with(stale_channel)
+    user.create_dm.assert_awaited_once()
+    dm_channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_fallback_guild_channel_to_user_dm(monkeypatch):
+    """A missing guild/group target must fail closed, never leak into a DM."""
+    class Forbidden(Exception):
+        pass
+
+    class NotFound(Exception):
+        pass
+
+    monkeypatch.setitem(
+        DiscordAdapter.send.__globals__,
+        "discord",
+        SimpleNamespace(Forbidden=Forbidden, NotFound=NotFound),
+    )
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    client = SimpleNamespace(
+        get_channel=MagicMock(return_value=None),
+        fetch_channel=AsyncMock(side_effect=Forbidden("Missing Access")),
+        get_user=MagicMock(),
+        fetch_user=AsyncMock(),
+    )
+    adapter._client = client
+
+    result = await adapter.send(
+        "555",
+        "Do not reroute me",
+        metadata={"chat_type": "dm", "user_id": "42"},
+    )
+
+    assert result.success is False
+    client.get_user.assert_not_called()
+    client.fetch_user.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +424,6 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
     message with zero attachments after an earlier image batch on the same
     channel — silent drop from the user's perspective.
     """
-    import plugins.platforms.discord.adapter as discord_platform
-
     video = tmp_path / "clip.mp4"
     video.write_bytes(b"\x00\x00\x00\x18ftypmp42fake")
 
@@ -295,7 +434,7 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
             captured["fp"] = fp
             captured["filename"] = filename
 
-    monkeypatch.setattr(discord_platform.discord, "File", _FakeFile)
+    monkeypatch.setattr(DiscordAdapter.send.__globals__["discord"], "File", _FakeFile)
 
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     sent_msg = SimpleNamespace(
@@ -327,13 +466,11 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_send_video_fails_loud_when_message_has_no_attachments(tmp_path, monkeypatch):
     """If Discord accepts the message but attaches nothing, fail loud (#66797)."""
-    import plugins.platforms.discord.adapter as discord_platform
-
     video = tmp_path / "clip.mp4"
     video.write_bytes(b"fake-mp4")
 
     monkeypatch.setattr(
-        discord_platform.discord,
+        DiscordAdapter.send.__globals__["discord"],
         "File",
         lambda fp, filename=None, **kwargs: SimpleNamespace(fp=fp, filename=filename),
     )
@@ -380,13 +517,11 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     """Forum-parent delivery must also route the path-based file through the
     plural ``files=[...]`` kwarg (#66797), so the create_thread starter message
     carries the attachment rather than silently dropping it."""
-    import plugins.platforms.discord.adapter as discord_platform
-
     video = tmp_path / "clip.mp4"
     video.write_bytes(b"fake-mp4")
 
     monkeypatch.setattr(
-        discord_platform.discord,
+        DiscordAdapter.send.__globals__["discord"],
         "File",
         lambda fp, filename=None, **kwargs: SimpleNamespace(fp=fp, filename=filename),
     )


### PR DESCRIPTION
## Summary

- carry the exact originating Discord DM user id only on origin-matching 1:1 Cron deliveries
- recover an inaccessible persisted DM channel—whether absent from cache or cached but unusable—by resolving or recreating that exact user's DM
- keep guild, group, thread, fan-out, and generic metadata delivery fail-closed
- make Discord send tests independent of optional-dependency import order

## Safety boundary

The adapter does **not** use generic `chat_type` or `user_id` metadata as rerouting authority. The private recovery key is emitted only when the current delivery target exactly matches the job's recorded Discord DM origin. Explicit fan-out targets do not receive it.

## Verification

- `uv run --extra dev pytest tests/gateway/test_discord_send.py tests/cron/test_scheduler.py -q` — 118 passed
- `uv run --extra dev --extra messaging pytest tests/gateway/test_discord_*.py tests/plugins/test_discord_runtime_failure.py tests/cron/test_scheduler.py -q` — 360 passed, 1 skipped
- `uv run ruff check cron/scheduler.py plugins/platforms/discord/adapter.py tests/cron/test_scheduler.py tests/gateway/test_discord_send.py`
- `uv run python -m py_compile cron/scheduler.py plugins/platforms/discord/adapter.py tests/cron/test_scheduler.py tests/gateway/test_discord_send.py`
- `git diff --check`

## Operational context

A completed origin-delivered Cron run could fail its final notification when Discord returned `403 Missing Access` for a stale persisted DM channel id. The scheduler had the exact originating user identity but discarded it before live adapter delivery, so the adapter could not safely recreate the 1:1 DM.
