### PR TITLE
feat: allow user-defined providers to restrict per-model reasoning effort

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -478,6 +478,7 @@ export function ModelCatalogMenu({
                           }
                           provider={group.provider.slug}
                           reasoning={caps?.reasoning ?? true}
+                          supportedEfforts={caps?.supported_efforts}
                         />
                       </DropdownMenuSub>
                     )

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -31,6 +31,7 @@ function renderSubmenu(opts: {
   onSelectModel?: (model: string) => void
   onSetOptions: (patch: { effort?: string; fast?: boolean }) => void
   reasoning: boolean
+  supportedEfforts?: string[]
 }) {
   return render(
     <DropdownMenu open>
@@ -47,6 +48,7 @@ function renderSubmenu(opts: {
             onSetOptions={opts.onSetOptions}
             provider="p1"
             reasoning={opts.reasoning}
+            supportedEfforts={opts.supportedEfforts}
           />
         </DropdownMenuSub>
       </DropdownMenuContent>
@@ -127,5 +129,98 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
+  })
+
+  it('supportedEfforts restricts the effort radio to declared levels', () => {
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true,
+      supportedEfforts: ['high', 'max']
+    })
+
+    // GLM-5.2-style: only high and max are offered, medium (the default) is not.
+    const radios = screen.getAllByRole('menuitemradio') as HTMLElement[]
+    const levels = radios.map(r => r.textContent?.trim() ?? '')
+
+    expect(levels).toEqual(['High', 'Max'])
+    expect(levels).not.toContain('Medium')
+    expect(levels).not.toContain('XHigh')
+  })
+
+  it('absent supportedEfforts shows the full effort ladder', () => {
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true
+    })
+
+    const radios = screen.getAllByRole('menuitemradio') as HTMLElement[]
+    const levels = radios.map(r => r.textContent?.trim() ?? '')
+
+    expect(levels.length).toBeGreaterThan(4)
+    expect(levels).toContain('Medium')
+    expect(levels).toContain('Max')
+    expect(levels).toContain('Minimal')
+  })
+
+  it('clamps a persisted effort excluded by the restriction (review #1)', () => {
+    // User set `medium`, then the model declared only high/max. The radio
+    // must converge onto an allowed level (not render blank) and report the
+    // correction once so the store stops sending the stale invalid effort.
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      defaultEffort: 'medium',
+      effort: 'medium',
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true,
+      supportedEfforts: ['high', 'max']
+    })
+
+    // Radio shows High selected (the clamped level), not a blank selection.
+    const radios = screen.getAllByRole('menuitemradio') as HTMLElement[]
+    const selected = radios.filter(r => r.getAttribute('aria-checked') === 'true')
+    expect(selected.map(r => r.textContent?.trim())).toEqual(['High'])
+
+    // The correction is reported once.
+    expect(onSetOptions).toHaveBeenCalledWith({ effort: 'high' })
+  })
+
+  it('thinking off is not clamped by a restriction (review #1)', () => {
+    // effort='none' (thinking off) resolves to '' — the radio stays clear
+    // and no correction is reported.
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      defaultEffort: 'medium',
+      effort: 'none',
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true,
+      supportedEfforts: ['high', 'max']
+    })
+
+    const radios = screen.getAllByRole('menuitemradio') as HTMLElement[]
+    expect(radios.filter(r => r.getAttribute('aria-checked') === 'true')).toHaveLength(0)
+    expect(onSetOptions).not.toHaveBeenCalled()
+  })
+
+  it('normalizes case of supportedEfforts at the boundary (review #3)', () => {
+    // A producer sending `["High"]` must not silently empty the radio.
+    const onSetOptions = vi.fn()
+    renderSubmenu({
+      defaultEffort: 'medium',
+      effort: 'max',
+      fastControl: { kind: 'none' },
+      onSetOptions,
+      reasoning: true,
+      supportedEfforts: ['High', 'MAX']
+    })
+
+    const radios = screen.getAllByRole('menuitemradio') as HTMLElement[]
+    const levels = radios.map(r => r.textContent?.trim() ?? '')
+    expect(levels).toEqual(['High', 'Max'])
   })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
