### PR TITLE
chore(gitignore): ignore OMH ephemeral runtime so update is not stranded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,4 +212,24 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# OMH scaffolding materialised into the checkout at runtime. `.omh/` ships its
+# own nested .gitignore, but git never reads an ignore file inside a directory
+# that is itself untracked, so the bare `?? .omh/` entry still reached
+# `git status --porcelain` — which is exactly what _assess_parked_branch_switch
+# reads. A clean tree is load-bearing for `hermes update`: on a parked branch a
+# dirty tree returns "dirty", the code update is SKIPPED and the run exits 1
+# (the desktop update button surfaces this as "Hermes update did not finish").
+# Two inert scaffolding files were enough to strand a checkout behind main.
+#
+# Ignore the ephemeral runtime only. `.omh/README.md` documents selective
+# sharing: state/logs/progress are per-session, while specs/, plans/ and
+# research/ are durable decision artifacts that stay committable — so this
+# must not become a blanket `.omh/` rule.
+.omh/README.md
+.omh/.gitignore
+.omh/state/
+.omh/logs/
+.omh/progress/
+
 .skills_prompt_snapshot.json


### PR DESCRIPTION
## Symptom

The desktop update button fails with a red **"Hermes update did not finish"** dialog (`Update failed (exit 1)`). The hand-off log shows the real reason:

```
⚠ CODE UPDATE SKIPPED — checkout is parked on 'fix/mcp-stdio-children-dead-inverted'
  Not auto-switching to main: the working tree has uncommitted changes.
  This checkout is 116 commit(s) BEHIND origin/main — the code you are running is stale.
```

The only "uncommitted change" was an untracked `.omh/` holding **two inert scaffolding files** — `README.md` and `.gitignore`. Nothing the user created.

## Why the nested .gitignore does not help

`.omh/` ships its own `.omh/.gitignore` that lists `state/`, `logs/`, `progress/` and even `.omh/` itself. But **git never reads an ignore file inside a directory that is itself untracked** — it stops at the directory and emits one collapsed entry:

```console
$ git status --porcelain
?? .omh/
```

## Why that breaks update

`_assess_parked_branch_switch()` (`hermes_cli/update_cmd.py`) reads that output verbatim:

```python
if status.stdout.strip():
    return False, "dirty"
```

`dirty` blocks the auto-switch, the code update is skipped, and the run exits 1. The guard itself is correct and doing its job — refusing to touch a tree it cannot vouch for. The bug is that repo-owned scaffolding makes the tree *look* dirty, so the guard fires on a checkout that has no user work in it at all.

Impact is quiet and cumulative: every update attempt fails the same way, so the checkout drifts further behind main while the dialog says nothing actionable. On the reporting machine that was **116 commits over several weeks**.

## Fix

Ignore the ephemeral runtime from the repo-level `.gitignore`, where git will actually read it.

Deliberately **not** a blanket `.omh/` rule. `.omh/README.md` documents selective sharing on purpose — `state/`, `logs/`, `progress/` are per-session, while `specs/`, `plans/`, `research/` are durable decision artifacts that must stay committable. A blanket rule would silently swallow them; I hit exactly that while testing the first draft of this patch.

## Verification

Clean worktree off `main`, with the scaffolding materialised:

| Check | Before | After |
|---|---|---|
| `git status --porcelain` | `?? .omh/` (dirty → update exits 1) | *empty* (clean → update proceeds) |
| `git check-ignore .omh/state/x.json` | not ignored | ignored |
| `git check-ignore .omh/plans/p.md` | not ignored | **still not ignored** (durable, trackable) |
| `git check-ignore .omh/specs/s.md` | not ignored | **still not ignored** (durable, trackable) |

Confirmed on the affected machine: adding the same rule to `.git/info/exclude` flipped `_assess_parked_branch_switch()` from `(False, 'dirty')` to `(True, 'unmerged:1')`, and `hermes update` then completed and pulled all 116 commits.

Windows 11, git 2.x.