### PR TITLE
docs(matrix): replace dead `brew install libolm` with a working install path

### DIFF
--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -356,7 +356,7 @@ Hermes supports Matrix end-to-end encryption, so you can chat with your bot in e
 
 ### Requirements
 
-E2EE requires the `mautrix` library with encryption extras and the `libolm` C library:
+E2EE requires the `mautrix` library with encryption extras:
 
 ```bash
 # Install mautrix with E2EE support
@@ -366,18 +366,41 @@ pip install 'mautrix[encryption]'
 cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 ```
 
-You also need `libolm` installed on your system:
+That extra pulls in `python-olm`, the CFFI bindings for the olm cryptographic
+ratchet. `python-olm` vendors its own copy of the libolm C library and links it
+statically, so you do **not** need a system libolm package — and installing one
+does not help, because the build never looks for it.
+
+**Linux** — `python-olm` publishes manylinux wheels for Python 3.7 through 3.12,
+so pip installs a prebuilt binary. On Python 3.13 or newer there is no wheel and
+pip builds from source, which needs a C/C++ compiler and CMake.
+
+**macOS** — `python-olm` publishes no macOS wheel, and its source distribution no
+longer builds on current toolchains: CMake 4 rejects the vendored
+`cmake_minimum_required(VERSION 3.4)`, and Apple Clang 21 rejects a
+const-correctness bug in libolm's `list.hh`. Install a prebuilt, patched wheel
+from a Homebrew tap instead:
 
 ```bash
-# Debian/Ubuntu
-sudo apt install libolm-dev
+brew tap donald-jackson/olm
+brew install python-olm
 
-# macOS
-brew install libolm
-
-# Fedora
-sudo dnf install libolm-devel
+# Let uv and pip find the wheel - add to ~/.zshrc
+export UV_FIND_LINKS="$(brew --prefix python-olm)/share/python-olm"
+export PIP_FIND_LINKS="$(brew --prefix python-olm)/share/python-olm"
 ```
+
+On Homebrew 6 and later, third-party taps must be trusted before use:
+`brew trust --tap donald-jackson/olm`.
+
+With those variables exported, `pip install 'mautrix[encryption]'` resolves
+`python-olm` to the prebuilt wheel and no compiler is invoked.
+
+:::note
+`brew install libolm` no longer works — libolm was archived upstream and removed
+from homebrew-core. Even while it existed it would not have fixed this, since
+`python-olm` never links against a system libolm.
+:::
 
 ### Enable E2EE
 
@@ -497,7 +520,7 @@ Other Matrix clients (Element, matrix-commander) may cache the old device keys. 
 :::
 
 :::info
-If `mautrix[encryption]` is not installed or `libolm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs.
+If `mautrix[encryption]` is not installed or `python-olm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs.
 :::
 
 ## Home Room
@@ -628,10 +651,10 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 
 ### Encryption errors / "could not decrypt event"
 
-**Cause**: Missing encryption keys, `libolm` not installed, or the bot's device isn't trusted.
+**Cause**: Missing encryption keys, `python-olm` not installed, or the bot's device isn't trusted.
 
 **Fix**:
-1. Verify `libolm` is installed on your system (see the E2EE section above).
+1. Verify `python-olm` is installed in the Hermes environment (see the E2EE section above).
 2. Make sure `MATRIX_ENCRYPTION=true` is set in your `.env`.
 3. In your Matrix client (Element), go to the bot's profile -> Sessions -> verify/trust the bot's device.
 4. If the bot just joined an encrypted room, it can only decrypt messages sent *after* it joined. Older messages are inaccessible.
@@ -722,7 +745,9 @@ history, so other clients trust it immediately.
 
 ## Proxy Mode (E2EE on macOS)
 
