### PR TITLE
fix(desktop): preserve primary gateway identity across source switches

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -652,6 +652,12 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewaySwitching.get()).toBe(false)
     // The switch committed: the registry remembers the new source as last-used.
     expect(setLastUsed).toHaveBeenCalledWith('coder-remote')
+
+    // Publishing the secondary must not relabel the primary socket. Returning
+    // to its source should reuse that socket, not dial the secondary endpoint.
+    const socketsAfterSwitch = FakeWebSocket.instances.length
+    await expect(requestGatewayForAgent('primary-vps', 'default', 'ping')).resolves.toEqual({ pong: true })
+    expect(FakeWebSocket.instances).toHaveLength(socketsAfterSwitch)
   })
 
   it('a Settings switch superseded while reading its descriptor cannot publish over a newer Sessions switch', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -32,7 +32,6 @@ import {
   reportPrimaryGatewayState,
   setPrimaryGateway,
   setPrimaryGatewayConnection,
-  setPrimaryGatewayConnectionId,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
@@ -187,7 +186,6 @@ export function useGatewayBoot({
             }
           : null
       )
-      setPrimaryGatewayConnectionId(next?.connectionId)
     }
 
     if (!desktop) {


### PR DESCRIPTION
## What does this PR do?

Prevents a secondary gateway publication from overwriting the identity of the primary gateway socket.

After booting with a remote primary, switching the Sessions source to another connection could relabel the unchanged primary socket. Switching back then reused the wrong socket, so resuming a stored session failed with session not found.

The fix removes that presentation-layer identity write. Primary boot, reconnect, and explicit primary switches remain the only paths that update primary connection identity.

## Related Issue

Follow-up to #95080. Refs #93937.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove the secondary publication path that mutates primary gateway connection identity.
- Extend the existing gateway-switch regression test to prove that returning to the primary source reuses its existing socket.

## How to Test

1. Start Desktop with a remote gateway as the primary connection.
2. Switch the Sessions source to This device, then open an existing local session.
3. Verify the session resumes and accepts a second message without a session not found error.

Automated verification:

- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null npm run check (from apps/desktop) — passed
- The check includes typechecking, lint, UI tests, Electron/platform tests, desktop tests, plugin tests, and a macOS package build.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] Python test suite: N/A — this PR changes only Desktop TypeScript; the complete Desktop check passed
- [x] I have added a regression test for the change
- [x] I tested on macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] cli-config.yaml.example update: N/A
- [x] CONTRIBUTING.md or AGENTS.md update: N/A
- [x] I considered cross-platform impact; the change is platform-independent gateway state handling
- [x] Tool descriptions or schemas update: N/A

## Screenshots / Logs

Manual macOS verification passed: remote primary → This device → existing local session → second message completed without a resume error.
