### PR TITLE
fix(approval): make the temp-artifact rm exemption reachable on Windows

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -99,15 +99,25 @@ class TestDetectDangerousRm:
             assert "delete" in desc.lower()
 
 
-    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self, tmp_path):
+        # Build the operand from a real directory rather than a hardcoded
+        # "/tmp": on Windows there is no /tmp (realpath("/tmp") is "C:\\tmp")
+        # and on macOS /tmp is a symlink to /private/tmp, so a literal operand
+        # can never equal the canonical temp dir the exemption compares
+        # against (#70797, #95456).
+        temp_dir = os.path.realpath(tmp_path)
+        with mock_patch("tempfile.gettempdir", return_value=temp_dir):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                operand = os.path.join(temp_dir, f"{prefix}example.py")
+                assert detect_dangerous_command(f"rm -f {operand}") == (
                     False,
                     None,
                     None,
                 )
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="creating a directory symlink needs elevation on Windows"
+    )
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"
         real_temp.mkdir()
@@ -122,6 +132,21 @@ class TestDetectDangerousRm:
                 None,
                 None,
             )
+
+    def test_temp_exemption_matches_native_separator_and_case(self, tmp_path):
+        # Regression for #95456. Assert on the helper directly rather than on
+        # detect_dangerous_command: a mangled operand also fails to match the
+        # dangerous-rm patterns, so the outer call returns False either way
+        # and would pass even while the exemption is broken.
+        temp_dir = os.path.realpath(tmp_path)
+        basename = "hermes-verify-example.py"
+        native = os.path.join(temp_dir, basename)
+        slashed = native.replace(os.sep, "/")
+
+        with mock_patch("tempfile.gettempdir", return_value=temp_dir):
+            assert approval_module._is_verification_artifact_cleanup(f"rm -f {native}") is True
+            assert approval_module._is_verification_artifact_cleanup(f"rm -f {slashed}") is True
+            assert detect_dangerous_command(f"rm -f {native}") == (False, None, None)
 
     def test_verification_cleanup_exemption_rejects_broader_deletions(self):
         commands = (

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2452,18 +2452,38 @@ def _command_detection_variants(command: str):
 def _is_verification_artifact_cleanup(command: str) -> bool:
     """Return whether *command* only removes one Hermes ad-hoc temp script."""
     try:
-        argv = shlex.split(command, posix=True)
+        # posix=True treats backslash as an escape character, which destroys
+        # native Windows paths ("C:\\Users\\..." -> "C:Users..."), so the
+        # operand could never match the temp dir there (#95456).
+        argv = shlex.split(command, posix=(os.name != "nt"))
     except ValueError:
         return False
     if len(argv) != 3 or argv[0] != "rm" or argv[1] != "-f":
         return False
 
+    # Windows shlex keeps the surrounding quotes; POSIX mode already removed them.
     operand = argv[2]
+    if os.name == "nt" and len(operand) >= 2 and operand[0] == operand[-1] and operand[0] in "\"'":
+        operand = operand[1:-1]
+
     temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
-    if operand != os.path.join(temp_dir, basename):
+    # Compare against the literal joined path, NOT a normalised one: keeping
+    # this a raw string comparison is what rejects traversal operands like
+    # "/tmp/nested/../hermes-verify-example.py". Only fold what is unsafe to
+    # compare literally across platforms — separator style and drive-letter
+    # case on Windows. On POSIX normcase() is the identity function, so the
+    # existing behaviour is untouched.
+    expected = os.path.join(temp_dir, basename)
+    if os.name == "nt":
+        matches = os.path.normcase(operand.replace("/", os.sep)) == os.path.normcase(expected)
+    else:
+        matches = operand == expected
+    if not matches:
         return False
 
+    # Canonical-only, fail closed: a symlinked path into the temp dir must not
+    # be exempted even though it resolves there.
     target = os.path.realpath(operand)
     if os.path.dirname(target) != temp_dir:
         return False


### PR DESCRIPTION
Fixes #95456. Refs #70797.

`_is_verification_artifact_cleanup()` (`tools/approval.py`) can never match a real Windows temp path, so the verifier's own cleanup command is never exempted there. Two independent causes, either sufficient on its own:

**1. `shlex.split(..., posix=True)` eats backslashes.** In POSIX mode `\` is an escape character:

```console
cmd    = rm -f C:\Users\Administrator\AppData\Local\Temp\hermes-verify-example.py
argv   = ['rm', '-f', 'C:UsersAdministratorAppDataLocalTemphermes-verify-example.py']
```

**2. Separator mismatch.** Forward slashes survive shlex, but the operand was compared literally against `os.path.join(temp_dir, basename)`, which builds with `\` on Windows:

```console
operand = 'C:/Users/.../Temp/hermes-verify-example.py'
joined  = 'C:\\Users\\...\\Temp\\hermes-verify-example.py'
False
```

## The fix

Parse with `posix=(os.name != "nt")`, and on Windows only fold separator style and drive-letter case before comparing.

The comparison deliberately stays a **string equality against the joined path** rather than a normalised or `abspath`'d form. My first draft used `os.path.abspath()` and it broke `test_verification_cleanup_exemption_rejects_broader_deletions` by silently normalising traversal away:

```console
AssertionError: rm -f /tmp/nested/../hermes-verify-example.py
assert False is True
```

That is the whole point of the literal comparison, so the final version keeps it. The canonical-only contract is unchanged — a symlinked path into the temp dir is still refused — and on POSIX `normcase()` is the identity function, so behaviour there is byte-for-byte identical.

## Verification

```console
$ python -m pytest tests/tools/test_approval.py -q
108 passed, 1 skipped in 6.30s      # was: 2 failed, 106 passed
```

RED/GREEN on the new regression test, same test file against both trees:

```console
# new test + old approval.py
FAILED tests/tools/test_approval.py::TestDetectDangerousRm::test_temp_exemption_matches_native_separator_and_case
1 failed, 107 passed, 1 skipped

# new test + patched approval.py
108 passed, 1 skipped
```

Behaviour against the real `%TEMP%`, exemption matching and still fail-closed:

```console
backslash (native): exemption=True   detect=(False, None, None)
forward slash     : exemption=True   detect=(False, None, None)
ad-hoc prefix     : exemption=True   detect=(False, None, None)

traversal         : exemption=False  rejected
traversal (fwd)   : exemption=False  rejected
glob              : exemption=False  rejected
two operands      : exemption=False  rejected
rm -rf            : exemption=False  rejected
non-matching name : exemption=False  rejected
```

`scripts/check-windows-footguns.py --diff origin/main` → clean, exit 0.

## Test changes

- `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` — build the operand from a real temp dir instead of a hardcoded `/tmp`. This is the same defect #70797 reports on macOS (`/tmp` → `/private/tmp`); on Windows there is no `/tmp` at all, so `realpath("/tmp")` is `C:\tmp`. This should make #76742 unnecessary, though that patch fixes the macOS half fine if it lands first — I am happy to rebase onto it either way.
- `test_symlinked_temp_dir_only_exempts_canonical_target` — skipped on Windows, where creating a directory symlink requires elevation. The property it pins is unchanged on POSIX.
- New `test_temp_exemption_matches_native_separator_and_case` asserts on `_is_verification_artifact_cleanup()` **directly**, not through `detect_dangerous_command()`. That indirection is a trap worth naming: a mangled operand also misses the dangerous-rm patterns, so the outer call returns `(False, None, None)` either way and the assertion passes while the exemption is still broken. It is the same reason a green Windows run after #76742 would not prove this fixed.

## Note on CI

Fork CI has not started on this PR (0 checks — first-time-contributor approval gate, not a failing gate). Everything above is local, on Windows 11 / Python 3.11, against `origin/main@1fe0f2f3a`.

I did not want to guess at the intended contract, so I kept the change as narrow as possible — happy to take it in a different direction if you would rather normalise elsewhere.
