### PR TITLE
fix: correct MCP stdio child liveness check

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -922,6 +922,30 @@ class TestMCPServerTask:
         asyncio.run(_test())
 
 
+    def test_stdio_children_dead_returns_false_when_child_alive(self, monkeypatch):
+        from tools.mcp_tool import MCPServerTask
+
+        fake_psutil = SimpleNamespace(pid_exists=lambda pid: True)
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        server = MCPServerTask("test_srv")
+        server._stdio_child_pids = {1234}
+
+        assert server._stdio_children_dead() is False
+
+
+    def test_stdio_children_dead_returns_true_when_child_dead(self, monkeypatch):
+        from tools.mcp_tool import MCPServerTask
+
+        fake_psutil = SimpleNamespace(pid_exists=lambda pid: False)
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        server = MCPServerTask("test_srv")
+        server._stdio_child_pids = {1234}
+
+        assert server._stdio_children_dead() is True
+
+
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,7 +2994,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## What does this PR do?

Fixes the inverted return value in `MCPServerTask._stdio_children_dead()`.

The method is intended to return `True` only when all tracked stdio child processes have exited. Previously, it returned `True` when `psutil.pid_exists(pid)` reported that a child was still alive, causing active MCP stdio connections to be incorrectly treated as dead.

This changes the alive-child path to return `False` and adds regression tests covering both alive and dead child processes.

## Related Issue

Fixes #95395

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Fixed `_stdio_children_dead()` in `tools/mcp_tool.py` so an alive stdio child returns `False`.
- Added regression tests in `tests/tools/test_mcp_tool.py` for alive and dead child processes.

## How to Test

1. Run the focused regression tests:
   `pytest tests/tools/test_mcp_tool.py -k "stdio_children_dead" -v`
2. Verify both alive and dead child cases pass.
3. Run the full MCP tool test suite:
   `pytest tests/tools/test_mcp_tool.py -v`

The focused regression tests pass. The full MCP test file has one unrelated Windows-specific `_build_safe_env` failure involving a missing `ProgramFiles` environment variable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant MCP tests
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas — N/A