### PR TITLE
fix(curator): keep read-before-write marks across tool worker snapshots

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1095,6 +1095,62 @@ class TestCuratorConsolidationDeleteGuard:
 
         _reset_background_review_read_marks()
 
+    def test_background_review_read_survives_tool_executor_thread_hop_without_parent_reset(
+        self, tmp_path, monkeypatch
+    ):
+        """Curator never pre-installs the mark store; each tool is a worker snapshot.
+
+        ``agent/tool_executor.py`` submits ``propagate_context_to_thread(...)``,
+        which runs the call inside ``copy_context()``. A ContextVar.set inside
+        that copy is discarded when the worker returns, so a mark recorded
+        only by ``skill_view`` is invisible to the next ``skill_manage``.
+        Binding the review write origin on the parent thread (as
+        ``build_turn_context`` does) must install a shared store first.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        from tools.skill_manager_tool import _background_review_read_paths
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+        from tools.skills_tool import skill_view
+        from tools.thread_context import propagate_context_to_thread
+
+        # Curator-shaped: origin bound, mark store NOT pre-installed.
+        _background_review_read_paths.set(None)
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+                _create_curator_skill("reviewed", _skill_content("reviewed"))
+
+                def _view():
+                    return skill_view("reviewed")
+
+                def _patch():
+                    return skill_manage(
+                        action="patch",
+                        name="reviewed",
+                        old_string="Step 1: Do the thing.",
+                        new_string="Step 1: Do the thing safely.",
+                    )
+
+                with ThreadPoolExecutor(max_workers=1) as ex:
+                    viewed = ex.submit(
+                        propagate_context_to_thread(_view)
+                    ).result(timeout=10)
+                    patched = ex.submit(
+                        propagate_context_to_thread(_patch)
+                    ).result(timeout=10)
+
+                assert json.loads(viewed)["success"] is True
+                result = json.loads(patched)
+                assert result["success"] is True, result
+        finally:
+            reset_current_write_origin(token)
+            _background_review_read_paths.set(None)
+
     def test_background_review_read_marks_stay_isolated_between_reviews(
         self, tmp_path, monkeypatch
     ):
@@ -1158,3 +1214,41 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+    def test_foreground_manage_not_gated_by_stale_review_read_marks(
+        self, tmp_path
+    ):
+        """Read-before-write gating is keyed on ORIGIN, not store presence.
+
+        When a review finishes, the parent context can keep a binding to
+        that review's mark store (the store is only replaced per-review by
+        ``_reset_background_review_read_marks``). If any path consulted the
+        store unconditionally, stale marks would gate — or leak into — later
+        FOREGROUND manages in the same context. Origin is foreground here
+        and the store is empty (target never viewed by any review), so the
+        patch must go through un-gated. A regression that drops the
+        ``is_background_review()`` gate from the read-before-write guard
+        fails this test with ``_read_before_write_required``.
+        """
+        from tools.skill_manager_tool import (
+            _background_review_read_paths,
+            _BackgroundReviewReadMarks,
+        )
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            # A stale review store left bound in this context; the target
+            # skill is not in it.
+            old = _background_review_read_paths.set(_BackgroundReviewReadMarks())
+            try:
+                result = json.loads(skill_manage(
+                    action="patch",
+                    name="my-skill",
+                    old_string="Step 1: Do the thing.",
+                    new_string="Step 1: Do the new thing.",
+                ))
+            finally:
+                _background_review_read_paths.reset(old)
+
+        assert result["success"] is True, result
+        assert result.get("_read_before_write_required") is not True

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -110,6 +110,21 @@ def _background_review_has_read(path: Path) -> bool:
     return marks is not None and marks.contains(resolved)
 
 
+def ensure_background_review_read_marks() -> None:
+    """Install a shared mark store in this context if one is not bound.
+
+    Tool workers receive a *copy* of the parent context
+    (``propagate_context_to_thread``). A store created here is therefore
+    visible to every subsequent tool call in the same review fork. A store
+    created inside a worker copy via ``ContextVar.set`` is not — that is
+    why ``skill_view`` then ``skill_manage`` used to be refused even in
+    the same review turn when the parent never pre-installed a store
+    (curator path).
+    """
+    if _background_review_read_paths.get() is None:
+        _background_review_read_paths.set(_BackgroundReviewReadMarks())
+
+
 def _reset_background_review_read_marks() -> None:
     """Start a fresh, isolated read set for the current review context."""
     _background_review_read_paths.set(_BackgroundReviewReadMarks())

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -32,6 +32,9 @@ Usage:
 """
 
 import contextvars
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 _write_origin: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -50,8 +53,35 @@ def set_current_write_origin(origin: str) -> contextvars.Token[str]:
 
     Returns a Token the caller must pass to reset_current_write_origin
     in a finally block.
