### PR TITLE
fix(checkpoints): stop safe restore deleting files the size cap excluded

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3479,6 +3479,14 @@ class GatewaySlashCommandsMixin:
                     "gateway.rollback.kept_user_edits",
                     files=shown + more,
                 )
+            oversize = result.get("skipped_oversize") or []
+            if oversize:
+                shown = ", ".join(oversize[:5])
+                more = f" (+{len(oversize) - 5})" if len(oversize) > 5 else ""
+                msg += "\n" + t(
+                    "gateway.rollback.kept_oversize",
+                    files=shown + more,
+                )
             return msg
         return t("gateway.rollback.restore_failed", error=result["error"])
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -165,6 +165,11 @@ class CLICommandsMixin:
                 more = f" (+{len(skipped) - 5} more)" if len(skipped) > 5 else ""
                 print(f"  ↷ Kept your hand-edits: {shown}{more}")
                 print("  Use /rollback <N> --all to restore those too.")
+            oversize = result.get("skipped_oversize") or []
+            if oversize:
+                shown = ", ".join(oversize[:5])
+                more = f" (+{len(oversize) - 5} more)" if len(oversize) > 5 else ""
+                print(f"  ↷ Kept (too large for checkpoints, no stored copy to revert to): {shown}{more}")
             print("  A pre-rollback snapshot was saved automatically.")
 
             # Also undo the last conversation turn so the agent's context

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Ongeldige kontrolepunt-nommer. Gebruik 1-{max}."
     restored:              "✅ Herstel na kontrolepunt {hash}: {reason}\n'n Voor-terugrol-momentopname is outomaties gestoor."
     kept_user_edits:       "↷ Jou handwysigings is behou: {files}\nGebruik /rollback <N> --all om dié ook te herstel."
+    kept_oversize:         "↷ Behou (te groot vir kontrolepunte, geen gestoorde kopie om na terug te keer nie): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -300,6 +300,7 @@ gateway:
     invalid_number:        "رقم نقطة تحقّق غير صالح. استخدم 1-{max}."
     restored:              "✅ استُعيد إلى نقطة التحقّق {hash}: {reason}\nحُفظت لقطة ما قبل التراجع تلقائيًا."
     kept_user_edits:       "↷ احتُفظ بتعديلاتك اليدوية: {files}\nاستخدم ‎/rollback <N> --all لاستعادتها أيضًا."
+    kept_oversize:         "↷ احتُفظ به (أكبر من أن يُحفظ في نقاط التفتيش، لا توجد نسخة مخزنة للرجوع إليها): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Ungültige Checkpoint-Nummer. Verwenden Sie 1-{max}."
     restored:              "✅ Auf Checkpoint {hash} wiederhergestellt: {reason}\nEin Pre-Rollback-Snapshot wurde automatisch gespeichert."
     kept_user_edits:       "↷ Deine manuellen Änderungen wurden behalten: {files}\nNutze /rollback <N> --all, um auch diese wiederherzustellen."
+    kept_oversize:         "↷ Behalten (zu groß für Checkpoints, keine gespeicherte Kopie zum Zurücksetzen): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -292,6 +292,7 @@ gateway:
     invalid_number:        "Invalid checkpoint number. Use 1-{max}."
     restored:              "✅ Restored to checkpoint {hash}: {reason}\nA pre-rollback snapshot was saved automatically."
     kept_user_edits:       "↷ Kept your hand-edits: {files}\nUse /rollback <N> --all to restore those too."
+    kept_oversize:         "↷ Kept (too large for checkpoints, no stored copy to revert to): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -277,6 +277,7 @@ gateway:
     invalid_number:        "Número de checkpoint inválido. Usa 1-{max}."
     restored:              "✅ Restaurado al checkpoint {hash}: {reason}\nSe guardó automáticamente un snapshot previo al rollback."
     kept_user_edits:       "↷ Se conservaron tus ediciones manuales: {files}\nUsa /rollback <N> --all para restaurarlas también."
+    kept_oversize:         "↷ Conservado (demasiado grande para los checkpoints, no hay copia guardada a la que revertir): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Numéro de point de contrôle invalide. Utilisez 1-{max}."
     restored:              "✅ Restauré au point de contrôle {hash} : {reason}\nUn instantané pré-rollback a été enregistré automatiquement."
     kept_user_edits:       "↷ Vos modifications manuelles ont été conservées : {files}\nUtilisez /rollback <N> --all pour les restaurer aussi."
