### PR TITLE
fix(terminal): ignore server package paths in foreground guard

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -79,3 +79,35 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            (
+                "grep -n spec_version "
+                "/workspace/.venv/lib/python3.13/site-packages/uvicorn/"
+                "protocols/http/h11_impl.py"
+            ),
+            "grep -n Arbiter /workspace/.venv/lib/python3.13/site-packages/gunicorn/arbiter.py",
+            r"type C:\workspace\.venv\Lib\site-packages\uvicorn\protocols\http\h11_impl.py",
+            r"type C:\workspace\.venv\Lib\site-packages\gunicorn\arbiter.py",
+        ],
+    )
+    def test_package_paths_are_not_mistaken_for_server_invocations(self, command):
+        assert _foreground_background_guidance(command) is None
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uvicorn app:create_app --factory",
+            "/workspace/.venv/bin/uvicorn app:create_app --factory",
+            r"C:\workspace\.venv\Scripts\uvicorn.exe app:create_app --factory",
+            "python -m uvicorn app:create_app --factory",
+            "gunicorn app:app",
+            "/workspace/.venv/bin/gunicorn app:app",
+        ],
+    )
+    def test_real_server_invocations_still_require_background(self, command):
+        message = _foreground_background_guidance(command)
+        assert message is not None
+        assert "background=true" in message

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2689,8 +2689,12 @@ _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\bnext\s+dev\b", re.IGNORECASE),
     re.compile(r"\bvite(?:\s|$)", re.IGNORECASE),
     re.compile(r"\bnodemon\b", re.IGNORECASE),
-    re.compile(r"\buvicorn\b", re.IGNORECASE),
-    re.compile(r"\bgunicorn\b", re.IGNORECASE),
+    # Package paths such as ``site-packages/uvicorn/protocols/...`` are
+    # arguments, not server invocations. Keep matching bare, module, and
+    # absolute-path executables while rejecting both POSIX and Windows package
+    # directory false positives by requiring no following path separator.
+    re.compile(r"\buvicorn\b(?![/\\])", re.IGNORECASE),
+    re.compile(r"\bgunicorn\b(?![/\\])", re.IGNORECASE),
     re.compile(r"\bpython(?:3)?\s+-m\s+http\.server\b", re.IGNORECASE),
 )
 


### PR DESCRIPTION
## Summary

Prevent the terminal foreground-server guard from treating read-only Python package-path inspection as a Uvicorn/Gunicorn server launch.

- ignore `uvicorn/…` and `gunicorn/…` package-directory segments on POSIX;
- ignore the same package-directory segments with Windows separators;
- preserve blocking for bare executables, absolute-path executables, Windows `.exe` invocations, and `python -m uvicorn`;
- add behavioral coverage for false-positive and positive-control paths.


## Reproduction

This read-only command is currently rejected as a long-lived foreground server:

```text
grep -n spec_version /workspace/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py
```

Real Uvicorn/Gunicorn invocations remain blocked. The defect is classification scope, not the existence of the guard.

## Verification

- **20 affected tests passed** on current upstream `main`;
- regression coverage includes POSIX and Windows package paths plus six real-server positive controls;
- Ruff passed;
- `git diff --check` clean.

## Scope

Two files: the existing foreground-server guidance regex and behavioral tests. No live runtime, configuration, gateway, plugin, or restart change.