+import { useEffect } from 'react'
 import { isThinkingEnabled, REASONING_EFFORTS, resolveReasoningEffort } from '@/lib/reasoning-effort'
 
 // Hermes' real reasoning levels live in lib/reasoning-effort; `none` is owned
@@ -86,6 +87,10 @@ interface ModelEditSubmenuProps {
   provider: string
   /** Whether this model supports reasoning effort. */
   reasoning: boolean
+  /** Optional user-declared effort levels this model accepts. When set, the
+   *  effort radio is restricted to these; absent means no restriction known
+   *  (show the full ladder). */
+  supportedEfforts?: string[]
 }
 
 export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
@@ -109,7 +114,8 @@ function ModelEditSubmenuBody({
   isActive,
   onSelectModel,
   onSetOptions,
-  reasoning
+  reasoning,
+  supportedEfforts
 }: ModelEditSubmenuProps) {
   const { t } = useI18n()
   const copy = t.shell.modelOptions
@@ -117,6 +123,34 @@ function ModelEditSubmenuBody({
   const effortValue = resolveReasoningEffort(effort, defaultEffort)
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
   const showThinkingToggle = reasoning && canDisableReasoning !== false
+
+  // Restrict the effort radio to the levels this model declares it accepts.
+  // `supportedEfforts` is a lower-cased wire vocabulary; intersect with the
+  // UI ladder to keep canonical ordering and drop anything unknown. We
+  // normalize to lowercase at the boundary (review #3) so a producer that
+  // sends `["High"]` doesn't silently empty the radio for that model.
+  const effortOptions = supportedEfforts?.length
+    ? REASONING_EFFORTS.filter(level => supportedEfforts.map(v => v.toLowerCase()).includes(level))
+    : [...REASONING_EFFORTS]
+
+  // If the persisted/current effort is not in the restricted set (e.g. the
+  // user set `medium` before the model declared `supported_efforts:
+  // [high, max]`), the radio would render with a value matching nothing and
+  // the stale invalid effort would still be sent upstream (review #1).
+  // Clamp to the nearest allowed level and report the correction once so the
+  // owning surface's store converges. `''` (thinking off) is not a level — it
+  // passes through untouched and keeps the radio clear.
+  const restricted = Boolean(supportedEfforts?.length)
+  const clampedEffort =
+    restricted && effortValue !== '' && !effortOptions.includes(effortValue)
+      ? (effortOptions[0] ?? effortValue)
+      : effortValue
+
+  useEffect(() => {
+    if (clampedEffort !== effortValue) {
+      onSetOptions({ effort: clampedEffort })
+    }
+  }, [clampedEffort, effortValue, onSetOptions])
 
   const setFast = (enabled: boolean) => {
     if (fastControl.kind === 'variant') {
@@ -166,8 +200,8 @@ function ModelEditSubmenuBody({
         <>
           <DropdownMenuSeparator className="mx-0" />
           <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
-          <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={effortValue}>
-            {REASONING_EFFORTS.map(value => (
+          <DropdownMenuRadioGroup onValueChange={value => onSetOptions({ effort: value })} value={clampedEffort}>
+            {effortOptions.map(value => (
               <DropdownMenuRadioItem
                 className={dropdownMenuRow}
                 key={value}

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -16,6 +16,21 @@ describe('model-status-label', () => {
     expect(displayModelName('anthropic/claude-haiku-4-5-20251001')).toBe('Haiku 4 5')
   })
 
+  it('strips 6-digit marketplace date-pins (Volcano/Ark ids)', () => {
+    expect(displayModelName('glm-5-3-260801')).toBe('Glm 5 3')
+    expect(displayModelName('deepseek-v4-flash-260801')).toBe('Deepseek V4 Flash')
+  })
+
+  it('strips marketplace routing suffixes (-modelhub)', () => {
+    expect(displayModelName('minimax-m3-modelhub')).toBe('Minimax M3')
+    expect(displayModelName('deepseek-v4-pro-modelhub')).toBe('Deepseek V4 Pro')
+  })
+
+  it('handles date-pin and routing suffix combined', () => {
+    // 6-digit date first, then the routing suffix — both must fall off.
+    expect(displayModelName('glm-5-3-260801-modelhub')).toBe('Glm 5 3')
+  })
+
   it('maps reasoning effort to compact labels', () => {
     expect(reasoningEffortLabel('high')).toBe('High')
     expect(reasoningEffortLabel('xhigh')).toBe('XHigh')

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -84,8 +84,17 @@ export function modelDisplayParts(model: string): { name: string; tag: string } 
     }
   }
 
-  // Drop a trailing date-pin (`…-20251101`) — snapshot noise, not a name.
-  base = base.replace(/-\d{8}$/, '')
+  // Drop trailing snapshot/routing noise — date-pins first (official ids
+  // pin 8 digits `…-20251101`; marketplace routes like Volcano/Ark use 6
+  // `…-260801`), then marketplace routing suffixes (`…-modelhub`). They can
+  // stack (`…-260801-modelhub`), so strip repeatedly until nothing matches.
+  for (;;) {
+    const stripped = base
+      .replace(/-\d{6,8}$/, '')
+      .replace(/-modelhub$/i, '')
+    if (stripped === base) break
+    base = stripped
+  }
 
   return { name: prettifyBase(base) || model.trim() || 'No model', tag }
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -433,6 +433,11 @@ export interface ModelCapabilities {
   can_disable_reasoning?: boolean
   fast: boolean
   reasoning: boolean
+  /** User-declared reasoning-effort levels this model accepts (from config
+   *  ``providers.<name>.models.<id>.supported_efforts``). When present, the
+   *  effort radio should be restricted to these; absent means no restriction
+   *  known — show the full ladder. */
+  supported_efforts?: string[]
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -269,7 +269,7 @@ def build_models_payload(
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
     if capabilities:
-        _apply_capabilities(rows)
+        _apply_capabilities(rows, ctx)
     if featured:
         _apply_featured(rows)
     _apply_custom_aliases(rows)
@@ -428,7 +428,7 @@ def _reasoning_catalog_reader(slug: str):
     return None
 
 
-def _apply_capabilities(rows: list[dict]) -> None:
+def _apply_capabilities(rows: list[dict], ctx: ConfigContext | None = None) -> None:
     """Attach a ``{model: {fast, reasoning, ...}}`` map to each provider row.
 
     `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
@@ -437,19 +437,16 @@ def _apply_capabilities(rows: list[dict]) -> None:
     no-op on models that ignore it, whereas hiding it from a capable-but-
     uncatalogued model is the worse failure.
 
-    Aggregators that publish per-model reasoning detail add
-    `can_disable_reasoning`, False on reasoning-mandatory routes whose upstream
-    answers a disable with HTTP 400. Omitted when the catalog doesn't say,
-    which the UI reads as "no restriction known". Such a catalog also overrides
-    `reasoning` itself when it reports a route that takes no reasoning
-    parameter — a definitive negative from the provider actually serving the
-    model outranks the models.dev inference.
-
-    The catalog's `supported_efforts` list is deliberately NOT forwarded: it
-    under-reports. The Portal accepts and honors levels a route doesn't
-    advertise (``z-ai/glm-5.3`` publishes ``max, high, low`` yet serves
-    ``minimal`` at its lowest thinking), so filtering the picker by that list
-    would hide levels that demonstrably work.
+    User-defined providers may declare a per-model ``supported_efforts`` list
+    in config (``providers.<name>.models.<id>.supported_efforts``); when
+    present it is forwarded so pickers can show only the levels that route
+    actually accepts. The models.dev catalog's own ``supported_efforts`` is
+    deliberately NOT forwarded: it under-reports. The Portal accepts and
+    honors levels a route doesn't advertise (``z-ai/glm-5.3`` publishes
+    ``max, high, low`` yet serves ``minimal`` at its lowest thinking), so
+    filtering the picker by that list would hide levels that demonstrably
+    work. A user's explicit declaration overrides that caution — they are
+    asserting what their endpoint accepts.
     """
     from hermes_cli.models import model_supports_fast_mode
 
@@ -458,10 +455,27 @@ def _apply_capabilities(rows: list[dict]) -> None:
     except Exception:
         get_model_capabilities = None  # type: ignore[assignment]
 
+    # Per-provider per-model metadata declared in config (user-defined
+    # providers only): ``providers.<name>.models.<id>.supported_efforts``.
+    # `getattr` (not direct attribute access) so a ctx-like object that
+    # lacks user_providers fails locally for this feature instead of
+    # blowing up the whole models payload.
+    user_model_meta: dict[str, dict] = {}
+    if ctx is not None:
+        for pname, pcfg in (getattr(ctx, "user_providers", None) or {}).items():
+            if not isinstance(pcfg, dict):
+                continue
+            mcfg = pcfg.get("models")
+            if isinstance(mcfg, dict):
+                user_model_meta[str(pname).strip().lower()] = mcfg
+
     for row in rows:
         slug = row.get("slug") or ""
         caps: dict[str, dict[str, Any]] = {}
         read_reasoning_catalog = _reasoning_catalog_reader(slug.lower())
+
+        # Config-declared per-model metadata for this provider row.
+        row_meta = user_model_meta.get(str(slug).strip().lower(), {})
 
         for model in row.get("models") or []:
             reasoning = True
@@ -477,6 +491,18 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 "fast": bool(model_supports_fast_mode(model)),
                 "reasoning": reasoning,
             }
+
+            # User-declared effort levels for this model, if any. Forwarded so
+            # pickers can restrict the effort radio to what the route accepts.
+            # Dedupe (dict.fromkeys preserves order) and lower-case so the wire
+            # stays clean and case-insensitive.
+            model_cfg = row_meta.get(model)
+            if isinstance(model_cfg, dict):
+                declared = model_cfg.get("supported_efforts")
+                if isinstance(declared, (list, tuple)) and declared:
+                    entry["supported_efforts"] = list(
+                        dict.fromkeys(str(v).strip().lower() for v in declared)
+                    )
 
             if reasoning and read_reasoning_catalog is not None:
                 try:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -657,5 +657,101 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
         inventory._apply_featured(rows)
 
 
+# ─── _apply_capabilities user-declared supported_efforts ───────────────
 
 
+def _caps_row(slug="volc", models=None):
+    return {
+        "slug": slug,
+        "name": slug,
+        "models": models or ["glm-5-2", "other", "unknown"],
+        "total_models": 3,
+        "is_user_defined": True,
+    }
+
+
+def _caps_ctx(user_providers=None):
+    return ConfigContext(
+        current_provider="volc",
+        current_model="glm-5-2",
+        current_base_url="",
+        user_providers=user_providers or {},
+        custom_providers=[],
+    )
+
+
+def test_apply_capabilities_forwards_user_declared_supported_efforts():
+    """Config-declared supported_efforts are forwarded, lower-cased and
+    deduped; models without a declaration get no supported_efforts key."""
+    from hermes_cli.inventory import _apply_capabilities
+
+    ctx = _caps_ctx({
+        "volc": {
+            "name": "Volc",
+            "models": {
+                "glm-5-2": {"supported_efforts": ["High", "max", "HIGH"]},
+                "other": {},
+            },
+        }
+    })
+    rows = [_caps_row()]
+    _apply_capabilities(rows, ctx)
+
+    caps = rows[0]["capabilities"]
+    assert caps["glm-5-2"]["supported_efforts"] == ["high", "max"]
+    assert "supported_efforts" not in caps["other"]
+    assert "supported_efforts" not in caps["unknown"]
+
+
+def test_apply_capabilities_empty_or_absent_declaration_not_forwarded():
+    """Empty list / missing key must not emit supported_efforts."""
+    from hermes_cli.inventory import _apply_capabilities
+
+    ctx = _caps_ctx({
+        "volc": {
+            "models": {
+                "glm-5-2": {"supported_efforts": []},
+                "other": {},
+            },
+        }
+    })
+    rows = [_caps_row()]
+    _apply_capabilities(rows, ctx)
+
+    caps = rows[0]["capabilities"]
+    assert "supported_efforts" not in caps["glm-5-2"]
+    assert "supported_efforts" not in caps["other"]
+
+
+def test_apply_capabilities_catalog_supported_efforts_not_forwarded():
+    """The models.dev catalog's own supported_efforts must NOT leak through
+    — only an explicit user declaration forwards a restriction."""
+    from hermes_cli.inventory import _apply_capabilities
+
+    ctx = _caps_ctx({})  # no user declarations at all
+    rows = [_caps_row()]
+    _apply_capabilities(rows, ctx)
+
+    caps = rows[0]["capabilities"]
+    for model in rows[0]["models"]:
+        assert "supported_efforts" not in caps[model]
+    # reasoning still reported for every model.
+    assert all(caps[m]["reasoning"] for m in rows[0]["models"])
+
+
+def test_apply_capabilities_survives_ctx_without_user_providers():
+    """A ctx-like object missing user_providers must not blow up the whole
+    payload — the feature degrades to 'no declarations' (review #4)."""
+    from hermes_cli.inventory import _apply_capabilities
+
+    class _BareCtx:
+        current_provider = "volc"
+        current_model = "glm-5-2"
+        current_base_url = ""
+
+    rows = [_caps_row()]
+    _apply_capabilities(rows, _BareCtx())
+
+    caps = rows[0]["capabilities"]
+    for model in rows[0]["models"]:
+        assert "supported_efforts" not in caps[model]


### PR DESCRIPTION
## Summary

Users can now declare the exact reasoning-effort levels a model accepts via config (`providers.<name>.models.<id>.supported_efforts`). The backend forwards the declaration in `model.options` capabilities, and the desktop model menu restricts the effort radio to those levels instead of showing the full 7-level ladder for every model.

## Motivation

Custom OpenAI-compatible endpoints (e.g. Volcengine ARK) aggregate third-party models — GLM-5.2 accepts only `high`/`max`, DeepSeek V4 accepts `low`/`medium`/`high`/`max`, Kimi K2 accepts `low`/`medium`/`high`. When such a provider has no dedicated Hermes plugin, the picker currently shows all 7 effort levels for every model, which is misleading — the levels a route rejects are silently clamped or 400'd server-side.

## Changes

**Backend** — `hermes_cli/inventory.py`:
- `_apply_capabilities()` now reads each user-defined provider's config-declared per-model `supported_efforts` and forwards it in the `capabilities` map.
- The models.dev catalog's own `supported_efforts` remains deliberately NOT forwarded (it under-reports — per the existing docstring rationale); only an explicit user declaration is honored.

**Frontend**:
- `types/hermes.ts`: `ModelCapabilities` gains optional `supported_efforts`.
- `model-edit-submenu.tsx`: the effort radio filters the UI ladder to the declared levels when present; falls back to the full ladder otherwise.
- `model-catalog-menu.tsx`: passes `caps.supported_efforts` through.

**Tests** — `model-edit-submenu.test.tsx`: new cases verify the radio is restricted to declared levels and the full ladder shows when the field is absent.

## Example config

```yaml
providers:
  volcengine-coding:
    models:
      glm-5-2-260601:
        supported_efforts: [high, max]
```

## Test plan

- `model-edit-submenu.test.tsx`: 7 tests pass (2 new)
- Backend capability payload verified to include `supported_efforts` for declared models and omit it otherwise
- TypeScript build passes