+    kept_oversize:         "↷ Conservé (trop volumineux pour les checkpoints, aucune copie enregistrée vers laquelle revenir) : {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -284,6 +284,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Uimhir seicphointe neamhbhailí. Úsáid 1-{max}."
     restored:              "✅ Aischurtha go seicphointe {hash}: {reason}\nSábháladh roghchóip réamh-rollback go huathoibríoch."
     kept_user_edits:       "↷ Coinníodh do chuid athruithe láimhe: {files}\nÚsáid /rollback <N> --all chun iad sin a aischur freisin."
+    kept_oversize:         "↷ Coinnithe (ró-mhór do sheicphointí, níl aon chóip stóráilte le filleadh uirthi): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Érvénytelen ellenőrzőpont-szám. Használj 1-{max} közötti értéket."
     restored:              "✅ Visszaállítva a(z) {hash} ellenőrzőpontra: {reason}\nA visszaállítás előtti pillanatkép automatikusan elmentve."
     kept_user_edits:       "↷ A kézi szerkesztéseid megmaradtak: {files}\nHasználd a /rollback <N> --all parancsot, hogy azokat is visszaállítsd."
+    kept_oversize:         "↷ Megtartva (túl nagy az ellenőrzőpontokhoz, nincs tárolt másolat, amire vissza lehetne állni): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Numero di checkpoint non valido. Usa 1-{max}."
     restored:              "✅ Ripristinato al checkpoint {hash}: {reason}\nUno snapshot pre-rollback è stato salvato automaticamente."
     kept_user_edits:       "↷ Le tue modifiche manuali sono state conservate: {files}\nUsa /rollback <N> --all per ripristinare anche quelle."
+    kept_oversize:         "↷ Conservato (troppo grande per i checkpoint, nessuna copia salvata a cui tornare): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "無効なチェックポイント番号です。1-{max} を使用してください。"
     restored:              "✅ チェックポイント {hash} に復元しました: {reason}\nロールバック前のスナップショットが自動的に保存されました。"
     kept_user_edits:       "↷ 手動編集は保持されました: {files}\nそれらも復元するには /rollback <N> --all を使用してください。"
+    kept_oversize:         "↷ 保持しました（チェックポイントには大きすぎるため、戻せる保存コピーがありません）: {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "잘못된 체크포인트 번호입니다. 1-{max}을 사용하세요."
     restored:              "✅ 체크포인트 {hash}(으)로 복원됨: {reason}\n롤백 전 스냅샷이 자동으로 저장되었습니다."
     kept_user_edits:       "↷ 직접 수정한 내용은 유지되었습니다: {files}\n해당 파일도 복원하려면 /rollback <N> --all 을 사용하세요."
+    kept_oversize:         "↷ 유지됨 (체크포인트에 저장하기엔 너무 커서 되돌릴 저장본이 없습니다): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Número de checkpoint inválido. Usa 1-{max}."
     restored:              "✅ Restaurado para o checkpoint {hash}: {reason}\nFoi guardado automaticamente um snapshot anterior ao rollback."
     kept_user_edits:       "↷ As suas edições manuais foram mantidas: {files}\nUse /rollback <N> --all para restaurar essas também."
+    kept_oversize:         "↷ Mantido (grande demais para os checkpoints, sem cópia guardada para reverter): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Недействительный номер контрольной точки. Используйте 1-{max}."
     restored:              "✅ Восстановлено до контрольной точки {hash}: {reason}\nСнимок перед откатом сохранён автоматически."
     kept_user_edits:       "↷ Ваши ручные правки сохранены: {files}\nИспользуйте /rollback <N> --all, чтобы восстановить и их."
+    kept_oversize:         "↷ Сохранено (слишком большой для контрольных точек, нет сохранённой копии для отката): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Geçersiz kontrol noktası numarası. 1-{max} aralığını kullanın."
     restored:              "✅ {hash} kontrol noktasına geri yüklendi: {reason}\nGeri alma öncesi anlık görüntü otomatik olarak kaydedildi."
     kept_user_edits:       "↷ Elle yaptığınız düzenlemeler korundu: {files}\nOnları da geri yüklemek için /rollback <N> --all kullanın."
