### PR TITLE
feat(kanban): surface block_kind on list rows and let callers filter on it

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -63,6 +63,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "body": t.body,
         "assignee": t.assignee,
         "status": t.status,
+        "block_kind": t.block_kind,
         "priority": t.priority,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,
@@ -429,6 +430,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_list.add_argument("--assignee", default=None)
     p_list.add_argument("--status", default=None,
                         choices=sorted(kb.VALID_STATUSES))
+    p_list.add_argument("--kind", default=None,
+                        choices=sorted(kb.VALID_BLOCK_KINDS),
+                        help="Filter by block kind. With --status blocked, "
+                             "'--kind needs_input' is the queue waiting on a "
+                             "human.")
     p_list.add_argument("--tenant", default=None)
     p_list.add_argument("--session", default=None,
                         help="Filter by originating chat/agent session id "
@@ -1650,6 +1656,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
             conn,
             assignee=assignee,
             status=args.status,
+            block_kind=getattr(args, "kind", None),
             tenant=args.tenant,
             session_id=args.session,
             include_archived=args.archived,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3652,6 +3652,7 @@ def list_tasks(
     *,
     assignee: Optional[str] = None,
     status: Optional[str] = None,
+    block_kind: Optional[str] = None,
     tenant: Optional[str] = None,
     session_id: Optional[str] = None,
     include_archived: bool = False,
@@ -3670,6 +3671,13 @@ def list_tasks(
             raise ValueError(f"status must be one of {sorted(VALID_STATUSES)}")
         query += " AND status = ?"
         params.append(status)
+    if block_kind is not None:
+        if block_kind not in VALID_BLOCK_KINDS:
+            raise ValueError(
+                f"block_kind must be one of {sorted(VALID_BLOCK_KINDS)}"
+            )
+        query += " AND block_kind = ?"
+        params.append(block_kind)
     if tenant is not None:
         query += " AND tenant = ?"
         params.append(tenant)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -179,3 +179,20 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+
+
+def test_task_to_dict_carries_block_kind(kanban_home):
+    """`--json` rows must expose the block kind.
+
+    This and tools/_task_summary_dict are separate dicts built by hand, so
+    they drift silently: dropping the key from one leaves the other passing.
+    Each front end pins its own.
+    """
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.kanban import _task_to_dict
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="decide this", assignee="ops")
+        kb.block_task(conn, tid, reason="your call", kind="needs_input")
+        row = _task_to_dict(kb.get_task(conn, tid))
+    assert row["block_kind"] == "needs_input"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1614,3 +1614,64 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# list_tasks: block_kind filter
+# ---------------------------------------------------------------------------
+
+def test_list_tasks_rejects_unknown_block_kind(kanban_home):
+    """Bad kinds are refused at the DB layer, naming the valid set.
+
+    Both front ends (CLI --kind, kanban_list tool) lean on this: the CLI's
+    argparse choices catch it earlier, but the tool passes the raw string
+    through, so this is the only thing standing between a model's typo and a
+    silently empty result set.
+    """
+    with kb.connect() as conn:
+        with pytest.raises(ValueError) as e:
+            kb.list_tasks(conn, block_kind="not_a_kind")
+        assert "block_kind must be one of" in str(e.value)
+        for kind in kb.VALID_BLOCK_KINDS:
+            assert kind in str(e.value)
+
+
+def test_list_tasks_filters_by_block_kind(kanban_home):
+    with kb.connect() as conn:
+        waiting = kb.create_task(conn, title="needs a human", assignee="ops")
+        walled = kb.create_task(conn, title="hard wall", assignee="ops")
+        open_card = kb.create_task(conn, title="still going", assignee="ops")
+        assert kb.block_task(conn, waiting, reason="which one?", kind="needs_input")
+        assert kb.block_task(conn, walled, reason="no creds", kind="capability")
+
+        got = {t.id for t in kb.list_tasks(conn, block_kind="needs_input")}
+        assert got == {waiting}, "filter must not leak other kinds"
+        assert {t.id for t in kb.list_tasks(conn, block_kind="capability")} == {walled}
+
+        # Omitting the filter is unchanged: every task still comes back.
+        assert {t.id for t in kb.list_tasks(conn)} >= {waiting, walled, open_card}
+
+
+def test_blocked_plus_needs_input_is_the_waiting_on_human_set(kanban_home):
+    """The pairing the filter exists for.
+
+    `dependency` blocks resolve themselves and must never show up as work
+    waiting on a person; `needs_input` is the set a human actually owes an
+    answer to.
+    """
+    with kb.connect() as conn:
+        human = kb.create_task(conn, title="decide this", assignee="ops")
+        dep = kb.create_task(conn, title="waiting on another card", assignee="ops")
+        wall = kb.create_task(conn, title="no credentials", assignee="ops")
+        kb.block_task(conn, human, reason="your call", kind="needs_input")
+        kb.block_task(conn, dep, reason="blocked on #1", kind="dependency")
+        # `capability` also lands in `blocked`, so status alone cannot
+        # separate it from `needs_input` — that is what makes this a real
+        # test of the kind filter rather than of the status filter.
+        kb.block_task(conn, wall, reason="no creds", kind="capability")
+
+        rows = kb.list_tasks(conn, status="blocked", block_kind="needs_input")
+        assert [t.id for t in rows] == [human]
+        assert all(t.block_kind == "needs_input" for t in rows)
+        # `dependency` waits in todo, never surfacing as work owed a person.
+        assert kb.get_task(conn, dep).status == "todo"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1134,3 +1134,28 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_task_summary_dict_carries_block_kind(monkeypatch, tmp_path):
+    """Tool listing rows must expose the block kind.
+
+    Counterpart to test_task_to_dict_carries_block_kind in the CLI tests: the
+    two serializers are independent literals, so each needs its own pin or a
+    dropped key only shows up in one of them.
+    """
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools.kanban_tools import _task_summary_dict
+
+    kb.init_db()
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="decide this", assignee="ops")
+        kb.block_task(conn, tid, reason="your call", kind="needs_input")
+        row = _task_summary_dict(kb, conn, kb.get_task(conn, tid))
+    assert row["block_kind"] == "needs_input"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -491,6 +491,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "title": task.title,
         "assignee": task.assignee,
         "status": task.status,
+        "block_kind": task.block_kind,
         "priority": task.priority,
         "tenant": task.tenant,
         "workspace_kind": task.workspace_kind,
@@ -598,6 +599,7 @@ def _handle_list(args: dict, **kw) -> str:
         return guard
     assignee = args.get("assignee")
     status = args.get("status")
+    block_kind = args.get("kind")
     tenant = args.get("tenant")
     include_archived, bool_error = _parse_bool_arg(args, "include_archived")
     if bool_error:
@@ -626,6 +628,7 @@ def _handle_list(args: dict, **kw) -> str:
                 conn,
                 assignee=assignee,
                 status=status,
+                block_kind=block_kind,
                 tenant=tenant,
                 include_archived=include_archived,
                 limit=limit + 1,
@@ -1742,6 +1745,14 @@ KANBAN_LIST_SCHEMA = {
                     "blocked", "done", "archived",
                 ],
                 "description": "Optional task status filter.",
+            },
+            "kind": {
+                "type": "string",
+                "enum": ["dependency", "needs_input", "capability", "transient"],
+                "description": (
+                    "Optional block-kind filter. Pair with status='blocked' to "
+                    "get just the cards waiting on a human: kind='needs_input'."
+                ),
             },
             "tenant": {
                 "type": "string",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1748,6 +1748,13 @@ KANBAN_LIST_SCHEMA = {
             },
             "kind": {
                 "type": "string",
+                # Mirrors kanban_db.VALID_BLOCK_KINDS, the same way
+                # KANBAN_BLOCK_SCHEMA below does: kanban_db is imported
+                # lazily in this module to avoid an import cycle, so it is
+                # not available where these schema dicts are built. Add a
+                # kind there and update both enums. Until then the handler
+                # still validates against the real constant, so an unlisted
+                # kind is rejected by name rather than silently mishandled.
                 "enum": ["dependency", "needs_input", "capability", "transient"],
                 "description": (
                     "Optional block-kind filter. Pair with status='blocked' to "


### PR DESCRIPTION
`block_kind` is already a column on `tasks`, already on the `Task` dataclass, and already hydrated on every read — but every listing surface drops it.

So "which cards are waiting on a human?" is not answerable from `kanban list` or the `kanban_list` tool: you get every blocked card back and have to `show` each one to tell a `needs_input` question apart from a `dependency` wait. That is the common operator question, and for an agent driving the board it is an N+1 over the whole blocked set.

This adds the filter where the other filters already live:

- `list_tasks(..., block_kind=...)`, validated against `VALID_BLOCK_KINDS`
- `hermes kanban list --kind {capability,dependency,needs_input,transient}`
- `kanban_list` tool: a `kind` parameter, same enum
- `block_kind` included in CLI `--json` rows and in the tool's summary rows

No behaviour change when the filter is omitted.

```
hermes kanban list --status blocked --kind needs_input
```

Verified against a live board: `needs_input` returned only the needs_input card, `capability` returned empty, and an invalid kind raises with the valid list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Hk5MYb7nq7E7L1M8PdrKy