### PR TITLE
chore(cli): remove eight orphaned startup fast-path wrappers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -374,50 +374,13 @@ def _suppress_mouse_residue_early() -> None:
 _suppress_mouse_residue_early()
 
 
-def _is_termux_startup_environment_fast() -> bool:
-    """Tiny Termux check for pre-import startup shortcuts."""
-    return _startup_fast.is_termux_env()
-
-
 def _is_termux_fast_version_argv(argv: list[str]) -> bool:
     return _startup_fast.is_termux_fast_version_argv(argv)
-
-
-def _is_global_fast_version_argv(argv: list[str]) -> bool:
-    return _startup_fast.is_global_fast_version_argv(argv)
-
-
-def _is_container_startup_environment_fast() -> bool:
-    return _startup_fast.is_container_startup_environment()
-
-
-def _active_profile_may_override_home_fast(hermes_root: str) -> bool:
-    return _startup_fast.active_profile_may_override_home(hermes_root)
-
-
-def _container_mode_may_be_active_fast() -> bool:
-    return _startup_fast.container_mode_may_be_active()
-
-
-def _read_openai_version_fast() -> str | None:
-    """Read OpenAI SDK version without importing ``importlib.metadata``."""
-    return _startup_fast.read_openai_version()
-
-
-def _print_fast_version_info() -> None:
-    _startup_fast.print_fast_version_info()
 
 
 def _try_ultrafast_version() -> bool:
     """Handle ``hermes --version`` before config/logging imports."""
     return _startup_fast.try_fast_version()
-
-
-def _try_termux_ultrafast_version() -> bool:
-    """Backward-compatible test hook for the Termux startup fast path."""
-    if not _is_termux_startup_environment_fast():
-        return False
-    return _try_ultrafast_version()
 
 
 _ensure_project_root_on_path_fast()


### PR DESCRIPTION
chore(cli): remove eight orphaned startup fast-path wrappers

The `refactor: single chokepoint for the pre-import version fast path`
change moved this logic into `hermes_cli/_startup_fast`, leaving thin
delegating wrappers in `main.py` that nothing calls.

Removed (all module-level, zero references outside their own def):

- `_is_termux_startup_environment_fast`
- `_is_global_fast_version_argv`
- `_is_container_startup_environment_fast`
- `_active_profile_may_override_home_fast`
- `_container_mode_may_be_active_fast`
- `_read_openai_version_fast`
- `_print_fast_version_info`
- `_try_termux_ultrafast_version`

Each was a one-line delegation to a live `_startup_fast` function, so no
behaviour changes: the underlying implementations keep their existing call
sites. `_is_termux_startup_environment_fast` was reached only from
`_try_termux_ultrafast_version`, so it is removed in the same pass.

`_try_termux_ultrafast_version` documented itself as a "backward-compatible
test hook", but no test references it — `git grep` across `tests/` returns
nothing for any of the eight names.

Pure deletion: 37 lines removed, 0 added.

Verification:
- `hermes --version` still resolves through the fast path (prints Python /
  OpenAI SDK / update status).
- `tests/hermes_cli/ -k "version or startup or termux or fast"`:
  5 failed, 139 passed, 8 skipped — byte-identical to the same run on
  pristine origin/main (baseline captured by stashing the deletion).
  The 5 failures are pre-existing and unrelated.