+    kept_oversize:         "↷ Korundu (denetim noktaları için çok büyük, geri dönülecek kayıtlı kopya yok): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "Недійсний номер контрольної точки. Використовуйте 1-{max}."
     restored:              "✅ Відновлено до контрольної точки {hash}: {reason}\nЗнімок перед відкатом збережено автоматично."
     kept_user_edits:       "↷ Ваші ручні правки збережено: {files}\nВикористайте /rollback <N> --all, щоб відновити і їх."
+    kept_oversize:         "↷ Збережено (завеликий для контрольних точок, немає збереженої копії для відкату): {files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "無效的檢查點編號。請使用 1-{max}。"
     restored:              "✅ 已還原至檢查點 {hash}：{reason}\n已自動儲存回復前的快照。"
     kept_user_edits:       "↷ 已保留您的手動編輯：{files}\n若也要還原這些檔案，請使用 /rollback <N> --all。"
+    kept_oversize:         "↷ 已保留（檔案過大無法納入檢查點，沒有可還原的儲存副本）：{files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -280,6 +280,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     invalid_number:        "无效的检查点编号。请使用 1-{max}。"
     restored:              "✅ 已恢复到检查点 {hash}：{reason}\n已自动保存回滚前的快照。"
     kept_user_edits:       "↷ 已保留您的手动编辑：{files}\n如需一并恢复这些文件，请使用 /rollback <N> --all。"
+    kept_oversize:         "↷ 已保留（文件过大无法纳入检查点，没有可恢复的存储副本）：{files}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -393,6 +393,102 @@ class TestSafeRestore:
         assert "README.md" in result["skipped_user_edits"]
         assert "agent.txt" in result["restored_files"]
 
