### PR TITLE
fix(macos): keep Hermes CLI bootable after TCC anchoring

### DIFF
--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -15,8 +15,9 @@ The anchor: replace the venv's ``bin/python`` symlink with a *real-file copy*
 of the interpreter binary.  The venv path (``<checkout>/venv/bin/python``) is
 stable across ``hermes update``, and because it is a regular file there is no
 symlink for TCC to resolve — so the TCC client path stays constant across
-interpreter patch bumps.  ``pyvenv.cfg`` keeps pointing at the uv store (``home``),
-which still provides the stdlib exactly as it does today.
+interpreter patch bumps.  ``pyvenv.cfg`` keeps pointing at the uv store
+(``home``) for the stdlib, while a dynamic build's adjacent ``libpython`` is
+copied into the venv so the relocated executable's rpath remains valid.
 
 The anchor self-heals: when ``hermes update`` / ``hermes doctor`` runs and the
 venv python is a symlink again (uv re-created it) or the recorded source no
@@ -37,6 +38,7 @@ import logging
 import os
 import platform
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -174,6 +176,38 @@ def _anchor_marker(venv_bin: Path) -> Path:
     return venv_bin / _MARKER_NAME
 
 
+def _runtime_libraries(source_file: Path) -> tuple[Path, ...]:
+    """Return dynamic libpython files required by a uv interpreter, if any."""
+    store_lib = source_file.parent.parent / "lib"
+    try:
+        return tuple(
+            sorted(
+                path for path in store_lib.glob("libpython*.dylib") if path.is_file()
+            )
+        )
+    except OSError:
+        return ()
+
+
+def _has_runtime_libraries(venv_dir: Path, source_file: Path) -> bool:
+    """Return whether every uv libpython dependency is present in the venv."""
+    return all(
+        (venv_dir / "lib" / library.name).is_file()
+        for library in _runtime_libraries(source_file)
+    )
+
+
+def _validate_staged_anchor(staged_python: Path) -> None:
+    """Prove the relocated interpreter can start before replacing the venv copy."""
+    subprocess.run(
+        [str(staged_python), "-V"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=15,
+    )
+
+
 def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
     """Re-point uv alias symlinks at the stable anchor.
 
@@ -212,28 +246,38 @@ def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
 def _install_anchor(venv_dir: Path, source_file: Path) -> None:
     """Replace ``bin/python`` with a real-file copy of *source_file*.
 
-    Atomic (temp file + rename) so a crash mid-copy cannot leave the venv
-    interpreter half-written.  Writes the source marker and re-points alias
-    symlinks so the whole venv bin dir resolves to stable paths.
+    The interpreter and any adjacent uv ``libpython`` runtime are staged in a
+    complete relocatable layout and executed before the working venv interpreter
+    is replaced.  Final files are atomically renamed so a partial copy cannot
+    brick the CLI.  Writes the source marker and re-points alias symlinks.
     """
     venv_py = venv_python_path(venv_dir)
     venv_bin = venv_py.parent
     venv_bin.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=".python-tcc-", dir=str(venv_bin))
-    os.close(fd)
-    tmp_path = Path(tmp_name)
-    try:
-        shutil.copy2(source_file, tmp_path)
-        os.chmod(tmp_path, source_file.stat().st_mode | 0o111)
-        os.replace(tmp_path, venv_py)
+    with tempfile.TemporaryDirectory(prefix=".tcc-anchor-", dir=str(venv_dir)) as tmp:
+        stage = Path(tmp)
+        staged_python = stage / "bin" / "python"
+        staged_python.parent.mkdir()
+        shutil.copy2(source_file, staged_python)
+        os.chmod(staged_python, source_file.stat().st_mode | 0o111)
+
+        staged_lib = stage / "lib"
+        runtime_libraries = _runtime_libraries(source_file)
+        if runtime_libraries:
+            staged_lib.mkdir()
+            for library in runtime_libraries:
+                shutil.copy2(library, staged_lib / library.name)
+
+        _validate_staged_anchor(staged_python)
+
+        if runtime_libraries:
+            venv_lib = venv_dir / "lib"
+            venv_lib.mkdir(parents=True, exist_ok=True)
+            for library in runtime_libraries:
+                os.replace(staged_lib / library.name, venv_lib / library.name)
+        os.replace(staged_python, venv_py)
         _anchor_marker(venv_bin).write_text(str(source_file), encoding="utf-8")
         _repoint_aliases(venv_bin, venv_py)
-    except Exception:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise
 
 
 def ensure_tcc_anchor(project_root: Path | None = None) -> Path | None:
@@ -263,8 +307,10 @@ def ensure_tcc_anchor(project_root: Path | None = None) -> Path | None:
         # Already anchored — refresh only when the interpreter changed.
         marker = _anchor_marker(venv_py.parent)
         try:
-            if marker.is_file() and marker.read_text(encoding="utf-8").strip() == str(
-                source_file
+            if (
+                marker.is_file()
+                and marker.read_text(encoding="utf-8").strip() == str(source_file)
+                and _has_runtime_libraries(venv_dir, source_file)
             ):
                 return venv_py
         except OSError:
@@ -301,8 +347,12 @@ def tcc_anchor_state(project_root: Path | None = None) -> tuple[str, str]:
     if not venv_py.is_symlink():
         marker = _anchor_marker(venv_py.parent)
         try:
-            if marker.is_file() and marker.read_text(encoding="utf-8").strip() == str(
-                source
+            source_file = _interpreter_file(source)
+            if (
+                marker.is_file()
+                and marker.read_text(encoding="utf-8").strip() == str(source)
+                and source_file is not None
+                and _has_runtime_libraries(venv_dir, source_file)
             ):
                 return "active", str(venv_py)
         except OSError:

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -8,7 +8,10 @@ macOS.
 """
 
 import os
+import sys
 from pathlib import Path
+
+import pytest
 
 import hermes_cli.doctor as doctor
 import hermes_cli.macos_tcc_anchor as tcc
@@ -145,6 +148,38 @@ class TestStagingHelpers:
                 },
             )
         ]
