### PR TITLE
fix(config): honor model: rows when normalizing legacy custom_providers models lists

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1510,9 +1510,17 @@ def _normalize_custom_provider_entry(
             if not isinstance(model_id, str) or not model_id.strip():
                 model_id = item.get("name")
             if not isinstance(model_id, str) or not model_id.strip():
+                # ``model:`` is the row-level spelling hand-edited configs
+                # reach for (it mirrors the entry-level singular ``model:``
+                # key). Rows keyed only by ``model:`` used to fall through
+                # to this ``continue``, silently dropping the entire models
+                # block — including per-model context_length/max_tokens —
+                # so downstream dict-only readers saw nothing (#95416).
+                model_id = item.get("model")
+            if not isinstance(model_id, str) or not model_id.strip():
                 continue
             model_meta = {
-                k: v for k, v in item.items() if k not in {"id", "name"}
+                k: v for k, v in item.items() if k not in {"id", "name", "model"}
             }
             normalized_models[model_id.strip()] = model_meta
         if normalized_models:

--- a/tests/hermes_cli/test_custom_provider_models_list_keys.py
+++ b/tests/hermes_cli/test_custom_provider_models_list_keys.py
@@ -1,0 +1,82 @@
+"""Regression tests for ``models:`` list-row key handling in
+``_normalize_custom_provider_entry`` (#95416).
+
+The legacy list-of-dicts ``models:`` format accepted rows keyed by ``id:`` or
+``name:``. Hand-edited configs naturally spell the row key as ``model:`` —
+mirroring the entry-level singular ``model:`` field — but those rows fell
+through the normalizer's ``continue``, silently dropping the whole models
+block (per-model ``context_length`` / ``max_tokens`` never applied; the user
+saw the default context-length fallback warning instead).
+"""
+
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+def _entry(models):
+    return {
+        "name": "my-prov",
+        "base_url": "https://example.com/v1",
+        "models": models,
+    }
+
+
+def test_list_rows_keyed_by_model_are_converted():
+    """The reporter's exact shape: ``[{model: X, ...}]`` rows (#95416)."""
+    out = _normalize_custom_provider_entry(
+        _entry([
+            {
+                "max_tokens": 32768,
+                "model": "my-model",
+                "context_length": 1000000,
+            }
+        ]),
+        provider_key="my-prov",
+    )
+    assert out is not None
+    assert out["models"] == {
+        "my-model": {"max_tokens": 32768, "context_length": 1000000}
+    }
+
+
+def test_list_rows_keyed_by_model_do_not_leak_key_into_metadata():
+    """``model`` is the id key, not per-model metadata — same as id/name."""
+    out = _normalize_custom_provider_entry(
+        _entry([{"model": "m1", "context_length": 8192}]),
+        provider_key="my-prov",
+    )
+    assert out is not None
+    assert out["models"] == {"m1": {"context_length": 8192}}
+
+
+def test_list_rows_accept_id_name_and_model_mixed():
+    """All three id spellings convert; existing id/name behavior unchanged."""
+    out = _normalize_custom_provider_entry(
+        _entry([
+            {"id": "by-id", "context_length": 4096},
+            {"name": "by-name", "max_tokens": 1024},
+            {"model": "by-model"},
+            "bare-string",
+            {"model": "  "},  # blank id row is still skipped
+            {"context_length": 1},  # no id key at all: skipped
+        ]),
+        provider_key="my-prov",
+    )
+    assert out is not None
+    assert out["models"] == {
+        "by-id": {"context_length": 4096},
+        "by-name": {"max_tokens": 1024},
+        "by-model": {},
+        "bare-string": {},
+    }
+
+
+def test_id_and_name_still_win_over_model_in_same_row():
+    """``model:`` is a fallback only — explicit id/name keep priority."""
+    out = _normalize_custom_provider_entry(
+        _entry([{"id": "canonical", "model": "ignored", "context_length": 8}]),
+        provider_key="my-prov",
+    )
+    assert out is not None
+    # All three id spellings are structural keys, so the losing ``model``
+    # value is stripped from metadata — same as id/name are today.
+    assert out["models"] == {"canonical": {"context_length": 8}}


### PR DESCRIPTION
## What does this PR do?

`_normalize_custom_provider_entry`'s legacy list-of-dicts `models:` conversion only recognized rows keyed by `id:` or `name:`. Rows keyed by `model:` — the spelling hand-edited configs naturally reach for, mirroring the entry-level singular `model:` field — fell through to `continue`, so a `models:` block written as `[{model: X, context_length: ...}]` was silently dropped whole. Downstream dict-only readers (e.g. `get_custom_provider_context_length`, which does `if not isinstance(models, dict): continue`) then never applied per-model `context_length` / `max_tokens` / `prompt_caching`, and the user saw the default context-length fallback warning instead.

This PR adds `model:` as a third accepted row-key spelling (tried after `id:` and `name:`, which keep priority) and adds `"model"` to the structural keys stripped from per-model metadata — exactly how `id`/`name` are treated today. Existing configs are unaffected: rows with `id:`/`name:` or bare strings behave identically.

## Related Issue

Fixes #95416

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — in the `models:` list branch of `_normalize_custom_provider_entry`, fall back to `item.get("model")` after `id`/`name`, and exclude `"model"` from the per-model metadata dict so the id spelling never leaks in as metadata (matches the unconditional `id`/`name` exclusion).
- `tests/hermes_cli/test_custom_provider_models_list_keys.py` — new regression file: the reporter's exact `[{model: X, ...}]` shape converts with metadata intact; `model` key doesn't leak into metadata; mixed `id`/`name`/`model`/bare-string/blank/unkeyed rows behave per the decision table; explicit `id:` still wins over `model:` in the same row.

- Note for hand-editors: `model:` is an accepted row key in legacy `models:` lists alongside `id:` / `name:` (tried last, so `id:`/`name:` keep priority in the same row).
- Observable change: rows that carried *both* `id:` (or `name:`) and `model:` previously leaked the stray `model` key into the per-model metadata map; the leak is gone, matching the unconditional `id`/`name` exclusion.

## How to Test

1. `python -c` with the reporter's repro (models row keyed by `model:`): before this PR `_normalize_custom_provider_entry(entry).get("models")` returns `None`; after it returns `{'my-model': {'max_tokens': 32768, 'context_length': 1000000}}`.
2. `.venv/bin/python -m pytest tests/hermes_cli/test_custom_provider_models_list_keys.py -q` — should pass: 4 passed with the fix, 4 failed on unmodified main (red/green verified via `git stash` of the config change).
3. Adjacent suites should pass: `pytest tests/hermes_cli/test_custom_provider_normalize_no_mutate.py tests/hermes_cli/test_api_mode_aliases.py -q` (32 passed), `pytest tests/hermes_cli/test_config.py -q -k "custom_provider or models"` (4 passed), and the picker-level consumers `pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_custom_provider_model_switch.py -q` (68 + 13 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Red/green verification of the new regression file:

```
# without the fix (stashed):
FAILED tests/hermes_cli/test_custom_provider_models_list_keys.py::test_list_rows_keyed_by_model_are_converted
FAILED tests/hermes_cli/test_custom_provider_models_list_keys.py::test_list_rows_keyed_by_model_do_not_leak_key_into_metadata
FAILED tests/hermes_cli/test_custom_provider_models_list_keys.py::test_list_rows_accept_id_name_and_model_mixed
FAILED tests/hermes_cli/test_custom_provider_models_list_keys.py::test_id_and_name_still_win_over_model_in_same_row
4 failed, 6 warnings in 0.26s

# with the fix:
4 passed, 6 warnings in 0.27s
```

