### PR TITLE
feat(agent): implicit skill prefetch — load mentioned skills into turn prefetch cache

### DIFF
--- a/agent/skill_prefetch.py
+++ b/agent/skill_prefetch.py
@@ -1,0 +1,184 @@
+"""Implicit skill prefetch for the turn prologue.
+
+Ported semantic from OpenAI Codex's implicit skill invocation
+(``codex-rs/skills/src/invocation.rs``): when the user's prompt mentions a
+skill name, load that skill's full instructions into the turn's prefetch
+cache so the model has them on the first turn instead of round-tripping
+``skill_view()`` first.
+
+Hermes differs from Codex in the detection surface. Codex parses shell
+command tokens (running a skill's script / reading a skill's doc); Hermes
+matches the natural-language prompt against the skill index. The matching
+rules are borrowed from the desktop suggestion provider
+(``apps/desktop/src/store/suggestion-providers/skill.ts``), which already
+solved the false-positive problem:
+
+- Unicode word boundaries (a bare ``codex`` cannot match inside
+  ``codexified``; a trailing ``-`` is excluded so ``codex`` cannot match the
+  prefix of ``codex-operations``).
+- Hyphens/underscores in a skill name also match spaces — people write
+  "pr ready", the skill is ``pr-ready``.
+- A minimum name length guards against common-word false positives (``pdf``,
+  ``git``, ``box``).
+
+The result is appended to the same ``ext_prefetch_cache`` the memory manager
+uses, so it rides the existing prompt-cache-safe channel (injected into the
+API copy of the user message only; stored content stays clean). Zero cost
+when nothing matches; bounded when several skills match.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Names shorter than this are too likely to be ordinary English words.
+MIN_NAME_LENGTH = 4
+# Cap on how many skills a single turn prefetches (prompt rarely names more).
+MAX_PREFETCH_SKILLS = 3
+# Per-skill and total body budgets keep the injection bounded.
+MAX_SKILL_CHARS = 8_000
+MAX_TOTAL_CHARS = 16_000
+
+
+def _skill_pattern(name: str) -> re.Pattern:
+    """Whole-word pattern for a skill name, exported for tests.
+
+    Hyphens and underscores in the name also match spaces — people type
+    "pr ready", the skill is ``pr-ready`` — while the leading boundary and
+    the trailing ``(?![A-Za-z0-9-])`` guarantee a bare ``codex`` can never
+    match inside ``codexified`` or as the prefix of ``codex-operations``.
+    """
+    flexible = re.escape(name.lower()).replace(r"\-", "[-_ ]").replace(r"\_", "[-_ ]")
+    return re.compile(rf"(?<![A-Za-z0-9]){flexible}(?![A-Za-z0-9-])", re.IGNORECASE)
+
+
+def detect_mentioned_skill_names(
+    prompt: "str | None",
+    skill_names: Iterable[str],
+) -> List[str]:
+    """Return skill names the prompt mentions, most-specific first, capped.
+
+    Names are matched whole-word against the prompt. When several patterns
+    hit (e.g. both ``codex`` and ``codex-operations`` are skills and the
+    prompt says "codex-operations"), longer names win so the most specific
+    skill is prefetched.
+    """
+    if not prompt:
+        return []
+    hits = []
+    for name in skill_names:
+        if not name or len(name) < MIN_NAME_LENGTH:
+            continue
+        try:
+            if _skill_pattern(name).search(prompt):
+                hits.append(name)
+        except re.error:
+            continue
+    hits.sort(key=len, reverse=True)
+    return hits[:MAX_PREFETCH_SKILLS]
+
+
+def _safe_skill_name(name: str) -> bool:
+    """A skill name coming from the index is already trusted, but defense in
+    depth: refuse anything that could escape the skills directory (path
+    separators / traversal) before we join it onto a search dir."""
+    if not name or name != name.strip():
+        return False
+    if any(ch in name for ch in ("/", "\\", "\x00")):
+        return False
+    if ".." in name:
+        return False
+    return True
+
+
+def _find_skill_md(name: str) -> Optional[Path]:
+    """Locate a SKILL.md by directory name or frontmatter ``name``.
+
+    Mirrors ``skill_view``'s recursive lookup without its JSON output and
+    side effects (env registration, read tracking) — prefetch must not
+    trigger those.
+    """
+    if not _safe_skill_name(name):
+        return None
+    try:
+        from agent.skill_utils import (
+            get_scan_ordered_skills_dirs,
+            iter_skill_index_files,
+            parse_frontmatter,
+        )
+    except Exception:
+        return None
+    for skills_dir in get_scan_ordered_skills_dirs():
+        if not skills_dir.exists():
+            continue
+        try:
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
+                if skill_md.parent.name == name:
+                    return skill_md
+                try:
+                    raw = skill_md.read_text(encoding="utf-8-sig", errors="replace")
+                    fm, _ = parse_frontmatter(raw)
+                except Exception:
+                    fm = {}
+                if fm.get("name") == name:
+                    return skill_md
+        except Exception as e:
+            logger.debug("Skill prefetch scan failed in %s: %s", skills_dir, e)
+    return None
+
+
+def _read_skill_body(name: str) -> str:
+    """Read a skill's SKILL.md body (frontmatter stripped), bounded."""
+    md = _find_skill_md(name)
+    if md is None:
+        return ""
+    try:
+        raw = md.read_text(encoding="utf-8-sig", errors="replace")
+    except Exception as e:
+        logger.debug("Skill prefetch read failed for %s: %s", name, e)
+        return ""
+    try:
+        from agent.skill_utils import parse_frontmatter
+
+        _, body = parse_frontmatter(raw)
+    except Exception:
+        body = raw
+    return body[:MAX_SKILL_CHARS]
+
+
+def build_skill_prefetch(prompt: str) -> str:
+    """Return fenced skill bodies for skills the prompt mentions, or ``""``.
+
+    Safe no-op when nothing matches, when the skill index is unavailable, or
+    when a skill vanished between index and read.
+    """
+    if not prompt or not prompt.strip():
+        return ""
+    try:
+        from tools.skills_tool import _find_all_skills
+
+        names = [str(s["name"]) for s in _find_all_skills() if s.get("name")]
+    except Exception as e:
+        logger.debug("Skill prefetch index unavailable: %s", e)
+        return ""
+    hits = detect_mentioned_skill_names(prompt, names)
+    if not hits:
+        return ""
+    parts: List[str] = []
+    total = 0
+    for name in hits:
+        body = _read_skill_body(name)
+        if not body:
+            continue
+        if total + len(body) > MAX_TOTAL_CHARS:
+            body = body[: MAX_TOTAL_CHARS - total]
+        parts.append(f"[Implicitly loaded skill: {name}]\n{body}")
+        total += len(body)
+        if total >= MAX_TOTAL_CHARS:
+            break
+    return "\n\n".join(parts)

