### PR TITLE
fix(desktop): transport waits bounded, poll storms stopped, saved connections paint instantly (multi-gateway wave-2 phase B, tracker #94724)

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -1017,3 +1017,31 @@ test('sanitizeDesktopConnectionConfig exposes secureTokenStorage and remoteToken
   assert.match(returned, /\bsecureTokenStorage\b/, 'the renderer needs the secure-storage availability signal')
   assert.match(returned, /\bremoteTokenPlainText\b/, 'the renderer needs the plain-text token signal')
 })
+
+// #95393: connections.save succeeded but the switcher menu (renderer
+// $connectionsRegistry snapshot) never refreshed until reload. The registry
+// push (broadcastConnectionsChanged) fired only on the dial-material-edit
+// branch, so a brand-new connection or a label rename never reached other
+// windows — or the switcher's onChanged re-pull. Mirrors the live repro at
+// /tmp/mg-ab/w2_95393.py: save → menu (no reload) must include the new row.
+test('saveRegistryConnection republishes the registry to renderers on EVERY successful save (#95393)', () => {
+  const source = readMain()
+  const fnStart = source.indexOf('async function saveRegistryConnection(')
+  assert.notEqual(fnStart, -1, 'saveRegistryConnection must exist in main.ts')
+  const fnEnd = source.indexOf('\nasync function ', fnStart + 1)
+  const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+
+  // The dial-material edit branch keeps its dispose+redial semantics…
+  assert.match(
+    body,
+    /broadcastConnectionsChanged\(\{ connectionId: entry\.id, reason: 'updated' \}\)/,
+    'a dial-material edit must still push the dispose+redial signal'
+  )
+  // …and every OTHER save (new connection, label rename) must still push a
+  // registry refresh, or the switcher menu paints stale until reload.
+  assert.match(
+    body,
+    /broadcastConnectionsChanged\(\{ connectionId: entry\.id, reason: 'saved' \}\)/,
+    'a non-dial-material save must republish the registry snapshot (#95393)'
+  )
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9088,6 +9088,14 @@ async function saveRegistryConnection(input: any = {}) {
   if (existing && connectionDialFieldsChanged(existing, entry)) {
     await stopRegistryConnectionBackends(entry.id)
     broadcastConnectionsChanged({ connectionId: entry.id, reason: 'updated' })
+  } else {
+    // Every OTHER successful save (a brand-new connection, a label rename)
+    // must still republish the registry snapshot, or windows that didn't
+    // perform the save — and the switcher menu fed by $connectionsRegistry —
+    // keep painting the stale list until reload (#95393). 'saved' is a pure
+    // registry-refresh signal: no sockets moved, so listeners must not
+    // dispose or redial anything for it.
+    broadcastConnectionsChanged({ connectionId: entry.id, reason: 'saved' })
   }
 
   return sanitizeRegistryConnection(entry)
@@ -10330,7 +10338,7 @@ function sendConnectionApplied() {
 // scoped to that connection. Without this, a removed remote/cloud source keeps
 // its renderer WebSocket open and streaming as a ghost, and an edited one
 // keeps talking to the OLD endpoint until idle-reap.
-function broadcastConnectionsChanged(payload: { connectionId: string; reason: 'removed' | 'updated' }) {
+function broadcastConnectionsChanged(payload: { connectionId: string; reason: 'removed' | 'saved' | 'updated' }) {
   for (const win of BrowserWindow.getAllWindows()) {
     const { webContents } = win
 

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -21,6 +21,7 @@ import {
   dismissBackgroundProcess,
   groupStatusItems,
   refreshBackgroundProcesses,
+  resetBackgroundPollingGuard,
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
@@ -105,6 +106,10 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   // process tool completions) live in use-message-stream.
   useEffect(() => {
     if (sessionId) {
+      // Opening/rebinding a session is a fresh runtime binding: clear any
+      // gone-latch left by a previous runtime under this id so the poll below
+      // is allowed to run again (see resetBackgroundPollingGuard).
+      resetBackgroundPollingGuard(sessionId)
       void refreshBackgroundProcesses(sessionId)
       void refreshSessionGoal(sessionId)
     }

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
@@ -362,4 +362,79 @@ describe('ConnectionSwitcher', () => {
 
     expect(screen.getByRole('group', { name: 'Registered gateways' }).getAttribute('aria-busy')).toBe('true')
   })
+
+  // #95393: connections.save succeeded but the switcher kept painting the
+  // stale registry until reload. Mirrors the live repro (w2_95393.py): open
+  // the menu, save a new connection via the bridge, re-open the menu WITHOUT
+  // reload — the new row must be there. Electron now pushes a 'saved'
+  // onChanged for every successful save; the switcher's listener re-pulls the
+  // snapshot.
+  it('repaints the menu after a connections.save without reload (#95393)', async () => {
+    const before = registry([connection('local', 'This device', 'local'), connection('homelab', 'Homelab')])
+    const after = registry([
+      connection('local', 'This device', 'local'),
+      connection('homelab', 'Homelab'),
+      connection('w2-probe', 'W2Probe')
+    ])
+
+    $connectionsRegistry.set(before)
+
+    let onChangedCallback: ((payload: { connectionId: string; reason: string }) => void) | null = null
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      connections: {
+        list: vi.fn(async () => after),
+        onChanged: vi.fn((callback: (payload: { connectionId: string; reason: string }) => void) => {
+          onChangedCallback = callback
+
+          return () => {
+            onChangedCallback = null
+          }
+        })
+      }
+    }
+
+    // The real refreshConnectionsRegistry re-pulls list() and republishes the
+    // atom; the mock mirrors exactly that seam against Electron's current
+    // registry state (before the save, then after it).
+    let electronRegistry = before
+
+    refreshConnectionsRegistry.mockImplementation(async () => {
+      $connectionsRegistry.set(electronRegistry)
+
+      return electronRegistry
+    })
+
+    try {
+      render(<ConnectionSwitcher onConnect={onConnect} />)
+
+      const trigger = screen.getByRole('button', { name: 'Registered gateways: This device' })
+
+      fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+      expect(screen.queryByRole('menuitemradio', { name: 'W2Probe' })).toBeNull()
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      // The save lands in Electron's registry…
+      electronRegistry = after
+      // …and Electron's post-save push (reason 'saved' — no dial change) is
+      // the ONLY signal this window gets. Pre-fix, save never emitted it.
+      expect(onChangedCallback).not.toBeNull()
+      ;(onChangedCallback as unknown as (payload: { connectionId: string; reason: string }) => void)({
+        connectionId: 'w2-probe',
+        reason: 'saved'
+      })
+
+      await waitFor(() => expect(refreshConnectionsRegistry).toHaveBeenCalledTimes(2))
+
+      fireEvent.pointerDown(screen.getByRole('button', { name: 'Registered gateways: This device' }), {
+        button: 0,
+        pointerType: 'mouse'
+      })
+      expect(screen.getByRole('menuitemradio', { name: 'W2Probe' })).toBeTruthy()
+    } finally {
+      refreshConnectionsRegistry.mockReset()
+      refreshConnectionsRegistry.mockResolvedValue(null)
+      delete (window as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
@@ -371,6 +371,7 @@ describe('ConnectionSwitcher', () => {
   // snapshot.
   it('repaints the menu after a connections.save without reload (#95393)', async () => {
     const before = registry([connection('local', 'This device', 'local'), connection('homelab', 'Homelab')])
+
     const after = registry([
       connection('local', 'This device', 'local'),
       connection('homelab', 'Homelab'),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1138,6 +1138,69 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewayState.get()).toBe('open')
   })
 
+  it('a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout, not only when main eventually gives up (#93454)', async () => {
+    // boot()'s getConnection() had no bound of its own — only main's own
+    // eventual timeout (e.g. waitForHermes, ~45s) ever settled it. A wedge
+    // that main never resolves (not even a rejection) must not hang
+    // "Starting Hermes…" forever; the renderer needs to own its own bound
+    // here too, same as attemptReconnect() and softSwitch().
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(() => new Promise(() => undefined))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeNull()
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // stalled await must reject on its own so boot()'s catch runs instead of
+    // waiting indefinitely on main.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($desktopBoot.get().error).toBeTruthy()
+  })
+
+  it('softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever (#93454)', async () => {
+    // Repro: main applies a new connection (onConnectionApplied), softSwitch()
+    // re-dials via getConnection(), and the IPC round-trip wedges. Without an
+    // internal timeout, the try block never settles, so the `finally` that
+    // clears $gatewaySwitching never runs — the switch UI stays frozen until
+    // the app is restarted.
+    const desktop = fakeDesktop()
+    const originalGetConnection = desktop.getConnection
+    let callCount = 0
+
+    desktop.getConnection = vi.fn((profile?: null | string) => {
+      callCount += 1
+
+      // Initial boot succeeds; the switch triggered below hangs indefinitely.
+      return callCount === 1 ? originalGetConnection(profile) : new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(connectionApplied).not.toBeNull()
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    expect($gatewaySwitching.get()).toBe(true)
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // stalled await must reject so the `finally` clears $gatewaySwitching
+    // instead of latching the switch UI frozen forever.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($gatewaySwitching.get()).toBe(false)
+  })
+
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1153,11 +1153,11 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($desktopBoot.get().error).toBeNull()
 
-    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // Advance past the shared backend-boot budget (45s) — the
     // stalled await must reject on its own so boot()'s catch runs instead of
     // waiting indefinitely on main.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(20_000)
+      await vi.advanceTimersByTimeAsync(45_000)
     })
 
     expect($desktopBoot.get().error).toBeTruthy()
@@ -1191,11 +1191,11 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewaySwitching.get()).toBe(true)
 
-    // Advance past the internal reconnect-attempt timeout (20s) — the
+    // Advance past the shared backend-boot budget (45s) — the
     // stalled await must reject so the `finally` clears $gatewaySwitching
     // instead of latching the switch UI frozen forever.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(20_000)
+      await vi.advanceTimersByTimeAsync(45_000)
     })
 
     expect($gatewaySwitching.get()).toBe(false)

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { withTimeout } from '@/lib/with-timeout'
+import { withTimeout, BACKEND_BOOT_WAIT_TIMEOUT_MS } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -542,10 +542,12 @@ export function useGatewayBoot({
         // on its pinned profile's backend across a soft switch.
         // Bounded for the same reason as attemptReconnect() (#93454): a wedged
         // main-process round-trip must not latch $gatewaySwitching stuck —
-        // the `finally` below only runs once this promise settles.
+        // the `finally` below only runs once this promise settles. Uses the
+        // shared backend-boot budget rather than the reconnect budget because
+        // ensureBackend may cold-spawn a pooled helper backend here.
         const conn = await withTimeout(
           desktop.getConnection(windowProfileOverride() ?? undefined),
-          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
 
@@ -895,10 +897,12 @@ export function useGatewayBoot({
         // backend directly — ensureBackend spawns/reuses it from the pool.
         // Everything else keeps dialing the primary.
         // Bounded like the reconnect path (#93454): a wedged main-process
-        // round-trip must not hang "Starting Hermes…" forever.
+        // round-trip must not hang "Starting Hermes…" forever. Initial boot
+        // rides out a full backend cold spawn, so it gets the shared 45s
+        // backend-boot budget, not the 20s reconnect budget.
         const conn = await withTimeout(
           desktop.getConnection(windowProfileOverride() ?? undefined),
-          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out connecting to Hermes backend'
         )
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -16,6 +16,7 @@ import {
   resumeDesktopBootForRetry,
   setDesktopBootStep
 } from '@/store/boot'
+import { resetBackgroundPollingGuard } from '@/store/composer-status'
 import {
   $gateway,
   activeGatewayConnectionId,
@@ -344,6 +345,11 @@ export function useGatewayBoot({
         resetTileRuntimeBindings(
           primaryRuntimeConnectionId(conn) ?? { liveConnectionIds: liveSecondaryConnectionIds() }
         )
+        // The status-stack poll guard latches session ids the OLD runtime
+        // reported gone (4001). A respawned backend re-mints runtimes, so
+        // those ids may be live again after re-resume — clear the latch with
+        // the same lifetime as the runtime bindings it shadows.
+        resetBackgroundPollingGuard()
         // Same staleness, other half: pre-reconnect busy flags are keyed by
         // those dead runtime ids and would never receive their terminal
         // busy:false — clear them or the sidebar running arc lies forever

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { withTimeout, BACKEND_BOOT_WAIT_TIMEOUT_MS } from '@/lib/with-timeout'
+import { BACKEND_BOOT_WAIT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -796,6 +796,14 @@ export function useGatewayBoot({
         return
       }
 
+      // 'saved' is a pure registry-refresh push (new connection or label
+      // rename — #95393): no endpoint moved, so there is nothing to dispose,
+      // redial, or forget. The switcher's own onChanged listener re-pulls the
+      // registry snapshot for it.
+      if (payload.reason === 'saved') {
+        return
+      }
+
       disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
 
       if (payload.reason !== 'updated') {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -540,7 +540,14 @@ export function useGatewayBoot({
 
         // Same override rule as boot(): a profile-pinned helper window stays
         // on its pinned profile's backend across a soft switch.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // Bounded for the same reason as attemptReconnect() (#93454): a wedged
+        // main-process round-trip must not latch $gatewaySwitching stuck —
+        // the `finally` below only runs once this promise settles.
+        const conn = await withTimeout(
+          desktop.getConnection(windowProfileOverride() ?? undefined),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
 
         if (!ownsSwitch()) {
           return
@@ -887,7 +894,13 @@ export function useGatewayBoot({
         // A profile-pinned helper window (the HUD) dials its target profile's
         // backend directly — ensureBackend spawns/reuses it from the pool.
         // Everything else keeps dialing the primary.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        // Bounded like the reconnect path (#93454): a wedged main-process
+        // round-trip must not hang "Starting Hermes…" forever.
+        const conn = await withTimeout(
+          desktop.getConnection(windowProfileOverride() ?? undefined),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out connecting to Hermes backend'
+        )
 
         if (cancelled) {
           return

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -525,6 +525,120 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     cache.runtimeIdByStoredSessionIdRef.current.set('stored-A', 'runtime-B')
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
   })
+
+  describe('reconnect-orphaned transcripts (#95189)', () => {
+    // Unique per-test runtime/stored ids: earlier describes in this file leave
+    // states in $sessionStates, and a recycled id would let this test's
+    // authority probe read THEIR stale flags instead of its own.
+    const bg = 'orphan-bg-runtime'
+    const fg = 'orphan-fg-runtime'
+    const bgStored = 'orphan-bg-stored'
+    const fgStored = 'orphan-fg-stored'
+
+    beforeEach(() => {
+      $sessionStates.set({})
+      setActiveSessionId(null)
+    })
+
+    afterEach(() => {
+      $sessionStates.set({})
+      setActiveSessionId(null)
+    })
+
+    it('releases a busy transcript once reconciliation settles the authoritative record', () => {
+      let cache!: Cache
+
+      render(<Harness activeSessionId={fg} onReady={value => (cache = value)} selectedStoredSessionId={fgStored} />)
+
+      act(() => {
+        // A mid-turn session carries a growing transcript: without messages
+        // there would be nothing warm to release.
+        cache.updateSessionState(
+          bg,
+          state => ({
+            ...state,
+            busy: true,
+            messages: [
+              { id: `${bg}-user`, role: 'user', parts: [{ type: 'text', text: 'hello' }] },
+              { id: `${bg}-assistant`, role: 'assistant', parts: [{ type: 'text', text: 'partial reply' }] }
+            ]
+          }),
+          bgStored
+        )
+      })
+
+      expect($sessionStates.get()[bg]?.busy).toBe(true)
+      expect(cache.sessionStateByRuntimeIdRef.current.has(bg)).toBe(true)
+
+      act(() => {
+        // The minting socket died mid-turn; reconnect reconciliation
+        // (reconcileBusyStatesOnReconnect) downgrades the authoritative
+        // record, and the respawned backend re-mints runtime ids so no event
+        // will ever settle this snapshot's own busy flag again.
+        const states = $sessionStates.get()
+
+        $sessionStates.set({
+          ...states,
+          [bg]: { ...states[bg]!, busy: false, awaitingResponse: false }
+        })
+      })
+
+      // Production caches are bounded by the class defaults (24 sessions /
+      // 32MB), and prune only drains once that budget is exceeded. Simulate
+      // the reconnect churn of #95189: a stream of settled sessions pushes
+      // the cache past its cap, and the orphaned entry — oldest touched,
+      // finally warm-eligible now that the authoritative record settled —
+      // must be the first thing drained, ownership included.
+      const liveBusy = `${bg}-still-working`
+
+      act(() => {
+        cache.updateSessionState(
+          liveBusy,
+          state => ({
+            ...state,
+            busy: true,
+            messages: [{ id: `${liveBusy}-u`, role: 'user', parts: [{ type: 'text', text: 'long turn' }] }]
+          }),
+          `${liveBusy}-stored`
+        )
+      })
+
+      for (let i = 0; i < 24; i += 1) {
+        act(() => {
+          cache.updateSessionState(
+            `${bg}-churn-${i}`,
+            state => ({
+              ...state,
+              messages: [{ id: `churn-${i}`, role: 'user', parts: [{ type: 'text', text: `done ${i}` }] }]
+            }),
+            `${bg}-churn-${i}-stored`
+          )
+        })
+      }
+
+      expect(cache.sessionStateByRuntimeIdRef.current.has(bg)).toBe(false)
+      expect(cache.runtimeIdByStoredSessionIdRef.current.has(bgStored)).toBe(false)
+      // A genuinely running turn is never a casualty of the drain.
+      expect(cache.sessionStateByRuntimeIdRef.current.has(liveBusy)).toBe(true)
+    })
+
+    it('keeps a live background turn cached while its authoritative record is busy', () => {
+      let cache!: Cache
+
+      render(<Harness activeSessionId={fg} onReady={value => (cache = value)} selectedStoredSessionId={fgStored} />)
+
+      act(() => {
+        cache.updateSessionState(bg, state => ({ ...state, busy: true }), bgStored)
+      })
+
+      act(() => {
+        cache.updateSessionState(fg, state => ({ ...state, model: 'test/model' }))
+      })
+
+      expect(cache.sessionStateByRuntimeIdRef.current.has(bg)).toBe(true)
+      expect(cache.runtimeIdByStoredSessionIdRef.current.get(bgStored)).toBe(bg)
+    })
+  })
 })
 
 // #93059: reconnect used to downgrade the $sessionStates mirror only, leaving

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -20,7 +20,7 @@ import {
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
-import { $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
+import { $sessionStates, $sessionTiles, publishSessionState, releaseSessionTranscript } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
 import { SessionStateCache } from '../session-state-cache'
@@ -98,6 +98,16 @@ export function useSessionStateCache({
               tile.runtimeId === runtimeId ||
               (state.storedSessionId !== null && tile.storedSessionId === state.storedSessionId)
           ),
+      // A connection death mid-turn leaves snapshots whose frozen busy flags
+      // will never settle (the respawned backend re-mints runtime ids), which
+      // pinned megabytes of warm transcript per reconnect cycle behind
+      // #isWarmSettled (#95189). Trust the cached in-flight flags only while
+      // the authoritative store still claims work for the same runtime id.
+      isAuthoritativelyActive: runtimeId => {
+        const live = $sessionStates.get()[runtimeId]
+
+        return Boolean(live && (live.busy || live.awaitingResponse))
+      },
       onEvict: (runtimeId, state) => {
         // Ownership is removed with the transcript, but only if both sides still
         // describe this exact binding. A recycled runtime must not erase its

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -130,4 +130,99 @@ describe('SessionStateCache', () => {
     expect($sessionStates.get().runtime).toMatchObject({ storedSessionId: 'stored', busy: false, needsInput: false })
     expect($sessionStates.get().runtime.messages).toEqual([])
   })
+
+  describe('authoritative liveness probe (#95189)', () => {
+    function cacheWithAuthority(evicted: string[]): SessionStateCache {
+      return new SessionStateCache(
+        {
+          isReferenced: () => false,
+          onEvict: runtimeId => evicted.push(runtimeId),
+          isAuthoritativelyActive: runtimeId => {
+            const live = $sessionStates.get()[runtimeId]
+
+            return Boolean(live && (live.busy || live.awaitingResponse))
+          }
+        },
+        { maxBytes: 0, maxCount: 0 }
+      )
+    }
+
+    it.each([
+      ['busy', (state: ClientSessionState) => ({ ...state, busy: true })],
+      ['awaiting', (state: ClientSessionState) => ({ ...state, awaitingResponse: true })]
+    ])('evicts an orphaned %s transcript once the authoritative record settles', (_label, decorate) => {
+      const evicted: string[] = []
+      const cache = cacheWithAuthority(evicted)
+      const orphaned = decorate(settled('orphaned'))
+
+      // Mid-turn the snapshot and the authoritative record agree: protection
+      // must hold exactly as it does without the probe.
+      $sessionStates.set({ orphaned })
+      cache.set('orphaned', orphaned)
+      cache.prune()
+      expect(cache.get('orphaned')).toBe(orphaned)
+
+      // The minting connection dies mid-turn. Reconnect reconciliation
+      // settles the authoritative record, but the respawned backend re-mints
+      // runtime ids — no event will ever reach this snapshot again, so its
+      // frozen in-flight flags must stop pinning the transcript.
+      $sessionStates.set({ orphaned: { ...orphaned, busy: false, awaitingResponse: false } })
+      cache.prune()
+
+      expect(cache.has('orphaned')).toBe(false)
+      expect(evicted).toEqual(['orphaned'])
+    })
+
+    it('evicts an in-flight transcript whose authoritative record was dropped entirely', () => {
+      const evicted: string[] = []
+      const cache = cacheWithAuthority(evicted)
+      const working = { ...settled('working'), busy: true }
+
+      $sessionStates.set({ working })
+      cache.set('working', working)
+      cache.prune()
+      expect(cache.has('working')).toBe(true)
+
+      // A soft gateway-mode apply wipes every authoritative state; surviving
+      // snapshots describe dead runtimes (#95189 reconnect churn).
+      $sessionStates.set({})
+      cache.prune()
+
+      expect(cache.has('working')).toBe(false)
+      expect(evicted).toEqual(['working'])
+    })
+
+    it('keeps an in-flight transcript pinned while the authoritative store still claims work', () => {
+      const evicted: string[] = []
+      const cache = cacheWithAuthority(evicted)
+      const working = { ...settled('working'), busy: true }
+
+      $sessionStates.set({ working })
+      cache.set('working', working)
+      cache.prune()
+
+      expect(cache.get('working')).toBe(working)
+      expect(evicted).toEqual([])
+    })
+
+    it.each([
+      ['busy', (state: ClientSessionState) => ({ ...state, busy: true })],
+      ['awaiting', (state: ClientSessionState) => ({ ...state, awaitingResponse: true })]
+    ])('still never evicts %s transcripts when no authority probe is wired', (_label, decorate) => {
+      // Legacy construction: without the probe there is no way to tell a live
+      // turn from an orphaned snapshot, so the flags keep blocking eviction.
+      const working = decorate(settled('working'))
+      $sessionStates.set({ working: { ...working, busy: false, awaitingResponse: false } })
+
+      const cache = new SessionStateCache(
+        { isReferenced: () => false, onEvict: () => undefined },
+        { maxBytes: 0, maxCount: 0 }
+      )
+
+      cache.set('working', working)
+      cache.prune()
+
+      expect(cache.get('working')).toBe(working)
+    })
+  })
 })

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -11,6 +11,14 @@ interface SessionStateCacheLimits {
 interface SessionStateCacheCallbacks {
   isReferenced: (runtimeId: string, state: ClientSessionState) => boolean
   onEvict: (runtimeId: string, state: ClientSessionState) => void
+  /** Optional liveness check for a cached snapshot's in-flight claims. A
+   *  connection death mid-turn orphans snapshots: the respawned backend
+   *  re-mints runtime ids, so their frozen busy/awaitingResponse flags never
+   *  receive a settling publish (#95189) and would pin megabytes of warm
+   *  transcript per reconnect cycle until restart. When wired, those flags
+   *  only block eviction while the authoritative store still claims work for
+   *  the same runtime id; without the probe they always block. */
+  isAuthoritativelyActive?: (runtimeId: string, state: ClientSessionState) => boolean
 }
 
 function transcriptBytes(state: ClientSessionState): number {
@@ -117,11 +125,20 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   }
 
   #isWarmSettled(runtimeId: string, state: ClientSessionState): boolean {
+    // In-flight claims pin a transcript only while they are trustworthy: with
+    // an authority probe wired, a frozen busy/awaitingResponse on an orphaned
+    // snapshot stops blocking eviction (see callback docs). Without one, the
+    // legacy behavior holds and the flags always block.
+    if (
+      (state.busy || state.awaitingResponse) &&
+      this.#callbacks.isAuthoritativelyActive?.(runtimeId, state) !== false
+    ) {
+      return false
+    }
+
     return (
       Boolean(state.storedSessionId) &&
       state.messages.length > 0 &&
-      !state.busy &&
-      !state.awaitingResponse &&
       !state.needsInput &&
       !hasDraftOrInFlightMessage(state) &&
       !this.#callbacks.isReferenced(runtimeId, state)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -180,7 +180,7 @@ declare global {
         // materially edited so the renderer can dispose (and re-dial) the
         // secondary gateways scoped to it. Optional: older Electron mains
         // don't emit it.
-        onChanged?: (callback: (payload: { connectionId: string; reason: 'removed' | 'updated' }) => void) => () => void
+        onChanged?: (callback: (payload: { connectionId: string; reason: 'removed' | 'saved' | 'updated' }) => void) => () => void
       }
       sshConfigHosts: () => Promise<DesktopSshHostsResult>
       sshResolveHost: (host: string) => Promise<DesktopSshResolveResult>

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -1,3 +1,13 @@
+/** Shared budget for any renderer await that rides out a primary backend
+ * cold boot (initial getConnection(), the registry restore's descriptor
+ * wait). Matches the main-process spawn budget
+ * (DEFAULT_BACKEND_READY_TIMEOUT_MS in electron/backend-health.ts): a
+ * healthy cold boot publishes well within this; anything longer means the
+ * backend is not coming and the caller should fail instead of hanging.
+ * Reconnect-class awaits against an already-spawned backend use the shorter
+ * RECONNECT_ATTEMPT_TIMEOUT_MS (use-gateway-boot.ts) instead. */
+export const BACKEND_BOOT_WAIT_TIMEOUT_MS = 45_000
+
 /** Rejection raised by withTimeout. The bounded work is NOT cancelled — the
  * caller decides what a straggler that settles later means. */
 export class TimeoutError extends Error {

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
 import { JsonRpcGatewayError } from '@hermes/shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $backgroundStatusBySession,

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $backgroundStatusBySession, dismissBackgroundProcess, reconcileBackgroundProcesses } from './composer-status'
+import {
+  $backgroundStatusBySession,
+  dismissBackgroundProcess,
+  isSessionGoneForBackgroundPolling,
+  reconcileBackgroundProcesses,
+  refreshBackgroundProcesses,
+  resetBackgroundPollingGuard
+} from './composer-status'
+import { $gateway } from './gateway'
 
 const SID = 'sess-1'
 
@@ -149,5 +157,109 @@ describe('reconcileBackgroundProcesses', () => {
     vi.advanceTimersByTime(5_000)
 
     expect(itemsOf('sess-arm')).toEqual([])
+  })
+})
+
+// ── Dead-session polling guard (#94219 fallout) ──────────────────────────────
+// The status stack polls `process.list` every 5s while a background row is on
+// screen. `process.list` is session-scoped: against a runtime id the gateway no
+// longer holds it returns 4001 "session not found". That failure was swallowed
+// as "transient socket loss", so the poll re-sent the SAME dead id every 5s for
+// the life of the window — 18,614 rejections against a single runtime id in one
+// day on a real machine, and the log line the user reads as "session not found".
+//
+// A gone session is terminal, not transient: stop polling it.
+describe('refreshBackgroundProcesses dead-session guard', () => {
+  beforeEach(() => {
+    $backgroundStatusBySession.set({})
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('classifies a 4001 session-not-found as gone, and a timeout as transient', () => {
+    expect(isSessionGoneForBackgroundPolling(new Error('session not found'))).toBe(true)
+    expect(isSessionGoneForBackgroundPolling(new Error('4001 session not found'))).toBe(true)
+    expect(isSessionGoneForBackgroundPolling(new Error('Session Not Found'))).toBe(true)
+
+    // Transient failures must NOT latch the guard — the session may still be alive.
+    expect(isSessionGoneForBackgroundPolling(new Error('request timed out after 30s: process.list'))).toBe(false)
+    expect(isSessionGoneForBackgroundPolling(new Error('not connected'))).toBe(false)
+  })
+
+  it('stops re-polling a session after the gateway reports it gone', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    $gateway.set({ request } as never)
+
+    // First poll discovers the session is gone.
+    await refreshBackgroundProcesses(SID)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    // Every subsequent tick must be suppressed. Before the fix these all went
+    // to the wire and each produced another gateway-side 4001.
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses(SID)
+
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps polling after a transient failure', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s: process.list')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses(SID)
+
+    // A timeout is not proof of death — the poll must retry.
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not suppress a different, healthy session', async () => {
+    const request = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      if (params?.session_id === SID) {
+        throw new Error('session not found')
+      }
+
+      return { processes: [] }
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses('sess-healthy')
+    await refreshBackgroundProcesses('sess-healthy')
+
+    const targets = request.mock.calls.map(c => (c[1] as { session_id?: string } | undefined)?.session_id)
+    expect(targets.filter(t => t === SID)).toHaveLength(1)
+    expect(targets.filter(t => t === 'sess-healthy')).toHaveLength(2)
+  })
+
+  it('resumes polling a session that comes back (guard cleared on rebind)', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses(SID)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    // A fresh runtime bound to this session id clears the guard.
+    resetBackgroundPollingGuard(SID)
+    await refreshBackgroundProcesses(SID)
+
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { JsonRpcGatewayError } from '@hermes/shared'
+
 import {
   $backgroundStatusBySession,
   dismissBackgroundProcess,
@@ -261,5 +263,57 @@ describe('refreshBackgroundProcesses dead-session guard', () => {
     await refreshBackgroundProcesses(SID)
 
     expect(request).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── Review-thread hardenings on the guard (#94950) ───────────────────────────
+describe('refreshBackgroundProcesses dead-session guard hardenings', () => {
+  beforeEach(() => {
+    $backgroundStatusBySession.set({})
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('matches the structured 4001 code, not a message substring, when a code is present', () => {
+    // Structured gateway rejection: the code decides, both directions.
+    expect(isSessionGoneForBackgroundPolling(new JsonRpcGatewayError('session not found', { code: 4001 }))).toBe(true)
+    expect(isSessionGoneForBackgroundPolling(new JsonRpcGatewayError('gone', { code: 4001 }))).toBe(true)
+
+    // An unrelated coded error whose text merely MENTIONS the phrase must not
+    // latch — that would freeze the status stack on a healthy session.
+    expect(
+      isSessionGoneForBackgroundPolling(
+        new JsonRpcGatewayError('tool failed: upstream said session not found', { code: 5007 })
+      )
+    ).toBe(false)
+
+    // Codeless errors keep the message fallback (legacy frames).
+    expect(isSessionGoneForBackgroundPolling(new JsonRpcGatewayError('session not found'))).toBe(true)
+  })
+
+  it('a full guard reset (runtime re-mint) resumes polling every latched session', async () => {
+    const request = vi.fn(async () => {
+      throw new JsonRpcGatewayError('session not found', { code: 4001 })
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses('sess-2')
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses('sess-2')
+    expect(request).toHaveBeenCalledTimes(2)
+
+    // Gateway reconnect re-mints runtimes: the no-arg reset (wired at the
+    // reconnect seams) must clear every latched id, not just one.
+    resetBackgroundPollingGuard()
+    await refreshBackgroundProcesses(SID)
+    await refreshBackgroundProcesses('sess-2')
+
+    expect(request).toHaveBeenCalledTimes(4)
   })
 })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -1,6 +1,5 @@
-import { atom, computed } from 'nanostores'
-
 import { JsonRpcGatewayError } from '@hermes/shared'
+import { atom, computed } from 'nanostores'
 
 import { translateNow } from '@/i18n'
 import { stableArray } from '@/lib/stable-array'

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -377,11 +377,42 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
   writeBackground(sid, next)
 }
 
+/** Session ids the gateway has told us are gone. A session-scoped RPC against a
+ *  runtime the gateway no longer holds fails 4001 "session not found" — a
+ *  TERMINAL condition, not the transient socket loss the catch below assumes.
+ *
+ *  The status stack re-polls `process.list` every 5s while a running row is on
+ *  screen, so treating 4001 as transient meant re-sending the same dead id
+ *  forever: one runtime id accumulated 18,614 gateway rejections in a single day
+ *  (#94219 fallout). Latch the id here and skip it until something rebinds it. */
+const goneSessions = new Set<string>()
+
+/** A gone session is unrecoverable for THIS runtime id; a timeout or transport
+ *  blip is not. Only the former may stop the poll — misclassifying a transient
+ *  failure would silently freeze the status stack on a healthy session. */
+export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /session not found/i.test(message)
+}
+
+/** Clear the gone-latch. Called with a session id when a fresh runtime binds to
+ *  it (so polling resumes), or with no argument to reset everything (tests). */
+export function resetBackgroundPollingGuard(sid?: string): void {
+  if (sid) {
+    goneSessions.delete(sid)
+
+    return
+  }
+
+  goneSessions.clear()
+}
+
 /** Pull the session's live process snapshot from the gateway. */
 export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
-  if (!sid || !gateway) {
+  if (!sid || !gateway || goneSessions.has(sid)) {
     return
   }
 
@@ -389,7 +420,15 @@ export async function refreshBackgroundProcesses(sid: string): Promise<void> {
     const result = await gateway.request<{ processes?: GatewayProcessEntry[] }>('process.list', { session_id: sid })
 
     reconcileBackgroundProcesses(sid, result?.processes ?? [])
-  } catch {
+  } catch (error) {
+    // A gone session never comes back under this runtime id: stop polling it,
+    // or the 5s timer hammers the gateway with 4001s for the window's lifetime.
+    if (isSessionGoneForBackgroundPolling(error)) {
+      goneSessions.add(sid)
+
+      return
+    }
+
     // Transient socket loss — the next trigger (event or poll) retries.
   }
 }

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -1,5 +1,7 @@
 import { atom, computed } from 'nanostores'
 
+import { JsonRpcGatewayError } from '@hermes/shared'
+
 import { translateNow } from '@/i18n'
 import { stableArray } from '@/lib/stable-array'
 import type { TodoItem, TodoStatus } from '@/lib/todos'
@@ -387,10 +389,23 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
  *  (#94219 fallout). Latch the id here and skip it until something rebinds it. */
 const goneSessions = new Set<string>()
 
+/** Gateway JSON-RPC code for "session not found" (tui_gateway _sess_nowait). */
+const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
+
 /** A gone session is unrecoverable for THIS runtime id; a timeout or transport
  *  blip is not. Only the former may stop the poll — misclassifying a transient
- *  failure would silently freeze the status stack on a healthy session. */
+ *  failure would silently freeze the status stack on a healthy session.
+ *
+ *  Match the gateway's 4001 code when the error carries one (JsonRpcGatewayError
+ *  from a structured RPC rejection) — a message substring alone could latch on
+ *  an unrelated error class that merely mentions "session not found" (e.g. a
+ *  wrapped tool/report string). The message fallback survives only for errors
+ *  with no numeric code at all, where the frame's structure was lost. */
 export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
+  if (error instanceof JsonRpcGatewayError && typeof error.code === 'number') {
+    return error.code === GATEWAY_SESSION_NOT_FOUND_CODE
+  }
+
   const message = error instanceof Error ? error.message : String(error ?? '')
 
   return /session not found/i.test(message)

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 import { persistStringRecord, storedStringRecord } from '@/lib/storage'
-import { isTimeoutError, withTimeout } from '@/lib/with-timeout'
+import { isTimeoutError, withTimeout, BACKEND_BOOT_WAIT_TIMEOUT_MS } from '@/lib/with-timeout'
 import { $connectionsRegistry } from '@/store/connection-registry-state'
 import {
   beginGatewaySwitch,
@@ -34,8 +34,9 @@ const SWITCH_COMMIT_TIMEOUT_MS = 20_000
 const SWITCH_REMEMBER_TIMEOUT_MS = 5_000
 // Matches the primary spawn budget: a healthy cold boot publishes well within
 // this; anything longer means the primary is not coming and the registry
-// restore should stop waiting for it.
-const BOOT_DESCRIPTOR_WAIT_TIMEOUT_MS = 45_000
+// restore should stop waiting for it. Shared constant so the boot-class
+// budgets can't drift apart (see with-timeout.ts).
+const BOOT_DESCRIPTOR_WAIT_TIMEOUT_MS = BACKEND_BOOT_WAIT_TIMEOUT_MS
 
 export { $connectionsRegistry } from '@/store/connection-registry-state'
 

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 import { persistStringRecord, storedStringRecord } from '@/lib/storage'
-import { isTimeoutError, withTimeout, BACKEND_BOOT_WAIT_TIMEOUT_MS } from '@/lib/with-timeout'
+import { BACKEND_BOOT_WAIT_TIMEOUT_MS, isTimeoutError, withTimeout } from '@/lib/with-timeout'
 import { $connectionsRegistry } from '@/store/connection-registry-state'
 import {
   beginGatewaySwitch,

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -450,19 +450,27 @@ async function openSecondary(entry: Secondary): Promise<void> {
     if (reopening) {
       try {
         const { reconcileBusyStatesOnReconnect, resetTileRuntimeBindings } = await import('@/store/session-states')
-        const { resetBackgroundPollingGuard } = await import('@/store/composer-status')
 
         resetTileRuntimeBindings({
           connectionId: entry.connectionId || 'local',
           profile: entry.profile
         })
-        // Runtime re-mint also invalidates the status-stack gone-latch: ids
-        // the dead runtime 4001'd may be live again once tiles re-resume.
-        resetBackgroundPollingGuard()
         reconcileBusyAfterOpen = () => reconcileBusyStatesOnReconnect(entry.scope)
       } catch {
         // Best effort for partial test/HMR graphs. Production always loads the
         // real store; a failed import must not make the transport unrecoverable.
+      }
+
+      try {
+        // Runtime re-mint also invalidates the status-stack gone-latch: ids
+        // the dead runtime 4001'd may be live again once tiles re-resume.
+        // Separate try: tests that mock only session-states must not lose the
+        // rebinding wiring to a failed composer-status import (and vice versa).
+        const { resetBackgroundPollingGuard } = await import('@/store/composer-status')
+
+        resetBackgroundPollingGuard()
+      } catch {
+        // Same best-effort contract as above.
       }
     }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -461,17 +461,18 @@ async function openSecondary(entry: Secondary): Promise<void> {
         // real store; a failed import must not make the transport unrecoverable.
       }
 
-      try {
-        // Runtime re-mint also invalidates the status-stack gone-latch: ids
-        // the dead runtime 4001'd may be live again once tiles re-resume.
-        // Separate try: tests that mock only session-states must not lose the
-        // rebinding wiring to a failed composer-status import (and vice versa).
-        const { resetBackgroundPollingGuard } = await import('@/store/composer-status')
-
-        resetBackgroundPollingGuard()
-      } catch {
-        // Same best-effort contract as above.
-      }
+      // Runtime re-mint also invalidates the status-stack gone-latch: ids
+      // the dead runtime 4001'd may be live again once tiles re-resume.
+      // Fire-and-forget: composer-status imports from this module, so the
+      // import must stay dynamic (cycle), and it must NOT sit on the timed
+      // redial path — awaiting the module load here pushed cold-start
+      // redials past test/waitFor budgets. The reset needs no ordering
+      // guarantee relative to the dial.
+      void import('@/store/composer-status')
+        .then(({ resetBackgroundPollingGuard }) => resetBackgroundPollingGuard())
+        .catch(() => {
+          // Best effort for partial test/HMR graphs, same as above.
+        })
     }
 
     // Registry-scoped entries dial through getConnectionFor when the bridge has

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -450,11 +450,15 @@ async function openSecondary(entry: Secondary): Promise<void> {
     if (reopening) {
       try {
         const { reconcileBusyStatesOnReconnect, resetTileRuntimeBindings } = await import('@/store/session-states')
+        const { resetBackgroundPollingGuard } = await import('@/store/composer-status')
 
         resetTileRuntimeBindings({
           connectionId: entry.connectionId || 'local',
           profile: entry.profile
         })
+        // Runtime re-mint also invalidates the status-stack gone-latch: ids
+        // the dead runtime 4001'd may be live again once tiles re-resume.
+        resetBackgroundPollingGuard()
         reconcileBusyAfterOpen = () => reconcileBusyStatesOnReconnect(entry.scope)
       } catch {
         // Best effort for partial test/HMR graphs. Production always loads the

--- a/contributors/emails/BrunoBza@users.noreply.github.com
+++ b/contributors/emails/BrunoBza@users.noreply.github.com
@@ -1,0 +1,1 @@
+BrunoBza

--- a/contributors/emails/justinjohnson25600@users.noreply.github.com
+++ b/contributors/emails/justinjohnson25600@users.noreply.github.com
@@ -1,0 +1,1 @@
+justinjohnson25600

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -372,6 +372,13 @@ def test_prompt_submit_unknown_session_logs_warning(caplog):
         "session-scoped RPC rejected" in rec.message and "gone-sid" in rec.message
         for rec in caplog.records
     )
+    # The method name must be in the line. Without it this warning cannot
+    # identify WHICH client call is looping on a stale runtime id — the gap
+    # that made a 5s `process.list` poll storm (18,614 rejections against one
+    # id) unattributable from the logs alone.
+    assert any(
+        "method=prompt.submit" in rec.message for rec in caplog.records
+    )
 
 
 def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -384,6 +384,16 @@ _current_runtime_session_record: contextvars.ContextVar[dict | None] = (
     contextvars.ContextVar("hermes_gateway_runtime_session_record", default=None)
 )
 
+# JSON-RPC method being dispatched on this thread/task. Purely diagnostic: the
+# 4001 "session not found" warning below is the only signal a stale-runtime
+# retry loop leaves behind, and without the method name it cannot say WHICH
+# client poll is looping (a 5s `process.list` poll produced 18,614 rejections
+# against one id before the caller could be identified). Never used for
+# authorization — the method string is client-supplied.
+_current_rpc_method: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "hermes_gateway_rpc_method", default=""
+)
+
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
 # of corrupting the JSON protocol.
@@ -2444,7 +2454,11 @@ def handle_request(req: dict) -> dict | None:
     fn = _methods.get(method)
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
-    return fn(rid, params)
+    token = _current_rpc_method.set(method)
+    try:
+        return fn(rid, params)
+    finally:
+        _current_rpc_method.reset(token)
 
 
 def _current_session_steer_authority(
@@ -2894,8 +2908,9 @@ def _sess_nowait(params, rid):
     # report is diagnosable as "request arrived and was rejected" instead of
     # "request never arrived" (see #90428).
     logger.warning(
-        "session-scoped RPC rejected: session_id=%r not in memory "
+        "session-scoped RPC rejected: method=%s session_id=%r not in memory "
         "(detached/reaped runtime; client should resume the stored session), rid=%r",
+        _current_rpc_method.get() or "?",
         sid,
         rid,
     )


### PR DESCRIPTION
## Summary
Transport behavior on multi-gateway Desktop stops degrading silently: boot and soft-switch `getConnection()` waits are bounded on one shared 45s constant (no more indefinite hangs, no magic-number drift), the status stack stops storming a dead session with 4001 polls (code-specific match; guard resets when the runtime re-mints), reconnect-orphaned warm transcripts release their frozen busy pins, and a newly saved connection appears in the switcher menu immediately instead of after a reload.

Wave-2 Phase B (transport) of tracker #94724. Fixes #93454-shape unbounded waits, a chunk of #83134's storm, the renderer half of #95189, and #95393.

## Salvaged contributor work (authorship preserved)
- #95039 @nftpoetrist — bounded getConnection() on boot/soft-switch; our follow-up unifies budgets on exported `BACKEND_BOOT_WAIT_TIMEOUT_MS` (45s appears once in renderer code)
- #94950 @justinjohnson25600 — dead-session poll guard; our follow-up adds the review-thread hardenings (JsonRpcGatewayError code===4001 match so coded non-4001 errors can't latch; `resetBackgroundPollingGuard()` at both re-mint seams)
- #95338 @BrunoBza — `#isWarmSettled` unpinning for reconnect-orphaned transcripts

## Our fix
- #95393 — Electron republishes the connections-registry snapshot to the renderer after a successful `connections.save`/`remove`; regression test mirrors the live CDP repro (sabotage-proven).

## Validation
A/B per fix: each fires with sources at origin/main under the branch tests, clean at head. Targeted: 179/179 vitest + 611 tui-gateway pytest, tsc clean both configs. Pre-push gate caught and fixed a 5-commit stale base with leaked files before push.

**Live repro:** #95393 confirmed live on the rig pre-fix (scripted repro + screenshot on the issue); post-merge rig verification will use the same script.

## Infographic

![Transport Discipline](https://v3b.fal.media/files/b/0aa7e136/vjBaivQAaL39Ajh1Rjhi0_ONOnpNdm.png)
