### PR TITLE
fix(desktop): SSH tunnels rebuild on wake and concurrent window dials spawn one backend (fixes #93910, #90812)

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { BackendDialClaims } from './backend-dial-claim'
+import { parseBackendScopeKey } from './connection-registry'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('BackendDialClaims (#90812)', () => {
+  it('coalesces two concurrent dials for the same (connectionId, profile) onto ONE backend spawn', async () => {
+    const claims = new BackendDialClaims()
+    let spawns = 0
+    let resolveSpawn: ((value: { baseUrl: string }) => void) | undefined
+
+    const dial = vi.fn(() => {
+      spawns += 1
+
+      return new Promise<{ baseUrl: string }>(resolve => {
+        resolveSpawn = resolve
+      })
+    })
+
+    // Two renderer windows race the same reconnect: reconnectGateway()'s
+    // in-flight lock is per-renderer, so BOTH invoke the main-process dial.
+    const first = claims.run('conn:office-ssh::default', dial)
+    const second = claims.run('conn:office-ssh::default', dial)
+
+    expect(spawns).toBe(1)
+
+    resolveSpawn?.({ baseUrl: 'http://127.0.0.1:53150' })
+
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    // The second caller receives the FIRST dial's result, not its own spawn.
+    expect(firstResult).toBe(secondResult)
+    expect(firstResult).toEqual({ baseUrl: 'http://127.0.0.1:53150' })
+    expect(dial).toHaveBeenCalledTimes(1)
+  })
+
+  it('scopes claims by key: different (connectionId, profile) pairs dial independently', async () => {
+    const claims = new BackendDialClaims()
+    const dialA = vi.fn(async () => 'a')
+    const dialB = vi.fn(async () => 'b')
+
+    const [a, b] = await Promise.all([
+      claims.run('conn:office-ssh::default', dialA),
+      claims.run('conn:office-ssh::work', dialB)
+    ])
+
+    expect(a).toBe('a')
+    expect(b).toBe('b')
+    expect(dialA).toHaveBeenCalledTimes(1)
+    expect(dialB).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the claim once the dial settles so a later reconnect can dial again (bounded, not latched)', async () => {
+    const claims = new BackendDialClaims()
+    const dial = vi.fn(async () => 'fresh')
+
+    await claims.run('default', dial)
+    expect(claims.inFlight('default')).toBe(false)
+
+    await claims.run('default', dial)
+    expect(dial).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates a failed dial to every coalesced waiter and never caches the rejection', async () => {
+    const claims = new BackendDialClaims()
+    let rejectSpawn: ((error: Error) => void) | undefined
+
+    const failingDial = vi.fn(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectSpawn = reject
+        })
+    )
+
+    const first = claims.run('conn:office-ssh::default', failingDial)
+    const second = claims.run('conn:office-ssh::default', failingDial)
+    expect(failingDial).toHaveBeenCalledTimes(1)
+
+    rejectSpawn?.(new Error('ssh dial failed'))
+
+    await expect(first).rejects.toThrow('ssh dial failed')
+    await expect(second).rejects.toThrow('ssh dial failed')
+
+    // Fail closed but not latched: the NEXT dial attempt runs fresh.
+    const recovered = vi.fn(async () => 'recovered')
+    await expect(claims.run('conn:office-ssh::default', recovered)).resolves.toBe('recovered')
+    expect(recovered).toHaveBeenCalledTimes(1)
+  })
+
+  it('a synchronously-throwing dial rejects the claim instead of escaping the coalescing seam', async () => {
+    const claims = new BackendDialClaims()
+
+    await expect(
+      claims.run('default', () => {
+        throw new Error('spawn refused')
+      })
+    ).rejects.toThrow('spawn refused')
+
+    expect(claims.inFlight('default')).toBe(false)
+  })
+})
+
+describe('parseBackendScopeKey (#90812/#93910)', () => {
+  it('round-trips the composite pool key back to (connectionId, profile)', () => {
+    expect(parseBackendScopeKey('conn:office-ssh::default')).toEqual({
+      connectionId: 'office-ssh',
+      profile: 'default'
+    })
+    expect(parseBackendScopeKey('conn:office-ssh::work')).toEqual({ connectionId: 'office-ssh', profile: 'work' })
+  })
+
+  it('treats a bare profile key as the local/primary scope', () => {
+    expect(parseBackendScopeKey('default')).toEqual({ connectionId: null, profile: 'default' })
+    expect(parseBackendScopeKey('work')).toEqual({ connectionId: null, profile: 'work' })
+  })
+})
+
+describe('main.ts wiring for #90812', () => {
+  it('routes the profile-scoped dial IPC through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:connection', ")
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 900)
+
+    expect(body).toContain('backendDialClaims.run(')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes the registry-scoped dial IPC through the claim keyed by backendScopeKey(connectionId, profile)', () => {
+    const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:connection:for', ")
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 1_200)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(id, profile)')
+    expect(body).toContain('ensureRegistryBackend(id, profile)')
+  })
+})

