### PR TITLE
fix(skills): resolve slash commands from the active profile, not import-time SKILLS_DIR

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -236,7 +236,13 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         return None
 
     try:
-        from tools.skills_tool import SKILLS_DIR, skill_view
+        # ``_skills_dir()`` not the module-level ``SKILLS_DIR``: under gateway
+        # multiplexing the module was imported before the profile's
+        # ``_profile_runtime_scope`` installed its HERMES_HOME override, so
+        # ``SKILLS_DIR`` is frozen on the DEFAULT profile. ``_skills_dir()``
+        # resolves the live profile home per call while still honoring a
+        # patched ``SKILLS_DIR`` (tests / external patchers).
+        from tools.skills_tool import _skills_dir, skill_view
         from agent.skill_utils import normalize_skill_lookup_name
 
         normalized = normalize_skill_lookup_name(raw_identifier)
@@ -262,7 +268,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         skill_dir = Path(abs_skill_dir)
     elif skill_path:
         try:
-            skill_dir = SKILLS_DIR / Path(skill_path).parent
+            skill_dir = _skills_dir() / Path(skill_path).parent
         except Exception:
             skill_dir = None
 
@@ -317,7 +323,8 @@ def _build_skill_message(
     session_id: str | None = None,
 ) -> str:
     """Format a loaded skill into a user/system message payload."""
-    from tools.skills_tool import SKILLS_DIR
+    # Profile-aware: see the note in ``_load_skill_payload``.
+    from tools.skills_tool import _skills_dir
 
     content = str(loaded_skill.get("content") or "")
 
