### PR TITLE
fix(desktop): switch model after refresh when it leaves the catalog

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -399,4 +399,50 @@ describe('ModelMenuPanel provider collapse', () => {
     expect($collapsedProviders.get()).toContain('google')
     expect($collapsedProviders.get()).toContain('deepseek')
   })
+
+  it('switches the session model when Refresh Models drops the current pick', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        model: 'glm-4.5-air',
+        provider: 'zhipu',
+        providers: [{ models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' }, MOA_PROVIDER]
+      })
+      .mockResolvedValueOnce({
+        model: 'glm-4.5-air',
+        provider: 'zhipu',
+        providers: [DEEPSEEK_PROVIDER, MOA_PROVIDER]
+      })
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findByText(/Glm 4\.5 Air/i)
+
+    fireEvent.click(await content.findByText('Refresh Models'))
+
+    await vi.waitFor(() => {
+      expect(onSelectModel).toHaveBeenCalledWith({
+        model: 'deepseek-v4-pro',
+        provider: 'deepseek',
+        sessionId: 'runtime-1'
+      })
+    })
+  })
+
+  it('does not switch when Refresh Models still lists the current pick', async () => {
+    $currentProvider.set('deepseek')
+    $currentModel.set('deepseek-v4-pro')
+    getGlobalModelOptions.mockResolvedValue({ providers: MOCK_PROVIDERS })
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findByText(/Deepseek V4 Pro/i)
+    fireEvent.click(await content.findByText('Refresh Models'))
+
+    await vi.waitFor(() => {
+      expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
+    })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -7,7 +7,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { DropdownMenuItem, dropdownMenuRow } from '@/components/ui/dropdown-menu'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { modelOptionsQueryKey, reconcileSelectionAfterCatalogRefresh, requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
@@ -105,6 +105,15 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
       })
 
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
+
+      // Group / credential swaps can return a catalog that no longer contains
+      // the session's current model. The store + currentPickerSelection would
+      // otherwise keep painting the stale id (it is not in the new list).
+      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers)
+
+      if (switchTo) {
+        await onSelectModel({ ...switchTo, sessionId: activeSessionId || null })
+      }
     } catch {
       // Network/backend hiccup — fall back to a plain invalidate so the next
       // open re-fetches (still cached, but no worse than before).

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelOptions } from '@/hermes'
 
-import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from './model-options'
+import {
+  firstSelectableCatalogModel,
+  manualPickRemoved,
+  modelOptionsQueryKey,
+  reconcileSelectionAfterCatalogRefresh,
+  requestModelOptions,
+  selectionInCatalog
+} from './model-options'
 
 const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
 
@@ -210,5 +217,37 @@ describe('manualPickRemoved', () => {
 
   it('never clobbers when there is no pick', () => {
     expect(manualPickRemoved(providers, '', '')).toBe(false)
+  })
+})
+
+describe('reconcileSelectionAfterCatalogRefresh', () => {
+  const zhipu = { name: '智谱2', slug: 'zhipu', models: ['glm-4.5-air', 'glm-5-turbo'] }
+  const bytea = {
+    name: '字节A',
+    slug: 'byteplus',
+    models: ['deepseek-v4-flash', 'doubao-seed-2.0-pro']
+  }
+  const moa = { name: 'Mixture of Agents', slug: 'moa', models: ['default'] }
+
+  it('switches to the first new-group model when the current pick is gone', () => {
+    expect(selectionInCatalog([bytea], 'glm-4.5-air')).toBe(false)
+    expect(firstSelectableCatalogModel([moa, bytea])).toEqual({
+      model: 'deepseek-v4-flash',
+      provider: 'byteplus'
+    })
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea])).toEqual({
+      model: 'deepseek-v4-flash',
+      provider: 'byteplus'
+    })
+  })
+
+  it('keeps the current pick when it is still in the refreshed catalog', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa])).toBeNull()
+  })
+
+  it('does not wipe the pick when the refreshed catalog has no selectable models', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined)).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -34,6 +34,64 @@ export function manualPickRemoved(
   return !models.includes(model)
 }
 
+const MOA_PROVIDER_SLUG = 'moa'
+
+/** True when `model` appears in any provider's live list. Used after Refresh
+ *  Models so a group/catalog swap can tell "still offered" from "gone". */
+export function selectionInCatalog(providers: ModelOptionProvider[] | undefined, model: string): boolean {
+  if (!providers?.length || !model) {
+    return false
+  }
+
+  return providers.some(provider => (provider.models ?? []).includes(model))
+}
+
+/** First real (non-MoA) catalog row that still has models. */
+export function firstSelectableCatalogModel(
+  providers: ModelOptionProvider[] | undefined
+): { model: string; provider: string } | null {
+  if (!providers?.length) {
+    return null
+  }
+
+  for (const provider of providers) {
+    if (provider.slug === MOA_PROVIDER_SLUG) {
+      continue
+    }
+
+    const model = provider.models?.[0]
+
+    if (model) {
+      return { model, provider: provider.slug }
+    }
+  }
+
+  return null
+}
+
+/**
+ * After Refresh Models replaces the catalog: keep the current pick when it is
+ * still listed; otherwise switch to the first available model in the new
+ * catalog. Returns null when the catalog is empty/unloaded so we never wipe
+ * a selection on a failed or still-hydrating refresh.
+ */
+export function reconcileSelectionAfterCatalogRefresh(
+  currentModel: string,
+  providers: ModelOptionProvider[] | undefined
+): { model: string; provider: string } | null {
+  const next = firstSelectableCatalogModel(providers)
+
+  if (!next) {
+    return null
+  }
+
+  if (selectionInCatalog(providers, currentModel)) {
+    return null
+  }
+
+  return next
+}
+
 interface ModelOptionsRequest {
   /** When false, include ambient/unconfigured providers (onboarding/setup
    *  surfaces). Chat pickers default to true so only explicitly configured


### PR DESCRIPTION
## What does this PR do?

After **Refresh Models**, the desktop composer could keep showing a model that is no longer in the refreshed catalog (for example after a multi-group gateway swap). The catalog list updated, but the session store and picker selection helper still preferred the old id.

Refresh now reconciles: if the current model is missing from the new list, the session switches to the first real (non-MoA) model in that catalog, using the same `onSelectModel` path as a row click. If the pick is still listed, or the catalog has no selectable models, the current selection is left alone.

## Related Issue

Fixes #95446

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/model-options.ts` — `selectionInCatalog`, `firstSelectableCatalogModel`, `reconcileSelectionAfterCatalogRefresh`
- `apps/desktop/src/app/shell/model-menu-panel.tsx` — after a successful Refresh Models fetch, switch the session when the current model is gone from the catalog
- `apps/desktop/src/lib/model-options.test.ts` — group-swap, keep-current, and empty-catalog cases
- `apps/desktop/src/app/shell/model-menu-panel.test.tsx` — Refresh Models switches when the pick is dropped; no switch when it remains listed

## How to Test

1. In the desktop app, open a session and note the model pill (bottom of the composer).
2. Open the model menu and click **Refresh Models**. If the current model is still in the list, the pill should stay on that model.
3. After a catalog change that no longer includes the current model (gateway group switch, or a provider list that dropped that id), click **Refresh Models** again. The pill and the checkmark should move to the first remaining catalog model, not keep the old id.
4. From `apps/desktop`: `npx vitest run src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (desktop app + vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
npx vitest run src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx
Test Files  2 passed (2)
     Tests  42 passed (42)
```
