### PR TITLE
Terminal no longer error-loops when macOS blocks the working directory (salvage #67308)

### DIFF
--- a/contributors/emails/dimar@wiseconnex.com
+++ b/contributors/emails/dimar@wiseconnex.com
@@ -1,0 +1,1 @@
+wiseconnex

--- a/tests/tools/test_safe_getcwd_permission_error.py
+++ b/tests/tools/test_safe_getcwd_permission_error.py
@@ -1,0 +1,91 @@
+"""Regression tests for _safe_getcwd() PermissionError handling (macOS TCC).
+
+Background: on macOS, when the process CWD is under a TCC-protected location
+(``~/Documents``, ``~/Desktop``, ``~/Downloads``) and the calling process
+lacks Full Disk Access, ``os.getcwd()`` raises ``PermissionError: [Errno 1]
+Operation not permitted`` — not ``FileNotFoundError``.
+
+Before the fix, ``_safe_getcwd`` only caught ``FileNotFoundError``, so the
+terminal-tool cleanup thread (which calls ``_get_env_config()`` →
+``_safe_getcwd()`` every 60 s) logged a full stack trace on every tick,
+accumulating hundreds of MB of noise in ``mcp-stderr.log`` without breaking
+functionality. After the fix, ``PermissionError`` falls back to
+``TERMINAL_CWD`` or ``$HOME`` just like a deleted CWD already does.
+"""
+
+import os
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+class _GetcwdPatcher:
+    """Context manager that temporarily replaces ``os.getcwd`` with *fn*."""
+
+    def __init__(self, fn):
+        self.fn = fn
+        self._original = None
+
+    def __enter__(self):
+        self._original = os.getcwd
+        os.getcwd = self.fn
+        return self
+
+    def __exit__(self, *exc):
+        os.getcwd = self._original
+
+
+def _raise(exc):
+    def _fn():
+        raise exc
+
+    return _fn
+
+
+def test_permission_error_falls_back_to_home(monkeypatch):
+    """macOS TCC EPERM on os.getcwd() must fall back to $HOME, not propagate."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    with _GetcwdPatcher(_raise(PermissionError(1, "Operation not permitted"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == os.path.expanduser("~")
+
+
+def test_permission_error_prefers_terminal_cwd(monkeypatch):
+    """TERMINAL_CWD takes priority over $HOME when the live CWD is TCC-blocked."""
+    monkeypatch.setenv("TERMINAL_CWD", "/custom/from/env")
+
+    with _GetcwdPatcher(_raise(PermissionError(1, "Operation not permitted"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == "/custom/from/env"
+
+
+def test_file_not_found_still_handled(monkeypatch):
+    """Regression guard: the existing FileNotFoundError path must keep working."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    with _GetcwdPatcher(_raise(FileNotFoundError(2, "No such file or directory"))):
+        result = terminal_tool._safe_getcwd()
+
+    assert result == os.path.expanduser("~")
+
+
+def test_happy_path_unchanged():
+    """Normal os.getcwd() must pass through untouched."""
+    # Don't patch getcwd — use the real one
+    result = terminal_tool._safe_getcwd()
+    assert result == os.getcwd()
+
+
+def test_os_error_not_swallowed(monkeypatch):
+    """Unrelated OSError subclasses must still propagate (don't over-catch)."""
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    # NotADirectoryError is an OSError but neither FileNotFoundError nor
+    # PermissionError — it should escape so callers see the real problem.
+    with pytest.raises(OSError):
+        with _GetcwdPatcher(_raise(NotADirectoryError(20, "Not a directory"))):
+            terminal_tool._safe_getcwd()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1618,16 +1618,21 @@ def _parse_env_var(name: str, default: str, converter: Any = int, type_label: st
 
 
 def _safe_getcwd() -> str:
-    """Return the current working directory, tolerating a deleted CWD.
+    """Return the current working directory, tolerating a deleted or
+    permission-restricted CWD.
 
     ``os.getcwd()`` raises FileNotFoundError when the process's working
     directory has been removed out from under it (e.g. a scratch workspace
-    that was cleaned up mid-session). Fall back to TERMINAL_CWD, then the
-    user's home directory, so terminal setup never crashes on a stale CWD.
+    that was cleaned up mid-session). On macOS with TCC (Transparency,
+    Consent, and Control), it raises PermissionError (EPERM) when the CWD
+    is under a protected location (~/Documents, ~/Desktop, ~/Downloads)
+    and the calling process lacks Full Disk Access. Fall back to
+    TERMINAL_CWD, then the user's home directory, so terminal setup never
+    crashes on a stale or TCC-blocked CWD.
     """
     try:
         return os.getcwd()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 


### PR DESCRIPTION
## Summary
The terminal subsystem no longer stack-traces in a loop when macOS TCC blocks the current working directory: `_safe_getcwd()` now tolerates `PermissionError` alongside `FileNotFoundError` and falls back to `TERMINAL_CWD` → `$HOME`. Before, a TCC-blocked live CWD made the 60s cleanup thread throw continuously — one report measured 184MB of log growth. Salvage of #67308 by @wiseconnex (commit cherry-picked, authorship preserved).

## Changes
- `tools/terminal_tool.py` (@wiseconnex): `except FileNotFoundError` → `except (FileNotFoundError, PermissionError)` in `_safe_getcwd()`; same fallback chain as before.
- `tests/tools/test_safe_getcwd_permission_error.py` (@wiseconnex): 5 regression tests, including an over-catch guard (`NotADirectoryError` still propagates — this is tolerance for two specific failure shapes, not a blanket except).

## Validation
| | Before | After |
|---|---|---|
| TCC-blocked CWD | PermissionError loop in cleanup thread | silent fallback to TERMINAL_CWD/$HOME |
| Tests | — | 5/5 passed |

**Live repro (premise):** verified on current main that `_safe_getcwd` catches only `FileNotFoundError` and the helper is used from the cleanup path; correctly distinguished from merged #66306 (PermissionError on the CONFIGURED cwd — different site).

Pure error-tolerance: nothing is skipped or denied; no user-requested operation affected.

Credit: @wiseconnex. Closes #67308.

## Infographic

![Terminal no longer chokes on locked folders](https://v3b.fal.media/files/b/0aa7e13f/GntAK4cNd7JHI746PVDEB_TPf82oAt.png)
