### PR TITLE
fix(config): keep auxiliary model pins when applying main models

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7707,14 +7707,14 @@ def _apply_model_assignment_sync(
                 # must never block saving the model assignment.
                 _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
 
-        # A main-model assignment owns only ``model`` (plus the explicit Nous
-        # tool defaults above). ``load_config`` is a cached, default-expanded
-        # snapshot and can lag a CLI/API write to an auxiliary slot; saving that
-        # whole snapshot would turn a pinned provider/model back into auto/empty.
-        # Re-read the raw auxiliary section at the write boundary so unrelated
-        # per-task pins remain authoritative. The mutation lock also prevents a
-        # concurrent REST config save from interleaving between the re-read and
-        # the atomic write.
+        # ``load_config`` is a cached, default-expanded snapshot and can lag a
+        # CLI/API write to an auxiliary slot; saving that whole snapshot would
+        # turn a pinned provider/model back into auto/empty. Re-read the raw
+        # auxiliary section at the write boundary so those independent per-task
+        # assignments remain authoritative. This is deliberately a targeted
+        # guard: other sections keep this endpoint's existing effective-snapshot
+        # write semantics. The mutation lock also prevents a concurrent REST
+        # config save from interleaving between the re-read and atomic write.
         with _CONFIG_MUTATION_LOCK:
             raw_config = read_raw_config()
             if "auxiliary" in raw_config:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17,6 +17,7 @@ import atexit
 import base64
 import binascii
 import concurrent.futures
+import copy
 import functools
 from collections import deque
 from dataclasses import dataclass
@@ -7706,7 +7707,21 @@ def _apply_model_assignment_sync(
                 # must never block saving the model assignment.
                 _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
 
-        save_config(cfg)
+        # A main-model assignment owns only ``model`` (plus the explicit Nous
+        # tool defaults above). ``load_config`` is a cached, default-expanded
+        # snapshot and can lag a CLI/API write to an auxiliary slot; saving that
+        # whole snapshot would turn a pinned provider/model back into auto/empty.
+        # Re-read the raw auxiliary section at the write boundary so unrelated
+        # per-task pins remain authoritative. The mutation lock also prevents a
+        # concurrent REST config save from interleaving between the re-read and
+        # the atomic write.
+        with _CONFIG_MUTATION_LOCK:
+            raw_config = read_raw_config()
+            if "auxiliary" in raw_config:
+                cfg["auxiliary"] = copy.deepcopy(raw_config["auxiliary"])
+            else:
+                cfg.pop("auxiliary", None)
+            save_config(cfg)
 
         # Register a named ``custom_providers`` entry for a custom/local
         # endpoint, mirroring the ``hermes model`` custom flow

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -228,6 +228,21 @@ class TestProfileScopedModel:
         """A stale effective snapshot cannot replace newer raw auxiliary pins."""
         import hermes_cli.web_server as web_server
 
+        default_config = isolated_profiles["default"] / "config.yaml"
+        default_config.write_text(
+            yaml.safe_dump(
+                {
+                    "auxiliary": {
+                        "curator": {
+                            "provider": "openrouter",
+                            "model": "default/curator",
+                            "reasoning_effort": "low",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
         worker_config = isolated_profiles["worker_beta"] / "config.yaml"
         worker_config.write_text(
             yaml.safe_dump(
@@ -278,6 +293,43 @@ class TestProfileScopedModel:
             "model": "grok-4.6",
             "reasoning_effort": "high",
         }
+
+    def test_main_assignment_does_not_materialize_default_auxiliary_config(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Raw auxiliary removal wins over a stale default-expanded snapshot."""
+        import hermes_cli.web_server as web_server
+
+        original_load_config = web_server.load_config
+        load_count = 0
+
+        def stale_load_config():
+            nonlocal load_count
+            load_count += 1
+            config = original_load_config()
+            if load_count == 1:
+                config["auxiliary"]["curator"] = {
+                    "provider": "xai-oauth",
+                    "model": "stale/curator",
+                    "reasoning_effort": "high",
+                }
+            return config
+
+        monkeypatch.setattr(web_server, "load_config", stale_load_config)
+
+        resp = client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "test/model-1",
+                "confirm_expensive_model": True,
+                "profile": "worker_beta",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert "auxiliary" not in _cfg(isolated_profiles["worker_beta"])
 
     def test_model_set_main_scoped(self, client, isolated_profiles):
         resp = client.post(

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -222,6 +222,63 @@ class TestProfileScopedMcp:
 
 
 class TestProfileScopedModel:
+    def test_main_assignment_preserves_auxiliary_model_pins(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """A stale effective snapshot cannot replace newer raw auxiliary pins."""
+        import hermes_cli.web_server as web_server
+
+        worker_config = isolated_profiles["worker_beta"] / "config.yaml"
+        worker_config.write_text(
+            yaml.safe_dump(
+                {
+                    "auxiliary": {
+                        "curator": {
+                            "provider": "xai-oauth",
+                            "model": "grok-4.6",
+                            "reasoning_effort": "high",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        original_load_config = web_server.load_config
+        load_count = 0
+
+        def stale_load_config():
+            nonlocal load_count
+            load_count += 1
+            config = original_load_config()
+            if load_count == 1:
+                config["auxiliary"]["curator"] = {
+                    "provider": "auto",
+                    "model": "",
+                    "reasoning_effort": "high",
+                }
+            return config
+
+        monkeypatch.setattr(web_server, "load_config", stale_load_config)
+
+        resp = client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "test/model-1",
+                "confirm_expensive_model": True,
+                "profile": "worker_beta",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert _cfg(isolated_profiles["worker_beta"])["auxiliary"]["curator"] == {
+            "provider": "xai-oauth",
+            "model": "grok-4.6",
+            "reasoning_effort": "high",
+        }
+
     def test_model_set_main_scoped(self, client, isolated_profiles):
         resp = client.post(
             "/api/model/set",


### PR DESCRIPTION
## What does this PR do?

Applying a main model can no longer replace independently pinned auxiliary provider/model settings with a stale default-expanded config snapshot. The main-model endpoint now re-reads the raw auxiliary section at the write boundary and preserves it while updating the main model.

### Symptom

After pinning `auxiliary.curator.provider` and `auxiliary.curator.model`, applying a main model from Desktop Settings can write `auto` and an empty model back to those unrelated fields while leaving `reasoning_effort` unchanged.

### Impact

Users lose explicit auxiliary routing choices and subsequent helper tasks run through the main-model resolution path instead of the provider/model they selected.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py:7710` in `_apply_model_assignment_sync`

**Causal chain:**
1. A main-model apply loads a cached, default-expanded config snapshot.
2. An auxiliary slot has newer raw provider/model pins than the snapshot, while an unchanged field such as `reasoning_effort` matches both copies.
3. `save_config(cfg)` persists the whole stale effective snapshot, replacing the raw provider/model pins with `auto` and an empty model.

**Why it is wrong:** A main-model assignment owns the main model and its explicit managed defaults, not independent auxiliary task assignments.

**Working sibling / contrast:** The schema-driven config endpoint already re-reads raw config under `_CONFIG_MUTATION_LOCK` before merging and saving. The main-model assignment previously saved its earlier effective snapshot directly.

**Ruled out:** The Desktop request shape is already targeted to `POST /api/model/set` with `scope: main`; no auxiliary reset request is sent by the Apply button.

### Fix

Re-read and deep-copy the raw `auxiliary` section under `_CONFIG_MUTATION_LOCK` immediately before saving a main-model assignment. A regression test forces the effective load to lag the raw profile config and verifies all auxiliary pin fields survive.

## Related Issue

Fixes #95460

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` - preserve the latest raw auxiliary assignments at the main-model write boundary.
- `tests/hermes_cli/test_web_server_profile_unification.py` - cover stale effective config versus newer profile-scoped auxiliary pins.

## How to Test

1. Run the profile-scoped model/config regression suite.
2. Run the existing main-model assignment tests.

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server_profile_unification.py -q
scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'model_set or set_model_main' -q
```

Results: 30 passed and 2 passed, respectively.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant repository test entry and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and regression coverage are self-contained
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the fix uses existing Python locking and config primitives
- [x] Tool description/schema updates are N/A; no model tool schema changed

## Screenshots / Logs

N/A - this is a config persistence fix covered by a deterministic red-to-green regression test.
