### PR TITLE
fix(slack): key native stream slots per turn so concurrent turns don't collide

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1274,11 +1274,16 @@ class SlackAdapter(BasePlatformAdapter):
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         # Native streaming (chat.startStream/appendStream/stopStream) state.
-        # One active stream per chat, keyed by chat_id. Each value:
+        # Active native streams, keyed by ``(chat_id, draft_id)``. Each value:
         # {"ts": str, "draft_id": int, "sent": str, "started": float}
         # ``sent`` is the raw (pre-mrkdwn) text streamed so far — deltas are
         # computed against it because the streaming API is append-only.
-        self._active_streams: Dict[str, Dict[str, Any]] = {}
+        #
+        # Keyed per TURN, not per chat: two turns in the same channel each own
+        # their own stream.  With a single per-chat slot they alternated in it,
+        # and every hand-off sealed the other turn's stream and opened a fresh
+        # one, so a single answer arrived as several separate Slack messages.
+        self._active_streams: Dict[Tuple[str, int], Dict[str, Any]] = {}
         # Set after the first startStream failure that indicates the Slack
         # app lacks the streaming feature (Agents & AI Apps not enabled /
         # missing scope). Future runs then skip straight to edit-based
@@ -2543,7 +2548,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Seal any dangling native streams so chats aren't left with a
         # live-typing indicator across a restart.
-        for chat_id, stream in list(self._active_streams.items()):
+        for (chat_id, _draft_id), stream in list(self._active_streams.items()):
             await self._seal_stream(chat_id, stream)
         self._active_streams.clear()
 
@@ -3399,16 +3404,18 @@ class SlackAdapter(BasePlatformAdapter):
 
         text = self._strip_stream_cursor(content)
         client = self._get_client(chat_id)
-        stream = self._active_streams.get(chat_id)
+        key = (chat_id, draft_id)
+        stream = self._active_streams.get(key)
 
         try:
-            if stream is not None and stream.get("draft_id") != draft_id:
-                # New segment started while a prior stream is open — seal the
-                # old one so it doesn't hang with a live-typing indicator.
-                await self._seal_stream(chat_id, stream)
-                stream = None
-
             if stream is None:
+                # A draft_id bump within the same turn (Telegram-shaped
+                # drafts, which open a new stream per tool boundary) leaves
+                # this turn's previous stream open.  Seal it so it does not
+                # hang with a live-typing indicator.  Streams belonging to
+                # OTHER turns in this channel are left alone — they have
+                # their own key and finalize themselves.
+                await self._seal_superseded_segment(chat_id, draft_id, metadata)
                 thread_ts = self._resolve_thread_ts(None, metadata)
                 if not thread_ts:
                     # Streamed messages must anchor to a thread_ts. The
@@ -3436,9 +3443,10 @@ class SlackAdapter(BasePlatformAdapter):
                 ts = response.get("ts") if response else None
                 if not ts:
                     raise RuntimeError("chat.startStream returned no ts")
-                self._active_streams[chat_id] = {
+                self._active_streams[key] = {
                     "ts": str(ts),
                     "draft_id": draft_id,
+                    "thread_ts": thread_ts,
                     "sent": text,
                     "started": time.time(),
                 }
@@ -3454,7 +3462,7 @@ class SlackAdapter(BasePlatformAdapter):
                 # segment). Fail the frame so the consumer falls back to the
                 # edit path; seal the stream first so it doesn't dangle.
                 await self._seal_stream(chat_id, stream)
-                self._active_streams.pop(chat_id, None)
+                self._active_streams.pop(key, None)
                 return SendResult(
                     success=False, error="stream prefix mismatch"
                 )
@@ -3468,7 +3476,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=stream["ts"])
 
         except Exception as e:  # pragma: no cover - network/API errors
-            self._active_streams.pop(chat_id, None)
+            self._active_streams.pop(key, None)
             err = str(e)
             # Feature-gate errors: cache unsupported so future runs skip the
             # native attempt entirely instead of erroring once per response.
@@ -3529,6 +3537,66 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return False
 
