### PR TITLE
fix(session_search): recover from an invalid scroll anchor instead of failing

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -393,13 +393,23 @@ class TestScrollShape:
             "reason": "invalid_around_message_id",
             "requested_around_message_id": 0,
             "message": (
-                "The requested message id is not in this session. A bounded "
-                "session read was returned instead. Do not retry scroll with a "
-                "guessed id; use only an id returned in messages, or use query "
-                "discovery to find a new anchor."
+                "The requested message id cannot anchor a window in this "
+                "session. It may be absent or stale, or the session may have "
+                "no messages here. A bounded session read was returned instead. "
+                "Do not retry scroll with a guessed id; use only an id returned "
+                "in messages, or use query discovery to find a new anchor."
             ),
         }
         assert result["messages"]
+
+    def test_scroll_with_missing_session_preserves_not_found_error(self, db):
+        result = json.loads(session_search(
+            session_id="missing", around_message_id=0, db=db
+        ))
+
+        assert result["success"] is False
+        assert result["error"] == "session_id not found: missing"
+        assert "scroll_recovery" not in result
 
 
     def test_scroll_rejects_active_delegation_child_in_current_lineage(self, db):

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -375,6 +375,32 @@ class TestScrollShape:
         ))
         assert result["window"] == 20
 
+    def test_scroll_with_invalid_anchor_returns_bounded_read_recovery(self, db):
+        _seed_modpack_sessions(db)
+
+        result = json.loads(session_search(
+            session_id="s_oldest", around_message_id=0, db=db
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "read"
+        assert list(result)[:4] == [
+            "success", "mode", "scroll_recovery", "next_step"
+        ]
+        assert result["session_id"] == "s_oldest"
+        assert result["message_count"] == 5
+        assert result["scroll_recovery"] == {
+            "reason": "invalid_around_message_id",
+            "requested_around_message_id": 0,
+            "message": (
+                "The requested message id is not in this session. A bounded "
+                "session read was returned instead. Do not retry scroll with a "
+                "guessed id; use only an id returned in messages, or use query "
+                "discovery to find a new anchor."
+            ),
+        }
+        assert result["messages"]
+
 
     def test_scroll_rejects_active_delegation_child_in_current_lineage(self, db):
         db.create_session("s_current", source="cli")

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -482,11 +482,14 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
             view, messages, session_id = rebind_view, rebind_view["window"], owning
             session_meta = _get_session_meta(db, owning) or session_meta
     if not messages:
-        # Do not surface a guessed or stale anchor as a retryable tool failure.
-        # Models otherwise retry the same scroll shape with another fabricated
-        # id, burning the turn before the loop guardrail can intervene. A
-        # bounded read is useful immediately and exposes real ids for a later
-        # scroll when one is genuinely needed.
+        # Do not surface an unusable anchor as a retryable tool failure.
+        # This can mean the id is guessed/stale or that the named session has
+        # no messages to anchor. Models otherwise retry the same scroll shape
+        # with another fabricated id, burning the turn before the loop guardrail
+        # can intervene. A bounded read is useful immediately and exposes real
+        # ids for a later scroll when one is genuinely needed. Deliberately use
+        # the read shape's own head/tail defaults instead of the scroll window:
+        # this fallback is discovery recovery, not another centered slice.
         try:
             fallback = json.loads(_read_session(db, session_id))
         except Exception:
@@ -497,10 +500,11 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
                 "reason": "invalid_around_message_id",
                 "requested_around_message_id": around_message_id,
                 "message": (
-                    "The requested message id is not in this session. A bounded "
-                    "session read was returned instead. Do not retry scroll with a "
-                    "guessed id; use only an id returned in messages, or use query "
-                    "discovery to find a new anchor."
+                    "The requested message id cannot anchor a window in this "
+                    "session. It may be absent or stale, or the session may have "
+                    "no messages here. A bounded session read was returned instead. "
+                    "Do not retry scroll with a guessed id; use only an id returned "
+                    "in messages, or use query discovery to find a new anchor."
                 ),
             }
             # Put the recovery contract before the transcript.  The bounded read

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -380,7 +380,7 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
                session_meta=_session_meta_block(meta), message_count=total, truncated=truncated,
                messages=shaped[:head] + shaped[-tail:] if truncated else shaped,
                **({"message": (f"Session has {total} messages; showing first {head} + last {tail}. "
-                               "Pass around_message_id (any id above) to scroll the middle.")} if truncated else {}))
+                               "Use only a message id returned above to scroll the middle; do not guess one.")} if truncated else {}))
 
 
 def _read_with_profile_fallback(db, sid: str, profile: Optional[str]) -> str:
@@ -482,6 +482,46 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
             view, messages, session_id = rebind_view, rebind_view["window"], owning
             session_meta = _get_session_meta(db, owning) or session_meta
     if not messages:
+        # Do not surface a guessed or stale anchor as a retryable tool failure.
+        # Models otherwise retry the same scroll shape with another fabricated
+        # id, burning the turn before the loop guardrail can intervene. A
+        # bounded read is useful immediately and exposes real ids for a later
+        # scroll when one is genuinely needed.
+        try:
+            fallback = json.loads(_read_session(db, session_id))
+        except Exception:
+            logging.debug("scroll recovery read failed for %s", session_id, exc_info=True)
+            fallback = {}
+        if fallback.get("success"):
+            recovery = {
+                "reason": "invalid_around_message_id",
+                "requested_around_message_id": around_message_id,
+                "message": (
+                    "The requested message id is not in this session. A bounded "
+                    "session read was returned instead. Do not retry scroll with a "
+                    "guessed id; use only an id returned in messages, or use query "
+                    "discovery to find a new anchor."
+                ),
+            }
+            # Put the recovery contract before the transcript.  The bounded read
+            # can be large; if its metadata is appended afterwards, models can
+            # miss that this was a successful recovery and retry the same bad
+            # scroll anchor.
+            recovery_response = {
+                "success": True,
+                "mode": "read",
+                "scroll_recovery": recovery,
+                "next_step": (
+                    "Do not retry this scroll anchor. Use a message id returned "
+                    "in messages, or query discovery for a new anchor."
+                ),
+            }
+            recovery_response.update({
+                key: value
+                for key, value in fallback.items()
+                if key not in {"success", "mode", "scroll_recovery"}
+            })
+            return json.dumps(recovery_response, ensure_ascii=False)
         return tool_error(f"around_message_id {around_message_id} not in session_id {session_id}", success=False)
     return _ok(
         mode="scroll", session_id=session_id, around_message_id=around_message_id,
@@ -620,17 +660,17 @@ SESSION_SEARCH_SCHEMA = {
             "session_id": {
                 "type": "string",
                 "description": (
-                    "Scroll shape. Session to read inside. Use the session_id returned "
-                    "from a prior discovery call. Must be paired with "
-                    "around_message_id."
+                    "Session to read inside. Pair with around_message_id only for "
+                    "scrolling; use session_id alone for a bounded read. For scroll, "
+                    "prefer a session_id returned from a prior discovery call."
                 ),
             },
             "around_message_id": {
                 "type": "integer",
                 "description": (
-                    "Scroll shape. Message id to center the window on — use "
-                    "match_message_id from a discovery result, or any id from a "
-                    "prior window."
+                    "Scroll shape. Message id to center the window on. Use only "
+                    "match_message_id from a discovery result, or an id from a prior "
+                    "window — never a guessed id. An unknown id returns a bounded read."
                 ),
             },
             "window": {


### PR DESCRIPTION
## Symptom

`session_search` SCROLL takes `session_id` + `around_message_id`. When that anchor is not in the session — a guessed id, or one that has gone stale — `_scroll()` finds no messages and returns a plain tool failure.

For a model that is the worst possible answer:

- the failure is **retryable**, so retrying looks reasonable
- the tool schema still advertises the same shape, so the model re-sends it
- nothing in the error says where a *valid* anchor is supposed to come from

The observed behaviour is a retry loop: the model invents another id, fails again, and burns the turn before any loop guardrail can intervene. The tool text made this worse by inviting it — a truncated read told the model to "pass around_message_id (any id above)".

## Fix

Return a **bounded session read** instead, tagged with a `scroll_recovery` block that names the rejected id and states plainly that anchors come from prior results rather than being guessed:

```json
{
  "success": true,
  "mode": "read",
  "scroll_recovery": {
    "reason": "invalid_around_message_id",
    "requested_around_message_id": 0,
    "message": "The requested message id is not in this session. A bounded session read was returned instead. Do not retry scroll with a guessed id; use only an id returned in messages, or use query discovery to find a new anchor."
  },
  "next_step": "Do not retry this scroll anchor. ..."
}
```

The recovery keys are emitted **before** the transcript. This is deliberate: a bounded read can be long, and metadata appended after it is easy to miss — which would reintroduce the very retry the change exists to stop.

The caller still gets something immediately useful, and the returned messages expose real ids for a genuine follow-up scroll.

Two doc touch-ups so the tool text agrees with the behaviour:
- the SCROLL description now says the anchor comes from a prior tool result, and that an invalid one falls back to a bounded read
- the truncated-read hint no longer invites "any id above"

If `_read_session` itself fails, the original failure path is preserved — recovery never masks a real error.

## Verification

New test `test_scroll_with_invalid_anchor_returns_bounded_read_recovery`:

- **fails on current `main`** — `assert result["success"] is True` → `assert False is True`
- **passes with the fix**
- full file: **54 passed**

Also asserts key ordering (`success`, `mode`, `scroll_recovery`, `next_step` first) so the contract cannot silently regress behind the transcript.

Rebased on `main@1fe0f2f3a`.