@@ -386,7 +393,7 @@ def _build_skill_message(
 
     if supporting and skill_dir:
         try:
-            skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
+            skill_view_target = str(skill_dir.relative_to(_skills_dir()))
         except ValueError:
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
@@ -438,7 +445,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     # each naming the same skill as its own incumbent (#74574).
     commands: Dict[str, Dict[str, Any]] = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
             get_external_skills_dirs,
             get_project_skills_dirs,
@@ -453,8 +460,15 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         # Project dirs iterate through the quarantine chokepoint.
         project_dirs = list(get_project_skills_dirs())
         dirs_to_scan = list(project_dirs)
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        # Resolve the ACTIVE profile's skills dir at scan time. The module-level
+        # ``SKILLS_DIR`` is bound when ``tools.skills_tool`` is first imported,
+        # which in a multiplexed gateway happens before any profile's
+        # ``_profile_runtime_scope`` installs its HERMES_HOME override — so it
+        # points at the default profile and profile-only skills (e.g. the
+        # learning profile's ``/review``) were never scanned (#88023 follow-up).
+        local_skills_dir = _skills_dir()
+        if local_skills_dir.exists():
+            dirs_to_scan.append(local_skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -930,7 +930,7 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # module cycle (tools.skills_tool imports agent.skill_utils).
     try:
         from tools import skills_tool as _skills_tool
-        primary_root = Path(_skills_tool.SKILLS_DIR)
+        primary_root = Path(_skills_tool._skills_dir())
     except Exception:
         primary_root = get_skills_dir()
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -997,10 +997,17 @@ def _collect_gateway_skill_entries(
     skill_triples: list[tuple[str, str, str]] = []
     try:
         from agent.skill_commands import get_skill_commands
-        from tools.skills_tool import SKILLS_DIR
+        # Profile-aware skills root. ``SKILLS_DIR`` is import-time bound and in a
+        # multiplexed gateway points at the DEFAULT profile, so a secondary
+        # profile's skills failed the allowed-prefix check below and were
+        # silently dropped from the menu even though get_skill_commands() found
+        # them. ``_skills_dir()`` resolves the live profile home per call and
+        # still honors a patched ``SKILLS_DIR``.
+        from tools.skills_tool import _skills_dir as _active_skills_dir
         from agent.skill_utils import get_external_skills_dirs, get_project_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
+        _root = _active_skills_dir()
+        _skills_dir = str(_root.resolve())
+        _hub_dir = str((_root / ".hub").resolve()).rstrip("/") + "/"
         # Build set of allowed directory prefixes: local skills dir + any
         # user-configured ``skills.external_dirs`` + trusted project dirs.
         # Ensure each prefix ends
@@ -1183,10 +1190,14 @@ def discord_skill_commands_by_category(
     try:
         from agent.skill_commands import get_skill_commands
         from agent.skill_utils import get_external_skills_dirs, get_project_skills_dirs
-        from tools.skills_tool import SKILLS_DIR
+        # Profile-aware skills root — see the note in
+        # ``_collect_gateway_skill_entries``; import-time SKILLS_DIR is stale under
+        # gateway multiplexing.
+        from tools.skills_tool import _skills_dir as _active_skills_dir
 
-        _skills_dir = SKILLS_DIR.resolve()
-        _hub_dir = (SKILLS_DIR / ".hub").resolve()
+        _root = _active_skills_dir()
+        _skills_dir = _root.resolve()
+        _hub_dir = (_root / ".hub").resolve()
         # Build list of (resolved_root, is_local) tuples. Each external dir
         # becomes its own scan root for category derivation — a skill at
         # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -879,3 +879,187 @@ class TestStackedSkillCommands:
         assert loaded == ["skill-a"]
         assert missing == ["gone"]
         assert "Skills missing (skipped): gone" in msg
+
+
+class TestMultiplexProfileSkillCommands:
+    """A multiplexed gateway routes each turn through ``_profile_runtime_scope``,
+    which installs a context-local ``HERMES_HOME`` override *after*
+    ``tools.skills_tool`` was already imported for the default profile.
+
+    These tests deliberately do NOT patch ``tools.skills_tool.SKILLS_DIR`` —
+    that is the whole point. The import-time constant stays pointed at the
+    default profile, exactly as it is in the live gateway, and discovery must
+    still find the routed profile's skills via the live profile home.
+    """
+
+    @staticmethod
+    def _profile_with_skill(tmp_path, profile_name, skill_name):
+        """Build a profile home containing a single skill, and no config.yaml
+        (so no external/project dirs bleed in from the profile side)."""
+        home = tmp_path / "profiles" / profile_name
+        skills = home / "skills"
+        skills.mkdir(parents=True)
+        _make_skill(skills, skill_name)
+        (home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+        return home
+
+    def _scan_in_profile(self, profile_home):
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(profile_home)
+            try:
+                return dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+    def test_scan_finds_profile_only_skill_with_stale_import_time_skills_dir(
+        self, tmp_path
+    ):
+        """Regression: a profile-only skill command was reported as an
+        unrecognized slash command because ``scan_skill_commands()`` scanned the
+        import-time ``SKILLS_DIR`` (the default profile) instead of the active
+        profile's skills dir."""
+        profile_home = self._profile_with_skill(tmp_path, "learning", "studynotes")
+
+        # Precondition: the import-time constant is NOT the profile's dir, so a
+        # pass here really does exercise the runtime resolution.
+        assert skills_tool_module.SKILLS_DIR != profile_home / "skills"
+
+        commands = self._scan_in_profile(profile_home)
+
+        assert "/studynotes" in commands, sorted(commands)
+        assert commands["/studynotes"]["skill_md_path"] == str(
+            profile_home / "skills" / "studynotes" / "SKILL.md"
+        )
+
+    def test_profile_skills_do_not_leak_between_profiles(self, tmp_path):
+        """Each routed profile sees only its own skills."""
+        learning = self._profile_with_skill(tmp_path, "learning", "studynotes")
+        other = self._profile_with_skill(tmp_path, "other", "other-only")
+
+        learning_commands = self._scan_in_profile(learning)
+        other_commands = self._scan_in_profile(other)
+
+        assert "/studynotes" in learning_commands
+        assert "/other-only" not in learning_commands
+        assert "/other-only" in other_commands
+        assert "/studynotes" not in other_commands
+
+    def test_telegram_menu_includes_profile_only_skill(self, tmp_path):
+        """The Telegram command menu registered for a secondary profile's bot
+        must contain that profile's skills. The allowed-prefix filter in
+        ``_collect_gateway_skill_entries`` previously rejected them because the
+        prefix was built from the stale import-time ``SKILLS_DIR``."""
+        import agent.skill_commands as sc_mod
+        from hermes_cli.commands import telegram_menu_commands
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = self._profile_with_skill(tmp_path, "learning", "studynotes")
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(profile_home)
+            try:
+                entries, _hidden = telegram_menu_commands()
+            finally:
+                reset_hermes_home_override(token)
+
+        names = [name for name, _desc in entries]
+        assert "studynotes" in names, names
+
+    def _invoke_in_profile(self, profile_home, command_key):
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import (
+            build_skill_invocation_message,
+            scan_skill_commands,
+        )
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(profile_home)
+            try:
+                scan_skill_commands()
+                return build_skill_invocation_message(
+                    command_key, user_instruction="go"
+                )
+            finally:
+                reset_hermes_home_override(token)
+
+    def test_profile_skill_actually_invokes_not_just_registers(self, tmp_path):
+        """Registration and menu presence are not enough: a profile skill that
+        scans fine can still fail to produce an invocation message, which looks
+        to the user like a command that exists and silently does nothing.
+
+        ``_load_skill_payload`` resolves the skill through ``skill_view()``, so
+        it needs a target that is valid under the ACTIVE profile root — the
+        surface the other tests in this class never reach.
+        """
+        profile_home = self._profile_with_skill(tmp_path, "learning", "studynotes")
+
+        message = self._invoke_in_profile(profile_home, "/studynotes")
+
+        assert message, "profile skill registered but produced no invocation"
+        assert str(profile_home / "skills" / "studynotes") in message, message
+
+    def test_profile_skill_with_bom_invokes(self, tmp_path):
+        """A SKILL.md authored with a UTF-8 BOM (Notepad) is stripped by the
+        canonical frontmatter parser, so it registers during the scan. The
+        invocation path must tolerate the BOM too, or exactly those skills
+        register and then fail to load."""
+        profile_home = tmp_path / "profiles" / "learning"
+        skills = profile_home / "skills"
+        (skills / "bomskill").mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+        # utf-8-sig writes the BOM ahead of the frontmatter fence.
+        (skills / "bomskill" / "SKILL.md").write_text(
+            "---\nname: bomskill\ndescription: Description for bomskill.\n---\n\n"
+            "# bomskill\n\nDo the thing.\n",
+            encoding="utf-8-sig",
+        )
+
+        message = self._invoke_in_profile(profile_home, "/bomskill")
+
+        assert message, "BOM-authored profile skill registered but did not load"
+        assert str(skills / "bomskill") in message, message
+
+    def test_profile_skill_with_colliding_name_invokes(self, tmp_path):
+        """Two skills in the profile share a frontmatter name. The scan keeps
+        the first and records its explicit ``skill_dir``; that path is the only
+        thing distinguishing them. Resolving by bare name instead makes
+        ``skill_view()`` refuse with "Ambiguous skill name ... load one
+        explicitly by its categorized path", so the command registers and then
+        cannot be invoked."""
+        profile_home = tmp_path / "profiles" / "learning"
+        skills = profile_home / "skills"
+        skills.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+        _make_skill(skills, "dupskill", category="alpha")
+        _make_skill(skills, "dupskill", category="beta")
+
+        message = self._invoke_in_profile(profile_home, "/dupskill")
+
+        assert message, "colliding-name profile skill registered but did not load"
+        assert "Ambiguous" not in message, message


### PR DESCRIPTION
## Summary
Under the gateway multiplexer, a non-default profile's own skills are invisible as slash commands — they don't register, and they don't appear in the Telegram/Discord menu. The user types `/their-skill` and gets `Unrecognized slash command`, with no indication that the profile is the reason.

Root cause: fourth and fifth modules in the same lineage as `skills_tool` (f8723c478), `skill_manager_tool` (c6a3d412d) and `skills_sync` (#89387) — `SKILLS_DIR` frozen at import, so `_profile_runtime_scope()`'s `set_hermes_home_override()` contextvar can't reach it. In the long-lived gateway the constant binds once from the default profile and never moves.

Three failures from that one constant, across the full path from discovery to dispatch: `scan_skill_commands()` scans the wrong directory; the menu's allowed-prefix filter, built from the same constant, would reject the profile's paths anyway; and `_normalize_skill_identifier()` resolves its trusted root from it, so even a correctly-registered profile skill fails to load. That last one is why registration alone isn't enough — without it the command appears in the menu and then silently does nothing when invoked.

## Changes
- `agent/skill_commands.py`: `scan_skill_commands()` resolves the skills root via call-time `_skills_dir()` instead of import-time `SKILLS_DIR`. Three sibling reads migrated for consistency (the `_load_skill_payload` fallback that reconstructs a skill dir when a legacy `skill_view` response omits `skill_dir`; the relative-target hint in `_build_skill_message`).
- `hermes_cli/commands.py`: `_collect_gateway_skill_entries()` and `discord_skill_commands_by_category()` build allowed prefixes, scan roots and the `.hub` exclusion from `_skills_dir()`.
- `agent/skill_utils.py`: `_normalize_skill_identifier()` takes its primary trusted root from `_skills_dir()`. Its own comment requires agreement with the root `skill_view()` enforces — and `skill_view()` already uses `_skills_dir()`, so this restores an invariant the file documents but no longer held. One line.
- `tests/agent/test_skill_commands.py`: 6 regression tests, covering registration, menu presence **and invocation** (including a BOM-authored `SKILL.md` and two skills sharing a frontmatter name). These deliberately **do not** patch `SKILLS_DIR` — leaving it bound to the default profile is the condition under test, mirroring the live gateway.

`tools/skills_tool.py` is unchanged: `_skills_dir()` (added in f8723c478) already honors an explicitly patched module global, so tests and `web_server.py`'s `_profile_scope()` retargeting keep working.

## Relationship to #67293 — complementary, not competing
#67293 proposed two changes for #67277. Its **cache-invalidation** half has since landed on main as `_resolve_skill_commands_home()` + the `_skill_commands_home` guard; its **`_skills_dir()`** half has not. So today `get_skill_commands()` correctly notices the profile changed and triggers a rescan — which then reads the wrong directory. This PR is that missing half.

It does **not** close #67277 on its own: that issue is the webhook surface, which also needs #67293's `gateway/platforms/webhook.py` scope entry. The two compose — #67293's webhook half plus this scan/menu half. This PR independently fixes the Telegram/Discord surface, where `_profile_runtime_scope()` already enters the scope.

## Validation
| | Before | After |
|---|---|---|
| Profile-scoped `scan_skill_commands()` | 136 cmds (default profile's), target skill absent | 118 cmds (profile's own), target skill present |
| Telegram menu under profile | 86 entries, skill absent | 66 entries, skill present |
| Default profile (regression check) | 136 cmds / 100 menu / 99 hidden | byte-identical, same first-five slugs |
| Profile skill invocation (`build_skill_invocation_message`) | returns `None` — command does nothing | builds, resolving the profile's own dir |
| Sabotage run (import-time binding restored) | — | all 6 new tests FAIL, correct failure shape |
| `tests/agent/test_skill_commands.py` | 29 passed | 35 passed |
| `tests/skills` + skills/profile/gateway modules | — | 1725 passed |

Verified against `main @ f0c0c986c4` (v0.20.5) via both `HERMES_HOME` and the contextvar-override path.

**Reproducing requires one ordering detail:** `tools.skills_tool` must be imported *before* the profile override is installed. `scan_skill_commands()` imports it inside the function body, so a probe that imports nothing first binds `SKILLS_DIR` *after* the override, lands on the profile dir by accident, and shows no bug. The gateway imports it at startup under the default profile, which is the case that matters.

Not run: `pytest tests/ -q` doesn't complete here — `prompt_toolkit`/`fastapi`/`wcwidth` are missing from the interpreter that has pytest, so `tests/hermes_cli/test_commands.py` fails at collection (pre-existing, unrelated). Targeted selections above instead; CI will cover the rest.

Related #67277
