### PR TITLE
fix(cron): report scheduled run API calls instead of zero

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -113,8 +113,10 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     The Codex app-server protocol does not currently expose cache-write tokens,
     so that bucket remains zero on this runtime.
 
-    Even when Codex omits usage for a turn, Hermes should still count that turn
-    as one API call for session/status accounting.
+    Even when Codex omits usage for a turn, Hermes still counts that server turn
+    for session/status accounting. The app-server protocol does not expose the
+    number of model calls performed inside the turn, so callers must not present
+    this counter as measured API-call usage.
     """
     agent.session_api_calls += 1
 
@@ -796,6 +798,7 @@ def run_codex_app_server_turn(
             ),
             "messages": messages,
             "api_calls": 0,
+            "api_calls_measured": False,
             "completed": False,
             "partial": True,
             "interrupted": _user_interrupted,
@@ -940,6 +943,7 @@ def run_codex_app_server_turn(
         "final_response": turn.final_text,
         "messages": messages,
         "api_calls": api_calls,
+        "api_calls_measured": False,
         "completed": not turn.interrupted and turn.error is None,
         "partial": turn.interrupted or turn.error is not None,
         "interrupted": _user_interrupted,

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -53,9 +53,19 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              claimed_at TEXT NOT NULL,
              started_at TEXT,
              finished_at TEXT,
-             error TEXT
+             error TEXT,
+             api_calls INTEGER
            )"""
     )
+    columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(executions)")
+    }
+    if "api_calls" not in columns:
+        from hermes_cli.sqlite_util import add_column_if_missing
+
+        add_column_if_missing(
+            conn, "executions", "api_calls", "api_calls INTEGER"
+        )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
         "ON executions(job_id, claimed_at DESC, id DESC)"
@@ -179,6 +189,7 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
 def finish_execution(
     execution_id: str, *, success: bool, error: Optional[str] = None,
     delivery_outcome: Optional[str] = None,
+    api_calls: Optional[int] = None,
 ) -> Optional[Dict[str, Any]]:
     """Write a terminal result once; terminal attempts cannot be rewritten."""
     now = _hermes_now().isoformat()
@@ -186,9 +197,9 @@ def finish_execution(
     detail = None if success else (str(error) if error else "unknown failure")
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions SET status=?, finished_at=?, error=?, api_calls=?
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (status, now, detail, api_calls, execution_id),
         )
         if cur.rowcount != 1:
             return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -603,6 +603,23 @@ from cron.jobs import (
 )
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
+_cron_execution_usage: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar(
+    "cron_execution_usage", default=None
+)
+
+
+@contextlib.contextmanager
+def _capture_execution_usage():
+    """Capture one run's usage without changing the run_job return contract."""
+    existing = _cron_execution_usage.get()
+    usage = existing if existing is not None else {}
+    token = _cron_execution_usage.set(usage)
+    try:
+        yield usage
+    finally:
+        _cron_execution_usage.reset(token)
+
+
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
@@ -5144,6 +5161,12 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    usage_out = _cron_execution_usage.get()
+    if usage_out is not None:
+        # Script-only, monitor-suppressed, and preflight-rejected paths make no
+        # model calls. Once an agent run starts, replace this with measured
+        # usage or None when the runtime cannot expose a real call count.
+        usage_out["api_calls"] = 0
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -6212,6 +6235,8 @@ def run_job(
         # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
         _audit_fire_id = uuid.uuid4().hex
         _audit_t_start = time.monotonic()
+        if usage_out is not None:
+            usage_out["api_calls"] = None
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
@@ -6293,6 +6318,12 @@ def run_job(
         if not isinstance(result, dict):
             raise RuntimeError(
                 f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
+            )
+        if usage_out is not None:
+            usage_out["api_calls"] = (
+                int(result.get("api_calls") or 0)
+                if result.get("api_calls_measured", True)
+                else None
             )
 
         # If the agent itself reported failure (e.g. all retries exhausted on
@@ -6821,6 +6852,14 @@ def _run_one_job_body(
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]
+    execution_usage = _cron_execution_usage.get()
+    if execution_usage is None:
+        execution_usage = {}
+
+    def _finish_execution(**kwargs):
+        if "api_calls" in execution_usage:
+            kwargs["api_calls"] = execution_usage["api_calls"]
+        return finish_execution(execution_id, **kwargs)
     delivery_attempted = False
     delivery_error = None
     # Durable failure-incident bookkeeping for this run (see cron.incidents):
@@ -6841,8 +6880,7 @@ def _run_one_job_body(
                 "Job '%s': one-shot dispatch limit reached — skipping",
                 job.get("name", job["id"]),
             )
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Dispatch claim rejected; execution was not started.",
             )
@@ -6877,19 +6915,23 @@ def _run_one_job_body(
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
-            if fire_claim_lost is None:
-                success, output, final_response, error = run_job(
-                    job,
-                    defer_agent_teardown=_deferred_agents,
-                    extra_prompt=extra_prompt,
-                )
-            else:
-                success, output, final_response, error = run_job(
-                    job,
-                    defer_agent_teardown=_deferred_agents,
-                    extra_prompt=extra_prompt,
-                    cancel_event=fire_claim_lost,
-                )
+            token = _cron_execution_usage.set(execution_usage)
+            try:
+                if fire_claim_lost is None:
+                    success, output, final_response, error = run_job(
+                        job,
+                        defer_agent_teardown=_deferred_agents,
+                        extra_prompt=extra_prompt,
+                    )
+                else:
+                    success, output, final_response, error = run_job(
+                        job,
+                        defer_agent_teardown=_deferred_agents,
+                        extra_prompt=extra_prompt,
+                        cancel_event=fire_claim_lost,
+                    )
+            finally:
+                _cron_execution_usage.reset(token)
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -6920,14 +6962,12 @@ def _run_one_job_body(
                     "Interrupted by shutdown before terminal completion.",
                     expected_fire_owner=fire_owner,
                 )
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
                 )
             else:
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
@@ -7106,14 +7146,12 @@ def _run_one_job_body(
                     "Interrupted by shutdown before terminal completion.",
                     expected_fire_owner=fire_owner,
                 )
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
                 )
             else:
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
@@ -7145,8 +7183,7 @@ def _run_one_job_body(
                         "Failed recording delivery_error for interrupted job %s: %s",
                         job["id"], _rec_err,
                     )
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Interrupted by gateway shutdown before terminal completion.",
             )