--- a/apps/desktop/electron/backend-dial-claim.ts
+++ b/apps/desktop/electron/backend-dial-claim.ts
@@ -1,0 +1,58 @@
+/**
+ * backend-dial-claim.ts
+ *
+ * Single-owner reconnect/dial claim for backend spawns, keyed by the pool
+ * scope key from backendScopeKey(connectionId, profile) (#90812).
+ *
+ * Why this exists: reconnectGateway()'s in-flight lock lives at renderer
+ * module scope, so it only dedupes reconnects INSIDE one window. Two windows
+ * (main + a session pop-out) racing the same wake both invoke the main-process
+ * dial IPC, and for a pooled SSH connection the loser of the pool-entry race
+ * could bootstrap a duplicate remote backend. Electron main is the single
+ * owner of backend lifecycles, so the claim belongs here: the first dial for a
+ * (connectionId, profile) key runs; every concurrent caller for the same key
+ * awaits and receives that first dial's result.
+ *
+ * Bounded by construction: a claim exists only while its dial promise is
+ * unsettled — both outcomes release it, so a failed dial is never cached and
+ * the next reconnect attempt runs fresh (fail closed, not latched).
+ */
+export class BackendDialClaims {
+  readonly #inflightByKey = new Map<string, Promise<unknown>>()
+
+  /** Whether a dial for this key is currently in flight (test/diagnostic seam). */
+  inFlight(key: string): boolean {
+    return this.#inflightByKey.has(key)
+  }
+
+  run<T>(key: string, dial: () => Promise<T> | T): Promise<T> {
+    const existing = this.#inflightByKey.get(key) as Promise<T> | undefined
+
+    if (existing) {
+      return existing
+    }
+
+    // Start the dial eagerly so the first caller's spawn is already in flight
+    // when a concurrent caller arrives; a synchronously-throwing dial is
+    // converted into a rejection of THIS claim so it cannot bypass the seam.
+    let pending: Promise<T>
+
+    try {
+      pending = Promise.resolve(dial())
+    } catch (error) {
+      pending = Promise.reject(error)
+    }
+
+    const release = () => {
+      if (this.#inflightByKey.get(key) === pending) {
+        this.#inflightByKey.delete(key)
+      }
+    }
+
+    this.#inflightByKey.set(key, pending)
+    // Release on both outcomes without creating an unhandled rejected branch.
+    void pending.then(release, release)
+
+    return pending
+  }
+}

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -171,6 +171,24 @@ export function backendScopeKey(connectionId: null | string | undefined, profile
   return `conn:${connection}::${profileKey}`
 }
 
