### PR TITLE
fix(auth): bind Codex pool reads to the effective auth store

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -63,6 +63,15 @@ def _load_config_safe() -> Optional[dict]:
         return None
 
 
+def _load_descriptor_codex_provider_state(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return only the Codex singleton physically in an effective store."""
+    providers = auth_store.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    state = providers.get("openai-codex")
+    return state if isinstance(state, dict) else None
+
+
 # --- Status and type constants ---
 
 STATUS_OK = "ok"
@@ -711,8 +720,19 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        *,
+        codex_store: Optional[Any] = None,
+    ):
         self.provider = provider
+        self.codex_store = (
+            codex_store or auth_mod.resolve_codex_auth_store()
+            if provider == "openai-codex"
+            else None
+        )
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
@@ -2561,10 +2581,21 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
-def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_from_singletons(
+    provider: str,
+    entries: List[PooledCredential],
+    *,
+    codex_store: Optional[Any] = None,
+) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
-    auth_store = _load_auth_store()
+    if provider == "openai-codex" and codex_store is not None and not codex_store.legacy:
+        if codex_store.path is None or codex_store.denied or codex_store.isolated:
+            return changed, active_sources
+        with auth_mod._codex_effective_store_lock(codex_store):
+            auth_store = auth_mod._load_effective_codex_auth_store(codex_store)
+    else:
+        auth_store = _load_auth_store()
 
     # Shared suppression gate — used at every upsert site so
     # `hermes auth remove <provider> <N>` is stable across all source types.
@@ -2870,7 +2901,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         if _is_suppressed(provider, "device_code"):
             return changed, active_sources
 
-        state = _load_provider_state(auth_store, "openai-codex")
+        state = _load_descriptor_codex_provider_state(auth_store)
         tokens = state.get("tokens") if isinstance(state, dict) else None
         # Hermes owns its own Codex auth state — we do NOT auto-import from
         # ~/.codex/auth.json at pool-load time.  OAuth refresh tokens are
@@ -3192,9 +3223,14 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     return changed, active_sources
 
 
-def load_pool(provider: str) -> CredentialPool:
+def load_pool(provider: str, *, codex_store: Optional[Any] = None) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    raw_entries = read_credential_pool(provider)
+    if provider == "openai-codex":
+        codex_store = codex_store or auth_mod.resolve_codex_auth_store()
+        raw_entries = read_credential_pool(provider, codex_store=codex_store)
+    else:
+        codex_store = None
+        raw_entries = read_credential_pool(provider)
     disk_ids = {
         entry.get("id")
         for entry in raw_entries
@@ -3215,7 +3251,11 @@ def load_pool(provider: str) -> CredentialPool:
         ) != payload.get("auth_type", AUTH_TYPE_API_KEY)
         for payload in raw_entries
     )
-    if raw_needs_auth_normalization:
+    if raw_needs_auth_normalization and not (
+        provider == "openai-codex"
+        and codex_store is not None
+        and not codex_store.legacy
+    ):
         # A profile may be reading this provider from the global-root fallback.
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
@@ -3229,7 +3269,11 @@ def load_pool(provider: str) -> CredentialPool:
         changed = raw_needs_sanitization or raw_needs_auth_normalization or custom_changed
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
-        singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
+        singleton_changed, singleton_sources = _seed_from_singletons(
+            provider,
+            entries,
+            codex_store=codex_store,
+        )
         env_changed, env_sources = _seed_from_env(provider, entries)
         changed = (
             raw_needs_sanitization
@@ -3248,11 +3292,21 @@ def load_pool(provider: str) -> CredentialPool:
         )
         changed |= _normalize_pool_priorities(provider, entries)
 
-    if changed:
+    # The explicit descriptor branch is deliberately read-only in the first
+    # effective-store slice.  ``load_pool()`` otherwise persists seeded or
+    # normalized rows, which would turn a read-boundary PR into an unreviewed
+    # auth-store mutation path.  Persistence/refresh binding follows in a
+    # separate lifecycle slice.
+    descriptor_read_only = bool(
+        provider == "openai-codex"
+        and codex_store is not None
+        and not codex_store.legacy
+    )
+    if changed and not descriptor_read_only:
         new_ids = {entry.id for entry in entries}
         write_credential_pool(
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
         )
-    return CredentialPool(provider, entries)
+    return CredentialPool(provider, entries, codex_store=codex_store)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -85,6 +85,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
     read_raw_config,
+    read_user_config_raw,
     require_readable_config_before_write,
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
@@ -1244,6 +1245,114 @@ def _auth_lock_holder_for(target_path: Path) -> threading.local:
         return _auth_target_lock_holders.setdefault(key, threading.local())
 
 
+@dataclass(frozen=True)
+class CodexAuthStore:
+    """Secret-free authorization boundary for descriptor-bound Codex reads."""
+
+    path: Optional[Path]
+    shared: bool = False
+    isolated: bool = False
+    denied: bool = False
+    legacy: bool = False
+
+    @property
+    def lock_path(self) -> Optional[Path]:
+        return self.path.with_suffix(".lock") if self.path is not None else None
+
+
+def _named_profile_root(home: Path) -> Optional[Path]:
+    """Return the root only for an exact ``<root>/profiles/<name>`` home."""
+    try:
+        resolved = home.expanduser().resolve(strict=False)
+        if resolved.parent.name != "profiles" or not resolved.name:
+            return None
+        return resolved.parent.parent
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def resolve_codex_auth_store(home: Optional[Path] = None) -> CodexAuthStore:
+    """Resolve named-profile Codex policy without widening legacy fallback.
+
+    A legacy descriptor intentionally leaves the existing generic fallback
+    untouched. Explicit local/shared descriptors select one physical store;
+    isolated and malformed policy is pathless and therefore fail-closed.
+    """
+    active_home = Path(home or get_hermes_home()).expanduser().resolve(strict=False)
+    root = _named_profile_root(active_home)
+    if root is None:
+        return CodexAuthStore(active_home / "auth.json", legacy=True)
+    try:
+        config = read_user_config_raw(active_home / "config.yaml")
+    except Exception:
+        return CodexAuthStore(None, denied=True)
+    if not isinstance(config, dict):
+        return CodexAuthStore(None, denied=True)
+
+    codex_config = config.get("openai_codex")
+    if codex_config is not None:
+        if not isinstance(codex_config, dict) or "shared_auth_store" not in codex_config:
+            return CodexAuthStore(None, denied=True)
+        canonical = (root / "auth.json").resolve(strict=False)
+        candidate = codex_config.get("shared_auth_store")
+        if not isinstance(candidate, str) or not candidate.strip():
+            return CodexAuthStore(None, denied=True)
+        configured = Path(candidate).expanduser()
+        if not configured.is_absolute() or configured != canonical:
+            return CodexAuthStore(None, denied=True)
+        return CodexAuthStore(canonical, shared=True)
+
+    auth_config = config.get("auth")
+    if auth_config is None:
+        return CodexAuthStore(active_home / "auth.json", legacy=True)
+    if not isinstance(auth_config, dict):
+        return CodexAuthStore(None, denied=True)
+    if "isolated_providers" not in auth_config:
+        return CodexAuthStore(active_home / "auth.json", legacy=True)
+    providers = auth_config.get("isolated_providers")
+    if not isinstance(providers, list) or any(
+        not isinstance(provider, str) or not provider.strip() for provider in providers
+    ):
+        return CodexAuthStore(None, denied=True)
+    if any(provider.strip().lower() == "openai-codex" for provider in providers):
+        return CodexAuthStore(None, isolated=True)
+    return CodexAuthStore(active_home / "auth.json", legacy=True)
+
+
+def _require_codex_auth_store(store: CodexAuthStore) -> Path:
+    if store.path is None or store.denied or store.isolated:
+        raise AuthError(
+            "Codex auth-store policy does not authorize credential access.",
+            provider="openai-codex",
+            code="codex_auth_store_denied",
+            relogin_required=True,
+        )
+    return store.path
+
+
+@contextmanager
+def _codex_effective_store_lock(
+    store: CodexAuthStore,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
+    """Lock one already-resolved Codex store without policy fallback."""
+    path = _require_codex_auth_store(store)
+    lock_path = store.lock_path
+    assert lock_path is not None
+    with _file_lock(
+        lock_path,
+        _auth_lock_holder_for(path),
+        timeout_seconds,
+        "Timed out waiting for Codex auth store lock",
+    ):
+        yield path
+
+
+def _load_effective_codex_auth_store(store: CodexAuthStore) -> Dict[str, Any]:
+    """Load exactly the descriptor-selected store; never generic fallback."""
+    return _load_auth_store(_require_codex_auth_store(store))
+
+
 @contextmanager
 def _file_lock(
     lock_path: Path,
@@ -1667,7 +1776,11 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def read_credential_pool(
+    provider_id: Optional[str] = None,
+    *,
+    codex_store: Optional[CodexAuthStore] = None,
+) -> Dict[str, Any] | List[Any]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1683,6 +1796,17 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     Writes always go to the profile (``write_credential_pool`` is unchanged).
     See issue #18594 follow-up.
     """
+    if provider_id == "openai-codex":
+        store = codex_store or resolve_codex_auth_store()
+        if not store.legacy:
+            if store.path is None or store.denied or store.isolated:
+                return []
+            with _codex_effective_store_lock(store):
+                auth_store = _load_effective_codex_auth_store(store)
+            pool = auth_store.get("credential_pool")
+            entries = pool.get(provider_id) if isinstance(pool, dict) else None
+            return list(entries) if isinstance(entries, list) else []
+
     auth_store = _load_auth_store()
     pool = auth_store.get("credential_pool")
     if not isinstance(pool, dict):
@@ -1929,6 +2053,17 @@ def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
     global-scope provider state (e.g. a globally-authenticated Anthropic
     OAuth or Nous device-code session). See issue #18594 follow-up.
     """
+    if provider_id == "openai-codex":
+        store = resolve_codex_auth_store()
+        if not store.legacy:
+            if store.path is None or store.denied or store.isolated:
+                return None
+            with _codex_effective_store_lock(store):
+                auth_store = _load_effective_codex_auth_store(store)
+            providers = auth_store.get("providers")
+            state = providers.get(provider_id) if isinstance(providers, dict) else None
+            return dict(state) if isinstance(state, dict) else None
+
     auth_store = _load_auth_store()
     return _load_provider_state(auth_store, provider_id)
 

--- a/tests/hermes_cli/test_codex_effective_auth_store_reads.py
+++ b/tests/hermes_cli/test_codex_effective_auth_store_reads.py
@@ -1,0 +1,135 @@
+"""Behaviour contracts for descriptor-bound Codex auth-store reads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.auth as auth
+from agent.credential_pool import load_pool
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _store(token: str) -> dict:
+    return {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": token, "refresh_token": f"{token}-refresh"}
+            }
+        },
+        "credential_pool": {
+            "openai-codex": [{
+                "id": token,
+                "label": token,
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "device_code",
+                "access_token": token,
+                "refresh_token": f"{token}-refresh",
+            }]
+        },
+    }
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "work"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    return root, profile
+
+
+def test_isolated_policy_never_reads_root_codex_store(profile_env, monkeypatch):
+    root, profile = profile_env
+    _write(root / "auth.json", _store("root-only"))
+    _write(profile / "auth.json", {"version": 1})
+    (profile / "config.yaml").write_text(
+        "auth:\n  isolated_providers: [openai-codex]\n", encoding="utf-8"
+    )
+
+    def root_read():
+        pytest.fail("isolated Codex read consulted the root auth store")
+
+    monkeypatch.setattr(auth, "_load_global_auth_store", root_read)
+    assert auth.read_credential_pool("openai-codex") == []
+    assert auth.get_provider_auth_state("openai-codex") is None
+    assert load_pool("openai-codex").entries() == []
+
+
+def test_invalid_policy_never_reads_root_codex_store(profile_env, monkeypatch):
+    root, profile = profile_env
+    _write(root / "auth.json", _store("root-only"))
+    _write(profile / "auth.json", {"version": 1})
+    (profile / "config.yaml").write_text("auth: invalid\n", encoding="utf-8")
+
+    def root_read():
+        pytest.fail("invalid Codex policy consulted the root auth store")
+
+    monkeypatch.setattr(auth, "_load_global_auth_store", root_read)
+    assert auth.read_credential_pool("openai-codex") == []
+    assert auth.get_provider_auth_state("openai-codex") is None
+
+
+def test_explicit_shared_policy_reads_only_selected_root_store(profile_env, monkeypatch):
+    root, profile = profile_env
+    root_store = _store("shared-root")
+    root_store["credential_pool"]["openai-codex"][0]["auth_type"] = "api_key"
+    _write(root / "auth.json", root_store)
+    _write(profile / "auth.json", _store("profile-shadow"))
+    (profile / "config.yaml").write_text(
+        f"openai_codex:\n  shared_auth_store: {root / 'auth.json'}\n",
+        encoding="utf-8",
+    )
+
+    loaded: list[Path | None] = []
+    real_load = auth._load_auth_store
+
+    def record_load(path=None):
+        loaded.append(path)
+        return real_load(path)
+
+    monkeypatch.setattr(auth, "_load_auth_store", record_load)
+    assert auth.read_credential_pool("openai-codex")[0]["access_token"] == "shared-root"
+    assert auth.get_provider_auth_state("openai-codex")["tokens"]["access_token"] == "shared-root"
+    assert loaded and all(path == root / "auth.json" for path in loaded)
+    assert (root / "auth.lock").exists()
+    assert not (profile / "auth.lock").exists()
+
+
+def test_legacy_profile_read_preserves_root_fallback(profile_env):
+    root, profile = profile_env
+    _write(root / "auth.json", _store("legacy-root"))
+    _write(profile / "auth.json", {"version": 1})
+
+    assert auth.read_credential_pool("openai-codex")[0]["access_token"] == "legacy-root"
+    assert auth.get_provider_auth_state("openai-codex")["tokens"]["access_token"] == "legacy-root"
+
+
+def test_local_descriptor_never_adopts_root_singleton_or_persists_seed(profile_env):
+    root, profile = profile_env
+    _write(root / "auth.json", _store("root-only"))
+    local_entry = _store("local-pool")["credential_pool"]["openai-codex"][0]
+    _write(profile / "auth.json", {"version": 1, "credential_pool": {"openai-codex": [local_entry]}})
+    store = auth.CodexAuthStore(profile / "auth.json")
+
+    loaded = load_pool("openai-codex", codex_store=store)
+    assert [entry.access_token for entry in loaded.entries()] == ["local-pool"]
+    local = json.loads((profile / "auth.json").read_text(encoding="utf-8"))
+    assert "openai-codex" not in local.get("providers", {})
+
+    seed_only = profile / "seed-only" / "auth.json"
+    seed_payload = _store("local-singleton")
+    seed_payload.pop("credential_pool")
+    _write(seed_only, seed_payload)
+    seeded = load_pool("openai-codex", codex_store=auth.CodexAuthStore(seed_only))
+    assert [entry.access_token for entry in seeded.entries()] == ["local-singleton"]
+    assert "credential_pool" not in json.loads(seed_only.read_text(encoding="utf-8") )


### PR DESCRIPTION
## Summary

- resolve a secret-free effective Codex auth-store descriptor for named profiles
- support explicit canonical-root sharing and fail-closed isolated/malformed policy
- bind Codex credential-pool and singleton read paths to the selected store
- preserve existing legacy profile-to-root fallback behaviour by default
- suppress credential-payload persistence from explicit descriptor reads

## Why

Named-profile credential reads can currently reach the generic/root fallback without carrying the profile's intended auth-store decision. This adds a narrow, reusable read boundary so isolated or malformed policy cannot silently select unrelated Codex credentials.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_codex_effective_auth_store_reads.py tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool_oauth_writethrough.py tests/hermes_cli/test_config_read_guard.py -q`
  - 17 passed
- `ruff check hermes_cli/auth.py agent/credential_pool.py tests/hermes_cli/test_codex_effective_auth_store_reads.py`
- `git diff --check origin/main...HEAD`

## Scope

This change covers descriptor resolution and read-boundary behaviour only. Credential refresh, recovery, removal, cleanup, quota handling, and other lifecycle mutations remain follow-up work.

Related to #95062.