### PR TITLE
macOS permissions survive security repairs — managed-runtime rotations signed with a stable identity, anchor re-anchors after (salvage #82529)

### DIFF
--- a/contributors/emails/salahxd99@gmail.com
+++ b/contributors/emails/salahxd99@gmail.com
@@ -1,0 +1,1 @@
+notkisk

--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -72,9 +72,18 @@ def _store_bin_names() -> tuple[str, ...]:
     return (f"python3.{_sys.version_info.minor}", "python3", "python")
 
 
-# Path fragments that identify a uv-managed macOS CPython store layout:
-# ``.../uv/python/cpython-<version>-macos-<arch>/bin/python*``.
-_UV_STORE_MARKERS = ("/uv/python/", "cpython-", "-macos-")
+# Path fragments that identify a MANAGED macOS CPython store layout — a
+# store whose path changes across updates, orphaning path-keyed TCC grants.
+# Two roots qualify:
+#   - uv store patch bumps:      .../uv/python/cpython-<ver>-macos-*/bin/...
+#   - CVE-repair generations:    .../.hermes-runtime/python/generation-*/
+#                                cpython-<ver>-macos-*/bin/...
+# (repair_vulnerable_runtime() rebuilds the venv against a generation store,
+# replacing the anchored bin/python with a fresh symlink — without the second
+# root the anchor would read 'not uv-managed' after every SQLite CVE repair
+# and never re-anchor, issue #82427.)
+_STORE_COMMON_MARKERS = ("cpython-", "-macos-")
+_STORE_ROOT_MARKERS = ("/uv/python/", "/.hermes-runtime/python/")
 
 
 def is_macos() -> bool:
@@ -83,9 +92,11 @@ def is_macos() -> bool:
 
 
 def _is_uv_macos_store(path: str | Path) -> bool:
-    """True when *path* lives inside a uv-managed macOS CPython store."""
+    """True when *path* lives inside a managed macOS CPython store."""
     text = str(path).replace("\\", "/")
-    return all(marker in text for marker in _UV_STORE_MARKERS)
+    if not all(marker in text for marker in _STORE_COMMON_MARKERS):
+        return False
+    return any(root in text for root in _STORE_ROOT_MARKERS)
 
 
 def _venv_dir(project_root: Path | None = None) -> Path | None:
@@ -225,6 +236,21 @@ def _install_anchor(venv_dir: Path, source_file: Path) -> None:
     try:
         shutil.copy2(source_file, tmp_path)
         os.chmod(tmp_path, source_file.stat().st_mode | 0o111)
+        # Give the anchor copy a stable identifier-pinned signature BEFORE it
+        # goes live. copy2 carries over the source build's signature, whose
+        # designated requirement is cdhash-based for ad-hoc/linker-signed
+        # python-build-standalone binaries — meaning every anchor REFRESH
+        # (patch bump, CVE repair) would still change the stored csreq and
+        # orphan the grant despite the stable path. Identifier-DR signing
+        # (same mechanism as managed_uv's generation signing, #82427) keeps
+        # the csreq constant across refreshes. Best-effort: a failed sign
+        # leaves the copy usable, just without refresh-stable signing.
+        try:
+            from hermes_cli.managed_uv import _macos_sign_managed_python
+
+            _macos_sign_managed_python(tmp_path)
+        except Exception:  # pragma: no cover - never block the anchor
+            logger.debug("anchor copy signing skipped", exc_info=True)
         os.replace(tmp_path, venv_py)
         _anchor_marker(venv_bin).write_text(str(source_file), encoding="utf-8")
         _repoint_aliases(venv_bin, venv_py)

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -44,6 +44,7 @@ _RUNTIME_DIR_NAME = ".hermes-runtime"
 _VENV_NAME = "venv"
 _ALT_VENV_NAME = ".venv"
 _REPAIR_LOCK_NAME = "runtime-repair.lock"
+_MACOS_MANAGED_PYTHON_IDENTIFIER = "com.nousresearch.hermes.managed-python"
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -114,6 +115,79 @@ def managed_python_env(
         "UV_PYTHON_INSTALL_REGISTRY": "0",
     })
     return env
