### PR TITLE
fix(macos): link the store's libpython next to the anchored TCC interpreter

### DIFF
--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -209,6 +209,35 @@ def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
             continue
 
 
+def _link_store_libpython(venv_dir: Path, source_file: Path) -> None:
+    """Materialise the store's libpython next to the anchored interpreter.
+
+    A copied CPython executable keeps its build-time ``LC_RPATH`` of
+    ``@executable_path/../lib``, valid inside the uv store but not inside a
+    venv whose ``lib/`` only holds ``python3.x/site-packages``.  Without the
+    dylib present the anchored interpreter dies in dyld before ``main`` —
+    bricking the whole CLI, ``hermes update`` included.  A symlink back into
+    the store keeps the anchor working and stays stable across checkouts on
+    the same machine.
+    """
+    venv_py = venv_python_path(venv_dir)
+    store_lib = source_file.parent.parent / "lib"
+    if not store_lib.is_dir():
+        return
+    for dylib in store_lib.glob("libpython3.*.dylib"):
+        target = venv_dir / "lib" / dylib.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            existing = target.parent / target.name
+            if existing.is_symlink() and os.readlink(existing) == str(dylib):
+                continue
+            tmp = target.parent / f".{target.name}.tcc-tmp"
+            os.symlink(dylib, tmp)
+            os.replace(tmp, existing)
+        except OSError:
+            continue
+
+
 def _install_anchor(venv_dir: Path, source_file: Path) -> None:
     """Replace ``bin/python`` with a real-file copy of *source_file*.
 
@@ -226,6 +255,7 @@ def _install_anchor(venv_dir: Path, source_file: Path) -> None:
         shutil.copy2(source_file, tmp_path)
         os.chmod(tmp_path, source_file.stat().st_mode | 0o111)
         os.replace(tmp_path, venv_py)
+        _link_store_libpython(venv_dir, source_file)
         _anchor_marker(venv_bin).write_text(str(source_file), encoding="utf-8")
         _repoint_aliases(venv_bin, venv_py)
     except Exception:
@@ -266,6 +296,7 @@ def ensure_tcc_anchor(project_root: Path | None = None) -> Path | None:
             if marker.is_file() and marker.read_text(encoding="utf-8").strip() == str(
                 source_file
             ):
+                _link_store_libpython(venv_dir, source_file)
                 return venv_py
         except OSError:
             pass

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -40,6 +40,9 @@ def _build_store(tmp_path, version: str = "3.11.15") -> Path:
     store_py = store_bin / "python3.11"
     store_py.write_bytes(f"#!fake interpreter {version}".encode())
     store_py.chmod(0o755)
+    store_lib = store / "lib"
+    store_lib.mkdir()
+    (store_lib / "libpython3.11.dylib").write_bytes(b"#!fake dylib")
     return store_bin
 
 
@@ -131,6 +134,11 @@ class TestEnsureTccAnchor:
         assert venv_py.is_file() and not venv_py.is_symlink()
         assert venv_py.read_bytes() == (store_bin / "python3.11").read_bytes()
         assert os.access(venv_py, os.X_OK)
+        # The copied interpreter's rpath is @executable_path/../lib, so the
+        # store's libpython must exist inside the venv for dyld to resolve it.
+        libpython = root / ".venv" / "lib" / "libpython3.11.dylib"
+        assert libpython.is_symlink()
+        assert os.readlink(libpython) == str(store_bin.parent / "lib" / "libpython3.11.dylib")
         # Marker records the store binary the copy came from.
         marker = venv_py.parent / ".tcc-anchor-source"
         assert marker.read_text(encoding="utf-8").strip() == str(
@@ -175,6 +183,32 @@ class TestEnsureTccAnchor:
         assert venv_py.read_bytes() == new_py.read_bytes()
         marker = venv_py.parent / ".tcc-anchor-source"
         assert marker.read_text(encoding="utf-8").strip() == str(new_py)
+        # The reanchored copy resolves libpython against the new store.
+        libpython = root / ".venv" / "lib" / "libpython3.11.dylib"
+        assert libpython.is_symlink()
+        assert os.readlink(libpython) == str(
+            new_bin.parent / "lib" / "libpython3.11.dylib"
+        )
+
+    def test_anchor_links_libpython_idempotently(self, tmp_path, monkeypatch):
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path)
+        root = _build_checkout(tmp_path, store_bin=store_bin)
+
+        first = tcc.ensure_tcc_anchor(root)
+        libpython = root / ".venv" / "lib" / "libpython3.11.dylib"
+        assert first is not None and libpython.is_symlink()
+
+        # A stale foreign file (e.g. a leftover copy from an earlier repair
+        # attempt) is replaced by the store symlink, not left in place.
+        libpython.unlink()
+        libpython.write_bytes(b"stale copy")
+        second = tcc.ensure_tcc_anchor(root)
+        assert second is not None
+        assert libpython.is_symlink()
+        assert os.readlink(libpython) == str(
+            store_bin.parent / "lib" / "libpython3.11.dylib"
+        )
 
     def test_skips_homebrew_interpreter(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)


### PR DESCRIPTION
## Summary
- `_install_anchor()` copies the uv-store interpreter over `venv/bin/python` but leaves its build-time `LC_RPATH` (`@executable_path/../lib`) pointing at a venv `lib/` that only contains `python3.x/site-packages` — so the anchored interpreter dies in dyld with `Library not loaded: @rpath/libpython3.11.dylib`, bricking the whole CLI including `hermes update`/`hermes doctor` (regression from the #85345 anchor).
- `_link_store_libpython()` now materialises a symlink to the store's `libpython3.<minor>.dylib` inside `venv/lib/` right after the copy, so the existing rpath resolves. Replaces stale foreign files (e.g. leftover copies from a manual workaround) and runs on the already-anchored early-return path too, so existing broken installs self-heal on the next `ensure_tcc_anchor()` call.
- No behaviour change for non-uv or non-macOS environments (the helper returns early when there is no store `lib/`).

Fixes #95425.

## Testing
- `pytest tests/hermes_cli/test_macos_tcc_anchor.py -q` — 21 passed (2 new assertions + a dedicated reanchor/idempotency test covering the stale-file replacement and the early-return repair path).
- Store fixture now ships a fake `lib/libpython3.11.dylib`, matching the real uv layout.
