### PR TITLE
fix(auth): give Anthropic OAuth the single-use-refresh-token protections

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1152,6 +1152,57 @@ class CredentialPool:
             logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
 
+    def _sync_anthropic_entry_from_pool_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
+        """Adopt an Anthropic token pair rotated by another pool instance.
+
+        Anthropic subscription OAuth refresh tokens are single-use — a
+        successful refresh rotates the pair and invalidates the old refresh
+        token (see ``agent/anthropic_adapter.py``).  Profiles sharing one
+        credential hold their own copy of the same pair with the same
+        ``expires_at_ms``, so they all enter the refresh window at once.
+
+        This helper is called while the shared auth-store lock is held and
+        re-reads the exact persisted row before a refresh POST is attempted,
+        so a waiter adopts the winner's rotated pair instead of POSTing a
+        token that has already been revoked.
+
+        ``claude_code`` entries keep using
+        ``_sync_anthropic_entry_from_credentials_file``: their canonical
+        store is ``~/.claude/.credentials.json``, which the Claude Code CLI
+        also writes.
+        """
+        if self.provider != "anthropic":
+            return entry
+        if entry.source == "claude_code":
+            return self._sync_anthropic_entry_from_credentials_file(entry)
+        try:
+            persisted = next(
+                (
+                    payload
+                    for payload in read_credential_pool(self.provider)
+                    if isinstance(payload, dict) and payload.get("id") == entry.id
+                ),
+                None,
+            )
+            if not isinstance(persisted, dict):
+                return entry
+            stored = PooledCredential.from_dict(self.provider, persisted)
+            if (
+                stored.access_token != entry.access_token
+                or stored.refresh_token != entry.refresh_token
+            ):
+                logger.debug(
+                    "Pool entry %s: adopting Anthropic OAuth tokens rotated by another pool instance",
+                    entry.id,
+                )
+                self._replace_entry(entry, stored)
+                return stored
+        except Exception as exc:
+            logger.debug("Failed to sync Anthropic entry from credential pool: %s", exc)
+        return entry
+
     def _sync_nous_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync a Nous pool entry from auth.json if tokens differ.
 
@@ -1373,7 +1424,7 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex and xAI OAuth refresh tokens are single-use.  The
+        # Codex, xAI, and Anthropic OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
         # processes: otherwise two processes can both adopt the same on-disk
         # token, both POST it, and the loser gets ``refresh_token_reused``.
@@ -1382,11 +1433,20 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth"):
+        #
+        # Anthropic is included because ``anthropic_adapter`` documents the
+        # same single-use semantics ("a successful refresh rotates the pair
+        # and invalidates the old refresh token"), and profiles sharing one
+        # credential enter the refresh window simultaneously: the entries
+        # carry the same ``expires_at_ms``, so ``_entry_needs_refresh`` fires
+        # for all of them at once.
+        if self.provider in ("openai-codex", "xai-oauth", "anthropic"):
             sync_entry = (
                 self._sync_codex_entry_from_auth_store
                 if self.provider == "openai-codex"
                 else self._sync_xai_oauth_entry_from_pool_store
+                if self.provider == "xai-oauth"
+                else self._sync_anthropic_entry_from_pool_store
             )
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
@@ -1417,6 +1477,8 @@ class CredentialPool:
         env_var = (
             "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
             if self.provider == "openai-codex"
+            else "HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS"
+            if self.provider == "anthropic"
             else "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
         )
         refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
@@ -2019,13 +2081,15 @@ class CredentialPool:
                     entry = cleared
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
-                if self.provider in ("openai-codex", "xai-oauth"):
+                if self.provider in ("openai-codex", "xai-oauth", "anthropic"):
                     # Defer single-use-token refresh to avoid holding the
                     # threading lock during cross-process flock + network I/O.
                     sync_fn = (
                         self._sync_codex_entry_from_auth_store
                         if self.provider == "openai-codex"
                         else self._sync_xai_oauth_entry_from_pool_store
+                        if self.provider == "xai-oauth"
+                        else self._sync_anthropic_entry_from_pool_store
                     )
                     pending_refresh.append((entry, sync_fn))
                     continue

