### PR TITLE
fix(agent): stop oversized browser results from stalling Codex retries

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from tools.budget_config import DEFAULT_MULTIMODAL_RESULT_SIZE_CHARS
 
 logger = logging.getLogger(__name__)
 
@@ -1511,6 +1512,104 @@ def _sanitize_consumer_codex_request(
     return sanitized
 
 
+def _bound_codex_tool_image_payloads(
+    request: dict[str, Any],
+    limit_chars: int = DEFAULT_MULTIMODAL_RESULT_SIZE_CHARS,
+) -> dict[str, Any]:
+    """Bound combined replayed tool images without mutating session history.
+
+    The per-result guard prevents any new multimodal tool result from crossing
+    ``limit_chars``. Several ordinary screenshots can still exceed that same
+    ceiling after the Responses adapter combines prior tool outputs into one
+    request, and old sessions may already contain a pathological screenshot.
+
+    Keep the newest tool-result images that fit the aggregate budget and
+    replace the rest in this request only. User-attached images are outside
+    ``function_call_output`` and are deliberately untouched.
+    """
+    if limit_chars <= 0:
+        return request
+
+    extra_body = request.get("extra_body")
+    if isinstance(extra_body, dict) and isinstance(extra_body.get("input"), list):
+        input_items = extra_body["input"]
+        input_location = "extra_body"
+    else:
+        input_items = request.get("input")
+        input_location = "top_level"
+    if not isinstance(input_items, list):
+        return request
+
+    images: list[tuple[int, int, int]] = []
+    for item_index, item in enumerate(input_items):
+        if not isinstance(item, dict) or item.get("type") != "function_call_output":
+            continue
+        output = item.get("output")
+        if not isinstance(output, list):
+            continue
+        for part_index, part in enumerate(output):
+            if not isinstance(part, dict) or part.get("type") != "input_image":
+                continue
+            image_url = part.get("image_url")
+            if isinstance(image_url, str):
+                images.append((item_index, part_index, len(image_url)))
+
+    total_chars = sum(size for _, _, size in images)
+    if total_chars <= limit_chars:
+        return request
+
+    remaining = limit_chars
+    stripped: set[tuple[int, int]] = set()
+    stripped_chars = 0
+    for item_index, part_index, size in reversed(images):
+        if size <= remaining:
+            remaining -= size
+        else:
+            stripped.add((item_index, part_index))
+            stripped_chars += size
+
+    bounded_input = list(input_items)
+    for item_index in {index for index, _ in stripped}:
+        item = input_items[item_index]
+        output = item["output"]
+        bounded_output: list[Any] = []
+        for part_index, part in enumerate(output):
+            if (item_index, part_index) in stripped:
+                bounded_output.append(
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "[Screenshot omitted from replay because combined tool "
+                            f"images exceeded the {limit_chars:,}-character safety limit.]"
+                        ),
+                    }
+                )
+            else:
+                bounded_output.append(part)
+        bounded_item = dict(item)
+        bounded_item["output"] = bounded_output
+        bounded_input[item_index] = bounded_item
+
+    bounded_request = dict(request)
+    if input_location == "extra_body":
+        bounded_extra_body = dict(extra_body)
+        bounded_extra_body["input"] = bounded_input
+        bounded_request["extra_body"] = bounded_extra_body
+    else:
+        bounded_request["input"] = bounded_input
+
+    logger.warning(
+        "Bound combined Codex tool-image replay: images=%d stripped=%d "
+        "inline_chars_before=%d stripped_chars=%d limit=%d",
+        len(images),
+        len(stripped),
+        total_chars,
+        stripped_chars,
+        limit_chars,
+    )
+    return bounded_request
+
+
 # Bulk request fields that carry the conversation payload. Everything else in
 # the request is scalar configuration the SDK transform handles in microseconds.
 _SDK_TRANSFORM_BYPASS_FIELDS = ("input", "tools")
