### PR TITLE
fix(search_files): include host arch and host-typical sibling in 'Path not found' error

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -21,8 +21,10 @@ when exit==2 AND no usable match payload remains.
 These tests drive the real methods through the real local terminal backend.
 """
 
+import json
 import os
 import shutil
+from unittest import mock
 
 import pytest
 
@@ -32,6 +34,7 @@ from tools.file_operations import (
     _split_tool_diagnostics,
 )
 from tools.environments.local import LocalEnvironment
+from tools.file_tools import search_tool
 
 
 def _ops(root):
@@ -130,3 +133,84 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+class TestHostArchConflation:
+    """Pins the host-arch hint added for the Apple-Silicon "Path not found"
+    conflation on /usr/local/bin (see FIX-DESIGN.md).
+
+    Three tests:
+
+    1. The verbatim-host case pins the user-visible contract: the error
+       string the model sees must include ``host=<system> <machine>``.
+    2. The sibling-hint case exercises the new helper with a mock so the
+       test is hermetic — it does not depend on whether the host has
+       Homebrew installed.
+    3. The typo case pins the negative side of the helper: the mapping only
+       fires for the architecture mismatch, not for arbitrary typos.
+       Without this pin a future widening of ``_HOST_TYPICAL_BIN_PARENTS``
+       could quietly expand the hint surface.
+    """
+
+    def test_error_includes_host_arch(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        # /usr/local/bin does not exist on this Apple-Silicon host, so the
+        # call against the verbatim path triggers the not-found branch.
+        r = json.loads(search_tool(
+            "bash", path="/usr/local/bin", target="files",
+            task_id="t-arch-conflation",
+        ))
+        assert r["total_count"] == 0
+        err = r.get("error", "")
+        # The original "Path not found:" prefix is preserved so existing
+        # pattern-matchers keep working.
+        assert "Path not found: /usr/local/bin" in err
+        # NEW: the fix surfaces the host arch so a model can recognize an
+        # arch mismatch instead of treating it as a guard misfire.
+        assert "host=" in err
+        assert any(token in err for token in ("Darwin", "Linux"))
+
+    def test_host_typical_sibling_hint_when_parent_exists(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        # Simulate Apple Silicon: /usr/local exists, /usr/local/bin does
+        # not, /opt/homebrew/bin does. We can't create real /usr/local in
+        # tests, so patch the helper to point at a tmp_path mirror.
+        homebrew = tmp_path / "homebrew_bin"
+        homebrew.mkdir()
+        (homebrew / "bash").write_text("#!/bin/sh\n")
+        usr_local = tmp_path / "usr_local"
+        usr_local.mkdir()  # parent exists, leaf (usr_local/bin) does not.
+
+        # Patch the sibling resolver so the test doesn't depend on the
+        # developer's actual host having Homebrew at /opt/homebrew/bin.
+        with mock.patch.object(
+            ShellFileOperations, "_host_typical_sibling",
+            return_value=str(homebrew),
+        ):
+            r = json.loads(search_tool(
+                "bash", path=str(usr_local / "bin"), target="files",
+                task_id="t-sibling-hint",
+            ))
+
+        err = r.get("error", "")
+        assert "Path not found" in err
+        assert "Host-typical sibling exists:" in err
+        assert str(homebrew) in err
+
+    def test_sibling_hint_absent_on_typo(self, tmp_path, monkeypatch):
+        """A typo'd leaf must NOT trigger the host-typical sibling hint;
+        the sibling mapping only fires for known-architecture mismatches.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)),
+                                  cwd=str(tmp_path))
+        # /usr/lcoal/bin is a typo — no mapping should fire.
+        assert ops._host_typical_sibling("/usr/lcoal/bin") is None
+        # The host-typical mapping either matches (Apple Silicon, with
+        # /opt/homebrew/bin installed) or doesn't (any other host, or no
+        # Homebrew). Both outcomes are correct, but the result must be a
+        # string in the mapping or None — never an unrelated sibling.
+        result = ops._host_typical_sibling("/usr/local/bin")
+        assert result in (None, "/opt/homebrew/bin")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import base64
 import binascii
 import os
+import platform
 import re
 import difflib
 import hashlib
@@ -2799,7 +2800,10 @@ class ShellFileOperations(FileOperations):
             # Try to suggest nearby paths
             parent = os.path.dirname(path) or "."
             basename_query = os.path.basename(path)
