### PR TITLE
fix(auth): stop bot profiles from hijacking dashboard login

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -55,6 +55,7 @@ from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional, Set,
 
 from hermes_constants import (
     get_hermes_home,
+    get_process_hermes_home,
     hermes_home_key,
     reset_hermes_home_override,
     set_hermes_home_override,
@@ -2408,6 +2409,18 @@ class PluginContext:
                 "Plugin '%s' tried to register a dashboard-auth provider "
                 "that does not inherit from DashboardAuthProvider. Ignoring.",
                 self.manifest.name,
+            )
+            return
+        launch_scope = hermes_home_key(get_process_hermes_home())
+        if self._manager.scope_key != launch_scope:
+            logger.warning(
+                "Plugin '%s' tried to register dashboard-auth provider %r "
+                "from profile scope %s; ignoring it because dashboard auth "
+                "is owned by launch scope %s.",
+                self.manifest.name,
+                provider.name,
+                self._manager.scope_key,
+                launch_scope,
             )
             return
         registry_name = provider.name

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -15,7 +15,7 @@ from hermes_cli.dashboard_auth.base import (
 )
 from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
 from hermes_cli.dashboard_auth import registry as _auth_registry
-from hermes_constants import hermes_home_key
+from hermes_constants import get_process_hermes_home, hermes_home_key
 
 
 class _Stub(DashboardAuthProvider):
@@ -191,6 +191,37 @@ def test_profile_manager_cannot_replace_launch_home_auth_provider():
     assert registration is None
     assert get_provider("basic") is launch_provider
     assert "basic" not in profile_manager._ownership_ledger
+
+
+def test_profile_manager_cannot_remove_launch_home_auth_provider():
+    """Foreign unload paths only dispose registrations in their own ledger."""
+    manager, ctx = _real_ctx()
+    launch_provider = _Basic("launch-home")
+    ctx.register_dashboard_auth_provider(launch_provider)
+
+    profile_scope = hermes_home_key(Path(manager.scope_key) / "profiles" / "bot")
+    profile_manager = PluginManager(scope_key=profile_scope)
+
+    assert profile_manager.unload("basic") is False
+    profile_manager.unload()
+    profile_manager._evict_stale_persistent_registrations()
+
+    assert get_provider("basic") is launch_provider
+    assert "basic" in manager._ownership_ledger
+
+
+def test_profile_directory_can_be_the_process_launch_home(monkeypatch, tmp_path):
+    """A process launched directly into a profile owns dashboard auth."""
+    launch_home = tmp_path / "profiles" / "bot"
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    manager, ctx = _real_ctx()
+    provider = _Basic("profile-launch-home")
+
+    registration = ctx.register_dashboard_auth_provider(provider)
+
+    assert manager.scope_key == hermes_home_key(get_process_hermes_home())
+    assert registration is not None
+    assert get_provider("basic") is provider
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -5,6 +5,8 @@ art).
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hermes_cli.dashboard_auth import clear_providers, get_provider
@@ -169,6 +171,26 @@ def test_auth_provider_re_register_rotates_in_place():
     # The superseded handle is identity-conditional: disposing it is a no-op.
     stale.dispose()
     assert get_provider("basic") is new
+
+
+def test_profile_manager_cannot_replace_launch_home_auth_provider():
+    """Profile plugin discovery must not rotate the dashboard's auth gate."""
+    manager, ctx = _real_ctx()
+    launch_provider = _Basic("launch-home")
+    ctx.register_dashboard_auth_provider(launch_provider)
+
+    profile_scope = hermes_home_key(Path(manager.scope_key) / "profiles" / "bot")
+    profile_manager = PluginManager(scope_key=profile_scope)
+    profile_ctx = PluginContext(
+        PluginManifest(name="basic", version="0.0.1", kind="backend"),
+        manager=profile_manager,
+    )
+
+    registration = profile_ctx.register_dashboard_auth_provider(_Basic("profile"))
+
+    assert registration is None
+    assert get_provider("basic") is launch_provider
+    assert "basic" not in profile_manager._ownership_ledger
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Opening a Bot Mode profile can no longer replace the running dashboard's login provider with stale profile credentials. Dashboard-auth registration is now accepted only from the process launch home, preserving the main password and signing secret while retaining launch-home provider rotation and unload persistence.

### Symptom

A dashboard starts with the main home's basic-auth password and signing secret. After opening a bot chat whose profile has an older `dashboard.basic_auth` block, the same dashboard process starts accepting the profile password, rejects the main password, and invalidates existing sessions.

### Impact

Multi-profile dashboard operators can lose access and have active sessions invalidated without a dashboard restart or a change to the main config.

### Bug Cause

**Trigger:** `hermes_cli/plugins.py:register_dashboard_auth_provider` when a profile-scoped plugin manager loads an auth provider.

**Causal chain:**
1. Bot Mode opens a profile session and discovers plugins under that profile home.
2. The profile's auth plugin unconditionally upserts its provider into the process-global dashboard-auth registry.
3. The dashboard gate then verifies logins and sessions with the profile password hash and signing secret instead of the launch home's credentials.

**Why it is wrong:** Per-profile plugin discovery is routine within the shared dashboard process, but dashboard authentication belongs to the process launch home. A profile manager must not mutate that host-owned gate.

**Working sibling / contrast:** Re-discovery from the launch-home manager must still rotate the provider in place, and routine manager unload must still preserve the provider as required by the existing lifecycle contract.

**Ruled out:** Registry teardown is not the cause. The provider remains present; its object is replaced by a later profile registration.

### Fix

Compare the registering manager's stable home scope with the process launch-home scope. Ignore and warn on foreign profile registration before it reaches the global registry or ownership ledger. A regression test constructs launch-home and profile managers in one process and proves that the profile provider cannot replace the active `basic` provider.

## Related Issue

Closes #95394

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` - reject dashboard-auth registration from a manager outside the process launch home.
- `tests/hermes_cli/test_dashboard_auth_plugin_hook.py` - reproduce and guard against profile replacement while preserving existing host rotation tests.

## How to Test

1. Run the dashboard-auth plugin hook tests.
2. Confirm all 12 tests pass, including the launch-home/profile isolation regression.

```bash
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_plugin_hook.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test entry and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] Config example changes are N/A because no config keys changed
- [x] Contributor guide changes are N/A because no development workflow changed
- [x] I've considered cross-platform impact; the scope comparison uses the existing normalized `hermes_home_key` abstraction
- [x] Tool description and schema changes are N/A