@@ -1629,6 +1728,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 agent,
                 next_api_kwargs,
             )
+            stream_kwargs = _bound_codex_tool_image_payloads(stream_kwargs)
             stream_kwargs["stream"] = True
             stream_kwargs = _bypass_sdk_request_transform(stream_kwargs)
             return active_client.responses.create(**stream_kwargs)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -47,6 +47,7 @@ from tools.terminal_tool import (
 )
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
+    maybe_persist_multimodal_tool_result,
     maybe_persist_tool_result,
     enforce_turn_budget,
     extract_persisted_path,
@@ -1809,13 +1810,22 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s){_status_suffix}")
 
         display_function_result = function_result
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=name,
-            tool_use_id=tool_call_id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        if _is_multimodal_tool_result(function_result):
+            function_result = maybe_persist_multimodal_tool_result(
+                content=function_result,
+                tool_name=name,
+                tool_use_id=tool_call_id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
+        else:
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=name,
+                tool_use_id=tool_call_id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
         _record_persisted_path_for_stub(agent, tool_call_id, function_result)
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
@@ -2731,13 +2741,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logging.debug("Tool result (%d chars): %s", len(_log_result), _log_result)
 
         display_function_result = function_result
-        function_result = maybe_persist_tool_result(
-            content=function_result,
-            tool_name=function_name,
-            tool_use_id=tool_call_id,
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        if _is_multimodal_tool_result(function_result):
+            function_result = maybe_persist_multimodal_tool_result(
+                content=function_result,
+                tool_name=function_name,
+                tool_use_id=tool_call_id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
+        else:
+            function_result = maybe_persist_tool_result(
+                content=function_result,
+                tool_name=function_name,
+                tool_use_id=tool_call_id,
+                env=get_active_env(effective_task_id),
+                config=_tool_budget,
+            )
         _record_persisted_path_for_stub(agent, tool_call_id, function_result)
 
         # Discover subdirectory context files from tool arguments

--- a/tests/run_agent/test_codex_sdk_transform_bypass.py
+++ b/tests/run_agent/test_codex_sdk_transform_bypass.py
@@ -19,6 +19,7 @@ sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 from agent.codex_runtime import (
+    _bound_codex_tool_image_payloads,
     _bypass_sdk_request_transform,
     _is_plain_json_data,
 )
@@ -112,6 +113,86 @@ class TestBypassSdkRequestTransform:
         kwargs = _wire_kwargs()
 
         assert _bypass_sdk_request_transform(kwargs) is kwargs
+
+
+class TestBoundCodexToolImagePayloads:
+    @staticmethod
+    def _tool_output(call_id: str, image_chars: int):
+        return {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": [
+                {"type": "input_text", "text": f"screenshot {call_id}"},
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64," + ("A" * image_chars),
+                },
+            ],
+        }
+
+    def test_multiple_screenshots_keep_newest_within_aggregate_budget(self):
+        request = _wire_kwargs()
+        request["input"] = [
+            self._tool_output("old", 300_000),
+            self._tool_output("new", 300_000),
+        ]
+
+        bounded = _bound_codex_tool_image_payloads(request)
+
+        old_output = bounded["input"][0]["output"]
+        new_output = bounded["input"][1]["output"]
+        assert not any(part.get("type") == "input_image" for part in old_output)
+        assert any("combined tool images exceeded" in part.get("text", "") for part in old_output)
+        assert any(part.get("type") == "input_image" for part in new_output)
+        # Request-local recovery must not poison or rewrite canonical history.
+        assert request["input"][0]["output"][1]["type"] == "input_image"
+
+    def test_single_oversized_stored_screenshot_is_removed_for_recovery(self):
+        request = _wire_kwargs()
+        request["input"] = [self._tool_output("poisoned", 760_000)]
+
+        bounded = _bound_codex_tool_image_payloads(request)
+
+        assert not any(
+            part.get("type") == "input_image"
+            for part in bounded["input"][0]["output"]
+        )
+
+    def test_under_budget_tool_images_and_user_images_are_unchanged(self):
+        request = _wire_kwargs()
+        user_image = {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": "data:image/png;base64," + ("U" * 400_000)},
+            ],
+        }
+        request["input"] = [user_image, self._tool_output("tool", 400_000)]
+
+        bounded = _bound_codex_tool_image_payloads(request)
+
+        assert bounded is request
+        assert bounded["input"][0] is user_image
+
+    def test_extra_body_input_is_bounded_when_it_is_the_effective_payload(self):
+        request = _wire_kwargs()
+        request.pop("input")
+        request["extra_body"] = {
+            "input": [
+                self._tool_output("old", 300_000),
+                self._tool_output("new", 300_000),
+            ]
+        }
+
+        bounded = _bound_codex_tool_image_payloads(request)
+
+        assert not any(
+            part.get("type") == "input_image"
+            for part in bounded["extra_body"]["input"][0]["output"]
+        )
+        assert any(
+            part.get("type") == "input_image"
+            for part in bounded["extra_body"]["input"][1]["output"]
+        )
 
 
 class TestRunCodexStreamRoutesPayloadViaExtraBody:

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -381,6 +381,51 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     ]
 
 
+@pytest.mark.parametrize("executor_mode", ["sequential", "concurrent"])
+def test_multimodal_tool_result_is_bounded_before_hot_context(executor_mode):
+    agent = _make_agent()
+    tool_call = _mock_tool_call(name="browser_exec", call_id="large-browser")
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    messages: list = []
+    raw_result = {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": "x" * 760_000},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ],
+        "text_summary": "browser result",
+    }
+    dispatch_patch = (
+        patch("run_agent.handle_function_call", return_value=raw_result)
+        if executor_mode == "sequential"
+        else patch.object(agent, "_invoke_tool", return_value=raw_result)
+    )
+
+    with (
+        dispatch_patch,
+        patch(
+            "agent.tool_executor.maybe_persist_multimodal_tool_result",
+            return_value="<persisted-output>bounded</persisted-output>",
+        ) as persist,
+    ):
+        if executor_mode == "sequential":
+            agent._execute_tool_calls_sequential(
+                assistant_message, messages, "task-1"
+            )
+        else:
+            agent._execute_tool_calls_concurrent(
+                assistant_message, messages, "task-1"
+            )
+
+    persist.assert_called_once()
+    assert persist.call_args.kwargs["content"] is raw_result
+    assert "<persisted-output>bounded</persisted-output>" in messages[-1]["content"]
+    assert len(messages[-1]["content"]) < 1_000
+
+
 def test_sequential_keyboard_interrupt_emits_results_for_all_calls():
     """A KeyboardInterrupt mid-batch must not leave dangling tool_calls.
 

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,7 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import json
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +24,7 @@ from tools.tool_result_storage import (
     enforce_turn_budget,
     generate_preview,
     get_spillover_dir,
+    maybe_persist_multimodal_tool_result,
     maybe_persist_tool_result,
 )
 
@@ -262,6 +265,60 @@ class TestMaybePersistToolResult:
         )
         # Any non-empty content with threshold=0 should be persisted
         assert PERSISTED_OUTPUT_TAG in result
+
+
+class TestMaybePersistMultimodalToolResult:
+    def test_oversized_browser_envelope_is_persisted_and_recoverable(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "browser state\n" + ("A" * 760_000)},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,AAAA",
+                    },
+                },
+            ],
+            "text_summary": "browser state",
+            "meta": {"action": "cua_browser_state"},
+        }
+
+        bounded = maybe_persist_multimodal_tool_result(
+            content=result,
+            tool_name="computer_use",
+            tool_use_id="call_browser_large",
+            env=None,
+        )
+
+        assert isinstance(bounded, str)
+        assert PERSISTED_OUTPUT_TAG in bounded
+        assert len(bounded) < 10_000
+        spill_file = get_spillover_dir() / "call_browser_large.txt"
+        assert json.loads(spill_file.read_text(encoding="utf-8")) == result
+
+    def test_normal_multimodal_result_is_unchanged(self):
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "browser state"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                },
+            ],
+            "text_summary": "browser state",
+        }
+
+        assert maybe_persist_multimodal_tool_result(
+            content=result,
+            tool_name="computer_use",
+            tool_use_id="call_browser_small",
+            env=None,
+        ) is result
 
 
 # ── enforce_turn_budget ───────────────────────────────────────────────

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -17,6 +17,10 @@ PINNED_THRESHOLDS: Dict[str, float] = {
 DEFAULT_RESULT_SIZE_CHARS: int = 100_000
 DEFAULT_TURN_BUDGET_CHARS: int = 200_000
 DEFAULT_PREVIEW_SIZE_CHARS: int = 1_500
+# Native screenshot results carry base64 image data and are intentionally
+# larger than text results. Keep the usual resized screenshot (~350K chars)
+# inline, but spill pathological/raw captures before they enter hot context.
+DEFAULT_MULTIMODAL_RESULT_SIZE_CHARS: int = 500_000
 
 # Tighter default per-result threshold for MCP tools (name prefix ``mcp_``).
 #

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -43,6 +43,7 @@ Defense against context-window overflow operates at three levels:
 """
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -52,6 +53,7 @@ import time
 import uuid
 
 from tools.budget_config import (
+    DEFAULT_MULTIMODAL_RESULT_SIZE_CHARS,
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
     DEFAULT_BUDGET,
@@ -318,6 +320,7 @@ def maybe_persist_tool_result(
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
+    preview_content: str | None = None,
 ) -> str:
     """Layer 2: persist oversized result into the sandbox, return preview + path.
 
@@ -332,6 +335,8 @@ def maybe_persist_tool_result(
         env: The active BaseEnvironment instance, or None.
         config: BudgetConfig controlling thresholds and preview size.
         threshold: Explicit override; takes precedence over config resolution.
+        preview_content: Optional preview source when *content* is an encoded
+            envelope whose leading bytes are not useful to the model.
 
     Returns:
         Original content if small, or <persisted-output> replacement.
@@ -345,7 +350,9 @@ def maybe_persist_tool_result(
         return content
 
     filename = _safe_result_filename(tool_use_id)
-    preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    preview_source = content if preview_content is None else preview_content
+    preview, _ = generate_preview(preview_source, max_chars=config.preview_size)
+    has_more = len(content) > len(preview)
 
     # Always persist host-side first: $HERMES_HOME/cache/spillover is the
     # single canonical home for spilled results (with the other Hermes-owned
@@ -393,6 +400,58 @@ def maybe_persist_tool_result(
         f"{preview}\n\n"
         f"[Truncated: tool response was {len(content):,} chars. "
         f"Full output could not be saved to sandbox.]"
+    )
+
+
+def maybe_persist_multimodal_tool_result(
+    content: dict,
+    tool_name: str,
+    tool_use_id: str,
+    env=None,
+    config: BudgetConfig = DEFAULT_BUDGET,
+    threshold: int = DEFAULT_MULTIMODAL_RESULT_SIZE_CHARS,
+):
+    """Persist a pathological multimodal envelope before serialization.
+
+    Multimodal results bypass the text-result cap so ordinary native screenshot
+    blocks survive intact. That exemption previously had no upper bound: a raw
+    browser capture could add hundreds of thousands of base64 characters to
+    every Codex retry. Serialize the complete envelope for durable recovery and
+    replace only envelopes above the dedicated multimodal ceiling.
+    """
+    if not (
+        isinstance(content, dict)
+        and content.get("_multimodal") is True
+        and isinstance(content.get("content"), list)
+    ):
+        return content
+
+    try:
+        serialized = json.dumps(content, ensure_ascii=False, default=str)
+    except Exception:
+        return content
+    if len(serialized) <= threshold:
+        return content
+
+    summary = content.get("text_summary")
+    if not isinstance(summary, str) or not summary:
+        text_parts = [
+            str(part.get("text", ""))
+            for part in content.get("content", [])
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        summary = "\n".join(part for part in text_parts if part)
+    if not summary:
+        summary = "[oversized multimodal tool result]"
+
+    return maybe_persist_tool_result(
+        content=serialized,
+        tool_name=tool_name,
+        tool_use_id=tool_use_id,
+        env=env,
+        config=config,
+        threshold=threshold,
+        preview_content=summary,
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents oversized native browser results from remaining inline in active conversation context, where they can inflate Codex requests and make every zero-event retry resend the same multi-megabyte payload. Multimodal envelopes above 500,000 characters are now saved to the existing durable spillover store and replaced with a bounded preview and recoverable file reference before the next model call.

### Symptom

A browser tool can return a multimodal envelope containing a large text payload plus an attached screenshot. A reported 760,396-character result remained inline and contributed to a 2,468,476-byte Codex request that repeatedly reached the no-byte TTFB cutoff.

### Impact

Affected sessions can appear stalled for several minutes, and retries repeat the same pathological request without reducing its hot-context size.

### Bug Cause

**Trigger:** `agent/tool_executor.py:1813` and `agent/tool_executor.py:2744` when a tool result satisfies `_is_multimodal_tool_result(...)`.

**Causal chain:**
1. `browser_exec` or another native-vision tool returns a multimodal dictionary containing large text or base64 image data.
2. Both sequential and concurrent executors exempt every multimodal envelope from `maybe_persist_tool_result(...)`, regardless of serialized size.
3. The complete envelope is appended to session history and serialized again on each Codex retry.

**Why it is wrong:** The multimodal exemption was needed to preserve ordinary screenshot parts, but it had no upper bound and bypassed the central persistence policy entirely.

**Working sibling / contrast:** String tool results already spill at the existing per-result threshold and remain recoverable through `cache/spillover`; only multimodal envelopes skipped that path.

**Ruled out:** The Codex TTFB timeout cap is not the source of the payload growth. Changing its duration would only alter how long the same oversized request waits.

### Fix

Add a dedicated 500,000-character ceiling for serialized multimodal envelopes. Oversized envelopes are serialized in full to the existing spillover store, represented in hot context by their text summary plus a recovery path, and recorded by the existing persisted-result guardrail. Normal-sized multimodal results remain byte-for-byte unchanged. Both executor paths apply the same policy before creating the tool message.

## Related Issue

Closes #95429

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/budget_config.py` - define the bounded multimodal-result ceiling.
- `tools/tool_result_storage.py` - persist and preview oversized multimodal envelopes while preserving the full serialized result.
- `agent/tool_executor.py` - apply the policy in sequential and concurrent tool execution.
- `tests/tools/test_tool_result_storage.py` - verify a synthetic 760K browser envelope is bounded and exactly recoverable.
- `tests/run_agent/test_tool_call_incremental_persistence.py` - verify both executor paths append only the bounded replacement to hot context.

## How to Test

1. Construct a multimodal browser result with a 760,000-character text part and a screenshot part.
2. Pass it through sequential or concurrent tool execution and verify hot context contains a small `<persisted-output>` reference while the spillover file round-trips to the complete envelope.
3. Run the targeted regression suites (64 passed locally):

```bash
scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/run_agent/test_codex_multimodal_tool_result.py tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_vision_tool_messages.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on the relevant suites and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; the behavior is internal and covered by docstrings
- [x] `cli-config.yaml.example` updates are N/A; no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; persistence uses the existing profile-aware spillover implementation
- [x] Tool description and schema updates are N/A; the public tool contract is unchanged

## Screenshots / Logs

N/A; the regression is covered by deterministic tests.