+    async def _seal_superseded_segment(
+        self,
+        chat_id: str,
+        draft_id: int,
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        """Seal a previous segment of the SAME turn before opening a new one.
+
+        Some transports bump ``draft_id`` at each tool boundary, so one turn
+        can open several streams in sequence; the superseded one must be
+        sealed or it hangs with a live-typing indicator.
+
+        Streams from *other* turns in the same channel must survive: they are
+        keyed separately and finalize themselves.  Same-turn segments are
+        recognized by their thread anchor, which is stable for a turn — the
+        gateway stamps ``reply_to_message_id`` / ``thread_id`` on every frame.
+        Without an anchor to compare, nothing is sealed: leaving a stream open
+        costs a stale indicator, while sealing a live sibling turn splits its
+        answer into two messages, which is the bug this keying fixes.
+        """
+        anchor = self._resolve_thread_ts(None, metadata)
+        if not anchor:
+            return
+        for other_key, other in list(self._active_streams.items()):
+            if other_key[0] != chat_id or other_key[1] == draft_id:
+                continue
+            if other.get("thread_ts") != anchor:
+                continue
+            await self._seal_stream(chat_id, other)
+            self._active_streams.pop(other_key, None)
+
+    def _find_stream_for_final(
+        self,
+        chat_id: str,
+        text: str,
+    ) -> Optional[Tuple[Tuple[str, int], Dict[str, Any]]]:
+        """Locate the open stream this final text belongs to.
+
+        ``send()`` carries no ``draft_id``, so the owning turn is identified by
+        content: the final text extends what that stream already streamed.
+        When several turns are open in the same channel, the longest matching
+        ``sent`` prefix wins — a short prefix could match a sibling turn whose
+        answer happens to start the same way.
+
+        Returns ``(key, stream)`` or ``None`` when no open stream claims it.
+        """
+        best: Optional[Tuple[Tuple[str, int], Dict[str, Any]]] = None
+        best_len = 0
+        for key, stream in self._active_streams.items():
+            if key[0] != chat_id:
+                continue
+            sent = stream.get("sent", "")
+            # An empty ``sent`` prefix would match everything, so require
+            # substance before letting a stream claim the send.
+            if not sent or not text.startswith(sent):
+                continue
+            if len(sent) > best_len:
+                best, best_len = (key, stream), len(sent)
+        return best
+
     async def _try_finalize_stream(
         self,
         chat_id: str,
@@ -3537,23 +3605,17 @@ class SlackAdapter(BasePlatformAdapter):
         """Finalize an active native stream with the turn-final content.
 
         Called from ``send()``.  Returns a SendResult when the final content
-        belongs to the active stream (the stream is sealed and the streamed
+        belongs to an active stream (the stream is sealed and the streamed
         message IS the final message — no new post needed).  Returns None
         when the content is unrelated (e.g. interim commentary), leaving the
         stream open and letting ``send()`` proceed normally.
         """
-        stream = self._active_streams.get(chat_id)
-        if stream is None:
-            return None
-        sent = stream.get("sent", "")
         text = self._strip_stream_cursor(content)
-        # Only treat this send as the stream's finalization when it extends
-        # (or equals) what was streamed. Unrelated sends (e.g. interim
-        # commentary) pass through. An empty ``sent`` prefix would match
-        # everything, so require substance before claiming the send.
-        if not sent or not text.startswith(sent):
+        found = self._find_stream_for_final(chat_id, text)
+        if found is None:
             return None
-        self._active_streams.pop(chat_id, None)
+        key, stream = found
+        self._active_streams.pop(key, None)
         ts = stream["ts"]
         ok = await self._seal_stream(chat_id, stream, final_text=text)
         if not ok:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3360,6 +3360,22 @@ class SlackAdapter(BasePlatformAdapter):
     # append deltas because the streaming API is append-only.
     _STREAM_CURSOR_GLYPHS = ("\u2589", "▍", "▌", "…")
 
+    # Per-turn keying removed the old single-slot self-limiting: a per-chat
+    # slot was evicted by the next turn, so an interrupted turn's stream could
+    # not outlive one response. Now every turn owns its own key and an
+    # abandoned entry (agent interrupted, process killed mid-turn, a final
+    # `send()` whose text fails the prefix match) would survive until
+    # `disconnect()`, holding a live-typing indicator open. Streams older than
+    # this are sealed and evicted on the next `send_draft`, which bounds the
+    # map without touching the concurrency fix. Well above any real turn
+    # duration so a slow-but-live turn is never reaped.
+    _STREAM_ABANDON_SECONDS = 1800.0
+
+    # A superseded same-turn segment always carries a LOWER draft_id than the
+    # segment replacing it (the stream consumer's counter is monotonic), so a
+    # higher-id stream belongs to a turn that started after us and is never
+    # ours. See `_seal_superseded_segment` for the residual same-thread case.
+
     def supports_draft_streaming(
         self,
         chat_type: Optional[str] = None,
@@ -3405,6 +3421,12 @@ class SlackAdapter(BasePlatformAdapter):
         text = self._strip_stream_cursor(content)
         client = self._get_client(chat_id)
         key = (chat_id, draft_id)
+
+        # Bound the (now per-turn) map: collect streams whose turn never
+        # reached a finalize, so an interrupted turn cannot hold a live-typing
+        # indicator open for the life of the process.  Runs before this turn's
+        # slot is read so a reaped entry is never appended to afterwards.
+        await self._reap_abandoned_streams()
         stream = self._active_streams.get(key)
 
         try:
@@ -3556,17 +3578,60 @@ class SlackAdapter(BasePlatformAdapter):
         Without an anchor to compare, nothing is sealed: leaving a stream open
         costs a stale indicator, while sealing a live sibling turn splits its
         answer into two messages, which is the bug this keying fixes.
+
+        The anchor alone separates turns in *different* threads.  Two turns in
+        the SAME thread (an interactive reply and a scheduled/background turn
+        under one parent) share it, so ``draft_id`` ordering narrows the
+        residual case: the stream consumer's counter is monotonic, so a
+        superseded segment of THIS turn always carries a *lower* id.  A stream
+        with a higher id belongs to a turn that started after us and is never
+        ours — previously any different id was sealed.
+
+        That is a narrowing, not an identity: a same-thread sibling that
+        started *before* us and is still live can still be sealed here, because
+        ``draft_id`` is the only turn identity this layer receives.  Closing
+        the gap needs the gateway to stamp a stable per-turn id on draft
+        metadata — the same missing contract noted in
+        ``_find_stream_for_final``.  Until then this errs towards sealing only
+        what is provably older, and ``_reap_abandoned_streams`` collects the
+        indicators left behind by the seals we skip.
         """
         anchor = self._resolve_thread_ts(None, metadata)
         if not anchor:
             return
         for other_key, other in list(self._active_streams.items()):
-            if other_key[0] != chat_id or other_key[1] == draft_id:
+            if other_key[0] != chat_id or other_key[1] >= draft_id:
                 continue
             if other.get("thread_ts") != anchor:
                 continue
             await self._seal_stream(chat_id, other)
             self._active_streams.pop(other_key, None)
+
+    async def _reap_abandoned_streams(self) -> None:
+        """Seal and evict streams whose turn never reached a finalize.
+
+        Per-turn keying means an entry is no longer displaced by the next
+        turn in the chat, so a turn that opens a stream and then dies
+        (interrupt, process exit, a final ``send()`` that fails the prefix
+        match) leaves a live-typing indicator up indefinitely.  Sweeping by
+        age on each ``send_draft`` bounds the map and clears the indicator
+        without any per-turn bookkeeping; the threshold is far above a real
+        turn, so a slow live turn is never touched.
+        """
+        now = time.time()
+        for key, stream in list(self._active_streams.items()):
+            started = stream.get("started")
+            if not isinstance(started, (int, float)):
+                continue
+            if now - started < self._STREAM_ABANDON_SECONDS:
+                continue
+            if self._active_streams.pop(key, None) is None:
+                continue
+            logger.debug(
+                "[Slack] Reaping abandoned native stream %s/%s (age %.0fs)",
+                key[0], stream.get("ts"), now - started,
+            )
+            await self._seal_stream(key[0], stream)
 
     def _find_stream_for_final(
         self,
@@ -3580,6 +3645,17 @@ class SlackAdapter(BasePlatformAdapter):
         When several turns are open in the same channel, the longest matching
         ``sent`` prefix wins — a short prefix could match a sibling turn whose
         answer happens to start the same way.
+
+        Longest-prefix is a heuristic, not an identity, and it can still
+        mis-attribute when one turn's streamed text nests inside another's:
+        turn A streams ``"The"``, turn B streams ``"The answer"``, and A
+        finalizes with ``"The answer is 42"`` — B's longer prefix wins, so A's
+        final seals B's stream and A's own entry dangles (until the reaper
+        collects it).  This is strictly better than the previous single-slot
+        behavior, where *every* concurrent pair mis-attributed, and it is the
+        floor for content-based matching: ``send()`` has no turn identity to
+        offer.  Removing it needs a ``draft_id`` (or equivalent) on the final
+        send, which is a gateway-side contract change.
 
         Returns ``(key, stream)`` or ``None`` when no open stream claims it.
         """

--- a/tests/gateway/test_slack_concurrent_turn_streams.py
+++ b/tests/gateway/test_slack_concurrent_turn_streams.py
@@ -1,0 +1,153 @@
+"""Concurrent turns in one Slack channel must not share a streaming slot.
+
+``_active_streams`` used to be keyed on ``chat_id`` alone, so two turns in the
+same channel competed for one slot. Each time a turn found the slot holding the
+other turn's stream it sealed that stream and opened a fresh one, so a single
+answer arrived as several separate Slack messages — the duplicate-message
+symptom in #95430 (cause C).
+
+Keying per ``(chat_id, draft_id)`` gives each turn its own stream. The
+same-turn segment hand-off (transports that bump ``draft_id`` at a tool
+boundary) must still seal its own predecessor, which is what distinguishes
+this from simply never sealing.
+
+Behaviour contract asserted here:
+  * two concurrent turns → exactly one startStream each, no cross-sealing
+  * each turn's final send seals its OWN stream, no chat.postMessage
+  * a same-turn draft_id bump still seals the superseded segment
+  * a sibling turn's stream survives that hand-off
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake", extra={})
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    client = AsyncMock()
+    counter = {"n": 0}
+
+    async def _start(**_kwargs):
+        # Real await boundary: the slot bookkeeping spans this call, which is
+        # exactly the window the two turns used to interleave in.
+        await asyncio.sleep(0)
+        counter["n"] += 1
+        return {"ok": True, "ts": f"ts-{counter['n']}"}
+
+    client.chat_startStream = AsyncMock(side_effect=_start)
+    client.chat_appendStream = AsyncMock(return_value={"ok": True})
+    client.chat_stopStream = AsyncMock(return_value={"ok": True})
+    client.chat_postMessage = AsyncMock(return_value={"ts": "999.000"})
+    client.chat_update = AsyncMock(return_value={"ts": "999.000"})
+    adapter._get_client = MagicMock(return_value=client)
+    adapter.stop_typing = AsyncMock()
+    adapter._running = True
+    return adapter, client
+
+
+# Distinct thread anchors: two people asking in the same channel each get
+# their own thread, which is what the gateway stamps on every frame.
+TURN_A = {"thread_id": "111.000", "user_id": "U1"}
+TURN_B = {"thread_id": "222.000", "user_id": "U2"}
+
+
+class TestConcurrentTurns:
+    @pytest.mark.asyncio
+    async def test_each_turn_opens_exactly_one_stream(self):
+        adapter, client = _make_adapter()
+
+        await asyncio.gather(
+            adapter.send_draft("C1", 1, "turn one ", metadata=TURN_A),
+            adapter.send_draft("C1", 2, "turn two ", metadata=TURN_B),
+        )
+        await asyncio.gather(
+            adapter.send_draft("C1", 1, "turn one continued", metadata=TURN_A),
+            adapter.send_draft("C1", 2, "turn two continued", metadata=TURN_B),
+        )
+
+        assert client.chat_startStream.await_count == 2, (
+            "each turn must open exactly one stream; extra startStream calls "
+            "mean the turns are taking the slot from each other"
+        )
+        assert client.chat_stopStream.await_count == 0, (
+            "no stream should be sealed while both turns are still streaming"
+        )
+        assert ("C1", 1) in adapter._active_streams
+        assert ("C1", 2) in adapter._active_streams
+        assert adapter._active_streams[("C1", 1)]["ts"] != (
+            adapter._active_streams[("C1", 2)]["ts"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_each_turn_finalizes_into_its_own_stream(self):
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "answer one", metadata=TURN_A)
+        await adapter.send_draft("C1", 2, "answer two", metadata=TURN_B)
+
+        first = await adapter.send("C1", "answer one, done.", metadata=TURN_A)
+        second = await adapter.send("C1", "answer two, done.", metadata=TURN_B)
+
+        assert first.success and second.success
+        assert first.message_id != second.message_id, (
+            "both turns finalized into the same stream"
+        )
+        client.chat_postMessage.assert_not_awaited()
+        assert not adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_interleaved_frames_keep_their_own_deltas(self):
+        """Appends must be computed against the sending turn's own text."""
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "AAA", metadata=TURN_A)
+        await adapter.send_draft("C1", 2, "BBB", metadata=TURN_B)
+        await adapter.send_draft("C1", 1, "AAA111", metadata=TURN_A)
+        await adapter.send_draft("C1", 2, "BBB222", metadata=TURN_B)
+
+        deltas = [
+            (c.kwargs["ts"], c.kwargs["markdown_text"])
+            for c in client.chat_appendStream.await_args_list
+        ]
+        ts_a = adapter._active_streams[("C1", 1)]["ts"]
+        ts_b = adapter._active_streams[("C1", 2)]["ts"]
+        assert (ts_a, "111") in deltas
+        assert (ts_b, "222") in deltas
+
+
+class TestSameTurnSegmentHandoff:
+    @pytest.mark.asyncio
+    async def test_draft_id_bump_seals_the_superseded_segment(self):
+        """Transports that bump draft_id per tool boundary still hand off."""
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 7, "segment one", metadata=TURN_A)
+        await adapter.send_draft("C1", 8, "segment two", metadata=TURN_A)
+
+        client.chat_stopStream.assert_awaited_once()
+        assert ("C1", 7) not in adapter._active_streams
+        assert ("C1", 8) in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_handoff_does_not_seal_a_sibling_turn(self):
+        """The other turn's stream must survive a same-turn segment bump."""
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "sibling turn", metadata=TURN_B)
+        await adapter.send_draft("C1", 7, "segment one", metadata=TURN_A)
+        sibling_ts = adapter._active_streams[("C1", 1)]["ts"]
+
+        await adapter.send_draft("C1", 8, "segment two", metadata=TURN_A)
+
+        assert ("C1", 1) in adapter._active_streams, (
+            "a same-turn segment hand-off sealed another turn's stream"
+        )
+        sealed = [c.kwargs["ts"] for c in client.chat_stopStream.await_args_list]
+        assert sibling_ts not in sealed

