### PR TITLE
增加飞书 JSON 2.0 互动卡片基础能力

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2948,6 +2948,55 @@ class PluginContext:
             name, current, replacement, scope=scope
         )
 
+    # -- Feishu card action handler registration ----------------------------
+
+    def register_feishu_card_action_handler(
+        self,
+        namespace: str,
+        callback: Callable,
+    ) -> PluginRegistration:
+        """Register a namespaced Feishu JSON 2.0 card handler.
+
+        The namespace is an exact bounded identifier selected by the plugin;
+        payload data is never interpreted as an import path, command, or tool.
+        The callback must return a validated immediate result. It may include
+        a complete JSON 2.0 ``card`` field to replace the original card in
+        place. Slow work is carried only in an explicit ``background`` result
+        field.
+        """
+        import re
+
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Feishu "
+                "card handler with a non-callable callback."
+            )
+        if (
+            not isinstance(namespace, str)
+            or not re.fullmatch(r"[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*", namespace)
+        ):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register an invalid "
+                f"Feishu card namespace: {namespace!r}."
+            )
+        if any(item[0] == namespace for item in self._manager._feishu_card_action_handlers):
+            raise ValueError(f"Feishu card namespace already registered: {namespace}")
+        entry = (namespace, callback, self.manifest.name)
+        self._manager._feishu_card_action_handlers.append(entry)
+        handle = self._track(
+            "feishu_card_action_handler",
+            namespace,
+            lambda: self._manager._remove_identity(
+                self._manager._feishu_card_action_handlers, entry
+            ),
+        )
+        logger.debug(
+            "Plugin %s registered Feishu card action handler: %s",
+            self.manifest.name,
+            namespace,
+        )
+        return handle
+
     # -- slack action handler registration ----------------------------------
 
     def register_slack_action_handler(
@@ -3523,6 +3572,10 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Feishu JSON 2.0 card handlers. Each entry is
+        # (fixed_namespace, callback, plugin_name); payload-derived dispatch is
+        # forbidden and callbacks return an immediate status mapping.
+        self._feishu_card_action_handlers: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3899,6 +3952,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
+            self._feishu_card_action_handlers.clear()
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
             self._context_engine = None
@@ -5659,6 +5713,14 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    # -----------------------------------------------------------------------
+    # Feishu card action handler accessor
+    # -----------------------------------------------------------------------
+
+    def get_feishu_card_action_handlers(self) -> List[tuple]:
+        """Return a copy of plugin-registered Feishu card handlers."""
+        return list(self._feishu_card_action_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -87,6 +87,27 @@ def _read_message_body(
     return None
 
 
+def _read_card_file(file_path: str) -> dict:
+    """Read and strictly validate a JSON 2.0 card without exposing contents."""
+    try:
+        raw = sys.stdin.read() if file_path == "-" else Path(file_path).read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        print(f"hermes send: card file is not UTF-8: {file_path}", file=sys.stderr)
+        raise SystemExit(_USAGE_EXIT) from exc
+    except OSError as exc:
+        print(f"hermes send: cannot read card file {file_path}: {exc}", file=sys.stderr)
+        raise SystemExit(_USAGE_EXIT) from exc
+    try:
+        from plugins.platforms.feishu.adapter import (
+            FeishuCardValidationError,
+            parse_feishu_card_json,
+        )
+        return parse_feishu_card_json(raw)
+    except FeishuCardValidationError as exc:
+        print(f"hermes send: {exc}", file=sys.stderr)
+        raise SystemExit(_USAGE_EXIT) from exc
+
+
 def _resolve_target(arg_to: Optional[str]) -> Optional[str]:
     """Return a cleaned ``--to`` value, or ``None`` when nothing is set."""
     if arg_to and arg_to.strip():
@@ -328,13 +349,49 @@ def _load_hermes_env() -> None:
 def cmd_send(args: argparse.Namespace) -> None:
     """Entry point wired into the top-level argparse dispatcher."""
 
+    if getattr(args, "card_capabilities", False):
+        if any(
+            getattr(args, name, None)
+            for name in (
+                "to", "message", "file", "subject", "card_file",
+                "patch_message_id", "list_targets",
+            )
+        ):
+            print(
+                "hermes send: --card-capabilities cannot be combined with send arguments",
+                file=sys.stderr,
+            )
+            sys.exit(_USAGE_EXIT)
+        from plugins.platforms.feishu.adapter import (
+            FEISHU_CARD_CAPABILITIES,
+            FEISHU_CARD_CONTRACT_VERSION,
+        )
+        payload = {
+            "success": True,
+            "platform": "feishu",
+            "contract": FEISHU_CARD_CONTRACT_VERSION,
+            "capabilities": sorted(FEISHU_CARD_CAPABILITIES),
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload, ensure_ascii=False))
+        else:
+            print(
+                f"feishu card contract {payload['contract']}: "
+                f"{', '.join(payload['capabilities'])}"
+            )
+        sys.exit(_SUCCESS_EXIT)
+
     # Bridge ~/.hermes/.env and ~/.hermes/config.yaml into os.environ so the
     # gateway config loader (invoked downstream by send_message_tool and by
     # the channel directory) can see platform credentials and home channels.
     _load_hermes_env()
 
-    # --list short-circuits everything else.
+    # --list short-circuits everything else, but never silently ignores card
+    # transport arguments.
     if getattr(args, "list_targets", False):
+        if getattr(args, "card_file", None) or getattr(args, "patch_message_id", None):
+            print("hermes send: --list is mutually exclusive with card transport", file=sys.stderr)
+            sys.exit(_USAGE_EXIT)
         # When `--list telegram` is used, argparse stores "telegram" in the
         # `message` positional (since list_targets takes no argument).
         platform_filter = getattr(args, "message", None)
@@ -352,6 +409,31 @@ def cmd_send(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
         sys.exit(_USAGE_EXIT)
+
+    card_file = getattr(args, "card_file", None)
+    patch_message_id = getattr(args, "patch_message_id", None)
+    if patch_message_id and not card_file:
+        print("hermes send: --patch-message-id requires --card-file", file=sys.stderr)
+        sys.exit(_USAGE_EXIT)
+    if card_file:
+        if any(getattr(args, name, None) for name in ("message", "file", "subject")):
+            print(
+                "hermes send: --card-file is mutually exclusive with text, --file, and --subject",
+                file=sys.stderr,
+            )
+            sys.exit(_USAGE_EXIT)
+        card = _read_card_file(card_file)
+        tool_args = {"action": "send", "target": target, "card": card}
+        if patch_message_id:
+            tool_args["patch_message_id"] = patch_message_id
+        from tools.send_message_tool import send_message_tool
+        result = send_message_tool(tool_args)
+        exit_code = _emit_result(
+            result,
+            json_mode=getattr(args, "json", False),
+            quiet=getattr(args, "quiet", False),
+        )
+        sys.exit(exit_code)
 
     message = _read_message_body(
         getattr(args, "message", None),
@@ -419,6 +501,9 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
             "  hermes send --to discord:#ops --file /tmp/report.md\n"
             "  hermes send --to slack:#eng --subject \"[CI]\" --file build.log\n"
             "  hermes send --to telegram \"MEDIA:/tmp/chart.png\"   # send a media attachment\n"
+            "  hermes send --to feishu --card-file card.json       # send JSON 2.0 card\n"
+            "  hermes send --to feishu --card-file card.json --patch-message-id om_xxx\n"
+            "  hermes send --card-capabilities --json               # offline contract check\n"
             "  hermes send --list                  # all platforms\n"
             "  hermes send --list telegram         # filter by platform\n"
             "\n"
@@ -458,8 +543,35 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         help=(
             "Read message body from PATH (text only). Use '-' to force stdin. "
             "To send an image/document as an attachment, use MEDIA:<path> in "
-            "the message text instead."
+            "the message text instead. Mutually exclusive with --card-file."
         ),
+    )
+
+    parser.add_argument(
+        "--card-file",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Send a Feishu JSON 2.0 card from PATH (use '-' for stdin). "
+            "Requires --to feishu[:CHAT_ID] and is mutually exclusive with text."
+        ),
+    )
+
+    parser.add_argument(
+        "--patch-message-id",
+        metavar="MESSAGE_ID",
+        default=None,
+        help=(
+            "PATCH the card from --card-file into this existing Feishu message ID; "
+            "requires --card-file and never falls back to text."
+        ),
+    )
+
+    parser.add_argument(
+        "--card-capabilities",
+        action="store_true",
+        default=False,
+        help="Print the installed Feishu card contract/capabilities without sending or loading credentials.",
     )
 
     parser.add_argument(

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -52,6 +52,7 @@ import collections
 import concurrent.futures
 import hashlib
 import hmac
+import inspect
 import itertools
 import json
 import logging
@@ -61,6 +62,7 @@ import re
 import threading
 import time
 import uuid
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -95,6 +97,8 @@ CreateImageRequest = None  # type: ignore[assignment]
 CreateImageRequestBody = None  # type: ignore[assignment]
 CreateMessageRequest = None  # type: ignore[assignment]
 CreateMessageRequestBody = None  # type: ignore[assignment]
+PatchMessageRequest = None  # type: ignore[assignment]
+PatchMessageRequestBody = None  # type: ignore[assignment]
 GetChatRequest = None  # type: ignore[assignment]
 GetMessageRequest = None  # type: ignore[assignment]
 GetMessageResourceRequest = None  # type: ignore[assignment]
@@ -109,6 +113,7 @@ FEISHU_DOMAIN = None  # type: ignore[assignment]
 LARK_DOMAIN = None  # type: ignore[assignment]
 BaseRequest = None  # type: ignore[assignment]
 CallBackCard = None  # type: ignore[assignment]
+CallBackToast = None  # type: ignore[assignment]
 P2CardActionTriggerResponse = None  # type: ignore[assignment]
 EventDispatcherHandler = None  # type: ignore[assignment]
 FeishuWSClient = None  # type: ignore[assignment]
@@ -242,6 +247,28 @@ _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS = 30          # max seconds to read request
 _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses before WARNING log
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
+_FEISHU_CARD_MAX_CALLBACK_VALUE_BYTES = 64 * 1024
+_FEISHU_CARD_MAX_CALLBACK_TEXT_LENGTH = 4096
+_FEISHU_CARD_ACTION_DEDUP_CACHE_SIZE = 2048
+_FEISHU_CARD_HANDLER_MAX_WORKERS = 4
+_FEISHU_CARD_HANDLER_TIMEOUT_SECONDS = 2.5
+_FEISHU_CARD_NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$")
+
+FEISHU_CARD_CONTRACT_VERSION = "mvp1"
+FEISHU_CARD_CAPABILITIES = frozenset({
+    "send_card",
+    "patch_card",
+    "card_action_envelope",
+})
+
+# Card handlers are plugin code. Keep both execution threads and in-flight
+# submissions bounded; timed-out running handlers retain their permit until
+# they actually return.
+_FEISHU_CARD_HANDLER_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_FEISHU_CARD_HANDLER_MAX_WORKERS,
+    thread_name_prefix="hermes-feishu-card",
+)
+_FEISHU_CARD_HANDLER_IN_FLIGHT = threading.BoundedSemaphore(_FEISHU_CARD_HANDLER_MAX_WORKERS)
 
 _APPROVAL_CHOICE_MAP: Dict[str, str] = {
     "approve_once": "once",
@@ -399,6 +426,115 @@ class FeishuNormalizedMessage:
     mentions: List[FeishuMentionRef] = field(default_factory=list)
     relation_kind: str = "plain"
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class FeishuCardValidationError(ValueError):
+    """Raised when a raw Feishu JSON 2.0 card violates the contract."""
+
+
+def validate_feishu_card(card: Any) -> Dict[str, Any]:
+    """Validate and return a raw JSON 2.0 card without changing its shape."""
+    if not isinstance(card, dict):
+        raise FeishuCardValidationError("Feishu card must be a JSON object")
+    if card.get("schema") != "2.0":
+        raise FeishuCardValidationError("Feishu card must declare schema='2.0'")
+    try:
+        json.dumps(card, ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise FeishuCardValidationError("Feishu card must contain JSON values") from exc
+    return card
+
+
+def parse_feishu_card_json(raw: str) -> Dict[str, Any]:
+    """Parse and strictly validate a JSON 2.0 card from text."""
+    try:
+        card = json.loads(raw)
+    except (TypeError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise FeishuCardValidationError("Feishu card file is not valid JSON") from exc
+    return validate_feishu_card(card)
+
+
+@dataclass(frozen=True)
+class FeishuCardHandlerResult:
+    """Immediate card-handler result with optional card and background work.
+
+    ``card`` is a complete JSON 2.0 card.  When present, the callback
+    response replaces the original interactive card in place; it is never a
+    partial patch or a text fallback.
+    """
+
+    status: str
+    message: str
+    background: Any = None
+    card: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class FeishuCardActionEnvelope:
+    """Bounded, LLM-free contract passed to a registered card handler."""
+
+    event_id: str
+    event_token: str
+    operator: Dict[str, str]
+    context: Dict[str, str]
+    action_tag: str
+    action_name: str
+    action_value: Dict[str, Any]
+    form_value: Dict[str, Any]
+    input_value: Optional[str]
+
+    @property
+    def token(self) -> str:
+        return self.event_token
+
+    @property
+    def chat_id(self) -> str:
+        return self.context.get("open_chat_id", "")
+
+    @property
+    def message_id(self) -> str:
+        return self.context.get("open_message_id", "")
+
+    @property
+    def namespace(self) -> str:
+        return str(self.action_value.get("namespace", "") or "")
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_token": self.event_token,
+            "operator": dict(self.operator),
+            "context": dict(self.context),
+            "action_tag": self.action_tag,
+            "action_name": self.action_name,
+            "action_value": dict(self.action_value),
+            "form_value": dict(self.form_value),
+            "input_value": self.input_value,
+        }
+
+
+@dataclass(frozen=True)
+class _FeishuCardActionDispatch:
+    envelope: FeishuCardActionEnvelope
+    callback: Any
+    plugin_name: str
+    dedup_key: str
+    dedup_reservation: object
+
+
+class _FeishuCardHandlerPermit:
+    """One idempotent permit for a submitted card handler future."""
+
+    def __init__(self) -> None:
+        self._released = False
+        self._lock = threading.Lock()
+
+    def release(self, _future: Any = None) -> None:
+        with self._lock:
+            if self._released:
+                return
+            self._released = True
+        _FEISHU_CARD_HANDLER_IN_FLIGHT.release()
 
 
 @dataclass(frozen=True)
@@ -1401,6 +1537,7 @@ def _load_lark_oapi() -> bool:
                 CreateImageRequest, CreateImageRequestBody,
                 CreateMessageRequest, CreateMessageRequestBody,
                 GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
+                PatchMessageRequest, PatchMessageRequestBody,
                 P2ImMessageMessageReadV1,
                 ReplyMessageRequest, ReplyMessageRequestBody,
                 UpdateMessageRequest, UpdateMessageRequestBody,
@@ -1409,7 +1546,7 @@ def _load_lark_oapi() -> bool:
             from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
             from lark_oapi.core.model import BaseRequest
             from lark_oapi.event.callback.model.p2_card_action_trigger import (
-                CallBackCard, P2CardActionTriggerResponse,
+                CallBackCard, CallBackToast, P2CardActionTriggerResponse,
             )
             from lark_oapi.event.dispatcher_handler import EventDispatcherHandler
             from lark_oapi.ws import Client as FeishuWSClient
@@ -1425,6 +1562,8 @@ def _load_lark_oapi() -> bool:
             "CreateImageRequestBody": CreateImageRequestBody,
             "CreateMessageRequest": CreateMessageRequest,
             "CreateMessageRequestBody": CreateMessageRequestBody,
+            "PatchMessageRequest": PatchMessageRequest,
+            "PatchMessageRequestBody": PatchMessageRequestBody,
             "GetChatRequest": GetChatRequest,
             "GetMessageRequest": GetMessageRequest,
             "GetMessageResourceRequest": GetMessageResourceRequest,
@@ -1439,6 +1578,7 @@ def _load_lark_oapi() -> bool:
             "LARK_DOMAIN": LARK_DOMAIN,
             "BaseRequest": BaseRequest,
             "CallBackCard": CallBackCard,
+            "CallBackToast": CallBackToast,
             "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
             "EventDispatcherHandler": EventDispatcherHandler,
             "FeishuWSClient": FeishuWSClient,
@@ -1529,7 +1669,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
-        self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
+        self._card_action_tokens: Dict[str, tuple[float, object]] = {}  # token → (first_seen_time, reservation)
+        self._card_action_tokens_lock = threading.Lock()
         # Inbound events that arrived before the adapter loop was ready
         # (e.g. during startup/restart or network-flap reconnect). A single
         # drainer thread replays them as soon as the loop becomes available.
@@ -2010,6 +2151,79 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._finalize_send_result(last_response, "send failed")
         except Exception as exc:
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def send_card(
+        self,
+        chat_id: str,
+        card: Dict[str, Any],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send one raw Feishu JSON 2.0 interactive card without text fallback."""
+        try:
+            validate_feishu_card(card)
+            payload = json.dumps(card, ensure_ascii=False, allow_nan=False)
+        except FeishuCardValidationError as exc:
+            return SendResult(success=False, error=str(exc))
+        except (TypeError, ValueError):
+            return SendResult(success=False, error="Feishu card must contain JSON values")
+
+        if not str(chat_id or "").strip():
+            return SendResult(success=False, error="Feishu card send requires chat_id")
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "card send failed")
+        except Exception as exc:
+            logger.error("[Feishu] Card send failed: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def patch_card(self, message_id: str, card: Dict[str, Any]) -> SendResult:
+        """Replace an existing message's raw JSON 2.0 content via PATCH only."""
+        try:
+            validate_feishu_card(card)
+            payload = json.dumps(card, ensure_ascii=False, allow_nan=False)
+        except FeishuCardValidationError as exc:
+            return SendResult(success=False, error=str(exc))
+        except (TypeError, ValueError):
+            return SendResult(success=False, error="Feishu card must contain JSON values")
+
+        normalized_message_id = str(message_id or "").strip()
+        if not normalized_message_id:
+            return SendResult(success=False, error="Feishu card patch requires message_id")
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            request_body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(
+                message_id=normalized_message_id,
+                request_body=request_body,
+            )
+            response = await self._feishu_patch_with_retry(
+                message_id=normalized_message_id,
+                request=request,
+            )
+            result = self._finalize_send_result(response, "card patch failed")
+            if result.success:
+                result.message_id = normalized_message_id
+            return result
+        except Exception as exc:
+            logger.error(
+                "[Feishu] Card patch failed for message %s: %s",
+                normalized_message_id,
+                exc,
+                exc_info=True,
+            )
             return SendResult(success=False, error=str(exc))
 
     async def edit_message(
@@ -2719,7 +2933,8 @@ class FeishuAdapter(BasePlatformAdapter):
         inline (the only reliable way to sync all clients), and schedules a
         lightweight async method to actually unblock the agent.
 
-        For other card actions: delegates to ``_handle_card_action_event``.
+        For other card actions: invokes the bounded synchronous handler
+        contract and returns its real status/message as a Toast.
         """
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
@@ -2728,8 +2943,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
         event = getattr(data, "event", None)
         action = getattr(event, "action", None)
-        action_value = getattr(action, "value", {}) or {}
-        hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
+        try:
+            action_value = self._bounded_callback_mapping(
+                getattr(action, "value", {}) or {},
+                field_name="action.value",
+            )
+        except ValueError:
+            action_value = {}
+        hermes_action = action_value.get("hermes_action")
         update_prompt_action = (
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
@@ -2744,18 +2965,39 @@ class FeishuAdapter(BasePlatformAdapter):
                 loop=loop,
             )
 
-        self._submit_on_loop(loop, self._handle_card_action_event(data))
-        if P2CardActionTriggerResponse is None:
-            return None
-        return P2CardActionTriggerResponse()
+        dispatch, reason = self._prepare_card_action_dispatch(data)
+        if dispatch is None:
+            result = self._card_action_result_for_reason(reason)
+        else:
+            # The immediate handler call is deliberately synchronous: Feishu
+            # needs the real status/message in this callback response. Slow
+            # work must be returned separately through
+            # ``FeishuCardHandlerResult.background``.
+            result = self._invoke_feishu_card_handler_sync(dispatch, loop=loop)
+        toast_type = {
+            "accepted": "success",
+            "ignored": "info",
+            "error": "error",
+        }.get(result["status"], "error")
+        return self._new_card_callback_response(
+            toast_type=toast_type,
+            toast_content=result["message"],
+            card=result.get("card"),
+        )
 
     @staticmethod
     def _loop_accepts_callbacks(loop: Any) -> bool:
         """Return True when the adapter loop can accept thread-safe submissions."""
         return loop is not None and not bool(getattr(loop, "is_closed", lambda: False)())
 
-    def _submit_on_loop(self, loop: Any, coro: Any) -> bool:
-        """Schedule background work on the adapter loop with shared failure logging."""
+    def _submit_on_loop(
+        self,
+        loop: Any,
+        coro: Any,
+        *,
+        redact_failure: bool = False,
+    ) -> bool:
+        """Schedule background work on the adapter loop with bounded logging."""
         from agent.async_utils import safe_schedule_threadsafe
         future = safe_schedule_threadsafe(
             coro, loop,
@@ -2765,7 +3007,8 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         if future is None:
             return False
-        future.add_done_callback(self._log_background_failure)
+        callback = self._log_card_background_failure if redact_failure else self._log_background_failure
+        future.add_done_callback(callback)
         return True
 
     def _is_interactive_operator_authorized(self, open_id: str) -> bool:
@@ -2777,6 +3020,382 @@ class FeishuAdapter(BasePlatformAdapter):
         if not allowed_ids:
             return True
         return "*" in allowed_ids or normalized in allowed_ids
+
+    @staticmethod
+    def _callback_field(value: Any, name: str, default: Any = "") -> Any:
+        if isinstance(value, dict):
+            return value.get(name, default)
+        return getattr(value, name, default)
+
+    @staticmethod
+    def _bounded_callback_text(value: Any, *, field_name: str) -> str:
+        text = str(value or "")
+        if len(text) > _FEISHU_CARD_MAX_CALLBACK_TEXT_LENGTH:
+            raise ValueError(f"card callback {field_name} is too large")
+        return text
+
+    @classmethod
+    def _bounded_callback_mapping(cls, value: Any, *, field_name: str) -> Dict[str, Any]:
+        if value is None:
+            return {}
+
+        def to_plain(item: Any) -> Any:
+            if isinstance(item, dict):
+                return {str(key): to_plain(child) for key, child in item.items()}
+            if isinstance(item, list):
+                return [to_plain(child) for child in item]
+            if hasattr(item, "__dict__"):
+                return {
+                    str(key): to_plain(child)
+                    for key, child in vars(item).items()
+                    if not str(key).startswith("_")
+                }
+            return item
+
+        plain = to_plain(value)
+        if not isinstance(plain, dict):
+            raise ValueError(f"card callback {field_name} must be an object")
+        try:
+            encoded = json.dumps(plain, ensure_ascii=False, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"card callback {field_name} is not JSON") from exc
+        if len(encoded.encode("utf-8")) > _FEISHU_CARD_MAX_CALLBACK_VALUE_BYTES:
+            raise ValueError(f"card callback {field_name} is too large")
+        return plain
+
+    def _build_card_action_envelope(
+        self,
+        data: Any,
+    ) -> tuple[Optional[FeishuCardActionEnvelope], str]:
+        event = self._callback_field(data, "event", None)
+        if event is None:
+            return None, "invalid"
+        header = self._callback_field(data, "header", None)
+        operator_obj = self._callback_field(event, "operator", None)
+        context_obj = self._callback_field(event, "context", None)
+        action_obj = self._callback_field(event, "action", None)
+        try:
+            operator = {
+                key: self._bounded_callback_text(
+                    self._callback_field(operator_obj, key, ""),
+                    field_name=f"operator.{key}",
+                )
+                for key in ("tenant_key", "user_id", "open_id", "union_id")
+            }
+            context = {
+                key: self._bounded_callback_text(
+                    self._callback_field(context_obj, key, ""),
+                    field_name=f"context.{key}",
+                )
+                for key in ("url", "preview_token", "open_message_id", "open_chat_id")
+            }
+            action_value = self._bounded_callback_mapping(
+                self._callback_field(action_obj, "value", {}),
+                field_name="action.value",
+            )
+            form_value = self._bounded_callback_mapping(
+                self._callback_field(action_obj, "form_value", {}),
+                field_name="form_value",
+            )
+            raw_input_value = self._callback_field(action_obj, "input_value", None)
+            input_value = (
+                None
+                if raw_input_value is None
+                else self._bounded_callback_text(raw_input_value, field_name="input_value")
+            )
+            envelope = FeishuCardActionEnvelope(
+                event_id=self._bounded_callback_text(
+                    self._callback_field(header, "event_id", ""), field_name="event_id"
+                ),
+                event_token=self._bounded_callback_text(
+                    self._callback_field(event, "token", ""), field_name="event_token"
+                ),
+                operator=operator,
+                context=context,
+                action_tag=self._bounded_callback_text(
+                    self._callback_field(action_obj, "tag", "") or "button",
+                    field_name="action.tag",
+                ),
+                action_name=self._bounded_callback_text(
+                    self._callback_field(action_obj, "name", ""), field_name="action.name"
+                ),
+                action_value=action_value,
+                form_value=form_value,
+                input_value=input_value,
+            )
+        except ValueError:
+            return None, "invalid"
+
+        if not envelope.chat_id or not any(
+            envelope.operator.get(key) for key in ("open_id", "user_id", "union_id")
+        ):
+            return None, "missing_context"
+        if not _FEISHU_CARD_NAMESPACE_RE.fullmatch(envelope.namespace):
+            return None, "unknown_namespace"
+
+        sender_id = SimpleNamespace(
+            open_id=envelope.operator.get("open_id", ""),
+            user_id=envelope.operator.get("user_id", ""),
+            union_id=envelope.operator.get("union_id", ""),
+        )
+        if not self._allow_group_message(sender_id, envelope.chat_id, is_bot=False):
+            return None, "unauthorized"
+        return envelope, ""
+
+    @staticmethod
+    def _card_action_dedup_key(envelope: FeishuCardActionEnvelope) -> str:
+        if envelope.event_token:
+            return f"token:{envelope.event_token}"
+        if envelope.event_id:
+            return f"event:{envelope.event_id}"
+        return hashlib.sha256(
+            json.dumps(envelope.as_dict(), ensure_ascii=False, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+
+    def _find_feishu_card_handler(
+        self,
+        namespace: str,
+    ) -> Optional[tuple[Any, str]]:
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            handlers = get_plugin_manager().get_feishu_card_action_handlers()
+        except Exception:
+            logger.warning("[Feishu] Failed to load card action handlers")
+            return None
+        for registered_namespace, callback, plugin_name in handlers:
+            if registered_namespace == namespace:
+                return callback, plugin_name
+        return None
+
+    def _prepare_card_action_dispatch(
+        self,
+        data: Any,
+    ) -> tuple[Optional[_FeishuCardActionDispatch], str]:
+        envelope, reason = self._build_card_action_envelope(data)
+        if envelope is None:
+            return None, reason
+        handler = self._find_feishu_card_handler(envelope.namespace)
+        if handler is None:
+            return None, "unknown_namespace"
+        dedup_key = self._card_action_dedup_key(envelope)
+        reservation = self._reserve_card_action_token(dedup_key)
+        if reservation is None:
+            return None, "duplicate"
+        callback, plugin_name = handler
+        return _FeishuCardActionDispatch(
+            envelope, callback, plugin_name, dedup_key, reservation
+        ), ""
+
+    @staticmethod
+    def _new_card_callback_response(
+        *,
+        toast_type: Optional[str] = None,
+        toast_content: Optional[str] = None,
+        card: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if toast_type and toast_content:
+            toast = CallBackToast() if CallBackToast is not None else SimpleNamespace()
+            toast.type = toast_type
+            toast.content = toast_content
+            response.toast = toast
+        if card is not None:
+            callback_card = CallBackCard() if CallBackCard is not None else SimpleNamespace()
+            callback_card.type = "raw"
+            callback_card.data = card
+            response.card = callback_card
+        return response
+
+    @staticmethod
+    def _serialize_card_callback_response(response: Any) -> Dict[str, Any]:
+        if response is None:
+            return {}
+        payload: Dict[str, Any] = {}
+        toast = getattr(response, "toast", None)
+        if toast is not None:
+            payload["toast"] = {
+                "type": getattr(toast, "type", None),
+                "content": getattr(toast, "content", None),
+            }
+        card = getattr(response, "card", None)
+        if card is not None:
+            payload["card"] = {
+                "type": getattr(card, "type", None),
+                "data": getattr(card, "data", None),
+            }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @staticmethod
+    def _invalid_card_handler_result() -> Dict[str, str]:
+        return {"status": "error", "message": "Card action handler returned an invalid result."}
+
+    @staticmethod
+    def _close_card_handler_background(background: Any) -> None:
+        if inspect.iscoroutine(background):
+            background.close()
+
+    @classmethod
+    def _discard_late_card_handler_result(cls, future: Any) -> None:
+        """Consume a timed-out result without scheduling or exposing its data."""
+        if future.cancelled():
+            return
+        try:
+            result = future.result()
+        except Exception:
+            logger.error("[Feishu] Timed-out card action handler failed")
+            return
+        if inspect.iscoroutine(result):
+            cls._close_card_handler_background(result)
+        elif isinstance(result, FeishuCardHandlerResult):
+            cls._close_card_handler_background(result.background)
+        elif isinstance(result, dict):
+            cls._close_card_handler_background(result.get("background"))
+
+    @classmethod
+    def _validate_card_handler_result(
+        cls,
+        result: Any,
+    ) -> tuple[Optional[Dict[str, Any]], Any]:
+        if isinstance(result, FeishuCardHandlerResult):
+            status = result.status
+            message = result.message
+            background = result.background
+            card = result.card
+            if background is not None and not (
+                callable(background) or inspect.isawaitable(background)
+            ):
+                return None, None
+        elif isinstance(result, dict):
+            if set(result) - {"status", "message", "background", "card"}:
+                return None, None
+            status = result.get("status")
+            message = result.get("message")
+            background = result.get("background")
+            card = result.get("card")
+            if background is not None and not (
+                callable(background) or inspect.isawaitable(background)
+            ):
+                return None, None
+        else:
+            return None, None
+        if status not in {"accepted", "ignored", "error"}:
+            return None, None
+        if (
+            not isinstance(message, str)
+            or not message.strip()
+            or len(message) > _FEISHU_CARD_MAX_CALLBACK_TEXT_LENGTH
+        ):
+            return None, None
+        if card is not None:
+            try:
+                validate_feishu_card(card)
+            except FeishuCardValidationError:
+                return None, None
+        normalized: Dict[str, Any] = {"status": status, "message": message}
+        if card is not None:
+            normalized["card"] = card
+        return normalized, background
+
+    async def _run_card_handler_background(self, background: Any) -> None:
+        work = background() if callable(background) else background
+        if not inspect.isawaitable(work):
+            raise TypeError("card handler background must be awaitable")
+        await work
+
+    def _schedule_card_handler_background(self, background: Any, loop: Any) -> bool:
+        coroutine = self._run_card_handler_background(background)
+        scheduled = self._submit_on_loop(loop, coroutine, redact_failure=True)
+        if not scheduled and inspect.iscoroutine(background):
+            background.close()
+        return scheduled
+
+    def _invoke_feishu_card_handler_sync(
+        self,
+        dispatch: _FeishuCardActionDispatch,
+        *,
+        loop: Any,
+    ) -> Dict[str, Any]:
+        if not _FEISHU_CARD_HANDLER_IN_FLIGHT.acquire(blocking=False):
+            self._rollback_card_action_token(dispatch.dedup_key, dispatch.dedup_reservation)
+            return {"status": "error", "message": "Card action handler is busy; please retry."}
+
+        permit = _FeishuCardHandlerPermit()
+        future = None
+        try:
+            try:
+                future = _FEISHU_CARD_HANDLER_EXECUTOR.submit(
+                    dispatch.callback, dispatch.envelope
+                )
+                future.add_done_callback(permit.release)
+            except Exception:
+                if future is not None:
+                    future.cancel()
+                permit.release()
+                self._rollback_card_action_token(dispatch.dedup_key, dispatch.dedup_reservation)
+                return {
+                    "status": "error",
+                    "message": "Card action handler could not be scheduled.",
+                }
+
+            try:
+                raw_result = future.result(timeout=_FEISHU_CARD_HANDLER_TIMEOUT_SECONDS)
+            except FutureTimeoutError:
+                future.add_done_callback(self._discard_late_card_handler_result)
+                future.cancel()
+                return {
+                    "status": "error",
+                    "message": "Card action handler timed out before the 3-second response deadline.",
+                }
+            except Exception:
+                logger.error(
+                    "[Feishu] Card action handler failed (namespace=%s, plugin=%s)",
+                    dispatch.envelope.namespace,
+                    dispatch.plugin_name,
+                )
+                return {"status": "error", "message": "Card action handler failed."}
+
+            if inspect.isawaitable(raw_result):
+                if inspect.iscoroutine(raw_result):
+                    self._close_card_handler_background(raw_result)
+                return {
+                    "status": "error",
+                    "message": "Card action handler must return an immediate result.",
+                }
+            result, background = self._validate_card_handler_result(raw_result)
+            if result is None:
+                if isinstance(raw_result, FeishuCardHandlerResult):
+                    self._close_card_handler_background(raw_result.background)
+                elif isinstance(raw_result, dict):
+                    self._close_card_handler_background(raw_result.get("background"))
+                return self._invalid_card_handler_result()
+            if background is not None and not self._schedule_card_handler_background(background, loop):
+                return {"status": "error", "message": "Card action background work could not be scheduled."}
+            return result
+        except Exception:
+            logger.error(
+                "[Feishu] Card action handler failed (namespace=%s, plugin=%s)",
+                dispatch.envelope.namespace,
+                dispatch.plugin_name,
+            )
+            return {"status": "error", "message": "Card action handler failed."}
+
+    async def _invoke_feishu_card_handler(
+        self,
+        dispatch: _FeishuCardActionDispatch,
+    ) -> Dict[str, Any]:
+        return self._invoke_feishu_card_handler_sync(dispatch, loop=self._loop)
+
+    @staticmethod
+    def _card_action_result_for_reason(reason: str) -> Dict[str, Any]:
+        if reason == "duplicate":
+            return {"status": "ignored", "message": "Card action was already received."}
+        if reason == "unauthorized":
+            return {"status": "error", "message": "Card action is not authorized."}
+        if reason == "unknown_namespace":
+            return {"status": "error", "message": "Unknown card action namespace."}
+        return {"status": "error", "message": "Card action was rejected."}
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -3047,68 +3666,45 @@ class FeishuAdapter(BasePlatformAdapter):
         logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
         await self._handle_message_with_guards(synthetic_event)
 
-    def _is_card_action_duplicate(self, token: str) -> bool:
-        """Return True if this card action token was already processed within the dedup window."""
+    def _reserve_card_action_token(self, token: str) -> Optional[object]:
+        """Atomically reserve a card action token, or return None if duplicated."""
         now = time.time()
-        # Prune expired tokens lazily each call.
-        expired = [t for t, ts in self._card_action_tokens.items() if now - ts > _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS]
-        for t in expired:
-            del self._card_action_tokens[t]
-        if token in self._card_action_tokens:
-            return True
-        self._card_action_tokens[token] = now
-        return False
+        with self._card_action_tokens_lock:
+            expired = [
+                key
+                for key, (seen_at, _reservation) in self._card_action_tokens.items()
+                if now - seen_at > _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS
+            ]
+            for key in expired:
+                del self._card_action_tokens[key]
+            if token in self._card_action_tokens:
+                return None
+            if len(self._card_action_tokens) >= _FEISHU_CARD_ACTION_DEDUP_CACHE_SIZE:
+                self._card_action_tokens.pop(next(iter(self._card_action_tokens)), None)
+            reservation = object()
+            self._card_action_tokens[token] = (now, reservation)
+            return reservation
 
-    async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
-        event = getattr(data, "event", None)
-        token = str(getattr(event, "token", "") or "")
-        if token and self._is_card_action_duplicate(token):
-            logger.debug("[Feishu] Dropping duplicate card action token: %s", token)
-            return
+    def _is_card_action_duplicate(self, token: str) -> bool:
+        """Compatibility helper that performs an atomic token reservation."""
+        return self._reserve_card_action_token(token) is None
 
-        context = getattr(event, "context", None)
-        chat_id = str(getattr(context, "open_chat_id", "") or "")
-        operator = getattr(event, "operator", None)
-        open_id = str(getattr(operator, "open_id", "") or "")
-        if not chat_id or not open_id:
-            logger.debug("[Feishu] Card action missing chat_id or operator open_id, dropping")
-            return
+    def _rollback_card_action_token(self, token: str, reservation: object) -> None:
+        """Remove only this dispatch's token reservation after no execution."""
+        with self._card_action_tokens_lock:
+            current = self._card_action_tokens.get(token)
+            if current is not None and current[1] is reservation:
+                del self._card_action_tokens[token]
 
-        action = getattr(event, "action", None)
-        action_tag = str(getattr(action, "tag", "") or "button")
-        action_value = getattr(action, "value", {}) or {}
-
-        synthetic_text = f"/card {action_tag}"
-        if action_value:
-            try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
-            except Exception:
-                pass
-
-        sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
-        sender_profile = await self._resolve_sender_profile(sender_id)
-        chat_info = await self.get_chat_info(chat_id)
-        source = self.build_source(
-            chat_id=chat_id,
-            chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
-            user_id=sender_profile["user_id"],
-            user_name=sender_profile["user_name"],
-            thread_id=None,
-            user_id_alt=sender_profile["user_id_alt"],
-        )
-        synthetic_event = MessageEvent(
-            text=synthetic_text,
-            message_type=MessageType.COMMAND,
-            source=source,
-            raw_message=data,
-            message_id=token or str(uuid.uuid4()),
-            channel_prompt=self._resolve_channel_prompt(chat_id),
-            timestamp=datetime.now(),
-        )
-        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
-        await self._handle_message_with_guards(synthetic_event)
+    async def _handle_card_action_event(self, data: Any) -> Dict[str, Any]:
+        """Dispatch a namespaced card action without entering the Agent/LLM path."""
+        dispatch, reason = self._prepare_card_action_dispatch(data)
+        if dispatch is None:
+            result = self._card_action_result_for_reason(reason)
+            if reason not in {"duplicate", "unknown_namespace"}:
+                logger.warning("[Feishu] Card action rejected before handler dispatch: %s", reason)
+            return result
+        return await self._invoke_feishu_card_handler(dispatch)
 
     # =========================================================================
     # Per-chat serialization and typing indicator
@@ -3641,6 +4237,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         event_type = str((payload.get("header") or {}).get("event_type") or "")
         data = self._namespace_from_mapping(payload)
+        callback_response = None
         if event_type == "im.message.receive_v1":
             self._on_message_event(data)
         elif event_type == "im.message.message_read_v1":
@@ -3652,13 +4249,17 @@ class FeishuAdapter(BasePlatformAdapter):
         elif event_type in {"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"}:
             self._on_reaction_event(event_type, data)
         elif event_type == "card.action.trigger":
-            self._on_card_action_trigger(data)
+            callback_response = self._on_card_action_trigger(data)
         elif event_type == "drive.notice.comment_add_v1":
             self._on_drive_comment_event(data)
         elif event_type == "vc.bot.meeting_invited_v1":
             self._on_meeting_invited_event(data)
         else:
             logger.debug("[Feishu] Ignoring webhook event type: %s", event_type or "unknown")
+        if callback_response is not None:
+            serialized = self._serialize_card_callback_response(callback_response)
+            if serialized:
+                return web.json_response(serialized)
         return web.json_response({"code": 0, "msg": "ok"})
 
     def _is_webhook_signature_valid(self, headers: Any, body_bytes: bytes) -> bool:
@@ -4341,6 +4942,15 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.exception("[Feishu] Background inbound processing failed")
 
+    @staticmethod
+    def _log_card_background_failure(future: Any) -> None:
+        try:
+            future.result()
+        except Exception:
+            # Do not include exception text: controlled card background work
+            # may contain user-provided form/input values.
+            logger.error("[Feishu] Card action background work failed")
+
     # =========================================================================
     # Inbound admission
     # =========================================================================
@@ -4988,6 +5598,28 @@ class FeishuAdapter(BasePlatformAdapter):
             .build()
         )
 
+    async def _feishu_patch_with_retry(self, *, message_id: str, request: Any) -> Any:
+        """PATCH a message with the same bounded retry policy as sends."""
+        last_error: Optional[Exception] = None
+        for attempt in range(_FEISHU_SEND_ATTEMPTS):
+            try:
+                response = await self._run_blocking(self._client.im.v1.message.patch, request)
+                if self._response_succeeded(response) or attempt >= _FEISHU_SEND_ATTEMPTS - 1:
+                    return response
+            except Exception as exc:
+                last_error = exc
+                if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
+                    raise
+                logger.warning(
+                    "[Feishu] Card patch attempt %d/%d failed for message %s; retrying in %ds",
+                    attempt + 1,
+                    _FEISHU_SEND_ATTEMPTS,
+                    message_id,
+                    2 ** attempt,
+                )
+            await asyncio.sleep(2 ** attempt)
+        raise last_error or RuntimeError("Feishu card patch failed")
+
     async def _feishu_send_with_retry(
         self,
         *,
@@ -5128,6 +5760,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if ReplyMessageRequest is not None:
             return (
                 ReplyMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        if PatchMessageRequestBody is not None:
+            return PatchMessageRequestBody.builder().content(content).build()
+        return SimpleNamespace(content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        if PatchMessageRequest is not None:
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()
@@ -5670,6 +6319,67 @@ async def _standalone_send(
         }
     except Exception as e:
         return {"error": f"Feishu send failed: {e}"}
+
+
+async def standalone_send_card(
+    pconfig: Any,
+    chat_id: str,
+    card: Dict[str, Any],
+    *,
+    reply_to: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Send a card from a process without a live gateway adapter."""
+    if not FEISHU_AVAILABLE and not await asyncio.to_thread(_load_lark_oapi):
+        return {"error": "Feishu dependencies not installed"}
+    try:
+        adapter = FeishuAdapter(pconfig)
+        domain_name = getattr(adapter, "_domain_name", "feishu")
+        domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
+        adapter._client = adapter._build_lark_client(domain)
+        result = await adapter.send_card(
+            chat_id,
+            card,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        if not result.success:
+            return {"error": f"Feishu card send failed: {result.error}"}
+        return {
+            "success": True,
+            "platform": "feishu",
+            "chat_id": chat_id,
+            "message_id": result.message_id,
+        }
+    except Exception:
+        logger.error("[Feishu] Standalone card send failed", exc_info=True)
+        return {"error": "Feishu card send failed"}
+
+
+async def standalone_patch_card(
+    pconfig: Any,
+    message_id: str,
+    card: Dict[str, Any],
+) -> Dict[str, Any]:
+    """PATCH a card from a process without a live gateway adapter."""
+    if not FEISHU_AVAILABLE and not await asyncio.to_thread(_load_lark_oapi):
+        return {"error": "Feishu dependencies not installed"}
+    try:
+        adapter = FeishuAdapter(pconfig)
+        domain_name = getattr(adapter, "_domain_name", "feishu")
+        domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
+        adapter._client = adapter._build_lark_client(domain)
+        result = await adapter.patch_card(message_id, card)
+        if not result.success:
+            return {"error": f"Feishu card patch failed: {result.error}"}
+        return {
+            "success": True,
+            "platform": "feishu",
+            "message_id": message_id,
+        }
+    except Exception:
+        logger.error("[Feishu] Standalone card patch failed", exc_info=True)
+        return {"error": "Feishu card patch failed"}
 
 
 def interactive_setup() -> None:

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -242,30 +242,24 @@ class TestResolveApproval:
 # ===========================================================================
 
 class TestNonApprovalCardAction:
-    """Non-approval card actions should still route as synthetic commands."""
+    """Unnamespaced card actions have no gateway or LLM side effect."""
 
     @pytest.mark.asyncio
-    async def test_routes_as_synthetic_command(self):
+    async def test_does_not_route_as_synthetic_command(self):
         adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_user1"}
 
         data = _make_card_action_data(
             action_value={"custom_action": "something_else"},
             token="tok_normal",
         )
 
-        with (
-            patch.object(
-                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
-                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
-            ),
-            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
-            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
-        ):
-            await adapter._handle_card_action_event(data)
+        with patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle:
+            result = await adapter._handle_card_action_event(data)
 
-        mock_handle.assert_called_once()
-        event = mock_handle.call_args[0][0]
-        assert "/card button" in event.text
+        assert result["status"] == "error"
+        assert "namespace" in result["message"]
+        mock_handle.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/gateway/test_feishu_card_callbacks.py
+++ b/tests/gateway/test_feishu_card_callbacks.py
@@ -1,0 +1,720 @@
+"""Offline tests for the Feishu card callback envelope and dispatch boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+import plugins.platforms.feishu.adapter as feishu_module
+from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuCardHandlerResult
+
+
+COMPLETED_CARD = {
+    "schema": "2.0",
+    "config": {"update_multi": True, "width_mode": "fill"},
+    "header": {
+        "template": "green",
+        "title": {"tag": "plain_text", "content": "CARD MVP1"},
+    },
+    "body": {
+        "direction": "vertical",
+        "elements": [
+            {
+                "tag": "div",
+                "text": {"tag": "plain_text", "content": "CARD MVP1: completed"},
+            }
+        ],
+    },
+}
+
+
+def _make_adapter() -> FeishuAdapter:
+    adapter = FeishuAdapter(PlatformConfig(enabled=True))
+    adapter._client = MagicMock()
+    adapter._allowed_group_users = {"ou_allowed"}
+    return adapter
+
+
+def _make_manager(callback=None, namespace="mvp1.test") -> PluginManager:
+    manager = PluginManager()
+    if callback is not None:
+        context = PluginContext(
+            manifest=PluginManifest(name="contract-test", version="1", description=""),
+            manager=manager,
+        )
+        context.register_feishu_card_action_handler(namespace, callback)
+    return manager
+
+
+def _data(
+    *,
+    token="event-token-1",
+    event_id="event-id-1",
+    namespace="mvp1.test",
+    open_id="ou_allowed",
+    form_value=None,
+    input_value="CARD-MVP1-OK",
+):
+    return SimpleNamespace(
+        header=SimpleNamespace(event_id=event_id, token="header-token"),
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(
+                url="https://open.feishu.cn/callback",
+                preview_token="preview-token",
+                open_message_id="om_card",
+                open_chat_id="oc_chat",
+            ),
+            operator=SimpleNamespace(
+                tenant_key="tenant-key",
+                user_id="u_allowed",
+                open_id=open_id,
+                union_id="on_allowed",
+            ),
+            # This models Feishu's callback payload after a JSON 2.0
+            # ``behaviors`` callback has been resolved; it is not card JSON.
+            action=SimpleNamespace(
+                tag="button",
+                name="submit",
+                value={"namespace": namespace, "action": "submit", "safe": True},
+                form_value=form_value or {"field": "CARD-MVP1-OK"},
+                input_value=input_value,
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_callback_envelope_preserves_operator_context_and_inputs():
+    received = []
+
+    def handler(envelope):
+        received.append(envelope)
+        return {"status": "accepted", "message": "queued"}
+
+    adapter = _make_adapter()
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        result = await adapter._handle_card_action_event(_data())
+
+    assert result == {"status": "accepted", "message": "queued"}
+    assert len(received) == 1
+    envelope = received[0]
+    assert envelope.event_id == "event-id-1"
+    assert envelope.event_token == "event-token-1"
+    assert envelope.operator == {
+        "tenant_key": "tenant-key",
+        "user_id": "u_allowed",
+        "open_id": "ou_allowed",
+        "union_id": "on_allowed",
+    }
+    assert envelope.context["open_chat_id"] == "oc_chat"
+    assert envelope.context["open_message_id"] == "om_card"
+    assert envelope.action_tag == "button"
+    assert envelope.action_name == "submit"
+    assert envelope.action_value["namespace"] == "mvp1.test"
+    assert envelope.form_value == {"field": "CARD-MVP1-OK"}
+    assert envelope.input_value == "CARD-MVP1-OK"
+
+
+@pytest.mark.asyncio
+async def test_acl_rejection_does_not_invoke_handler():
+    calls = []
+
+    def handler(_envelope):
+        calls.append(True)
+        return {"status": "accepted", "message": "handled"}
+
+    adapter = _make_adapter()
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        result = await adapter._handle_card_action_event(_data(open_id="ou_intruder"))
+
+    assert result["status"] == "error"
+    assert "authorized" in result["message"]
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_invokes_handler_once():
+    calls = []
+
+    def handler(_envelope):
+        calls.append(True)
+        return {"status": "accepted", "message": "handled"}
+
+    adapter = _make_adapter()
+    manager = _make_manager(handler)
+    data = _data()
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        first = await adapter._handle_card_action_event(data)
+        second = await adapter._handle_card_action_event(data)
+
+    assert first["status"] == "accepted"
+    assert second == {"status": "ignored", "message": "Card action was already received."}
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_namespace_has_zero_gateway_side_effect():
+    adapter = _make_adapter()
+    manager = _make_manager(
+        namespace="mvp1.registered",
+        callback=lambda _e: {"status": "accepted", "message": "handled"},
+    )
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as handle_message:
+        result = await adapter._handle_card_action_event(_data(namespace="mvp1.unknown"))
+
+    assert result == {"status": "error", "message": "Unknown card action namespace."}
+    handle_message.assert_not_called()
+
+
+def test_sync_callback_returns_handler_result_toast_inline():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    calls = []
+
+    def handler(_envelope):
+        calls.append(True)
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="queued",
+            card=COMPLETED_CARD,
+        )
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "success"
+    assert response.toast.content == "queued"
+    assert COMPLETED_CARD["config"] == {"update_multi": True, "width_mode": "fill"}
+    assert "wide_screen_mode" not in json.dumps(COMPLETED_CARD)
+    assert response.card.type == "raw"
+    assert response.card.data == COMPLETED_CARD
+    assert calls == [True]
+
+
+@pytest.mark.parametrize("card", [{"schema": "1.0"}, {"schema": "2.0", "body": object()}])
+def test_invalid_handler_card_fails_closed_without_background_or_llm(card):
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    background_calls = []
+
+    def background():
+        background_calls.append(True)
+        return asyncio.sleep(0)
+
+    def handler(_envelope):
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="should not be accepted",
+            background=background,
+            card=card,
+        )
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_submit_on_loop", new_callable=MagicMock
+    ) as submit, patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as llm:
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "error"
+    assert "invalid result" in response.toast.content
+    assert getattr(response, "card", None) is None
+    submit.assert_not_called()
+    llm.assert_not_called()
+    assert background_calls == []
+
+
+def test_sync_callback_invalid_result_returns_error_toast():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    manager = _make_manager(lambda _e: {"status": "accepted"})
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "error"
+    assert "invalid result" in response.toast.content
+
+
+def test_sync_callback_exception_returns_error_toast_without_llm(caplog):
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+
+    def handler(_envelope):
+        raise RuntimeError("CARD-MVP1-OK")
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as handle_message:
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "error"
+    assert response.toast.content == "Card action handler failed."
+    assert "CARD-MVP1-OK" not in response.toast.content
+    assert "CARD-MVP1-OK" not in caplog.text
+    handle_message.assert_not_called()
+
+
+def test_sync_callback_acl_duplicate_and_unknown_return_real_toasts():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    calls = []
+
+    def handler(_envelope):
+        calls.append(True)
+        return {"status": "accepted", "message": "processed"}
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        first = adapter._on_card_action_trigger(_data())
+        duplicate = adapter._on_card_action_trigger(_data())
+        unauthorized = adapter._on_card_action_trigger(_data(event_id="event-id-2", token="event-token-2", open_id="ou_intruder"))
+        unknown = adapter._on_card_action_trigger(
+            _data(event_id="event-id-3", token="event-token-3", namespace="mvp1.unknown")
+        )
+
+    assert first.toast.type == "success"
+    assert first.toast.content == "processed"
+    assert duplicate.toast.type == "info"
+    assert "already" in duplicate.toast.content
+    assert unauthorized.toast.type == "error"
+    assert "authorized" in unauthorized.toast.content
+    assert unknown.toast.type == "error"
+    assert "Unknown" in unknown.toast.content
+    assert calls == [True]
+
+
+def test_sync_handler_wall_clock_timeout_returns_before_three_seconds():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    entered = threading.Event()
+    release = threading.Event()
+    late_returned = threading.Event()
+    background_runs = threading.Event()
+    late_backgrounds = []
+
+    async def late_background():
+        background_runs.set()
+
+    def handler(_envelope):
+        entered.set()
+        release.wait(timeout=10)
+        background = late_background()
+        late_backgrounds.append(background)
+        late_returned.set()
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="late result",
+            background=background,
+        )
+
+    manager = _make_manager(handler)
+    try:
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+            adapter, "_handle_message_with_guards", new_callable=MagicMock
+        ) as llm:
+            started = time.monotonic()
+            response = adapter._on_card_action_trigger(_data())
+            elapsed = time.monotonic() - started
+
+        assert entered.wait(timeout=1)
+        assert elapsed < 3.0
+        assert response.toast.type == "error"
+        assert "timed out" in response.toast.content
+        llm.assert_not_called()
+        assert not background_runs.is_set()
+    finally:
+        release.set()
+
+    assert late_returned.wait(timeout=2)
+    deadline = time.monotonic() + 1
+    while late_backgrounds and late_backgrounds[0].cr_frame is not None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert late_backgrounds[0].cr_frame is None
+    assert not background_runs.is_set()
+
+
+def test_concurrent_duplicate_callback_reserves_token_once():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    barrier = threading.Barrier(2)
+    calls = []
+    calls_lock = threading.Lock()
+    responses = [None, None]
+    errors = []
+
+    def handler(_envelope):
+        with calls_lock:
+            calls.append(True)
+        return {"status": "accepted", "message": "handled"}
+
+    def find_handler(_namespace):
+        barrier.wait(timeout=2)
+        return handler, "contract-test"
+
+    def invoke(index):
+        try:
+            responses[index] = adapter._on_card_action_trigger(_data())
+        except BaseException as exc:  # pragma: no cover - assertion reports the failure
+            errors.append(exc)
+
+    threads = [threading.Thread(target=invoke, args=(index,)) for index in range(2)]
+    with patch.object(adapter, "_find_feishu_card_handler", side_effect=find_handler), patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as llm, patch.object(
+        adapter,
+        "_invoke_feishu_card_handler_sync",
+        wraps=adapter._invoke_feishu_card_handler_sync,
+    ) as invoke_handler:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=3)
+
+    assert errors == []
+    assert all(response is not None for response in responses)
+    assert sorted(response.toast.type for response in responses) == ["info", "success"]
+    assert calls == [True]
+    assert invoke_handler.call_count == 1
+    llm.assert_not_called()
+
+
+def test_concurrent_different_tokens_both_dispatch():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    barrier = threading.Barrier(2)
+    calls = []
+    calls_lock = threading.Lock()
+    responses = [None, None]
+    errors = []
+
+    def handler(envelope):
+        with calls_lock:
+            calls.append(envelope.event_token)
+        barrier.wait(timeout=2)
+        return {"status": "accepted", "message": "handled"}
+
+    def invoke(index):
+        try:
+            responses[index] = adapter._on_card_action_trigger(
+                _data(event_id=f"different-{index}", token=f"different-token-{index}")
+            )
+        except BaseException as exc:  # pragma: no cover - assertion reports the failure
+            errors.append(exc)
+
+    threads = [threading.Thread(target=invoke, args=(index,)) for index in range(2)]
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as llm:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=3)
+
+    assert errors == []
+    assert all(response is not None for response in responses)
+    assert all(response.toast.type == "success" for response in responses)
+    assert sorted(calls) == ["different-token-0", "different-token-1"]
+    llm.assert_not_called()
+
+
+def test_sync_handler_pool_saturation_rejects_without_submit_and_recovers(monkeypatch):
+    monkeypatch.setattr(feishu_module, "_FEISHU_CARD_HANDLER_TIMEOUT_SECONDS", 0.1)
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    release = threading.Event()
+    lock = threading.Lock()
+    started = 0
+    returned = 0
+    late_backgrounds = []
+    background_runs = threading.Event()
+    max_workers = feishu_module._FEISHU_CARD_HANDLER_MAX_WORKERS
+
+    async def late_background():
+        background_runs.set()
+
+    def handler(_envelope):
+        nonlocal started, returned
+        with lock:
+            started += 1
+            invocation = started
+        release.wait(timeout=5)
+        if invocation > max_workers:
+            return {"status": "accepted", "message": "recovered"}
+        background = late_background()
+        with lock:
+            late_backgrounds.append(background)
+            returned += 1
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="late result",
+            background=background,
+        )
+
+    manager = _make_manager(handler)
+    responses = []
+    try:
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+            feishu_module._FEISHU_CARD_HANDLER_EXECUTOR,
+            "submit",
+            wraps=feishu_module._FEISHU_CARD_HANDLER_EXECUTOR.submit,
+        ) as submit:
+            for index in range(max_workers):
+                responses.append(
+                    adapter._on_card_action_trigger(
+                        _data(event_id=f"saturation-{index}", token=f"saturation-token-{index}")
+                    )
+                )
+            started_extra = time.monotonic()
+            extra = adapter._on_card_action_trigger(
+                _data(event_id="saturation-extra", token="saturation-token-extra")
+            )
+            extra_elapsed = time.monotonic() - started_extra
+
+            assert all(response.toast.type == "error" for response in responses)
+            assert all("timed out" in response.toast.content for response in responses)
+            assert extra.toast.type == "error"
+            assert "busy" in extra.toast.content
+            assert extra_elapsed < 0.2
+            assert submit.call_count == max_workers
+            with lock:
+                assert started == max_workers
+                assert returned == 0
+    finally:
+        release.set()
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        with lock:
+            if returned == started:
+                break
+        time.sleep(0.01)
+    with lock:
+        assert returned == started == max_workers
+        assert len(late_backgrounds) == returned
+    deadline = time.monotonic() + 1
+    while any(background.cr_frame is not None for background in late_backgrounds) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert all(background.cr_frame is None for background in late_backgrounds)
+    assert not background_runs.is_set()
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        feishu_module._FEISHU_CARD_HANDLER_EXECUTOR,
+        "submit",
+        wraps=feishu_module._FEISHU_CARD_HANDLER_EXECUTOR.submit,
+    ) as submit:
+        recovered = adapter._on_card_action_trigger(
+            _data(event_id="saturation-extra", token="saturation-token-extra")
+        )
+    assert recovered.toast.type == "success"
+    assert recovered.toast.content == "recovered"
+    assert submit.call_count == 1
+
+
+def test_submit_failure_releases_permit_and_allows_retry():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    calls = []
+
+    def handler(_envelope):
+        calls.append(True)
+        return {"status": "accepted", "message": "retried"}
+
+    manager = _make_manager(handler)
+    data = _data()
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        feishu_module._FEISHU_CARD_HANDLER_EXECUTOR,
+        "submit",
+        side_effect=RuntimeError("executor unavailable"),
+    ):
+        failed = adapter._on_card_action_trigger(data)
+
+    assert failed.toast.type == "error"
+    assert "scheduled" in failed.toast.content
+    assert calls == []
+    assert feishu_module._FEISHU_CARD_HANDLER_IN_FLIGHT.acquire(blocking=False)
+    feishu_module._FEISHU_CARD_HANDLER_IN_FLIGHT.release()
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        retried = adapter._on_card_action_trigger(data)
+    assert retried.toast.type == "success"
+    assert retried.toast.content == "retried"
+    assert calls == [True]
+
+
+def test_async_handler_is_rejected_instead_of_awaited_for_callback():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+
+    async def handler(_envelope):
+        return {"status": "accepted", "message": "should not run"}
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "error"
+    assert "immediate result" in response.toast.content
+
+
+def test_controlled_background_is_separate_from_immediate_toast():
+    adapter = _make_adapter()
+    adapter._loop = MagicMock()
+    adapter._loop.is_closed.return_value = False
+    scheduled = []
+
+    def close_scheduled(_loop, coro, **_kwargs):
+        scheduled.append(coro)
+        coro.close()
+        return True
+
+    def handler(_envelope):
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="queued",
+            background=lambda: asyncio.sleep(0),
+        )
+
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_submit_on_loop", side_effect=close_scheduled
+    ):
+        response = adapter._on_card_action_trigger(_data())
+
+    assert response.toast.type == "success"
+    assert response.toast.content == "queued"
+    assert len(scheduled) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler, expected",
+    [
+        (lambda _e: "not a result", "invalid result"),
+        (lambda _e: {"status": "accepted", "unexpected": True}, "invalid result"),
+    ],
+)
+async def test_invalid_handler_result_is_rejected(handler, expected):
+    adapter = _make_adapter()
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        result = await adapter._handle_card_action_event(_data())
+
+    assert result["status"] == "error"
+    assert expected in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_is_contained_and_never_enters_llm():
+    def handler(_envelope):
+        raise RuntimeError("handler failure")
+
+    adapter = _make_adapter()
+    manager = _make_manager(handler)
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager), patch.object(
+        adapter, "_handle_message_with_guards", new_callable=MagicMock
+    ) as handle_message:
+        result = await adapter._handle_card_action_event(_data())
+
+    assert result == {"status": "error", "message": "Card action handler failed."}
+    handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_card_callback_serializes_real_toast_response():
+    adapter = _make_adapter()
+    adapter._loop = asyncio.get_running_loop()
+    calls = []
+
+    def handler(envelope):
+        calls.append(envelope.event_id)
+        return FeishuCardHandlerResult(
+            status="accepted",
+            message="callback accepted",
+            card=COMPLETED_CARD,
+        )
+
+    payload = {
+        "header": {
+            "event_type": "card.action.trigger",
+            "event_id": "webhook-event-1",
+            "token": "header-token",
+        },
+        "event": {
+            "token": "event-token-webhook",
+            "context": {
+                "open_message_id": "om_webhook",
+                "open_chat_id": "oc_chat",
+            },
+            "operator": {"open_id": "ou_allowed"},
+            "action": {
+                "tag": "button",
+                "name": "submit",
+                "value": {"namespace": "mvp1.test"},
+                "form_value": {"field": "CARD-MVP1-OK"},
+                "input_value": "CARD-MVP1-OK",
+            },
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    request = SimpleNamespace(
+        remote="127.0.0.1",
+        headers={"Content-Type": "application/json"},
+        content_length=len(body),
+        content=SimpleNamespace(readexactly=AsyncMock(return_value=body)),
+    )
+    manager = _make_manager(handler)
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=manager):
+        response = await adapter._handle_webhook_request(request)
+
+    assert response.status == 200
+    assert json.loads(response.text) == {
+        "toast": {"type": "success", "content": "callback accepted"},
+        "card": {"type": "raw", "data": COMPLETED_CARD},
+    }
+    assert calls == ["webhook-event-1"]
+
+
+def test_plugin_namespace_registration_is_fixed_and_validated():
+    manager = PluginManager()
+    context = PluginContext(
+        manifest=PluginManifest(name="contract-test", version="1", description=""),
+        manager=manager,
+    )
+    with pytest.raises(ValueError, match="invalid"):
+        context.register_feishu_card_action_handler("../../shell", lambda _e: {"status": "accepted"})
+    with pytest.raises(ValueError, match="non-callable"):
+        context.register_feishu_card_action_handler("mvp1.test", "not callable")  # type: ignore[arg-type]
+
+    context.register_feishu_card_action_handler("mvp1.test", lambda _e: {"status": "accepted"})
+    with pytest.raises(ValueError, match="already registered"):
+        context.register_feishu_card_action_handler("mvp1.test", lambda _e: {"status": "accepted"})

--- a/tests/gateway/test_feishu_cards.py
+++ b/tests/gateway/test_feishu_cards.py
@@ -1,0 +1,154 @@
+"""Offline tests for Feishu JSON 2.0 card transport."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.feishu.adapter import (
+    FeishuAdapter,
+    FeishuCardValidationError,
+    parse_feishu_card_json,
+)
+
+
+CARD = {
+    "schema": "2.0",
+    "config": {"update_multi": True, "width_mode": "fill"},
+    "header": {
+        "template": "blue",
+        "title": {"tag": "plain_text", "content": "CARD MVP1"},
+    },
+    "body": {
+        "direction": "vertical",
+        "elements": [
+            {
+                "tag": "div",
+                "text": {"tag": "plain_text", "content": "CARD MVP1"},
+            }
+        ],
+    },
+}
+
+
+def test_card_fixture_uses_official_json_2_0_fields():
+    assert CARD["schema"] == "2.0"
+    assert CARD["config"] == {"update_multi": True, "width_mode": "fill"}
+    assert "wide_screen_mode" not in json.dumps(CARD)
+    assert CARD["header"]["title"]["tag"] == "plain_text"
+    assert CARD["body"]["direction"] == "vertical"
+
+
+def _response(message_id: str | None = None, *, success: bool = True):
+    return SimpleNamespace(
+        success=lambda: success,
+        data=SimpleNamespace(message_id=message_id) if message_id else None,
+        code=0 if success else 123,
+        msg="ok" if success else "rejected",
+    )
+
+
+def _make_adapter():
+    adapter = FeishuAdapter(PlatformConfig(enabled=True))
+    client = MagicMock()
+    adapter._client = client
+    return adapter, client
+
+
+@pytest.mark.asyncio
+async def test_send_card_uses_interactive_create_and_returns_message_id():
+    adapter, client = _make_adapter()
+    client.im.v1.message.create.return_value = _response("om_created")
+
+    result = await adapter.send_card("oc_chat", CARD)
+
+    assert result.success is True
+    assert result.message_id == "om_created"
+    client.im.v1.message.create.assert_called_once()
+    request = client.im.v1.message.create.call_args.args[0]
+    assert request.request_body.receive_id == "oc_chat"
+    assert request.request_body.msg_type == "interactive"
+    assert json.loads(request.request_body.content) == CARD
+
+
+@pytest.mark.asyncio
+async def test_send_card_preserves_thread_metadata():
+    adapter, client = _make_adapter()
+    client.im.v1.message.create.return_value = _response("om_threaded")
+
+    result = await adapter.send_card("oc_chat", CARD, metadata={"thread_id": "omt_thread"})
+
+    assert result.success is True
+    request = client.im.v1.message.create.call_args.args[0]
+    assert request.receive_id_type == "thread_id"
+    assert request.request_body.receive_id == "omt_thread"
+
+
+@pytest.mark.asyncio
+async def test_patch_card_uses_message_id_and_content_only():
+    adapter, client = _make_adapter()
+    client.im.v1.message.patch.return_value = _response()
+
+    result = await adapter.patch_card("om_existing", CARD)
+
+    assert result.success is True
+    assert result.message_id == "om_existing"
+    client.im.v1.message.patch.assert_called_once()
+    request = client.im.v1.message.patch.call_args.args[0]
+    assert request.message_id == "om_existing"
+    assert request.request_body.content == json.dumps(CARD, ensure_ascii=False)
+    assert not hasattr(request.request_body, "msg_type")
+    client.im.v1.message.create.assert_not_called()
+    client.im.v1.message.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "card",
+    [
+        {"schema": "1.0"},
+        [],
+        "not an object",
+        {"schema": "2.0", "body": object()},
+    ],
+)
+async def test_invalid_card_is_rejected_before_any_feishu_request(card):
+    adapter, client = _make_adapter()
+
+    result = await adapter.send_card("oc_chat", card)  # type: ignore[arg-type]
+    patch_result = await adapter.patch_card("om_existing", card)  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert patch_result.success is False
+    client.im.v1.message.create.assert_not_called()
+    client.im.v1.message.patch.assert_not_called()
+    client.im.v1.message.update.assert_not_called()
+
+
+def test_damaged_card_json_fails_closed():
+    with pytest.raises(FeishuCardValidationError, match="not valid JSON"):
+        parse_feishu_card_json("{broken")
+
+
+def test_non_object_and_non_2_0_roots_fail_closed():
+    with pytest.raises(FeishuCardValidationError, match="JSON object"):
+        parse_feishu_card_json("[]")
+    with pytest.raises(FeishuCardValidationError, match="schema='2.0'"):
+        parse_feishu_card_json('{"msg_type":"text"}')
+
+
+@pytest.mark.asyncio
+async def test_sdk_error_does_not_fall_back_to_text():
+    adapter, client = _make_adapter()
+    client.im.v1.message.create.side_effect = RuntimeError("SDK failure")
+
+    result = await adapter.send_card("oc_chat", CARD)
+
+    assert result.success is False
+    assert client.im.v1.message.create.call_count == 3
+    client.im.v1.message.update.assert_not_called()
+    client.im.v1.message.reply.assert_not_called()

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -72,6 +72,86 @@ def fake_tool(monkeypatch):
 
 
 
+def test_feishu_card_file_is_passed_as_structured_card(fake_tool, tmp_path):
+    card_file = tmp_path / "card.json"
+    card = {"schema": "2.0", "body": {"elements": []}}
+    card_file.write_text(json.dumps(card), encoding="utf-8")
+
+    args = _parse(["--to", "feishu:oc_chat", "--card-file", str(card_file)])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 0
+    assert fake_tool.calls == [{"action": "send", "target": "feishu:oc_chat", "card": card}]
+
+
+def test_feishu_card_patch_requires_no_text_fallback(fake_tool, tmp_path):
+    card_file = tmp_path / "card.json"
+    card = {"schema": "2.0", "body": {"elements": []}}
+    card_file.write_text(json.dumps(card), encoding="utf-8")
+
+    args = _parse([
+        "--to", "feishu", "--card-file", str(card_file),
+        "--patch-message-id", "om_existing",
+    ])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 0
+    assert fake_tool.calls == [{
+        "action": "send",
+        "target": "feishu",
+        "card": card,
+        "patch_message_id": "om_existing",
+    }]
+
+
+def test_invalid_feishu_card_file_is_usage_error(fake_tool, capsys, tmp_path):
+    card_file = tmp_path / "bad.json"
+    card_file.write_text("{broken", encoding="utf-8")
+
+    args = _parse(["--to", "feishu", "--card-file", str(card_file)])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 2
+    assert fake_tool.calls == []
+    assert "not valid JSON" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "raw_card, expected_error",
+    [
+        ("[]", "must be a JSON object"),
+        ('{"schema":"1.0"}', "must declare schema='2.0'"),
+    ],
+)
+def test_invalid_card_shape_is_usage_error_before_tool(fake_tool, capsys, tmp_path, raw_card, expected_error):
+    card_file = tmp_path / "bad-card.json"
+    card_file.write_text(raw_card, encoding="utf-8")
+
+    args = _parse(["--to", "feishu", "--card-file", str(card_file)])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 2
+    assert fake_tool.calls == []
+    assert expected_error in capsys.readouterr().err
+
+
+def test_card_file_is_mutually_exclusive_with_text(fake_tool, capsys, tmp_path):
+    card_file = tmp_path / "card.json"
+    card_file.write_text('{"schema":"2.0"}', encoding="utf-8")
+
+    args = _parse(["--to", "feishu", "--card-file", str(card_file), "text"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 2
+    assert fake_tool.calls == []
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
@@ -174,6 +254,19 @@ def test_list_json_includes_configured_platform(monkeypatch, capsys):
     assert payload["platforms"]["simplex"] == []
     assert "local" not in payload["platforms"]  # infra pseudo-platform skipped
     assert payload["platforms"]["telegram"]  # discovered entries preserved
+
+
+def test_card_capabilities_is_offline_json(capsys):
+    args = _parse(["--card-capabilities", "--json"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["platform"] == "feishu"
+    assert payload["contract"] == "mvp1"
+    assert set(payload["capabilities"]) >= {
+        "send_card", "patch_card", "card_action_envelope"
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -17,6 +17,89 @@ def _run_async_immediately(coro):
     return asyncio.run(coro)
 
 
+def test_send_message_routes_feishu_card_without_text_fallback() -> None:
+    feishu_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={Platform.FEISHU: feishu_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="oc_home"),
+    )
+    card = {"schema": "2.0", "body": {"elements": []}}
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch(
+             "tools.send_message_tool._send_feishu_card_via_adapter",
+             new=AsyncMock(return_value={"success": True, "message_id": "om_card"}),
+         ) as card_send, \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock()) as text_send:
+        result = json.loads(send_message_tool({
+            "action": "send",
+            "target": "feishu",
+            "card": card,
+        }))
+
+    assert result["success"] is True
+    card_send.assert_awaited_once_with(
+        feishu_cfg,
+        chat_id="oc_home",
+        card=card,
+        patch_message_id=None,
+        thread_id=None,
+    )
+    text_send.assert_not_awaited()
+
+
+def test_send_message_rejects_invalid_feishu_card_before_transport() -> None:
+    feishu_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={Platform.FEISHU: feishu_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="oc_home"),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), patch(
+        "tools.send_message_tool._send_feishu_card_via_adapter", new=AsyncMock()
+    ) as card_send:
+        result = json.loads(send_message_tool({
+            "action": "send",
+            "target": "feishu",
+            "card": {"schema": "1.0"},
+        }))
+
+    assert "error" in result
+    card_send.assert_not_awaited()
+
+
+def test_send_message_routes_feishu_card_patch_by_message_id() -> None:
+    feishu_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={Platform.FEISHU: feishu_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+    card = {"schema": "2.0", "body": {"elements": []}}
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch(
+             "tools.send_message_tool._send_feishu_card_via_adapter",
+             new=AsyncMock(return_value={"success": True, "message_id": "om_existing"}),
+         ) as card_send:
+        result = json.loads(send_message_tool({
+            "action": "send",
+            "target": "feishu",
+            "card": card,
+            "patch_message_id": "om_existing",
+        }))
+
+    assert result["success"] is True
+    card_send.assert_awaited_once_with(
+        feishu_cfg,
+        chat_id=None,
+        card=card,
+        patch_message_id="om_existing",
+        thread_id=None,
+    )
+
+
 def test_photon_e164_target_is_explicit() -> None:
     chat_id, thread_id, is_explicit = _parse_target_ref("photon", "+15551234567")
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -258,6 +258,9 @@ def send_message_tool(args, **kw):
     if action == "unreact":
         return _handle_react(args, remove=True)
 
+    if "card" in args or args.get("patch_message_id"):
+        return _handle_card_send(args)
+
     return _handle_send(args)
 
 
@@ -358,6 +361,86 @@ def _handle_react(args, remove=False):
     if isinstance(result, dict):
         return json.dumps(result)
     return json.dumps({"success": bool(result)})
+
+
+def _handle_card_send(args):
+    """Send or PATCH a Feishu JSON 2.0 card without a text fallback."""
+    target = str(args.get("target", "") or "").strip()
+    if not target:
+        return tool_error("'target' is required for Feishu card transport")
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    if platform_name != "feishu":
+        return tool_error("Feishu card transport only supports target platform 'feishu'")
+
+    card = args.get("card")
+    if not isinstance(card, dict):
+        return tool_error("'card' must be a JSON object")
+    try:
+        from plugins.platforms.feishu.adapter import validate_feishu_card
+        validate_feishu_card(card)
+    except Exception as exc:
+        return json.dumps(_error(str(exc)))
+
+    patch_message_id = str(args.get("patch_message_id") or "").strip() or None
+    if target_ref:
+        chat_id, thread_id, is_explicit = _parse_target_ref("feishu", target_ref)
+        if not is_explicit:
+            if patch_message_id:
+                return json.dumps(_error("PATCH target must be feishu or an explicit Feishu chat ID"))
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name("feishu", target_ref)
+            except Exception:
+                resolved = None
+            if not resolved:
+                return json.dumps(_error(f"Could not resolve '{target_ref}' on feishu"))
+            chat_id, thread_id, _ = _parse_target_ref("feishu", resolved)
+    else:
+        chat_id = None
+        thread_id = None
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+        config = load_gateway_config()
+        platform = Platform.FEISHU
+    except Exception as exc:
+        return json.dumps(_error(f"Failed to load gateway config: {exc}"))
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        return tool_error(
+            "Platform 'feishu' is not configured. Set up credentials in "
+            "~/.hermes/config.yaml or environment variables."
+        )
+
+    if not patch_message_id and not chat_id:
+        home = config.get_home_channel(platform)
+        if home:
+            chat_id = home.chat_id
+        else:
+            return json.dumps(_error(
+                "No home channel set for feishu. Specify 'feishu:CHAT_ID' when sending a card."
+            ))
+
+    try:
+        from model_tools import _run_async
+        result = _run_async(
+            _send_feishu_card_via_adapter(
+                pconfig,
+                chat_id=chat_id,
+                card=card,
+                patch_message_id=patch_message_id,
+                thread_id=thread_id,
+            )
+        )
+    except Exception as exc:
+        return json.dumps(_error(f"Feishu card transport failed: {exc}"))
+    if isinstance(result, dict) and result.get("error"):
+        result["error"] = _sanitize_error_text(result["error"])
+    return json.dumps(result)
 
 
 def _handle_send(args):
@@ -825,6 +908,77 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
             "your final response instead, or use a different target if you want an additional message."
         ),
     }
+
+
+async def _send_feishu_card_via_adapter(
+    pconfig,
+    *,
+    chat_id,
+    card,
+    patch_message_id=None,
+    thread_id=None,
+):
+    """Use the live Feishu adapter or its explicit standalone card API."""
+    from gateway.config import Platform
+
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        try:
+            adapter = runner.adapters.get(Platform.FEISHU)
+        except Exception:
+            adapter = None
+        if adapter is not None:
+            try:
+                if patch_message_id:
+                    fn = getattr(adapter, "patch_card", None)
+                    if not callable(fn):
+                        return {"error": "Feishu adapter does not support card PATCH"}
+                    result = await fn(patch_message_id, card)
+                else:
+                    fn = getattr(adapter, "send_card", None)
+                    if not callable(fn):
+                        return {"error": "Feishu adapter does not support card sending"}
+                    metadata = {"thread_id": thread_id} if thread_id else None
+                    result = await fn(chat_id, card, metadata=metadata)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.error("Feishu live card transport failed", exc_info=True)
+                return {"error": "Feishu live card transport failed"}
+            if result.success:
+                return {
+                    "success": True,
+                    "platform": "feishu",
+                    "chat_id": chat_id,
+                    "message_id": result.message_id or patch_message_id,
+                }
+            return {"error": f"Feishu card transport failed: {result.error}"}
+
+    try:
+        from plugins.platforms.feishu.adapter import (
+            standalone_patch_card,
+            standalone_send_card,
+        )
+        if patch_message_id:
+            return await standalone_patch_card(pconfig, patch_message_id, card)
+        metadata = {"thread_id": thread_id} if thread_id else None
+        return await standalone_send_card(
+            pconfig,
+            chat_id,
+            card,
+            metadata=metadata,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.error("Feishu standalone card transport failed", exc_info=True)
+        return {"error": "Feishu standalone card transport failed"}
 
 
 async def _send_via_adapter(


### PR DESCRIPTION
## 变更说明

- 为飞书 Adapter 增加严格的 JSON 2.0 `send_card()` 与按 `message_id` 的 `patch_card()`，非法输入在 API 调用前失败且不回退文本。
- 为 `hermes send` 增加 `--card-file`、`--patch-message-id` 与离线 capability 查询。
- 将 `card.action.trigger` 规范化为有界 envelope，完整保留 operator/context/value/form/input，并以固定 namespace 分发到插件 handler。
- 未注册、未授权、重复、超时、资源饱和和 handler 异常均 fail closed，不再进入未知 `/card`/LLM 路径。
- handler 支持即时 Toast、严格 raw JSON 2.0 原卡替换及显式 background；同步处理有 2.5 秒硬超时、固定 in-flight 上限和并发原子去重。
- 保留审批卡、update prompt、普通文本/Post/媒体与最新 plugin registration 生命周期。

## 验证

- latest main `b2bd1ac6` rebase 后 Feishu + plugin/CLI 相关 19 个文件：`281 passed, 0 failed`
- card/回调/审批/CLI/tool 聚焦：`78 passed`
- Ruff changed-files：通过
- `git diff --check origin/main...HEAD`：通过
- 授权后的 `hc-arch-test` 真实数据面：JSON 2.0 create、唯一 `card.action.trigger`、完整 form 值、inline card result 与同 message ID PATCH 均成功；测试后恢复原 Gateway/profile
- 额外 `test_send_message_plugin_extensibility.py` 的两个 cron target normalization 失败在干净基线同样存在，与本 PR 差异无关。

## 边界

- 真实飞书仅在授权的 `hc-arch-test` 测试 App/会话验证；未触碰生产 profile，测试插件和 latest Gateway 已清理并恢复原基线。
- Agent 状态卡和定向消息业务由后续项目 PR 实现，本 PR 只提供通用卡片 transport/handler 合同。

关联 PRD：https://github.com/dawei777f/hermes-config/issues/21

Refs dawei777f/hermes-config#21