+/**
+ * Inverse of backendScopeKey(): recover (connectionId, profile) from a pool
+ * key. A bare profile key (the local/primary scope) maps to a null
+ * connectionId. Used by the post-resume rebuild path (#93910) to re-dial a
+ * retired pool entry through the same claim-guarded ensure path a renderer
+ * would use.
+ */
+export function parseBackendScopeKey(key: string): { connectionId: null | string; profile: string } {
+  const value = String(key ?? '').trim()
+  const match = /^conn:(.+?)::(.+)$/.exec(value)
+
+  if (!match) {
+    return { connectionId: null, profile: value || 'default' }
+  }
+
+  return { connectionId: match[1], profile: match[2] }
+}
+
 /** All pool keys owned by a connection share this prefix (used to stop them on remove). */
 export function backendScopePrefix(connectionId: string): string {
   return `conn:${String(connectionId).trim()}::`

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -45,6 +45,7 @@ import {
 } from './backend-claim'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
+import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import {
   isReauthRequiredError,
@@ -131,6 +132,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  parseBackendScopeKey,
   reconcileAppliedGlobalConnection,
   reconcileRegistryDrift,
   registrySourceOwnsPrimaryBackend,
@@ -288,11 +290,13 @@ import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySet
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
+  attachPowerResumeRemoteRevalidation,
   ensureHealthyPooledRemoteBackendForDispatch,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
-  revalidateRemoteConnection
+  revalidateRemoteConnection,
+  revalidateSuspectPooledRemoteBackends
 } from './remote-liveness'
 import {
   applyRemoteRequestHeaders,
@@ -1342,6 +1346,12 @@ const backendConnectionState = createBackendConnectionState<ReturnType<typeof sp
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
 const registryDispatchRevalidation = new RemoteRevalidationCoordinator()
+// Single-owner reconnect/dial claim (#90812): reconnectGateway()'s in-flight
+// lock is per-renderer, so two windows racing one wake can both invoke the
+// backend ensure IPC and double-dial a pooled SSH backend. Main owns backend
+// lifecycles, so concurrent dials for one (connectionId, profile) scope
+// coalesce here — the second caller awaits the first spawn's result.
+const backendDialClaims = new BackendDialClaims()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
@@ -6356,6 +6366,15 @@ function registerPowerResumeListeners() {
     powerMonitor.on('on-battery', () => broadcastBatteryState(true))
     powerMonitor.on('on-ac', () => broadcastBatteryState(false))
     onBatteryPower = powerMonitor.isOnBatteryPower()
+    // Pooled remote/SSH backends are also suspect after a wake (#93910): the
+    // renderer nudge above only re-drives the PRIMARY socket, while pooled
+    // tunnels have no renderer loop of their own. Bounded + coalesced inside;
+    // never a hot loop.
+    attachPowerResumeRemoteRevalidation({
+      log: rememberLog,
+      powerMonitor,
+      revalidate: () => revalidateSuspectPoolAfterResume()
+    })
   } catch {
     // powerMonitor is unavailable before app 'ready' on some platforms; the
     // caller registers after 'ready', so this should not normally throw.
@@ -13071,7 +13090,12 @@ function createWindow() {
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => {
-  const connection = await ensureBackend(profile)
+  // Coalesce concurrent renderer dials for one profile scope (#90812): the
+  // renderer-side reconnect lock is per-window, so two windows waking at once
+  // both land here. The claim key mirrors ensureBackend()'s own profile
+  // normalization so every spelling of the primary coalesces onto one dial.
+  const profileKey = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
+  const connection = await backendDialClaims.run(backendScopeKey(null, profileKey), () => ensureBackend(profile))
   const connectionId = resolvedConnectionId(readDesktopConnectionsRegistry(), connection)
 
   return connectionId ? { ...connection, connectionId } : connection
@@ -13085,7 +13109,10 @@ ipcMain.handle('hermes:connection:for', async (_event, payload) => {
   const { connectionId, profile } = payload && typeof payload === 'object' ? (payload as any) : ({} as any)
   const registry = readDesktopConnectionsRegistry()
   const id = String(connectionId || '').trim() || registry.primary
-  const connection = await ensureRegistryBackend(id, profile)
+  // Same single-owner claim as 'hermes:connection', keyed by the composite
+  // (connectionId, profile) scope (#90812): concurrent registry dials for one
+  // scope share the first spawn instead of bootstrapping duplicate remotes.
+  const connection = await backendDialClaims.run(backendScopeKey(id, profile), () => ensureRegistryBackend(id, profile))
 
   return { ...connection, connectionId: id, registryScoped: true }
 })
@@ -13176,6 +13203,50 @@ function revalidatePool() {
     stopBackend: stopPoolBackend,
     tracker: remoteLiveness
   })
+}
+
+// Re-dial one retired pool key through the SAME claim-guarded ensure path a
+// renderer dial takes (#90812), so a resume-driven rebuild and a concurrent
+// renderer reconnect coalesce onto one spawn instead of racing.
+function redialPoolBackendAfterResume(poolKey: string) {
+  const { connectionId, profile } = parseBackendScopeKey(poolKey)
+
+  return backendDialClaims.run(poolKey, () =>
+    connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
+  )
+}
+
+// Identity for coalescing post-resume sweeps in the shared revalidation
+// coordinator: overlapping resume/unlock/network-restore kicks join the one
+// in-flight sweep instead of stacking probes.
+const suspectPoolSweepScope = {}
+
+// Sleep/wake recovery for POOLED remote/SSH backends (#93910). The primary
+// renderer socket already has wake-path probe/reconnect nudges, but pooled
+// descriptors (Bots pane, secondary connections) kept serving dead SSH
+// tunnels after macOS resume: no child 'exit' fires for a remote, and the
+// background failure-streak policy takes several rounds to drop one. On
+// resume every pooled remote is suspect — probe each once (bounded), tear
+// down the dead ones (pool entry + SSH bootstrap + tunnel/master) and rebuild
+// them through the claim-guarded dial path.
+function revalidateSuspectPoolAfterResume() {
+  return remoteRevalidation.run(suspectPoolSweepScope, () =>
+    revalidateSuspectPooledRemoteBackends({
+      entries: backendPool.entries(),
+      log: rememberLog,
+      probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
+      rebuild: poolKey => redialPoolBackendAfterResume(poolKey),
+      retire: async poolKey => {
+        await stopPoolBackend(poolKey)
+        // The pool key doubles as the SSH scope for registry SSH backends and
+        // resolves through sshScopeKey() for bare-profile remotes; both
+        // teardown calls no-op when the scope holds no SSH state.
+        await sshBootstrapCoordinator.cancelAndWait(poolKey)
+        await teardownSshConnection(poolKey)
+      },
+      tracker: remoteLiveness
+    })
+  )
 }
 
 ipcMain.handle('hermes:backend:touch', async (_event, profile) => {

--- a/apps/desktop/electron/power-resume-remote-revalidation.test.ts
+++ b/apps/desktop/electron/power-resume-remote-revalidation.test.ts
@@ -1,0 +1,278 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  attachPowerResumeRemoteRevalidation,
+  POWER_RESUME_REVALIDATION_HOLDOFF_MS,
+  RemoteLivenessTracker,
+  revalidateSuspectPooledRemoteBackends
+} from './remote-liveness'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('revalidateSuspectPooledRemoteBackends (#93910)', () => {
+  const descriptor = (baseUrl: string) => ({ baseUrl, mode: 'remote' })
+
+  const remoteEntry = (baseUrl: string) => ({
+    connectionPromise: Promise.resolve(descriptor(baseUrl)),
+    process: null,
+    remoteBaseUrl: baseUrl
+  })
+
+  it('retires and rebuilds a dead-tunnel descriptor while leaving a healthy one alone', async () => {
+    const entries: Array<[string, ReturnType<typeof remoteEntry>]> = [
+      ['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')],
+      ['conn:ssh-live::default', remoteEntry('http://127.0.0.1:53102')]
+    ]
+
+    const probe = vi.fn(async (connection: { baseUrl?: null | string }) => {
+      if (connection.baseUrl === 'http://127.0.0.1:53101') {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:53101')
+      }
+
+      return { ok: true }
+    })
+
+    const retire = vi.fn(async (_poolKey: string) => undefined)
+    const rebuild = vi.fn(async (_poolKey: string) => descriptor('http://127.0.0.1:53109'))
+
+    const result = await revalidateSuspectPooledRemoteBackends({
+      entries,
+      log: vi.fn(),
+      probe,
+      rebuild,
+      retire,
+      tracker: new RemoteLivenessTracker()
+    })
+
+    expect(retire.mock.calls.map(call => call[0])).toEqual(['conn:ssh-dead::default'])
+    expect(rebuild.mock.calls.map(call => call[0])).toEqual(['conn:ssh-dead::default'])
+    expect(result).toEqual({ rebuilt: ['conn:ssh-dead::default'], retired: ['conn:ssh-dead::default'] })
+  })
+
+  it('retires a dead descriptor on the FIRST failed post-resume probe, not after a failure streak', async () => {
+    // The background revalidation policy tolerates REMOTE_LIVENESS_FAILURE_LIMIT
+    // consecutive failures before dropping a descriptor. After sleep/wake the
+    // SSH master is gone for good — a suspect descriptor that fails one bounded
+    // probe must be retired immediately instead of surviving two more rounds.
+    const retire = vi.fn(async () => undefined)
+
+    const result = await revalidateSuspectPooledRemoteBackends({
+      entries: [['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')]],
+      log: vi.fn(),
+      probe: vi.fn(async () => {
+        throw new Error('socket hang up')
+      }),
+      rebuild: vi.fn(async () => descriptor('http://127.0.0.1:53110')),
+      retire,
+      tracker: new RemoteLivenessTracker()
+    })
+
+    expect(retire).toHaveBeenCalledTimes(1)
+    expect(result.retired).toEqual(['conn:ssh-dead::default'])
+  })
+
+  it('skips local child-backed entries entirely', async () => {
+    const probe = vi.fn(async () => ({ ok: true }))
+    const retire = vi.fn()
+    const rebuild = vi.fn()
+
+    const result = await revalidateSuspectPooledRemoteBackends({
+      entries: [
+        ['default', { connectionPromise: Promise.resolve(descriptor('http://127.0.0.1:9')), process: { pid: 4 }, remoteBaseUrl: null }],
+        ['work', { connectionPromise: Promise.resolve(descriptor('http://127.0.0.1:9')), process: { pid: 5 }, remoteBaseUrl: '' }]
+      ],
+      log: vi.fn(),
+      probe,
+      rebuild,
+      retire,
+      tracker: new RemoteLivenessTracker()
+    })
+
+    expect(probe).not.toHaveBeenCalled()
+    expect(retire).not.toHaveBeenCalled()
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(result).toEqual({ rebuilt: [], retired: [] })
+  })
+
+  it('fails closed when the rebuild dial rejects: descriptor is retired, no throw, no rebuilt claim', async () => {
+    const log = vi.fn()
+
+    const result = await revalidateSuspectPooledRemoteBackends({
+      entries: [['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')]],
+      log,
+      probe: vi.fn(async () => {
+        throw new Error('socket hang up')
+      }),
+      rebuild: vi.fn(async () => {
+        throw new Error('ssh bootstrap failed')
+      }),
+      retire: vi.fn(async () => undefined),
+      tracker: new RemoteLivenessTracker()
+    })
+
+    expect(result.retired).toEqual(['conn:ssh-dead::default'])
+    expect(result.rebuilt).toEqual([])
+    expect(log.mock.calls.some(call => String(call[0]).includes('ssh bootstrap failed'))).toBe(true)
+  })
+
+  it('does not rebuild on top of a descriptor whose retire failed', async () => {
+    const rebuild = vi.fn(async () => descriptor('http://127.0.0.1:53110'))
+
+    const result = await revalidateSuspectPooledRemoteBackends({
+      entries: [['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')]],
+      log: vi.fn(),
+      probe: vi.fn(async () => {
+        throw new Error('socket hang up')
+      }),
+      rebuild,
+      retire: vi.fn(async () => {
+        throw new Error('stop timed out')
+      }),
+      tracker: new RemoteLivenessTracker()
+    })
+
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(result).toEqual({ rebuilt: [], retired: [] })
+  })
+
+  it('clears the shared failure streak for a retired base URL so the rebuilt tunnel starts clean', async () => {
+    const tracker = new RemoteLivenessTracker()
+    tracker.recordFailure('http://127.0.0.1:53101')
+    tracker.recordFailure('http://127.0.0.1:53101')
+
+    await revalidateSuspectPooledRemoteBackends({
+      entries: [['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')]],
+      log: vi.fn(),
+      probe: vi.fn(async () => {
+        throw new Error('socket hang up')
+      }),
+      rebuild: vi.fn(async () => descriptor('http://127.0.0.1:53110')),
+      retire: vi.fn(async () => undefined),
+      tracker
+    })
+
+    expect(tracker.recordFailure('http://127.0.0.1:53101')).toEqual({ failures: 1, shouldReset: false })
+  })
+})
+
+describe('attachPowerResumeRemoteRevalidation (#93910)', () => {
+  function fakePowerMonitor() {
+    const listeners = new Map<string, Array<() => void>>()
+
+    return {
+      emit(event: string) {
+        for (const listener of listeners.get(event) ?? []) {
+          listener()
+        }
+      },
+      on(event: string, listener: () => void) {
+        listeners.set(event, [...(listeners.get(event) ?? []), listener])
+
+        return this
+      }
+    }
+  }
+
+  it('kicks one bounded revalidation per resume, coalescing resume + unlock-screen bursts (no hot loop)', async () => {
+    const powerMonitor = fakePowerMonitor()
+    let resolveRevalidate: (() => void) | undefined
+    const revalidate = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveRevalidate = resolve
+        })
+    )
+
+    let now = 1_000_000
+    attachPowerResumeRemoteRevalidation({
+      log: vi.fn(),
+      now: () => now,
+      powerMonitor,
+      revalidate
+    })
+
+    // macOS wake fires 'resume' and 'unlock-screen' near-simultaneously.
+    powerMonitor.emit('resume')
+    powerMonitor.emit('unlock-screen')
+    powerMonitor.emit('resume')
+    expect(revalidate).toHaveBeenCalledTimes(1)
+
+    resolveRevalidate?.()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Still inside the holdoff window: no re-kick even after the run settled.
+    now += POWER_RESUME_REVALIDATION_HOLDOFF_MS - 1
+    powerMonitor.emit('resume')
+    expect(revalidate).toHaveBeenCalledTimes(1)
+
+    // A later, distinct wake is allowed through.
+    now += POWER_RESUME_REVALIDATION_HOLDOFF_MS
+    powerMonitor.emit('resume')
+    expect(revalidate).toHaveBeenCalledTimes(2)
+  })
+
+  it('swallows and logs a rejected revalidation without wedging future wakes', async () => {
+    const powerMonitor = fakePowerMonitor()
+    const log = vi.fn()
+    const revalidate = vi.fn(async () => {
+      throw new Error('probe exploded')
+    })
+
+    let now = 5_000_000
+    const trigger = attachPowerResumeRemoteRevalidation({
+      log,
+      now: () => now,
+      powerMonitor,
+      revalidate
+    })
+
+    powerMonitor.emit('resume')
+    await trigger()
+    expect(log.mock.calls.some(call => String(call[0]).includes('probe exploded'))).toBe(true)
+
+    now += POWER_RESUME_REVALIDATION_HOLDOFF_MS + 1
+    powerMonitor.emit('resume')
+    expect(revalidate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('main.ts wiring for #93910', () => {
+  it('registers the suspect-pool revalidation on powerMonitor resume/unlock', () => {
+    const fnStart = mainSource.indexOf('function registerPowerResumeListeners()')
+    expect(fnStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(fnStart, mainSource.indexOf('\nfunction ', fnStart + 1))
+
+    expect(body).toContain('attachPowerResumeRemoteRevalidation(')
+    expect(body).toContain('revalidateSuspectPoolAfterResume()')
+  })
+
+  it('drives suspect revalidation through the shared coordinator, teardown and claimed re-dial primitives', () => {
+    const fnStart = mainSource.indexOf('function revalidateSuspectPoolAfterResume()')
+    expect(fnStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(fnStart, fnStart + 2_500)
+
+    expect(body).toContain('remoteRevalidation.run(')
+    expect(body).toContain('revalidateSuspectPooledRemoteBackends({')
+    expect(body).toContain('stopPoolBackend(')
+    expect(body).toContain('sshBootstrapCoordinator.cancelAndWait(')
+    expect(body).toContain('teardownSshConnection(')
+    expect(body).toContain('redialPoolBackendAfterResume')
+    expect(body).toContain('tracker: remoteLiveness')
+  })
+
+  it('re-dials a retired pool key through the single-owner dial claim', () => {
+    const fnStart = mainSource.indexOf('function redialPoolBackendAfterResume(')
+    expect(fnStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(fnStart, fnStart + 1_200)
+
+    expect(body).toContain('parseBackendScopeKey(')
+    expect(body).toContain('backendDialClaims.run(')
+    expect(body).toContain('ensureRegistryBackend(')
+  })
+})

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -240,6 +240,159 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
   return { dropped }
 }
 
+export interface RevalidateSuspectPooledRemoteBackendsOptions<TConnection extends RemoteConnectionDescriptor> {
+  entries: Iterable<[string, PooledRemoteEntry<TConnection>]>
+  log: (message: string) => void
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
+  /** Re-dial a retired pool key so the tunnel is rebuilt eagerly, not on the next click. */
+  rebuild: (poolKey: string) => Promise<unknown>
+  /** Tear down the dead descriptor (pool entry + SSH tunnel/master) for this key. */
+  retire: (poolKey: string) => Promise<void> | void
+  tracker: RemoteLivenessTracker
+}
+
+/**
+ * Post-resume sweep of pooled REMOTE descriptors (#93910).
+ *
+ * After a sleep/wake or network restore every pooled SSH tunnel is suspect:
+ * the SSH master died with the network, but the local forward's descriptor is
+ * still cached and the renderer keepalive keeps the idle reaper off it. Unlike
+ * the background policy in revalidatePooledRemoteBackends — which tolerates a
+ * failure streak because transient blips are common in steady state — a
+ * suspect descriptor that fails ONE bounded probe after resume is dead: retire
+ * it immediately and rebuild, instead of serving "Gateway offline" through two
+ * more failure rounds.
+ *
+ * Bounded by construction: one probe per remote entry per invocation, retire
+ * and rebuild each awaited once; the caller coalesces invocations and applies
+ * the resume holdoff, so there is no polling loop here. A failed retire skips
+ * the rebuild (never dial on top of a descriptor that is still installed) and
+ * a failed rebuild is logged and left for the renderer's normal reconnect
+ * path — fail closed, never throw out of the sweep.
+ */
+export async function revalidateSuspectPooledRemoteBackends<TConnection extends RemoteConnectionDescriptor>({
+  entries,
+  log,
+  probe,
+  rebuild,
+  retire,
+  tracker
+}: RevalidateSuspectPooledRemoteBackendsOptions<TConnection>): Promise<{ rebuilt: string[]; retired: string[] }> {
+  const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
+  const rebuilt: string[] = []
+  const retired: string[] = []
+
+  await Promise.all(
+    remotes.map(async ([poolKey, entry]) => {
+      const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+
+      try {
+        if (!entry.connectionPromise) {
+          throw new Error('Remote backend descriptor is unavailable.')
+        }
+
+        const connection = await entry.connectionPromise
+        await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        tracker.recordSuccess(baseUrl)
+
+        return
+      } catch (probeError) {
+        log(
+          `Pooled remote backend "${poolKey}" failed its post-resume probe (${probeError instanceof Error ? probeError.message : String(probeError)}); rebuilding tunnel.`
+        )
+      }
+
+      try {
+        await retire(poolKey)
+      } catch (retireError) {
+        // The dead entry may still be installed; rebuilding on top of it could
+        // double-dial one scope. Leave it — the dispatch-time probe retires it
+        // on the next use.
+        log(
+          `Pooled remote backend "${poolKey}" could not be retired after resume (${retireError instanceof Error ? retireError.message : String(retireError)}); leaving descriptor for dispatch-time recovery.`
+        )
+
+        return
+      }
+
+      retired.push(poolKey)
+      // The rebuilt tunnel must start from a clean failure state; stale
+      // pre-sleep failures should not count against the fresh descriptor.
+      tracker.recordSuccess(baseUrl)
+
+      try {
+        await rebuild(poolKey)
+        rebuilt.push(poolKey)
+      } catch (rebuildError) {
+        log(
+          `Pooled remote backend "${poolKey}" could not be rebuilt after resume (${rebuildError instanceof Error ? rebuildError.message : String(rebuildError)}); renderer reconnect will retry.`
+        )
+      }
+    })
+  )
+
+  return { rebuilt, retired }
+}
+
+// macOS fires 'resume' and 'unlock-screen' near-simultaneously on wake, and a
+// flapping Wi-Fi association can restore the network several times in a few
+// seconds. One sweep per window is enough: the sweep itself probes every
+// remote entry, and the renderer's revalidate IPC covers anything that dies
+// later. Keep this comfortably above the dispatch probe timeout so overlapping
+// signals can never queue back-to-back sweeps into a hot loop.
+export const POWER_RESUME_REVALIDATION_HOLDOFF_MS = 15_000
+
+export interface AttachPowerResumeRemoteRevalidationOptions {
+  log: (message: string) => void
+  now?: () => number
+  // Method syntax (bivariant) so Electron's overloaded PowerMonitor.on
+  // satisfies this structural seam while tests can pass a tiny fake.
+  powerMonitor: { on(event: 'resume' | 'unlock-screen', listener: () => void): unknown }
+  revalidate: () => Promise<unknown>
+}
+
+/**
+ * Wire the suspect-pool sweep to the Electron powerMonitor seam (#93910).
+ *
+ * Returns the trigger so tests (and the network-restore nudge, if main ever
+ * wants one) can drive the exact code path the events run. The trigger is a
+ * plain function: holdoff first (one sweep per wake window, never a hot
+ * loop), then a fire-and-forget revalidation whose rejection is logged and
+ * swallowed — a broken sweep must never take down the resume handler or wedge
+ * future wakes.
+ */
+export function attachPowerResumeRemoteRevalidation({
+  log,
+  now = Date.now,
+  powerMonitor,
+  revalidate
+}: AttachPowerResumeRemoteRevalidationOptions): () => Promise<void> {
+  let lastKickAt: null | number = null
+
+  const trigger = async (): Promise<void> => {
+    const at = now()
+
+    if (lastKickAt !== null && at - lastKickAt < POWER_RESUME_REVALIDATION_HOLDOFF_MS) {
+      return
+    }
+
+    lastKickAt = at
+
+    try {
+      await revalidate()
+    } catch (error) {
+      log(
+        `Post-resume remote revalidation failed (${error instanceof Error ? error.message : String(error)}); will retry on the next wake or renderer reconnect.`
+      )
+    }
+  }
+
+  powerMonitor.on('resume', () => void trigger())
+  powerMonitor.on('unlock-screen', () => void trigger())
+
+  return trigger
+}
+
 /**
  * Probe the cached primary remote connection and apply the failure policy.
  * The caller owns single-flight coordination; identity checks here ensure an


### PR DESCRIPTION
## Summary
Two multi-gateway process-lifecycle holes closed with our own fixes: (1) after system sleep/resume, pooled remote/SSH backends are health-probed and dead tunnels torn down and rebuilt (bounded, 15s holdoff, healthy links untouched) — previously only the primary renderer socket had wake handling, so SSH remotes stayed "Gateway offline" until manual reconnection; (2) backend dials are claimed per (connectionId, profile) in Electron main, so two windows racing a reconnect coalesce onto ONE backend spawn instead of spawning duplicate SSH backends.

Wave-2 Phase B of tracker #94724. Fixes #93910 and #90812 (whose only prior PR contained no fix).

## Changes
- `remote-liveness.ts`: `revalidateSuspectPooledRemoteBackends()` — one bounded probe per pooled entry; dead → retire (stopPoolBackend + cancelAndWait + teardownSshConnection) then claim-guarded rebuild; retire-failure skips rebuild, rebuild-failure logs (fail closed). `attachPowerResumeRemoteRevalidation()` wires powerMonitor resume/unlock-screen with a 15s holdoff.
- New `BackendDialClaims` in main keyed by parsed backend scope: concurrent dials await the first claim's result; extends the wave-1 effective-identity reuse seam rather than adding a parallel one.

## Validation
TDD with sabotage-proof: both regression files written first — 11/11 assertion tests FAIL on unmodified origin/main, 20/20 pass post-fix. Dead-vs-healthy discrimination proven; two-concurrent-dials→one-spawn proven. 323 tests green across the adjacent electron suites; tsc clean both configs.

**Live repro (honest limitation):** macOS sleep is not reachable from this Linux box — the resume signal is exercised through the powerMonitor seam in tests. The wake path composes from live-proven parts (wave-1's dispatch probe was live-verified). Flagging for a macOS spot-check post-merge if you want belt-and-braces.

## Infographic

![Waking the Tunnels](https://v3b.fal.media/files/b/0aa7e136/ReiQ5Q_wRPY6BzG4ifc8V_V84UySvh.png)
