### PR TITLE
fix(terminal): isolate execution lineage from shared snapshots

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -34,6 +34,17 @@ _NON_DISPATCHER_OWNED_CONTEXT: ContextVar[bool] = ContextVar(
 
 DELEGATED_CHILD_ENV_MARKER = "HERMES_DELEGATED_CHILD_CONTEXT"
 
+# Env markers SCOPED to a lifetime shorter than a terminal snapshot
+# (delegation child, cron session bridge). Whatever injects these into
+# subprocess envs must keep this tuple authoritative: the terminal-snapshot
+# unset command (tools/environments/base.py) is BUILT from it, so a future
+# marker added here is excluded from snapshots automatically instead of
+# reproducing the #90782 persistence leak per-incident.
+SCOPED_SUBPROCESS_ENV_MARKERS: tuple[str, ...] = (
+    DELEGATED_CHILD_ENV_MARKER,
+    "HERMES_CRON_SESSION",
+)
+
 KANBAN_ENV_KEYS: tuple[str, ...] = (
     "HERMES_KANBAN_TASK",
     "HERMES_KANBAN_RUN_ID",

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -107,3 +107,47 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# #90782: scope-limited markers must not persist into the snapshot either.
+# ---------------------------------------------------------------------------
+
+def test_export_snippet_unsets_delegation_and_cron_session_markers():
+    """The delegate_task child marker and the cron session bridge are
+    injected into the SUBPROCESS env while their scope is live; a snapshot
+    captured in that window must not persist them past the scope — otherwise
+    every later ``source`` re-asserts them (e.g. locking kanban mutations
+    out of the parent session)."""
+    snippet = _export_dump_excluding_session_vars('"$__hermes_snap_tmp"')
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
+    assert "HERMES_CRON_SESSION" in snippet
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_snapshot_does_not_persist_delegated_child_marker(tmp_path):
+    """End-to-end: a command run with the delegated-child marker in its env
+    must not leave that marker in the snapshot file."""
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    env.init_session()
+    try:
+        os.environ["HERMES_DELEGATED_CHILD_CONTEXT"] = "1"
+        try:
+            res = env.execute("echo marker-captured")
+        finally:
+            del os.environ["HERMES_DELEGATED_CHILD_CONTEXT"]
+        assert "marker-captured" in res.get("output", "")
+
+        snap = env._snapshot_path
+        if os.path.exists(snap):
+            with open(snap) as f:
+                content = f.read()
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in content, (
+                "the delegated-child marker leaked into the terminal "
+                "snapshot — later commands would inherit it and kanban "
+                "mutations would stay locked out of the parent (#90782)"
+            )
+    finally:
+        env.cleanup()

--- a/tests/tools/test_terminal_lineage_snapshot_isolation.py
+++ b/tests/tools/test_terminal_lineage_snapshot_isolation.py
@@ -19,6 +19,7 @@ from agent.delegation_context import (
     SCOPED_SUBPROCESS_ENV_MARKERS,
     delegated_child_context,
 )
+from gateway.session_context import _CRON_SESSION
 from tools.environments.local import LocalEnvironment
 
 
@@ -120,7 +121,7 @@ def test_current_lineage_wins_over_preexisting_poisoned_snapshot(
 ):
     """Per-call identity must survive while stale snapshot identity is discarded."""
     _clear_lineage_env(monkeypatch)
-    monkeypatch.setenv("HERMES_CRON_SESSION", "current-cron-session")
+    cron_token = _CRON_SESSION.set("current-cron-session")
     monkeypatch.setenv("HERMES_KANBAN_TASK", "current-parent-task")
 
     env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
@@ -144,4 +145,5 @@ def test_current_lineage_wins_over_preexisting_poisoned_snapshot(
         assert observed["HERMES_KANBAN_TASK"] == "current-parent-task"
         _assert_snapshot_has_no_lineage(env)
     finally:
+        _CRON_SESSION.reset(cron_token)
         env.cleanup()

--- a/tests/tools/test_terminal_lineage_snapshot_isolation.py
+++ b/tests/tools/test_terminal_lineage_snapshot_isolation.py
@@ -1,0 +1,147 @@
+"""Execution-lineage isolation for shared terminal shell snapshots.
+
+Parent agents and delegate_task children intentionally share an execution
+backend. The shell snapshot may preserve user state across calls, but it must
+never own delegated-child or dispatcher identity.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    KANBAN_ENV_KEYS,
+    SCOPED_SUBPROCESS_ENV_MARKERS,
+    delegated_child_context,
+)
+from tools.environments.local import LocalEnvironment
+
+
+LINEAGE_ENV_KEYS = tuple(sorted({*SCOPED_SUBPROCESS_ENV_MARKERS, *KANBAN_ENV_KEYS}))
+
+
+def _probe(env: LocalEnvironment) -> dict[str, str | None]:
+    code = (
+        "import json, os; "
+        f"print(json.dumps({{key: os.environ.get(key) for key in {LINEAGE_ENV_KEYS!r}}}, "
+        "sort_keys=True))"
+    )
+    result = env.execute(
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}",
+        timeout=15,
+    )
+    assert result["returncode"] == 0, result
+    return json.loads(result["output"].strip())
+
+
+def _clear_lineage_env(monkeypatch) -> None:
+    for name in LINEAGE_ENV_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _assert_snapshot_has_no_lineage(env: LocalEnvironment) -> None:
+    snapshot = Path(env._snapshot_path).read_text(encoding="utf-8")
+    for name in LINEAGE_ENV_KEYS:
+        assert name not in snapshot
+
+
+def test_parent_child_parent_calls_keep_lineage_out_of_shared_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    """A valid child call must not poison the next root terminal command."""
+    _clear_lineage_env(monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "parent-task-sentinel")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "parent-board-sentinel")
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        # init_session itself runs with the parent worker env, but lineage must
+        # not enter the initial snapshot.
+        _assert_snapshot_has_no_lineage(env)
+
+        root_before = _probe(env)
+        with delegated_child_context():
+            child = _probe(env)
+        root_after = _probe(env)
+
+        assert root_before[DELEGATED_CHILD_ENV_MARKER] is None
+        assert root_before["HERMES_KANBAN_TASK"] == "parent-task-sentinel"
+        assert root_before["HERMES_KANBAN_BOARD"] == "parent-board-sentinel"
+
+        assert child[DELEGATED_CHILD_ENV_MARKER] == "1"
+        for name in KANBAN_ENV_KEYS:
+            assert child[name] is None
+
+        assert root_after == root_before
+        _assert_snapshot_has_no_lineage(env)
+    finally:
+        env.cleanup()
+
+
+def test_preexisting_poisoned_snapshot_is_neutralized_and_cleaned(
+    monkeypatch,
+    tmp_path,
+):
+    """The first command after upgrade must self-heal an old bad snapshot."""
+    _clear_lineage_env(monkeypatch)
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        Path(env._snapshot_path).write_text(
+            '\n'.join(
+                [
+                    'declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"',
+                    'declare -x HERMES_CRON_SESSION="stale-cron-session"',
+                    'declare -x HERMES_KANBAN_TASK="stale-parent-task"',
+                    'declare -x HERMES_KANBAN_BOARD="stale-parent-board"',
+                    '',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        observed = _probe(env)
+
+        assert all(observed[name] is None for name in LINEAGE_ENV_KEYS)
+        _assert_snapshot_has_no_lineage(env)
+    finally:
+        env.cleanup()
+
+
+def test_current_lineage_wins_over_preexisting_poisoned_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    """Per-call identity must survive while stale snapshot identity is discarded."""
+    _clear_lineage_env(monkeypatch)
+    monkeypatch.setenv("HERMES_CRON_SESSION", "current-cron-session")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "current-parent-task")
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        Path(env._snapshot_path).write_text(
+            '\n'.join(
+                [
+                    'declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"',
+                    'declare -x HERMES_CRON_SESSION="stale-cron-session"',
+                    'declare -x HERMES_KANBAN_TASK="stale-parent-task"',
+                    '',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        observed = _probe(env)
+
+        assert observed[DELEGATED_CHILD_ENV_MARKER] is None
+        assert observed["HERMES_CRON_SESSION"] == "current-cron-session"
+        assert observed["HERMES_KANBAN_TASK"] == "current-parent-task"
+        _assert_snapshot_has_no_lineage(env)
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -613,6 +613,8 @@ def _export_dump_excluding_session_vars(
     ``mv``. The brace-group redirect is expanded in the current shell,
     keeping both expansions consistent.
     """
+    from agent.delegation_context import SCOPED_SUBPROCESS_ENV_MARKERS
+
     # ${!PREFIX*} is bash 3.2+ name-prefix expansion; empty matches are fine
     # because ``unset`` with only missing names is ignored under 2>/dev/null.
     # Quote caller-provided names so malformed configuration can never become
@@ -635,14 +637,14 @@ def _export_dump_excluding_session_vars(
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
         "AI_AGENT HERMES_AGENT "
-        # HERMES_DELEGATED_CHILD_CONTEXT is scoped to the delegate_task
-        # child's lifetime by the ContextVar, but scrub_kanban_env()
-        # injects it into the SUBPROCESS env — if a snapshot is captured
-        # while that child runs, the marker outlives the child and every
-        # later `source` re-asserts it, locking kanban mutations out of
-        # the PARENT session (#90782).  HERMES_CRON_SESSION is the same
-        # shape: a per-scope bridge that must not persist.
-        "HERMES_DELEGATED_CHILD_CONTEXT HERMES_CRON_SESSION "
+        # Scoped subprocess markers (delegation child, cron session bridge):
+        # injected into subprocess envs by scrub_kanban_env()/cron bridging,
+        # excluded here by construction. The unset list is BUILT from
+        # SCOPED_SUBPROCESS_ENV_MARKERS so a marker added at the injection
+        # side is excluded automatically — persisting one would make every
+        # later `source` re-assert it (#90782's leak class, closed
+        # structurally rather than per-incident).
+        f"{' '.join(SCOPED_SUBPROCESS_ENV_MARKERS)} "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -635,6 +635,14 @@ def _export_dump_excluding_session_vars(
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
         "AI_AGENT HERMES_AGENT "
+        # HERMES_DELEGATED_CHILD_CONTEXT is scoped to the delegate_task
+        # child's lifetime by the ContextVar, but scrub_kanban_env()
+        # injects it into the SUBPROCESS env — if a snapshot is captured
+        # while that child runs, the marker outlives the child and every
+        # later `source` re-asserts it, locking kanban mutations out of
+        # the PARENT session (#90782).  HERMES_CRON_SESSION is the same
+        # shape: a per-scope bridge that must not persist.
+        "HERMES_DELEGATED_CHILD_CONTEXT HERMES_CRON_SESSION "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -563,19 +563,19 @@ def _cwd_marker(session_id: str) -> str:
     return f"__HERMES_CWD_{session_id}__"
 
 
-# Per-session variables that the gateway bridges freshly onto every command's
-# process environment (via tools/environments/local._inject_session_context_env,
-# reading gateway.session_context._VAR_MAP). They must NEVER be persisted into
-# the shared bash session snapshot: a single long-lived backend serves many
-# concurrent sessions (the messaging gateway, TUI, desktop/web dashboard all
-# collapse the terminal to one "default" environment), so ``export -p`` dumping
-# the FIRST session's HERMES_SESSION_ID into the snapshot makes every LATER
-# session ``source`` that stale value and see a FOREIGN session's identity —
-# overriding the correct per-command Popen env (issue: cross-session
-# HERMES_SESSION_ID leak via the shared snapshot). Stripping them from the
-# snapshot is safe because they are re-injected on every command; a snapshot
-# should only carry the user's own shell state (PATH, functions, exports they
-# set), not Hermes' per-turn session identity.
+# Runtime-scoped identity variables must NEVER persist into the shared bash
+# session snapshot. A single long-lived backend can serve many concurrent
+# sessions and delegated children (the gateway, TUI, desktop/web dashboard, and
+# delegate_task all collapse the terminal to one "default" environment). If an
+# identity value is dumped by one command, the next command sources the stale
+# value *after* its correct per-call Popen environment was built.
+#
+# Prefix-owned gateway/cron variables are removed directly by the shell dump
+# helper. Explicit scoped subprocess and Kanban lineage names come from
+# agent.delegation_context via ``_snapshot_runtime_scoped_names`` below so the
+# terminal snapshot contract stays aligned with the mutation trust boundary.
+# A snapshot should carry the user's shell state (PATH, functions, exports),
+# never Hermes' per-turn execution identity.
 #
 # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
 # with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
@@ -586,6 +586,23 @@ _SNAPSHOT_EXCLUDED_ENV_REGEX = (
     "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _snapshot_runtime_scoped_names() -> tuple[str, ...]:
+    """Return explicit execution-identity names that snapshots must not own.
+
+    These values are injected or scrubbed for every subprocess according to
+    the current Python ContextVar / dispatcher process. Parent and delegated
+    child terminal calls intentionally share an execution backend, so snapshot
+    persistence would turn a valid child marker into sticky parent state and
+    could reintroduce dispatcher identity after the child env was scrubbed.
+    """
+    from agent.delegation_context import (
+        KANBAN_ENV_KEYS,
+        SCOPED_SUBPROCESS_ENV_MARKERS,
+    )
+
+    return tuple(sorted({*SCOPED_SUBPROCESS_ENV_MARKERS, *KANBAN_ENV_KEYS}))
 
 
 def _export_dump_excluding_session_vars(
@@ -764,6 +781,13 @@ class BaseEnvironment(ABC):
             )
         return tuple(sorted(self._snapshot_passthrough_names))
 
+    def _snapshot_excluded_names(self) -> tuple[str, ...]:
+        """Return all explicit names saved around and excluded from snapshots."""
+        return tuple(sorted({
+            *self._snapshot_excluded_passthrough_names(),
+            *_snapshot_runtime_scoped_names(),
+        }))
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
@@ -810,7 +834,7 @@ class BaseEnvironment(ABC):
         # every later expansion is consistent.
         _snap_tmp_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXXXXXX")
         _snap_tmp = '"$__hermes_snap_tmp"'
-        snapshot_excluded = self._snapshot_excluded_passthrough_names()
+        snapshot_excluded = self._snapshot_excluded_names()
         bootstrap = (
             f"umask 077\n"
             f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) || exit 1\n"
@@ -931,7 +955,7 @@ class BaseEnvironment(ABC):
         _snap_tmp = '"$__hermes_snap_tmp"'
 
         parts = []
-        passthrough_names = self._snapshot_excluded_passthrough_names()
+        snapshot_excluded = self._snapshot_excluded_names()
 
         # A shared snapshot may contain the previous profile's value. Save
         # the current process environment before sourcing it, then restore the
@@ -939,8 +963,8 @@ class BaseEnvironment(ABC):
         # Values stay in environment memory and never enter the shell command
         # string, so secrets are not exposed through process arguments/logs.
         saved_names: list[tuple[str, str, str]] = []
-        for name in passthrough_names:
-            marker = f"_HERMES_RUNTIME_PASSTHROUGH_{name}"
+        for name in snapshot_excluded:
+            marker = f"_HERMES_RUNTIME_SNAPSHOT_{name}"
             present = f"{marker}_PRESENT"
             value = f"{marker}_VALUE"
             saved_names.append((name, present, value))
@@ -1006,7 +1030,7 @@ class BaseEnvironment(ABC):
         if self._snapshot_ready:
             parts.append(
                 f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) && "
-                f"{{ {_export_dump_excluding_session_vars(_snap_tmp, passthrough_names)} "
+                f"{{ {_export_dump_excluding_session_vars(_snap_tmp, snapshot_excluded)} "
                 f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )


### PR DESCRIPTION
## Problem

Delegated children and their parent intentionally share a persistent terminal backend. The shell snapshot could therefore outlive the execution scope that owned `HERMES_DELEGATED_CHILD_CONTEXT`, `HERMES_CRON_SESSION`, or `HERMES_KANBAN_*` identity.

A stale snapshot could reintroduce parent Kanban identity into a delegated child, persist child lineage into a later parent command, or keep an already-poisoned legacy snapshot effective for one more command.


## Approach

- treat the canonical scoped subprocess markers plus `KANBAN_ENV_KEYS` as runtime lineage that snapshots must never own;
- capture the current command's lineage before sourcing the shared snapshot;
- restore the current per-call value, or explicitly unset the variable, after sourcing;
- exclude lineage variables from both initial and rewritten snapshots;
- model cron identity through the current ContextVar-authoritative session seam.

This preserves legitimate per-call identity while making poisoned snapshots self-heal before the first user command observes stale state.

## Provenance

This PR preserves the authorship of the two commits originating from #90786 and adds the complete lineage-isolation fix on top.

## Verification

- **43 affected tests passed** on current upstream `main`;
- coverage includes snapshot leakage, multiline session injection, terminal env bridge/config sync, local session isolation, delegated Kanban isolation, and poisoned-snapshot recovery;
- Ruff passed for all changed Python files;
- `git diff --check` clean.

## Scope

Terminal snapshot construction, lineage constants, and regression tests only. No live deployment, config change, gateway restart, or snapshot deletion.