### PR TITLE
feat: add opt-in banner reveal animation

### DIFF
--- a/apps/shared/src/skin.ts
+++ b/apps/shared/src/skin.ts
@@ -80,7 +80,8 @@ export const SKIN_BRANDING_TOKENS = [
   'goodbye',
   'response_label',
   'prompt_symbol',
-  'help_header'
+  'help_header',
+  'banner_animation'
 ] as const
 
 export type SkinBrandingToken = (typeof SKIN_BRANDING_TOKENS)[number]

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -91,6 +91,52 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 [#B8860B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]"""
 
 
+def _reveal_banner_markup(markup: str, visible_columns: int):
+    """Build one fixed-size left-to-right reveal frame from Rich markup."""
+    from rich.text import Text
+
+    lines = Text.from_markup(markup).split("\n", allow_blank=True)
+    width = max((line.cell_len for line in lines), default=0)
+    visible = max(0, min(width, int(visible_columns)))
+    frame = Text()
+
+    for index, line in enumerate(lines):
+        revealed = line[:visible]
+        revealed.append(" " * max(0, width - revealed.cell_len))
+        frame.append_text(revealed)
+        if index + 1 < len(lines):
+            frame.append("\n")
+
+    return frame
+
+
+def _animate_banner_logo(console: "Console", markup: str) -> None:
+    """Reveal a banner once, then leave the complete frame on screen."""
+    from rich.live import Live
+    from rich.text import Text
+
+    lines = Text.from_markup(markup).split("\n", allow_blank=True)
+    width = max((line.cell_len for line in lines), default=0)
+
+    with Live(
+        _reveal_banner_markup(markup, 0),
+        console=console,
+        refresh_per_second=30,
+    ) as live:
+        for visible in range(1, width + 1):
+            live.update(_reveal_banner_markup(markup, visible), refresh=True)
+            time.sleep(0.035)
+
+
+def _print_banner_logo(console: "Console", markup: str, *, animation: str = "none") -> None:
+    """Print a logo statically, or animate it when an interactive skin opts in."""
+    if animation == "reveal" and console.is_terminal:
+        _animate_banner_logo(console, markup)
+        return
+
+    console.print(markup)
+
+
 
 # =========================================================================
 # Skills scanning
@@ -1263,6 +1309,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     term_width = shutil.get_terminal_size().columns
     if term_width >= 95:
         _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
-        console.print(_logo)
+        _animation = str((_bskin.branding or {}).get("banner_animation", "none")) if _bskin else "none"
+        _print_banner_logo(console, _logo, animation=_animation.strip().lower())
         console.print()
     console.print(outer_panel)

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,12 +1,43 @@
 """Tests for banner toolset name normalization and skin color usage."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from rich.console import Console
 
 import hermes_cli.banner as banner
 import model_tools
 import tools.mcp_tool
+
+
+def test_reveal_banner_markup_keeps_height_and_width_while_revealing_columns():
+    frame = banner._reveal_banner_markup(
+        "[#ffffff]ABCD[/]\n[#ffffff]XY[/]",
+        visible_columns=2,
+    )
+
+    assert frame.plain == "AB  \nXY  "
+
+
+def test_print_banner_logo_animates_only_when_requested_on_a_terminal():
+    console = Mock()
+    console.is_terminal = True
+
+    with patch.object(banner, "_animate_banner_logo") as animate:
+        banner._print_banner_logo(console, "LOGO", animation="reveal")
+
+    animate.assert_called_once_with(console, "LOGO")
+    console.print.assert_not_called()
+
+
+def test_print_banner_logo_stays_static_for_non_terminal_output():
+    console = Mock()
+    console.is_terminal = False
+
+    with patch.object(banner, "_animate_banner_logo") as animate:
+        banner._print_banner_logo(console, "LOGO", animation="reveal")
+
+    animate.assert_not_called()
+    console.print.assert_called_once_with("LOGO")
 
 
 def test_cprint_falls_back_to_plain_print_when_prompt_toolkit_has_no_console(capsys):

--- a/ui-tui/src/__tests__/bannerAnimation.test.ts
+++ b/ui-tui/src/__tests__/bannerAnimation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { revealArtLines } from '../banner.js'
+
+describe('revealArtLines', () => {
+  const lines: [string, string][] = [
+    ['#ffffff', 'ABCD'],
+    ['#ffffff', 'XY']
+  ]
+
+  it('reveals the art left-to-right without changing its width', () => {
+    expect(revealArtLines(lines, 2)).toEqual([
+      ['#ffffff', 'AB  '],
+      ['#ffffff', 'XY  ']
+    ])
+  })
+
+  it('clamps frames before the start and after the end', () => {
+    expect(revealArtLines(lines, -1)).toEqual([
+      ['#ffffff', '    '],
+      ['#ffffff', '    ']
+    ])
+    expect(revealArtLines(lines, 99)).toEqual([
+      ['#ffffff', 'ABCD'],
+      ['#ffffff', 'XY  ']
+    ])
+  })
+})

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -258,10 +258,18 @@ describe('fromSkin', () => {
 
   it('overrides branding', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
-    const { brand } = fromSkin({}, { agent_name: 'TestBot', prompt_symbol: '$' })
+    const { brand } = fromSkin({}, { agent_name: 'TestBot', banner_animation: 'reveal', prompt_symbol: '$' })
 
     expect(brand.name).toBe('TestBot')
+    expect(brand.bannerAnimation).toBe('reveal')
     expect(brand.prompt).toBe('$')
+  })
+
+  it('disables unknown banner animations', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    expect(fromSkin({}, { banner_animation: 'spin' }).brand.bannerAnimation).toBe('none')
+    expect(fromSkin({}, {}).brand.bannerAnimation).toBe('none')
   })
 
   it('normalizes skin prompt symbols to trimmed single-line text', async () => {

--- a/ui-tui/src/banner.ts
+++ b/ui-tui/src/banner.ts
@@ -90,4 +90,11 @@ export const caduceus = (c: ThemeColors, customHero?: string): Line[] =>
 
 export const artWidth = (lines: Line[]) => lines.reduce((m, [, t]) => Math.max(m, t.length), 0)
 
+export const revealArtLines = (lines: Line[], visibleColumns: number): Line[] => {
+  const width = artWidth(lines)
+  const visible = Math.max(0, Math.min(width, Math.floor(visibleColumns)))
+
+  return lines.map(([color, text]) => [color, text.slice(0, visible).padEnd(width)] as Line)
+}
+
 type Line = [string, string]

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useStdout } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
-import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
+import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH, revealArtLines } from '../banner.js'
 import { mix } from '../lib/color.js'
 import { flat } from '../lib/text.js'
 import type { Theme } from '../theme.js'
@@ -13,6 +13,7 @@ import { ShimmerRows } from './loaders.js'
 import { WidgetGrid } from './widgetGrid.js'
 
 const LOADER_TICK_MS = 120
+const BANNER_REVEAL_TICK_MS = 35
 
 function InlineLoader({ label, t }: { label: string; t: Theme }) {
   const [tick, setTick] = useState(0)
@@ -47,6 +48,36 @@ export function ArtLines({ lines }: { lines: [string, string][] }) {
       ))}
     </Box>
   )
+}
+
+function AnimatedArtLines({ animate, lines }: { animate: boolean; lines: [string, string][] }) {
+  const width = artWidth(lines)
+  const signature = lines.map(([color, text]) => `${color}\u0000${text}`).join('\u0001')
+  const [visibleColumns, setVisibleColumns] = useState(animate ? 0 : width)
+
+  useEffect(() => {
+    setVisibleColumns(animate ? 0 : width)
+
+    if (!animate || width === 0) {
+      return
+    }
+
+    const id = setInterval(() => {
+      setVisibleColumns(current => {
+        if (current >= width) {
+          clearInterval(id)
+
+          return width
+        }
+
+        return current + 1
+      })
+    }, BANNER_REVEAL_TICK_MS)
+
+    return () => clearInterval(id)
+  }, [animate, signature, width])
+
+  return <ArtLines lines={animate ? revealArtLines(lines, visibleColumns) : lines} />
 }
 
 // Responsive Banner: full art → compact rule → text → hidden.
@@ -126,7 +157,10 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
           paddingY={0}
           rowGap={0}
           widgets={[
-            { children: <ArtLines lines={logoLines} />, id: 'banner-art' },
+            {
+              children: <AnimatedArtLines animate={t.brand.bannerAnimation === 'reveal'} lines={logoLines} />,
+              id: 'banner-art'
+            },
             {
               children: (
                 <Text color={t.color.muted} wrap="truncate-end">

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -57,6 +57,7 @@ export interface ThemeBrand {
   goodbye: string
   tool: string
   helpHeader: string
+  bannerAnimation: 'none' | 'reveal'
 }
 
 export interface Theme {
@@ -256,7 +257,8 @@ const BRAND: ThemeBrand = {
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
   tool: '┊',
-  helpHeader: '(^_^)? Commands'
+  helpHeader: '(^_^)? Commands',
+  bannerAnimation: 'none'
 }
 
 const cleanPromptSymbol = (s: string | undefined, fallback: string) => {
@@ -957,7 +959,8 @@ export function fromSkin(
         welcome: branding.welcome ?? d.brand.welcome,
         goodbye: branding.goodbye ?? d.brand.goodbye,
         tool: toolPrefix || d.brand.tool,
-        helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader)
+        helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader),
+        bannerAnimation: branding.banner_animation === 'reveal' ? 'reveal' : 'none'
       },
 
       bannerLogo,


### PR DESCRIPTION
## Summary
- add `branding.banner_animation: reveal` as an opt-in skin setting
- render a fixed-size left-to-right reveal in both classic CLI and Ink TUI
- preserve static rendering for non-terminal output and skins without the setting

## Verification
- `tests/hermes_cli/test_banner.py`: 6 passed
- focused TUI theme/animation suite: 52 passed
- TUI typecheck: passed
- TUI build: passed
- live Hugin cloud-host fresh-chat proof: canonical Hugin rune plus `runi.services`, prompt ready, no raw Rich markup

## Delivery state
The generic implementation is proposed here. A profile-owned skin opted into it independently; that host configuration is not part of this PR.