### PR TITLE
fix(mattermost): support progress-message cleanup

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -69,6 +69,7 @@ _CHANNEL_TYPE_MAP = {
 }
 
 _MATTERMOST_DISABLE_MENTIONS_PROPS = {"disable_mentions": True}
+_MATTERMOST_ID_RE = re.compile(r"[A-Za-z0-9]{26}\Z")
 
 # Reconnect parameters (exponential backoff).
 _RECONNECT_BASE_DELAY = 2.0
@@ -278,6 +279,31 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
+    async def _api_delete(self, path: str) -> bool:
+        """DELETE /api/v4/{path}; return whether Mattermost accepted it."""
+        import aiohttp
+        # Reject raw and encoded path-control input before yarl canonicalizes
+        # the URL.  In particular, ``%2e%2e`` would otherwise become ``..``
+        # and escape the intended endpoint while retaining bearer auth.
+        if ".." in path or "%" in path or "\\" in path:
+            logger.error("MM API path traversal blocked: %s", path)
+            return False
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url,
+                headers=self._headers(),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM API DELETE %s → %s: %s", path, resp.status, body[:200])
+                    return False
+                return True
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return False
+
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
     ) -> Optional[str]:
@@ -448,6 +474,21 @@ class MattermostAdapter(BasePlatformAdapter):
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to edit post")
         return SendResult(success=True, message_id=data["id"])
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Mattermost post.
+
+        Mattermost post IDs are globally unique, so the channel ID is not
+        needed by the REST endpoint.  The gateway only tracks IDs returned from
+        sends it performed itself; Mattermost enforces token permissions server
+        side if a caller ever passes an invalid/unauthorized post ID.
+        """
+        # Mattermost IDs are 26 ASCII alphanumeric characters.  Validate the
+        # path segment before interpolation so encoded dots or separators can
+        # never be canonicalized into another authenticated API endpoint.
+        if not isinstance(message_id, str) or not _MATTERMOST_ID_RE.fullmatch(message_id):
+            return False
+        return await self._api_delete(f"posts/{message_id}")
 
     async def send_image(
         self,

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -261,6 +261,87 @@ class TestMattermostSend:
         payload = self.adapter._api_post.call_args_list[0][0][1]
         assert payload["root_id"] == "bad_root"
 
+    @pytest.mark.asyncio
+    async def test_delete_message_calls_api_delete(self):
+        """delete_message() should delete the Mattermost post by ID."""
+        post_id = "a" * 26
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.delete = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.delete_message("channel_1", post_id)
+
+        assert result is True
+        call_args = self.adapter._session.delete.call_args
+        assert call_args.args[0].endswith(f"/api/v4/posts/{post_id}")
+
+    @pytest.mark.asyncio
+    async def test_delete_message_failure_returns_false(self):
+        post_id = "a" * 26
+        mock_resp = AsyncMock()
+        mock_resp.status = 403
+        mock_resp.text = AsyncMock(return_value="Forbidden")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.delete = MagicMock(return_value=mock_resp)
+
+        assert await self.adapter.delete_message("channel_1", post_id) is False
+
+    @pytest.mark.parametrize(
+        "post_id",
+        [
+            "",
+            "a" * 25,
+            "../../users/me",
+            "%2e%2e/users/target",
+            "a%2Fusers%2Ftarget",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_delete_message_rejects_invalid_post_id(self, post_id):
+        self.adapter._session.delete = MagicMock()
+
+        assert await self.adapter.delete_message("channel_1", post_id) is False
+        self.adapter._session.delete.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "posts/../../users/me",
+            "posts/%2e%2e/users/me",
+            "posts/a%2Fusers%2Ftarget",
+            "posts/a\\..\\users\\target",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_api_delete_rejects_path_traversal(self, path):
+        self.adapter._session.delete = MagicMock()
+
+        assert await self.adapter._api_delete(path) is False
+        self.adapter._session.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_delete_network_failure_returns_false(self):
+        post_id = "a" * 26
+        client_error = pytest.importorskip("aiohttp").ClientError
+        self.adapter._session.delete = MagicMock(
+            side_effect=client_error("connection lost")
+        )
+
+        assert await self.adapter.delete_message("channel_1", post_id) is False
+
+    @pytest.mark.asyncio
+    async def test_api_delete_timeout_returns_false(self):
+        post_id = "a" * 26
+        self.adapter._session.delete = MagicMock(side_effect=TimeoutError())
+
+        assert await self.adapter.delete_message("channel_1", post_id) is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket event parsing


### PR DESCRIPTION
## Summary

Mattermost currently inherits `BasePlatformAdapter.delete_message()`, which always returns `False`. That means the generic `display.cleanup_progress` lifecycle added in #21186 cannot remove temporary Mattermost progress posts after a successful final response.

This change adds the narrow adapter capability needed by that existing lifecycle:

- `DELETE /api/v4/posts/{message_id}` through the authenticated Mattermost API helper;
- `delete_message()` support for Mattermost;
- empty-ID rejection without an API call;
- 26-character Mattermost post-ID validation before path interpolation;
- HTTP, network, and total-timeout handling that returns `False` without breaking final delivery;
- rejection of literal and percent-encoded path-control input before URL canonicalization.

The generic gateway lifecycle remains unchanged: progress posts are deleted only after successful final delivery, while failed runs keep their breadcrumbs for diagnostics.

## Supersedes

Supersedes #33012 from @admin-prodesign, which is now conflicted and more than 10,000 commits behind current `main`. This replacement preserves the original change's author metadata by salvaging its commit, rebases it onto current `main`, and incorporates the relevant security feedback from overlapping Mattermost DELETE work in #47593.

Compared with #33012, this version also covers invalid/encoded IDs, authenticated path-traversal rejection, network failures, and total request timeouts. It intentionally excludes the old provider-error sanitizer changes that upstream review identified as already implemented more broadly on `main`.

Other overlapping PRs (#47593 and #54230) bundle deletion with much broader, unrelated Mattermost features and unresolved review concerns.

## Tests

- Mattermost adapter and plugin setup tests
- Mattermost WebSocket auth retry tests
- multiple-image and media-metadata compatibility tests
- generic cleanup-progress lifecycle tests
- `53 passed`
- Ruff passed
- Python compilation passed
- `git diff --check` passed
