### PR TITLE
fix(cli): bound persistent_output replay to visible terminal height

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3602,8 +3602,23 @@ def _record_output_history(text: str) -> None:
         _record_output_history_entry(line)
 
 
+def _visible_terminal_rows() -> int:
+    """Return the terminal's current visible row count (fallback 24)."""
+    try:
+        return shutil.get_terminal_size((80, 24)).lines
+    except Exception:
+        return 24
+
+
 def _replay_output_history() -> None:
-    """Repaint recent output above the prompt after a full screen clear."""
+    """Repaint recent output above the prompt after a full screen clear.
+
+    The pre-replay clear only wipes the *visible* viewport (CSI 2J), not the
+    scrollback, so re-printing the full ``_OUTPUT_HISTORY`` buffer on every
+    resize/redraw would append a duplicate copy of the history to scrollback
+    (#95375). Bound the replay to the visible terminal height so a redraw
+    restores the visible transcript without stacking duplicate blocks.
+    """
     global _OUTPUT_HISTORY_REPLAYING
     if not _OUTPUT_HISTORY_ENABLED or not _OUTPUT_HISTORY:
         return
@@ -3622,6 +3637,14 @@ def _replay_output_history() -> None:
                 lines = [entry]
             rendered_lines.extend(str(line) for line in lines)
         if rendered_lines:
+            # Only re-print what fits on the visible screen. The clear that
+            # precedes this replay wipes the viewport (CSI 2J) but not the
+            # scrollback, so re-printing the whole buffer would append a
+            # duplicate block to scrollback on every resize/redraw. Bounding
+            # the replay to the visible row count keeps the transcript intact
+            # without stacking duplicates.
+            visible_rows = max(1, _visible_terminal_rows())
+            rendered_lines = rendered_lines[-visible_rows:]
             # Replay after resize can contain hundreds of history lines. A
             # per-line prompt_toolkit print forces one synchronous terminal I/O
             # and redraw cycle per line, which users perceive as a waterfall of

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -391,6 +391,85 @@ class TestFirstSigwinchBaseline:
         assert getattr(bare_cli, "_last_resize_width", None) is None
 
 
+class TestReplayBoundedToVisibleHeight:
+    """Bug #95375: persistent_output replay must not append a duplicate block
+    to scrollback on resize/redraw.
+
+    The pre-replay clear only wipes the visible viewport (CSI 2J), not the
+    scrollback, so re-printing the full ``_OUTPUT_HISTORY`` buffer on every
+    resize/redraw stacked a fresh copy of the history below the old content.
+    The replay must be bounded to the terminal's visible row count.
+    """
+
+    def test_replay_emits_at_most_visible_rows(self, monkeypatch):
+        """With 200 history lines and a 10-row terminal, replay emits ~10 lines,
+        not all 200."""
+        cli_mod._configure_output_history(True, 200)
+        for i in range(200):
+            cli_mod._record_output_history(f"history line {i}")
+
+        printed = []
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+        monkeypatch.setattr(
+            cli_mod.shutil,
+            "get_terminal_size",
+            lambda *a, **k: __import__("os").terminal_size((80, 10)),
+        )
+
+        cli_mod._replay_output_history()
+
+        assert len(printed) == 1, "replay must emit a single ANSI payload"
+        replayed = printed[0].split("\n")
+        assert len(replayed) <= 10, (
+            f"replay emitted {len(replayed)} lines, expected at most 10 "
+            "(visible terminal height) — full 200-line buffer was re-printed"
+        )
+        # The LAST visible lines are replayed, not the first.
+        assert replayed == [f"history line {i}" for i in range(190, 200)]
+
+    def test_replay_keeps_full_history_buffer(self, monkeypatch):
+        """Bounding the replay must NOT truncate _OUTPUT_HISTORY itself — the
+        deque keeps the full history for other consumers."""
+        cli_mod._configure_output_history(True, 200)
+        for i in range(200):
+            cli_mod._record_output_history(f"history line {i}")
+
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: None)
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+        monkeypatch.setattr(
+            cli_mod.shutil,
+            "get_terminal_size",
+            lambda *a, **k: __import__("os").terminal_size((80, 10)),
+        )
+
+        cli_mod._replay_output_history()
+
+        assert len(cli_mod._OUTPUT_HISTORY) == 200, (
+            "_OUTPUT_HISTORY must keep the full buffer after a bounded replay"
+        )
+
+    def test_replay_emits_all_when_history_fits(self, monkeypatch):
+        """When the history is shorter than the visible height, everything is
+        replayed (no regression for small transcripts)."""
+        cli_mod._configure_output_history(True, 200)
+        for i in range(5):
+            cli_mod._record_output_history(f"line {i}")
+
+        printed = []
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+        monkeypatch.setattr(
+            cli_mod.shutil,
+            "get_terminal_size",
+            lambda *a, **k: __import__("os").terminal_size((80, 10)),
+        )
+
+        cli_mod._replay_output_history()
+
+        assert printed[0].split("\n") == [f"line {i}" for i in range(5)]
+
+
 class TestFocusRegainRedraw:
     """Focus-in (CSI I) routes through the same recovery as Ctrl+L, rate-limited.
 


### PR DESCRIPTION
## Summary

In the classic CLI (`cli.py`, not the `--tui` frontend), the `persistent_output` "replay history after redraw" feature re-printed the full `_OUTPUT_HISTORY` buffer (default 200 lines) on every terminal resize/redraw. The pre-replay clear only wipes the *visible* screen (CSI 2J), not the scrollback, so each replay appended a fresh duplicate copy of the history below the old content. Over a session, scrolling up showed the same replies stacked 2–3+ times.

This is render-only — the session DB and `_OUTPUT_HISTORY` deque each hold exactly one copy of every message.

## Changes

- **`cli.py`** — `_replay_output_history()` now bounds the replay to the terminal's visible row count (`shutil.get_terminal_size().lines`, fallback 24) via a small `_visible_terminal_rows()` helper. A redraw restores the visible transcript without dumping a large duplicate block into scrollback. The deque still keeps the full history; only what gets re-printed is bounded.
- **`tests/cli/test_cli_force_redraw.py`** — new `TestReplayBoundedToVisibleHeight` class (3 tests): replay emits at most the visible row count, `_OUTPUT_HISTORY` is not truncated, and small transcripts are still fully replayed.

The fix lives inside `_replay_output_history()`, so it covers both call paths — the resize handler (`_recover_after_resize`) and Ctrl+L / `/redraw` (`_force_full_redraw`).

## Tests

```
36 passed in 0.60s   (tests/cli/test_cli_force_redraw.py + tests/cli/test_interrupt_output_history_regression.py)
```

The regression test is proven by revert: with the bounding removed, `test_replay_emits_at_most_visible_rows` fails (emits 200 lines instead of ≤10); with the fix restored it passes.

Closes #95375