+
+
+@pytest.mark.macos_only
+def test_real_uv_interpreter_survives_relocation(tmp_path):
+    """Exercise dyld with the macOS CI runner's actual uv interpreter."""
+    source = Path(sys.executable).resolve()
+    if not tcc._is_uv_macos_store(source):
+        pytest.skip("test interpreter is not a uv-managed macOS build")
+    runtime_libraries = tcc._runtime_libraries(source)
+    if not runtime_libraries:
+        pytest.skip("test interpreter does not use an adjacent dynamic libpython")
+
+    venv = tmp_path / "venv"
+    venv_bin = venv / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(f"home = {source.parent}\n", encoding="utf-8")
+    os.symlink(source, venv_bin / "python")
+
+    tcc._install_anchor(venv, source)
+
+    anchored = venv_bin / "python"
+    completed = tcc.subprocess.run(
+        [str(anchored), "-V"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert completed.stdout.startswith("Python ") or completed.stderr.startswith(
+        "Python "
+    )
+    assert all((venv / "lib" / library.name).is_file() for library in runtime_libraries)
 
 
 class TestEnsureTccAnchor:

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -10,8 +10,6 @@ macOS.
 import os
 from pathlib import Path
 
-import pytest
-
 import hermes_cli.doctor as doctor
 import hermes_cli.macos_tcc_anchor as tcc
 from hermes_constants import venv_python_path
@@ -21,13 +19,16 @@ _STORE_ROOT = "cpython-3.11.15-macos-aarch64-none"
 
 def _darwin(monkeypatch):
     monkeypatch.setattr(tcc.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(tcc, "_validate_staged_anchor", lambda _path: None)
 
 
 def _linux(monkeypatch):
     monkeypatch.setattr(tcc.platform, "system", lambda: "Linux")
 
 
-def _build_store(tmp_path, version: str = "3.11.15") -> Path:
+def _build_store(
+    tmp_path, version: str = "3.11.15", *, with_libpython: bool = False
+) -> Path:
     store = (
         tmp_path
         / "uv-store"
@@ -40,6 +41,12 @@ def _build_store(tmp_path, version: str = "3.11.15") -> Path:
     store_py = store_bin / "python3.11"
     store_py.write_bytes(f"#!fake interpreter {version}".encode())
     store_py.chmod(0o755)
+    if with_libpython:
+        store_lib = store / "lib"
+        store_lib.mkdir()
+        (store_lib / "libpython3.11.dylib").write_bytes(
+            f"fake libpython {version}".encode()
+        )
     return store_bin
 
 
@@ -107,6 +114,39 @@ class TestUvStoreDetection:
         assert not tcc._is_uv_macos_store(path)
 
 
+class TestStagingHelpers:
+    def test_finds_uv_libpython_runtime(self, tmp_path):
+        store_bin = _build_store(tmp_path, with_libpython=True)
+
+        assert tcc._runtime_libraries(store_bin / "python3.11") == (
+            store_bin.parent / "lib" / "libpython3.11.dylib",
+        )
+
+    def test_validation_executes_staged_interpreter(self, tmp_path, monkeypatch):
+        staged = tmp_path / "bin" / "python"
+        calls = []
+
+        monkeypatch.setattr(
+            tcc.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        tcc._validate_staged_anchor(staged)
+
+        assert calls == [
+            (
+                ([str(staged), "-V"],),
+                {
+                    "check": True,
+                    "stdout": tcc.subprocess.PIPE,
+                    "stderr": tcc.subprocess.PIPE,
+                    "timeout": 15,
+                },
+            )
+        ]
+
+
 class TestEnsureTccAnchor:
     def test_noop_on_non_macos(self, tmp_path, monkeypatch):
         _linux(monkeypatch)
@@ -140,6 +180,40 @@ class TestEnsureTccAnchor:
         alias = venv_py.parent / "python3"
         assert not tcc._is_uv_macos_store(str(alias.resolve(strict=False)))
 
+    def test_materializes_store_libpython_next_to_anchor(self, tmp_path, monkeypatch):
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path, with_libpython=True)
+        root = _build_checkout(tmp_path, store_bin=store_bin)
+
+        anchored = tcc.ensure_tcc_anchor(root)
+
+        assert anchored == venv_python_path(root / ".venv")
+        installed = root / ".venv" / "lib" / "libpython3.11.dylib"
+        assert (
+            installed.read_bytes()
+            == (store_bin.parent / "lib" / "libpython3.11.dylib").read_bytes()
+        )
+
+    def test_validation_failure_leaves_working_interpreter_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path, with_libpython=True)
+        root = _build_checkout(tmp_path, store_bin=store_bin)
+        venv_py = venv_python_path(root / ".venv")
+        original_target = os.readlink(venv_py)
+
+        def reject(_path):
+            raise RuntimeError("dyld could not load libpython")
+
+        monkeypatch.setattr(tcc, "_validate_staged_anchor", reject)
+
+        assert tcc.ensure_tcc_anchor(root) is None
+        assert venv_py.is_symlink()
+        assert os.readlink(venv_py) == original_target
+        assert not (venv_py.parent / ".tcc-anchor-source").exists()
+        assert not (root / ".venv" / "lib" / "libpython3.11.dylib").exists()
+
     def test_idempotent(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)
         store_bin = _build_store(tmp_path)
@@ -153,6 +227,18 @@ class TestEnsureTccAnchor:
         assert anchored == venv_py
         assert venv_py.is_file() and not venv_py.is_symlink()
         assert marker.read_text(encoding="utf-8") == before
+
+    def test_repairs_legacy_anchor_missing_libpython(self, tmp_path, monkeypatch):
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path, with_libpython=True)
+        root = _build_checkout(tmp_path, store_bin=store_bin, anchored=True)
+
+        assert tcc.tcc_anchor_state(root)[0] == "stale"
+        anchored = tcc.ensure_tcc_anchor(root)
+
+        assert anchored == venv_python_path(root / ".venv")
+        assert (root / ".venv" / "lib" / "libpython3.11.dylib").is_file()
+        assert tcc.tcc_anchor_state(root)[0] == "active"
 
     def test_reanchors_after_patch_bump(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Keeps every Hermes CLI command bootable after macOS TCC anchoring relocates a uv-managed dynamic CPython executable. The anchor now carries its required libpython runtime into the venv and proves the staged interpreter starts before replacing the working interpreter.

### Symptom

After a command installs the TCC anchor, subsequent `hermes` invocations can terminate in dyld before Python starts because `@rpath/libpython3.11.dylib` is absent from the venv.

### Impact

Affected macOS uv installations lose every Hermes CLI entry point, including `hermes update` and `hermes doctor`, until libpython is restored manually.

### Bug Cause

**Trigger:** `hermes_cli/macos_tcc_anchor.py` / `_install_anchor()` when anchoring a dynamic uv-managed CPython build.

**Causal chain:**
1. The uv interpreter resolves `@rpath/libpythonX.Y.dylib` through `@executable_path/../lib`.
2. `_install_anchor()` copies only the executable from the uv store into `venv/bin`.
3. The rpath now resolves inside `venv/lib`, where libpython is absent, and dyld aborts every CLI startup.

**Why it is wrong:** The best-effort anchor atomically commits a copied file without first proving that the relocated runtime is complete and executable.

**Working sibling / contrast:** Static uv Python builds have no adjacent `libpython*.dylib`; they continue through the same staging and validation path without an unnecessary library copy.

**Ruled out:** `pyvenv.cfg home` is not sufficient for dyld. It supplies Python's stdlib location after process startup, but dyld must load libpython before Python can read that configuration.

### Fix

Stage the copied interpreter with every adjacent uv `libpython*.dylib`, execute the staged interpreter with `-V`, and only then atomically install the libraries and anchor. Existing anchors missing their runtime are reported stale and self-repaired; validation failures leave the original venv interpreter untouched.

## Related Issue

N/A

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/macos_tcc_anchor.py` - stage, validate, install, and repair the relocated interpreter runtime.
- `tests/hermes_cli/test_macos_tcc_anchor.py` - cover runtime discovery, validation, failed-install safety, materialization, and legacy-anchor repair.

## How to Test

1. On macOS arm64, create a uv-managed venv whose interpreter links `@rpath/libpythonX.Y.dylib`.
2. Run the TCC anchor path, then execute `venv/bin/python -V` and `hermes --version`.
3. Automated subset run on Windows 11: `scripts/run_tests.sh tests/hermes_cli/test_macos_tcc_anchor.py -k 'TestStagingHelpers or TestUvStoreDetection or TestDoctorCheck' -q` - 11 passed. The macOS integration path is required before final approval.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested the platform-independent subset on Windows 11; macOS integration verification is pending review

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config documentation is N/A because no config keys changed
- [x] Architecture documentation is N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; behavior remains gated to macOS
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

N/A
