### PR TITLE
chore: remove eleven orphaned private helpers

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -176,15 +176,6 @@ def _is_thread_not_found_delivery_error(result: Any) -> bool:
     return bool(error and "thread not found" in error.lower())
 
 
-def _send_result_error_kind(result: Any) -> Optional[str]:
-    """Return the machine-readable error_kind from a SendResult/dict, if any."""
-    if isinstance(result, dict):
-        kind = result.get("error_kind")
-    else:
-        kind = getattr(result, "error_kind", None)
-    return str(kind) if kind else None
-
-
 def _classify_dead_from_error_text(error_text: Optional[str]) -> Optional[str]:
     """Best-effort dead-target classification from a raised error's text.
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2145,17 +2145,6 @@ def _path_lacks_deliverable_extension(path: str) -> bool:
     return not suffix or suffix not in MEDIA_DELIVERY_EXTS
 
 
-def _resolve_extensionless_candidate(path: str) -> Optional[str]:
-    """Validate a bare extensionless-branch path (no forward extension).
-
-    Thin wrapper kept for call sites that only have the normalized path
-    (no scan-text context for spaced-path recovery).
-    """
-    if not path:
-        return None
-    return validate_media_delivery_path(path)
-
-
 def _strip_media_tag_directives(text: str) -> str:
     """Remove MEDIA: tags and [[audio_as_voice]] / [[as_document]] markers.
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -290,12 +290,6 @@ def _invoke_namespace(args: argparse.Namespace) -> object:
     return func(args)
 
 