--- a/tests/agent/test_credential_pool_anthropic_single_use_refresh.py
+++ b/tests/agent/test_credential_pool_anthropic_single_use_refresh.py
@@ -1,0 +1,212 @@
+"""Anthropic OAuth must get the single-use-refresh-token protections.
+
+``agent/anthropic_adapter.py`` documents that Claude Code / subscription OAuth
+refresh tokens are single-use: a successful refresh rotates the pair and
+invalidates the old refresh token. ``openai-codex`` and ``xai-oauth`` have the
+same semantics and are serialized through the cross-process auth-store flock
+before the refresh POST, with an in-lock re-read that adopts a pair another
+process already rotated.
+
+``anthropic`` was absent from that allow-list, so two profiles sharing one
+credential could both POST the same refresh token and the loser would get
+``refresh_token_reused`` / ``invalid_grant``. The entries carry the same
+``expires_at_ms``, so ``_entry_needs_refresh`` fires for all of them at once —
+the race is the normal case, not a rare interleaving.
+
+These tests assert the behaviour contract (serialize + adopt-instead-of-POST),
+not the literal contents of the provider tuple.
+"""
+
+import threading
+
+import pytest
+
+from agent import credential_pool as CP
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    CredentialPool,
+    PooledCredential,
+)
+
+
+def _entry(
+    *,
+    id: str = "anthropic-1",
+    access_token: str = "acc-old",
+    refresh_token: str = "ref-old",
+    source: str = "manual:hermes_pkce",
+    expires_at_ms: int = 1_000,
+) -> PooledCredential:
+    return PooledCredential(
+        provider="anthropic",
+        id=id,
+        label="anthropic-oauth-1",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at_ms=expires_at_ms,
+    )
+
+
+@pytest.fixture
+def pool(monkeypatch):
+    """A CredentialPool for anthropic that never touches the real auth store."""
+    monkeypatch.setattr(CP, "read_credential_pool", lambda provider=None: [])
+    monkeypatch.setattr(CP, "write_credential_pool", lambda *a, **k: None)
+    return CredentialPool("anthropic", [_entry()])
+
+
+def test_refresh_takes_the_cross_process_lock(pool, monkeypatch):
+    """The refresh POST must happen while the auth-store flock is held.
+
+    Without this, two processes both POST the same single-use token and the
+    loser is left holding a revoked refresh token.
+    """
+    events = []
+
+    class _Lock:
+        def __enter__(self):
+            events.append("lock-acquired")
+            return self
+
+        def __exit__(self, *exc):
+            events.append("lock-released")
+            return False
+
+    monkeypatch.setattr(CP, "_auth_store_lock", lambda **kwargs: _Lock())
+    monkeypatch.setattr(
+        CredentialPool,
+        "_refresh_entry_impl",
+        lambda self, entry, *, force: (events.append("refresh-post"), entry)[1],
+    )
+
+    pool._refresh_entry(pool._entries[0], force=True)
+
+    assert "refresh-post" in events, "refresh never ran"
+    assert events.index("lock-acquired") < events.index("refresh-post") < events.index(
+        "lock-released"
+    ), f"refresh POST ran outside the cross-process lock: {events}"
+
+
+def test_rotated_pair_is_adopted_instead_of_posting_a_revoked_token(pool, monkeypatch):
+    """A waiter must adopt the winner's rotated pair, not POST the stale one."""
+    rotated = {
+        "id": "anthropic-1",
+        "label": "anthropic-oauth-1",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "priority": 0,
+        "source": "manual:hermes_pkce",
+        "access_token": "acc-new",
+        "refresh_token": "ref-new",
+        "expires_at_ms": 9_999_999,
+    }
+    monkeypatch.setattr(CP, "read_credential_pool", lambda provider=None: [rotated])
+
+    class _Lock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(CP, "_auth_store_lock", lambda **kwargs: _Lock())
+
+    posted = []
+    monkeypatch.setattr(
+        CredentialPool,
+        "_refresh_entry_impl",
+        lambda self, entry, *, force: (posted.append(entry.refresh_token), entry)[1],
+    )
+
+    result = pool._refresh_entry(pool._entries[0], force=True)
+
+    assert posted == [], (
+        "posted an already-rotated (revoked) refresh token instead of adopting "
+        f"the persisted pair: {posted}"
+    )
+    assert result is not None
+    assert result.access_token == "acc-new"
+    assert result.refresh_token == "ref-new"
+
+
+def test_claude_code_entries_still_sync_from_the_credentials_file(pool, monkeypatch):
+    """``claude_code`` keeps its canonical store (~/.claude/.credentials.json).
+
+    The Claude Code CLI writes that file too, so those entries must not be
+    switched over to the pool-store sync.
+    """
+    entry = _entry(source="claude_code")
+    pool._entries = [entry]
+    called = []
+
+    monkeypatch.setattr(
+        CredentialPool,
+        "_sync_anthropic_entry_from_credentials_file",
+        lambda self, e: (called.append(e.id), e)[1],
+    )
+
+    pool._sync_anthropic_entry_from_pool_store(entry)
+
+    assert called == [entry.id], "claude_code entry bypassed the credentials-file sync"
+
+
+def test_concurrent_refresh_posts_the_token_only_once(monkeypatch):
+    """Two pools racing on one credential must produce exactly one POST.
+
+    This is the end-to-end shape of the bug: same credential, same expiry, two
+    profiles entering the refresh window together.
+    """
+    store = {
+        "rows": [
+            {
+                "id": "anthropic-1",
+                "label": "anthropic-oauth-1",
+                "auth_type": AUTH_TYPE_OAUTH,
+                "priority": 0,
+                "source": "manual:hermes_pkce",
+                "access_token": "acc-old",
+                "refresh_token": "ref-old",
+                "expires_at_ms": 1_000,
+            }
+        ]
+    }
+    posts = []
+    real_lock = threading.Lock()
+
+    class _Lock:
+        def __enter__(self):
+            real_lock.acquire()
+            return self
+
+        def __exit__(self, *exc):
+            real_lock.release()
+            return False
+
+    monkeypatch.setattr(CP, "_auth_store_lock", lambda **kwargs: _Lock())
+    monkeypatch.setattr(CP, "read_credential_pool", lambda provider=None: store["rows"])
+    monkeypatch.setattr(CP, "write_credential_pool", lambda *a, **k: None)
+
+    def fake_impl(self, entry, *, force):
+        posts.append(entry.refresh_token)
+        rotated = {**store["rows"][0], "access_token": "acc-new", "refresh_token": "ref-new"}
+        store["rows"] = [rotated]
+        return PooledCredential.from_dict("anthropic", rotated)
+
+    monkeypatch.setattr(CredentialPool, "_refresh_entry_impl", fake_impl)
+
+    def worker():
+        p = CredentialPool("anthropic", [_entry()])
+        p._refresh_entry(p._entries[0], force=True)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(posts) == 1, (
+        f"single-use refresh token was POSTed {len(posts)} times: {posts} — "
+        "the loser would get refresh_token_reused"
+    )


