### PR TITLE
chore: mailmap kshitijkapoorr@gmail.com to kshitijk4poor

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,6 +18,7 @@ Teknium <127238744+teknium1@users.noreply.github.com> <teknium@nousresearch.com>
 # Format: Canonical Name <GH-noreply> <commit-email>
 
 # Verified via GH API email search
+kshitijk4poor <82637225+kshitijk4poor@users.noreply.github.com> <kshitijkapoorr@gmail.com>
 luyao618 <364939526@qq.com> <364939526@qq.com>
 ethernet8023 <arilotter@gmail.com> <arilotter@gmail.com>
 nicoloboschi <boschi1997@gmail.com> <boschi1997@gmail.com>


### PR DESCRIPTION
## Summary
Six commits merged via #95366 / #95367 carry an incorrect author email (`kshitijkapoorr@gmail.com`) that was set by tooling error during salvage — it is not an address the contributor owns, and it maps to no GitHub account (verified via the users search API, 0 results). This adds the .mailmap entry canonicalizing it to `82637225+kshitijk4poor@users.noreply.github.com` so `git shortlog` / contributor tooling attribute those commits correctly.

The `contributors/emails/` mapping file merged in the same PRs already covers release-notes attribution; this closes the git-tooling side.

## Changes
- `.mailmap`: one entry in the verified-contributors block.

## Validation
| | Before | After |
|---|---|---|
| `git shortlog -sne` | 6 commits under a separate fabricated-email identity | folded into kshitijk4poor's canonical noreply |