+
+    Binding ``background_review`` also installs the shared read-before-write
+    mark store on *this* context so later tool-worker snapshots can see
+    ``skill_view`` marks. Creating that store inside a worker copy does
+    not propagate back to the parent (or to the next tool call).
     """
-    return _write_origin.set(origin or "foreground")
+    bound = origin or "foreground"
+    token = _write_origin.set(bound)
+    if bound == BACKGROUND_REVIEW:
+        try:
+            from tools.skill_manager_tool import ensure_background_review_read_marks
+
+            ensure_background_review_read_marks()
+        except Exception:
+            # Do NOT swallow this silently: if installing the shared mark
+            # store fails, the review fork regresses to exactly the bug this
+            # PR fixes (skill_view marks stuck in worker copies, every later
+            # skill_manage refused) with zero signal. The origin binding
+            # itself still succeeds, so the caller has no other way to notice.
+            # Log loudly enough that development runs surface it; the guard
+            # remains fail-closed (writes without a readable store are
+            # refused), which is the correct degradation.
+            logger.warning(
+                "Failed to install the background-review read-before-write "
+                "mark store; skill_view marks may not survive tool-worker "
+                "snapshots in this review fork.",
+                exc_info=True,
+            )
+    return token
 
 
 def reset_current_write_origin(token: contextvars.Token[str]) -> None:


### PR DESCRIPTION
## Bug Description

Background-review `skill_manage(action="patch")` is refused even after a successful `skill_view` in the same fork. The refusal is:

> Refusing background curator patch ... has not been loaded in this review turn. Call skill_view first.

The curator then retries skill_view → skill_manage until the iteration budget is exhausted. The existing unit tests missed this because they pre-install the mark store on the parent (`_reset_background_review_read_marks()`) before `copy_context()`.

Related (same class, larger scope): #88198. Closed earlier attempts: #93537, #94326. This PR is the minimal parent-store install; it does not add a circuit breaker or notifications.

## Root Cause

`tools/skill_manager_tool.py` stores read-before-write marks in `_background_review_read_paths` (`ContextVar`, default `None`). `skill_view` calls `mark_background_review_skill_read()`, which creates and `set()`s the store when it is missing.

`agent/tool_executor.py` dispatches every tool via `propagate_context_to_thread()`, which runs the call inside `contextvars.copy_context()`. A `ContextVar.set` inside that copy is discarded when the worker returns. The parent loop thread still has `None`, so the next worker's `skill_manage` never sees the view.

`build_turn_context` already binds `set_current_write_origin(agent._memory_write_origin)` on the parent thread. The review fork sets `_memory_write_origin = "background_review"`. That bind never installed a mark store, so production never had a parent object for workers to share.

## Fix

- When `set_current_write_origin("background_review")` runs on the parent, install a shared `_BackgroundReviewReadMarks` if one is not bound.
- Worker snapshots then mutate the same object, so a view in one tool call authorizes a patch in the next.
- Isolation between reviews is unchanged: `_reset_background_review_read_marks()` still replaces the store.

## How to Verify

1. Bind `background_review` on the parent **without** calling `_reset_background_review_read_marks()`.
2. Dispatch `skill_view` then `skill_manage(patch)` each via `propagate_context_to_thread` on a `ThreadPoolExecutor` (production dispatch).
3. The patch succeeds. On current `main` it is refused with `_read_before_write_required`.
4. The existing isolation test still refuses a patch in a second review that did not view.

## Test Plan

- [x] Added regression test that reproduces the worker snapshot (`tests/tools/test_skill_manager_tool.py::test_background_review_read_survives_tool_executor_thread_hop_without_parent_reset`)
- [x] Existing skill-manager / provenance tests still pass (53 tests)
- [x] RED on `origin/main` (patch refused with `_read_before_write_required`); GREEN after the parent-store install

```
HERMES_PYTHON=<venv>/bin/python ./scripts/run_tests.sh \
  tests/tools/test_skill_manager_tool.py \
  tests/tools/test_skill_provenance.py -q
# 2 files, 53 tests passed
```

## Risk Assessment

Low — only the background-review origin bind installs a store. Foreground writes are unchanged. Concurrent reviews remain isolated by separate ContextVar objects. Fail-closed if the install import fails: the guard still refuses un-viewed writes.
