### PR TITLE
feat(google-workspace): add verified Drive move command

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -241,6 +241,7 @@ $GAPI drive create-folder "Q4" --parent FOLDER_ID
 
 # Move — preview is the default and never writes. After explicit confirmation,
 # repeat with --execute. Cross-drive moves require separate confirmation.
+# Folder self/descendant moves and unexpected multi-parent state fail safely.
 $GAPI drive move FILE_ID --to FOLDER_ID
 $GAPI drive move FILE_ID --to FOLDER_ID --execute
 $GAPI drive move FILE_ID --to FOLDER_ID --execute --allow-cross-drive

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -239,6 +239,12 @@ $GAPI drive download DOC_ID --export-mime text/plain --output ~/doc.txt
 $GAPI drive create-folder "Reports"
 $GAPI drive create-folder "Q4" --parent FOLDER_ID
 
+# Move — preview is the default and never writes. After explicit confirmation,
+# repeat with --execute. Cross-drive moves require separate confirmation.
+$GAPI drive move FILE_ID --to FOLDER_ID
+$GAPI drive move FILE_ID --to FOLDER_ID --execute
+$GAPI drive move FILE_ID --to FOLDER_ID --execute --allow-cross-drive
+
 # Share
 $GAPI drive share FILE_ID --email alice@example.com --role reader
 $GAPI drive share FILE_ID --email alice@example.com --role writer --notify
@@ -301,6 +307,8 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Drive upload**: `{status: "uploaded", id, name, mimeType, webViewLink}`
 - **Drive download**: `{status: "downloaded", id, name, path, mimeType}`
 - **Drive create-folder**: `{status: "created", id, name, webViewLink}`
+- **Drive move preview**: `{status: "preview", file, from, to, crossDrive, duplicateNameWarning, requiresConfirmation}`
+- **Drive move execute**: `{status: "moved", verified: true, file, from, to, crossDrive, duplicateNameWarning, rollback}`
 - **Drive share**: `{status: "shared", permissionId, fileId, role, type}`
 - **Drive delete**: `{status: "trashed" | "deleted", fileId, permanent}`
 - **Contacts list**: `[{name, emails: [...], phones: [...]}]`
@@ -311,7 +319,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/delete calendar events, delete/share/move Drive files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, current parent, destination, content, share role) and ask for approval. For `drive move`, run the preview first; use `--execute` only after confirmation, and require separate confirmation before `--allow-cross-drive`. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -610,6 +610,7 @@ def drive_get(args):
 
 _DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
 _DRIVE_MOVE_FIELDS = "id, name, mimeType, parents, driveId, webViewLink"
+_DRIVE_MOVE_MAX_PARENT_HOPS = 100
 
 
 def _drive_move_get(file_id: str) -> dict:
@@ -630,30 +631,84 @@ def _drive_move_duplicates(name: str, destination_id: str, moving_file_id: str) 
     params = {
         "q": f"'{escaped_parent}' in parents and name = '{escaped_name}' and trashed = false",
         "pageSize": 100,
-        "fields": "files(id, name, mimeType, webViewLink)",
+        "fields": "nextPageToken, files(id, name, mimeType, webViewLink)",
         "supportsAllDrives": True,
         "includeItemsFromAllDrives": True,
     }
-    if _gws_binary():
-        result = _run_gws(["drive", "files", "list"], params=params)
-    else:
-        service = build_service("drive", "v3")
-        result = service.files().list(**params).execute()
-    return [item for item in result.get("files", []) if item.get("id") != moving_file_id]
+    use_gws = bool(_gws_binary())
+    service = None if use_gws else build_service("drive", "v3")
+    files = []
+    while True:
+        if use_gws:
+            result = _run_gws(["drive", "files", "list"], params=params)
+        else:
+            assert service is not None
+            result = service.files().list(**params).execute()
+        files.extend(result.get("files", []))
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
+        params = {**params, "pageToken": page_token}
+
+    duplicates = []
+    seen_ids = set()
+    for item in files:
+        item_id = item.get("id")
+        if item_id == moving_file_id or item_id in seen_ids:
+            continue
+        seen_ids.add(item_id)
+        duplicates.append(item)
+    return duplicates
 
 
 def _drive_move_update(file_id: str, destination_id: str, current_parents: list[str]) -> dict:
     params = {
         "fileId": file_id,
         "addParents": destination_id,
-        "removeParents": ",".join(current_parents),
         "supportsAllDrives": True,
         "fields": _DRIVE_MOVE_FIELDS,
     }
