### PR TITLE
fix(mattermost): silence tool-progress notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -552,6 +552,19 @@ def _interim_metadata(
     return merged
 
 
+def _tool_progress_metadata(
+    metadata: Optional[Dict[str, Any]] = None,
+    *,
+    platform: Any = None,
+) -> Optional[Dict[str, Any]]:
+    """Mark Mattermost tool-progress posts for silent delivery."""
+    if _gateway_platform_value(platform) != "mattermost":
+        return metadata
+    merged = dict(metadata or {})
+    merged["silent"] = True
+    return merged
+
+
 def _seed_hygiene_system_prompt(
     agent: Any,
     session_row: Optional[Dict[str, Any]],
@@ -28871,7 +28884,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # No real thread yet, but the connector will auto-thread on the
             # reply anchor; carry it so progress joins that thread.
             _progress_metadata = {"reply_to_message_id": event_message_id}
-        _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        _progress_metadata = _non_conversational_metadata(
+            _progress_metadata, platform=source.platform
+        )
+        _progress_metadata = _tool_progress_metadata(
+            _progress_metadata, platform=source.platform
+        )
         if _native_slack_task_cards:
             # chat.startStream in channels requires the recipient team/user
             # pair; harmless extras elsewhere, so stamp them whenever known.

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -86,6 +86,13 @@ def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def _posts_api_path(metadata: Optional[Dict[str, Any]]) -> str:
+    """Return the post endpoint for normal or silent delivery."""
+    if not isinstance(metadata, dict) or metadata.get("notify") is True:
+        return "posts"
+    return "posts?silent=true" if metadata.get("silent") is True else "posts"
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter runtime dependency is available."""
     try:
@@ -235,7 +242,8 @@ class MattermostAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         """Post once, optionally falling back flat for final notify content."""
-        data = await self._api_post("posts", payload)
+        posts_path = _posts_api_path(metadata)
+        data = await self._api_post(posts_path, payload)
         if data or "root_id" not in payload:
             return data
         if not (isinstance(metadata, dict) and metadata.get("notify")):
@@ -254,7 +262,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "Mattermost: falling back to flat channel delivery for notify-worthy post in %s",
             chat_id,
         )
-        return await self._api_post("posts", flat_payload)
+        return await self._api_post(posts_path, flat_payload)
 
     async def _api_put(
         self, path: str, payload: Dict[str, Any]

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -10,6 +10,7 @@ from gateway.platforms.base import MessageType
 from gateway.run import (
     _resolve_gateway_display_bool,
     _resolve_progress_thread_id,
+    _tool_progress_metadata,
 )
 
 
@@ -20,6 +21,31 @@ class TestMattermostProgressThreadRouting:
             source_thread_id=None,
             event_message_id="top_post_123",
         ) == "top_post_123"
+
+
+class TestMattermostSilentProgressMetadata:
+    def test_progress_is_silent_without_mutating_thread_metadata(self):
+        original = {"thread_id": "root-post"}
+
+        metadata = _tool_progress_metadata(
+            original, platform=Platform.MATTERMOST
+        )
+
+        assert metadata == {"thread_id": "root-post", "silent": True}
+        assert original == {"thread_id": "root-post"}
+
+    def test_threadless_progress_builds_metadata(self):
+        assert _tool_progress_metadata(None, platform="mattermost") == {
+            "silent": True
+        }
+
+    def test_other_platform_metadata_is_unchanged(self):
+        original = {"thread_id": "thread"}
+
+        metadata = _tool_progress_metadata(original, platform=Platform.SLACK)
+
+        assert metadata is original
+        assert "silent" not in metadata
 
 
 class TestMattermostDisplayHygiene:
@@ -153,9 +179,9 @@ class TestMattermostSend:
         assert result.success is True
         assert result.message_id == "post123"
 
-        # Verify post was called with correct URL
+        # Normal posts must not use Mattermost's silent notification query.
         call_args = self.adapter._session.post.call_args
-        assert "/api/v4/posts" in call_args[0][0]
+        assert call_args[0][0].endswith("/api/v4/posts")
         # Verify payload
         payload = call_args[1]["json"]
         assert payload["channel_id"] == "channel_1"
@@ -192,6 +218,62 @@ class TestMattermostSend:
 
         assert result.success is True
         payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_tool_progress_uses_silent_post_query(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "progress_post"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Running terminal...",
+            metadata={"silent": True},
+        )
+
+        assert result.success is True
+        call_args = self.adapter._session.post.call_args
+        assert call_args.args[0].endswith("/api/v4/posts?silent=true")
+        payload = call_args.kwargs["json"]
+        assert payload["channel_id"] == "channel_1"
+        assert payload["message"] == "Running terminal..."
+        assert payload["props"]["disable_mentions"] is True
+
+    @pytest.mark.asyncio
+    async def test_notify_metadata_overrides_silent_marker(self):
+        self.adapter._api_post = AsyncMock(return_value={"id": "final_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Final answer",
+            metadata={"silent": True, "notify": True},
+        )
+
+        assert result.success is True
+        assert self.adapter._api_post.call_args.args[0] == "posts"
+
+    @pytest.mark.asyncio
+    async def test_silent_thread_progress_preserves_root_id(self):
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "root_post", "root_id": ""}
+        )
+        self.adapter._api_post = AsyncMock(return_value={"id": "progress_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Running tool...",
+            metadata={"thread_id": "root_post", "silent": True},
+        )
+
+        assert result.success is True
+        path, payload = self.adapter._api_post.call_args.args
+        assert path == "posts?silent=true"
         assert payload["root_id"] == "root_post"
 
 


### PR DESCRIPTION
## Summary

Mattermost's CreatePost API supports `?silent=true`, but Hermes currently sends tool-progress posts through the normal `POST /api/v4/posts` endpoint. As a result, each temporary progress update can trigger a desktop or push notification even though it is not the final answer.

This change:

- marks only Mattermost tool-progress metadata as `silent: true` in the gateway;
- maps that marker to `POST /api/v4/posts?silent=true` in the Mattermost adapter;
- keeps normal and final/notify-worthy replies on `POST /api/v4/posts`;
- preserves thread roots and existing disabled-mention props;
- leaves every other platform unchanged.

Mattermost documents `silent` as a boolean query parameter on CreatePost. The adapter also treats Hermes's existing `notify: true` marker as authoritative, so final answers cannot accidentally inherit silent delivery.

## Related work searched

I searched open and closed Hermes issues and pull requests for Mattermost silent posts, `silent=true`, silent tool progress, and progress notifications. I did not find an equivalent implementation. #54230 concerns an opt-in live-thinking bubble and has different behavior and scope.

## Tests

- `pytest tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py -q` (`30 passed`)
- Mattermost compatibility suite covering WebSocket auth retries, multi-image delivery, and media metadata (`44 passed`)
- `ruff check gateway/run.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`
- `py_compile` for all changed Python files
- `git diff --check`
