### PR TITLE
fix(desktop): bound the model pill loader and budget tile resumes (split from #94178)

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,12 +1,12 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { $activeSessionId, $currentModel, setCurrentModel, setCurrentModelSource } from '@/store/session'
 
-import { ModelPill } from './model-pill'
+import { MODEL_RESOLVE_GRACE_MS, ModelPill } from './model-pill'
 
 const modelState = (over: Partial<ChatBarState['model']> = {}): ChatBarState['model'] => ({
   canSwitch: true,
@@ -113,5 +113,91 @@ describe('ModelPill per-surface model label', () => {
 
     expect(screen.getByText('Sonnet · High')).toBeTruthy()
     expect(screen.queryByText(/primary/i)).toBeNull()
+  })
+})
+
+// #93892: the pill's loader used to spin for as long as the surface had no
+// model — with no timer, error or retry cap. It is now a bounded grace per
+// surface identity, after which the pill admits "no model" and stays usable.
+describe('ModelPill bounded loader', () => {
+  const tileView = (runtimeId: string, model = ''): SessionView => ({
+    kind: 'tile',
+    $awaitingResponse: atom(false),
+    $busy: atom(false),
+    $cwd: atom(''),
+    $fast: atom(false),
+    $lastVisibleIsUser: atom(false),
+    $messages: atom([]),
+    $messagesEmpty: atom(true),
+    $model: atom(model),
+    $provider: atom(''),
+    $reasoningEffort: atom(''),
+    $runtimeId: atom(runtimeId),
+    $storedId: atom('stored-tile'),
+    $turnStartedAt: atom<number | null>(null)
+  })
+
+  const renderEmptyPill = (view: SessionView) =>
+    render(
+      <SessionViewProvider value={view}>
+        <ModelPill disabled={false} model={modelState({ model: '', provider: '', modelMenuContent: <div /> })} />
+      </SessionViewProvider>
+    )
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('spins only for the grace window, then shows the empty label', () => {
+    vi.useFakeTimers()
+    renderEmptyPill(tileView('rt-1'))
+
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS - 1)
+    })
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(screen.getByTestId('model-pill-no-model').textContent).toBe('no model')
+  })
+
+  it('does not re-arm the loader when the runtime is rebound (reclaim → resume)', () => {
+    vi.useFakeTimers()
+    const view = tileView('rt-1')
+    renderEmptyPill(view)
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS)
+    })
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+
+    // The loop's signature: same stored session, a fresh runtime every cycle.
+    act(() => {
+      ;(view.$runtimeId as ReturnType<typeof atom<null | string>>).set('rt-2')
+    })
+
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+  })
+
+  it('paints the model as soon as one lands, before or after the grace', () => {
+    vi.useFakeTimers()
+    const view = tileView('rt-1')
+    renderEmptyPill(view)
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS)
+    })
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+
+    act(() => {
+      ;(view.$model as ReturnType<typeof atom<string>>).set('tile/claude-sonnet')
+    })
+
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+    expect(screen.getByText(/^Sonnet/)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -27,6 +27,16 @@ const PILL = cn(
 )
 
 /**
+ * How long the pill shows its loader for a surface with no model before it
+ * admits "no model" (#93892). The loader exists to hide the beat between a
+ * gateway/session coming up and its `session.info` landing — not to spin
+ * for as long as a session's owner socket churns. Past the grace the pill
+ * paints the (translated) empty label and stays a working control: the menu
+ * still opens and a pick still lands.
+ */
+export const MODEL_RESOLVE_GRACE_MS = 8_000
+
+/**
  * Composer model selector — the relocated status-bar pill. Reuses the live
  * `model.options` dropdown (`modelMenuContent`) verbatim; falls back to the
  * full picker when the gateway is closed and no live menu exists.
@@ -56,9 +66,30 @@ export function ModelPill({
   const modelSource = useStore($currentModelSource)
   const defaultEffort = useStore($defaultReasoningEffort)
   const runtimeId = useStore(view.$runtimeId)
+  const storedId = useStore(view.$storedId)
   const [open, setOpen] = useState(false)
   const scope = useComposerScope()
   const hasLiveMenu = Boolean(model.modelMenuContent)
+  const hasModel = Boolean(currentModel.trim())
+
+  // Bounded loader: one grace window per surface identity (the durable stored
+  // id, not the runtime — a reclaimed/re-resumed runtime must not re-arm it).
+  // Once the grace has lapsed for this surface it stays lapsed until a model
+  // lands, so a model that comes and goes never brings the loader back.
+  const graceKey = storedId ?? runtimeId ?? 'draft'
+  const [graceLapsedFor, setGraceLapsedFor] = useState<null | string>(null)
+
+  useEffect(() => {
+    if (hasModel) {
+      return
+    }
+
+    const timer = window.setTimeout(() => setGraceLapsedFor(graceKey), MODEL_RESOLVE_GRACE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [graceKey, hasModel])
+
+  const showNoModel = !hasModel && graceLapsedFor === graceKey
 
   // The `composer.modelPicker` hotkey, routed to exactly one surface (the pane
   // under the pointer, else the active composer — see requestModelMenuToggle).
@@ -96,9 +127,13 @@ export function ModelPill({
     <ChevronDown className="size-3.5 shrink-0 opacity-70" />
   ) : (
     <>
-      {currentModel.trim() ? (
+      {hasModel ? (
         <span className="truncate">
           {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
+        </span>
+      ) : showNoModel ? (
+        <span className="truncate" data-testid="model-pill-no-model">
+          {copy.noModel}
         </span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />

--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { sessionTileResumeFailure } from './session-tile'
+import {
+  createTileResumeBudget,
+  recentTileResumes,
+  sessionTileResumeFailure,
+  TILE_RESUME_STORM_LIMIT,
+  TILE_RESUME_STORM_WINDOW_MS,
+  tileResumeStormed
+} from './session-tile'
 
 describe('sessionTileResumeFailure', () => {
   it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
@@ -15,5 +22,61 @@ describe('sessionTileResumeFailure', () => {
 
   it('does not overwrite a tile that rebound while the lookup was pending', () => {
     expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})
+
+// #93892: the resume chain had per-step timeouts but no overall budget, so a
+// runtime that resumed and was reclaimed over and over spun the loader
+// forever. These pin the budget helpers and the pane's use of them.
+describe('tile resume storm budget', () => {
+  it('counts only resumes inside the window', () => {
+    const now = 1_000_000
+    const stale = now - TILE_RESUME_STORM_WINDOW_MS
+    const fresh = now - TILE_RESUME_STORM_WINDOW_MS + 1
+
+    expect(recentTileResumes([stale, fresh, now], now)).toEqual([fresh, now])
+  })
+
+  it('trips once the limit of successful resumes lands inside one window', () => {
+    const now = 1_000_000
+    const underLimit = Array.from({ length: TILE_RESUME_STORM_LIMIT - 1 }, (_, i) => now - i * 1_000)
+    const atLimit = Array.from({ length: TILE_RESUME_STORM_LIMIT }, (_, i) => now - i * 1_000)
+
+    expect(tileResumeStormed(underLimit, now)).toBe(false)
+    expect(tileResumeStormed(atLimit, now)).toBe(true)
+  })
+
+  it('lets an old storm age out of the window', () => {
+    const then = 1_000_000
+    const storm = Array.from({ length: TILE_RESUME_STORM_LIMIT }, (_, i) => then - i * 1_000)
+
+    expect(tileResumeStormed(storm, then)).toBe(true)
+    expect(tileResumeStormed(storm, then + TILE_RESUME_STORM_WINDOW_MS)).toBe(false)
+  })
+
+  it('createTileResumeBudget: successes spend it, the next take past the limit latches, Retry starts clean', () => {
+    let now = 1_000_000
+    const budget = createTileResumeBudget(() => now)
+
+    // The reclaim loop: each cycle resumes (take + spend) ~20s apart.
+    for (let cycle = 0; cycle < TILE_RESUME_STORM_LIMIT; cycle += 1) {
+      expect(budget.take()).toBe(true)
+      budget.spend()
+      now += 20_000
+    }
+
+    // One more cycle inside the window: the pane must latch, not dial.
+    expect(budget.take()).toBe(false)
+
+    // The user's Retry (or a gateway reopen) gets a clean budget.
+    expect(budget.take()).toBe(true)
+  })
+
+  it('createTileResumeBudget: failed resumes do not spend it', () => {
+    const budget = createTileResumeBudget(() => 1_000_000)
+
+    for (let attempt = 0; attempt < TILE_RESUME_STORM_LIMIT * 2; attempt += 1) {
+      expect(budget.take()).toBe(true)
+    }
   })
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -76,6 +76,66 @@ import { ChatView } from '.'
 
 const NO_MESSAGES: ChatMessage[] = []
 
+/**
+ * Total resume budget for one tile (#93892). Every dial/RPC/hydration in the
+ * resume chain has its own timeout, but the chain as a whole had none: a
+ * runtime that genuinely resumes and is then reclaimed (`session.reclaimed`
+ * unbinds the tile, which re-arms the resume effect) looped forever behind
+ * the loader. More than TILE_RESUME_STORM_LIMIT successful resumes inside
+ * TILE_RESUME_STORM_WINDOW_MS is not recovery any more — latch the error
+ * card so the user gets a terminal state and a Retry (which re-opens the
+ * budget). A normal sleep/wake or backend restart re-resumes once or twice;
+ * the reclaim loop cycles roughly every orphan-reap grace (~20s).
+ */
+export const TILE_RESUME_STORM_WINDOW_MS = 120_000
+export const TILE_RESUME_STORM_LIMIT = 4
+export const TILE_RESUME_STORM_MESSAGE =
+  'Session keeps losing its backend runtime right after resuming — retry to resume it again.'
+
+/** The resume timestamps still inside the storm window at `now`. */
+export function recentTileResumes(resumedAt: readonly number[], now: number): number[] {
+  return resumedAt.filter(at => now - at < TILE_RESUME_STORM_WINDOW_MS)
+}
+
+/** True once the resume budget is exhausted: the next resume must latch the
+ *  error card instead of dialing again. */
+export function tileResumeStormed(resumedAt: readonly number[], now: number): boolean {
+  return recentTileResumes(resumedAt, now).length >= TILE_RESUME_STORM_LIMIT
+}
+
+export interface TileResumeBudget {
+  /** Ask before dialing. False = the budget is spent: latch the error card
+   *  instead. The budget resets on that answer so a Retry gets a clean cycle. */
+  take: () => boolean
+  /** A resume SUCCEEDED (bound a runtime) — only successes spend budget;
+   *  failures already latch their own error. */
+  spend: () => void
+}
+
+/** One tile's resume budget — the pane keeps one for its lifetime. */
+export function createTileResumeBudget(now: () => number = Date.now): TileResumeBudget {
+  let resumedAt: number[] = []
+
+  return {
+    take: () => {
+      const at = now()
+
+      if (tileResumeStormed(resumedAt, at)) {
+        resumedAt = []
+
+        return false
+      }
+
+      resumedAt = recentTileResumes(resumedAt, at)
+
+      return true
+    },
+    spend: () => {
+      resumedAt = [...resumedAt, now()]
+    }
+  }
+}
+
 export function sessionTileResumeFailure(
   message: string,
   durableSessionFound: boolean | undefined,
@@ -282,6 +342,8 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const gatewayOpen = useStore($gatewayState) === 'open'
   const delegateRevision = useStore($sessionTileDelegateRevision)
   const resumingRef = useRef(false)
+  // This tile's overall resume budget (#93892).
+  const resumeBudget = useRef(createTileResumeBudget()).current
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
 
   const storedSessionStillExists = useCallback(
@@ -352,11 +414,23 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       return
     }
 
+    // Bounded overall budget (#93892): a runtime that keeps resuming and
+    // getting reclaimed is a loop, not recovery. Latch the error card (and
+    // reset the budget so Retry gets a clean cycle) instead of dialing again.
+    if (!resumeBudget.take()) {
+      patchSessionTile(storedSessionId, { error: TILE_RESUME_STORM_MESSAGE })
+
+      return
+    }
+
     resumingRef.current = true
 
     delegate
       .resumeTile(storedSessionId)
-      .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
+      .then(id => {
+        resumeBudget.spend()
+        patchSessionTile(storedSessionId, { error: undefined, runtimeId: id })
+      })
       .catch(async (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
 
@@ -382,7 +456,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       .finally(() => {
         resumingRef.current = false
       })
-  }, [delegateRevision, gatewayOpen, ownerRoute, runtimeId, storedSessionId, tile?.error])
+  }, [delegateRevision, gatewayOpen, ownerRoute, resumeBudget, runtimeId, storedSessionId, tile?.error])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it