-            hint_parts = [f"Path not found: {path}"]
+            hint_parts = [
+                f"Path not found: {path} "
+                f"(host={platform.system()} {platform.machine()})"
+            ]
             # Check if parent directory exists and list similar entries
             parent_check = self._exec(
                 f"test -d {self._escape_shell_arg(parent)} && echo yes || echo no"
@@ -2821,6 +2825,16 @@ class ShellFileOperations(FileOperations):
                         hint_parts.append(
                             "Similar paths: " + ", ".join(candidates[:5])
                         )
+            # Host-typical sibling: only when the leaf is absent because of
+            # arch, not when the path is a typo. Same shell-probe idiom used
+            # elsewhere in this method to keep failure modes uniform.
+            sibling = self._host_typical_sibling(path)
+            if sibling:
+                hint_parts.append(
+                    f"Host-typical sibling exists: {sibling} "
+                    f"(the requested path may be absent because the host is "
+                    f"{platform.system()} {platform.machine()})"
+                )
             return SearchResult(
                 error=". ".join(hint_parts),
                 total_count=0
@@ -2829,9 +2843,36 @@ class ShellFileOperations(FileOperations):
         if target == "files":
             return self._search_files(pattern, path, limit, offset)
         else:
-            return self._search_content(pattern, path, file_glob, limit, offset, 
+            return self._search_content(pattern, path, file_glob, limit, offset,
                                         output_mode, context)
-    
+
+    # Mapping of arch-typical dirs: (parent of the missing leaf) -> sibling to
+    # suggest when the requested path is absent because of host architecture,
+    # not because of a typo. Today the only encoded case is Apple Silicon,
+    # where /usr/local/bin does not exist but /opt/homebrew/bin does.
+    _HOST_TYPICAL_BIN_PARENTS: ClassVar = (
+        ("/usr/local", "/opt/homebrew/bin"),
+    )
+
+    def _host_typical_sibling(self, path: str) -> Optional[str]:
+        """If ``path`` is missing but a host-typical sibling exists, return it.
+
+        Today the only mapping we encode is the Apple-Silicon case where
+        ``/usr/local/bin`` is absent and ``/opt/homebrew/bin`` is the
+        Homebrew install root. Returns None when no mapping applies.
+        """
+        for parent, sibling in self._HOST_TYPICAL_BIN_PARENTS:
+            # Normalize trailing slashes so "/usr/local/bin/" still matches.
+            p = path.rstrip("/")
+            if p == os.path.join(parent, os.path.basename(p)):
+                chk = self._exec(
+                    f"test -e {self._escape_shell_arg(sibling)} && echo exists "
+                    f"|| echo not_found"
+                )
+                if "exists" in chk.stdout:
+                    return sibling
+        return None
+
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,
                                output_mode: str, context: int) -> Optional[SearchResult]:


### PR DESCRIPTION
## What I was trying to do

`search_files` tool call failed when searching under `/usr/local/bin` on an Apple Silicon Mac.

## Verbatim error (before this fix)

```json
{
  "total_count": 0,
  "error": "Path not found: /usr/local/bin"
}
```

## Verbatim error (after this fix)

```json
{
  "total_count": 0,
  "error": "Path not found: /usr/local/bin (host=Darwin arm64). Host-typical sibling exists: /opt/homebrew/bin (the requested path may be absent because the host is Darwin arm64)"
}
```

Control run against the existing `/opt/homebrew/bin` is unchanged.

## Workaround used (if any)

None at the time of capture. The model had to recognize the verbatim error meant "this host doesn't have /usr/local/bin" and re-issue the call with `/opt/homebrew/bin` by hand.

## Why this is preventable

The guard at `tools/file_operations.py` `FileOperations.search` (L2788) ran an unconditional `test -e {path}` probe before searching and, on miss, returned a verbatim `Path not found: {path}` error. That string conflates two distinct conditions — "this host genuinely doesn't have that path" (environmental) and "the tool cannot operate here" (guard misfire). On Apple Silicon the path `/usr/local/bin` does not exist (`uname -m=arm64`; system toolchain lives at `/usr/bin`, Homebrew at `/opt/homebrew/bin`), so the probe faithfully reported absence, but the model had no signal in the error text that the failure was host-architecture rather than a permission/sandbox/rejection. The same probe is also load-bearing for the negative-result cache in `tools/file_tools.py:2595-2632`, so any fix had to leave the probe intact and improve the error wording.

## Suggested fix

Append a `host=<system> <machine>` clause to the literal `Path not found:` prefix (preserves existing pattern matchers) and, when the missing leaf matches a known arch-typical sibling mapping, add a `Host-typical sibling exists: ...` hint. Encoded as a small `ClassVar` tuple `_HOST_TYPICAL_BIN_PARENTS` on `ShellFileOperations` so future architecture mappings are a one-line addition. Helper `_host_typical_sibling(path)` does the shell-probe with the same idiom already used elsewhere in the method. Probe and negative cache stay untouched.

## Changes

| File | Lines | What |
|---|---|---|
| `tools/file_operations.py` | +44 / −3 | Import `platform`; add `host=...` to the `Path not found:` error; add `Host-typical sibling exists: ...` hint; add `_HOST_TYPICAL_BIN_PARENTS` ClassVar and `_host_typical_sibling(path)` helper. |
| `tests/tools/test_search_error_guard.py` | +84 / −0 | New class `TestHostArchConflation` with three tests: verbatim-host arch in error, sibling-hint via mock (hermetic), negative pin against typo widening. |

## Tests

`pytest tests/tools/test_search_error_guard.py -v` — 13/13 PASSED (10 prior + 3 new).

```
tests/tools/test_search_error_guard.py::TestHostArchConflation::test_error_includes_host_arch PASSED
tests/tools/test_search_error_guard.py::TestHostArchConflation::test_host_typical_sibling_hint_when_parent_exists PASSED
tests/tools/test_search_error_guard.py::TestHostArchConflation::test_sibling_hint_absent_on_typo PASSED
```

## Reproduction recipe (before → after)

```python
import json
from tools.file_tools import search_tool
r = json.loads(search_tool(
    "bash", path="/usr/local/bin", target="files",
    task_id="repro-t_7109b2b9",
))
print(r["error"])
```

Before: `Path not found: /usr/local/bin`
After:  `Path not found: /usr/local/bin (host=Darwin arm64). Host-typical sibling exists: /opt/homebrew/bin (the requested path may be absent because the host is Darwin arm64)`

Closes [frx] search_files tool call failed (kanban t_0c6da9e4 / t_7109b2b9).
Design in `t_64d6f064/FIX-DESIGN.md`.