### PR TITLE
fix(desktop): chat video fullscreen — labeled button + dblclick drive HTML5 fullscreen

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
@@ -79,3 +79,79 @@ describe('MarkdownImage media routing', () => {
     expect(container.querySelector('audio')).toBeNull()
   })
 })
+
+// Regression for the "fullscreen button does nothing" report: Electron's
+// renderer never services macOS's native media-controls fullscreen button, so
+// chat videos must expose our own HTML5-fullscreen toggle (labeled button +
+// double-click) instead of relying on the native controls.
+describe('MediaAttachment video fullscreen', () => {
+  afterEach(cleanup)
+
+  const renderVideo = async (text = `[clip](#media:%2Ftmp%2Fclip.mp4)`) => {
+    const { container } = render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    await waitFor(() => expect(container.querySelector('video')).not.toBeNull())
+
+    return container
+  }
+
+  it('exposes a labeled Fullscreen button next to the filename', async () => {
+    const container = await renderVideo()
+
+    expect(screen.getByRole('button', { name: 'Fullscreen' })).not.toBeNull()
+    // The native controls stay on for play/seek/volume.
+    expect(container.querySelector('video[controls]')).not.toBeNull()
+  })
+
+  it('requests element fullscreen on the video when clicked', async () => {
+    const container = await renderVideo()
+    const video = container.querySelector('video')!
+
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(video, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fullscreen' }))
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggles via double-click and exits when already fullscreen', async () => {
+    const container = await renderVideo()
+    const video = container.querySelector('video')!
+
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(video, 'requestFullscreen', { configurable: true, value: requestFullscreen })
+    const exitFullscreen = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(window.document, 'exitFullscreen', { configurable: true, value: exitFullscreen })
+    Object.defineProperty(window.document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null
+    })
+
+    fireEvent.doubleClick(video)
+    expect(requestFullscreen).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(window.document, 'fullscreenElement', {
+      configurable: true,
+      get: () => video
+    })
+
+    fireEvent.doubleClick(video)
+    expect(exitFullscreen).toHaveBeenCalledTimes(1)
+
+    delete (window.document as any).fullscreenElement
+    delete (window.document as any).exitFullscreen
+  })
+
+  it('swallows a rejected requestFullscreen instead of throwing', async () => {
+    const container = await renderVideo()
+
+    Object.defineProperty(container.querySelector('video')!, 'requestFullscreen', {
+      configurable: true,
+      value: vi.fn().mockRejectedValue(new Error('denied'))
+    })
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: 'Fullscreen' }))).not.toThrow()
+  })
+})
+

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,7 +8,7 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, memo, useEffect, useMemo, useRef, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -208,18 +208,7 @@ function MediaAttachment({ path }: { path: string }) {
   }
 
   if (kind === 'video' && src) {
-    return (
-      <span className="my-3 block max-w-2xl rounded-xl border border-(--ui-stroke-tertiary) bg-muted/35 p-3">
-        <span className="mb-2 block truncate text-xs font-medium text-muted-foreground">{name}</span>
-        <video
-          className="block max-h-112 w-full rounded-lg bg-black"
-          controls
-          onError={() => setFailed(true)}
-          src={src}
-        />
-        {failed && <OpenMediaButton kind="video" path={path} />}
-      </span>
-    )
+    return <VideoAttachment failed={failed} name={name} onError={() => setFailed(true)} open={open} src={src} />
   }
 
   return (
@@ -235,6 +224,77 @@ function MediaAttachment({ path }: { path: string }) {
         {failed ? `Open ${name}` : `Loading ${name}...`}
       </a>
       {openFailed && <OpenMediaFailedNote name={name} />}
+    </span>
+  )
+}
+
+// Inline chat video player. Electron's renderer never services macOS's native
+// media-controls fullscreen button (the AVKit-style overlay fullscreen path is
+// a silent no-op in Electron windows), so we drive HTML5 fullscreen ourselves:
+// a labeled button in the header row plus double-click on the video.
+// requestFullscreen works fine in our frameless windows.
+function VideoAttachment({
+  failed,
+  name,
+  onError,
+  open,
+  src
+}: {
+  failed: boolean
+  name: string
+  onError: () => void
+  open: () => void
+  src: string
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen()
+
+      return
+    }
+
+    const element = videoRef.current
+
+    if (!element) {
+      return
+    }
+
+    void element.requestFullscreen().catch(() => {
+      // Fullscreen denied (e.g. window without a screen) — stay inline quietly.
+    })
+  }
+
+  return (
+    <span className="my-3 block max-w-2xl rounded-xl border border-(--ui-stroke-tertiary) bg-muted/35 p-3">
+      <span className="mb-2 flex items-center justify-between gap-2">
+        <span className="truncate text-xs font-medium text-muted-foreground">{name}</span>
+        <button
+          className="ref shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground"
+          onClick={toggleFullscreen}
+          type="button"
+        >
+          Fullscreen
+        </button>
+      </span>
+      <video
+        className="block max-h-112 w-full rounded-lg bg-black"
+        controls
+        onDoubleClick={toggleFullscreen}
+        onError={onError}
+        playsInline
+        ref={videoRef}
+        src={src}
+      />
+      {failed && <OpenMediaFailedNote name={name} />}
+      {failed && (
+        <span className="block">
+          <button className="mt-2 ref text-xs font-medium text-muted-foreground hover:text-foreground" onClick={open} type="button">
+            Open video file
+          </button>
+        </span>
+      )}
     </span>
   )
 }


### PR DESCRIPTION
## Problem

Clicking the native fullscreen button on an inline chat video attachment does nothing — no error, no log line, nothing (reported with a screenshot on macOS 26.5.1, Hermes 0.17.0 / Electron 40.10.2).

## Root cause

Inline video attachments render as bare `<video controls>` (`MediaAttachment` in `markdown-text.tsx`). On macOS, Chromium's native media-controls fullscreen button drives the AVKit-style overlay-fullscreen path, which Electron's renderer/BrowserWindow combination never services — so the click is silently swallowed. This is an Electron-level gap, not a window-flag problem.

**Verified by reproduction:** in a minimal Electron 40.10.2 harness replicating the chat window's flags (`titleBarStyle: 'hidden'`, sandboxed, custom streaming protocol src), the JS Fullscreen API works fine — `video.requestFullscreen()` resolves and fires `fullscreenchange` in both frameless and titled windows. Only the shadow-DOM media-controls button is dead (its closed shadow root also makes it untestable via CDP piercing).

## Fix

Drive HTML5 element fullscreen ourselves:

- Labeled **Fullscreen** button in the attachment card header row (visible affordance instead of the hidden-state native control)
- Double-click on the video toggles fullscreen
- Toggle exits when already fullscreen; rejected `requestFullscreen()` is swallowed quietly
- Native controls remain for play/seek/volume; audio attachments unchanged

## Tests

New `MediaAttachment video fullscreen` suite in `markdown-text.media.test.tsx`:
- labeled button renders next to filename, native `controls` attr preserved
- click calls `requestFullscreen()` on the video element
- double-click toggles and exits when already fullscreen
- rejected promise doesn't throw

`vitest run markdown-text.media.test.tsx` → 8 passed · `tsc -p . --noEmit` → clean · `eslint` on touched files → 0 problems