+    # -- size-capped files -------------------------------------------------
+    #
+    # ``max_file_size_mb`` keeps generated assets out of a checkpoint
+    # (test_max_file_size_mb_skips_large_files). Safe restore then sees such a
+    # file as "changed since the checkpoint and absent from it" — the same
+    # shape as a file Hermes created — and the delete branch treats absence as
+    # proof of authorship. For a capped file that is wrong: no checkpoint holds
+    # a copy, so deleting it destroys the only one.
+
+    @staticmethod
+    def _capped_mgr(checkpoint_base, monkeypatch, cap_mb=1):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        return CheckpointManager(enabled=True, max_snapshots=50, max_file_size_mb=cap_mb)
+
+    def test_safe_restore_keeps_an_oversize_file_the_cap_excluded(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """The file is in no checkpoint, so deleting it is unrecoverable."""
+        m = self._capped_mgr(checkpoint_base, monkeypatch)
+        corpus = work_dir / "corpus.jsonl"
+        corpus.write_bytes(b"original\n" + b"x" * (2 * 1024 * 1024))
+        base = self._checkpoint(m, work_dir)
+
+        corpus.write_bytes(b"agent appended\n" + b"y" * (2 * 1024 * 1024))
+        m.record_agent_write(str(corpus))
+
+        result = m.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert corpus.exists(), "safe restore deleted a file no checkpoint holds"
+        assert corpus.read_bytes().startswith(b"agent appended")
+        assert "corpus.jsonl" in result.get("skipped_oversize", [])
+
+    def test_safe_restore_does_not_report_a_kept_file_as_restored(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Misreporting is what made the loss silent — the user was told
+        "Restored" for a path that had just been unlinked."""
+        m = self._capped_mgr(checkpoint_base, monkeypatch)
+        corpus = work_dir / "corpus.jsonl"
+        corpus.write_bytes(b"o" * (2 * 1024 * 1024))
+        base = self._checkpoint(m, work_dir)
+
+        corpus.write_bytes(b"a" * (2 * 1024 * 1024))
+        m.record_agent_write(str(corpus))
+        (work_dir / "main.py").write_text("agent version\n")
+        m.record_agent_write(str(work_dir / "main.py"))
+
+        result = m.restore(str(work_dir), base, safe=True)
+
+        assert result["restored_files"] == ["main.py"]
+        assert (work_dir / "main.py").read_text() == "print('hello')\n"
+
+    def test_safe_restore_still_reverts_a_file_that_grew_past_the_cap(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """Regression guard for the tempting wrong fix.
+
+        Dropping every oversize path from the restore plan would also strand
+        this one — small enough to be checkpointed, then bloated by the agent.
+        It IS in the checkpoint, so a prior version exists and reverting to it
+        is exactly what the user asked for. The rule has to key on "absent from
+        the checkpoint", not on "large now".
+        """
+        m = self._capped_mgr(checkpoint_base, monkeypatch)
+        grew = work_dir / "grew.txt"
+        grew.write_text("precious original\n")
+        base = self._checkpoint(m, work_dir)
+
+        grew.write_bytes(b"agent bloated it\n" + b"b" * (2 * 1024 * 1024))
+        m.record_agent_write(str(grew))
+
+        result = m.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert grew.read_text() == "precious original\n"
+        assert "grew.txt" in result["restored_files"]
+        assert "grew.txt" not in result.get("skipped_oversize", [])
+
+    def test_safe_restore_still_deletes_a_small_agent_created_file(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """The delete branch keeps working for the case it was written for."""
+        m = self._capped_mgr(checkpoint_base, monkeypatch)
+        base = self._checkpoint(m, work_dir)
+
+        scratch = work_dir / "scratch.txt"
+        scratch.write_text("agent scratch\n")
+        m.record_agent_write(str(scratch))
+
+        result = m.restore(str(work_dir), base, safe=True)
+
+        assert not scratch.exists()
+        assert "scratch.txt" in result["restored_files"]
+        assert "skipped_oversize" not in result
+
     def test_unsafe_restore_overwrites_everything(self, mgr, work_dir):
         base = self._checkpoint(mgr, work_dir)
         (work_dir / "main.py").write_text("agent version\n")

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -472,6 +472,45 @@ class TestSafeRestore:
         assert "grew.txt" in result["restored_files"]
         assert "grew.txt" not in result.get("skipped_oversize", [])
 
+    def test_the_cap_boundary_is_the_same_on_both_sides_of_the_round_trip(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        """One threshold, checked from both ends.
+
+        The checkpoint decides what to store and safe restore decides what may
+        be deleted, and the safety of the pair rests on the two agreeing. A file
+        at exactly the cap is stored (the test is strictly greater-than), so it
+        must revert; one byte more is excluded, so it must be kept. Were the
+        checkpoint side to drift to ``>=`` while restore kept ``>``, the at-cap
+        file would be stored nowhere and recognised as capped nowhere — the
+        exact gap that deletes it — and this fails.
+        """
+        cap = 1024 * 1024
+        m = self._capped_mgr(checkpoint_base, monkeypatch, cap_mb=1)
+
+        at_cap = work_dir / "at_cap.bin"
+        over_cap = work_dir / "over_cap.bin"
+        at_cap.write_bytes(b"o" * cap)
+        over_cap.write_bytes(b"o" * (cap + 1))
+        base = self._checkpoint(m, work_dir)
+
+        at_cap.write_bytes(b"a" * cap)
+        over_cap.write_bytes(b"a" * (cap + 1))
+        m.record_agent_write(str(at_cap))
+        m.record_agent_write(str(over_cap))
+
+        result = m.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        # Stored, therefore recoverable, therefore reverted.
+        assert at_cap.read_bytes() == b"o" * cap
+        assert "at_cap.bin" in result["restored_files"]
+        assert "at_cap.bin" not in result.get("skipped_oversize", [])
+        # Never stored, therefore unrecoverable, therefore left alone.
+        assert over_cap.read_bytes() == b"a" * (cap + 1)
+        assert "over_cap.bin" in result.get("skipped_oversize", [])
+        assert "over_cap.bin" not in result["restored_files"]
+
     def test_safe_restore_still_deletes_a_small_agent_created_file(
         self, work_dir, checkpoint_base, monkeypatch,
     ):

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -528,6 +528,33 @@ class TestSafeRestore:
         assert "scratch.txt" in result["restored_files"]
         assert "skipped_oversize" not in result
 
+    def test_safe_restore_does_not_report_a_failed_delete_as_restored(
+        self, mgr, work_dir, monkeypatch,
+    ):
+        """A delete_target whose unlink fails stays on disk — reporting it in
+        restored_files is the same silent misreport the oversize fix closed."""
+        base = self._checkpoint(mgr, work_dir)
+
+        stubborn = work_dir / "stubborn.txt"
+        stubborn.write_text("agent scratch\n")
+        mgr.record_agent_write(str(stubborn))
+
+        import pathlib
+
+        real_unlink = pathlib.Path.unlink
+
+        def failing_unlink(self, *args, **kwargs):
+            if self.name == "stubborn.txt":
+                raise OSError(13, "Permission denied")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "unlink", failing_unlink)
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert stubborn.exists()
+        assert "stubborn.txt" not in result["restored_files"]
+
     def test_unsafe_restore_overwrites_everything(self, mgr, work_dir):
         base = self._checkpoint(mgr, work_dir)
         (work_dir / "main.py").write_text("agent version\n")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1124,6 +1124,8 @@ class CheckpointManager:
                     "debug": err or None}
 
         skipped_user_edits: List[str] = []
+        kept_oversize: List[str] = []
+        failed_deletes: List[str] = []
         restore_paths: Optional[List[str]] = None
         if safe and not file_path:
             plan = self.safe_restore_plan(abs_dir, commit_hash)
@@ -1157,7 +1159,6 @@ class CheckpointManager:
             # Hermes-created files absent from it (delete to restore state).
             checkout_targets: List[str] = []
             delete_targets: List[str] = []
-            kept_oversize: List[str] = []
             for rel in restore_paths:
                 ok_in_commit, _, _ = _run_git(
                     ["cat-file", "-e", f"{commit_hash}:{rel}"],
@@ -1184,6 +1185,7 @@ class CheckpointManager:
                         target.unlink()
                 except OSError as exc:
                     logger.debug("Safe restore: could not remove %s: %s", rel, exc)
+                    failed_deletes.append(rel)
             if not checkout_targets:
                 ok, stdout, err = True, "", ""
             else:
@@ -1218,11 +1220,13 @@ class CheckpointManager:
             result["file"] = file_path
         if restore_paths is not None:
             # Only what was actually acted on. A kept oversize path was not
-            # restored, and reporting it as such is how the data loss above
-            # stayed silent: the user was told "Restored" for a file that had
-            # just been unlinked.
+            # restored (and a failed unlink left the file in place), and
+            # reporting either as restored is how the data loss above stayed
+            # silent: the user was told "Restored" for a file that had just
+            # been unlinked.
+            not_restored = set(kept_oversize) | set(failed_deletes)
             result["restored_files"] = [
-                rel for rel in restore_paths if rel not in kept_oversize
+                rel for rel in restore_paths if rel not in not_restored
             ]
             result["skipped_user_edits"] = skipped_user_edits
             if kept_oversize:

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1409,8 +1409,7 @@ class CheckpointManager:
         Lets the agent keep snapshotting source code while refusing to
         swallow generated assets (datasets, model weights, logs, videos).
         """
-        cap = self.max_file_size_mb * 1024 * 1024
-        if cap <= 0:
+        if self.max_file_size_mb <= 0:
             return
         ok, stdout, _ = _run_git(
             ["ls-files", "--cached", "-z"],
@@ -1422,14 +1421,13 @@ class CheckpointManager:
         # whitespace but that leaves NULs alone; rebuild list.
         paths = [p for p in stdout.split("\x00") if p]
         abs_workdir = _normalize_path(working_dir)
-        oversize: List[str] = []
-        for rel in paths:
-            try:
-                size = (abs_workdir / rel).stat().st_size
-            except OSError:
-                continue
-            if size > cap:
-                oversize.append(rel)
+        # Same predicate safe restore consults, called rather than restated:
+        # a threshold that drifted between the two would make a file both
+        # absent from the checkpoint and not recognised as capped at restore,
+        # which is precisely the deletion this change exists to prevent.
+        oversize = [
+            rel for rel in paths if self._exceeds_size_cap(abs_workdir / rel)
+        ]
         if not oversize:
             return
         logger.debug(

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1157,12 +1157,26 @@ class CheckpointManager:
             # Hermes-created files absent from it (delete to restore state).
             checkout_targets: List[str] = []
             delete_targets: List[str] = []
+            kept_oversize: List[str] = []
             for rel in restore_paths:
                 ok_in_commit, _, _ = _run_git(
                     ["cat-file", "-e", f"{commit_hash}:{rel}"],
                     store, abs_dir, allowed_returncodes={1, 128},
                 )
-                (checkout_targets if ok_in_commit else delete_targets).append(rel)
+                if ok_in_commit:
+                    checkout_targets.append(rel)
+                elif self._exceeds_size_cap(Path(abs_dir) / rel):
+                    # Absent from the checkpoint because ``max_file_size_mb``
+                    # kept it out (_drop_oversize_from_index), not because
+                    # Hermes created it. Deleting it would not restore a prior
+                    # state — no checkpoint holds one — it would destroy the
+                    # only copy. The ledger records a content hash, not whether
+                    # a write created or modified the file, so an oversize path
+                    # cannot be proven agent-created; leaving it costs a stale
+                    # file, deleting it costs the file.
+                    kept_oversize.append(rel)
+                else:
+                    delete_targets.append(rel)
             for rel in delete_targets:
                 try:
                     target = Path(abs_dir) / rel
@@ -1203,8 +1217,16 @@ class CheckpointManager:
         if file_path:
             result["file"] = file_path
         if restore_paths is not None:
-            result["restored_files"] = restore_paths
+            # Only what was actually acted on. A kept oversize path was not
+            # restored, and reporting it as such is how the data loss above
+            # stayed silent: the user was told "Restored" for a file that had
+            # just been unlinked.
+            result["restored_files"] = [
+                rel for rel in restore_paths if rel not in kept_oversize
+            ]
             result["skipped_user_edits"] = skipped_user_edits
+            if kept_oversize:
+                result["skipped_oversize"] = kept_oversize
         return result
 
     def get_working_dir_for_path(self, file_path: str) -> str:
@@ -1362,6 +1384,22 @@ class CheckpointManager:
         self._enforce_size_cap(store)
 
         return True
+
+    def _exceeds_size_cap(self, path: Path) -> bool:
+        """Whether *path* is larger than ``max_file_size_mb``.
+
+        The same test :meth:`_drop_oversize_from_index` applies when building a
+        checkpoint, so "excluded from the checkpoint" and "refused deletion at
+        restore" agree on one definition. A cap of 0 disables it, and an
+        unstattable path is not claimed to be oversize.
+        """
+        cap = self.max_file_size_mb * 1024 * 1024
+        if cap <= 0:
+            return False
+        try:
+            return path.stat().st_size > cap
+        except OSError:
+            return False
 
     def _drop_oversize_from_index(
         self, store: Path, working_dir: str, index_file: Path,


### PR DESCRIPTION
## Summary
Safe `/rollback` no longer deletes files that `max_file_size_mb` kept out of every checkpoint, and rollback output no longer claims files were restored when they weren't.

Salvage of #95207 by @RickyYii (both commits cherry-picked, authorship preserved), rebased onto current main, plus one follow-up commit completing the misreport bug class.

**Who hits this:** anyone whose agent appends to a large file (a dataset, corpus, export, or log over the 10MB default cap) and then runs `/rollback <N>`. Safe mode treated "absent from the checkpoint" as "Hermes created it, delete it" — but capped files are absent because `_drop_oversize_from_index` excluded them, so the delete destroyed the only copy in existence (the pre-rollback snapshot excludes them too) while `restored_files` reported the path as restored.

## Changes
- `tools/checkpoint_manager.py` (contributor): new `_exceeds_size_cap()` shared by checkpoint-build and restore; restore's delete branch keeps oversize paths and reports them under `skipped_oversize`; `restored_files` no longer lists kept paths.
- `tools/checkpoint_manager.py` (follow-up): a `delete_target` whose `unlink()` fails is also dropped from `restored_files` — same silent-misreport class.
- `hermes_cli/cli_commands_mixin.py` + `gateway/slash_commands.py` + all 17 `locales/*.yaml` (follow-up): `/rollback` output now tells the user which files were kept because no checkpoint holds a copy (`gateway.rollback.kept_oversize`); previously the file was preserved but with zero notice.
- `tests/tools/test_checkpoint_manager.py`: 5 contributor tests (incl. a boundary-agreement test pinning both sides to the same `>` threshold) + 1 follow-up regression test for the failed-unlink misreport.

## Validation
| | Before (main) | After |
|---|---|---|
| 2MB agent-appended file, cap 1MB, `/rollback 1` | deleted, unrecoverable; listed in `restored_files` | kept intact; `skipped_oversize=[...]`; user notified |
| File checkpointed small, later grew past cap | reverts | reverts (unchanged, test-pinned) |
| `--all` / file-path / unsafe / cap=0 paths | — | byte-identical to main (behavior-parity traced incl. `tui_gateway/methods_tools.py`) |
| Tests | — | 89/89 (checkpoint + i18n parity); mutation check on the new guard test fails on mutated code |

E2E reproduced on main and verified fixed with real `CheckpointManager` calls in an isolated HERMES_HOME. Ruff clean.

Closes #95207.

## Credit
Fix authored by @RickyYii — both commits cherry-picked with authorship preserved. Follow-up (failed-delete misreport + user-facing surfacing + locales) by @kshitijk4poor.
