### PR TITLE
fix(cli): a failed git fetch can no longer cache a false 'up to date' for 6 hours (#82166, salvage #83367)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -340,13 +340,22 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
+        fetch_proc = subprocess.run(
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
+        fetch_ok = fetch_proc.returncode == 0
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        fetch_ok = False  # Offline or timeout — don't use stale refs
+
+    # When the fetch fails, the local origin/main tracking ref is stale.
+    # Comparing HEAD against it can report "0 behind" (up to date) even when
+    # upstream has moved forward — the exact stale-cache symptom in #82166.
+    # Return None so the caller knows the check was inconclusive and doesn't
+    # cache a false "up to date".
+    if not fetch_ok:
+        return None
 
     if is_shallow:
         # No history to count across the shallow boundary. `origin/main` may not
@@ -444,10 +453,16 @@ def check_for_updates() -> Optional[int]:
             behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
+        # Don't cache inconclusive results (None). A None means the check
+        # could not run — typically a failed git fetch. Caching None would
+        # suppress retries for the full 6-hour cache window, leaving the
+        # user with a stale "up to date" or no information for hours after
+        # connectivity is restored (#82166).
+        if behind is not None:
+            cache_file.write_text(
+                json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+                encoding="utf-8",
+            )
     except Exception:
         pass
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -349,12 +349,27 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     except Exception:
         fetch_ok = False  # Offline or timeout — don't use stale refs
 
-    # When the fetch fails, the local origin/main tracking ref is stale.
-    # Comparing HEAD against it can report "0 behind" (up to date) even when
-    # upstream has moved forward — the exact stale-cache symptom in #82166.
-    # Return None so the caller knows the check was inconclusive and doesn't
-    # cache a false "up to date".
+    # When the fetch fails, the local origin/main tracking ref is stale. It
+    # cannot prove *currentness* (a 0 behind-count may just mean the stale ref
+    # hasn't caught up), but if it already shows HEAD behind, that is sound
+    # evidence an update exists — the ref was good at some point in the past.
+    # Return the positive stale count; return None (inconclusive) otherwise so
+    # the caller doesn't cache a false "up to date". (#82166, review #92578)
     if not fetch_ok:
+        if not is_shallow:
+            try:
+                result = subprocess.run(
+                    ["git", "rev-list", "--count", "HEAD..origin/main"],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=5,
+                    cwd=str(repo_dir),
+                )
+                if result.returncode == 0:
+                    behind = int(result.stdout.strip())
+                    if behind > 0:
+                        return behind
+            except Exception:
+                pass
         return None
 
     if is_shallow:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -59,12 +59,12 @@ def test_prefetch_non_blocking():
 
 
 def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
-    """When git fetch fails, _check_via_local_git must return None instead of
-    comparing against stale origin/main refs (#82166).
+    """When git fetch fails and the stale origin/main ref is not ahead,
+    _check_via_local_git must return None (#82166).
 
-    Without this fix, a fetch failure silently falls through to
-    ``git rev-list --count HEAD..origin/main`` using the stale tracking ref,
-    which can report 0 (up to date) even when upstream has moved forward.
+    A stale tracking ref cannot prove *currentness* (rev-list 0 just means
+    the ref hasn't caught up), so returning None is the honest inconclusive
+    result — and the caller must not cache it as "up to date".
     """
     from hermes_cli import banner
 
@@ -80,17 +80,109 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
             return "false"
         return None
 
-    # Simulate fetch failure (returncode != 0)
+    # Fetch fails (returncode != 0); stale rev-list reports 0 behind
     failed_proc = MagicMock()
     failed_proc.returncode = 1
     failed_proc.stdout = ""
     failed_proc.stderr = "fatal: could not reach remote"
 
+    stale_zero_proc = MagicMock()
+    stale_zero_proc.returncode = 0
+    stale_zero_proc.stdout = "0"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return stale_zero_proc
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
     monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
-    monkeypatch.setattr(banner.subprocess, "run", MagicMock(return_value=failed_proc))
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
 
     result = banner._check_via_local_git(repo_dir)
-    assert result is None, "Fetch failure must return None, not a stale behind-count"
+    assert result is None, (
+        "Fetch failure with stale 0-behind must return None, not 'up to date'"
+    )
+
+
+def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, monkeypatch):
+    """A failed fetch must preserve sound evidence: if the stale origin/main
+    ref already shows HEAD behind, that positive count is still an update
+    signal and must be returned (review #92578)."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    stale_behind_proc = MagicMock()
+    stale_behind_proc.returncode = 0
+    stale_behind_proc.stdout = "5"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return stale_behind_proc
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result == 5, "Stale positive behind-count must be preserved on fetch failure"
+
+
+def test_check_via_local_git_fetch_failure_rev_list_error_returns_none(tmp_path, monkeypatch):
+    """If the stale rev-list itself fails, the check stays inconclusive (None)."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    bad_rev_list = MagicMock()
+    bad_rev_list.returncode = 128
+    bad_rev_list.stdout = ""
+    bad_rev_list.stderr = "fatal: ambiguous argument 'HEAD..origin/main'"
+
+    def mock_run(args, **kwargs):
+        if args[:2] == ["git", "fetch"]:
+            return failed_proc
+        if args[:2] == ["git", "rev-list"]:
+            return bad_rev_list
+        raise AssertionError(f"unexpected subprocess.run: {args}")
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", mock_run)
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result is None
 
 
 def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -58,5 +58,100 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
+    """When git fetch fails, _check_via_local_git must return None instead of
+    comparing against stale origin/main refs (#82166).
+
+    Without this fix, a fetch failure silently falls through to
+    ``git rev-list --count HEAD..origin/main`` using the stale tracking ref,
+    which can report 0 (up to date) even when upstream has moved forward.
+    """
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # Simulate a non-shallow, non-SSH-remote checkout
+    def mock_git_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["remote", "get-url"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        return None
+
+    # Simulate fetch failure (returncode != 0)
+    failed_proc = MagicMock()
+    failed_proc.returncode = 1
+    failed_proc.stdout = ""
+    failed_proc.stderr = "fatal: could not reach remote"
+
+    monkeypatch.setattr(banner, "_git_stdout", mock_git_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", MagicMock(return_value=failed_proc))
+
+    result = banner._check_via_local_git(repo_dir)
+    assert result is None, "Fetch failure must return None, not a stale behind-count"
+
+
+def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):
+    """check_for_updates must not cache None results so a transient fetch
+    failure doesn't suppress retries for the full 6-hour cache window (#82166).
+
+    Instead of mocking the full Path resolution chain, we verify the cache-write
+    guard directly: call check_for_updates with a mocked _check_via_local_git
+    that returns None, and confirm no cache file is created.
+    """
+    import hermes_cli.banner as banner
+
+    cache_file = tmp_path / ".update_check"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    # Create a fake repo dir so the .git check passes
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # Mock the internal functions to force the local-git path returning None
+    monkeypatch.setattr(banner, "_check_via_local_git", lambda rd: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method", lambda root: "git"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_project_root", lambda: repo_dir
+    )
+
+    # Patch __file__ resolution by monkeypatching the module's Path calls.
+    # check_for_updates does: Path(__file__).parent.parent.resolve()
+    # We intercept by making the resolve() return our fake repo_dir.
+    original_init = Path.__init__
+
+    def patched_path_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+
+    # Simpler: just patch the get_hermes_home and the repo_dir resolution
+    # by making check_for_updates find our fake repo via hermes_home fallback.
+    # The code checks Path(__file__).parent.parent/.git first, then falls
+    # back to hermes_home / "hermes-agent". We ensure the fallback hits.
+    # To do this, we make Path(__file__).parent.parent.resolve() return
+    # a path without .git, so it falls through to hermes_home / "hermes-agent".
+    real_resolve = Path.resolve
+
+    def fake_resolve(self, *args, **kwargs):
+        s = str(self)
+        if "banner.py" in s or s.endswith("hermes_cli"):
+            # Return a path that has no .git, forcing the fallback
+            return tmp_path / "no-git-here"
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    result = banner.check_for_updates()
+    assert result is None
+
+    # The cache file must NOT have been written with a None result
+    assert not cache_file.exists(), "None result must not be cached"
+
+
 
 


### PR DESCRIPTION
## Summary

The update check can no longer serve a cached "up to date" built from stale refs after a failed `git fetch` — the exact failure that hid releases from a daily cron for 4+ days while a manual force-check found them instantly (#82166; salvage of #83367 by @rkfshakti, both commits cherry-picked with authorship preserved). Fleet relevance (#91277): the check feeds the CLI banner, `hermes update --check`, and the dashboard's update endpoint — a false "up to date" upstream of everything.

Root cause: `_check_via_local_git()` swallowed fetch failures ("use stale refs, that's fine") and counted `HEAD..origin/main` against the stale tracking ref, yielding 0; `check_for_updates()` then cached that false 0 for 6 hours. A recurring fetch failure (DNS, slow link, sandboxed network) reproduces multi-day false negatives.

## Changes

- `hermes_cli/banner.py`:
  - Fetch failure no longer falls through to a stale-ref count as truth. A stale ref can't prove *currentness* — but a stale positive behind-count is still sound evidence an update exists, so it is preserved (the #92578 review case, handled in the contributor's second commit); a stale 0 or a rev-list error returns None (inconclusive).
  - `check_for_updates()` never caches None — a transient network blip no longer suppresses retries for the 6-hour cache window.
- 4 new tests (fetch-fail + stale 0 → None; fetch-fail + stale 5 → 5; rev-list error → None; None never cached).

## Validation

| | Result |
|---|---|
| Suite at head | 6/6 passed |
| A/B (banner.py reverted to merge-base, tests kept) | 2 failed — bug shape proven |
| Live E2E (real git repos, really-unreachable remote) | CASE A: upstream moved, stale ref says 0, fetch fails → None (main returns false 0). CASE B: ref already 2 behind, fetch fails → 2 preserved. CASE C: healthy fetch → 2, unchanged |

**Live repro:** real clone + real upstream with the remote URL pointed at a nonexistent path — before: fetch failure yields 0 ("up to date") while upstream is 2 ahead; after: inconclusive None, positive evidence preserved, healthy path intact.

Both check consumers run off-thread (CLI daemon-thread prefetch, web `asyncio.to_thread`), so the changed failure path adds no blocking.

Fixes #82166. Also covers the #92578 stale-positive concern. Credit: @rkfshakti.

## Infographic

![Stale refs](https://v3b.fal.media/files/b/0aa7e0f4/Ie8s4z7oUB2SFKw08Aotu_S8NJpmTy.png)