+    if current_parents:
+        params["removeParents"] = ",".join(current_parents)
     if _gws_binary():
         return _run_gws(["drive", "files", "update"], params=params)
     service = build_service("drive", "v3")
     return service.files().update(**params).execute()
+
+
+def _drive_move_reject_descendant(source_id: str, destination: dict) -> None:
+    """Reject moving a folder beneath itself without following ancestry forever."""
+    current = destination
+    seen: set[str] = set()
+    parent_hops = 0
+    while True:
+        current_id = current.get("id")
+        if current_id in seen:
+            raise SystemExit("ERROR: Drive folder ancestry contains a cycle; manual handling is required.")
+        if current_id:
+            seen.add(current_id)
+
+        parents = list(current.get("parents") or [])
+        if not parents:
+            return
+        if len(parents) > 1:
+            raise SystemExit(
+                "ERROR: Drive folder ancestry contains multiple parents; "
+                "manual handling is required."
+            )
+        parent_id = parents[0]
+        if parent_id == source_id:
+            raise SystemExit("ERROR: A folder cannot be moved into its descendant.")
+        if parent_id in seen:
+            raise SystemExit("ERROR: Drive folder ancestry contains a cycle; manual handling is required.")
+
+        parent_hops += 1
+        if parent_hops > _DRIVE_MOVE_MAX_PARENT_HOPS:
+            raise SystemExit(
+                "ERROR: Drive folder ancestry exceeded the safe traversal limit; "
+                "manual handling is required."
+            )
+        current = _drive_move_get(parent_id)
 
 
 def drive_move(args):
@@ -667,6 +722,11 @@ def drive_move(args):
         raise SystemExit("ERROR: The destination ID is not a Google Drive folder.")
 
     current_parents = list(source.get("parents") or [])
+    if len(current_parents) > 1:
+        raise SystemExit(
+            "ERROR: Drive returned multiple current parents for this item. "
+            "Drive v3 supports a single parent; manual handling is required."
+        )
     if current_parents == [args.destination_id]:
         print(json.dumps({
             "status": "unchanged",
@@ -675,6 +735,9 @@ def drive_move(args):
             "parent": {"id": destination.get("id", args.destination_id), "name": destination.get("name", "")},
         }, indent=2, ensure_ascii=False))
         return
