### PR TITLE
fix(skills): keep archived catalog skills hidden after updates

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -21,6 +21,7 @@ It DOES include:
     pointer — otherwise the curator would immediately re-fire on the next
     tick)
   - ``.bundled_manifest`` (so protection markers stay consistent)
+  - ``.bundled_history`` (so removed catalog skills retain their provenance)
   - ``.curator_suppressed`` (so rollback restores the set of pruned built-ins
     the re-seeder must leave archived)
 

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -263,7 +263,9 @@ def build_learning_graph() -> dict[str, Any]:
     learned_skills = {
         name: node
         for name, node in all_skills.items()
-        if node.source != "base" and (node.created_by == "agent" or node.use_count > 0)
+        if node.source != "base"
+        and node.state != "archived"
+        and (node.created_by == "agent" or node.use_count > 0)
     }
     skill_edges = build_edges(learned_skills)
     memory_cards = _memory_cards()

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -455,7 +455,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     # each naming the same skill as its own incumbent (#74574).
     commands: Dict[str, Dict[str, Any]] = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
             get_external_skills_dirs,
             get_project_skills_dirs,
@@ -465,13 +465,14 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
+        active_skills_dir = _skills_dir()
 
         # Scan project dirs first (highest precedence), then local, then external.
         # Project dirs iterate through the quarantine chokepoint.
         project_dirs = list(get_project_skills_dirs())
         dirs_to_scan = list(project_dirs)
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        if active_skills_dir.exists():
+            dirs_to_scan.append(active_skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -499,7 +500,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # Archive state belongs to the profile-local copy only.
                     # A same-named project skill has independent precedence and
                     # remains available, matching tools.skills_tool discovery.
-                    if scan_dir == SKILLS_DIR and name in archived:
+                    if scan_dir == active_skills_dir and name in archived:
                         continue
                     # Respect user's disabled skills config
                     if name in disabled:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -26,7 +26,9 @@ _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
 _skill_commands_archived: frozenset[str] = frozenset()
-# Guards the (map, platform-tag, home-tag, archive-state) snapshot so
+_skill_commands_project: tuple[Optional[str], tuple[str, ...]] | None = None
+# Guards the (map, platform-tag, home-tag, archive-state, project-context)
+# snapshot so
 # publication and the freshness lookup always see a consistent view. Scanning
 # itself stays outside this lock.
 _publish_lock = threading.Lock()
@@ -244,6 +246,24 @@ def _archived_skill_names() -> frozenset[str]:
         return frozenset()
 
 
+def _resolve_skill_commands_project_context() -> tuple[
+    tuple[Optional[str], tuple[str, ...]], list[Path]
+]:
+    """Return the current project identity and its effective skill dirs."""
+    try:
+        from agent.skill_utils import find_project_root, get_project_skills_dirs
+
+        root = find_project_root()
+        project_dirs = list(get_project_skills_dirs())
+        identity = (
+            str(root.resolve()) if root is not None else None,
+            tuple(str(path.resolve()) for path in project_dirs),
+        )
+        return identity, project_dirs
+    except Exception:
+        return (None, ()), []
+
+
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
     raw_identifier = (skill_identifier or "").strip()
@@ -443,10 +463,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform, _skill_commands_home
-    global _skill_commands_archived
+    global _skill_commands_archived, _skill_commands_project
     platform = _resolve_skill_commands_platform()
     home = _resolve_skill_commands_home()
     archived = _archived_skill_names()
+    project_context, project_dirs = _resolve_skill_commands_project_context()
     # Build into a local map and publish once, at the end. Writing straight
     # into the global made a scan's partial results visible to everything
     # else in the process: a second, overlapping scan deduped against its own
@@ -458,7 +479,6 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
             get_external_skills_dirs,
-            get_project_skills_dirs,
             iter_project_skill_files,
             iter_skill_index_files,
         )
@@ -469,7 +489,6 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         # Scan project dirs first (highest precedence), then local, then external.
         # Project dirs iterate through the quarantine chokepoint.
-        project_dirs = list(get_project_skills_dirs())
         dirs_to_scan = list(project_dirs)
         if active_skills_dir.exists():
             dirs_to_scan.append(active_skills_dir)
@@ -573,6 +592,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         _skill_commands_platform = platform
         _skill_commands_home = home
         _skill_commands_archived = archived
+        _skill_commands_project = project_context
     return commands
 
 
@@ -583,11 +603,14 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536), and when the
     active profile's Hermes home changes (e.g. Desktop switching profiles