-def _set_attrs(args: argparse.Namespace, **attrs: object) -> argparse.Namespace:
-    for name, value in attrs.items():
-        setattr(args, name, value)
-    return args
-
-
 def _dispatch_extracted_subcommand(
     *,
     root: str,

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -216,28 +216,6 @@ def _draw_radio_item(stdscr, y: int, x: int, item: RadioItem, max_x: int, *, is_
         col += len(chunk)
 
 
-def _query_matches(label: str, query: str) -> bool:
-    """Return True when every query token is a case-insensitive subsequence."""
-    normalized = label.lower()
-    tokens = query.lower().split()
-
-    if not tokens:
-        return True
-
-    for token in tokens:
-        pos = 0
-
-        for ch in token:
-            pos = normalized.find(ch, pos)
-
-            if pos < 0:
-                return False
-
-            pos += 1
-
-    return True
-
-
 _WORD_BOUNDARY = frozenset("-_/. ")
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -52,20 +52,6 @@ _APPLIED_HOMES: set[str] = set()
 _SECRET_SOURCE_CACHE_LOCK = threading.RLock()
 
 
-def _known_hermes_env_keys() -> set[str]:
-    """Return the combined set of known Hermes env-var keys.
-
-    Includes both ``OPTIONAL_ENV_VARS`` (setup-flow vars with metadata) and
-    ``_EXTRA_ENV_KEYS`` (provider/platform keys managed outside the setup
-    wizard).  Lazy-imported to avoid circular-dependency during early-bootstrap
-    ``load_hermes_dotenv()`` calls.
-    """
-    from hermes_cli.config import _EXTRA_ENV_KEYS
-    from hermes_cli.config_defaults import OPTIONAL_ENV_VARS
-
-    return set(OPTIONAL_ENV_VARS.keys()) | set(_EXTRA_ENV_KEYS)
-
-
 # Behavioral routing keys a parent Hermes process injects into child env and
 # that silently redirect a profile onto the wrong provider path (ACP auth
 # method, copilot-ACP endpoints). These — and ONLY these — are scrubbed from

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12300,22 +12300,6 @@ def cmd_console(args):
     return run_console_repl()
 
 
-def _build_provider_choices() -> list[str]:
-    """Build the --provider choices list from CANONICAL_PROVIDERS + 'auto'."""
-    try:
-        from hermes_cli.models import CANONICAL_PROVIDERS as _cp
-        return ["auto"] + [p.slug for p in _cp]
-    except Exception:
-        # Fallback: static list guarantees the CLI always works
-        return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
-            "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
-            "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
-            "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",
-            "nvidia", "deepseek", "alibaba", "qwen-oauth", "opencode-zen", "opencode-go",
-        ]
-
-
 # Top-level subcommands that argparse knows about WITHOUT running plugin
 # discovery.  Used to short-circuit eager plugin imports (which can take
 # 500ms+ pulling in google.cloud.pubsub_v1, aiohttp, grpc, etc.) when the

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -50,27 +50,6 @@ def _get_credential_pool_strategies(config: Dict[str, Any]) -> Dict[str, str]:
     return dict(strategies) if isinstance(strategies, dict) else {}
 
 
-def _set_credential_pool_strategy(config: Dict[str, Any], provider: str, strategy: str) -> None:
-    if not provider:
-        return
-    strategies = _get_credential_pool_strategies(config)
-    strategies[provider] = strategy
-    config["credential_pool_strategies"] = strategies
-
-
-def _supports_same_provider_pool_setup(provider: str) -> bool:
-    if not provider or provider == "custom":
-        return False
-    if provider == "openrouter":
-        return True
-    from hermes_cli.auth import PROVIDER_REGISTRY
-
-    pconfig = PROVIDER_REGISTRY.get(provider)
-    if not pconfig:
-        return False
-    return pconfig.auth_type in {"api_key", "oauth_device_code"}
-
-
 # Default model lists per provider — used as fallback when the live
 # /models endpoint can't be reached.
 _DEFAULT_PROVIDER_MODELS = {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2423,15 +2423,6 @@ def _path_text(raw_path: str | None) -> str:
     return text
 
 
-def _local_dashboard_request(request: Request) -> bool:
-    if getattr(request.app.state, "auth_required", False):
-        return False
-    host = (request.url.hostname or "").lower()
-    client_host = (request.client.host if request.client else "").lower()
-    local_hosts = {"", "localhost", "127.0.0.1", "::1", "testserver", "testclient"}
-    return host in local_hosts or client_host in local_hosts
-
-
 def _default_hermes_root_is_opt_data() -> bool:
     raw = os.environ.get("HERMES_HOME", "").strip()
     if not raw:
@@ -13708,12 +13699,6 @@ def _gc_mcp_oauth_flows() -> None:
             _mcp_oauth_flows.pop(flow_id, None)
 
 
-def _mcp_oauth_callback_url_from_base(base_url: str, server_name: str) -> str:
-    from urllib.parse import quote
-
-    return f"{base_url.rstrip('/')}/api/mcp/oauth/callback/{quote(server_name, safe='')}"
-
-
 def _mcp_oauth_callback_url(request: Request, server_name: str) -> str:
     """Build the externally reachable callback URL for a dashboard flow."""
     from urllib.parse import urlparse, urlunparse
@@ -16327,11 +16312,6 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
     same bound dashboard host.
     """
     return _ws_host_origin_reason(ws) is None
-
-
-def _ws_request_reason(ws: "WebSocket") -> Optional[str]:
-    """First Host/Origin or peer-IP rejection reason, or None when allowed."""
-    return _ws_host_origin_reason(ws) or _ws_client_reason(ws)
 
 
 def _ws_request_is_allowed(ws: "WebSocket") -> bool:


### PR DESCRIPTION
chore: remove eleven orphaned private helpers

Each function below has zero references anywhere in the repo — verified with
`git grep -w` (word-boundary, excluding the definition line) against
`origin/main@1fe0f2f3ac`, plus a check that none appear in tests, docs, or as
quoted strings for registry/string dispatch:

  gateway/delivery.py           _send_result_error_kind
  gateway/platforms/base.py     _resolve_extensionless_candidate
  hermes_cli/console_engine.py  _set_attrs
  hermes_cli/curses_ui.py       _query_matches
  hermes_cli/env_loader.py      _known_hermes_env_keys
  hermes_cli/main.py            _build_provider_choices
  hermes_cli/setup.py           _set_credential_pool_strategy
  hermes_cli/setup.py           _supports_same_provider_pool_setup
  hermes_cli/web_server.py      _local_dashboard_request
  hermes_cli/web_server.py      _mcp_oauth_callback_url_from_base
  hermes_cli/web_server.py      _ws_request_reason

Several are thin wrappers whose underlying implementation stays fully live and
reachable under its own name, so no behaviour changes:

  _resolve_extensionless_candidate -> validate_media_delivery_path (23 refs)
  _send_result_error_kind          -> the error_kind attribute (15 refs)
  _set_credential_pool_strategy    -> _get_credential_pool_strategies (2 refs)

Deletions only: +0 -119. No imports become orphaned (pyflakes reports no new
unused imports), and every touched file still compiles.

Test scope `-k "delivery or console or curses or env_loader or setup or
web_server or platforms"` over tests/hermes_cli/ and tests/gateway/:

  with deletions: 12 failed, 977 passed, 15 skipped, 9 errors
  origin/main:    12 failed, 977 passed, 15 skipped, 9 errors

Identical — the failures are pre-existing (the curses ones are
`ModuleNotFoundError: No module named '_curses'`, a Windows-only gap).

Public-looking orphans were deliberately left in place: unload_plugins,
prepare_session_start, poll_pairing_once, auto_setup_telegram_bot,
list_moa_presets and parent_results carry no underscore prefix and may serve
external callers.