+
+    if source.get("mimeType") == _DRIVE_FOLDER_MIME:
+        _drive_move_reject_descendant(args.file_id, destination)
 
     duplicates = _drive_move_duplicates(
         source.get("name", ""), args.destination_id, args.file_id

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -13,6 +13,7 @@ Usage:
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
+  python google_api.py drive move FILE_ID --to FOLDER_ID [--execute]
   python google_api.py contacts list [--max 20]
   python google_api.py sheets get SHEET_ID RANGE
   python google_api.py sheets update SHEET_ID RANGE --values '[[...]]'
@@ -607,6 +608,117 @@ def drive_get(args):
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
 
+_DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
+_DRIVE_MOVE_FIELDS = "id, name, mimeType, parents, driveId, webViewLink"
+
+
+def _drive_move_get(file_id: str) -> dict:
+    params = {
+        "fileId": file_id,
+        "fields": _DRIVE_MOVE_FIELDS,
+        "supportsAllDrives": True,
+    }
+    if _gws_binary():
+        return _run_gws(["drive", "files", "get"], params=params)
+    service = build_service("drive", "v3")
+    return service.files().get(**params).execute()
+
+
+def _drive_move_duplicates(name: str, destination_id: str, moving_file_id: str) -> list[dict]:
+    escaped_name = name.replace("\\", "\\\\").replace("'", "\\'")
+    escaped_parent = destination_id.replace("\\", "\\\\").replace("'", "\\'")
+    params = {
+        "q": f"'{escaped_parent}' in parents and name = '{escaped_name}' and trashed = false",
+        "pageSize": 100,
+        "fields": "files(id, name, mimeType, webViewLink)",
+        "supportsAllDrives": True,
+        "includeItemsFromAllDrives": True,
+    }
+    if _gws_binary():
+        result = _run_gws(["drive", "files", "list"], params=params)
+    else:
+        service = build_service("drive", "v3")
+        result = service.files().list(**params).execute()
+    return [item for item in result.get("files", []) if item.get("id") != moving_file_id]
+
+
+def _drive_move_update(file_id: str, destination_id: str, current_parents: list[str]) -> dict:
+    params = {
+        "fileId": file_id,
+        "addParents": destination_id,
+        "removeParents": ",".join(current_parents),
+        "supportsAllDrives": True,
+        "fields": _DRIVE_MOVE_FIELDS,
+    }
+    if _gws_binary():
+        return _run_gws(["drive", "files", "update"], params=params)
+    service = build_service("drive", "v3")
+    return service.files().update(**params).execute()
+
+
+def drive_move(args):
+    """Preview or execute a single-parent Drive move."""
+    if args.file_id == args.destination_id:
+        raise SystemExit("ERROR: A file or folder cannot be moved into itself.")
+
+    source = _drive_move_get(args.file_id)
+    destination = _drive_move_get(args.destination_id)
+    if destination.get("mimeType") != _DRIVE_FOLDER_MIME:
+        raise SystemExit("ERROR: The destination ID is not a Google Drive folder.")
+
+    current_parents = list(source.get("parents") or [])
+    if current_parents == [args.destination_id]:
+        print(json.dumps({
+            "status": "unchanged",
+            "verified": True,
+            "file": {"id": source.get("id", args.file_id), "name": source.get("name", "")},
+            "parent": {"id": destination.get("id", args.destination_id), "name": destination.get("name", "")},
+        }, indent=2, ensure_ascii=False))
+        return
+
+    duplicates = _drive_move_duplicates(
+        source.get("name", ""), args.destination_id, args.file_id
+    )
+    cross_drive = source.get("driveId") != destination.get("driveId")
+
+    if not args.execute:
+        print(json.dumps({
+            "status": "preview",
+            "file": {"id": source.get("id", args.file_id), "name": source.get("name", "")},
+            "from": {"id": current_parents[0]} if current_parents else None,
+            "to": {"id": destination.get("id", args.destination_id), "name": destination.get("name", "")},
+            "crossDrive": cross_drive,
+            "duplicateNameWarning": duplicates,
+            "requiresConfirmation": True,
+        }, indent=2, ensure_ascii=False))
+        return
+
+    if cross_drive and not args.allow_cross_drive:
+        raise SystemExit(
+            "ERROR: This move crosses My Drive/shared-drive boundaries. "
+            "Preview it, obtain separate confirmation, then add --allow-cross-drive."
+        )
+
+    _drive_move_update(args.file_id, args.destination_id, current_parents)
+    verified = _drive_move_get(args.file_id)
+    if list(verified.get("parents") or []) != [args.destination_id]:
+        raise SystemExit(
+            "ERROR: Drive accepted the move but parent verification failed; "
+            f"observed parents: {verified.get('parents') or []}"
+        )
+
+    print(json.dumps({
+        "status": "moved",
+        "verified": True,
+        "file": {"id": verified.get("id", args.file_id), "name": verified.get("name", source.get("name", ""))},
+        "from": {"id": current_parents[0]} if current_parents else None,
+        "to": {"id": destination.get("id", args.destination_id), "name": destination.get("name", "")},
+        "crossDrive": cross_drive,
+        "duplicateNameWarning": duplicates,
+        "rollback": ({"fileId": args.file_id, "to": current_parents[0]} if current_parents else None),
+    }, indent=2, ensure_ascii=False))
+
+
 def drive_upload(args):
     """Upload a local file to Drive. Falls through to Python client even when gws
     is installed, because gws doesn't do multipart uploads."""
@@ -1132,6 +1244,30 @@ def main():
     p = drv_sub.add_parser("get")
     p.add_argument("file_id")
     p.set_defaults(func=drive_get)
+
+    p = drv_sub.add_parser(
+        "move",
+        help="Preview or move a Drive item to another folder",
+    )
+    p.add_argument("file_id", metavar="FILE_ID")
+    p.add_argument(
+        "--to",
+        dest="destination_id",
+        metavar="DESTINATION_ID",
+        required=True,
+        help="Destination folder ID",
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="Perform the move after reviewing the default preview",
+    )
+    p.add_argument(
+        "--allow-cross-drive",
+        action="store_true",
+        help="Allow a separately confirmed My Drive/shared-drive boundary move",
+    )
+    p.set_defaults(func=drive_move)
 
     p = drv_sub.add_parser("upload")
     p.add_argument("path", help="Local file path to upload")

--- a/tests/skills/test_google_workspace_drive_move_skill.py
+++ b/tests/skills/test_google_workspace_drive_move_skill.py
@@ -1,0 +1,484 @@
+"""Behavior tests for the bundled Google Drive move command."""
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+API_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/google_api.py"
+)
+FOLDER_MIME = "application/vnd.google-apps.folder"
+
+
+@pytest.fixture
+def api_module(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    spec = importlib.util.spec_from_file_location("local_google_api_test", API_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._gws_binary = lambda: "/usr/bin/gws"
+    module._ensure_authenticated = lambda: None
+    return module
+
+
+def test_move_defaults_to_preview_without_updating(api_module, capsys):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder"],
+                "webViewLink": "https://drive.example/file-1",
+            }
+        if parts[-1] == "get" and params["fileId"] == "new-folder":
+            return {
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+                "webViewLink": "https://drive.example/new-folder",
+            }
+        if parts[-1] == "list":
+            return {"files": [{"id": "duplicate", "name": "Report.pdf"}]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "preview"
+    assert result["file"] == {"id": "file-1", "name": "Report.pdf"}
+    assert result["from"] == {"id": "old-folder"}
+    assert result["to"] == {"id": "new-folder", "name": "Archive"}
+    assert result["duplicateNameWarning"][0]["id"] == "duplicate"
+    assert result["requiresConfirmation"] is True
+    assert not any(parts[-1] == "update" for parts, _, _ in calls)
+
+
+def test_execute_moves_once_and_verifies_parent(api_module, capsys):
+    calls = []
+    source_reads = 0
+
+    def fake_gws(parts, *, params=None, body=None):
+        nonlocal source_reads
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            source_reads += 1
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder"] if source_reads == 1 else ["new-folder"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "new-folder":
+            return {
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            return {"files": [{"id": "duplicate", "name": "Report.pdf"}]}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["new-folder"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "moved"
+    assert result["verified"] is True
+    assert result["duplicateNameWarning"] == [{"id": "duplicate", "name": "Report.pdf"}]
+    assert result["from"] == {"id": "old-folder"}
+    assert result["to"] == {"id": "new-folder", "name": "Archive"}
+    assert result["rollback"] == {
+        "fileId": "file-1",
+        "to": "old-folder",
+    }
+    updates = [(params, body) for parts, params, body in calls if parts[-1] == "update"]
+    assert updates == [({
+        "fileId": "file-1",
+        "addParents": "new-folder",
+        "removeParents": "old-folder",
+        "supportsAllDrives": True,
+        "fields": api_module._DRIVE_MOVE_FIELDS,
+    }, None)]
+    assert source_reads == 2
+
+
+def test_cross_drive_execute_requires_separate_override(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "shared-folder":
+            return {
+                "id": "shared-folder",
+                "name": "Shared Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["shared-root"],
+                "driveId": "shared-drive-1",
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["shared-folder"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="shared-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="--allow-cross-drive"):
+        api_module.drive_move(args)
+
+    assert not any(parts[-1] == "update" for parts, _, _ in calls)
+
+
+def test_cross_drive_override_allows_verified_move(api_module, capsys):
+    calls = []
+    source_reads = 0
+
+    def fake_gws(parts, *, params=None, body=None):
+        nonlocal source_reads
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            source_reads += 1
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder"] if source_reads == 1 else ["shared-folder"],
+                **({} if source_reads == 1 else {"driveId": "shared-drive-1"}),
+            }
+        if parts[-1] == "get" and params["fileId"] == "shared-folder":
+            return {
+                "id": "shared-folder",
+                "name": "Shared Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["shared-root"],
+                "driveId": "shared-drive-1",
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["shared-folder"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="shared-folder",
+        execute=True,
+        allow_cross_drive=True,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "moved"
+    assert result["verified"] is True
+    assert result["crossDrive"] is True
+    assert sum(parts[-1] == "update" for parts, _, _ in calls) == 1
+
+
+def test_cross_drive_override_allows_shared_drive_to_my_drive(api_module, capsys):
+    calls = []
+    source_reads = 0
+
+    def fake_gws(parts, *, params=None, body=None):
+        nonlocal source_reads
+        assert params is not None
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            source_reads += 1
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["shared-folder"] if source_reads == 1 else ["my-folder"],
+                **({"driveId": "shared-drive-1"} if source_reads == 1 else {}),
+            }
+        if parts[-1] == "get" and params["fileId"] == "my-folder":
+            return {
+                "id": "my-folder",
+                "name": "My Drive Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["my-folder"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="my-folder",
+        execute=True,
+        allow_cross_drive=True,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "moved"
+    assert result["verified"] is True
+    assert result["crossDrive"] is True
+    assert sum(parts[-1] == "update" for parts, _, _ in calls) == 1
+
+
+def test_same_folder_is_verified_noop(api_module, capsys):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["folder-1"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "folder-1":
+            return {
+                "id": "folder-1",
+                "name": "Current",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["folder-1"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="folder-1",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result == {
+        "status": "unchanged",
+        "verified": True,
+        "file": {"id": "file-1", "name": "Report.pdf"},
+        "parent": {"id": "folder-1", "name": "Current"},
+    }
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
+def test_non_folder_destination_is_rejected_before_write(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["folder-1"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "not-a-folder":
+            return {
+                "id": "not-a-folder",
+                "name": "Other.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["root"],
+            }
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="not-a-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="not a Google Drive folder"):
+        api_module.drive_move(args)
+
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
+def test_folder_cannot_be_moved_into_itself(api_module):
+    api_module._run_gws = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("No Drive API call should happen for a self move")
+    )
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="folder-1",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="cannot be moved into itself"):
+        api_module.drive_move(args)
+
+
+def test_cli_exposes_preview_execute_and_cross_drive_flags():
+    result = subprocess.run(
+        [sys.executable, str(API_PATH), "drive", "move", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "FILE_ID" in result.stdout
+    assert "--to DESTINATION_ID" in result.stdout
+    assert "--execute" in result.stdout
+    assert "--allow-cross-drive" in result.stdout
+
+
+def test_python_client_fallback_executes_and_verifies(api_module, capsys):
+    api_module._gws_binary = lambda: None
+    calls = []
+    source_reads = 0
+
+    class Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class Files:
+        def get(self, **params):
+            nonlocal source_reads
+            calls.append(("get", params))
+            if params["fileId"] == "file-1":
+                source_reads += 1
+                return Request({
+                    "id": "file-1",
+                    "name": "Report.pdf",
+                    "mimeType": "application/pdf",
+                    "parents": ["old-folder"] if source_reads == 1 else ["new-folder"],
+                })
+            return Request({
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            })
+
+        def list(self, **params):
+            calls.append(("list", params))
+            return Request({"files": []})
+
+        def update(self, **params):
+            calls.append(("update", params))
+            return Request({"id": "file-1", "parents": ["new-folder"]})
+
+    class Service:
+        def __init__(self):
+            self._files = Files()
+
+        def files(self):
+            return self._files
+
+    service = Service()
+    api_module.build_service = lambda api, version: service
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "moved"
+    assert result["verified"] is True
+    update = next(params for name, params in calls if name == "update")
+    assert update["addParents"] == "new-folder"
+    assert update["removeParents"] == "old-folder"
+    assert update["supportsAllDrives"] is True
+    assert source_reads == 2
+
+
+def test_execute_fails_loudly_when_parent_readback_disagrees(api_module):
+    reads = iter([
+        {
+            "id": "file-1",
+            "name": "Report.pdf",
+            "mimeType": "application/pdf",
+            "parents": ["old-folder"],
+        },
+        {
+            "id": "new-folder",
+            "name": "Archive",
+            "mimeType": FOLDER_MIME,
+            "parents": ["root"],
+        },
+        {
+            "id": "file-1",
+            "name": "Report.pdf",
+            "mimeType": "application/pdf",
+            "parents": ["old-folder"],
+        },
+    ])
+    api_module._drive_move_get = lambda file_id: next(reads)
+    api_module._drive_move_duplicates = lambda *args: []
+    api_module._drive_move_update = lambda *args: {
+        "id": "file-1",
+        "parents": ["new-folder"],
+    }
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="parent verification failed"):
+        api_module.drive_move(args)

--- a/tests/skills/test_google_workspace_drive_move_skill.py
+++ b/tests/skills/test_google_workspace_drive_move_skill.py
@@ -77,6 +77,46 @@ def test_move_defaults_to_preview_without_updating(api_module, capsys):
     assert not any(parts[-1] == "update" for parts, _, _ in calls)
 
 
+def test_multiple_current_parents_are_rejected_before_lookup_or_write(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder-1", "old-folder-2"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "new-folder":
+            return {
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match="Drive v3 supports a single parent; manual handling is required",
+    ):
+        api_module.drive_move(args)
+
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
 def test_execute_moves_once_and_verifies_parent(api_module, capsys):
     calls = []
     source_reads = 0
@@ -134,6 +174,53 @@ def test_execute_moves_once_and_verifies_parent(api_module, capsys):
         "fields": api_module._DRIVE_MOVE_FIELDS,
     }, None)]
     assert source_reads == 2
+
+
+def test_gws_parentless_source_omits_remove_parents(api_module, capsys):
+    calls = []
+    source_reads = 0
+
+    def fake_gws(parts, *, params=None, body=None):
+        nonlocal source_reads
+        calls.append((parts, params, body))
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            source_reads += 1
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                **({} if source_reads == 1 else {"parents": ["new-folder"]}),
+            }
+        if parts[-1] == "get" and params["fileId"] == "new-folder":
+            return {
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            return {"files": []}
+        if parts[-1] == "update":
+            return {"id": "file-1", "parents": ["new-folder"]}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["verified"] is True
+    assert result["from"] is None
+    assert result["rollback"] is None
+    update = next(params for parts, params, _ in calls if parts[-1] == "update")
+    assert "removeParents" not in update
+    assert update["addParents"] == "new-folder"
 
 
 def test_cross_drive_execute_requires_separate_override(api_module):
@@ -365,6 +452,242 @@ def test_folder_cannot_be_moved_into_itself(api_module):
         api_module.drive_move(args)
 
 
+def test_folder_cannot_be_moved_into_descendant_before_lookup_or_write(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get":
+            items = {
+                "folder-1": {
+                    "id": "folder-1",
+                    "name": "Parent",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["old-folder"],
+                },
+                "child-2": {
+                    "id": "child-2",
+                    "name": "Grandchild",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["child-1"],
+                },
+                "child-1": {
+                    "id": "child-1",
+                    "name": "Child",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["folder-1"],
+                },
+            }
+            return items[params["fileId"]]
+        if parts[-1] == "list":
+            return {"files": []}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="child-2",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="cannot be moved into its descendant"):
+        api_module.drive_move(args)
+
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
+def test_ordinary_folder_move_preview_walks_to_root(api_module, capsys):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get":
+            items = {
+                "folder-1": {
+                    "id": "folder-1",
+                    "name": "Project",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["old-folder"],
+                },
+                "new-folder": {
+                    "id": "new-folder",
+                    "name": "Archive",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["root"],
+                },
+                "root": {
+                    "id": "root",
+                    "name": "My Drive",
+                    "mimeType": FOLDER_MIME,
+                },
+            }
+            return items[params["fileId"]]
+        if parts[-1] == "list":
+            return {"files": []}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="new-folder",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "preview"
+    assert result["file"] == {"id": "folder-1", "name": "Project"}
+    assert result["to"] == {"id": "new-folder", "name": "Archive"}
+    ancestry_reads = [
+        params["fileId"]
+        for parts, params, _ in calls
+        if parts[-1] == "get"
+    ]
+    assert ancestry_reads == ["folder-1", "new-folder", "root"]
+    assert not any(parts[-1] == "update" for parts, _, _ in calls)
+
+
+def test_folder_ancestry_cycle_fails_loudly_before_lookup_or_write(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get":
+            items = {
+                "folder-1": {
+                    "id": "folder-1",
+                    "name": "Project",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["old-folder"],
+                },
+                "child-a": {
+                    "id": "child-a",
+                    "name": "Child A",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["child-b"],
+                },
+                "child-b": {
+                    "id": "child-b",
+                    "name": "Child B",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["child-a"],
+                },
+            }
+            return items[params["fileId"]]
+        if parts[-1] == "list":
+            return {"files": []}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="child-a",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="ancestry contains a cycle"):
+        api_module.drive_move(args)
+
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
+def test_folder_ancestry_with_multiple_parents_fails_loudly(api_module):
+    calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        if parts[-1] == "get":
+            assert params is not None
+            items = {
+                "folder-1": {
+                    "id": "folder-1",
+                    "name": "Project",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["old-folder"],
+                },
+                "destination": {
+                    "id": "destination",
+                    "name": "Ambiguous",
+                    "mimeType": FOLDER_MIME,
+                    "parents": ["parent-a", "parent-b"],
+                },
+            }
+            return items[params["fileId"]]
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="destination",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    with pytest.raises(SystemExit, match="ancestry contains multiple parents"):
+        api_module.drive_move(args)
+
+    assert [params["fileId"] for parts, params, _ in calls if parts[-1] == "get"] == [
+        "folder-1",
+        "destination",
+    ]
+    assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+
+
+@pytest.mark.parametrize(
+    ("parent_hops", "should_fail"),
+    [(100, False), (101, True)],
+)
+def test_folder_ancestry_enforces_drive_depth_boundary(
+    api_module, capsys, parent_hops, should_fail
+):
+    calls = []
+    chain = {
+        f"node-{index}": {
+            "id": f"node-{index}",
+            "name": f"Node {index}",
+            "mimeType": FOLDER_MIME,
+            **({"parents": [f"node-{index + 1}"]} if index < parent_hops else {}),
+        }
+        for index in range(parent_hops + 1)
+    }
+    chain["folder-1"] = {
+        "id": "folder-1",
+        "name": "Project",
+        "mimeType": FOLDER_MIME,
+        "parents": ["old-folder"],
+    }
+
+    def fake_gws(parts, *, params=None, body=None):
+        calls.append((parts, params, body))
+        assert params is not None
+        if parts[-1] == "get":
+            return chain[params["fileId"]]
+        if parts[-1] == "list":
+            return {"files": []}
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="folder-1",
+        destination_id="node-0",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    if should_fail:
+        with pytest.raises(SystemExit, match="exceeded the safe traversal limit"):
+            api_module.drive_move(args)
+        assert not any(parts[-1] in {"list", "update"} for parts, _, _ in calls)
+    else:
+        api_module.drive_move(args)
+        assert json.loads(capsys.readouterr().out)["status"] == "preview"
+        assert sum(parts[-1] == "get" for parts, _, _ in calls) == parent_hops + 2
+
+
 def test_cli_exposes_preview_execute_and_cross_drive_flags():
     result = subprocess.run(
         [sys.executable, str(API_PATH), "drive", "move", "--help"],
@@ -377,6 +700,138 @@ def test_cli_exposes_preview_execute_and_cross_drive_flags():
     assert "--to DESTINATION_ID" in result.stdout
     assert "--execute" in result.stdout
     assert "--allow-cross-drive" in result.stdout
+
+
+def test_gws_duplicate_lookup_paginates_and_deduplicates(api_module, capsys):
+    list_calls = []
+
+    def fake_gws(parts, *, params=None, body=None):
+        if parts[-1] == "get" and params["fileId"] == "file-1":
+            return {
+                "id": "file-1",
+                "name": "Report.pdf",
+                "mimeType": "application/pdf",
+                "parents": ["old-folder"],
+            }
+        if parts[-1] == "get" and params["fileId"] == "new-folder":
+            return {
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            }
+        if parts[-1] == "list":
+            list_calls.append(params)
+            if "pageToken" not in params:
+                return {
+                    "files": [
+                        {"id": "file-1", "name": "Report.pdf"},
+                        {"id": "duplicate-1", "name": "Report.pdf"},
+                    ],
+                    "nextPageToken": "page-2",
+                }
+            assert params["pageToken"] == "page-2"
+            return {
+                "files": [
+                    {"id": "duplicate-1", "name": "Report.pdf"},
+                    {"id": "duplicate-2", "name": "Report.pdf"},
+                ],
+            }
+        raise AssertionError((parts, params, body))
+
+    api_module._run_gws = fake_gws
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["duplicateNameWarning"] == [
+        {"id": "duplicate-1", "name": "Report.pdf"},
+        {"id": "duplicate-2", "name": "Report.pdf"},
+    ]
+    assert len(list_calls) == 2
+    assert "pageToken" not in list_calls[0]
+    assert list_calls[1]["pageToken"] == "page-2"
+    assert all("nextPageToken" in call["fields"] for call in list_calls)
+
+
+def test_python_duplicate_lookup_paginates_and_deduplicates(api_module, capsys):
+    api_module._gws_binary = lambda: None
+    list_calls = []
+
+    class Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class Files:
+        def get(self, **params):
+            if params["fileId"] == "file-1":
+                return Request({
+                    "id": "file-1",
+                    "name": "Report.pdf",
+                    "mimeType": "application/pdf",
+                    "parents": ["old-folder"],
+                })
+            return Request({
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            })
+
+        def list(self, **params):
+            list_calls.append(params)
+            if "pageToken" not in params:
+                return Request({
+                    "files": [
+                        {"id": "file-1", "name": "Report.pdf"},
+                        {"id": "duplicate-1", "name": "Report.pdf"},
+                    ],
+                    "nextPageToken": "page-2",
+                })
+            assert params["pageToken"] == "page-2"
+            return Request({
+                "files": [
+                    {"id": "duplicate-1", "name": "Report.pdf"},
+                    {"id": "duplicate-2", "name": "Report.pdf"},
+                ],
+            })
+
+    class Service:
+        def __init__(self):
+            self._files = Files()
+
+        def files(self):
+            return self._files
+
+    service = Service()
+    api_module.build_service = lambda api, version: service
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=False,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["duplicateNameWarning"] == [
+        {"id": "duplicate-1", "name": "Report.pdf"},
+        {"id": "duplicate-2", "name": "Report.pdf"},
+    ]
+    assert len(list_calls) == 2
+    assert "pageToken" not in list_calls[0]
+    assert list_calls[1]["pageToken"] == "page-2"
+    assert all("nextPageToken" in call["fields"] for call in list_calls)
 
 
 def test_python_client_fallback_executes_and_verifies(api_module, capsys):
@@ -444,6 +899,70 @@ def test_python_client_fallback_executes_and_verifies(api_module, capsys):
     assert update["removeParents"] == "old-folder"
     assert update["supportsAllDrives"] is True
     assert source_reads == 2
+
+
+def test_python_parentless_source_omits_remove_parents(api_module, capsys):
+    api_module._gws_binary = lambda: None
+    calls = []
+    source_reads = 0
+
+    class Request:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def execute(self):
+            return self.payload
+
+    class Files:
+        def get(self, **params):
+            nonlocal source_reads
+            if params["fileId"] == "file-1":
+                source_reads += 1
+                return Request({
+                    "id": "file-1",
+                    "name": "Report.pdf",
+                    "mimeType": "application/pdf",
+                    **({} if source_reads == 1 else {"parents": ["new-folder"]}),
+                })
+            return Request({
+                "id": "new-folder",
+                "name": "Archive",
+                "mimeType": FOLDER_MIME,
+                "parents": ["root"],
+            })
+
+        def list(self, **params):
+            return Request({"files": []})
+
+        def update(self, **params):
+            calls.append(params)
+            return Request({"id": "file-1", "parents": ["new-folder"]})
+
+    class Service:
+        def __init__(self):
+            self._files = Files()
+
+        def files(self):
+            return self._files
+
+    service = Service()
+    api_module.build_service = lambda api, version: service
+    args = argparse.Namespace(
+        file_id="file-1",
+        destination_id="new-folder",
+        execute=True,
+        allow_cross_drive=False,
+    )
+
+    api_module.drive_move(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["verified"] is True
+    assert result["from"] is None
+    assert result["rollback"] is None
+    assert len(calls) == 1
+    assert "removeParents" not in calls[0]
+    assert calls[0]["addParents"] == "new-folder"
 
 
 def test_execute_fails_loudly_when_parent_readback_disagrees(api_module):


### PR DESCRIPTION
## Summary

- add `drive move FILE_ID --to FOLDER_ID` to the bundled Google Workspace CLI
- default to a read-only preview; require `--execute` for the parent update
- validate the destination, fully enumerate duplicate-name warnings, and require a separate cross-drive override
- reject ambiguous multi-parent state and folder-descendant cycles before mutation
- omit `removeParents` for parentless items, then read the file back before reporting `verified: true`
- preserve the original parent as rollback metadata and support both `gws` and Python-client paths

## Safety contract

- preview performs no `files.update`
- same-folder requests are verified no-ops
- self-moves, folder-descendant moves, multi-parent state, and non-folder destinations fail before mutation
- My Drive/shared-drive boundary moves require `--allow-cross-drive`
- execution uses one `addParents`/conditional `removeParents` update with `supportsAllDrives=true`
- duplicate-name warnings paginate all result pages and never block the move
- tests use fakes only and make no live Google calls

## Verification

- `scripts/run_tests.sh tests/skills/test_google_workspace_drive_move_skill.py tests/skills/test_google_workspace_api.py -q` — 26 passed
- `scripts/run_tests.sh tests/skills/ -q` — 1,632 passed
- `ruff check skills/productivity/google-workspace/scripts/google_api.py tests/skills/test_google_workspace_drive_move_skill.py` — passed
- Python compile and CLI help checks — passed
- disposable live Drive proof outside CI on the original implementation: preview non-writing, move readback verified, rollback readback verified, all test artifacts permanently deleted
