### PR TITLE
fix(desktop): tick curator + skill sync on desktop backend

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -465,6 +465,10 @@ async def _lifespan(app: "FastAPI"):
     # sweeping stale sessions on schedule, independent of list requests.
     auto_archive_task = asyncio.create_task(_auto_archive_ticker_loop())
 
+    # Live curator timer — a Desktop/serve backend that stays up for days still
+    # gets weekly skill maintenance (mirrors the gateway housekeeping loop).
+    curator_task = asyncio.create_task(_curator_ticker_loop())
+
     try:
         yield
     finally:
@@ -473,6 +477,7 @@ async def _lifespan(app: "FastAPI"):
         pty_reaper_task.cancel()
         selftest_task.cancel()
         auto_archive_task.cancel()
+        curator_task.cancel()
         await PTY_REGISTRY.close_all()
         if os.getenv("HERMES_DESKTOP") == "1":
             _terminate_desktop_managed_gateway()
@@ -12566,6 +12571,44 @@ async def _auto_archive_ticker_loop(
             _log.debug("auto-archive tick skipped: %s", exc)
         await asyncio.sleep(interval_s)
 
+
+async def _curator_ticker_loop(
+    interval_s: float = 3600.0, initial_delay_s: float = 90.0
+) -> None:
+    """Live timer for weekly curator skill maintenance on a Desktop/serve backend.
+
+    A long-running Desktop backend (no CLI chat session, no ``hermes gateway
+    run``) previously never auto-ran the curator — the only production call
+    sites were the CLI session startup and the gateway housekeeping loop. This
+    loop is the Desktop sibling: it polls ``maybe_run_curator`` on a fixed
+    cadence so a backend that stays up for days still gets weekly skill
+    maintenance. ``maybe_run_curator`` is internally gated by
+    ``curator.interval_hours`` (7 days by default), so this is only the poll
+    rate; ``maybe_pull_skills`` is inert unless the access gate is open and a
+    sync base URL is configured. Both are best-effort and never raise.
+    """
+
+    def _tick() -> None:
+        try:
+            from agent.curator import maybe_run_curator
+
+            maybe_run_curator(
+                idle_for_seconds=float("inf"),
+                on_summary=lambda msg: _log.info("curator: %s", msg),
+            )
+        except Exception as exc:
+            _log.debug("Curator tick error: %s", exc)
+        try:
+            from tools.skills_sync_client import maybe_pull_skills
+
+            maybe_pull_skills()
+        except Exception as exc:
+            _log.debug("Sync pull tick error: %s", exc)
+
+    await asyncio.sleep(initial_delay_s)
+    while True:
+        await asyncio.to_thread(_tick)
+        await asyncio.sleep(interval_s)
 
 
 

--- a/tests/hermes_cli/test_desktop_curator_ticker.py
+++ b/tests/hermes_cli/test_desktop_curator_ticker.py
@@ -1,0 +1,56 @@
+"""Desktop curator ticker: a Desktop-only backend still runs the curator.
+
+A Desktop install (Electron app) has no CLI chat session and never runs
+``hermes gateway run``, so the only curator call sites — the CLI session
+startup and the gateway housekeeping loop — never fire. That left a
+Desktop-only user without weekly skill maintenance (issue #95441). This test
+drives the Desktop backend's ``_curator_ticker_loop`` directly and asserts
+that both ``maybe_run_curator`` and ``maybe_pull_skills`` actually get called
+on a short cadence.
+"""
+
+import asyncio
+
+import pytest
+
+import hermes_cli.web_server as ws
+
+
+@pytest.mark.asyncio
+async def test_curator_ticker_ticks_curator_and_skill_sync(monkeypatch):
+    """The desktop curator loop must call curator + skill-sync, never raise."""
+
+    called = []
+
+    def _curator(**kwargs):
+        called.append("curator")
+
+    def _skills():
+        called.append("skills")
+
+    # The loop imports these names inside _tick via function-local imports, so
+    # patch the source modules; the loop re-reads them every iteration.
+    import agent.curator as curator_mod
+    import tools.skills_sync_client as sync_mod
+
+    monkeypatch.setattr(curator_mod, "maybe_run_curator", _curator)
+    monkeypatch.setattr(sync_mod, "maybe_pull_skills", _skills)
+
+    task = asyncio.create_task(
+        ws._curator_ticker_loop(interval_s=0.05, initial_delay_s=0)
+    )
+
+    try:
+        for _ in range(200):
+            if "curator" in called and "skills" in called:
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert "curator" in called, "maybe_run_curator was never called by the ticker"
+    assert "skills" in called, "maybe_pull_skills was never called by the ticker"


### PR DESCRIPTION
## Summary

Fixes #95441 — Desktop-only installs never auto-tick the curator.

A Desktop-only install (Electron app — no CLI chat session, no `hermes gateway run`) never triggers weekly skill maintenance or the skills-sync periodic pull. `maybe_run_curator` only has two production call sites: CLI session startup (`cli.py`) and gateway housekeeping (`gateway/run.py`). Desktop chat rides `tui_gateway` and never hits either, so a user who only opens Desktop never gets curator passes or skill-sync pulls — even when `curator.interval_hours` and idle are both satisfied.

This is the same class of gap auto-archive already fixed on Desktop: a long-running backend needs a periodic sweep independent of request traffic.

## Changes

- **`hermes_cli/web_server.py`**: add `_curator_ticker_loop`, modeled on the existing `_auto_archive_ticker_loop`. It polls `maybe_run_curator(idle_for_seconds=float("inf"), ...)` and `maybe_pull_skills()` on a 1-hour cadence via `asyncio.to_thread` (no event-loop block). Both are internally gated (`maybe_run_curator` by `curator.interval_hours`, default 7 days; `maybe_pull_skills` inert unless the access gate is open and a sync base URL is configured), so the loop is purely a poll rate — real work only fires once per config interval. Each call is wrapped in its own try/except that logs at debug and never raises, mirroring the gateway housekeeping block.
- Wire it into the lifespan alongside `auto_archive_task` and cancel it in the same `finally` block.

## Tests

- **`tests/hermes_cli/test_desktop_curator_ticker.py`** (new): drives the loop with a short cadence and asserts both `maybe_run_curator` and `maybe_pull_skills` actually get called. Regression-proven: reverting either call makes the test fail (`AssertionError: maybe_run_curator was never called by the ticker`); with the fix applied it passes.
- Focused suite: `55 passed in 2.58s` across the desktop cron/lifecycle tests.

Closes #95441