@@ -7159,8 +7196,7 @@ def _run_one_job_body(
             mark_kwargs["status"] = "blocked_config"
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
         if fire_owner is not None and not marked:
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Fire claim ownership lost before terminal completion.",
             )
@@ -7184,8 +7220,7 @@ def _run_one_job_body(
             # configured target) — record it on the incident so the CLI
             # distinguishes "failure seen" from "operator was pinged".
             _mark_incident_alerted(failure_incident_id)
-        finish_execution(
-            execution_id,
+        _finish_execution(
             success=success,
             error=error,
             delivery_outcome=delivery_outcome,
@@ -7274,8 +7309,7 @@ def _run_one_job_body(
                 job["id"], record_err,
             )
         try:
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error=_err_text,
                 delivery_outcome=delivery_outcome,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6235,9 +6235,17 @@ def run_job(
         # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
         _audit_fire_id = uuid.uuid4().hex
         _audit_t_start = time.monotonic()
-        if usage_out is not None:
-            usage_out["api_calls"] = None
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+
+        def _run_agent_conversation():
+            # Flip measured zero to unknown only once the worker actually starts.
+            # A submit failure means no model call was attempted.
+            if usage_out is not None:
+                usage_out["api_calls"] = None
+            return agent.run_conversation(prompt)
+
+        _cron_future = _cron_pool.submit(
+            _cron_context.run, _run_agent_conversation
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6662,7 +6662,9 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         if not execution_id:
             return
         try:
-            finish_execution(execution_id, success=False, error=error)
+            finish_execution(
+                execution_id, success=False, error=error, api_calls=0
+            )
         except Exception:
             logger.warning(
                 "Job '%s': failed to close unstarted execution ledger row",
@@ -7614,6 +7616,7 @@ def tick(
                     job["execution_id"],
                     success=False,
                     error="Fire claim lost; execution was not started.",
+                    api_calls=0,
                 )
                 return True
             # Production CAS returns the exact persisted record with its unique
@@ -7728,6 +7731,7 @@ def tick(
                     execution["id"],
                     success=False,
                     error=f"Executor dispatch failed: {submit_err}",
+                    api_calls=0,
                 )
                 # Interpreter began finalizing between the guard above and the
                 # submit — release the in-flight claim we just took and skip.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6322,6 +6322,8 @@ def run_job(
         if usage_out is not None:
             usage_out["api_calls"] = (
                 int(result.get("api_calls") or 0)
+                # run_conversation results are measured unless a runtime
+                # explicitly marks its turn counter otherwise (Codex app-server).
                 if result.get("api_calls_measured", True)
                 else None
             )
@@ -6855,6 +6857,9 @@ def _run_one_job_body(
     execution_usage = _cron_execution_usage.get()
     if execution_usage is None:
         execution_usage = {}
+    # The execution has not entered the agent path yet, so early terminal
+    # exits (for example, a rejected one-shot dispatch claim) are measured zero.
+    execution_usage.setdefault("api_calls", 0)
 
     def _finish_execution(**kwargs):
         if "api_calls" in execution_usage:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -193,6 +193,7 @@ class CronScheduler(ABC):
                 execution["id"],
                 success=False,
                 error=f"Fire claim failed before dispatch: {type(exc).__name__}: {exc}",
+                api_calls=0,
             )
             raise
         if not isinstance(claimed_job, dict):
@@ -200,6 +201,7 @@ class CronScheduler(ABC):
                 execution["id"],
                 success=False,
                 error="Fire claim was not acquired",
+                api_calls=0,
             )
             return None
         claimed_job["execution_id"] = execution["id"]

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -250,10 +250,12 @@ def cron_runs(job_id: Optional[str] = None, limit: int = 20):
         print("No cron execution attempts recorded.")
         return
     for record in records:
+        api_calls = record.get("api_calls")
+        api_calls_display = "n/a" if api_calls is None else str(api_calls)
         print(
             f"{record.get('id', '?')}  {record.get('status', '?'):<9}  "
             f"job={record.get('job_id', '?')}  source={record.get('source', '?')}  "
-            f"{record.get('claimed_at', '?')}"
+            f"api_calls={api_calls_display}  {record.get('claimed_at', '?')}"
         )
         if record.get("error"):
             print(f"    {record['error']}")

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -110,14 +110,16 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     _Codex401ThenSuccessAgent.refresh_attempts = 0
     _Codex401ThenSuccessAgent.last_init = {}
 
-    success, output, final_response, error = cron_scheduler.run_job(
-        {"id": "job-1", "name": "Codex Refresh Test", "prompt": "ping", "model": "gpt-5.3-codex"}
-    )
+    with cron_scheduler._capture_execution_usage() as usage:
+        success, output, final_response, error = cron_scheduler.run_job(
+            {"id": "job-1", "name": "Codex Refresh Test", "prompt": "ping", "model": "gpt-5.3-codex"}
+        )
 
     assert success is True
     assert error is None
     assert final_response == "Recovered via refresh"
     assert "Recovered via refresh" in output
+    assert usage["api_calls"] == 1
     assert _Codex401ThenSuccessAgent.refresh_attempts == 1
     assert _Codex401ThenSuccessAgent.last_init["provider"] == "openai-codex"
     assert _Codex401ThenSuccessAgent.last_init["api_mode"] == "codex_responses"

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -30,10 +30,13 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     assert running["status"] == "running"
     assert running["started_at"]
 
-    completed = executions.finish_execution(claimed["id"], success=True)
+    completed = executions.finish_execution(
+        claimed["id"], success=True, api_calls=3
+    )
     assert completed["status"] == "completed"
     assert completed["finished_at"]
     assert completed["error"] is None
+    assert completed["api_calls"] == 3
 
     persisted = executions.list_executions(job_id="job-1")
     assert persisted == [completed]
@@ -104,7 +107,68 @@ def test_cron_runs_cli_prints_execution_history(monkeypatch, tmp_path, capsys):
     output = capsys.readouterr().out
     assert row["id"] in output
     assert "failed" in output
+    assert "api_calls=n/a" in output
     assert "boom" in output
+
+
+def test_existing_execution_database_migrates_api_calls_to_unknown(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY,
+                 job_id TEXT NOT NULL,
+                 source TEXT NOT NULL,
+                 process_id TEXT NOT NULL,
+                 pid INTEGER NOT NULL,
+                 process_started_at INTEGER,
+                 status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL,
+                 started_at TEXT,
+                 finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO executions
+               (id, job_id, source, process_id, pid, status, claimed_at)
+               VALUES ('legacy', 'legacy-job', 'builtin', 'owner', 1,
+                       'completed', '2026-01-01T00:00:00')"""
+        )
+
+    records = executions.list_executions(job_id="legacy-job")
+
+    assert records[0]["api_calls"] is None
+
+
+def test_run_one_job_persists_measured_api_calls(monkeypatch):
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _id: None)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    def measured_run(_job, **_kwargs):
+        scheduler._cron_execution_usage.get()["api_calls"] = 4
+        return True, "output", "response", None
+
+    monkeypatch.setattr(scheduler, "run_job", measured_run)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    assert scheduler.run_one_job(
+        {"id": "measured", "execution_id": "exec-measured"}
+    ) is True
+    assert finished[-1][1]["api_calls"] == 4
 
 
 def test_quick_backup_includes_execution_ledger():

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -298,9 +298,45 @@ def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch)
         ("exec-submit-fail", {
             "success": False,
             "error": "Executor dispatch failed: executor rejected",
+            "api_calls": 0,
         })
     ]
     assert "submit-fail" not in scheduler.get_running_job_ids()
+
+
+def test_builtin_lost_fire_claim_finishes_with_zero_usage(monkeypatch):
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(
+        scheduler,
+        "create_execution",
+        lambda *_args, **_kwargs: {"id": "exec-lost-claim"},
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+    monkeypatch.setattr(
+        scheduler, "get_due_jobs", lambda: [{"id": "lost-claim"}]
+    )
+    monkeypatch.setattr(
+        scheduler, "claim_job_for_fire", lambda _job_id, **_kwargs: False
+    )
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert finished == [
+        (
+            "exec-lost-claim",
+            {
+                "success": False,
+                "error": "Fire claim lost; execution was not started.",
+                "api_calls": 0,
+            },
+        )
+    ]
+    assert "lost-claim" not in scheduler.get_running_job_ids()
 
 
 def test_run_one_job_records_running_then_terminal(monkeypatch):

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -171,6 +171,32 @@ def test_run_one_job_persists_measured_api_calls(monkeypatch):
     assert finished[-1][1]["api_calls"] == 4
 
 
+def test_run_one_job_persists_zero_when_dispatch_is_rejected(monkeypatch):
+    import cron.scheduler as scheduler
+
+    finished = []
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: False)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert scheduler.run_one_job(
+        {"id": "already-dispatched", "execution_id": "exec-rejected"}
+    ) is True
+    assert finished == [
+        (
+            "exec-rejected",
+            {
+                "success": False,
+                "error": "Dispatch claim rejected; execution was not started.",
+                "api_calls": 0,
+            },
+        )
+    ]
+
+
 def test_quick_backup_includes_execution_ledger():
     from hermes_cli.backup import _QUICK_STATE_FILES
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -128,6 +128,7 @@ def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
                 "success": False,
                 "error": "Gemini HTTP 503 (UNAVAILABLE)",
                 "delivery_outcome": "delivered",
+                "api_calls": 0,
             },
         )
     ]
@@ -322,6 +323,7 @@ def test_run_one_job_keyboard_interrupt_skips_delivery_and_reraises(monkeypatch)
                 "success": False,
                 "error": "KeyboardInterrupt",
                 "delivery_outcome": "suppressed",
+                "api_calls": 0,
             },
         )
     ]

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -894,6 +894,38 @@ class TestRunJobSessionPersistence:
             "heartbeat-job", expected_owner="owner-token"
         )
 
+    def test_run_job_submit_failure_keeps_known_zero_usage(self, tmp_path):
+        job = {"id": "submit-failure", "name": "submit failure", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_pool = MagicMock()
+        fake_pool.submit.side_effect = RuntimeError("worker unavailable")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._preflight_job_config", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent"), \
+             patch(
+                 "cron.scheduler.concurrent.futures.ThreadPoolExecutor",
+                 return_value=fake_pool,
+             ):
+            from cron.scheduler import _capture_execution_usage
+
+            with _capture_execution_usage() as usage:
+                success, _output, _final_response, error = run_job(job)
+
+        assert success is False
+        assert "worker unavailable" in error
+        assert usage["api_calls"] == 0
+
     def test_run_job_resets_secret_source_cache_before_reload(self, tmp_path, monkeypatch):
         """Each run must clear the secret-source cache before re-reading the
         env, so a long-running gateway re-resolves Bitwarden/BSM-backed secrets

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -20,6 +20,8 @@ import threading
 import time
 from unittest.mock import patch
 
+import pytest
+
 
 def _wait_until(predicate, timeout=10.0, interval=0.005):
     """Block until ``predicate()`` is truthy or ``timeout`` elapses.
@@ -443,11 +445,23 @@ def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
 def test_fire_due_lost_claim_does_not_run(monkeypatch):
     """If the CAS claim is lost (another machine/retry won), fire_due returns
     False and never runs the job."""
+    import cron.executions as executions
     import cron.jobs as jobs
     import cron.scheduler as sched
     from cron.scheduler_provider import InProcessCronScheduler
 
     ran = []
+    finished = []
+    monkeypatch.setattr(
+        executions,
+        "create_execution",
+        lambda *_args, **_kwargs: {"id": "exec-lost-claim"},
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
     monkeypatch.setattr(
         jobs,
         "claim_job_for_fire",
@@ -458,6 +472,53 @@ def test_fire_due_lost_claim_does_not_run(monkeypatch):
 
     assert InProcessCronScheduler().fire_due("j1") is False
     assert ran == []
+    assert finished == [
+        (
+            "exec-lost-claim",
+            {
+                "success": False,
+                "error": "Fire claim was not acquired",
+                "api_calls": 0,
+            },
+        )
+    ]
+
+
+def test_fire_due_claim_exception_finishes_zero_usage(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    finished = []
+    monkeypatch.setattr(
+        executions,
+        "create_execution",
+        lambda *_args, **_kwargs: {"id": "exec-claim-error"},
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("store unavailable")),
+    )
+
+    with pytest.raises(OSError, match="store unavailable"):
+        InProcessCronScheduler().fire_due("j1")
+
+    assert finished == [
+        (
+            "exec-claim-error",
+            {
+                "success": False,
+                "error": "Fire claim failed before dispatch: OSError: store unavailable",
+                "api_calls": 0,
+            },
+        )
+    ]
 
 
 def test_fire_due_missing_job_does_not_run(monkeypatch):

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -577,4 +577,5 @@ def test_terminal_owner_cas_failure_marks_ledger_ownership_lost(monkeypatch):
         "execution-cas",
         success=False,
         error="Fire claim ownership lost before terminal completion.",
+        api_calls=0,
     )

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -425,6 +425,7 @@ def test_initially_lost_fire_claim_finishes_execution_without_running(monkeypatc
         "stale-execution",
         success=False,
         error="Fire claim ownership lost before execution started.",
+        api_calls=0,
     )
 
 
@@ -476,6 +477,7 @@ def test_initial_heartbeat_exception_does_not_start_execution(monkeypatch):
         "validation-execution",
         success=False,
         error="Fire claim ownership could not be validated before execution started.",
+        api_calls=0,
     )
 
 
@@ -506,6 +508,7 @@ def test_heartbeat_thread_start_failure_does_not_start_execution(monkeypatch):
         "thread-execution",
         success=False,
         error="Fire claim heartbeat could not be started; execution was not run.",
+        api_calls=0,
     )
 
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -121,6 +121,7 @@ class TestRunConversationCodexPath:
         assert result["cache_write_tokens"] == 0
         assert result["reasoning_tokens"] == 5
         assert result["last_prompt_tokens"] == 100
+        assert result["api_calls_measured"] is False
 
         assert agent.session_api_calls == 1
         assert agent.session_prompt_tokens == 100

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -752,6 +752,14 @@ def test_gateway_formatter_renders_async_block():
     assert "Investigate flaky test" in txt
 
 
+def test_async_formatter_renders_unmeasured_api_calls_as_na():
+    text = format_process_notification(_make_async_evt(api_calls=None))
+
+    assert text is not None
+    assert "API calls: n/a" in text
+    assert "API calls: None" not in text
+
+
 def test_gateway_cli_origin_event_left_unrouted():
     """An empty session_key (CLI origin) is left without routing fields."""
     from gateway.run import GatewayRunner

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -221,6 +221,7 @@ class TestInFlightDedupe:
                 res = _run_claimed_job(_job('job-bg-08'))
             assert res["success"] is False
             assert "already running" in res["error"]
+            assert res["api_calls"] == 0
             m_run.assert_not_called()
         finally:
             sched.release_running_job("job-bg-08")
@@ -248,6 +249,26 @@ class TestInFlightDedupe:
         assert seen_during_run["registered"] is True
         assert "job-bg-09" not in sched.get_running_job_ids()   # released after
 
+    def test_run_claimed_job_preserves_usage_when_refresh_fails(self):
+        from cron import scheduler as sched
+        from tools.cronjob_tools import _run_claimed_job
+
+        def measured_run(_job, **_kw):
+            sched._cron_execution_usage.get()["api_calls"] = 5
+            return True
+
+        with patch("cron.scheduler.run_one_job", side_effect=measured_run), \
+             patch(
+                 "tools.cronjob_tools.get_job",
+                 side_effect=OSError("refresh unavailable"),
+             ):
+            res = _run_claimed_job(_job("job-bg-refresh-error"))
+
+        assert res["success"] is False
+        assert res["api_calls"] == 5
+        assert "refresh unavailable" in res["error"]
+        assert "job-bg-refresh-error" not in sched.get_running_job_ids()
+
     def test_background_dispatch_reports_running_job_immediately(self):
         """The dispatch path pre-checks the running set so a mid-run job
         reports in the tool response, not as a delayed completion event."""
@@ -261,6 +282,7 @@ class TestInFlightDedupe:
                     res = _try_dispatch_background_run(_job('job-bg-10'))
             assert res["claimed"] is False
             assert "already running" in res["error"]
+            assert res["api_calls"] == 0
             m_claim.assert_not_called()   # no claim consumed for a skipped run
             m_disp.assert_not_called()
         finally:

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -90,13 +90,21 @@ class TestBackgroundDispatch:
         the job outcome onto process_registry.completion_queue."""
         import time
 
+        from cron import scheduler as sched
         from tools.process_registry import process_registry
+
+        def measured_run(_job, **_kw):
+            sched._cron_execution_usage.get()["api_calls"] = 6
+            return True
 
         # The runner executes on a daemon thread — the patches must stay
         # active until the completion event lands, so poll INSIDE the blocks.
         with _bound_session_key("agent:main:telegram:dm:777"):
             with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
-                 patch("cron.scheduler.run_one_job", return_value=True), \
+                 patch(
+                     "cron.scheduler.run_one_job",
+                     side_effect=measured_run,
+                 ), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
                                      "next_run_at": "2026-08-07T09:00:00"}):
@@ -119,6 +127,7 @@ class TestBackgroundDispatch:
         assert found is not None, "completion event never reached the queue"
         assert found["session_key"] == "agent:main:telegram:dm:777"
         assert found["status"] == "completed"
+        assert found["api_calls"] == 6
         assert "bg run" in (found.get("summary") or "")
         assert "Next scheduled run" in found["summary"]
 
@@ -226,6 +235,7 @@ class TestInFlightDedupe:
 
         def probe_run(job, **kw):
             seen_during_run["registered"] = "job-bg-09" in sched.get_running_job_ids()
+            sched._cron_execution_usage.get()["api_calls"] = 2
             return True
 
         with patch("cron.scheduler.run_one_job", side_effect=probe_run), \
@@ -234,6 +244,7 @@ class TestInFlightDedupe:
             res = _run_claimed_job(_job('job-bg-09'))
 
         assert res["success"] is True
+        assert res["api_calls"] == 2
         assert seen_during_run["registered"] is True
         assert "job-bg-09" not in sched.get_running_job_ids()   # released after
 
@@ -294,15 +305,25 @@ class TestCronjobRunToolIntegration:
     def test_run_action_sync_path_unchanged_without_session(self):
         """No session context → the legacy synchronous behavior (executed +
         execution_success populated from the completed run)."""
+        from cron import scheduler as sched
+
+        def measured_run(_job, **_kw):
+            sched._cron_execution_usage.get()["api_calls"] = 3
+            return True
+
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-13')), \
              patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
-             patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
+             patch(
+                 "cron.scheduler.run_one_job",
+                 side_effect=measured_run,
+             ) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-bg-13"))
 
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
+        assert out["job"]["execution_api_calls"] == 3
         m_claim.assert_called_once_with("job-bg-13", return_job=True)
         m_run.assert_called_once()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -783,6 +783,7 @@ def _run_claimed_job(
     fire_owner = None
     try:
         from cron.scheduler import (
+            _capture_execution_usage,
             release_running_job,
             run_one_job,
             try_register_running_job,
@@ -887,10 +888,11 @@ def _run_claimed_job(
 
         try:
             try:
-                processed = run_one_job(
-                    job, adapters=adapters, loop=gateway_loop,
-                    extra_prompt=extra_prompt,
-                )
+                with _capture_execution_usage() as usage:
+                    processed = run_one_job(
+                        job, adapters=adapters, loop=gateway_loop,
+                        extra_prompt=extra_prompt,
+                    )
             finally:
                 _heartbeat_stop.set()
                 if _heartbeat_thread is not None:
@@ -904,6 +906,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": bool(processed and ok),
             "error": refreshed.get("last_error"),
+            "api_calls": usage.get("api_calls"),
         }
 
     except Exception as e:
@@ -1160,7 +1163,7 @@ def _try_dispatch_background_run(
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
             "error": res.get("error"),
-            "api_calls": 0,
+            "api_calls": res.get("api_calls"),
             "duration_seconds": duration,
         }
 
@@ -1555,6 +1558,8 @@ def cronjob(
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)
             result["execution_success"] = exec_result.get("success", False)
+            if "api_calls" in exec_result:
+                result["execution_api_calls"] = exec_result["api_calls"]
             if not exec_result.get("claimed", False):
                 result["execution_skipped"] = exec_result.get("error") or (
                     "Already being fired by the scheduler; not run again."

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -735,7 +735,8 @@ def _execute_job_now(
     failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
     identical across paths and can't drift.
 
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
+    Returns {"claimed": bool, "success": bool, "error": str|None,
+    "api_calls": int|None}.
     """
     job_id = job["id"]
     claimed_job = None
@@ -754,14 +755,24 @@ def _execute_job_now(
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return {
+                "claimed": False,
+                "success": False,
+                "error": reason,
+                "api_calls": 0,
+            }
     except Exception as e:
         logger.error("Failed to claim cron job %s for immediate run: %s", job_id, e)
         try:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return {
+            "claimed": True,
+            "success": False,
+            "error": str(e),
+            "api_calls": 0,
+        }
 
     return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
 
@@ -776,11 +787,13 @@ def _run_claimed_job(
     the tool response can report "paused"/"already firing" immediately — and
     hand the actual run to a daemon worker.
 
-    Returns {"claimed": True, "success": bool, "error": str|None}.
+    Returns {"claimed": True, "success": bool, "error": str|None,
+    "api_calls": int|None}.
     """
     job_id = job["id"]
     _registered = False
     fire_owner = None
+    usage = {"api_calls": 0}
     try:
         from cron.scheduler import (
             _capture_execution_usage,
@@ -804,6 +817,7 @@ def _run_claimed_job(
                     "Job is already running (a scheduler tick or another "
                     "manual run is executing it); not started again."
                 ),
+                "api_calls": 0,
             }
         _registered = True
 
@@ -935,6 +949,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": False,
             "error": str(e),
+            "api_calls": usage.get("api_calls"),
         }
 
 
@@ -1080,6 +1095,7 @@ def _try_dispatch_background_run(
                         "Job is already running (a scheduler tick or another "
                         "manual run is executing it); not started again."
                     ),
+                    "api_calls": 0,
                 }
         except Exception:
             pass
@@ -1095,14 +1111,25 @@ def _try_dispatch_background_run(
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return {
+                "claimed": False,
+                "success": False,
+                "error": reason,
+                "api_calls": 0,
+            }
     except Exception as e:
         logger.error("Failed to claim cron job %s for background run: %s", job_id, e)
         try:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "dispatched": False, "success": False, "error": str(e)}
+        return {
+            "claimed": True,
+            "dispatched": False,
+            "success": False,
+            "error": str(e),
+            "api_calls": 0,
+        }
 
     origin_ui_session_id = ""
     try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2977,6 +2977,7 @@ def _format_async_delegation(evt: dict) -> str:
     summary = evt.get("summary")
     error = evt.get("error")
     api_calls = evt.get("api_calls", 0)
+    api_calls_display = "n/a" if api_calls is None else str(api_calls)
     duration = evt.get("duration_seconds", "?")
     truncated = evt.get("truncated") or evt.get("exit_reason") == "max_iterations"
     dispatched_at = evt.get("dispatched_at")
@@ -3081,7 +3082,10 @@ def _format_async_delegation(evt: dict) -> str:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
     _trunc = " [TRUNCATED: hit max_iterations — work may be incomplete]" if truncated else ""
-    lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s{_trunc}")
+    lines.append(
+        f"Status: {status}   API calls: {api_calls_display}   "
+        f"Duration: {duration}s{_trunc}"
+    )
     lines.append("--- RESULT ---")
     if status in ("completed", "success") and summary:
         if truncated:


### PR DESCRIPTION
## What does this PR do?

Cron execution history now persists measured model API-call counts instead of losing them and presenting a fabricated zero. Runs whose runtime cannot expose a real count remain `null` in the ledger and render as `api_calls=n/a`, so operators do not mistake an unknown cost for a free run.

### Symptom

`hermes cron runs` could not report API-call usage from durable execution records, and detached manual-run completions always reported `api_calls: 0` regardless of the work performed.

### Impact

Operators could read a definite zero for scheduled jobs that made real model calls, making usage and cost decisions from incorrect data.

### Bug Cause

**Trigger:** `cron/scheduler.py` / `run_job()` returning an execution outcome without carrying usage into `finish_execution()`

**Causal chain:**
1. A scheduled or manual cron job executes an agent turn and produces runtime API-call accounting.
2. The four-field `run_job()` result drops that accounting before the durable execution is finalized, while the `executions` table has no `api_calls` column.
3. The manual background adapter fills the missing value with `0`, and execution history cannot distinguish zero calls from an unavailable measurement.

**Why it is wrong:** Missing telemetry was rendered as a measured zero, and Codex app-server's one outer turn was labelled as one API call even though the protocol does not expose the number of model calls inside that turn.

**Working sibling / contrast:** Script-only and monitor-suppressed jobs genuinely make zero model calls, so their zero remains a measured value.

**Ruled out:** The issue is not a CLI-only formatting defect. The durable row itself lacked the column, so changing display text alone would still lose the measurement across restarts.

### Fix

- Add a race-safe additive `api_calls` migration to the execution ledger and persist the value during terminal transitions.
- Capture per-run usage through a context-local holder so parallel jobs remain isolated without changing the established `run_job()` tuple contract.
- Preserve unknown counts as `null` and render them as `n/a`.
- Carry measured counts through synchronous and detached manual-run results instead of hardcoding zero.
- Mark Codex app-server turn accounting as unmeasured for this purpose because its internal model-call count is unavailable.

## Related Issue

Closes #95427

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/executions.py` - migrate and persist nullable API-call counts.
- `cron/scheduler.py` - capture isolated per-execution usage and finalize it with the ledger row.
- `tools/cronjob_tools.py` - report measured manual-run usage without fabricating zero.
- `hermes_cli/cron.py` - display unavailable measurements as `n/a`.
- `agent/codex_runtime.py` - distinguish app-server turn accounting from measured API calls.
- `tests/` - cover migration, persistence, CLI rendering, manual-run propagation, and Codex semantics.

## How to Test

1. Run the focused cron ledger, scheduler, manual-run, and Codex accounting tests.
2. Confirm a measured agent run persists its count and `hermes cron runs` prints that value.
3. Confirm legacy or unmeasured rows retain `null` and print `api_calls=n/a`.

```bash
scripts/run_tests.sh tests/cron/test_execution_ledger.py tests/cron/test_run_one_job.py tests/cron/test_script_claim_heartbeat.py tests/cron/test_codex_execution_paths.py tests/tools/test_cronjob_run_background.py tests/run_agent/test_codex_app_server_integration.py -q
```

Result: 88 passed, 1 skipped.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the repository test entry on the relevant tests and all targeted tests pass
- [x] I added tests for my changes
- [x] I tested on my platform: Windows 11

### Documentation and Housekeeping

- [x] Documentation updates are not required; the CLI output is self-describing
- [x] `cli-config.yaml.example` is not applicable; no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not applicable; no workflow or architecture contract changed
- [x] Cross-platform impact was considered; the implementation uses SQLite and ContextVar primitives supported on all target platforms
- [x] Tool schema updates are not applicable; the cronjob tool input contract is unchanged
