### PR TITLE
fix(delegation): add scoped fallback chains for pinned subagents

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1531,6 +1531,9 @@ delegation:
   #                                           # delegation.model to an inexpensive one — children carry the
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1991,6 +1991,9 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "fallback_providers": None,  # fallback chain for delegated children, same entry
+                           # format as the top-level fallback_providers list. null =
+                           # inherit the parent agent's chain; [] = disable child fallback.
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1836,7 +1836,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,
@@ -1857,7 +1860,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         parent._fallback_chain = []
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -9,6 +9,7 @@ pin+declared-chain composition cell raised in the #80450 cross-PR map.
 import unittest
 from unittest.mock import MagicMock, patch
 
+import hermes_cli.config as hermes_config
 from tools.delegate_tool import _build_child_agent, _resolve_child_fallback_chain
 from tests.tools.test_delegate import _make_mock_parent
 
@@ -198,6 +199,49 @@ class TestBuildChildAgentWiring(unittest.TestCase):
     def test_default_inheritance_preserved(self):
         kwargs = self._spawn(_parent(list(PARENT_CHAIN)), {})
         self.assertEqual(kwargs["fallback_model"], PARENT_CHAIN)
+
+
+def test_real_config_loader_wires_declared_chain_into_pinned_child(tmp_path, monkeypatch):
+    """Exercise config.yaml -> _load_config() -> _build_child_agent without
+    mocking the configuration seam.  A pinned child must receive its explicit
+    delegation-scoped fallback rather than the parent's unrelated chain."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "delegation:\n"
+        "  provider: zai\n"
+        "  model: glm-5.3\n"
+        "  fallback_providers:\n"
+        "    - provider: kimi-coding\n"
+        "      model: k3-256k\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_config._LOAD_CONFIG_CACHE.clear()
+
+    parent = _parent(list(PARENT_CHAIN))
+    try:
+        with patch("run_agent.AIAgent") as mock_agent:
+            mock_agent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="real config fallback wiring",
+                context=None,
+                toolsets=None,
+                model="glm-5.3",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="zai",
+                override_base_url="https://api.z.ai/api/coding/paas/v4",
+                override_api_key="zai-key",
+            )
+        chain = mock_agent.call_args.kwargs["fallback_model"]
+        assert [(entry["provider"], entry["model"]) for entry in chain] == [
+            ("kimi-coding", "k3-256k")
+        ]
+    finally:
+        hermes_config._LOAD_CONFIG_CACHE.clear()
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -130,6 +130,7 @@ class TestBuildChildAgentWiring(unittest.TestCase):
     """End-to-end through _build_child_agent: the resolver is actually wired."""
 
     def _spawn(self, parent, cfg, **overrides):
+        model = overrides.pop("model", None)
         with (
             patch("tools.delegate_tool._load_config", return_value=cfg),
             patch("run_agent.AIAgent") as MockAgent,
@@ -140,7 +141,7 @@ class TestBuildChildAgentWiring(unittest.TestCase):
                 goal="matrix wiring",
                 context=None,
                 toolsets=None,
-                model=None,
+                model=model,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -170,6 +171,25 @@ class TestBuildChildAgentWiring(unittest.TestCase):
             override_provider="deepseek",
             override_base_url="https://api.deepseek.example/v1",
             override_api_key="sk-ds",
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_model_only_pin_gets_no_parent_chain(self):
+        """The model arm of #80450: delegation.model without delegation.provider
+        must not inherit the parent chain — a mid-run failure would silently
+        swap the pinned model."""
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)), {}, model="deepseek-chat",
+        )
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_model_only_pin_with_declared_chain_uses_declared(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            model="deepseek-chat",
         )
         providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
         self.assertIn("deepseek", providers)

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -1,0 +1,184 @@
+"""Full decision matrix for _resolve_child_fallback_chain (#80450 class).
+
+Composes the pin semantics of PR #80465 (@teknium1), the
+delegation.fallback_providers semantics of PRs #80438 (@wz-heng) /
+#80421 (@andrexibiza) for issue #65038 (@mlahatte), and settles the
+pin+declared-chain composition cell raised in the #80450 cross-PR map.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _build_child_agent, _resolve_child_fallback_chain
+from tests.tools.test_delegate import _make_mock_parent
+
+PARENT_CHAIN = [
+    {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-parent"}
+]
+DECLARED_CHAIN = [
+    {"provider": "deepseek", "model": "deepseek-chat", "api_key": "sk-ds-child"}
+]
+
+
+def _parent(chain=None):
+    parent = _make_mock_parent(depth=0)
+    parent._fallback_chain = chain
+    return parent
+
+
+class TestResolveChildFallbackChainMatrix(unittest.TestCase):
+    """All six cells of the pin x declared-chain matrix."""
+
+    # pin=yes ------------------------------------------------------------
+
+    def test_pin_declared_nonempty_uses_declared_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            pinned=True,
+        )
+        providers = {e.get("provider") for e in (chain or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_pin_declared_empty_disables_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {"fallback_providers": []}, pinned=True
+        )
+        self.assertIsNone(chain)
+
+    def test_pin_absent_gets_no_chain(self):
+        """#80450: a pinned child must fail loudly, not silently reroute."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {}, pinned=True
+        )
+        self.assertIsNone(chain)
+
+    # pin=no -------------------------------------------------------------
+
+    def test_unpinned_declared_nonempty_uses_declared_chain(self):
+        """#65038: delegation.fallback_providers reaches the child."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            pinned=False,
+        )
+        providers = {e.get("provider") for e in (chain or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_unpinned_declared_empty_disables_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {"fallback_providers": []}, pinned=False
+        )
+        self.assertIsNone(chain)
+
+    def test_unpinned_absent_inherits_parent_chain(self):
+        """Historical default is preserved exactly."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {}, pinned=False
+        )
+        self.assertEqual(chain, PARENT_CHAIN)
+
+    # edges ----------------------------------------------------------------
+
+    def test_unpinned_absent_with_empty_parent_chain_is_none(self):
+        self.assertIsNone(_resolve_child_fallback_chain(_parent([]), {}, pinned=False))
+
+    def test_declared_chain_is_normalized_and_deduped(self):
+        """Entries route through the canonical get_fallback_chain normalizer."""
+        chain = _resolve_child_fallback_chain(
+            _parent(None),
+            {"fallback_providers": list(DECLARED_CHAIN) + list(DECLARED_CHAIN)},
+            pinned=False,
+        )
+        routes = [(e.get("provider"), e.get("model")) for e in (chain or [])]
+        self.assertEqual(len(routes), len(set(routes)))
+
+    def test_malformed_declared_value_pin_aware_fallback(self):
+        """Malformed config logs and falls back pin-aware: None when pinned
+        (never reintroduce the silent drag through the error path), parent
+        chain otherwise — extends #80421's log-and-inherit contract."""
+        with patch(
+            "hermes_cli.fallback_config.get_fallback_chain",
+            side_effect=TypeError("boom"),
+        ):
+            self.assertIsNone(
+                _resolve_child_fallback_chain(
+                    _parent(list(PARENT_CHAIN)),
+                    {"fallback_providers": "not-a-list"},
+                    pinned=True,
+                )
+            )
+            self.assertEqual(
+                _resolve_child_fallback_chain(
+                    _parent(list(PARENT_CHAIN)),
+                    {"fallback_providers": "not-a-list"},
+                    pinned=False,
+                ),
+                PARENT_CHAIN,
+            )
+
+    def test_non_dict_config_uses_default(self):
+        self.assertEqual(
+            _resolve_child_fallback_chain(_parent(list(PARENT_CHAIN)), None, pinned=False),
+            PARENT_CHAIN,
+        )
+
+
+class TestBuildChildAgentWiring(unittest.TestCase):
+    """End-to-end through _build_child_agent: the resolver is actually wired."""
+
+    def _spawn(self, parent, cfg, **overrides):
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="matrix wiring",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                **overrides,
+            )
+        return MockAgent.call_args[1]
+
+    def test_pinned_child_gets_no_parent_chain(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)), {}, override_provider="minimax",
+            override_base_url="https://api.minimax.example/v1", override_api_key="sk-mm",
+        )
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_configured_delegation_chain_reaches_child(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+
+    def test_pin_plus_declared_chain_uses_declared(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            override_provider="deepseek",
+            override_base_url="https://api.deepseek.example/v1",
+            override_api_key="sk-ds",
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_default_inheritance_preserved(self):
+        kwargs = self._spawn(_parent(list(PARENT_CHAIN)), {})
+        self.assertEqual(kwargs["fallback_model"], PARENT_CHAIN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1603,6 +1603,58 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _resolve_child_fallback_chain(parent_agent, delegation_cfg, pinned):
+    """Decide which fallback chain a delegated child gets — the full matrix.
+
+    ============ ======================= =========================================
+    pin          delegation.             result
+    (provider)   fallback_providers
+    ============ ======================= =========================================
+    yes          declared, non-empty     declared chain (delegation-scoped recovery)
+    yes          declared, empty []      None — explicit disable
+    yes          absent                  None — pin fails loudly (#80450)
+    no           declared, non-empty     declared chain (#65038)
+    no           declared, empty []      None — explicit disable
+    no           absent                  inherit parent chain (historical default)
+    ============ ======================= =========================================
+
+    Rationale for the pin+declared cell: the silent-drag problem in #80450 is
+    specifically the *parent's* chain substituting a pinned provider with no
+    surfaced signal. A chain declared under ``delegation.*`` is scoped to
+    workers by construction — honoring it respects both explicit intents.
+
+    A malformed declared value logs and falls back to the PIN-AWARE default
+    (None when pinned, parent chain otherwise): falling back to the parent
+    chain on a pinned child would reintroduce the silent drag through the
+    config-error path.
+
+    Entries are normalized through the canonical
+    ``hermes_cli.fallback_config.get_fallback_chain`` so ordering, dedupe,
+    and malformed-entry handling match top-level ``fallback_providers``.
+    """
+    parent_chain = getattr(parent_agent, "_fallback_chain", None) or None
+    default = None if pinned else parent_chain
+    declared = (
+        delegation_cfg.get("fallback_providers")
+        if isinstance(delegation_cfg, dict)
+        else None
+    )
+    if declared is None:
+        return default
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        return get_fallback_chain({"fallback_providers": declared}) or None
+    except Exception as exc:
+        logger.warning(
+            "Ignoring malformed delegation.fallback_providers (%s); "
+            "using %s.",
+            exc,
+            "no chain (provider pinned)" if pinned else "parent chain",
+        )
+        return default
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1869,22 +1921,11 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    #
-    # EXCEPT when the user pinned delegation.provider: an explicit pin means
-    # "children run on THIS provider".  Inheriting the parent chain would let
-    # a mid-run auth/429 failure silently reroute the quiet-mode child onto
-    # the parent's fallback models with no surfaced signal (#80450) — the
-    # same class of silent-drag the override_provider filter-clearing below
-    # already prevents for OpenRouter routing preferences.  Predictability >
-    # liveness for explicit pins: the pinned child fails loudly instead.
-    parent_fallback = (
-        None
-        if override_provider
-        else (getattr(parent_agent, "_fallback_chain", None) or None)
+    # Fallback chain: full decision matrix in _resolve_child_fallback_chain
+    # (#80450 cross-PR map — composes the pin semantics of #80465 with the
+    # delegation.fallback_providers semantics of #80438/#80421).
+    parent_fallback = _resolve_child_fallback_chain(
+        parent_agent, delegation_cfg, pinned=bool(override_provider)
     )
 
     # Inherit the parent's OpenRouter provider-preference filters by default

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1619,9 +1619,12 @@ def _resolve_child_fallback_chain(parent_agent, delegation_cfg, pinned):
     ============ ======================= =========================================
 
     Rationale for the pin+declared cell: the silent-drag problem in #80450 is
-    specifically the *parent's* chain substituting a pinned provider with no
-    surfaced signal. A chain declared under ``delegation.*`` is scoped to
-    workers by construction — honoring it respects both explicit intents.
+    specifically the *parent's* chain substituting a pinned provider or model
+    with no surfaced signal. A chain declared under ``delegation.*`` is scoped
+    to workers by construction — honoring it respects both explicit intents.
+    "Pinned" covers every explicit routing arm of #80450: delegation.provider,
+    delegation.base_url (which resolves to a provider override), and a
+    model-only delegation.model pin.
 
     A malformed declared value logs and falls back to the PIN-AWARE default
     (None when pinned, parent chain otherwise): falling back to the parent
@@ -1924,8 +1927,13 @@ def _build_child_agent(
     # Fallback chain: full decision matrix in _resolve_child_fallback_chain
     # (#80450 cross-PR map — composes the pin semantics of #80465 with the
     # delegation.fallback_providers semantics of #80438/#80421).
+    # Pin = any explicit delegation routing: provider, base_url (which
+    # resolves to a provider override), or a model-only pin — `model` here is
+    # creds["model"], i.e. delegation.model config, at both call sites. A
+    # model-only pin with the parent chain inherited would let a mid-run
+    # failure silently swap the pinned model (the model arm of #80450).
     parent_fallback = _resolve_child_fallback_chain(
-        parent_agent, delegation_cfg, pinned=bool(override_provider)
+        parent_agent, delegation_cfg, pinned=bool(override_provider or model)
     )
 
     # Inherit the parent's OpenRouter provider-preference filters by default

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2502,6 +2502,8 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
+**Subagent fallback chain:** By default, delegated children inherit the parent agent's top-level `fallback_providers` chain. Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list) so a failed worker does not silently escalate onto head-agent fallback models. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely. When the key is absent or `null`, parent-chain inheritance is preserved (#65038).
+
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
 **Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -175,7 +175,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 


### PR DESCRIPTION
## Summary

Add a delegation-scoped fallback chain for pinned subagents.

- resolve fallback behavior through an explicit pin × config matrix;
- treat either `delegation.provider` or `delegation.model` as a pin;
- use declared `delegation.fallback_providers` for pinned children;
- preserve parent-chain inheritance only for unpinned children when the key is absent;
- make explicit `[]` disable fallback;
- fail safely on malformed configuration rather than silently inheriting an incompatible parent chain;
- document the config surface and add matrix plus real-loader regression coverage.


## Incident

A child pinned to a specific provider/model could fail on quota exhaustion even while another configured provider was healthy, because the old path discarded fallback providers whenever the child was explicitly pinned.

## Verification

- **86 affected tests passed** on current upstream `main`;
- fallback coverage includes provider pin, model pin, absent, empty, malformed, normalized, inherited, and real-config-loader paths;
- Ruff passed;
- `git diff --check` clean.

## Scope

Code, tests, config defaults/example, and documentation only. No live deployment, provider/config mutation, gateway reload, or restart.