### PR TITLE
fix(agent): stop recovered streams from repeating completed reply tails

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -373,15 +373,20 @@ def _continuation_overlap_length(previous: str, continuation: str) -> int:
     return matched if matched >= _MIN_CONTINUATION_OVERLAP else 0
 
 
-def _join_truncated_parts(parts: List[str]) -> str:
-    """Join continuation fragments without repeating a recovered tail."""
+def _join_truncated_parts(parts: List[str | tuple[str, bool]]) -> str:
+    """Join continuation fragments, deduping only interrupted-stream seams."""
     joined = ""
-    for part in parts:
-        if joined and part:
+    previous_was_partial_stub = False
+    for fragment in parts:
+        part, is_partial_stub = (
+            fragment if isinstance(fragment, tuple) else (fragment, False)
+        )
+        if previous_was_partial_stub and joined and part:
             part = part[_continuation_overlap_length(joined, part):]
         if joined and not joined[-1].isspace() and part and not part[0].isspace():
             joined += "\n"
         joined += part
+        previous_was_partial_stub = is_partial_stub
     return joined
 
 
@@ -1988,7 +1993,7 @@ def run_conversation(
     # Total outer-loop exceptions this turn (#92450) — see _MAX_OUTER_LOOP_ERRORS.
     _outer_error_count = 0
     truncated_tool_call_retries = 0
-    truncated_response_parts: List[str] = []
+    truncated_response_parts: List[tuple[str, bool]] = []
     compression_attempts = 0
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
@@ -3954,7 +3959,10 @@ def run_conversation(
                                 interim_msg["_length_continuation_fragment"] = True
                                 append_message(messages, interim_msg)
                                 if assistant_message.content:
-                                    truncated_response_parts.append(assistant_message.content)
+                                    truncated_response_parts.append((
+                                        assistant_message.content,
+                                        getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID,
+                                    ))
 
                             if length_continue_retries < 4:
                                 _is_partial_stream_stub = (
@@ -8166,7 +8174,10 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    final_response = _join_truncated_parts([*truncated_response_parts, final_response])
+                    final_response = _join_truncated_parts([
+                        *truncated_response_parts,
+                        (final_response, False),
+                    ])
                     truncated_response_parts = []
                     length_continue_retries = 0
                     # The continuation recovered, so the fragments stay in the transcript.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -342,10 +342,43 @@ def _moa_client_consumes_prepared_request(client: Any) -> bool:
     return callable(getattr(completions, "prepare", None))
 
 
+_MIN_CONTINUATION_OVERLAP = 32
+
+
+def _continuation_overlap_length(previous: str, continuation: str) -> int:
+    """Return the longest continuation prefix that repeats the previous suffix."""
+    if len(previous) < _MIN_CONTINUATION_OVERLAP or len(continuation) < _MIN_CONTINUATION_OVERLAP:
+        return 0
+
+    prefix_lengths = [0] * len(continuation)
+    matched = 0
+    for index in range(1, len(continuation)):
+        while matched and continuation[index] != continuation[matched]:
+            matched = prefix_lengths[matched - 1]
+        if continuation[index] == continuation[matched]:
+            matched += 1
+            prefix_lengths[index] = matched
+
+    matched = 0
+    last_index = len(previous) - 1
+    for index, char in enumerate(previous):
+        while matched and char != continuation[matched]:
+            matched = prefix_lengths[matched - 1]
+        if char == continuation[matched]:
+            matched += 1
+            if matched == len(continuation):
+                if index == last_index:
+                    return matched
+                matched = prefix_lengths[matched - 1]
+    return matched if matched >= _MIN_CONTINUATION_OVERLAP else 0
+
+
 def _join_truncated_parts(parts: List[str]) -> str:
-    """Join continuation fragments, adding a newline where two would glue together (#78577)."""
+    """Join continuation fragments without repeating a recovered tail."""
     joined = ""
     for part in parts:
+        if joined and part:
+            part = part[_continuation_overlap_length(joined, part):]
         if joined and not joined[-1].isspace() and part and not part[0].isspace():
             joined += "\n"
         joined += part

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -301,16 +301,16 @@ class TestLengthContinuationAssembly:
         )
 
         joined = _join_truncated_parts([
-            f"Investigation details.\n\n{conclusion}",
-            conclusion,
+            (f"Investigation details.\n\n{conclusion}", True),
+            (conclusion, False),
         ])
 
         assert joined.count(conclusion) == 1
 
     def test_distinct_continuation_is_preserved(self):
         assert _join_truncated_parts([
-            "The first half ends here",
-            "and the second half adds new information.",
+            ("The first half ends here", True),
+            ("and the second half adds new information.", False),
         ]) == (
             "The first half ends here\n"
             "and the second half adds new information."
@@ -320,8 +320,8 @@ class TestLengthContinuationAssembly:
         repeated = "A sufficiently long repeated transition sentence ends here."
 
         assert _join_truncated_parts([
-            f"Existing answer. {repeated}",
-            f"{repeated} New inbound details remain visible.",
+            (f"Existing answer. {repeated}", True),
+            (f"{repeated} New inbound details remain visible.", False),
         ]) == (
             f"Existing answer. {repeated} New inbound details remain visible."
         )
@@ -425,6 +425,26 @@ class TestConversationLoopPartialStreamContinuation:
         assert "first half of" in result["final_response"]
         assert "forty-two" in result["final_response"]
         assert result["final_response"].count(repeated_tail) == 1
+
+    def test_output_limit_continuation_preserves_intentional_repetition(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_response
+
+        repeated = "This intentionally repeated sentence is longer than thirty-two characters."
+        first = _mock_response(
+            content=f"First copy: {repeated}", finish_reason=FINISH_REASON_LENGTH,
+        )
+        continuation = _mock_response(content=repeated, finish_reason="stop")
+        loop_agent.client.chat.completions.create.side_effect = [first, continuation]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("repeat this sentence twice")
+
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert result["final_response"].count(repeated) == 2
 
 
 class TestContentFilterStallActivatesFallback:

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
-from agent.conversation_loop import _get_continuation_prompt
+from agent.conversation_loop import _get_continuation_prompt, _join_truncated_parts
 
 
 # ── Helpers (mirrors test_streaming.py) ────────────────────────────────────
@@ -293,6 +293,40 @@ class TestLengthContinuationPromptBranching:
         assert "output length limit" in prompt
 
 
+class TestLengthContinuationAssembly:
+    def test_repeated_complete_tail_is_not_joined_twice(self):
+        conclusion = (
+            "**Conclusion**: the project remains on standby until the stable "
+            "release. Nothing changes."
+        )
+
+        joined = _join_truncated_parts([
+            f"Investigation details.\n\n{conclusion}",
+            conclusion,
+        ])
+
+        assert joined.count(conclusion) == 1
+
+    def test_distinct_continuation_is_preserved(self):
+        assert _join_truncated_parts([
+            "The first half ends here",
+            "and the second half adds new information.",
+        ]) == (
+            "The first half ends here\n"
+            "and the second half adds new information."
+        )
+
+    def test_repeated_tail_is_trimmed_without_losing_new_text(self):
+        repeated = "A sufficiently long repeated transition sentence ends here."
+
+        assert _join_truncated_parts([
+            f"Existing answer. {repeated}",
+            f"{repeated} New inbound details remain visible.",
+        ]) == (
+            f"Existing answer. {repeated} New inbound details remain visible."
+        )
+
+
 
 # ── Integration: live conversation loop ───────────────────────────────────
 
@@ -334,19 +368,26 @@ class TestConversationLoopPartialStreamContinuation:
         from tests.run_agent.test_run_agent import _mock_response, _mock_assistant_msg
 
         # First API call: the partial-stream stub (length on partial-stream-stub id).
+        repeated_tail = (
+            "**Conclusion**: the project remains on standby until the stable "
+            "release. Nothing changes."
+        )
         partial_stub = SimpleNamespace(
             id=PARTIAL_STREAM_STUB_ID,
             model="test/model",
             choices=[SimpleNamespace(
                 index=0,
-                message=_mock_assistant_msg(content="The first half of "),
+                message=_mock_assistant_msg(
+                    content=f"The first half of the answer is forty-two.\n\n{repeated_tail}"
+                ),
                 finish_reason=FINISH_REASON_LENGTH,
             )],
             usage=None,
         )
-        # Second API call: model continues with the rest, clean stop.
+        # Second API call: the model restarts from the complete-looking tail
+        # even though the nudge said not to repeat it, then stops cleanly.
         continuation = _mock_response(
-            content="the answer is forty-two.", finish_reason="stop",
+            content=repeated_tail, finish_reason="stop",
         )
 
         loop_agent.client.chat.completions.create.side_effect = [
@@ -383,6 +424,7 @@ class TestConversationLoopPartialStreamContinuation:
         # And the final response stitches both halves together.
         assert "first half of" in result["final_response"]
         assert "forty-two" in result["final_response"]
+        assert result["final_response"].count(repeated_tail) == 1
 
 
 class TestContentFilterStallActivatesFallback:


### PR DESCRIPTION
## What does this PR do?

Prevents a recovered partial stream from repeating a complete-looking reply tail in the final response. When an upstream stream ends before its finish marker and the model restarts its continuation from a conclusion already received, Hermes now removes the exact overlap while preserving all new continuation text.

### Symptom

A user can receive a final reply whose concluding paragraph appears twice after a stream interruption. The duplicated text is already present in the assembled `final_response`, so a gateway fallback delivery faithfully exposes the duplicate.

### Impact

Affected turns show repeated final content and store a misleading response. The blast radius is limited to partial-stream recovery where the continuation starts with at least 32 characters that exactly match the prior fragment's suffix.

### Bug Cause

**Trigger:** `agent/conversation_loop.py:345` / `_join_truncated_parts`

**Causal chain:**
1. An upstream response stream provides text but ends before a finish marker, so Hermes creates a partial-stream stub and requests continuation.
2. The model restarts from an already received conclusion despite the no-repeat continuation nudge.
3. `_join_truncated_parts` concatenates both fragments verbatim, placing the same tail twice in the user-visible final response.

**Why it is wrong:** Continuation assembly treated every fragment as entirely novel even when the next fragment had an exact prefix equal to the previous assembled suffix.

**Working sibling / contrast:** Non-overlapping continuation fragments already assemble correctly and retain the existing newline separator behavior.

**Ruled out:** The queued gateway branch does not inject the network continuation prompt. It re-delivers the completed turn and then recursively processes the queued inbound event; the prompt originates in the agent's upstream partial-stream recovery path.

### Fix

Compute the longest exact suffix/prefix overlap in linear time and remove overlaps of at least 32 characters before joining continuation fragments. The threshold avoids treating short common phrases as recovery duplication, while tests verify that repeated tails are removed and novel continuation text remains intact.

## Related Issue

Fixes #95369

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` - deduplicate exact repeated tails during partial-stream continuation assembly.
- `tests/run_agent/test_partial_stream_finish_reason.py` - cover repeated tails, distinct continuations, retained novel text, and the real conversation-loop recovery seam.

## How to Test

1. Simulate a partial-stream stub whose complete-looking fragment ends in a distinct conclusion.
2. Return a clean continuation that repeats that conclusion.
3. Verify the assembled final response contains the conclusion once and all new continuation text remains present.

```bash
scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_queue_consumption.py tests/gateway/test_stream_final_contract.py -q
```

Result: 42 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant agent and gateway tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure Python behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Targeted test result: 42 passed, 0 failed.