### PR DESCRIPTION
## Problem

`agent/anthropic_adapter.py` documents that Anthropic subscription OAuth refresh tokens are single-use:

> Claude Code's OAuth refresh tokens are single-use: a successful refresh rotates the pair and invalidates the old refresh token.

But `anthropic` was absent from the provider allow-list in `credential_pool.py` that serializes the sync → POST → write-back sequence through the cross-process auth-store flock. `openai-codex` and `xai-oauth` — same semantics — were already covered:

```python
if self.provider in ("openai-codex", "xai-oauth"):
    with _auth_store_lock(timeout_seconds=self._single_use_refresh_lock_timeout()):
        ...
return self._refresh_entry_impl(entry, force=force)   # anthropic landed here
```

The comment directly above that branch describes the exact hazard Anthropic was exposed to.

**This race is the normal case, not a rare interleaving.** Profiles sharing one credential each hold their own copy of the same pair with the same `expires_at_ms`, and `_entry_needs_refresh` fires 120s before expiry:

```python
if self.provider == "anthropic":
    return int(entry.expires_at_ms) <= int(time.time() * 1000) + 120_000
```

They all enter the window together. The winner rotates the pair; every loser POSTs an already-revoked token and gets `refresh_token_reused` / `invalid_grant`.

Reported in #95431.

## Changes

- **`_refresh_entry` / `_available_entries`** — include `anthropic` in the flock branch (both the direct and the deferred refresh path), with a sync function that re-reads the persisted pool row while the lock is held, so a waiter adopts the rotated pair instead of POSTing a revoked one.
- **`_sync_anthropic_entry_from_pool_store`** — new helper mirroring `_sync_xai_oauth_entry_from_pool_store`. `claude_code` entries delegate to the existing `_sync_anthropic_entry_from_credentials_file`, since their canonical store is `~/.claude/.credentials.json`, which the Claude Code CLI writes as well.
- **`_single_use_refresh_lock_timeout`** — honour `HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS`, matching the existing Codex/xAI pattern.

## Deliberately not in this PR

The root write-through in `_sync_device_code_entry_to_auth_store` (item 2 of #95431). That path resolves `providers.<id>` state and is gated on `source == "device_code"`, whereas Anthropic OAuth persists under `credential_pool` with `manual:hermes_pkce` / `claude_code` sources — the existing dispatch shape does not transfer, and `write_credential_pool` already merges on-disk rows under the same lock.

Adding an `anthropic` branch there would mean inventing a new state shape, so I left it out rather than guess. Happy to follow up if you'd like it covered, and to hear which shape you'd prefer.

## Verification

Tests assert the behaviour contract (serialize + adopt-instead-of-POST), not the literal provider tuple.

**The concurrency test reproduces the reported bug.** With the fix reverted:

```
AssertionError: single-use refresh token was POSTed 2 times: ['ref-old', 'ref-old']
 — the loser would get refresh_token_reused
4 failed in 0.23s
```

With the fix applied:

```
4 passed in 0.27s
```

No regressions in the surrounding suites:

```
$ pytest tests/agent/ -k "credential_pool or anthropic"
491 passed, 4959 deselected in 23.55s
```

(The `anthropic` SDK must be installed for that selection to be green — without it, 5 unrelated `anthropic_messages` client-shape tests fail on `main` too, independent of this change.)

Environment: Python 3.11.15, macOS (arm64).