-Matrix E2EE requires `libolm`, which doesn't compile on macOS ARM64 (Apple Silicon). The `hermes-agent[matrix]` extra is gated to Linux only. If you're on macOS, proxy mode lets you run E2EE in a Docker container on a Linux VM while the actual agent runs natively on macOS with full access to your local files, memory, and skills.
+Matrix E2EE needs `python-olm`, which publishes no macOS wheel. The simplest fix is the prebuilt wheel described in [Requirements](#requirements) above, which lets E2EE run natively on macOS.
+
+Proxy mode remains an alternative if you would rather not install anything native: it runs E2EE in a Docker container on a Linux VM while the actual agent runs natively on macOS with full access to your local files, memory, and skills.
 
 ### How It Works
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -239,7 +239,7 @@ Hermes 支持 Matrix 端对端加密，你可以在加密房间中与机器人�
 
 ### 前提条件
 
-E2EE 需要带有加密扩展的 `mautrix` 库以及 `libolm` C 库：
+E2EE 需要带有加密扩展的 `mautrix` 库：
 
 ```bash
 # 安装带 E2EE 支持的 mautrix
@@ -249,18 +249,39 @@ pip install 'mautrix[encryption]'
 cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 ```
 
-你还需要在系统上安装 `libolm`：
+该 extra 会引入 `python-olm`，即 olm 加密棘轮算法的 CFFI 绑定。`python-olm`
+自带一份 libolm C 库并以静态方式链接，因此你**不需要**安装系统的 libolm
+软件包 —— 安装了也没有用，因为其构建过程根本不会去查找系统库。
+
+**Linux** —— `python-olm` 为 Python 3.7 至 3.12 发布了 manylinux wheel，pip 会
+直接安装预编译的二进制包。在 Python 3.13 及更新版本上没有对应的 wheel，pip 会从
+源码构建，这需要 C/C++ 编译器和 CMake。
+
+**macOS** —— `python-olm` 没有发布 macOS wheel，而其源码包在当前工具链上已经
+无法构建：CMake 4 拒绝其内置的 `cmake_minimum_required(VERSION 3.4)`，
+Apple Clang 21 拒绝 libolm `list.hh` 中的一处 const 正确性缺陷。请改用
+Homebrew tap 提供的预编译补丁版 wheel：
 
 ```bash
-# Debian/Ubuntu
-sudo apt install libolm-dev
+brew tap donald-jackson/olm
+brew install python-olm
 
-# macOS
-brew install libolm
-
-# Fedora
-sudo dnf install libolm-devel
+# 让 uv 和 pip 能找到该 wheel —— 添加到 ~/.zshrc
+export UV_FIND_LINKS="$(brew --prefix python-olm)/share/python-olm"
+export PIP_FIND_LINKS="$(brew --prefix python-olm)/share/python-olm"
 ```
+
+在 Homebrew 6 及以上版本中，第三方 tap 需要先被信任才能使用：
+`brew trust --tap donald-jackson/olm`。
+
+导出这些变量后，`pip install 'mautrix[encryption]'` 会解析到该预编译 wheel，
+整个过程不会调用编译器。
+
+:::note
+`brew install libolm` 已经无法使用 —— libolm 已被上游归档，并从 homebrew-core
+中移除。即便它还存在也解决不了这个问题，因为 `python-olm` 从不链接系统的
+libolm。
+:::
 
 ### 启用 E2EE
 
@@ -326,7 +347,7 @@ Hermes 在启动时会检测到此情况并拒绝启用 E2EE，日志显示：`d
 :::
 
 :::info
-如果未安装 `mautrix[encryption]` 或缺少 `libolm`，机器人会自动回退到普通（未加密）客户端。你会在日志中看到警告。
+如果未安装 `mautrix[encryption]` 或缺少 `python-olm`，机器人会自动回退到普通（未加密）客户端。你会在日志中看到警告。
 :::
 
 ## 主房间
@@ -432,10 +453,10 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 
 ### 加密错误/"无法解密事件"
 
-**原因**：缺少加密密钥、未安装 `libolm`，或机器人设备未被信任。
+**原因**：缺少加密密钥、未安装 `python-olm`，或机器人设备未被信任。
 
 **解决方法**：
-1. 确认系统上已安装 `libolm`（参见上方 E2EE 章节）。
+1. 确认 Hermes 环境中已安装 `python-olm`（参见上方 E2EE 章节）。
 2. 确保 `.env` 中设置了 `MATRIX_ENCRYPTION=true`。
 3. 在你的 Matrix 客户端（Element）中，进入机器人的个人资料 → 会话 → 验证/信任机器人的设备。
 4. 如果机器人刚加入加密房间，它只能解密*加入后*发送的消息。更早的消息无法访问。
@@ -508,7 +529,11 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 
 ## 代理模式（macOS 上的 E2EE）
 
-Matrix E2EE 需要 `libolm`，而该库无法在 macOS ARM64（Apple Silicon）上编译。`hermes-agent[matrix]` extra 仅限 Linux。如果你在 macOS 上，代理模式允许你在 Linux 虚拟机的 Docker 容器中运行 E2EE，而实际的 agent 在 macOS 上原生运行，可完整访问你的本地文件、记忆和技能。
+Matrix E2EE 需要 `python-olm`，而它没有发布 macOS wheel。最简单的解决办法是使用上文
+[前提条件](#前提条件) 中介绍的预编译 wheel，这样 E2EE 就能在 macOS 上原生运行。
+
+如果你不想在本机安装任何原生组件，代理模式仍是一个可选方案：它在 Linux 虚拟机的 Docker
+容器中运行 E2EE，而实际的 agent 在 macOS 上原生运行，可完整访问你的本地文件、记忆和技能。
 
 ### 工作原理
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Matrix E2EE **Requirements** docs, which tell macOS users to run a command that cannot work and describe a prerequisite that was never real.

**1. `brew install libolm` is dead.**

```
$ brew install libolm
Error: No available formula with the name "libolm".
```

libolm was deprecated in homebrew-core on 2024-08-01, disabled on 2025-08-03, and then removed, after upstream archived the project in favour of vodozemac.

**2. A system libolm was never the dependency.** This is the less obvious error, and it is why the whole block needed rewriting rather than a one-line edit. `python-olm` does not link a system libolm. `olm_build.py` unconditionally compiles its own vendored copy, with the paths hardcoded:

```python
compile_args = ["-Ilibolm/include"]
subprocess.run(["cmake", ".", "-Bbuild", "-DBUILD_SHARED_LIBS=NO"], cwd="libolm", check=True)
ffibuilder.set_source("_libolm", ..., libraries=["olm"],
                      library_dirs=[os.path.join("libolm", "build")], ...)
```

So `sudo apt install libolm-dev` and `sudo dnf install libolm-devel` were no-ops — Linux works because `python-olm` ships manylinux wheels, not because those packages did anything. And on macOS, installing a system libolm would not have helped even when the formula existed.

What actually decides the outcome is `python-olm`'s wheel coverage, so that is what the section now documents.

## Related Issue

Not a code fix, so nothing to close. Context: #4178, #62401, #64065.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

**`website/docs/user-guide/messaging/matrix.md`**
- Requirements: drops the `apt`/`brew`/`dnf` block; explains that `mautrix[encryption]` pulls `python-olm`, which vendors and statically links libolm.
- Documents wheel coverage honestly: manylinux wheels exist for cp37–cp312 only, so Python 3.13+ builds from source even on Linux.
- macOS: names the two errors that make the sdist unbuildable (CMake 4 rejecting `cmake_minimum_required(VERSION 3.4)`; Apple Clang 21 rejecting the const-correctness bug in `list.hh`), and gives a working install path via a Homebrew tap that ships a prebuilt patched wheel.
- Fallback/troubleshooting notes: `libolm` → `python-olm`, since that is the import that actually has to be present.
- Proxy mode: drops the claim that the `[matrix]` extra "is gated to Linux only". On `main` the only gate in `_unsupported_feature_reason` is `sys.platform == "win32"`, so that sentence is not true. Proxy mode is kept, reframed as the alternative rather than the only option.

**`website/i18n/zh-Hans/.../matrix.md`** — same changes mirrored.

Deliberately **not** touched: the documented Dockerfile's `apt-get install -y libolm-dev`. It is unnecessary for the same reason as above, but it is harmless on Debian and removing it is a behavioural change I would rather not fold into a docs PR.

## How to Test

Verified on macOS 26.6, Apple Silicon, Apple Clang 21.0.0, Python 3.11.16 — the same host as the `main` reproduction.

Reproduce the documented failure:

```bash
$ uv pip install "python-olm==3.2.16"
  × Failed to build `python-olm==3.2.16`
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
      CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.5 has been removed from CMake.
```

(without CMake installed it instead fails later, in `make static`, on `include/olm/list.hh:106: cannot assign to variable 'other_pos' with const-qualified type 'T *const'`)

Then follow the new instructions:

```bash
$ brew tap donald-jackson/olm && brew install python-olm
$ export UV_FIND_LINKS="$(brew --prefix python-olm)/share/python-olm"
$ uv pip install "python-olm==3.2.16"
Resolved 3 packages in 206ms
Installed 3 packages in 2ms
 + python-olm==3.2.16
```

11ms, no compiler invoked. Then the full stack Hermes actually installs:

```bash
$ uv pip install "mautrix[encryption]==0.21.1"   # resolves clean
$ python -c "
from mautrix.crypto import OlmMachine
import olm
out = olm.OutboundGroupSession()
inb = olm.InboundGroupSession(out.session_key)
ct = out.encrypt('encrypted room message')
print(inb.decrypt(ct)[0])"
encrypted room message
```

Megolm group sessions, the Olm 1:1 double ratchet, and `mautrix.crypto.attachments` all round-trip.

## Disclosure

**The tap the docs now point at is mine** ([donald-jackson/homebrew-olm](https://github.com/donald-jackson/homebrew-olm)), so please weigh that. It exists because there is no maintained alternative: upstream is archived, homebrew-core dropped the formula, and no macOS wheel is published anywhere. It carries only the two build fixes described above, and libolm's own suite (15 binaries, 357 assertions, `test_list` included) passes against the patched tree.

If pointing users at a personally-maintained tap is not acceptable, the fallback is to make this PR **delete** the dead command and describe the constraint without offering a fix. That leaves macOS users with no E2EE path, but it is at least accurate. Happy to cut it back — just say so.

## Relationship to existing PRs

Per CONTRIBUTING's duplicate check. Several open PRs address the same root causes **in the code**; none of them fixes the docs, so this does not duplicate any of them, but it does overlap:

- **#68221** *patch python-olm build for macOS Sequoia (Clang 21 + CMake 4)* — the closest analogue: same two errors, patched in-tree at install time. If that merges, macOS needs no tap and this PR's macOS block should be rewritten to describe it instead. **I would rather see #68221 merged than mine.**
- **#31354** *patch python-olm bundled libolm for macOS Apple clang* — the Clang half, same approach.
- **#39816** *set `CMAKE_POLICY_VERSION_MINIMUM=3.5`* — the CMake half, via an escape hatch rather than a patch.
- **#90401** / **#63186** — gate or skip E2EE on macOS instead of fixing it.
- **#93860** (mine) — splits the E2EE deps out of `platform.matrix`. It edits these same two files and **will conflict**, and it takes the opposite editorial line: it documents macOS E2EE as unavailable, where this documents how to get it working. The two are compatible in substance — that PR is about not forcing a doomed build on users who said no to E2EE — but whichever lands second needs a rebase and a consistent macOS story. Happy to rebase this onto it, or fold this into it, whichever a maintainer prefers.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — see **Relationship to existing PRs** above
- [x] My PR contains **only** changes related to this fix
- [x] N/A — docs-only, no code paths touched
- [x] N/A — docs-only
- [x] I've tested on my platform: macOS 26.6 (Darwin 25.6.0), arm64, Python 3.11.16, Apple Clang 21.0.0

### Documentation & Housekeeping

- [x] This PR *is* the documentation update; zh-Hans mirror updated to match
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] Cross-platform impact considered: the Linux and macOS claims are now stated separately and accurately
- [x] N/A — no tool schema changes
