### PR TITLE
fix(desktop): look up v1 SSH terminals with the bootstrap pool key

### DIFF
--- a/apps/desktop/electron/desktop-remote-route.test.ts
+++ b/apps/desktop/electron/desktop-remote-route.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { normalizeRegistry, REGISTRY_VERSION } from './connection-registry'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { backendScopeKey } from './connection-registry'
+import { resolveDesktopRemoteRoute, v1SshTerminalPoolKey } from './desktop-remote-route'
 
 const tokenA = { encoding: 'plain', value: 'token-a' }
 const tokenB = { encoding: 'plain', value: 'token-b' }
@@ -151,6 +152,46 @@ test('global SSH treats an omitted port as 22 and checks the primary route', () 
 
   assert.equal(route?.kind, 'ssh')
   assert.equal(route?.connectionId, 'ssh-primary')
+})
+
+test('v1 settings SSH pool key ignores registry identity tags', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: { mode: 'ssh', host: 'box.test', user: 'hermes' } },
+    profile: 'worker',
+    registry: registry('ssh-primary', [
+      { id: 'ssh-primary', kind: 'ssh', label: 'SSH primary', host: 'box.test', user: 'hermes', port: 22 }
+    ])
+  })
+
+  assert.ok(route)
+  assert.equal(route.kind, 'ssh')
+  assert.equal(route.connectionId, 'ssh-primary')
+  assert.equal(v1SshTerminalPoolKey(route, 'worker'), '')
+  assert.notEqual(v1SshTerminalPoolKey(route, 'worker'), backendScopeKey(route.connectionId, 'worker'))
+})
+
+test('v1 profile SSH pool key is the profile, not conn:id::profile', () => {
+  const ssh = {
+    mode: 'ssh',
+    host: 'box.test',
+    user: 'hermes',
+    port: 2222,
+    keyPath: '/keys/a',
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'worker'
+  }
+
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'local', profiles: { worker: ssh } },
+    profile: 'worker',
+    registry: registry('local', [{ id: 'worker-ssh', kind: 'ssh', label: 'Worker SSH', ...ssh }])
+  })
+
+  assert.ok(route)
+  assert.equal(route.kind, 'ssh')
+  assert.equal(route.connectionId, 'worker-ssh')
+  assert.equal(v1SshTerminalPoolKey(route, 'worker'), 'worker')
+  assert.notEqual(v1SshTerminalPoolKey(route, 'worker'), backendScopeKey(route.connectionId, 'worker'))
 })
 
 test('profile route omits identity when two registry entries match exactly', () => {

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -52,6 +52,22 @@ function withConnectionId<T extends object>(route: T, connectionId?: string): T 
 }
 
 /**
+ * Pool key used by v1 settings/profile SSH (`sshConnections`).
+ *
+ * Bootstrap stores the tunnel under sshScopeKey(profile or null).
+ * resolveDesktopRemoteRoute may also stamp a registry connectionId when
+ * the host matches a v2 row. That id is identity, not the pool key.
+ * Looking up backendScopeKey(connectionId, profile) misses the live tunnel.
+ */
+export function v1SshTerminalPoolKey(route: { source: string }, profile?: null | string): string {
+  if (route.source === 'profile') {
+    return connectionScopeKey(profile) || ''
+  }
+
+  return ''
+}
+
+/**
  * Select one remote route with the existing precedence and freeze any exact
  * registry identity before I/O. A null result means the profile resolves
  * locally. Invalid dial data remains the dialler's error, except the existing

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -152,7 +152,7 @@ import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { resolveDesktopRemoteRoute, v1SshTerminalPoolKey } from './desktop-remote-route'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -9586,9 +9586,7 @@ function activeSshTerminalTarget(webContentsId?: number) {
     return null
   }
 
-  const scope = route.connectionId
-    ? backendScopeKey(route.connectionId, profile)
-    : sshScopeKey(route.source === 'profile' ? profile : null)
+  const scope = v1SshTerminalPoolKey(route, profile)
 
   const state = sshConnections.get(scope)
 


### PR DESCRIPTION
## What does this PR do?

#95081 keyed SSH tunnels per connection. v2 registry windows look up `sshConnections` with `backendScopeKey(connectionId, profile)`. That is correct for registry-scoped windows.

v1 settings/profile SSH still bootstraps with `sshScopeKey(profile or null)`. `resolveDesktopRemoteRoute` also stamps a registry `connectionId` when the host matches a v2 row. `activeSshTerminalTarget` then used that id, so the lookup was `conn:<id>::<profile>` while the live tunnel sat under `''` or the profile name. The embedded terminal stayed pending.

v1 pool lookup now matches bootstrap and ignores the identity tag. The v2 registry-scoped branch at the top of `activeSshTerminalTarget` is unchanged.

## Related Issue

Fixes #95472

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/electron/desktop-remote-route.ts`: `v1SshTerminalPoolKey` returns `''` for settings SSH and the profile name for profile SSH.
- `apps/desktop/electron/main.ts`: `activeSshTerminalTarget` uses that helper on the v1 path.
- `apps/desktop/electron/desktop-remote-route.test.ts`: settings SSH with a matching registry id still pools under `''`. Profile SSH pools under the profile name, not `conn:id::profile`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. From `apps/desktop`: `npx vitest run electron/desktop-remote-route.test.ts`
2. v1 settings SSH whose host matches a registry row must have `connectionId` set and `v1SshTerminalPoolKey` still `''`.
3. v1 profile SSH must pool under the profile name, not `backendScopeKey(connectionId, profile)`.

I could not run the desktop vitest project in this checkout (no `node_modules`). The new tests are next to the existing route tests.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
