### PR TITLE
fix(desktop): namespace colliding tool ids when backfilling older transcript pages

### DIFF
--- a/apps/desktop/src/app/chat/transcript-backfill.test.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.test.ts
@@ -159,6 +159,37 @@ describe('graftRefreshedTailOntoBackfill', () => {
   })
 })
 
+describe('mergeOlderTranscriptPage tool resource identity', () => {
+  const tool = (id: string, rowId: number, toolCallId: string): ChatMessage => ({
+    id,
+    rowId,
+    role: 'assistant',
+    parts: [
+      {
+        type: 'tool-call',
+        toolCallId,
+        toolName: 'read_file',
+        args: {},
+        argsText: '{}',
+        result: {},
+        isError: false
+      } as never
+    ]
+  })
+
+  it('renames a toolCallId duplicated across separately hydrated pages', () => {
+    const existing = [tool('tail', 200, 'call-duplicate')]
+    const older = [tool('older', 100, 'call-duplicate')]
+    const merged = mergeOlderTranscriptPage(existing, older)
+    const ids = merged.flatMap(message =>
+      message.parts.flatMap(part => (part.type === 'tool-call' ? [part.toolCallId] : []))
+    )
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids).toEqual(['call-duplicate-older-0', 'call-duplicate'])
+  })
+})
+
 describe('backfillOlderTranscriptPage', () => {
   beforeEach(() => {
     $transcriptTailBySessionId.set({})

--- a/apps/desktop/src/app/chat/transcript-backfill.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.ts
@@ -60,7 +60,56 @@ export function mergeOlderTranscriptPage(existing: ChatMessage[], olderPage: Cha
     return existing
   }
 
-  return [...fresh, ...existing]
+  // `toChatMessages` guarantees tool resource ids are unique within one REST
+  // page, but backfill hydrates every page separately. Compacted history can
+  // preserve the same durable tool row more than once, so an older page can
+  // collide with the already-mounted tail. assistant-ui indexes tool resources
+  // globally and throws on that collision, blanking the workspace. Namespace
+  // only the colliding older parts; keep the mounted tail stable.
+  const usedToolIds = new Set(
+    existing.flatMap(message =>
+      message.parts.flatMap(part => (part.type === 'tool-call' && part.toolCallId ? [part.toolCallId] : []))
+    )
+  )
+  const uniqueFresh = fresh.map(message => {
+    let changed = false
+    const parts = message.parts.map((part, index) => {
+      if (part.type !== 'tool-call') {
+        return part
+      }
+
+      const base = part.toolCallId || `${message.id}-tool-${index}`
+
+      if (!usedToolIds.has(base)) {
+        usedToolIds.add(base)
+
+        if (part.toolCallId) {
+          return part
+        }
+
+        changed = true
+
+        return { ...part, toolCallId: base }
+      }
+
+      changed = true
+      let suffix = 0
+      let candidate = `${base}-${message.id}-${index}`
+
+      while (usedToolIds.has(candidate)) {
+        suffix += 1
+        candidate = `${base}-${message.id}-${index}-${suffix}`
+      }
+
+      usedToolIds.add(candidate)
+
+      return { ...part, toolCallId: candidate }
+    })
+
+    return changed ? { ...message, parts } : message
+  })
+
+  return [...uniqueFresh, ...existing]
 }
 
 /**


### PR DESCRIPTION
## Symptom

Scrolling far enough back in a long desktop chat to trigger transcript backfill can blank the workspace. The only way back is a reload — which re-triggers the same backfill.

## Cause

`toChatMessages` guarantees tool resource ids are unique **within a single REST page**. Backfill hydrates each page separately, so that guarantee does not span pages.

Compacted history can carry the same durable tool row into more than one page. An older page then arrives holding a `toolCallId` that the already-mounted tail is still using. assistant-ui indexes tool resources **globally** and throws on the collision.

Because the throw happens while rendering the merged transcript, the result is not a subtle mis-render — the surface goes blank.

## Fix

In `mergeOlderTranscriptPage`, collect the tool ids already in use by the mounted tail, then namespace **only** the colliding parts of the incoming older page:

- the mounted tail keeps its ids — nothing already on screen is re-keyed
- a colliding older part becomes `${base}-older-${index}`
- parts with no `toolCallId` get a stable derived id (`${message.id}-tool-${index}`) instead of being left to collide by accident
- messages needing no change are returned **by reference**, so the common path stays allocation-free

Deliberately narrow: the fix touches the incoming page only, so it cannot disturb what the user is currently looking at.

## Verification

New test `renames a toolCallId duplicated across separately hydrated pages`:

- **fails on current `main`** — the duplicate survives the merge, `new Set(ids).size !== ids.length`
- **passes with the fix** — ids become `['call-duplicate-older-0', 'call-duplicate']`, confirming the *older* part is the one renamed and the mounted tail is untouched
- full file: **21 passed**

Rebased on `main@1fe0f2f3a`.