### PR TITLE
fix(streaming): require terminal evidence for tool calls

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4427,8 +4427,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(possible upstream error or malformed SSE response)."
             )
 
-        # A stream that delivered a tool call but only partial/unparseable
-        # JSON args splits into two very different cases:
+        # A stream that delivered a tool call without an explicit finish
+        # marker is not executable, even if its JSON parses or can be repaired.
+        # Iterator EOF proves only that transport consumption stopped; it does
+        # not authorize the tool-call boundary. The two terminal cases are:
         #
         #   1. Provider sent finish_reason="length" → a genuine output-cap
         #      truncation.  Boosting max_tokens on retry is the right move.
@@ -4446,17 +4448,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         #      due to output length limit" — the red herring this guards
         #      against.  Route it through the partial-stream-stub path
         #      instead so the loop reports an honest mid-tool-call stream
-        #      drop and fails fast rather than escalating output budget.
-        _tool_args_dropped_no_finish = has_truncated_tool_args and finish_reason is None
-        if _tool_args_dropped_no_finish:
+        #      drop and fails fast rather than escalating output budget. This
+        #      also covers complete-looking JSON: payload validity is not
+        #      terminal evidence or permission to execute.
+        _tool_call_dropped_no_finish = bool(tool_calls_acc) and finish_reason is None
+        if _tool_call_dropped_no_finish:
             _dropped_names = [
                 (tool_calls_acc[idx]["function"]["name"] or "?")
                 for idx in sorted(tool_calls_acc)
             ]
             logger.warning(
-                "Stream ended with no finish_reason while a tool call's "
-                "arguments were still incomplete (tools=%s); treating as a "
-                "mid-tool-call stream drop, not an output-length truncation.",
+                "Stream ended with no finish_reason after delivering tool-call "
+                "payload (tools=%s); treating as a mid-tool-call stream drop, "
+                "not permission to execute or an output-length truncation.",
                 _dropped_names,
             )
             return _build_partial_stream_stub(

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -207,6 +207,85 @@ class TestCleanStreamEndBeforeAnyToolArgs:
         assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
 
 
+# ── Complete-looking payload without terminal evidence ────────────────────
+
+class TestToolCallsRequireTerminalEvidence:
+    """Valid JSON and iterator EOF do not authorize tool execution."""
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            '{"confirm":true}',
+            '{"confirm":true,}',
+        ],
+        ids=["valid-json", "repairable-json"],
+    )
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_payload_without_finish_reason_routes_to_stub(
+        self, _mock_close, mock_create, monkeypatch, arguments,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _unterminated_stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_unterminated",
+                    name="dangerous_tool",
+                    arguments=arguments,
+                ),
+            ])
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _unterminated_stream()
+        )
+        mock_create.return_value = mock_client
+
+        response = _make_agent()._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None
+        assert response._dropped_tool_names == ["dangerous_tool"]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_explicit_tool_calls_terminal_preserves_payload(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _complete_stream():
+            yield _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(
+                        index=0,
+                        tc_id="call_complete",
+                        name="read_file",
+                        arguments='{"path":"README.md"}',
+                    ),
+                ],
+                finish_reason="tool_calls",
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _complete_stream()
+        )
+        mock_create.return_value = mock_client
+
+        response = _make_agent()._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "tool_calls"
+        tool_calls = response.choices[0].message.tool_calls
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "read_file"
+        assert tool_calls[0].function.arguments == '{"path":"README.md"}'
+
+
 # ── Mixed response: one complete call, one dropped (#80498) ─────────────────
 
 class TestMixedToolCallsOneDroppedOneComplete:


### PR DESCRIPTION
## What does this PR do?

This prevents a streamed tool call from becoming executable when the provider iterator ends without an explicit `finish_reason`.

The existing guard only treated missing terminal evidence as a partial stream when the accumulated arguments were truncated or unparseable. Valid JSON, and JSON repaired by the existing argument-repair path, could fall through to the later `finish_reason or "stop"` fallback and be returned as a normal response. This change keeps payload validity separate from terminal evidence: any accumulated tool call without an explicit finish marker is routed to the existing partial-stream recovery path, while an explicit `finish_reason="tool_calls"` still preserves the payload.

## Related Issue

Follow-up to #80498 and #42314. This PR does not close an issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/chat_completion_helpers.py` so any accumulated tool call without an explicit `finish_reason` uses the existing partial-stream stub instead of being normalized as a completed response.
- Add regression coverage in `tests/run_agent/test_partial_stream_finish_reason.py` for valid JSON, repairable JSON, and the explicit `tool_calls` terminal control case.

## How to Test

1. Run `pytest tests/run_agent/test_partial_stream_finish_reason.py -q` (20 tests).
2. Run the adjacent streaming, Relay, and agent regression files listed below (388 tests total):
   ```bash
   pytest -q \
     tests/run_agent/test_streaming.py \
     tests/run_agent/test_partial_stream_finish_reason.py \
     tests/run_agent/test_stream_single_writer_65991.py \
     tests/run_agent/test_stream_interrupt_retry.py \
     tests/run_agent/test_streaming_tool_call_repair.py \
     tests/agent/test_relay_llm.py \
     tests/run_agent/test_run_agent.py
   ```
3. Remove the production change while retaining the new tests: the valid and repairable no-finish cases fail on `upstream/main`, while the explicit-terminal control passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the behavior and regression tests are self-contained
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Focused regression file: **20 passed**.
- Adjacent streaming/Relay/agent suite: **388 passed, 0 failed** after rebasing onto current `upstream/main`.
- Ruff, `git diff --check`, and the Windows footgun scanner pass for the two changed files.
- The full local wrapper run was not green on this macOS host: **38,244 passed, 98 failed, 365 skipped** across 3,270 files. The all-tests-pass checkbox is intentionally left unchecked. In clean detached worktrees, two sampled failure classes reproduced identically on both unmodified `upstream/main` and this commit: the Feishu connect-time rebinding test under the active macOS system proxy (3/3 failures on each SHA), and the scale-to-zero Unix-socket path-limit file (2 failures on each SHA). I am not claiming the remaining unrelated full-suite failures as baseline-confirmed.
- The first upstream CI run passed every substantive check outside the main Python lane; the derived `All required checks pass` gate failed because that lane was non-green. The Python lane reported six additional flaky files that failed once and passed its built-in retry, then ended non-green on two timing-sensitive tests: `test_ws_orphan_reap_releases_resume_lock_before_slow_teardown` and `test_bare_path_history_lookup_timeout_fails_open`. The former also failed on the official `main` run for this PR's exact base SHA ([run 32947494491](https://github.com/NousResearch/hermes-agent/actions/runs/32947494491)); the latter failed about eight minutes before this PR on an unrelated branch whose diff did not touch that test ([run 32949318481](https://github.com/NousResearch/hermes-agent/actions/runs/32949318481)). Both terminal failures pass 10/10 on this head and 10/10 on the exact base in isolated local runs, and neither their tests nor production implementations differ in this PR. This is evidence of suspected upstream timing flakiness, not a claim that every transient failure has been baseline-confirmed. Direct Actions reruns require repository admin rights, so the supported maintainer `ci-reviewed` label/rerun path is pending; I did not create a no-op commit or rewrite the published branch to manufacture a new run.