+
+
+def _macos_sign_managed_python(python: Path) -> bool:
+    """Give a newly downloaded managed Python a stable macOS code identity.
+
+    python-build-standalone binaries are ad-hoc signed, which leaves macOS
+    TCC with a cdhash-only identity that changes whenever Hermes provisions a
+    new runtime generation.  An identifier-pinned designated requirement
+    gives those generations a stable identity even when no Developer ID
+    certificate is available locally.
+
+    Signing is deliberately best effort.  Runtime repair exists to remove a
+    security vulnerability, so an unavailable or incompatible ``codesign``
+    must not prevent the fixed interpreter from being installed.
+    """
+    if platform.system() != "Darwin":
+        return False
+
+    codesign = shutil.which("codesign")
+    if not codesign:
+        logger.info(
+            "macOS codesign is unavailable; using the downloaded Python signature"
+        )
+        return False
+
+    requirement = (
+        "=designated => identifier "
+        f'"{_MACOS_MANAGED_PYTHON_IDENTIFIER}"'
+    )
+    try:
+        signed = subprocess.run(
+            [
+                codesign,
+                "--force",
+                "--deep",
+                "--sign",
+                "-",
+                "--timestamp=none",
+                "--identifier",
+                _MACOS_MANAGED_PYTHON_IDENTIFIER,
+                "--requirements",
+                requirement,
+                str(python),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if signed.returncode != 0:
+            logger.warning(
+                "could not stably sign managed Python %s: %s",
+                python,
+                (signed.stderr or signed.stdout or "codesign failed").strip(),
+            )
+            return False
+
+        verified = subprocess.run(
+            [codesign, "--verify", "--deep", "--strict", str(python)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if verified.returncode != 0:
+            logger.warning(
+                "macOS signature verification failed for managed Python %s: %s",
+                python,
+                (verified.stderr or verified.stdout or "verification failed").strip(),
+            )
+            return False
+        return True
+    except Exception as exc:
+        logger.warning("could not sign managed Python %s: %s", python, exc)
+        return False
 
 
 @dataclass(frozen=True)
@@ -595,6 +669,12 @@ def _attempt_install_generation(
         logger.warning("uv resolved Python outside the Hermes generation: %s", python)
         _remove_tree(generation, boundary=python_root)
         return None
+
+    # Do this before the candidate is probed or promoted.  On macOS, the
+    # stable identifier prevents each immutable generation from looking like
+    # a new TCC principal.  Failure is non-fatal: the SQLite repair must still
+    # proceed when codesign is unavailable or rejects a particular artifact.
+    _macos_sign_managed_python(python)
 
     candidate = probe_sqlite_runtime(python)
     if candidate is None:

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -89,6 +89,17 @@ class TestUvStoreDetection:
         )
         assert tcc._is_uv_macos_store(path)
 
+    def test_matches_hermes_runtime_repair_generation(self):
+        # repair_vulnerable_runtime() rebuilds the venv against a generation
+        # store under .hermes-runtime/python/ — no /uv/python/ segment. The
+        # anchor must recognize it or every SQLite CVE repair silently
+        # un-anchors the interpreter (issue #82427 integration).
+        path = (
+            "/Users/u/hermes-agent/.hermes-runtime/python/"
+            "generation-a1b2c3/cpython-3.11.15-macos-aarch64-none/bin/python3.11"
+        )
+        assert tcc._is_uv_macos_store(path)
+
     def test_rejects_homebrew_interpreter(self):
         path = (
             "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/"
@@ -115,6 +126,54 @@ class TestEnsureTccAnchor:
 
         assert tcc.ensure_tcc_anchor(root) is None
         assert venv_py.is_symlink()  # untouched
+
+    def test_install_signs_the_anchor_copy(self, tmp_path, monkeypatch):
+        """The anchor copy gets identifier-DR signing before going live —
+        without it every refresh changes the stored csreq (cdhash-based for
+        ad-hoc source builds) and orphans the grant despite the stable path."""
+        _darwin(monkeypatch)
+        signed = []
+        import hermes_cli.managed_uv as managed_uv
+
+        monkeypatch.setattr(
+            managed_uv, "_macos_sign_managed_python", lambda p: signed.append(Path(p)) or True
+        )
+        store_bin = _build_store(tmp_path)
+        root = _build_checkout(tmp_path, store_bin=store_bin)
+
+        anchored = tcc.ensure_tcc_anchor(root)
+
+        assert anchored is not None
+        # Signing ran on the temp copy inside the venv bin dir (pre-rename).
+        assert len(signed) == 1
+        assert signed[0].parent == anchored.parent
+
+    def test_anchors_repair_generation_interpreter(self, tmp_path, monkeypatch):
+        """A venv re-created against a .hermes-runtime CVE-repair generation
+        store must anchor too (issue #82427 integration)."""
+        _darwin(monkeypatch)
+        store = (
+            tmp_path
+            / "checkout"
+            / ".hermes-runtime"
+            / "python"
+            / "generation-a1b2c3"
+            / "cpython-3.11.15-macos-aarch64-none"
+        )
+        store_bin = store / "bin"
+        store_bin.mkdir(parents=True)
+        store_py = store_bin / "python3.11"
+        store_py.write_bytes(b"#!fake generation interpreter")
+        store_py.chmod(0o755)
+        root = _build_checkout(tmp_path, store_bin=store_bin)
+        venv_py = venv_python_path(root / ".venv")
+        assert venv_py.is_symlink()
+
+        anchored = tcc.ensure_tcc_anchor(root)
+
+        assert anchored == venv_py
+        assert not venv_py.is_symlink()
+        assert venv_py.read_bytes() == store_py.read_bytes()
 
     def test_anchors_uv_managed_interpreter(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -83,6 +83,74 @@ class TestManagedUvPath:
             assert managed_uv_path() == tmp_path / "bin" / "uv"
 
 
+class TestMacOSManagedPythonSigning:
+    def test_signs_with_stable_identifier_and_verifies(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        python = tmp_path / "generation" / "bin" / "python3.11"
+        python.parent.mkdir(parents=True)
+        python.touch()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(managed_uv.shutil, "which", lambda name: "/usr/bin/codesign")
+        monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+        assert managed_uv._macos_sign_managed_python(python) is True
+        assert calls[0][0] == [
+            "/usr/bin/codesign",
+            "--force",
+            "--deep",
+            "--sign",
+            "-",
+            "--timestamp=none",
+            "--identifier",
+            "com.nousresearch.hermes.managed-python",
+            "--requirements",
+            '=designated => identifier "com.nousresearch.hermes.managed-python"',
+            str(python),
+        ]
+        assert calls[1][0] == [
+            "/usr/bin/codesign",
+            "--verify",
+            "--deep",
+            "--strict",
+            str(python),
+        ]
+
+    def test_is_non_blocking_when_signing_fails(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        python = tmp_path / "python3.11"
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(managed_uv.shutil, "which", lambda name: "/usr/bin/codesign")
+        monkeypatch.setattr(
+            managed_uv.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1, stdout="", stderr="not signable"
+            ),
+        )
+
+        assert managed_uv._macos_sign_managed_python(python) is False
+
+    def test_skips_non_macos(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            managed_uv.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("codesign must not run on Linux"),
+        )
+
+        assert managed_uv._macos_sign_managed_python(tmp_path / "python") is False
+
+
 # ---------------------------------------------------------------------------
 # resolve_uv
 # ---------------------------------------------------------------------------
@@ -1286,4 +1354,3 @@ class TestVenvPythonUpdateBoundary:
         expected = Path("/opt/hermes/venv/Scripts/python.exe") \
             if sys.platform == "win32" else Path("/opt/hermes/venv/bin/python")
         assert _venv_python(Path("/opt/hermes/venv")) == expected
-


### PR DESCRIPTION
## Summary
macOS terminal permissions no longer reset when Hermes rotates its managed Python runtime for a security repair: freshly provisioned CVE-repair interpreters get a stable identifier-pinned code signature, and the TCC interpreter anchor now survives (re-anchors after) the venv rebuild that a repair performs. Salvage of #82529 by @notkisk (commit cherry-picked, authorship preserved). Fixes #82427.

This closes the last interpreter-side TCC gap: #95131 anchored the normal uv-store patch-bump path, but `repair_vulnerable_runtime()` (run on every `hermes update`) builds a NEW venv against a `.hermes-runtime/python/generation-*` store and renames it over `venv/` — bypassing the anchor entirely, and the anchor's store detection didn't recognize generation paths, so it would never re-anchor afterward. Each fix alone left the other's rotation path broken; together they cover both.

## Changes
- `hermes_cli/managed_uv.py` (@notkisk): `_macos_sign_managed_python()` — signs freshly provisioned generation interpreters ad-hoc but with a stable `--identifier com.nousresearch.hermes.managed-python` and identifier-pinned designated requirement, then `codesign --verify --strict`. Called from `_attempt_install_generation()` before probe/promotion. Best-effort: failure warns and never blocks the CVE repair.
- Integration commit (ours):
  - `macos_tcc_anchor` store detection accepts `.hermes-runtime/python/` generation stores alongside `/uv/python/` — after a repair the update-time self-heal now re-anchors instead of reading "not uv-managed" and silently orphaning grants.
  - `_install_anchor` signs the anchor copy with the same identifier-DR mechanism before it goes live (copy2 carries the source's cdhash-based signature, so unsigned refreshes would still churn the stored csreq on every bump/repair despite the stable path).

## Validation
| | Before | After |
|---|---|---|
| Repair-generation interpreter | unsigned ad-hoc (cdhash DR, new per generation) | identifier-pinned DR, verified |
| Anchor after CVE repair | never re-anchors (store unrecognized) | re-anchors + signed copy |
| Tests | 40+3 (PR's) | 66 passed, 1 skipped (3 new integration tests) |

Sabotage-verified: removing the generation-root marker fails both new detection/anchoring tests.

**Live repro (premise):** verified on main that `repair_vulnerable_runtime` renames a fresh venv over the anchored one and that generation paths carry no `/uv/python/` segment; #82427 carries the reporter's TCC.db dump showing per-generation-path client rows. Real-Mac grant-survival smoke test flagged for hardware verification.

Credit: @notkisk. Closes #82529. Fixes #82427.

## Infographic

![Security repairs no longer cost your permissions](https://v3b.fal.media/files/b/0aa7e067/yDTWfs5AGs5TGZTyZGBs7_adopFqn8.png)