--- a/tests/gateway/test_slack_concurrent_turn_streams.py
+++ b/tests/gateway/test_slack_concurrent_turn_streams.py
@@ -15,7 +15,10 @@ Behaviour contract asserted here:
   * two concurrent turns → exactly one startStream each, no cross-sealing
   * each turn's final send seals its OWN stream, no chat.postMessage
   * a same-turn draft_id bump still seals the superseded segment
-  * a sibling turn's stream survives that hand-off
+  * a sibling turn's stream survives that hand-off, including one sharing
+    the same thread anchor that started later (higher ``draft_id``)
+  * a turn that never finalizes is swept by age, so per-turn keys cannot
+    accumulate stale entries or leave a live-typing indicator up
 """
 
 import asyncio
@@ -151,3 +154,87 @@ class TestSameTurnSegmentHandoff:
         )
         sealed = [c.kwargs["ts"] for c in client.chat_stopStream.await_args_list]
         assert sibling_ts not in sealed
+
+    @pytest.mark.asyncio
+    async def test_handoff_does_not_seal_a_newer_same_thread_turn(self):
+        """A same-thread sibling that started LATER must survive the hand-off.
+
+        The thread anchor alone cannot separate two turns under one parent
+        (an interactive reply and a scheduled turn), so the anchor match used
+        to seal the sibling and reproduce the split-answer symptom narrowly.
+        ``draft_id`` ordering closes that direction: only a provably older
+        segment can be this turn's predecessor.
+        """
+        adapter, client = _make_adapter()
+
+        # Same thread anchor, higher draft_id => a turn that started after us.
+        await adapter.send_draft("C1", 9, "newer same-thread turn", metadata=TURN_A)
+        newer_ts = adapter._active_streams[("C1", 9)]["ts"]
+
+        await adapter.send_draft("C1", 7, "our segment one", metadata=TURN_A)
+        await adapter.send_draft("C1", 8, "our segment two", metadata=TURN_A)
+
+        assert ("C1", 9) in adapter._active_streams, (
+            "a hand-off sealed a same-thread turn that started later"
+        )
+        sealed = [c.kwargs["ts"] for c in client.chat_stopStream.await_args_list]
+        assert newer_ts not in sealed
+        # Our own predecessor is still handed off.
+        assert ("C1", 7) not in adapter._active_streams
+
+
+class TestAbandonedStreamReaper:
+    """Per-turn keys are no longer displaced by the next turn, so a turn that
+    never finalizes would hold a live-typing indicator open forever."""
+
+    @pytest.mark.asyncio
+    async def test_abandoned_stream_is_sealed_and_evicted(self):
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "turn that dies here", metadata=TURN_B)
+        stale = adapter._active_streams[("C1", 1)]
+        stale_ts = stale["ts"]
+        # Age it past the threshold rather than sleeping.
+        stale["started"] -= adapter._STREAM_ABANDON_SECONDS + 1
+
+        await adapter.send_draft("C1", 2, "a later turn", metadata=TURN_A)
+
+        assert ("C1", 1) not in adapter._active_streams, (
+            "abandoned stream survived the sweep; the map is unbounded"
+        )
+        sealed = [c.kwargs["ts"] for c in client.chat_stopStream.await_args_list]
+        assert stale_ts in sealed, "abandoned stream evicted without sealing"
+
+    @pytest.mark.asyncio
+    async def test_reaper_leaves_live_streams_alone(self):
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "live sibling", metadata=TURN_B)
+        await adapter.send_draft("C1", 2, "our turn", metadata=TURN_A)
+
+        assert ("C1", 1) in adapter._active_streams
+        assert ("C1", 2) in adapter._active_streams
+        client.chat_stopStream.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sweep_precedes_the_slot_read_so_no_append_hits_a_dead_ts(self):
+        """The sweep runs before this turn's slot is read.
+
+        Order matters: reading the slot first would hand back an entry the
+        sweep then seals, and the append would target a stopped ``ts``.  A
+        turn aged past the threshold is instead reopened as a fresh stream.
+        """
+        adapter, client = _make_adapter()
+
+        await adapter.send_draft("C1", 1, "long turn", metadata=TURN_A)
+        adapter._active_streams[("C1", 1)]["started"] -= (
+            adapter._STREAM_ABANDON_SECONDS + 1
+        )
+
+        result = await adapter.send_draft("C1", 1, "long turn continues", metadata=TURN_A)
+
+        assert result.success
+        # Reaped, then reopened as a fresh stream for the same turn — the
+        # invariant that matters is that no append targets a dead ts.
+        assert ("C1", 1) in adapter._active_streams
+        client.chat_appendStream.assert_not_awaited()

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -124,7 +124,7 @@ class TestSendDraft:
         result = await adapter.send_draft("D1", 7, "Rewritten text", metadata=META)
         assert not result.success
         client.chat_stopStream.assert_awaited()
-        assert "D1" not in adapter._active_streams
+        assert ("D1", 7) not in adapter._active_streams
 
     @pytest.mark.asyncio
     async def test_no_thread_ts_fails_cleanly(self):
@@ -141,7 +141,9 @@ class TestSendDraft:
         result = await adapter.send_draft("D1", 8, "Segment two", metadata=META)
         assert result.success
         client.chat_stopStream.assert_awaited()  # sealed segment one
-        assert adapter._active_streams["D1"]["ts"] == "124.000"
+        assert adapter._active_streams[("D1", 8)]["ts"] == "124.000"
+        # The superseded segment is gone; only the new one remains.
+        assert ("D1", 7) not in adapter._active_streams
 
 
 class TestFeatureGateFallback:
@@ -176,7 +178,7 @@ class TestSendFinalization:
         kwargs = client.chat_stopStream.await_args.kwargs
         assert kwargs["markdown_text"] == "rld, done."
         client.chat_postMessage.assert_not_awaited()
-        assert "D1" not in adapter._active_streams
+        assert ("D1", 7) not in adapter._active_streams
 
     @pytest.mark.asyncio
     async def test_final_send_equal_content_seals_without_delta(self):
@@ -196,7 +198,7 @@ class TestSendFinalization:
         assert result.success
         client.chat_postMessage.assert_awaited()
         # Stream stays open for its own finalization.
-        assert "D1" in adapter._active_streams
+        assert ("D1", 7) in adapter._active_streams
 
     @pytest.mark.asyncio
     async def test_stop_stream_failure_falls_back_to_post(self):


### PR DESCRIPTION
## Problem

`_active_streams` was keyed on `chat_id` alone, so two turns in the same channel competed for **one** streaming slot. Whenever a turn found the slot holding the other turn's stream, it sealed that stream and opened a fresh one — so a single answer arrived as several separate Slack messages, visible to every member of the channel.

The reporter of #95430 filed this, retracted it as a misdiagnosis, and noted the retraction was itself the mistake. It reproduces deterministically once the frames actually overlap:

```
# before: two turns, frames interleaved
startStream calls: 4      (for 2 turns)
slot after 1st round: only ts-2 — ts-1 dropped, never sealed
```

`send_draft` read-modify-writes the slot across an `await` (`chat.startStream` / `chat.appendStream`), and the loser's stream is removed from the dict without a `chat.stopStream`. Its later frames then land on a stream the adapter no longer tracks — the `message_not_in_streaming_state` / `appendStream onto a sealed stream` signature in the report.

## Changes

- **`_active_streams` keyed `(chat_id, draft_id)`** so each turn owns its stream. `draft_id` already identifies a turn — `stream_consumer` assigns it once per run.
- **`_find_stream_for_final`** — `_try_finalize_stream` is called from `send()` and has no `draft_id`, so it resolves the owning stream by content, taking the **longest** matching `sent` prefix. A short prefix could otherwise match a sibling turn whose answer happens to start the same way.
- **`_seal_superseded_segment`** preserves the same-turn hand-off. Transports that bump `draft_id` at a tool boundary still seal their own predecessor, matched on the turn's thread anchor so a sibling turn's live stream is left alone. With no anchor to compare, nothing is sealed — a stale typing indicator is cheaper than splitting a live turn's answer in two.
- `disconnect()` unpacks the new key shape. Existing assertions in `test_slack_native_streaming.py` were updated for it (behaviour unchanged; one now additionally asserts the superseded segment is gone).

## Scope

This is **cause C only** of #95430. Causes A (late append onto a sealed stream) and B (final text not a prefix of what was streamed) are independent and untouched.

Worth noting for triage: A's log signature partly overlaps this one — `appendStream onto a sealed stream` is exactly what the slot collision produced — so A is worth re-checking against a build carrying this fix before being investigated separately. B is not yet reproduced even by the reporter, so it isn't actionable here.

## Verification

Five new tests in `tests/gateway/test_slack_concurrent_turn_streams.py` assert the behaviour contract: one stream per turn, each turn finalizing into its own stream, deltas computed against the sending turn's own text, and the same-turn hand-off still sealing its predecessor without touching a sibling.

**With the fix reverted, all five fail** — including the sibling case, where the other turn's stream had already been sealed away:

```
KeyError: ('C1', 1)
5 failed in 0.36s
```

With the fix:

```
$ pytest tests/gateway -k "slack or stream or draft"
774 passed, 2 skipped, 5509 deselected in 47.13s
```

Environment: Python 3.11.15, macOS (arm64).