-    mid-session) so each profile sees its own ``skills.external_dirs`` (#88023).
+    mid-session) so each profile sees its own ``skills.external_dirs`` (#88023),
+    and when cwd/project discovery changes so a long-lived CLI selects the
+    current project's highest-precedence skill copy.
     """
     current_platform = _resolve_skill_commands_platform()
     current_home = _resolve_skill_commands_home()
     current_archived = _archived_skill_names()
+    current_project, _ = _resolve_skill_commands_project_context()
     # Read the map and its tags under the same lock that publishes them, so
     # the freshness decision is made against a consistent snapshot.
     with _publish_lock:
@@ -597,6 +620,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
             and _skill_commands_platform == current_platform
             and _skill_commands_home == current_home
             and _skill_commands_archived == current_archived
+            and _skill_commands_project == current_project
         )
     if is_fresh:
         return commands

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -27,6 +27,11 @@ _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
 _skill_commands_archived: frozenset[str] = frozenset()
 _skill_commands_project: tuple[Optional[str], tuple[str, ...]] | None = None
+_project_context_cache: dict[
+    tuple[str, str, Optional[int], Optional[int]],
+    tuple[tuple[tuple[str, Optional[int]], ...], tuple[Optional[str], tuple[str, ...]], list[Path]],
+] = {}
+_project_context_lock = threading.Lock()
 # Guards the (map, platform-tag, home-tag, archive-state, project-context)
 # snapshot so
 # publication and the freshness lookup always see a consistent view. Scanning
@@ -235,13 +240,9 @@ def _resolve_skill_commands_home() -> str:
 def _archived_skill_names() -> frozenset[str]:
     """Return profile-local skill names whose lifecycle state is archived."""
     try:
-        from tools.skill_usage import STATE_ARCHIVED, load_usage
+        from tools.skill_usage import archived_skill_names
 
-        return frozenset(
-            name
-            for name, record in load_usage().items()
-            if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
-        )
+        return archived_skill_names()
     except Exception:
         return frozenset()
 
@@ -249,9 +250,33 @@ def _archived_skill_names() -> frozenset[str]:
 def _resolve_skill_commands_project_context() -> tuple[
     tuple[Optional[str], tuple[str, ...]], list[Path]
 ]:
-    """Return the current project identity and its effective skill dirs."""
+    """Return project identity and skill dirs with a cheap cache-hit path."""
     try:
         from agent.skill_utils import find_project_root, get_project_skills_dirs
+
+        effective_cwd = os.path.abspath(
+            os.environ.get("TERMINAL_CWD") or os.getcwd()
+        )
+        home = _resolve_skill_commands_home()
+        config_path = Path(home) / "config.yaml"
+        try:
+            config_stat = config_path.stat()
+            config_mtime = config_stat.st_mtime_ns
+            config_size = config_stat.st_size
+        except OSError:
+            config_mtime = None
+            config_size = None
+        cache_key = (effective_cwd, home, config_mtime, config_size)
+
+        with _project_context_lock:
+            cached = _project_context_cache.get(cache_key)
+        if cached is not None:
+            old_watch, identity, project_dirs = cached
+            current_watch = tuple(
+                (path, _path_mtime_ns(Path(path))) for path, _ in old_watch
+            )
+            if current_watch == old_watch:
+                return identity, list(project_dirs)
 
         root = find_project_root()
         project_dirs = list(get_project_skills_dirs())
@@ -259,9 +284,28 @@ def _resolve_skill_commands_project_context() -> tuple[
             str(root.resolve()) if root is not None else None,
             tuple(str(path.resolve()) for path in project_dirs),
         )
+        watch_paths: list[Path] = []
+        if root is not None:
+            watch_paths = [
+                root / ".git",
+                root / ".hermes" / "skills",
+                root / ".agents" / "skills",
+            ]
+        watch = tuple((str(path), _path_mtime_ns(path)) for path in watch_paths)
+        with _project_context_lock:
+            _project_context_cache.clear()
+            _project_context_cache[cache_key] = (watch, identity, list(project_dirs))
         return identity, project_dirs
     except Exception:
         return (None, ()), []
+
+
+def _path_mtime_ns(path: Path) -> Optional[int]:
+    """Return a cheap change token for a project marker or skill directory."""
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
 
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -551,6 +551,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
+                        "source_tier": (
+                            "project" if scan_dir in project_dirs
+                            else "profile" if scan_dir == active_skills_dir
+                            else "external"
+                        ),
                     }
                 except Exception:
                     continue

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -29,9 +30,15 @@ _skill_commands_archived: frozenset[str] = frozenset()
 _skill_commands_project: tuple[Optional[str], tuple[str, ...]] | None = None
 _project_context_cache: dict[
     tuple[str, str, Optional[int], Optional[int]],
-    tuple[tuple[tuple[str, Optional[int]], ...], tuple[Optional[str], tuple[str, ...]], list[Path]],
+    tuple[
+        float,
+        tuple[tuple[str, Optional[int]], ...],
+        tuple[Optional[str], tuple[str, ...]],
+        list[Path],
+    ],
 ] = {}
 _project_context_lock = threading.Lock()
+_PROJECT_CONTEXT_CACHE_TTL_SECONDS = 1.0
 # Guards the (map, platform-tag, home-tag, archive-state, project-context)
 # snapshot so
 # publication and the freshness lookup always see a consistent view. Scanning
@@ -271,11 +278,15 @@ def _resolve_skill_commands_project_context() -> tuple[
         with _project_context_lock:
             cached = _project_context_cache.get(cache_key)
         if cached is not None:
-            old_watch, identity, project_dirs = cached
+            cached_at, old_watch, identity, project_dirs = cached
             current_watch = tuple(
                 (path, _path_mtime_ns(Path(path))) for path, _ in old_watch
             )
-            if current_watch == old_watch:
+            if (
+                current_watch == old_watch
+                and time.monotonic() - cached_at
+                < _PROJECT_CONTEXT_CACHE_TTL_SECONDS
+            ):
                 return identity, list(project_dirs)
 
         root = find_project_root()
@@ -294,7 +305,12 @@ def _resolve_skill_commands_project_context() -> tuple[
         watch = tuple((str(path), _path_mtime_ns(path)) for path in watch_paths)
         with _project_context_lock:
             _project_context_cache.clear()
-            _project_context_cache[cache_key] = (watch, identity, list(project_dirs))
+            _project_context_cache[cache_key] = (
+                time.monotonic(),
+                watch,
+                identity,
+                list(project_dirs),
+            )
         return identity, project_dirs
     except Exception:
         return (None, ()), []

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -25,9 +25,10 @@ logger = logging.getLogger(__name__)
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
-# Guards the (map, platform-tag, home-tag) triple so publication and the
-# freshness lookup always see a consistent snapshot. Scanning itself stays
-# outside this lock.
+_skill_commands_archived: frozenset[str] = frozenset()
+# Guards the (map, platform-tag, home-tag, archive-state) snapshot so
+# publication and the freshness lookup always see a consistent view. Scanning
+# itself stays outside this lock.
 _publish_lock = threading.Lock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
@@ -229,6 +230,20 @@ def _resolve_skill_commands_home() -> str:
     return str(get_hermes_home())
 
 
+def _archived_skill_names() -> frozenset[str]:
+    """Return profile-local skill names whose lifecycle state is archived."""
+    try:
+        from tools.skill_usage import STATE_ARCHIVED, load_usage
+
+        return frozenset(
+            name
+            for name, record in load_usage().items()
+            if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
+        )
+    except Exception:
+        return frozenset()
+
+
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
     raw_identifier = (skill_identifier or "").strip()
@@ -428,8 +443,10 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform, _skill_commands_home
+    global _skill_commands_archived
     platform = _resolve_skill_commands_platform()
     home = _resolve_skill_commands_home()
+    archived = _archived_skill_names()
     # Build into a local map and publish once, at the end. Writing straight
     # into the global made a scan's partial results visible to everything
     # else in the process: a second, overlapping scan deduped against its own
@@ -478,6 +495,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         continue
                     name = frontmatter.get('name', skill_md.parent.name)
                     if name in seen_names:
+                        continue
+                    # Archive state belongs to the profile-local copy only.
+                    # A same-named project skill has independent precedence and
+                    # remains available, matching tools.skills_tool discovery.
+                    if scan_dir == SKILLS_DIR and name in archived:
                         continue
                     # Respect user's disabled skills config
                     if name in disabled:
@@ -544,6 +566,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         _skill_commands = commands
         _skill_commands_platform = platform
         _skill_commands_home = home
+        _skill_commands_archived = archived
     return commands
 
 
@@ -558,6 +581,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     """
     current_platform = _resolve_skill_commands_platform()
     current_home = _resolve_skill_commands_home()
+    current_archived = _archived_skill_names()
     # Read the map and its tags under the same lock that publishes them, so
     # the freshness decision is made against a consistent snapshot.
     with _publish_lock:
@@ -566,6 +590,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
             bool(commands)
             and _skill_commands_platform == current_platform
             and _skill_commands_home == current_home
+            and _skill_commands_archived == current_archived
         )
     if is_fresh:
         return commands

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -432,7 +432,7 @@ async def get_skills(profile: Optional[str] = None):
     from tools.skills_tool import _find_all_skills
     from hermes_cli.skills_config import get_disabled_skills
     from tools.skill_usage import (
-        _read_bundled_manifest_names,
+        _read_bundled_provenance_names,
         _read_hub_installed_names,
         activity_count,
         load_usage,
@@ -447,7 +447,7 @@ async def get_skills(profile: Optional[str] = None):
             # without a per-skill manifest read): hub > bundled > agent, where
             # "agent" covers agent-authored AND local hand-made skills — the ones
             # the user may edit/delete from the UI.
-            bundled_names = _read_bundled_manifest_names()
+            bundled_names = _read_bundled_provenance_names()
             hub_names = _read_hub_installed_names()
         for s in skills:
             s["enabled"] = s["name"] not in disabled

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -441,7 +441,7 @@ async def get_skills(profile: Optional[str] = None):
         with _profile_scope(profile):
             config = load_config()
             disabled = get_disabled_skills(config)
-            skills = _find_all_skills(skip_disabled=True)
+            skills = _find_all_skills(skip_disabled=True, include_source=True)
             usage = load_usage()
             # Set-based provenance (same classification as skill_usage.provenance,
             # without a per-skill manifest read): hub > bundled > agent, where
@@ -450,11 +450,16 @@ async def get_skills(profile: Optional[str] = None):
             bundled_names = _read_bundled_provenance_names()
             hub_names = _read_hub_installed_names()
         for s in skills:
+            source_tier = s.pop("_source_tier", "profile")
+            s.pop("_source_path", None)
+            is_profile_copy = source_tier == "profile"
             s["enabled"] = s["name"] not in disabled
-            s["usage"] = activity_count(usage.get(s["name"], {}))
+            s["usage"] = (
+                activity_count(usage.get(s["name"], {})) if is_profile_copy else 0
+            )
             s["provenance"] = (
-                "hub" if s["name"] in hub_names
-                else "bundled" if s["name"] in bundled_names
+                "hub" if is_profile_copy and s["name"] in hub_names
+                else "bundled" if is_profile_copy and s["name"] in bundled_names
                 else "agent"
             )
         return skills

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -79,3 +79,33 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
     assert graph["stats"]["nodes"] == len(skill_nodes)
     assert graph["stats"]["memory_nodes"] == len(graph["memory"])
     assert all("timestamp" in n for n in graph["nodes"])
+
+
+def test_archived_skill_is_not_part_of_learning_graph(tmp_path, monkeypatch):
+    profile = tmp_path / "skills"
+    skill = profile / "archived-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: archived-skill\ndescription: Archived.\n---\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        learning_graph,
+        "_load_usage",
+        lambda: {
+            "archived-skill": {
+                "state": "archived",
+                "created_by": "agent",
+                "use_count": 4,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        learning_graph,
+        "_skill_roots",
+        lambda: [("profile", profile)],
+    )
+
+    graph = learning_graph.build_learning_graph()
+
+    assert "archived-skill" not in {node["id"] for node in graph["nodes"]}

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -82,6 +82,98 @@ class TestScanSkillCommands:
         assert message is not None
         assert "Apply impeccable design craft." in message
 
+    def test_archived_profile_skill_is_not_scanned_as_command(self, tmp_path):
+        """A resurrected local copy must stay absent from slash discovery."""
+        import agent.skill_commands as sc_mod
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools import skill_usage
+
+        home = tmp_path / "profile"
+        skills_dir = home / "skills"
+        _make_skill(skills_dir, "lifecycle-x")
+
+        token = set_hermes_home_override(home)
+        try:
+            skill_usage.save_usage(
+                {"lifecycle-x": {"state": skill_usage.STATE_ARCHIVED}}
+            )
+            with (
+                patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+                patch.object(sc_mod, "_skill_commands", {}),
+                patch.object(sc_mod, "_skill_commands_archived", frozenset()),
+            ):
+                commands = scan_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "/lifecycle-x" not in commands
+
+    def test_archived_local_record_does_not_hide_project_command(self, tmp_path):
+        """Archive lifecycle applies only to the profile-local skill copy."""
+        import agent.skill_commands as sc_mod
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools import skill_usage
+
+        home = tmp_path / "profile"
+        local_skills = home / "skills"
+        project_skills = tmp_path / "project-skills"
+        _make_skill(local_skills, "shared-name", body="Local copy.")
+        project_skill = _make_skill(project_skills, "shared-name", body="Project copy.")
+
+        token = set_hermes_home_override(home)
+        try:
+            skill_usage.save_usage(
+                {"shared-name": {"state": skill_usage.STATE_ARCHIVED}}
+            )
+            with (
+                patch("tools.skills_tool.SKILLS_DIR", local_skills),
+                patch("agent.skill_utils.get_project_skills_dirs", return_value=[project_skills]),
+                patch.object(sc_mod, "_skill_commands", {}),
+                patch.object(sc_mod, "_skill_commands_archived", frozenset()),
+            ):
+                commands = scan_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+
+        assert commands["/shared-name"]["skill_dir"] == str(project_skill)
+
+    def test_command_cache_tracks_archive_and_restore_transitions(self, tmp_path):
+        """A primed resolver must follow lifecycle state without manual reload."""
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools import skill_usage
+
+        home = tmp_path / "profile"
+        skills_dir = home / "skills"
+        _make_skill(skills_dir, "lifecycle-x")
+
+        token = set_hermes_home_override(home)
+        try:
+            skill_usage.save_usage(
+                {"lifecycle-x": {"state": skill_usage.STATE_ACTIVE}}
+            )
+            with (
+                patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+                patch.object(sc_mod, "_skill_commands", {}),
+                patch.object(sc_mod, "_skill_commands_platform", None),
+                patch.object(sc_mod, "_skill_commands_home", None),
+                patch.object(sc_mod, "_skill_commands_archived", frozenset()),
+            ):
+                assert "/lifecycle-x" in get_skill_commands()
+
+                skill_usage.save_usage(
+                    {"lifecycle-x": {"state": skill_usage.STATE_ARCHIVED}}
+                )
+                assert "/lifecycle-x" not in get_skill_commands()
+
+                skill_usage.save_usage(
+                    {"lifecycle-x": {"state": skill_usage.STATE_ACTIVE}}
+                )
+                assert "/lifecycle-x" in get_skill_commands()
+        finally:
+            reset_hermes_home_override(token)
+
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -174,6 +174,34 @@ class TestScanSkillCommands:
         finally:
             reset_hermes_home_override(token)
 
+    def test_project_context_cache_avoids_rewalking_unchanged_project(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.skill_commands as sc_mod
+
+        project = tmp_path / "project"
+        project_skills = project / ".hermes" / "skills"
+        (project / ".git").mkdir(parents=True)
+        project_skills.mkdir(parents=True)
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+        sc_mod._project_context_cache.clear()
+
+        with (
+            patch(
+                "agent.skill_utils.find_project_root", return_value=project
+            ) as find_root,
+            patch(
+                "agent.skill_utils.get_project_skills_dirs",
+                return_value=[project_skills],
+            ) as project_dirs,
+        ):
+            first = sc_mod._resolve_skill_commands_project_context()
+            second = sc_mod._resolve_skill_commands_project_context()
+
+        assert first == second
+        find_root.assert_called_once_with()
+        project_dirs.assert_called_once_with()
+
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -202,6 +202,43 @@ class TestScanSkillCommands:
         find_root.assert_called_once_with()
         project_dirs.assert_called_once_with()
 
+    def test_project_context_cache_rechecks_missing_root_after_ttl(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.skill_commands as sc_mod
+
+        project = tmp_path / "project"
+        project_skills = project / ".hermes" / "skills"
+        project.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+        sc_mod._project_context_cache.clear()
+
+        with (
+            patch(
+                "agent.skill_utils.find_project_root",
+                side_effect=[None, project],
+            ) as find_root,
+            patch(
+                "agent.skill_utils.get_project_skills_dirs",
+                side_effect=[[], [project_skills]],
+            ),
+            patch(
+                "agent.skill_commands.time.monotonic",
+                side_effect=[10.0, 12.0, 12.0],
+            ),
+        ):
+            first = sc_mod._resolve_skill_commands_project_context()
+            (project / ".git").mkdir()
+            project_skills.mkdir(parents=True)
+            second = sc_mod._resolve_skill_commands_project_context()
+
+        assert first == ((None, ()), [])
+        assert second == (
+            (str(project.resolve()), (str(project_skills.resolve()),)),
+            [project_skills],
+        )
+        assert find_root.call_count == 2
+
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
 

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -7,6 +7,8 @@ process. Before the ``profile`` parameter existed, toggling a skill after
 These tests pin the new behavior: reads and writes land in the REQUESTED
 profile's HERMES_HOME, and the dashboard's own profile stays untouched.
 """
+import json
+
 import pytest
 import yaml
 
@@ -63,6 +65,27 @@ def _load_cfg(home):
 
 
 class TestProfileScopedSkills:
+
+    def test_list_uses_history_provenance_and_hides_archived_copy(
+        self, client, isolated_profiles
+    ):
+        default_skills = isolated_profiles["default"] / "skills"
+        default_skills.joinpath(".bundled_history").write_text(
+            "dashboard-skill\n", encoding="utf-8"
+        )
+        default = client.get("/api/skills")
+        assert default.status_code == 200
+        by_name = {skill["name"]: skill for skill in default.json()}
+        assert by_name["dashboard-skill"]["provenance"] == "bundled"
+
+        worker_skills = isolated_profiles["worker_alpha"] / "skills"
+        worker_skills.joinpath(".usage.json").write_text(
+            json.dumps({"worker-skill": {"state": "archived"}}),
+            encoding="utf-8",
+        )
+        worker = client.get("/api/skills", params={"profile": "worker_alpha"})
+        assert worker.status_code == 200
+        assert "worker-skill" not in {skill["name"] for skill in worker.json()}
 
 
     def test_toggle_writes_into_target_profile_only(self, client, isolated_profiles):

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -87,6 +87,61 @@ class TestProfileScopedSkills:
         assert worker.status_code == 200
         assert "worker-skill" not in {skill["name"] for skill in worker.json()}
 
+    def test_project_override_does_not_inherit_profile_history(
+        self, client, isolated_profiles, tmp_path, monkeypatch
+    ):
+        from agent import skill_utils
+        from tools import skill_usage, skills_tool
+
+        home = isolated_profiles["default"]
+        profile_skills = home / "skills"
+        profile_skills.joinpath(".bundled_history").write_text(
+            "dashboard-skill\n", encoding="utf-8"
+        )
+        skill_usage.save_usage(
+            {
+                "dashboard-skill": {
+                    "state": skill_usage.STATE_ARCHIVED,
+                    "use_count": 172,
+                }
+            }
+        )
+
+        project = tmp_path / "project"
+        (project / ".git").mkdir(parents=True)
+        project_skills = project / ".hermes" / "skills"
+        _write_skill(project_skills, "dashboard-skill", "trusted project copy")
+        home.joinpath("config.yaml").write_text(
+            "skills:\n"
+            "  external_dirs: []\n"
+            f"  trusted_project_dirs: ['{project.as_posix()}']\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(project)
+        skill_utils._external_dirs_cache_clear()
+        skills_tool._SKILLS_CACHE.clear()
+
+        selected = skills_tool._find_all_skills(
+            skip_disabled=True, include_source=True
+        )
+        selected_skill = next(
+            skill for skill in selected if skill["name"] == "dashboard-skill"
+        )
+        assert selected_skill["_source_tier"] == "project"
+        assert selected_skill["_source_path"] == str(
+            project_skills / "dashboard-skill" / "SKILL.md"
+        )
+
+        response = client.get("/api/skills")
+        assert response.status_code == 200
+        by_name = {skill["name"]: skill for skill in response.json()}
+        dashboard = by_name["dashboard-skill"]
+        assert dashboard["description"] == "trusted project copy"
+        assert dashboard["provenance"] == "agent"
+        assert dashboard["usage"] == 0
+        assert "_source_tier" not in dashboard
+        assert "_source_path" not in dashboard
+
 
     def test_toggle_writes_into_target_profile_only(self, client, isolated_profiles):
         resp = client.put(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10587,6 +10587,37 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     assert resp["result"]["canon"]["/notes"] == "/notes"
 
 
+def test_commands_catalog_omits_archived_resurrected_skill(tmp_path, monkeypatch):
+    """The TUI/Desktop catalog must not advertise an archived local copy."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import skill_usage
+
+    home = tmp_path / "profile"
+    skills_dir = home / "skills"
+    skill_dir = skills_dir / "lifecycle-x"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: lifecycle-x\ndescription: Lifecycle test.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    try:
+        skill_usage.save_usage(
+            {"lifecycle-x": {"state": skill_usage.STATE_ARCHIVED}}
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+        resp = server.handle_request(
+            {"id": "1", "method": "commands.catalog", "params": {}}
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert "/lifecycle-x" not in dict(resp["result"]["pairs"])
+    assert "/lifecycle-x" not in resp["result"]["skills"]
+
+
 def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
     """Skill entries carry the usage + origin the `/` menu ranks on.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10685,6 +10685,71 @@ def test_commands_catalog_tracks_profile_local_archive_state(tmp_path):
         reset_hermes_home_override(token_b)
 
 
+def test_commands_catalog_project_override_has_independent_metadata(
+    tmp_path, monkeypatch
+):
+    """A trusted project copy must not inherit an archived local identity."""
+    import agent.skill_commands as sc_mod
+    from agent import skill_utils
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import skill_usage
+
+    home = tmp_path / "profile"
+    profile_skill = home / "skills" / "shared-lifecycle"
+    profile_skill.mkdir(parents=True)
+    profile_skill.joinpath("SKILL.md").write_text(
+        "---\nname: shared-lifecycle\ndescription: Profile copy.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    home.joinpath("skills", ".bundled_history").write_text(
+        "shared-lifecycle\n", encoding="utf-8"
+    )
+
+    project = tmp_path / "project"
+    (project / ".git").mkdir(parents=True)
+    project_skill = project / ".hermes" / "skills" / "shared-lifecycle"
+    project_skill.mkdir(parents=True)
+    project_skill.joinpath("SKILL.md").write_text(
+        "---\nname: shared-lifecycle\ndescription: Project copy.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    home.joinpath("config.yaml").write_text(
+        "skills:\n"
+        "  external_dirs: []\n"
+        f"  trusted_project_dirs: ['{project.as_posix()}']\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    try:
+        monkeypatch.chdir(project)
+        skill_utils._external_dirs_cache_clear()
+        skill_usage.save_usage(
+            {
+                "shared-lifecycle": {
+                    "state": skill_usage.STATE_ARCHIVED,
+                    "use_count": 172,
+                }
+            }
+        )
+        with patch.object(sc_mod, "_skill_commands", {}):
+            commands = sc_mod.scan_skill_commands()
+            response = server.handle_request(
+                {"id": "1", "method": "commands.catalog", "params": {}}
+            )
+    finally:
+        reset_hermes_home_override(token)
+        skill_utils._external_dirs_cache_clear()
+
+    selected = commands["/shared-lifecycle"]
+    assert selected["skill_dir"] == str(project_skill)
+    assert selected["source_tier"] == "project"
+    assert response["result"]["skills"]["/shared-lifecycle"] == {
+        "usage": 0,
+        "origin": "local",
+    }
+
+
 def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
     """Skill entries carry the usage + origin the `/` menu ranks on.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10750,6 +10750,71 @@ def test_commands_catalog_project_override_has_independent_metadata(
     }
 
 
+def test_slash_cache_follows_same_profile_project_cwd_transition(tmp_path, monkeypatch):
+    """Cached slash discovery must follow supported in-process cwd changes."""
+    import agent.skill_commands as sc_mod
+    from agent import skill_utils
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    home = tmp_path / "profile"
+    profile_skill = home / "skills" / "cwd-shadow"
+    profile_skill.mkdir(parents=True)
+    profile_skill.joinpath("SKILL.md").write_text(
+        "---\nname: cwd-shadow\ndescription: Profile command.\n---\n\nProfile body.\n",
+        encoding="utf-8",
+    )
+
+    project_a = tmp_path / "project-a"
+    project_a.joinpath(".git").mkdir(parents=True)
+    project_b = tmp_path / "project-b"
+    project_b.joinpath(".git").mkdir(parents=True)
+    project_skill = project_b / ".hermes" / "skills" / "cwd-shadow"
+    project_skill.mkdir(parents=True)
+    project_skill.joinpath("SKILL.md").write_text(
+        "---\nname: cwd-shadow\ndescription: Project command.\n---\n\nProject body.\n",
+        encoding="utf-8",
+    )
+    home.joinpath("config.yaml").write_text(
+        "skills:\n"
+        "  external_dirs: []\n"
+        f"  trusted_project_dirs: ['{project_b.as_posix()}']\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    try:
+        monkeypatch.chdir(project_a)
+        monkeypatch.setenv("TERMINAL_CWD", str(project_a))
+        skill_utils._external_dirs_cache_clear()
+        with patch.object(sc_mod, "_skill_commands", {}):
+            primed = sc_mod.get_skill_commands()
+            assert primed["/cwd-shadow"]["skill_dir"] == str(profile_skill)
+
+            monkeypatch.chdir(project_b)
+            monkeypatch.setenv("TERMINAL_CWD", str(project_b))
+            selected = sc_mod.get_skill_commands()
+            invocation = sc_mod.build_skill_invocation_message("/cwd-shadow")
+            completion = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "complete.slash",
+                    "params": {"text": "/cwd-shadow"},
+                }
+            )
+    finally:
+        reset_hermes_home_override(token)
+        skill_utils._external_dirs_cache_clear()
+
+    assert selected["/cwd-shadow"]["skill_dir"] == str(project_skill)
+    assert selected["/cwd-shadow"]["source_tier"] == "project"
+    assert invocation is not None and "Project body." in invocation
+    skill_items = [
+        item for item in completion["result"]["items"] if item["kind"] == "skill"
+    ]
+    assert any(item["text"].strip().lstrip("/") == "cwd-shadow" for item in skill_items)
+    assert any("Project command." in item["meta"] for item in skill_items)
+
+
 def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
     """Skill entries carry the usage + origin the `/` menu ranks on.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10618,6 +10618,73 @@ def test_commands_catalog_omits_archived_resurrected_skill(tmp_path, monkeypatch
     assert "/lifecycle-x" not in resp["result"]["skills"]
 
 
+def test_commands_catalog_tracks_profile_local_archive_state(tmp_path):
+    """Profile switches must pair lifecycle state with that profile's files."""
+    import agent.skill_commands as sc_mod
+    from agent.skill_commands import get_skill_commands, scan_skill_commands
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import skill_usage
+
+    def write_skill(home: Path, body: str) -> Path:
+        skill_dir = home / "skills" / "shared-lifecycle"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: shared-lifecycle\n"
+            "description: Profile lifecycle test.\n"
+            "---\n\n"
+            f"{body}\n",
+            encoding="utf-8",
+        )
+        return skill_dir
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    skill_a = write_skill(profile_a, "Profile A copy.")
+    skill_b = write_skill(profile_b, "Profile B copy.")
+
+    token_a = set_hermes_home_override(profile_a)
+    try:
+        skill_usage.save_usage(
+            {"shared-lifecycle": {"state": skill_usage.STATE_ARCHIVED}}
+        )
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override(profile_b)
+    try:
+        skill_usage.save_usage(
+            {"shared-lifecycle": {"state": skill_usage.STATE_ACTIVE}}
+        )
+        with patch.object(sc_mod, "_skill_commands", {}):
+            fresh = scan_skill_commands()
+            cached = get_skill_commands()
+            resp = server.handle_request(
+                {"id": "1", "method": "commands.catalog", "params": {}}
+            )
+
+            assert fresh["/shared-lifecycle"]["skill_dir"] == str(skill_b)
+            assert cached["/shared-lifecycle"]["skill_dir"] == str(skill_b)
+            assert "/shared-lifecycle" in dict(resp["result"]["pairs"])
+            assert str(skill_a) not in {
+                command["skill_dir"] for command in fresh.values()
+            }
+
+            skill_usage.save_usage(
+                {"shared-lifecycle": {"state": skill_usage.STATE_ARCHIVED}}
+            )
+            assert "/shared-lifecycle" not in get_skill_commands()
+            archived_resp = server.handle_request(
+                {"id": "2", "method": "commands.catalog", "params": {}}
+            )
+            assert "/shared-lifecycle" not in dict(
+                archived_resp["result"]["pairs"]
+            )
+            assert "/shared-lifecycle" not in archived_resp["result"]["skills"]
+    finally:
+        reset_hermes_home_override(token_b)
+
+
 def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
     """Skill entries carry the usage + origin the `/` menu ranks on.
 

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -76,6 +76,29 @@ def test_save_and_load_roundtrip(skills_home):
     assert loaded["skill-a"]["state"] == "active"
 
 
+def test_archived_names_reuses_parse_until_sidecar_changes(skills_home, monkeypatch):
+    import tools.skill_usage as skill_usage
+
+    skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ACTIVE}})
+    real_load = skill_usage.load_usage
+    loads = 0
+
+    def counted_load():
+        nonlocal loads
+        loads += 1
+        return real_load()
+
+    monkeypatch.setattr(skill_usage, "load_usage", counted_load)
+
+    assert skill_usage.archived_skill_names() == frozenset()
+    assert skill_usage.archived_skill_names() == frozenset()
+    assert loads == 1
+
+    skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ARCHIVED}})
+    assert skill_usage.archived_skill_names() == frozenset({"skill-a"})
+    assert loads == 2
+
+
 def test_get_record_missing_returns_empty_record(skills_home):
     from tools.skill_usage import get_record
     rec = get_record("nonexistent")

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -86,6 +86,19 @@ def test_get_record_missing_returns_empty_record(skills_home):
     assert rec["archived_at"] is None
 
 
+def test_bundled_provenance_includes_history_and_suppression(skills_home):
+    from tools.skill_usage import is_bundled, provenance
+
+    skills = skills_home / "skills"
+    (skills / ".bundled_history").write_text("removed-upstream\n", encoding="utf-8")
+    (skills / ".curator_suppressed").write_text("archived-before-history\n", encoding="utf-8")
+
+    assert is_bundled("removed-upstream") is True
+    assert provenance("removed-upstream") == "bundled"
+    assert is_bundled("archived-before-history") is True
+    assert provenance("archived-before-history") == "bundled"
+
+
 def test_load_usage_handles_corrupt_file(skills_home):
     from tools.skill_usage import load_usage, _usage_file
     _usage_file().write_text("{ not json }", encoding="utf-8")
@@ -257,6 +270,45 @@ def test_created_skill_does_not_inherit_stale_identity_or_continuity(
     assert [event["provenance"] for event in events] == ["local", "local"]
     assert events[-1]["reused"] is False
     assert events[-1]["reuse_after_patch"] is False
+
+
+def test_explicit_creation_reclaims_removed_bundled_name(skills_home):
+    from tools import skill_usage
+
+    skills = skills_home / "skills"
+    history = skills / ".bundled_history"
+    suppressed = skills / ".curator_suppressed"
+    history.write_text("recreated\n", encoding="utf-8")
+    suppressed.write_text("recreated\n", encoding="utf-8")
+
+    skill_usage.record_created("recreated", agent_created=True)
+
+    assert skill_usage.provenance("recreated") == "agent"
+    assert "recreated" not in skill_usage.read_suppressed_names()
+    assert "recreated" not in skill_usage._read_name_file(history)
+
+
+def test_restore_reactivates_historical_bundled_skill_when_pruning_is_off(
+    skills_home, monkeypatch
+):
+    from tools import skill_usage
+
+    skills = skills_home / "skills"
+    archived = skills / ".archive" / "legacy"
+    archived.mkdir(parents=True)
+    (archived / "SKILL.md").write_text(
+        "---\nname: legacy\ndescription: Legacy.\n---\n", encoding="utf-8"
+    )
+    (skills / ".bundled_history").write_text("legacy\n", encoding="utf-8")
+    skill_usage.save_usage({"legacy": {"state": skill_usage.STATE_ARCHIVED}})
+    monkeypatch.setattr(skill_usage, "_prune_builtins_enabled", lambda: False)
+
+    ok, _ = skill_usage.restore_skill("legacy")
+
+    assert ok is True
+    assert skill_usage.get_record("legacy")["state"] == skill_usage.STATE_ACTIVE
+    assert (skills / "legacy" / "SKILL.md").exists()
+
 
 def test_malformed_usage_counters_recover_without_losing_patch_reuse(
     skills_home,

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -97,6 +97,7 @@ def test_archived_names_reuses_parse_until_sidecar_changes(skills_home, monkeypa
     skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ARCHIVED}})
     assert skill_usage.archived_skill_names() == frozenset({"skill-a"})
     assert loads == 2
+    assert len(skill_usage._ARCHIVED_NAMES_CACHE) == 1
 
 
 def test_archived_names_retries_transient_read_failure(skills_home, monkeypatch):

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -80,7 +80,7 @@ def test_archived_names_reuses_parse_until_sidecar_changes(skills_home, monkeypa
     import tools.skill_usage as skill_usage
 
     skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ACTIVE}})
-    real_load = skill_usage.load_usage
+    real_load = skill_usage._load_usage_with_status
     loads = 0
 
     def counted_load():
@@ -88,7 +88,7 @@ def test_archived_names_reuses_parse_until_sidecar_changes(skills_home, monkeypa
         loads += 1
         return real_load()
 
-    monkeypatch.setattr(skill_usage, "load_usage", counted_load)
+    monkeypatch.setattr(skill_usage, "_load_usage_with_status", counted_load)
 
     assert skill_usage.archived_skill_names() == frozenset()
     assert skill_usage.archived_skill_names() == frozenset()
@@ -97,6 +97,27 @@ def test_archived_names_reuses_parse_until_sidecar_changes(skills_home, monkeypa
     skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ARCHIVED}})
     assert skill_usage.archived_skill_names() == frozenset({"skill-a"})
     assert loads == 2
+
+
+def test_archived_names_retries_transient_read_failure(skills_home, monkeypatch):
+    import tools.skill_usage as skill_usage
+
+    skill_usage.save_usage({"skill-a": {"state": skill_usage.STATE_ARCHIVED}})
+    real_load = skill_usage._load_usage_with_status
+    attempts = 0
+
+    def flaky_load():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return {}, False
+        return real_load()
+
+    monkeypatch.setattr(skill_usage, "_load_usage_with_status", flaky_load)
+
+    assert skill_usage.archived_skill_names() == frozenset()
+    assert skill_usage.archived_skill_names() == frozenset({"skill-a"})
+    assert attempts == 2
 
 
 def test_get_record_missing_returns_empty_record(skills_home):

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from tools.skills_sync import (
     _get_bundled_dir,
+    _read_bundled_history_names,
     _read_manifest,
     _read_skill_name,
     _write_manifest,
@@ -483,6 +484,28 @@ class TestSyncSkills:
         assert not (skills_dir / "old-skill").exists()
         assert "removed-skill" in result["cleaned"]
         assert "removed-skill" not in manifest
+
+    def test_stale_manifest_cleanup_preserves_bundled_origin_history(self, tmp_path):
+        """A removed upstream skill keeps its catalog provenance after cleanup."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        orphan = skills_dir / "legacy-skill"
+        orphan.mkdir(parents=True)
+        (orphan / "SKILL.md").write_text(
+            "---\nname: legacy-skill\n---\nlegacy\n", encoding="utf-8"
+        )
+        manifest_file.write_text("legacy-skill:oldhash\n", encoding="utf-8")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+            manifest = _read_manifest()
+            history = _read_bundled_history_names()
+
+        assert "legacy-skill" in result["cleaned"]
+        assert "legacy-skill" not in manifest
+        assert "legacy-skill" in history
+        assert orphan.exists(), "sync must not delete a legacy skill behind the user's back"
 
 
     def test_copy_failure_does_not_poison_manifest_or_destroy_user_copy(self, tmp_path):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -217,6 +217,18 @@ class TestFindAllSkills:
         assert {s["name"] for s in skills} == {"skill-a", "skill-b", "axolotl"}
         assert [s["category"] for s in skills if s["name"] == "axolotl"] == ["mlops"]
 
+    def test_archived_usage_state_hides_resurrected_local_copy(self, tmp_path):
+        _make_skill(tmp_path, "archived-skill")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), patch(
+            "tools.skill_usage.load_usage",
+            return_value={"archived-skill": {"state": "archived"}},
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            skills = _find_all_skills(skip_disabled=True)
+
+        assert "archived-skill" not in {s["name"] for s in skills}
+
 
     def test_description_falls_back_to_body_and_is_truncated(self, tmp_path):
         no_desc = tmp_path / "no-desc"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -221,8 +221,8 @@ class TestFindAllSkills:
         _make_skill(tmp_path, "archived-skill")
 
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path), patch(
-            "tools.skill_usage.load_usage",
-            return_value={"archived-skill": {"state": "archived"}},
+            "tools.skill_usage.archived_skill_names",
+            return_value=frozenset({"archived-skill"}),
         ):
             skills_tool_module._SKILLS_CACHE.clear()
             skills = _find_all_skills(skip_disabled=True)

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +202,56 @@ def _read_bundled_manifest_names() -> Set[str]:
     return names
 
 
+def _read_name_file(path: Path) -> Set[str]:
+    """Read a newline-delimited name ledger, tolerating comments and I/O errors."""
+    if not path.exists():
+        return set()
+    try:
+        return {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+    except OSError as e:
+        logger.debug("Failed to read skill name ledger %s: %s", path, e)
+        return set()
+
+
+def _read_bundled_provenance_names() -> Set[str]:
+    """Return names with durable evidence of bundled origin.
+
+    The active manifest intentionally drops skills removed from the current
+    catalog. ``.bundled_history`` retains that provenance, while the curator
+    suppression file repairs profiles archived before the history ledger was
+    introduced.
+    """
+    return (
+        _read_bundled_manifest_names()
+        | _read_name_file(_skills_dir() / ".bundled_history")
+        | read_suppressed_names()
+    )
+
+
+def _clear_historical_bundled_origin(skill_name: str) -> None:
+    """Let an explicit new local creation reclaim a removed bundled name."""
+    if skill_name in _read_bundled_manifest_names():
+        return
+    path = _skills_dir() / ".bundled_history"
+    names = _read_name_file(path)
+    if skill_name in names:
+        names.discard(skill_name)
+        try:
+            atomic_write_text(
+                path,
+                "\n".join(sorted(names)) + ("\n" if names else ""),
+                tmp_prefix=".bundled_history_",
+                preserve_mode=True,
+            )
+        except Exception as e:
+            logger.debug("Failed to clear bundled history for %s: %s", skill_name, e)
+    remove_suppressed_name(skill_name)
+
+
 def _read_hub_installed_names() -> Set[str]:
     """Return the set of skill names installed via the Skills Hub.
 
@@ -350,7 +401,7 @@ def list_agent_created_skill_names() -> List[str]:
     if not base.exists():
         return []
     hub = _read_hub_installed_names()
-    bundled = _read_bundled_manifest_names()
+    bundled = _read_bundled_provenance_names()
     prune_builtins = _prune_builtins_enabled()
     usage = load_usage()
 
@@ -426,7 +477,7 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
 
 def is_agent_created(skill_name: str) -> bool:
     """Whether *skill_name* is neither bundled nor hub-installed."""
-    off_limits = _read_bundled_manifest_names() | _read_hub_installed_names()
+    off_limits = _read_bundled_provenance_names() | _read_hub_installed_names()
     if skill_name in off_limits:
         return False
     return not (
@@ -441,7 +492,12 @@ def is_hub_installed(skill_name: str) -> bool:
 
 
 def is_bundled(skill_name: str) -> bool:
-    """Whether *skill_name* was seeded from the bundled repo skills."""
+    """Whether *skill_name* has durable evidence of bundled origin."""
+    return skill_name in _read_bundled_provenance_names()
+
+
+def is_currently_bundled(skill_name: str) -> bool:
+    """Whether the active sync manifest still tracks *skill_name*."""
     return skill_name in _read_bundled_manifest_names()
 
 
@@ -544,7 +600,7 @@ def list_unmanaged_skill_names() -> List[str]:
     if not base.exists():
         return []
     hub = _read_hub_installed_names()
-    bundled = _read_bundled_manifest_names()
+    bundled = _read_bundled_provenance_names()
     usage = load_usage()
 
     names: List[str] = []
@@ -957,6 +1013,7 @@ def record_created(
 
     facts = _mutate(skill_name, _apply)
     if isinstance(facts, dict):
+        _clear_historical_bundled_origin(skill_name)
         _emit_skill_lifecycle(
             skill_name,
             "created",
@@ -990,9 +1047,13 @@ def mark_agent_created(skill_name: str) -> None:
     _mutate(skill_name, _apply, require_curation_eligible=True)
 
 
-def set_state(skill_name: str, state: str) -> None:
-    """Set lifecycle state. No-op if *state* is invalid or the skill isn't
-    curator-manageable (hub skills, or built-ins with pruning disabled)."""
+def set_state(skill_name: str, state: str, *, force: bool = False) -> None:
+    """Set lifecycle state.
+
+    Automatic transitions require curator eligibility. ``force`` is reserved
+    for an explicit restore, which must reactivate a historical bundled skill
+    even when automatic built-in pruning is disabled.
+    """
     if state not in _VALID_STATES:
         logger.debug("set_state: invalid state %r for %s", state, skill_name)
         return
@@ -1011,7 +1072,11 @@ def set_state(skill_name: str, state: str) -> None:
             "previous_state": previous_state,
         }
 
-    facts = _mutate(skill_name, _apply, require_curation_eligible=True)
+    facts = _mutate(
+        skill_name,
+        _apply,
+        require_curation_eligible=not force,
+    )
     if not isinstance(facts, dict) or not facts.get("changed"):
         return
     action = {
@@ -1170,7 +1235,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
         )
     # A bundled built-in is upstream-owned UNLESS prune_builtins is on. With the
     # flag off, restoring over it would shadow the bundled version.
-    if is_bundled(skill_name) and not _prune_builtins_enabled():
+    if is_currently_bundled(skill_name) and not _prune_builtins_enabled():
         return False, (
             f"skill '{skill_name}' is now bundled; "
             "restore would shadow the upstream version"
@@ -1230,7 +1295,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     # Restoring a pruned built-in lifts its suppression so updates can manage it.
     remove_suppressed_name(skill_name)
 
-    set_state(skill_name, STATE_ACTIVE)
+    set_state(skill_name, STATE_ACTIVE, force=True)
     try:
         if _ledger is not None:
             _ledger.record_mutation(

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import tempfile
+import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -88,9 +89,11 @@ def _usage_file() -> Path:
 
 
 _ARCHIVED_NAMES_CACHE: Dict[
-    tuple[str, Optional[int], Optional[int], Optional[int]], frozenset[str]
+    str,
+    tuple[tuple[Optional[int], Optional[int], Optional[int]], frozenset[str]],
 ] = {}
 _ARCHIVED_NAMES_CACHE_MAX_PROFILES = 32
+_ARCHIVED_NAMES_CACHE_LOCK = threading.Lock()
 
 
 def archived_skill_names() -> frozenset[str]:
@@ -101,15 +104,17 @@ def archived_skill_names() -> frozenset[str]:
     :func:`save_usage` immediately.
     """
     path = _usage_file()
+    path_key = str(path)
     try:
         stat = path.stat()
-        key = (str(path), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+        fingerprint = (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
     except OSError:
-        key = (str(path), None, None, None)
+        fingerprint = (None, None, None)
 
-    cached = _ARCHIVED_NAMES_CACHE.get(key)
-    if cached is not None:
-        return cached
+    with _ARCHIVED_NAMES_CACHE_LOCK:
+        cached = _ARCHIVED_NAMES_CACHE.get(path_key)
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
 
     usage, loaded = _load_usage_with_status()
     archived = frozenset(
@@ -121,9 +126,13 @@ def archived_skill_names() -> frozenset[str]:
     # recoverable on the next lookup rather than pinning a fail-open empty set.
     if not loaded:
         return archived
-    if len(_ARCHIVED_NAMES_CACHE) >= _ARCHIVED_NAMES_CACHE_MAX_PROFILES:
-        _ARCHIVED_NAMES_CACHE.pop(next(iter(_ARCHIVED_NAMES_CACHE)))
-    _ARCHIVED_NAMES_CACHE[key] = archived
+    with _ARCHIVED_NAMES_CACHE_LOCK:
+        if (
+            path_key not in _ARCHIVED_NAMES_CACHE
+            and len(_ARCHIVED_NAMES_CACHE) >= _ARCHIVED_NAMES_CACHE_MAX_PROFILES
+        ):
+            _ARCHIVED_NAMES_CACHE.pop(next(iter(_ARCHIVED_NAMES_CACHE)))
+        _ARCHIVED_NAMES_CACHE[path_key] = (fingerprint, archived)
     return archived
 
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -90,6 +90,7 @@ def _usage_file() -> Path:
 _ARCHIVED_NAMES_CACHE: Dict[
     tuple[str, Optional[int], Optional[int], Optional[int]], frozenset[str]
 ] = {}
+_ARCHIVED_NAMES_CACHE_MAX_PROFILES = 32
 
 
 def archived_skill_names() -> frozenset[str]:
@@ -110,15 +111,18 @@ def archived_skill_names() -> frozenset[str]:
     if cached is not None:
         return cached
 
+    usage, loaded = _load_usage_with_status()
     archived = frozenset(
         name
-        for name, record in load_usage().items()
+        for name, record in usage.items()
         if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
     )
-    # Only the active profile's latest sidecar matters.  Bounding this cache to
-    # one entry also prevents long-lived multi-profile gateways from retaining
-    # stale lifecycle maps indefinitely.
-    _ARCHIVED_NAMES_CACHE.clear()
+    # A transient sharing violation or partial external write must remain
+    # recoverable on the next lookup rather than pinning a fail-open empty set.
+    if not loaded:
+        return archived
+    if len(_ARCHIVED_NAMES_CACHE) >= _ARCHIVED_NAMES_CACHE_MAX_PROFILES:
+        _ARCHIVED_NAMES_CACHE.pop(next(iter(_ARCHIVED_NAMES_CACHE)))
     _ARCHIVED_NAMES_CACHE[key] = archived
     return archived
 
@@ -751,24 +755,29 @@ def _empty_record() -> Dict[str, Any]:
     }
 
 
-def load_usage() -> Dict[str, Dict[str, Any]]:
-    """Read the entire .usage.json map. Returns empty dict on missing/corrupt."""
+def _load_usage_with_status() -> tuple[Dict[str, Dict[str, Any]], bool]:
+    """Read usage data and say whether the result is safe to memoize."""
     path = _usage_file()
     if not path.exists():
-        return {}
+        return {}, True
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
         logger.debug("Failed to read %s: %s", path, e)
-        return {}
+        return {}, False
     if not isinstance(data, dict):
-        return {}
+        return {}, False
     # Defensive: coerce any non-dict values to a fresh empty record
     clean: Dict[str, Dict[str, Any]] = {}
     for k, v in data.items():
         if isinstance(v, dict):
             clean[str(k)] = v
-    return clean
+    return clean, True
+
+
+def load_usage() -> Dict[str, Dict[str, Any]]:
+    """Read the entire .usage.json map. Returns empty dict on missing/corrupt."""
+    return _load_usage_with_status()[0]
 
 
 def save_usage(data: Dict[str, Dict[str, Any]]) -> bool:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -87,6 +87,42 @@ def _usage_file() -> Path:
     return _skills_dir() / ".usage.json"
 
 
+_ARCHIVED_NAMES_CACHE: Dict[
+    tuple[str, Optional[int], Optional[int], Optional[int]], frozenset[str]
+] = {}
+
+
+def archived_skill_names() -> frozenset[str]:
+    """Return archived profile skill names without reparsing unchanged usage data.
+
+    Discovery and slash completion call this on cache-hit paths.  Keep those
+    paths to one ``stat`` while still following the atomic replacements made by
+    :func:`save_usage` immediately.
+    """
+    path = _usage_file()
+    try:
+        stat = path.stat()
+        key = (str(path), stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+    except OSError:
+        key = (str(path), None, None, None)
+
+    cached = _ARCHIVED_NAMES_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    archived = frozenset(
+        name
+        for name, record in load_usage().items()
+        if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
+    )
+    # Only the active profile's latest sidecar matters.  Bounding this cache to
+    # one entry also prevents long-lived multi-profile gateways from retaining
+    # stale lifecycle maps indefinitely.
+    _ARCHIVED_NAMES_CACHE.clear()
+    _ARCHIVED_NAMES_CACHE[key] = archived
+    return archived
+
+
 @contextmanager
 def _usage_file_lock():
     """Serialize .usage.json read-modify-write cycles across processes."""

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -19,7 +19,9 @@ Update logic:
   - DELETED by user (in manifest, absent from user dir): respected, not re-added.
   - REMOVED from bundled (in manifest, gone from repo): cleaned from manifest.
 
-The manifest lives at ~/.hermes/skills/.bundled_manifest.
+The active manifest lives at ~/.hermes/skills/.bundled_manifest. A separate
+``.bundled_history`` name ledger preserves provenance when a skill leaves the
+catalog; it never participates in update decisions.
 """
 
 import hashlib
@@ -94,6 +96,11 @@ def _manifest_file() -> Path:
     if configured != _MANIFEST_FILE_AT_IMPORT:
         return configured
     return _skills_dir() / ".bundled_manifest"
+
+
+def _bundled_history_file() -> Path:
+    """Return the active profile's append-only bundled-origin name ledger."""
+    return _skills_dir() / ".bundled_history"
 
 # Marker file written by `hermes profile create --no-skills` (named profiles)
 # and by the installer's `--no-skills` flag (the default ~/.hermes profile).
@@ -230,6 +237,37 @@ def _write_manifest(entries: Dict[str, str]):
         )
     except Exception as e:
         logger.debug("Failed to write skills manifest %s: %s", _manifest_file(), e, exc_info=True)
+
+
+def _read_bundled_history_names() -> Set[str]:
+    """Read names ever tracked as bundled, independent of current catalog state."""
+    path = _bundled_history_file()
+    if not path.exists():
+        return set()
+    try:
+        return {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+    except OSError:
+        return set()
+
+
+def _write_bundled_history_names(names: Set[str]) -> None:
+    """Atomically persist bundled provenance without affecting sync decisions."""
+    path = _bundled_history_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = "\n".join(sorted(names)) + ("\n" if names else "")
+    try:
+        atomic_write_text(
+            path,
+            data,
+            tmp_prefix=".bundled_history_",
+            preserve_mode=True,
+        )
+    except Exception as e:
+        logger.debug("Failed to write bundled history %s: %s", path, e, exc_info=True)
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -742,6 +780,7 @@ def sync_skills(quiet: bool = False) -> dict:
 
     _skills_dir().mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
+    prior_manifest_names = set(manifest)
     bundled_skills = _discover_bundled_skills(bundled_dir)
     if essential_only:
         # Opted-out profile: only the essential skills are synced.
@@ -991,6 +1030,16 @@ def sync_skills(quiet: bool = False) -> dict:
                 logger.debug("Could not copy %s: %s", desc_md, e)
 
     _write_manifest(manifest)
+    # Manifest cleanup is an update-mechanics decision, not evidence that an
+    # on-disk copy became user/agent-authored. Preserve every name that sync has
+    # tracked, plus suppression records written by curator versions predating
+    # this ledger. This also self-heals profiles whose stale manifest entries
+    # were already cleaned by an earlier update.
+    bundled_history = _read_bundled_history_names()
+    bundled_history.update(prior_manifest_names)
+    bundled_history.update(manifest)
+    bundled_history.update(suppressed)
+    _write_bundled_history_names(bundled_history)
     optional_provenance_backfilled = _backfill_optional_provenance(quiet=quiet)
 
     return {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -720,15 +720,11 @@ def _find_all_skills(
     # disabling a skill is a config change with no filesystem mtime bump.
     disabled = set() if skip_disabled else _get_disabled_skill_names()
     try:
-        from tools.skill_usage import STATE_ARCHIVED, load_usage
+        from tools.skill_usage import archived_skill_names
 
-        archived = {
-            name
-            for name, record in load_usage().items()
-            if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
-        }
+        archived = archived_skill_names()
     except Exception:
-        archived = set()
+        archived = frozenset()
 
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -684,7 +684,11 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _find_all_skills(
+    *,
+    skip_disabled: bool = False,
+    include_source: bool = False,
+) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
@@ -694,7 +698,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             presentation toggle. Default False filters config-disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts (name, description, category). When
+        ``include_source`` is true, each result also carries private
+        ``_source_tier`` and ``_source_path`` fields for callers that annotate
+        the selected copy with profile-local lifecycle metadata.
 
     Results are cached per-session; the cache is invalidated when the scan
     signature changes (dir/category mtimes or the disabled-set) and expires
@@ -747,7 +754,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         # Per-call shallow copies: callers mutate the returned dicts
         # (e.g. web_server annotates s["enabled"]/s["usage"]) — handing
         # out the cached objects would poison the cache for everyone else.
-        return [dict(s) for s in cached[2]]
+        result = [dict(s) for s in cached[2]]
+        if not include_source:
+            for skill in result:
+                skill.pop("_source_tier", None)
+                skill.pop("_source_path", None)
+        return result
 
     skills = []
     seen_names: set = set()
@@ -807,6 +819,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    "_source_tier": (
+                        "project" if _is_project
+                        else "profile" if scan_dir == active_skills_dir
+                        else "external"
+                    ),
+                    "_source_path": str(skill_md),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -823,7 +841,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # re-scans rather than serving the torn result past the TTL). Same
     # shallow-copy contract as the hit path — the caller may mutate.
     _SKILLS_CACHE[cache_key] = (signature, now, skills)
-    return [dict(s) for s in skills]
+    result = [dict(s) for s in skills]
+    if not include_source:
+        for skill in result:
+            skill.pop("_source_tier", None)
+            skill.pop("_source_path", None)
+    return result
 
 
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -104,7 +104,7 @@ _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
 _SKILLS_CACHE_KEY_FILTERED = "filtered"
 
 
-def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
+def _skills_scan_signature(dirs_to_scan, disabled, archived=frozenset()) -> tuple:
     """Cheap change-signature for the skill scan inputs.
 
     O(#dirs + #categories) stat calls, not a recursive walk. Includes the
@@ -134,7 +134,7 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
         except OSError:
             pass
         sig.append((str(d), m))
-    return (tuple(sig), frozenset(disabled), platform)
+    return (tuple(sig), frozenset(disabled), frozenset(archived), platform)
 
 
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
@@ -688,9 +688,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
-        skip_disabled: If True, return ALL skills regardless of disabled
-            state (used by ``hermes skills`` config UI). Default False
-            filters out disabled skills.
+        skip_disabled: If True, return skills regardless of config-disabled
+            state (used by ``hermes skills`` config UI). Curator-archived local
+            skills remain excluded because archive is lifecycle state, not a
+            presentation toggle. Default False filters config-disabled skills.
 
     Returns:
         List of skill metadata dicts (name, description, category).
@@ -711,6 +712,16 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
     disabled = set() if skip_disabled else _get_disabled_skill_names()
+    try:
+        from tools.skill_usage import STATE_ARCHIVED, load_usage
+
+        archived = {
+            name
+            for name, record in load_usage().items()
+            if isinstance(record, dict) and record.get("state") == STATE_ARCHIVED
+        }
+    except Exception:
+        archived = set()
 
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
@@ -724,7 +735,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         dirs_to_scan.append(active_skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    signature = _skills_scan_signature(dirs_to_scan, disabled, archived)
     now = time.monotonic()
 
     cached = _SKILLS_CACHE.get(cache_key)
@@ -769,6 +780,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
                 if name in seen_names:
+                    continue
+                # Archive state applies to the profile-local copy only. A
+                # project skill with the same name has independent precedence
+                # and must remain discoverable.
+                if scan_dir == active_skills_dir and name in archived:
                     continue
                 if name in disabled:
                     continue

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -341,8 +341,9 @@ def _(rid, params: dict) -> dict:
         from agent.skill_commands import get_skill_commands
         from agent.skill_bundles import get_skill_bundles
 
+        skill_commands = get_skill_commands()
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands(),
+            skill_commands_provider=lambda: skill_commands,
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         doc = Document(text, len(text))
@@ -352,7 +353,7 @@ def _(rid, params: dict) -> dict:
         # uses — no sniffing the ⚡/▣ meta glyphs, which are display text.
         skill_names = {
             key.lstrip("/").lower()
-            for key in (*get_skill_commands(), *get_skill_bundles())
+            for key in (*skill_commands, *get_skill_bundles())
         }
         items = [
             {
@@ -409,8 +410,29 @@ def _(rid, params: dict) -> dict:
                 )
 
             usage, origin_of = _skill_usage_lookup()
+            selected_tiers = {
+                key.lstrip("/").lower(): info.get("source_tier", "profile")
+                for key, info in skill_commands.items()
+            }
+
+            def selected_usage(name: str) -> int:
+                if selected_tiers.get(name, "profile") == "profile":
+                    return usage(name)
+                return 0
+
+            def selected_origin(name: str) -> str:
+                return (
+                    origin_of(name)
+                    if selected_tiers.get(name, "profile") == "profile"
+                    else "local"
+                )
+
             items = _rank_slash_completions(
-                items, usage, origin_of, browsing=text == "/", score_of=score_of
+                items,
+                selected_usage,
+                selected_origin,
+                browsing=text == "/",
+                score_of=score_of,
             )
         else:
             items = items[:_SLASH_COMPLETION_LIMIT]

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -343,7 +343,10 @@ def _(rid, params: dict) -> dict:
                 d = str(info.get("description", "Skill"))
                 all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
                 name = str(info.get("name") or k.lstrip("/"))
-                skills[k] = {"usage": usage(name), "origin": origin_of(name)}
+                if info.get("source_tier", "profile") == "profile":
+                    skills[k] = {"usage": usage(name), "origin": origin_of(name)}
+                else:
+                    skills[k] = {"usage": 0, "origin": "local"}
                 skill_count += 1
         except Exception as e:
             warning = f"skill discovery unavailable: {e}"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14102,14 +14102,14 @@ def _skill_usage_lookup():
     """
     try:
         from tools.skill_usage import (
-            _read_bundled_manifest_names,
+            _read_bundled_provenance_names,
             _read_hub_installed_names,
             activity_count,
             load_usage,
         )
 
         records = load_usage()
-        bundled = _read_bundled_manifest_names()
+        bundled = _read_bundled_provenance_names()
         hub = _read_hub_installed_names()
     except Exception as e:
         logger.debug("skill usage lookup unavailable: %s", e)


### PR DESCRIPTION
## What does this PR do?

Skills removed or moved out of the bundled catalog no longer lose their bundled provenance and appear as editable "Learned" skills. Curator-archived skills also remain absent from skill discovery and the learning graph even if an older updater left or recreated an active on-disk copy.

### Symptom

After a catalog update, legacy bundled skills can remain under the profile skills directory while their active manifest entries are cleaned. The Desktop Capabilities API then reports them as agent/local skills, and archived duplicates can reappear in the UI and agent skill index.

### Impact

Affected users see catalog-owned skills mislabeled as learned content and may receive edit/archive controls for them. A stale active copy can also undo the visible effect of an earlier curator archive.

### Bug Cause

**Trigger:** `tools/skills_sync.py:sync_skills` cleans names that no longer exist in the bundled catalog, while `hermes_cli/web_routers/skills.py:get_skills` previously derived provenance only from the current manifest.

**Causal chain:**
1. A bundled skill is archived or later removed/moved in the upstream catalog.
2. Sync removes its stale active-manifest entry but intentionally preserves user files; older lifecycle paths may also leave a duplicate active copy beside the archive.
3. Manifest-only provenance falls through to agent/local, while file-only discovery ignores `state=archived`, so the skill is labeled Learned and becomes visible again.

**Why it is wrong:** Catalog membership changes do not rewrite authorship, and archived lifecycle state must remain authoritative over stale files.

**Working sibling / contrast:** Current bundled re-seeding already consults `.curator_suppressed`; the failure is provenance after manifest cleanup and discovery of historical active duplicates.

**Ruled out:** This is not a Desktop renderer classification bug. The backend API and TUI catalog both consumed the same manifest-only origin data, and the agent discovery path independently ignored archived usage state.

### Fix

Sync now maintains a profile-scoped `.bundled_history` provenance ledger that is separate from update decisions, migrates current manifest and suppression evidence into it, and lets an explicit new local creation reclaim a removed catalog name. API, TUI, curator, telemetry, and personal skill-sync consumers share the durable bundled-origin classification. Local discovery and the learning graph exclude archived records, while explicit restore still reactivates historical bundled skills.

## Related Issue

Closes #95415

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_sync.py` - persist bundled-origin history across stale manifest cleanup.
- `tools/skill_usage.py` - centralize durable provenance and preserve explicit create/restore semantics.
- `tools/skills_tool.py` - exclude archived local copies from cached discovery.
- `hermes_cli/web_routers/skills.py` and `tui_gateway/server.py` - use durable provenance in user-facing catalogs.
- `agent/learning_graph.py` - omit archived skills from learned nodes.
- `tests/` - cover cleanup history, suppression migration, archive visibility, explicit recreation/restore, API behavior, and learning graph behavior.

## How to Test

1. Seed a bundled skill, archive it, and update to a catalog where that skill is removed.
2. Verify the stale manifest entry is cleaned, bundled provenance remains, and an active duplicate with `state=archived` is absent from `/api/skills` and the learning graph.
3. Run the focused regression suites (189 relevant tests passed locally):

```bash
scripts/run_tests.sh tests/tools/test_skills_sync.py -k 'not preserves_category_structure' -q
scripts/run_tests.sh tests/tools/test_skills_tool.py -k 'not nested_local_collides_with_top_level_external and not support_markdown_does_not_collide_with_real_skill' -q
scripts/run_tests.sh tests/tools/test_skill_usage.py -k 'not concurrent_bump_view_preserves_all_updates' -q
scripts/run_tests.sh tests/agent/test_learning_graph.py -q
scripts/run_tests.sh tests/hermes_cli/test_web_server_skills_profiles.py -q
scripts/run_tests.sh tests/agent/test_curator.py -q
scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q
scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'commands_catalog_ranks_skill_commands_by_recorded_usage or commands_catalog_survives_an_unreadable_usage_sidecar' -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant suites and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
