### PR TITLE
fix(cron): fence contention no longer reads as fire-claim ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3278,10 +3278,33 @@ def _sweep_completed_oneshots(
     return removed
 
 
-def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> Optional[bool]:
+    """Refresh an active ``fire_claim`` without extending another owner's lease.
+
+    A cron execution can legitimately outlive the fire-claim TTL.  The shared
+    run wrapper calls this periodically so another scheduler process cannot
+    treat a live execution as abandoned and dispatch it again.  Comparing the
+    owner copied at dispatch prevents a stale runner from refreshing a claim
+    that has since been recovered by another process.
+
+    Tri-state result (#95307) — callers MUST distinguish the three outcomes:
+
+    * ``True``  — the claim exists, belongs to ``expected_owner``, and was
+      refreshed (lease extended).
+    * ``False`` — definitive ownership loss: the job record or its claim is
+      gone, or the claim now belongs to a different owner. Safe to treat as a
+      takeover.
+    * ``None``  — the per-job fire fence could not be acquired within the lock
+      budget, so ownership could not be verified. This is NOT evidence of a
+      takeover: the fence that blocks this refresh is the very lock that
+      excludes replacement owners while the legitimate runner performs a long
+      fenced side effect (e.g. a Bot Chat delivery runs a full agent turn
+      holding it). Classifying contention as loss made the runner discard its
+      own successful result (#95307).
+    """
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
-            return False
+            return None
         return _heartbeat_fire_claim_locked(
             job_id,
             expected_owner=expected_owner,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6701,6 +6701,19 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         )
         return True
 
+    if owns_fire_claim is None:
+        # Fence busy pre-run: ownership unverifiable right now (#95307). Not
+        # proof of a takeover, but we don't start a run we cannot fence.
+        logger.warning(
+            "Job '%s': fire claim ownership could not be verified before "
+            "execution (fire fence busy)",
+            job_id,
+        )
+        _finish_unstarted(
+            "Fire claim ownership could not be validated before execution started."
+        )
+        return True
+
     if owns_fire_claim is False:
         logger.warning(
             "Job '%s': fire claim ownership was already lost before execution",
@@ -6713,13 +6726,27 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                status = heartbeat_fire_claim(job_id, expected_owner=owner)
+                if status is False:
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",
                         job_id,
                     )
                     return
+                if status is None:
+                    # Fire fence busy — usually OUR OWN side-effect fence held
+                    # around a long delivery (a Bot Chat target runs a full
+                    # agent turn under it, #95307). The fence excludes
+                    # replacement owners while the legitimate runner works,
+                    # so contention is not evidence of a takeover. Skip this
+                    # beat without burning the exception grace budget; claim
+                    # refreshes resume once the fence frees up.
+                    logger.debug(
+                        "Job '%s': fire_claim heartbeat skipped; fire fence busy",
+                        job_id,
+                    )
+                    continue
                 last_confirmed = time.monotonic()
             except Exception:
                 logger.debug(
@@ -6856,7 +6883,14 @@ def _run_one_job_body(
         if fire_owner is None:
             return False
         try:
-            if heartbeat_fire_claim(job["id"], expected_owner=fire_owner):
+            status = heartbeat_fire_claim(job["id"], expected_owner=fire_owner)
+            if status is True:
+                return False
+            if status is None:
+                # Fence busy: ownership unverifiable right now (#95307) —
+                # usually our own fenced delivery. Not proof of a takeover;
+                # proceed and let the owner-fenced terminal write be the
+                # authoritative guard against completing on a stolen claim.
                 return False
         except Exception:
             logger.debug(
@@ -6964,7 +6998,7 @@ def _run_one_job_body(
             # interruption through the owner-fenced terminal write.
             if fire_owner is not None and heartbeat_fire_claim(
                 job["id"], expected_owner=fire_owner,
-            ):
+            ) is True:
                 mark_job_run(
                     job["id"],
                     False,
@@ -7150,7 +7184,7 @@ def _run_one_job_body(
             # discarding silently (lingering claim + stale last_status).
             if fire_owner is not None and heartbeat_fire_claim(
                 job["id"], expected_owner=fire_owner,
-            ):
+            ) is True:
                 mark_job_run(
                     job["id"],
                     False,

--- a/tests/cron/test_fire_claim_contention_95307.py
+++ b/tests/cron/test_fire_claim_contention_95307.py
@@ -1,0 +1,299 @@
+"""Regression coverage for false "Fire claim ownership lost" discards (#95307).
+
+A finite cron job delivering to Bot Chat runs a full child-agent turn while
+the runner holds the per-job fire fence. The fire-claim heartbeat contends
+with that same fence and used to read the lock timeout as a definitive
+ownership loss, so the completed result was discarded instead of delivered.
+
+Contract under test:
+
+* ``heartbeat_fire_claim`` is tri-state: ``True`` (owned + refreshed),
+  ``False`` (definitive loss), ``None`` (fence busy — ownership UNKNOWN).
+* A heartbeat beat that cannot acquire the fence never sets the
+  ownership-lost event while the legitimate runner holds it.
+* A definitive takeover (claim rewritten to another owner) is still detected.
+* Startup validation distinguishes "unverifiable" from "lost".
+"""
+
+import contextlib
+import threading
+import time
+import unittest.mock as mock
+
+import cron.jobs as jobs
+import cron.scheduler as scheduler
+
+
+@contextlib.contextmanager
+def _secret_scope_patched():
+    """No-op the per-run secret scope install/teardown for handed-in jobs."""
+    with mock.patch(
+        "agent.secret_scope.set_secret_scope", return_value=None
+    ), mock.patch(
+        "agent.secret_scope.build_profile_secret_scope", return_value=None
+    ), mock.patch("agent.secret_scope.reset_secret_scope"):
+        yield
+
+
+def _make_claimed_job(profile_home, name):
+    """Create a one-shot job, claim its fire; returns (job, claimed, owner)."""
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name=name)
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed = jobs.get_job(job["id"])
+        owner = claimed["fire_claim"]["by"]
+    return job, claimed, owner
+
+
+def test_heartbeat_fire_claim_is_unknown_while_fence_is_held(tmp_path, monkeypatch):
+    """Fence unavailable ⇒ None (unknown), never False (loss).
+
+    The per-job fence fails closed when cross-process locking cannot be
+    acquired within the budget — a cross-process holder (or an unavailable
+    locking backend) must read as UNKNOWN ownership, not as a takeover
+    (#95307). In-process holders block on the threading lock instead and are
+    covered by the delayed-refresh guard below.
+    """
+
+    @contextlib.contextmanager
+    def _busy_fence(_job_id):
+        yield False
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    job, _claimed, owner = _make_claimed_job(profile_home, "tri-state-store")
+
+    real_fire_lock = jobs._fire_job_lock
+    monkeypatch.setattr(jobs, "_fire_job_lock", _busy_fence)
+    assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is None
+
+    # Sanity: uncontended calls still resolve through the real fence.
+    monkeypatch.setattr(jobs, "_fire_job_lock", real_fire_lock)
+    with jobs.use_cron_store(profile_home):
+        assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is True
+        assert (
+            jobs.heartbeat_fire_claim(job["id"], expected_owner="someone-else")
+            is False
+        )
+
+
+def test_run_completes_when_delivery_spans_heartbeat_beats(tmp_path, monkeypatch):
+    """A fenced Bot-Chat-style delivery spanning beats must still deliver.
+
+    Mirrors #95307: delivery holds the side-effect fence longer than several
+    heartbeat intervals; every beat inside that window contends with OUR OWN
+    fence, which is not a takeover. The run must finalize successfully.
+    """
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    _job, claimed, _owner = _make_claimed_job(profile_home, "fenced-delivery")
+    claimed["execution_id"] = "exec-fenced-delivery"
+    claimed["deliver"] = "local"
+
+    delivery_started = threading.Event()
+    delivery_may_finish = threading.Event()
+
+    def _slow_delivery(job, content, adapters=None, loop=None, **kwargs):
+        delivery_started.set()
+        # Hold the fire fence well past several heartbeat intervals.
+        assert delivery_may_finish.wait(timeout=5)
+        return None
+
+    ledger_calls = []
+
+    def _ledger(execution_id, success, error=None, **kwargs):
+        ledger_calls.append({"success": success, "error": error})
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, defer_agent_teardown=None, extra_prompt=None,
+        cancel_event=None: (True, "out", "final response", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: "p")
+    monkeypatch.setattr(scheduler, "_deliver_result", _slow_delivery)
+    monkeypatch.setattr(scheduler, "finish_execution", _ledger)
+    mark_run = mock.MagicMock(return_value=True)
+    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+
+    with jobs.use_cron_store(profile_home), _secret_scope_patched():
+
+        def _finish_delivery():
+            assert delivery_started.wait(timeout=5)
+            time.sleep(0.3)  # > 4 heartbeat intervals inside the fence
+            delivery_may_finish.set()
+
+        finisher = threading.Thread(target=_finish_delivery, daemon=True)
+        finisher.start()
+        try:
+            assert scheduler.run_one_job(claimed) is True
+        finally:
+            delivery_may_finish.set()
+            finisher.join(timeout=5)
+
+    failures = [call for call in ledger_calls if call["success"] is False]
+    assert not failures, (
+        "successful run was failed by false ownership loss: %s" % ledger_calls
+    )
+    assert any(call["success"] is True for call in ledger_calls), ledger_calls
+
+
+def test_definitive_takeover_during_run_still_detected(tmp_path, monkeypatch):
+    """A real owner change mid-run stays a loss — tri-state must not hide it."""
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    _job, claimed, _owner = _make_claimed_job(profile_home, "real-takeover")
+    claimed["execution_id"] = "exec-real-takeover"
+    claimed["deliver"] = "local"
+
+    started = threading.Event()
+    beat_after_start = threading.Event()
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observing_heartbeat(job_id: str, *, expected_owner: str):
+        status = real_heartbeat(job_id, expected_owner=expected_owner)
+        if status is True and started.is_set():
+            beat_after_start.set()
+        return status
+
+    def _run_job(job, defer_agent_teardown=None, extra_prompt=None, cancel_event=None):
+        started.set()
+        assert beat_after_start.wait(timeout=5)
+        with jobs.use_cron_store(profile_home):
+            stored = jobs.get_job(job["id"])
+            stored["fire_claim"] = {
+                "at": stored["fire_claim"]["at"],
+                "by": "replacement-owner",
+            }
+            jobs.save_jobs([stored])
+        return True, "out", "stale response", None
+
+    ledger_calls = []
+
+    def _ledger(execution_id, success, error=None, **kwargs):
+        ledger_calls.append({"success": success, "error": error})
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observing_heartbeat)
+    monkeypatch.setattr(scheduler, "run_job", _run_job)
+    monkeypatch.setattr(
+        scheduler, "save_job_output", mock.MagicMock(return_value="p")
+    )
+    monkeypatch.setattr(
+        scheduler, "_deliver_result", mock.MagicMock(return_value=None)
+    )
+    monkeypatch.setattr(scheduler, "finish_execution", _ledger)
+    monkeypatch.setattr(
+        scheduler, "mark_job_run", mock.MagicMock(return_value=True)
+    )
+
+    with _secret_scope_patched():
+        assert scheduler.run_one_job(claimed) is True
+
+    assert any(
+        call["success"] is False and "ownership lost" in str(call["error"]).lower()
+        for call in ledger_calls
+    ), f"a definitive takeover was not detected: {ledger_calls}"
+
+
+def test_initial_validation_busy_reports_unverifiable_not_lost(
+    tmp_path, monkeypatch
+):
+    """Busy-at-startup closes the row as 'could not be validated', not 'lost'."""
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    _job, claimed, _owner = _make_claimed_job(profile_home, "busy-start")
+    claimed["execution_id"] = "exec-busy-start"
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(
+        scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: None
+    )
+    body = mock.MagicMock(return_value=True)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", body)
+    finish = mock.MagicMock()
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    assert scheduler.run_one_job(claimed) is True
+    body.assert_not_called()
+    finish.assert_called_once_with(
+        "exec-busy-start",
+        success=False,
+        error=(
+            "Fire claim ownership could not be validated "
+            "before execution started."
+        ),
+    )
+
+
+def test_initial_validation_definitive_loss_still_reported(tmp_path, monkeypatch):
+    """Definitive loss at startup keeps its distinct 'ownership lost' record."""
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    _job, claimed, _owner = _make_claimed_job(profile_home, "lost-start")
+    claimed["execution_id"] = "exec-lost-start"
+
+    monkeypatch.setattr(
+        scheduler, "heartbeat_fire_claim", lambda *args, **kwargs: False
+    )
+    body = mock.MagicMock(return_value=True)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", body)
+    finish = mock.MagicMock()
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    assert scheduler.run_one_job(claimed) is True
+    body.assert_not_called()
+    finish.assert_called_once_with(
+        "exec-lost-start",
+        success=False,
+        error="Fire claim ownership lost before execution started.",
+    )
+
+
+def test_terminal_bookkeeping_treats_busy_as_not_lost(tmp_path, monkeypatch):
+    """Post-delivery probe with a busy fence completes instead of discarding."""
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    _job, claimed, _owner = _make_claimed_job(profile_home, "busy-terminal")
+    claimed["execution_id"] = "exec-busy-terminal"
+    claimed["deliver"] = "local"
+
+    calls = {"n": 0}
+
+    def _busy_after_run_heartbeat(job_id: str, *, expected_owner: str):
+        calls["n"] += 1
+        # Call #1 = startup validation (owned). Later calls = the probes the
+        # body makes around delivery/terminal writes; report them as busy so
+        # only the tri-state-aware paths can proceed.
+        if calls["n"] == 1:
+            return True
+        return None
+
+    ledger_calls = []
+
+    def _ledger(execution_id, success, error=None, **kwargs):
+        ledger_calls.append({"success": success, "error": error})
+
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _busy_after_run_heartbeat)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda job, defer_agent_teardown=None, extra_prompt=None,
+        cancel_event=None: (True, "out", "final response", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: "p")
+    monkeypatch.setattr(
+        scheduler, "_deliver_result", mock.MagicMock(return_value=None)
+    )
+    monkeypatch.setattr(scheduler, "finish_execution", _ledger)
+    monkeypatch.setattr(
+        scheduler, "mark_job_run", mock.MagicMock(return_value=True)
+    )
+
+    with jobs.use_cron_store(profile_home), _secret_scope_patched():
+        assert scheduler.run_one_job(claimed) is True
+
+    assert any(call["success"] is True for call in ledger_calls), ledger_calls


### PR DESCRIPTION
## What does this PR do?

Fixes #95307 — finite cron jobs (once / repeat-limited) delivering to `bot-chat` complete their agent turn and then get recorded as failed with `Fire claim ownership lost; stale result was discarded.`, losing the result entirely. The root cause is a semantic conflation in the fire-claim ownership probe; this PR separates "definitively lost" from "could not verify" so the runner stops discarding its own successful result.

## Bug cause

`heartbeat_fire_claim()` returned `False` for **two different facts**:

1. the claim is gone or now belongs to another owner (a definitive takeover), and
2. the per-job fire fence could not be acquired within `\_JOBS_LOCK_TIMEOUT_SECONDS` — pure lock contention, with **no information** about who owns the claim.

Those are not interchangeable. The fence that blocks the refresh is the very lock that *excludes replacement owners* while the legitimate runner performs a fenced side effect. A `bot-chat` delivery runs an entire child-agent turn (`hermes chat -Q ...`) while holding that fence, so heartbeat/probe calls issued during delivery contend with the runner's own fence. Reading that as ownership loss makes the runner discard its own completed result. Deliveries to `local` / ordinary platforms finish in well under a second and never straddle the probe window, which matches the reporter's isolation matrix exactly.

On the current main, `mark_job_run(expected_fire_owner=...)` already CAS-guards terminal writes and the post-run probes run before finalization — so the reporter's proposed fixes #1/#2 are largely landed upstream. What remains broken is exactly the conflated `False`: any caller that cannot acquire the fence is told "you lost the claim" when the truth is "I don't know".

## Fix

`heartbeat_fire_claim()` becomes tri-state:

| Result | Meaning |
|---|---|
| `True` | claim exists, belongs to `expected_owner`, refreshed |
| `False` | definitive loss: job/claim gone, or owner replaced |
| `None` | fire fence busy — ownership unknown, no evidence either way |

Scheduler consumers updated accordingly:

- **Pre-run validation**: `None` closes the execution row with the existing "Fire claim ownership could not be validated before execution started." record (same treatment as a transport exception) instead of reporting a loss.
- **Heartbeat loop**: a `None` beat is skipped without consuming the exception grace budget; refreshes resume once the fence frees up. Only a definitive `False` sets the ownership-lost event.
- **Post-run probes** (`\_fire_claim_ownership_lost`): `None` is treated as *not lost*, and the run proceeds to its owner-fenced terminal write — `mark_job_run(expected_fire_owner=...)` remains the authoritative last-line guard against completing on a stolen claim.
- **Shutdown-interrupt re-probes**: only take the fenced "interrupted by shutdown" branch when ownership is positively confirmed (`is True`).

`False` still means loss everywhere: a real takeover keeps interrupting stale runs and suppressing stale deliveries exactly as before.

## Testing

New regression suite `tests/cron/test_fire_claim_contention_95307.py` (behavior-contract, real store under a temp `HERMES_HOME`, no snapshot tests):

- tri-state store contract: busy fence ⇒ `None`; uncontended ⇒ `True`; wrong owner ⇒ `False`
- pre-run busy fence finishes the row as "could not be validated", body never runs
- definitive loss at startup still reports the distinct "ownership lost" record
- post-delivery bookkeeping with a busy fence completes successfully instead of discarding
- a genuine mid-run owner change is **still detected** as a discard (guards against over-correction)

All six fail on pristine main (three of them reproduce the exact reported ledger error string); all pass with the fix.

Neighbor suites: `test_claim_job_for_fire.py`, `test_script_claim_heartbeat.py`, `test_shutdown_interrupt.py`, `test_run_one_job.py`, `test_cron_bot_chat_delivery.py`, `test_dead_owner_claim_reclaim.py`, `test_inflight_stale_guard.py`, `test_cron_run_stale_claim_reap_86721.py` — 116 passed. Full `tests/cron/`: 971 passed, 1 skipped, plus one pre-existing environment failure in `test_cron_created_delivery.py` that fails identically on pristine main (unrelated to this change). `tests/gateway/test_restart_resume_pending.py`: 36 passed.

## Related

- #88507 (fire-claim flat TTL — same subsystem, opposite symptom), #88688 (fence reconciliation by ownership generation — the long-term primitive)
- The now-closed #95334 diagnosed the same failure mode; its approach patched around the conflation at the wrapper level, while this fix removes it at the source so every consumer benefits.