### PR TITLE
fix(egress): let --no-bitwarden use header-auth keys from dotenv

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -1496,6 +1496,16 @@ def discover_provider_mappings(
     return mappings
 
 
+def known_credential_env_names() -> set[str]:
+    """Return every provider credential name and alias recognized by egress."""
+
+    names = set(_BEARER_PROVIDERS) | set(_NON_BEARER_PROVIDERS)
+    for env_name, spec in _HEADER_AUTH_PROVIDERS.items():
+        names.add(env_name)
+        names.update(spec.get("aliases") or ())
+    return names
+
+
 def discover_uncovered_providers(
     *,
     available_env_names: Optional[List[str]] = None,
@@ -2483,6 +2493,7 @@ __all__ = [
     "get_status",
     "install_iron_proxy",
     "iron_proxy_version",
+    "known_credential_env_names",
     "load_mappings",
     "merge_mappings",
     "mint_proxy_token",

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -870,8 +870,9 @@ def _load_env_file_into_environ() -> int:
     keys plainly exist — a confusing first-run papercut.
 
     Only fills names that aren't already set in the process env (an exported
-    value always wins), and only for known bearer-provider names so we don't
-    slurp unrelated secrets into the process. Returns the count of names added.
+    value always wins), and only for known provider credential names and aliases
+    so we don't slurp unrelated secrets into the process. Returns the count of
+    names added.
     """
     try:
         from hermes_cli.config import load_env

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -883,11 +883,7 @@ def _load_env_file_into_environ() -> int:
     except Exception:  # noqa: BLE001 — best-effort convenience, never fatal
         return 0
     added = 0
-    known = set(ip._BEARER_PROVIDERS) | set(ip._NON_BEARER_PROVIDERS)
-    for env_name, spec in ip._HEADER_AUTH_PROVIDERS.items():
-        known.add(env_name)
-        known.update(spec.get("aliases") or ())
-    for name in known:
+    for name in ip.known_credential_env_names():
         if name in os.environ and os.environ[name].strip():
             continue
         val = (file_env.get(name) or "").strip()

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -883,6 +883,9 @@ def _load_env_file_into_environ() -> int:
         return 0
     added = 0
     known = set(ip._BEARER_PROVIDERS) | set(ip._NON_BEARER_PROVIDERS)
+    for env_name, spec in ip._HEADER_AUTH_PROVIDERS.items():
+        known.add(env_name)
+        known.update(spec.get("aliases") or ())
     for name in known:
         if name in os.environ and os.environ[name].strip():
             continue

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -55,6 +55,16 @@ def test_mint_proxy_token_has_prefix_and_length():
     assert len(t) >= len("alpha-") + 32
 
 
+def test_known_credential_env_names_includes_provider_kinds_and_aliases():
+    names = ip.known_credential_env_names()
+
+    assert "OPENAI_API_KEY" in names
+    assert "ANTHROPIC_API_KEY" in names
+    assert "GEMINI_API_KEY" in names
+    assert "GOOGLE_API_KEY" in names
+    assert "AWS_ACCESS_KEY_ID" in names
+
+
 
 
 

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -200,6 +200,29 @@ def test_cmd_restart_propagates_start_failure(hermes_home, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("env_name", "expected_mapping"),
+    [
+        ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+        ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    ],
+)
+def test_load_env_file_backfills_header_auth_provider_keys(
+    hermes_home, monkeypatch, env_name, expected_mapping,
+):
+    """Env setup must cover header-auth providers and their aliases."""
+
+    monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_env",
+        lambda: {env_name: "test-provider-key"},
+    )
+
+    assert proxy_cli._load_env_file_into_environ() == 1
+    mappings = ip.discover_provider_mappings()
+    assert [mapping.real_env_name for mapping in mappings] == [expected_mapping]
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes egress setup --no-bitwarden` now discovers header-auth provider credentials stored only in the active profile's `.env`. Without this fix, users whose configured key is for Anthropic, Azure OpenAI, or Gemini can be told that no provider key exists and cannot switch egress back to environment-backed credentials.

### Symptom

With a supported header-auth key such as `ANTHROPIC_API_KEY` present only in `.env`, env-mode setup reports `No known provider API keys found in env/Bitwarden.` instead of minting a mapping.

### Impact

Affected users cannot complete egress setup using their existing `.env` credential unless they export the key into the parent shell or use a bearer-auth provider key.

### Bug Cause

**Trigger:** `hermes_cli/proxy_cli.py:863` / `_load_env_file_into_environ()` when a supported header-auth credential exists only in `.env`.

**Causal chain:**
1. Env-mode setup parses `.env` and filters names before copying them into `os.environ`.
2. The filter includes bearer and uncovered providers but omits `_HEADER_AUTH_PROVIDERS` and their aliases.
3. `discover_provider_mappings()` sees no credential and setup exits with the no-keys error.

**Why it is wrong:** Header-auth providers are first-class proxy mappings, so the `.env` discovery whitelist had drifted from the actual provider registry.

**Working sibling / contrast:** The same credential works when exported by the parent shell because `discover_provider_mappings()` already checks header-auth providers and aliases.

**Ruled out:** Bitwarden enumeration is not the failing path; `--no-bitwarden` takes the env branch before provider discovery.

### Fix

Extend `.env` backfill to include every header-auth provider's canonical environment name and aliases. Regression coverage verifies both an Anthropic canonical key and the `GOOGLE_API_KEY` alias used for Gemini.

## Related Issue

Closes #95400

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/proxy_cli.py` - include header-auth provider keys and aliases in `.env` backfill.
- `tests/test_iron_proxy_cli.py` - verify header-auth canonical and alias keys reach provider mapping discovery.

## How to Test

1. Put `ANTHROPIC_API_KEY` or `GOOGLE_API_KEY` in the active profile's `.env` without exporting it in the shell.
2. Run `hermes egress setup --no-bitwarden` and confirm setup discovers the provider mapping.
3. Run the targeted automated suite:

```bash
scripts/run_tests.sh tests/test_iron_proxy_cli.py -q
```

Result: 13 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact; the change uses platform-independent Python mappings
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

N/A