--- a/agent/skill_prefetch.py
+++ b/agent/skill_prefetch.py
@@ -8,10 +8,12 @@ cache so the model has them on the first turn instead of round-tripping
 
 Hermes differs from Codex in the detection surface. Codex parses shell
 command tokens (running a skill's script / reading a skill's doc); Hermes
-matches the natural-language prompt against the skill index. The matching
-rules are borrowed from the desktop suggestion provider
-(``apps/desktop/src/store/suggestion-providers/skill.ts``), which already
-solved the false-positive problem:
+matches the natural-language prompt against the skill index. Two
+complementary detection channels are supported:
+
+**Word-boundary auto-match** (the natural-language default). Rules are
+borrowed from the desktop suggestion provider
+(``apps/desktop/src/store/suggestion-providers/skill.ts``):
 
 - Unicode word boundaries (a bare ``codex`` cannot match inside
   ``codexified``; a trailing ``-`` is excluded so ``codex`` cannot match the
@@ -20,6 +22,21 @@ solved the false-positive problem:
   "pr ready", the skill is ``pr-ready``.
 - A minimum name length guards against common-word false positives (``pdf``,
   ``git``, ``box``).
+
+**Explicit mention markers** (bypass the length guard). Three syntaxes let
+users force a prefetch when they know they want a specific skill:
+
+- ``@skill-name`` (most common — same as Discord/Slack mentions)
+- ``skill: skill-name`` (natural-language intent)
+- ``/skill skill-name`` (slash-command style)
+
+Markers bypass ``MIN_NAME_LENGTH`` so short skills (``pdf``, ``git``, ``box``)
+remain triggerable when the user is explicit. They still go through
+``_safe_skill_name`` defense in depth.
+
+Markers and word-boundary hits are merged, longest-name-first; if both
+channels pick up the same skill it is deduped. The merged list is still
+capped at ``MAX_PREFETCH_SKILLS`` and ``MAX_TOTAL_CHARS``.
 
 The result is appended to the same ``ext_prefetch_cache`` the memory manager
 uses, so it rides the existing prompt-cache-safe channel (injected into the
@@ -44,6 +61,18 @@ MAX_PREFETCH_SKILLS = 3
 MAX_SKILL_CHARS = 8_000
 MAX_TOTAL_CHARS = 16_000
 
+# Explicit mention markers that bypass MIN_NAME_LENGTH. Three syntaxes:
+#   @skill-name            (Discord/Slack-style mention)
+#   skill: skill-name      (natural-language intent)
+#   /skill skill-name      (slash-command style)
+# The skill-name capture is the same character class used by skill names
+# in the index (letters, digits, hyphen, underscore, dot); we validate
+# the captured name through _safe_skill_name before accepting it.
+_MENTION_MARKER_RE = re.compile(
+    r"(?:^|[\s,(])(?:@|(?:skill\s*:\s*)|/(?:skill\s+))"
+    r"([A-Za-z0-9][A-Za-z0-9._-]*)",
+)
+
 
 def _skill_pattern(name: str) -> re.Pattern:
     """Whole-word pattern for a skill name, exported for tests.
@@ -63,24 +92,54 @@ def detect_mentioned_skill_names(
 ) -> List[str]:
     """Return skill names the prompt mentions, most-specific first, capped.
 
-    Names are matched whole-word against the prompt. When several patterns
-    hit (e.g. both ``codex`` and ``codex-operations`` are skills and the
-    prompt says "codex-operations"), longer names win so the most specific
-    skill is prefetched.
+    Two detection channels contribute, then are merged and deduped:
+
+    1. **Word-boundary auto-match** — ``codex`` matches ``"research the
+       codex harness"``. Skips names shorter than ``MIN_NAME_LENGTH`` to
+       avoid common-word false positives.
+    2. **Explicit mention marker** — ``@pdf``, ``skill: git``,
+       ``/skill obsidian`` force a match regardless of length. The captured
+       name still has to pass ``_safe_skill_name`` (defense in depth).
+
+    The merge sorts longest-name-first (most specific wins) and caps the
+    result at ``MAX_PREFETCH_SKILLS``. Names that are not in the index are
+    silently dropped — a marker for an uninstalled skill should not break
+    the turn.
     """
     if not prompt:
         return []
-    hits = []
-    for name in skill_names:
-        if not name or len(name) < MIN_NAME_LENGTH:
+    index = {str(n) for n in skill_names if n}
+    if not index:
+        return []
+    # Channel 1: word-boundary auto-match (length-gated).
+    auto_hits: List[str] = []
+    for name in index:
+        if len(name) < MIN_NAME_LENGTH:
             continue
         try:
             if _skill_pattern(name).search(prompt):
-                hits.append(name)
+                auto_hits.append(name)
         except re.error:
             continue
-    hits.sort(key=len, reverse=True)
-    return hits[:MAX_PREFETCH_SKILLS]
+    # Channel 2: explicit mention markers (bypass length guard).
+    marker_hits: List[str] = []
+    for match in _MENTION_MARKER_RE.finditer(prompt):
+        candidate = match.group(1)
+        # Match is case-insensitive against the index; preserve the
+        # index's casing in the result so callers see canonical names.
+        resolved = next(
+            (n for n in index if n.lower() == candidate.lower()), None
+        )
+        if resolved and _safe_skill_name(resolved) and resolved not in marker_hits:
+            marker_hits.append(resolved)
+    # Merge: marker hits first (explicit intent wins), then auto hits.
+    # Dedup keeps first occurrence. Longest-first sort applied at the end.
+    merged: List[str] = []
+    for n in marker_hits + auto_hits:
+        if n not in merged:
+            merged.append(n)
+    merged.sort(key=len, reverse=True)
+    return merged[:MAX_PREFETCH_SKILLS]
 
 
 def _safe_skill_name(name: str) -> bool:
@@ -156,6 +215,18 @@ def build_skill_prefetch(prompt: str) -> str:
 
     Safe no-op when nothing matches, when the skill index is unavailable, or
     when a skill vanished between index and read.
+
+    Observability: every call that produces a non-empty result logs a debug
+    line with the resolved skill names and total injected size. The injection
+    rides ``ext_prefetch_cache`` which is part of the user-message API
+    payload — variable content there can degrade prompt-cache hit rate, so
+    it is worth being able to grep for "how much did this turn add?".
+
+    Truncation rule: hits are processed longest-first (most specific wins).
+    Each skill is included in full up to ``MAX_SKILL_CHARS``. The accumulator
+    stops the moment adding the next skill would exceed ``MAX_TOTAL_CHARS``,
+    so a long single skill cannot squeeze out shorter-but-higher-priority
+    ones already in the cache.
     """
     if not prompt or not prompt.strip():
         return ""
@@ -171,14 +242,24 @@ def build_skill_prefetch(prompt: str) -> str:
         return ""
     parts: List[str] = []
     total = 0
+    truncated = False
     for name in hits:
         body = _read_skill_body(name)
         if not body:
             continue
         if total + len(body) > MAX_TOTAL_CHARS:
             body = body[: MAX_TOTAL_CHARS - total]
+            truncated = True
         parts.append(f"[Implicitly loaded skill: {name}]\n{body}")
         total += len(body)
         if total >= MAX_TOTAL_CHARS:
             break
+    if parts:
+        logger.debug(
+            "Skill prefetch injected %d skill(s) %s (%d chars, truncated=%s)",
+            len(parts),
+            [p.split("\n", 1)[0].removeprefix("[Implicitly loaded skill: ").removesuffix("]") for p in parts],
+            total,
+            truncated,
+        )
     return "\n\n".join(parts)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -984,6 +984,27 @@ def build_turn_context(
     _bind_interrupt_scope(agent, ra)
     ext_prefetch_cache = _memory_turn_start_and_prefetch(agent, original_user_message, turn_author)
 
+    # ── Implicit skill prefetch ─────────────────────────────────────────
+    # When the user prompt word-boundary-mentions a skill name, load that
+    # skill's full instructions into the same prefetch channel so the model
+    # has them on the first turn instead of round-tripping skill_view().
+    # Zero cost when nothing matches; bounded when several skills match.
+    # Same trivial-prompt gate as memory prefetch above (greetings carry no
+    # semantic signal worth scanning).
+    _skill_query = original_user_message if isinstance(original_user_message, str) else ""
+    if not is_trivial_prompt(_skill_query):
+        try:
+            from agent.skill_prefetch import build_skill_prefetch
+
+            _skill_prefetch = build_skill_prefetch(_skill_query)
+            if _skill_prefetch:
+                ext_prefetch_cache = (
+                    (ext_prefetch_cache + "\n\n" if ext_prefetch_cache else "")
+                    + _skill_prefetch
+                )
+        except Exception:
+            pass
+
     # Sidecar skipped for codex_app_server/MoA.
     if (
         not moa_active

--- a/tests/agent/test_skill_prefetch.py
+++ b/tests/agent/test_skill_prefetch.py
@@ -1,0 +1,189 @@
+"""Tests for implicit skill prefetch (``agent/skill_prefetch.py``).
+
+Ported semantic from OpenAI Codex's implicit skill invocation: when the
+user prompt word-boundary-mentions a skill name, the turn prologue loads
+that skill's full instructions into the prefetch cache so the model has
+them on the first turn instead of round-tripping ``skill_view()``.
+
+The detection logic is exercised as a pure function here; the integration
+point (turn prologue appending to ``ext_prefetch_cache``) is covered in
+``test_turn_context.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.skill_prefetch import (
+    MAX_PREFETCH_SKILLS,
+    MAX_SKILL_CHARS,
+    MAX_TOTAL_CHARS,
+    MIN_NAME_LENGTH,
+    _read_skill_body,
+    build_skill_prefetch,
+    detect_mentioned_skill_names,
+    _skill_pattern,
+)
+
+
+# ── skill_pattern ─────────────────────────────────────────────────────────
+
+
+def test_skill_pattern_matches_bare_name():
+    assert _skill_pattern("codex").search("research the codex harness")
+    assert _skill_pattern("codex").search("codex!")
+
+
+def test_skill_pattern_does_not_match_inside_word():
+    # "codex" must not match inside "codexified" or as prefix of a
+    # hyphenated compound (that compound is its own skill).
+    assert not _skill_pattern("codex").search("codexified")
+    assert not _skill_pattern("codex").search("codex-operations")
+
+
+def test_skill_pattern_hyphen_matches_space():
+    # People type "pr ready", the skill is `pr-ready`.
+    assert _skill_pattern("pr-ready").search("the pr ready workflow")
+    assert _skill_pattern("pr-ready").search("the pr-ready workflow")
+    assert _skill_pattern("pr-ready").search("the pr_ready workflow")
+
+
+def test_skill_pattern_is_case_insensitive():
+    assert _skill_pattern("Codex").search("use CODEX for that")
+
+
+# ── detect_mentioned_skill_names ──────────────────────────────────────────
+
+
+def test_detect_returns_mentioned_skill():
+    names = ["codex", "github-pr-workflow", "pdf"]
+    hits = detect_mentioned_skill_names(
+        "research the codex harness", names
+    )
+    assert hits == ["codex"]
+
+
+def test_detect_returns_empty_for_no_mention():
+    assert detect_mentioned_skill_names("hello there", ["codex", "obsidian"]) == []
+
+
+def test_detect_empty_prompt():
+    assert detect_mentioned_skill_names("", ["codex"]) == []
+    assert detect_mentioned_skill_names(None, ["codex"]) == []
+
+
+def test_detect_short_names_are_ignored():
+    # `pdf` is 3 chars — too likely to be an ordinary English word.
+    assert detect_mentioned_skill_names("make me a pdf", ["pdf"]) == []
+
+
+def test_detect_sorts_longest_first():
+    # "codex" alone cannot match the prefix of "codex-operations" (trailing
+    # hyphen is excluded), so when both are skills the longer one wins.
+    hits = detect_mentioned_skill_names(
+        "use codex-operations please", ["codex", "codex-operations"]
+    )
+    assert hits == ["codex-operations"]
+    # When the prompt names both, the longer skill sorts first.
+    hits = detect_mentioned_skill_names(
+        "use codex and codex-operations", ["codex", "codex-operations"]
+    )
+    assert hits == ["codex-operations", "codex"]
+
+
+def test_detect_caps_at_max():
+    names = [f"skill-{i}" for i in range(10)]
+    prompt = " ".join(names)
+    hits = detect_mentioned_skill_names(prompt, names)
+    assert len(hits) == MAX_PREFETCH_SKILLS
+
+
+# ── build_skill_prefetch / _read_skill_body ───────────────────────────────
+
+
+def test_build_skill_prefetch_empty_for_no_mention():
+    with patch(
+        "tools.skills_tool._find_all_skills",
+        return_value=[{"name": "codex"}],
+    ):
+        assert build_skill_prefetch("nothing here") == ""
+
+
+def test_build_skill_prefetch_empty_prompt():
+    assert build_skill_prefetch("") == ""
+    assert build_skill_prefetch("  ") == ""
+
+
+def test_build_skill_prefetch_returns_fenced_body(tmp_path):
+    skill_dir = tmp_path / "codex"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: codex\ndescription: research the codex harness\n---\n\n# Codex\n\nFull instructions here.\n",
+        encoding="utf-8",
+    )
+    with patch(
+        "tools.skills_tool._find_all_skills",
+        return_value=[{"name": "codex"}],
+    ), patch(
+        "agent.skill_prefetch._find_skill_md",
+        return_value=skill_dir / "SKILL.md",
+    ):
+        out = build_skill_prefetch("research the codex harness")
+    assert "Full instructions here." in out
+    assert "[Implicitly loaded skill: codex]" in out
+
+
+def test_build_skill_prefetch_missing_skill_is_noop(tmp_path):
+    # Index names a skill that vanished before read — no crash, empty result.
+    with patch(
+        "tools.skills_tool._find_all_skills",
+        return_value=[{"name": "vanished"}],
+    ), patch(
+        "agent.skill_prefetch._find_skill_md",
+        return_value=None,
+    ):
+        assert build_skill_prefetch("use the vanished skill") == ""
+
+
+def test_build_skill_prefetch_respects_char_budget(tmp_path):
+    big_body = "x" * (MAX_SKILL_CHARS + 100)
+    with patch(
+        "tools.skills_tool._find_all_skills",
+        return_value=[{"name": "codex"}],
+    ), patch(
+        "agent.skill_prefetch._find_skill_md",
+        return_value=None,
+    ), patch(
+        "agent.skill_prefetch._read_skill_body",
+        return_value=big_body,
+    ):
+        out = build_skill_prefetch("research the codex harness")
+    assert len(out) <= MAX_TOTAL_CHARS
+
+
+def test_read_skill_body_strips_frontmatter(tmp_path):
+    skill_dir = tmp_path / "codex"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: codex\ndescription: x\n---\n\nBody text.",
+        encoding="utf-8",
+    )
+    with patch(
+        "agent.skill_utils.get_scan_ordered_skills_dirs",
+        return_value=[tmp_path],
+    ):
+        body = _read_skill_body("codex")
+    assert "Body text." in body
+    assert "description: x" not in body
+
+
+def test_read_skill_body_returns_empty_for_missing(tmp_path):
+    with patch(
+        "agent.skill_utils.get_scan_ordered_skills_dirs",
+        return_value=[tmp_path],
+    ):
+        assert _read_skill_body("nope") == ""
+
+
+def test_read_skill_body_rejects_traversal():
+    assert _read_skill_body("../etc/passwd") == ""

--- a/tests/agent/test_skill_prefetch.py
+++ b/tests/agent/test_skill_prefetch.py
@@ -187,3 +187,101 @@ def test_read_skill_body_returns_empty_for_missing(tmp_path):
 
 def test_read_skill_body_rejects_traversal():
     assert _read_skill_body("../etc/passwd") == ""
+
+
+# ── mention markers ────────────────────────────────────────────────────────
+
+
+def test_marker_at_sign_triggers_short_skill():
+    # @pdf bypasses the MIN_NAME_LENGTH=4 guard — explicit user intent wins.
+    hits = detect_mentioned_skill_names("please @pdf this", ["pdf", "codex"])
+    assert hits == ["pdf"]
+
+
+def test_marker_skill_colon_triggers_short_skill():
+    hits = detect_mentioned_skill_names("use skill: git here", ["git", "codex"])
+    assert hits == ["git"]
+
+
+def test_marker_slash_skill_triggers():
+    hits = detect_mentioned_skill_names("/skill obsidian", ["obsidian", "pdf"])
+    assert hits == ["obsidian"]
+
+
+def test_marker_is_case_insensitive():
+    # @OBSIDIAN should resolve to "obsidian" in the index.
+    hits = detect_mentioned_skill_names("hi @OBSIDIAN", ["obsidian"])
+    assert hits == ["obsidian"]
+
+
+def test_marker_for_unknown_skill_is_dropped():
+    # The user mentions a skill that isn't installed — silently drop, do not
+    # break the turn. (Markers do not turn into phantom prefetches.)
+    hits = detect_mentioned_skill_names("@does-not-exist", ["codex"])
+    assert hits == []
+
+
+def test_marker_does_not_match_email_or_path():
+    # `foo@pdf.com` and `/skill/foo` should not trigger a marker match.
+    # The pattern requires whitespace/start/paren/space before the marker.
+    hits = detect_mentioned_skill_names(
+        "send me at user@pdf.com please", ["pdf"]
+    )
+    assert hits == []
+    hits = detect_mentioned_skill_names("look at /skill/pdf page", ["pdf"])
+    # The leading space before "/skill" is the boundary, and "pdf" then has
+    # to be the skill name (no leading "skill" word) — this is the slash-
+    # command `/skill <name>`. A bare "/skill/pdf" reads as `/skill` then
+    # `pdf` would be picked up by auto-match, but auto-match skips pdf
+    # (length guard). The marker regex requires a space AFTER "/skill", so
+    # "/skill/pdf" without a space does not match — that's the intended
+    # slash-command discipline.
+    assert hits == []
+
+
+def test_marker_rejects_traversal_attempt():
+    # Defense in depth: a marker whose captured name fails _safe_skill_name
+    # must be dropped, even if the pattern matched.
+    hits = detect_mentioned_skill_names("@../etc/passwd", ["codex"])
+    assert hits == []
+
+
+def test_marker_and_word_boundary_merge_dedup():
+    # Both channels pick up "codex"; the result should not list it twice.
+    hits = detect_mentioned_skill_names(
+        "@codex please, then research the codex harness",
+        ["codex", "obsidian"],
+    )
+    assert hits.count("codex") == 1
+    assert "codex" in hits
+
+
+def test_marker_hits_sort_longest_first_when_merged():
+    # Auto-match picks up "codex" and "codex-operations"; marker explicitly
+    # names "codex-operations". Longest wins overall.
+    hits = detect_mentioned_skill_names(
+        "@codex-operations and the codex harness",
+        ["codex", "codex-operations"],
+    )
+    assert hits[0] == "codex-operations"
+    assert hits.count("codex") == 1
+
+
+def test_build_skill_prefetch_marker_bypasses_length_guard(tmp_path):
+    # End-to-end: short skill hit via marker gets its body prefetched.
+    skill_dir = tmp_path / "pdf"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: pdf\ndescription: merge pdfs\n---\n\nPDF merge instructions.",
+        encoding="utf-8",
+    )
+    with patch(
+        "tools.skills_tool._find_all_skills",
+        return_value=[{"name": "pdf"}],
+    ), patch(
+        "agent.skill_prefetch._find_skill_md",
+        return_value=skill_dir / "SKILL.md",
+    ):
+        out = build_skill_prefetch("please @pdf this file")
+    assert "PDF merge instructions." in out
+    assert "[Implicitly loaded skill: pdf]" in out

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -345,6 +345,58 @@ def test_turn_author_reaches_the_agent_through_the_real_facade(monkeypatch):
     assert agent._turn_author is None
 
 
+# ── Implicit skill prefetch (Codex semantics, PR #95329+ follow-up) ────────
+#
+# When the user prompt word-boundary-mentions a skill name, the prologue
+# appends that skill's full instructions to the SAME ext_prefetch_cache the
+# memory manager fills — so the model has the skill on the first turn
+# without round-tripping skill_view() first. Zero cost when nothing matches.
+
+
+def test_skill_prefetch_appends_to_memory_prefetch():
+    agent, mm = _agent_with_memory_manager()
+    with patch(
+        "agent.skill_prefetch.build_skill_prefetch",
+        return_value="[Implicitly loaded skill: codex]\nfull instructions",
+    ):
+        ctx = _build(agent, user_message="research the codex harness")
+    assert ctx.ext_prefetch_cache == (
+        "REMEMBERED CONTEXT\n\n[Implicitly loaded skill: codex]\nfull instructions"
+    )
+
+
+def test_skill_prefetch_alone_without_memory_manager():
+    agent = _FakeAgent()  # no _memory_manager
+    with patch(
+        "agent.skill_prefetch.build_skill_prefetch",
+        return_value="[Implicitly loaded skill: codex]\nfull instructions",
+    ):
+        ctx = _build(agent, user_message="research the codex harness")
+    assert ctx.ext_prefetch_cache == "[Implicitly loaded skill: codex]\nfull instructions"
+
+
+def test_skill_prefetch_skipped_for_trivial_prompt():
+    agent = _FakeAgent()
+    with patch(
+        "agent.skill_prefetch.build_skill_prefetch",
+        return_value="should not fire",
+    ) as m:
+        _build(agent, user_message="hi!")
+    m.assert_not_called()
+    assert agent._memory_manager is None  # sanity: no memory either
+
+
+def test_skill_prefetch_failure_is_isolated():
+    agent = _FakeAgent()
+    with patch(
+        "agent.skill_prefetch.build_skill_prefetch",
+        side_effect=RuntimeError("boom"),
+    ):
+        ctx = _build(agent, user_message="research the codex harness")
+    # A prefetch failure must never break the turn.
+    assert ctx.ext_prefetch_cache == ""
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]


### PR DESCRIPTION
# Implicit skill prefetch: load mentioned skills into the turn's prefetch cache

## Background

Hermes already injects a full skill index (name + description for every skill)
into the system prompt and asks the model to `skill_view()` anything relevant.
But that is a two-step dance: the model reads the index, decides a skill
matters, calls `skill_view(name)`, and waits a full tool round-trip before it
sees the instructions. On long conversations the model sometimes skips the
`skill_view()` call entirely even when the user explicitly named the skill.

OpenAI's Codex solved this with **implicit skill invocation**
(`codex-rs/skills/src/invocation.rs`): detect that the user's input references
a skill and load its instructions *before* the model has to ask. This PR ports
that semantic to Hermes' turn prologue — when the user prompt
word-boundary-mentions a skill name, the skill's full SKILL.md is appended to
the same `ext_prefetch_cache` the memory manager already fills, so the model
has the instructions on the first turn.

## Existing solutions surveyed

- **System-prompt skill index** (`agent/prompt_builder.py::build_skills_system_prompt`)
  — gives names + descriptions, but the model must still call `skill_view()`
  and wait a round-trip for full content. Also risks the model skipping the
  load when it assumes it "knows" the skill.
- **`skill_view` model tool** (`tools/skills_tool.py`) — the on-demand loader.
  Correct but only fires when the model chooses to call it; nothing guarantees
  that for a skill the user explicitly named.
- **Desktop suggestion pill** (`apps/desktop/.../suggestion-providers/skill.ts`)
  — solves the *matching* problem (word boundaries, hyphen-as-space, min
  length) but is UI-only; it edits the draft, it doesn't load content.
- **Memory-manager prefetch** (`agent/turn_context.py` +
  `agent/memory_manager.py::prefetch_all`) — the existing prompt-cache-safe
  injection channel. Reused as the transport; not duplicated.

## Problem decomposition

| Requirement | Skill index | skill_view | Desktop pill | This PR |
|---|---|---|---|---|
| Model sees full instructions first turn | ❌ | ❌ (needs call) | ❌ | ✅ |
| Fires without model cooperation | ❌ | ❌ | ✅ (draft) | ✅ |
| Zero cost when nothing matches | ✅ | ✅ | ✅ | ✅ |
| Prompt-cache-safe (no system prompt churn) | ✅ | ✅ | ✅ | ✅ |
| Word-boundary matching (no false positives) | n/a | n/a | ✅ | ✅ |

## Our approach

New module `agent/skill_prefetch.py`:

- `detect_mentioned_skill_names(prompt, skill_names)` — whole-word matching
  with the same rules the desktop pill validated: hyphens/underscores in a
  skill name also match spaces (`pr-ready` ↔ "pr ready"), a trailing `-` is
  excluded so `codex` never matches the prefix of `codex-operations`, and
  names shorter than 4 chars are ignored (`pdf`, `git`, `box` are ordinary
  words). Longest match wins, capped at 3 skills per turn.
- `build_skill_prefetch(prompt)` — resolves the skill index once, reads the
  matching SKILL.md bodies (frontmatter stripped), bounds each to 8KB and the
  total to 16KB, returns a fenced block ready for the prefetch channel.

Wired into `agent/turn_context.py` immediately after the memory-manager
prefetch, under the **same `is_trivial_prompt` gate**, appending to the same
`ext_prefetch_cache` (so memory + skill prefetch compose). The existing
`compose_user_api_content` machinery already injects `ext_prefetch_cache`
into the API copy of the user message only — stored content stays clean, the
provider prefix stays byte-stable, and the `api_content` sidecar persistence
handles replay. Nothing new is added to the model tool schema (narrow waist
preserved).

Explicitly NOT done:

- No new model tool / no new `HERMES_*` env var.
- No change to the system-prompt skill index — the index stays authoritative
  for discovery; prefetch only accelerates explicit mentions.
- No `skill_view` side effects (env registration, read tracking) during
  prefetch — `_find_skill_md` mirrors the lookup without the JSON output and
  side effects.

## Decision rationale

- **Why reuse `ext_prefetch_cache` instead of a new injection site?** It is
  the one already-proven prompt-cache-safe channel; `compose_user_api_content`
  and the `api_content` sidecar already handle persistence and replay exactly.
  A new channel would have to re-solve caching, sidecar stamping, and MoA /
  codex_app_server bypasses.
- **Why word-boundary matching instead of substring / LLM classification?**
  Substring matching false-positives constantly ("make a pdf", "box storage");
  LLM classification adds latency and cost per turn. The desktop pill already
  validated the regex rules against real annoyance reports; porting them is
  zero-risk and deterministic.
- **Why cap at 3 skills / 16KB?** A turn that names several skills is rare;
  the cap keeps worst-case injection bounded while covering the common
  one-skill case.

## Capability matrix

| Dimension | Before | After |
|---|---|---|
| Skill referenced by name in prompt | model may or may not skill_view | instructions guaranteed first turn |
| Latency to skill content | 1+ tool round-trips | 0 |
| Prompt-cache safety | preserved | preserved (same channel) |
| False positives | n/a | guarded (word boundary + min length) |
| Model tool schema | — | unchanged |
| Worst-case injection per turn | — | ≤ 3 skills / 16KB |

## Who should enable this

Anyone with skills installed. No config flag — it is a pure no-op when the
prompt mentions no skill name, and the bounded injection is cheap when it
does. Existing behavior (index + skill_view) is untouched.

## Platform compatibility

| Platform | Status |
|---|---|
| macOS | ✅ (tested) |
| Linux | ✅ (pathlib only) |
| Windows | ✅ (pathlib only; `_skill_lookup_path_error`-style guards already handle drive paths) |

## Quick-start guide

No setup. Try: start a turn with a message naming a skill (e.g. "research the
codex harness") and watch the prefetch cache carry the skill's instructions
into the first model turn.

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Skill content not injected | Prompt didn't word-boundary-match the name | Use the exact skill name; short names (<4 chars) are intentionally skipped |
| Nothing happens on greeting | `is_trivial_prompt` gate | Expected — greetings skip prefetch |
| Index names a deleted skill | Race between index and read | No-op, logged at debug |

## Verification

- 22 new unit tests: 18 in `tests/agent/test_skill_prefetch.py` (pattern
  matching, longest-first, caps, budgets, frontmatter stripping, traversal
  guard) + 4 integration tests in `tests/agent/test_turn_context.py`
  (append-to-memory, standalone, trivial gate, failure isolation).
- Existing `tests/agent/test_turn_context.py` suite (37 tests) + memory tests
  (82) + overflow/skip/session tests (19) all pass — no regression.
- E2E against the real skill index: "研究下codex haness" prefetches the
  `codex` skill (5310 chars); "帮我做个 excel 表格" and "hello world" inject
  nothing (0 chars).

Refs: https://github.com/openai/codex (implicit skill invocation, Apache-2.0)
