### PR TITLE
fix(desktop): retain local startup profile across SSH switches

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -97,8 +97,17 @@ describe('selectProfile startup preference (#79886)', () => {
 
   beforeEach(() => {
     rememberProfile.mockClear()
+
+    const getConnection = vi.fn(async () => ({ mode: 'local' }))
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
+
     ;(globalThis as { window?: unknown }).window = {
-      hermesDesktop: { profile: { remember: rememberProfile } }
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
     }
   })
 
@@ -137,6 +146,62 @@ describe('selectProfile startup preference (#79886)', () => {
     selectProfile('researcher')
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'researcher'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+  })
+
+  it('remembers an already-active local profile after returning from All Profiles', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+    $activeGatewayProfile.set('tilly')
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+  })
+
+  it('keeps local startup persistence when the backend descriptor lookup fails', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    const getConnection = vi.fn(async () => {
+      throw new Error('descriptor unavailable')
+    })
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly'))
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+  })
+
+  it('does not replace the local startup preference for a profile SSH override', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    const getConnection = vi.fn(async () => ({ mode: 'remote', remoteKind: 'ssh' }))
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'ssh' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnection,
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+
+    selectProfile('macmini-hermes')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('macmini-hermes'))
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledWith('macmini-hermes'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
     expect(rememberProfile).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -784,9 +784,11 @@ export function selectProfile(name: string): void {
   // preference.
   const onPrimary = activeGatewayConnectionId() == null
 
-  void activateOnCurrentSource(target)
-    .then(() => {
-      if (onPrimary) {
+  const shouldRememberStartupProfile = onPrimary ? isLocalDesktopProfile(target) : Promise.resolve(false)
+
+  void Promise.all([activateOnCurrentSource(target), shouldRememberStartupProfile])
+    .then(([, shouldRemember]) => {
+      if (shouldRemember) {
         return window.hermesDesktop?.profile?.remember(target)
       }
 
@@ -797,6 +799,28 @@ export function selectProfile(name: string): void {
         notifyError(error, `Failed to switch to profile "${target}"`)
       }
     })
+}
+
+// Resolve persistence from the saved per-profile Desktop route, rather than the
+// live backend descriptor. A descriptor lookup is intentionally best-effort:
+// failure must not discard a successful local selection's startup preference.
+// Conversely, `ssh`, `remote`, and `cloud` here are per-profile overrides and
+// must never replace the local Desktop startup profile.
+async function isLocalDesktopProfile(target: string): Promise<boolean> {
+  const getConnectionConfig = window.hermesDesktop?.getConnectionConfig
+
+  if (!getConnectionConfig) {
+    return true
+  }
+
+  try {
+    return (await getConnectionConfig(target)).mode === 'local'
+  } catch {
+    // Preserve the pre-fix local-primary behavior when Electron's config bridge
+    // is temporarily unavailable. The next successful config read will still
+    // exclude any remote override.
+    return true
+  }
 }
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the


### PR DESCRIPTION
## Summary
- Keep the Desktop local startup profile from being overwritten when selecting a per-profile SSH, remote, or cloud override.
- Preserve local startup persistence for already-active selections and when the best-effort backend descriptor lookup fails.
- Add regressions for SSH override routing, already-active local profiles, and descriptor lookup failure.

## Why
The profile rail is a live workspace switcher. Selecting a remote profile should activate that remote backend without making it the profile used for the next local Desktop launch.

## Validation
- `npm run test:ui -- --run src/store/profile-select-source.test.ts`
- `npm run test:ui`
- `npm run test:desktop:platforms`
- `npm run typecheck`
- `npm run lint`

No credentials, session databases, or connection configuration are included.