### PR DESCRIPTION
## Summary

Two small Desktop polish pieces split out of #94178, as suggested when that PR was closed in favour of #93916 (tracker #94724). Both stand alone on current `main`; neither touches the owner-routing/retention code that already landed.

- **Model pill bounded loader** — the composer model pill showed a spinner for as long as a surface had no model, which on a churning owner socket meant "forever". It now spins for one grace window per surface identity (`MODEL_RESOLVE_GRACE_MS`, keyed by the durable stored id so a re-resumed runtime does not re-arm it), then paints the existing translated `no model` label and stays a working control (menu opens, pick lands).
- **Tile resume budget** — the tile resume chain had per-step timeouts but no overall budget, so a session that kept losing its backend runtime right after resuming looped indefinitely. `createTileResumeBudget` allows `TILE_RESUME_STORM_LIMIT` successful resumes per `TILE_RESUME_STORM_WINDOW_MS`; past that the tile latches an actionable error card, and Retry (or a gateway reopen) starts with a clean budget. Failed resumes do not spend the budget.

Related: #93892 (the loader/loop symptoms are the user-visible half of that issue).

## Changes

- `apps/desktop/src/app/chat/composer/model-pill.tsx` / `.test.tsx`
- `apps/desktop/src/app/chat/session-tile.tsx` / `.test.ts`

## Validation

- `tsc --noEmit` clean; prettier clean on changed files; eslint clean apart from one pre-existing `Unused eslint-disable directive` warning on `session-tile.tsx` that `main` already has.
- `vitest run --project ui` on the two changed test files: 16/16; `--changed origin/main`: 5 files, 33/33.
- Clean `git merge-tree` against `main`.