### PR TITLE
fix(mattermost): support typed command prefixes

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2399,6 +2399,7 @@ DEFAULT_CONFIG = {
 
     # Mattermost platform settings (gateway mode)
     "mattermost": {
+        "command_prefix": "!",          # Alternate prefix for typed Hermes commands; "" disables it
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -86,6 +86,36 @@ def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def _rewrite_known_typed_command(text: str, prefix: str) -> str:
+    """Rewrite a known Mattermost-friendly command prefix to ``/``.
+
+    Mattermost clients intercept unregistered slash commands before they
+    reach the WebSocket. Only rewrite commands the gateway can dispatch so
+    ordinary prose such as ``!important`` remains normal text.
+    """
+    if not prefix or not text.startswith(prefix):
+        return text
+
+    remainder = text[len(prefix):]
+    if not remainder or remainder[:1].isspace():
+        return text
+
+    try:
+        from hermes_cli.commands import is_gateway_known_command
+
+        first_token = remainder.split(maxsplit=1)[0]
+        command_name = first_token.split("@", 1)[0].lower()
+        if (
+            command_name
+            and "/" not in command_name
+            and is_gateway_known_command(command_name)
+        ):
+            return "/" + remainder
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return text
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter runtime dependency is available."""
     try:
@@ -114,6 +144,9 @@ class MattermostAdapter(BasePlatformAdapter):
     """Gateway adapter for Mattermost (self-hosted or cloud)."""
 
     splits_long_messages = True  # send() chunks via truncate_message(MAX_POST_LENGTH)
+    # Mattermost intercepts typed native slash commands. This alternate
+    # prefix reaches Hermes and is normalized only for registered commands.
+    typed_command_prefix = "!"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATTERMOST)
@@ -126,6 +159,14 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._bot_user_id: str = ""
         self._bot_username: str = ""
+        command_prefix = config.extra.get("command_prefix", "!")
+        self._command_prefix = (
+            command_prefix.strip() if isinstance(command_prefix, str) else "!"
+        )
+        # Shared gateway prompts interpolate typed_command_prefix. When the
+        # alternate prefix is disabled, advertise the native slash form rather
+        # than rendering invalid bare commands such as ``approve``.
+        self.typed_command_prefix = self._command_prefix or "/"
 
         # aiohttp session + websocket handle
         self._session: Any = None  # aiohttp.ClientSession
@@ -928,6 +969,14 @@ class MattermostAdapter(BasePlatformAdapter):
         ):
             thread_id = post_id
 
+        # Mattermost clients reserve typed slash commands for native
+        # integrations. Normalize the configured alternate prefix only when
+        # it names a registered gateway/plugin command, matching Slack's
+        # behavior and preserving ordinary prose such as ``!important``.
+        message_text = _rewrite_known_typed_command(
+            message_text, self._command_prefix
+        )
+
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
@@ -1215,8 +1264,8 @@ def interactive_setup() -> None:
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")
     print_info("   To get a channel ID: click channel name → View Info → copy the ID")
-    print_info("   You can also set this later by typing /set-home in a Mattermost channel.")
-    home_channel = prompt("Home channel ID (leave empty to set later with /set-home)").strip()
+    print_info("   You can also set this later by typing !sethome in a Mattermost channel.")
+    home_channel = prompt("Home channel ID (leave empty to set later with !sethome)").strip()
     if home_channel:
         save_env_value("MATTERMOST_HOME_CHANNEL", home_channel)
     else:
@@ -1237,18 +1286,14 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     Mirrors the legacy ``mattermost_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The MattermostAdapter reads its runtime configuration via
-    ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
-    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
-    ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
-    to read from ``PlatformConfig.extra``, this hook keeps the env-driven
-    model and merely owns the YAML→env translation here, next to the
-    adapter that consumes it.
+    The MattermostAdapter reads mention/channel settings via ``os.getenv()``
+    and receives ``command_prefix`` through ``PlatformConfig.extra``. Rather
+    than teach core ``gateway/config.py`` this platform schema, the hook keeps
+    the translation next to the adapter that consumes it.
 
-    Env vars take precedence over YAML — every assignment is guarded
-    by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    Env vars take precedence over YAML for the legacy env-backed settings.
+    ``command_prefix`` is behavioral config and intentionally remains a YAML
+    extra rather than a new user-facing environment variable.
     """
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
@@ -1263,7 +1308,12 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    extras = {}
+    if "command_prefix" in mattermost_cfg:
+        prefix = mattermost_cfg["command_prefix"]
+        if isinstance(prefix, str):
+            extras["command_prefix"] = prefix.strip()
+    return extras or None
 
 
 # ---------------------------------------------------------------------------
@@ -1311,12 +1361,9 @@ def register(ctx) -> None:
         # Interactive setup wizard — replaces the central
         # hermes_cli/setup.py::_setup_mattermost function.
         setup_fn=interactive_setup,
-        # YAML→env config bridge — owns the translation of
-        # ``config.yaml`` ``mattermost:`` keys (require_mention,
-        # free_response_channels, allowed_channels) into ``MATTERMOST_*``
-        # env vars that the adapter reads via ``os.getenv()``.  Replaces
-        # the hardcoded block that used to live in ``gateway/config.py``.
-        # Hook contract: #24836 / #25443.
+        # YAML config bridge — owns translation of ``mattermost:`` keys.
+        # Mention/channel settings retain their legacy internal env bridge;
+        # command_prefix is returned as PlatformConfig.extra behavioral config.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration.
         allowed_users_env="MATTERMOST_ALLOWED_USERS",

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -98,6 +98,72 @@ def _make_adapter():
     return adapter
 
 
+class TestMattermostTypedCommandPrefix:
+    def test_rewrites_only_registered_commands(self):
+        from plugins.platforms.mattermost.adapter import _rewrite_known_typed_command
+
+        assert _rewrite_known_typed_command("!status", "!") == "/status"
+        assert _rewrite_known_typed_command("!approve session", "!") == "/approve session"
+        assert _rewrite_known_typed_command("!important", "!") == "!important"
+
+    def test_supports_custom_and_disabled_prefixes(self):
+        from plugins.platforms.mattermost.adapter import (
+            MattermostAdapter,
+            _rewrite_known_typed_command,
+        )
+
+        assert _rewrite_known_typed_command("?status", "?") == "/status"
+        assert _rewrite_known_typed_command("!status", "") == "!status"
+        assert _rewrite_known_typed_command("! status", "!") == "! status"
+
+        disabled = MattermostAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"url": "https://mm.example.com", "command_prefix": ""},
+            )
+        )
+        assert disabled._command_prefix == ""
+        assert disabled.typed_command_prefix == "/"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("message", "expected_text", "expected_type"),
+        [
+            ("!new", "/new", MessageType.COMMAND),
+            ("!important", "!important", MessageType.TEXT),
+        ],
+    )
+    async def test_dm_event_normalizes_only_known_commands(
+        self, message, expected_text, expected_type
+    ):
+        adapter = _make_adapter()
+        adapter._bot_user_id = "bot_user_id"
+        adapter._bot_username = "hermes-bot"
+        adapter.handle_message = AsyncMock()
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(
+                    {
+                        "id": "post_cmd",
+                        "user_id": "user_123",
+                        "channel_id": "chan_dm",
+                        "message": message,
+                    }
+                ),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await adapter._handle_ws_event(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == expected_text
+        assert msg_event.message_type is expected_type
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()

--- a/tests/gateway/test_mattermost_plugin_setup.py
+++ b/tests/gateway/test_mattermost_plugin_setup.py
@@ -6,9 +6,83 @@ The interactive_setup wizard lazy-imports its CLI helpers from
 source modules. Covers the home-channel clear-on-blank behavior added in
 PR #58421 and extended in the follow-up.
 """
+import json
+from unittest.mock import AsyncMock
+
+import pytest
 import hermes_cli.config as config_mod
 import hermes_cli.cli_output as cli_output_mod
-from plugins.platforms.mattermost.adapter import interactive_setup
+
+from gateway.platforms.base import MessageType
+from plugins.platforms.mattermost.adapter import _apply_yaml_config, interactive_setup
+
+
+def test_command_prefix_flows_from_yaml_to_platform_extras():
+    assert _apply_yaml_config({}, {"command_prefix": " ? "}) == {
+        "command_prefix": "?"
+    }
+
+
+def test_command_prefix_can_be_disabled_in_yaml():
+    assert _apply_yaml_config({}, {"command_prefix": ""}) == {
+        "command_prefix": ""
+    }
+
+
+def test_gateway_loader_applies_command_prefix_extra(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        'mattermost:\n  command_prefix: "?"\n', encoding="utf-8"
+    )
+
+    from gateway.config import Platform, load_gateway_config
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+    config = load_gateway_config()
+    platform_config = config.platforms[Platform.MATTERMOST]
+    assert platform_config.extra["command_prefix"] == "?"
+    assert MattermostAdapter(platform_config).typed_command_prefix == "?"
+
+
+@pytest.mark.asyncio
+async def test_disabled_prefix_survives_loader_and_real_event(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        'mattermost:\n  command_prefix: ""\n', encoding="utf-8"
+    )
+
+    from gateway.config import Platform, load_gateway_config
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+    config = load_gateway_config()
+    adapter = MattermostAdapter(config.platforms[Platform.MATTERMOST])
+    assert adapter._command_prefix == ""
+    assert adapter.typed_command_prefix == "/"
+
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+    await adapter._handle_ws_event(
+        {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(
+                    {
+                        "id": "post_disabled_prefix",
+                        "user_id": "user_123",
+                        "channel_id": "chan_dm",
+                        "message": "!new",
+                    }
+                ),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+    )
+
+    event = adapter.handle_message.call_args[0][0]
+    assert event.text == "!new"
+    assert event.message_type is MessageType.TEXT
 
 
 def _patch_setup_io(monkeypatch, prompts, saved, removed, existing):

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -20,6 +20,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
 | **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
+| **Commands** | Type `!help`, `!model`, etc. because Mattermost reserves `/commands` for native integrations. Only registered Hermes commands are rewritten; ordinary text such as `!important` stays text. |
 
 :::tip
 If you want Hermes to reply as threaded conversations (nested under your original message), set `MATTERMOST_REPLY_MODE=thread`. The default is `off`, which sends flat messages in the channel.
@@ -161,9 +162,12 @@ Optional behavior settings in `~/.hermes/config.yaml`:
 
 ```yaml
 group_sessions_per_user: true
+mattermost:
+  command_prefix: "!"  # Set to "" to disable the alternate prefix
 ```
 
 - `group_sessions_per_user: true` keeps each participant's context isolated inside shared channels and threads
+- `mattermost.command_prefix` sets the typed prefix that Hermes normalizes to `/` for known commands only
 
 ### Start the Gateway
 
@@ -183,9 +187,9 @@ You can run `hermes gateway` in the background or as a systemd service for persi
 
 You can designate a "home channel" where the bot sends proactive messages (such as cron job output, reminders, and notifications). There are two ways to set it:
 
-### Using the Slash Command
+### Using a Command
 
-Type `/sethome` in any Mattermost channel where the bot is present. That channel becomes the home channel.
+Type `!sethome` in any Mattermost channel where the bot is present. That channel becomes the home channel. Mattermost may intercept `/sethome` as an unregistered native command before Hermes receives it.
 
 ### Manual Configuration
 


### PR DESCRIPTION
## Summary

Mattermost clients intercept unregistered `/commands` before Hermes can receive them. This adds a configurable typed command prefix, defaulting to `!`, so users can send commands such as `!help` and `!model` through Mattermost.

The rewrite is deliberately limited to commands registered with the Hermes gateway (including plugin commands). Ordinary text such as `!important` remains ordinary text.

Configuration is user-facing behavioral config in `config.yaml`, not a new environment variable:

```yaml
mattermost:
  command_prefix: "!"
```

Set `command_prefix: ""` to disable the alternate prefix.

## Changes

- expose `typed_command_prefix` on the current Mattermost plugin adapter
- bridge `mattermost.command_prefix` into `PlatformConfig.extra`
- normalize the alternate prefix only for registered gateway/plugin commands
- document command usage and configuration
- cover default, custom, disabled, command, normal-text, and whitespace behavior
- verify the real `config.yaml` → gateway config → adapter → WebSocket-event path

## Context

This is a clean replacement for the command-prefix portion of #17606 and incorporates its maintainer review:

- ported from the removed legacy adapter to `plugins/platforms/mattermost/adapter.py`
- uses `config.yaml` rather than a new user-facing env var
- rewrites only known commands, avoiding false positives like `!important`
- adds configured/disabled and behavior tests
- leaves unrelated reaction support out of this PR

Credit to @cdwaters for the original proposal and implementation direction in #17606.

Addresses the Mattermost portion of #12688.

## Testing

```text
./scripts/run_tests.sh -q tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py
32 passed

ruff check hermes_cli/config_defaults.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py
python3 -m py_compile hermes_cli/config_defaults.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py
git diff --check
```
