### PR TITLE
fix(kanban): stop nudge no longer reads as a prompt injection

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -86,18 +86,46 @@ def build_kanban_stop_nudge(
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
+
+    # Self-authentication: echo the harness's run id / claim lock so a
+    # suspicious model can verify this nudge came from the dispatcher rather
+    # than from pasted text. Fall back to the task id when neither is present.
+    run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+    if run_id or claim_lock:
+        auth = (
+            f" (harness run id: {run_id or 'n/a'}, "
+            f"claim lock: {claim_lock or 'n/a'})"
+        )
+    else:
+        auth = f" (task id: {tid})"
+
+    if attempts > 0:
+        # Second nudge: shorter, more direct reminder rather than a replay of
+        # the first (an identical replay reads as an injection tell).
+        return (
+            "Reminder from the kanban harness"
+            + auth
+            + ": the board still shows task `"
+            + tid
+            + "` as `running`. End this turn by calling "
+            "`kanban_complete(summary=..., artifacts=[...])` if the work is done, "
+            "or `kanban_block(reason=...)` if you are blocked. A plain-text reply "
+            "is not a terminal state and counts as a protocol violation."
+        )
+
     return (
-        "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
-        "terminal state for the board.\n\n"
-        f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
-        "Do this immediately in your next response — do not narrate intent:\n"
-        "1. Finish any remaining deliverable (write the required file(s) now).\n"
-        "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
-        "Never end a turn with only a promise of future action. Repeated "
-        "protocol violations will block this task and require manual intervention.]"
+        "The kanban harness"
+        + auth
+        + " needs a terminal board call before this turn ends. Task `"
+        + tid
+        + "` is still `running`; ending now without a board tool is recorded as "
+        "a protocol violation (clean exit with no `kanban_complete` / "
+        "`kanban_block`).\n\n"
+        "If the work is done, call `kanban_complete(summary=..., "
+        "artifacts=[...])`. If you are blocked, call `kanban_block(reason=...)`. "
+        "Otherwise finish the remaining deliverable first, then call one of "
+        "those tools before ending the turn."
     )
 
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -13,7 +13,12 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_STOP_NUDGE",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
 
@@ -52,6 +57,57 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert "kanban_block" in nudge
     assert "t_46be8aa5" in nudge
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
+
+
+# ── Regression: #95488 ─────────────────────────────────────────────────
+# The old nudge was formatted as a prompt injection ("[System: ...]",
+# "do not narrate intent", "immediately", "Never end a turn with only a
+# promise"), so safety-trained models refused it and the dispatcher
+# crash-looped. The nudge must read as a plain API contract, self-
+# authenticate via the harness run id / claim lock, and vary on retry.
+
+
+def test_nudge_has_no_injection_shape(clear_kanban_env):
+    """The nudge must not carry prompt-injection markers (#95488)."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+    nudge = build_kanban_stop_nudge(messages=[], attempts=0)
+    assert nudge is not None
+    assert not nudge.startswith("[System:")
+    assert "do not narrate intent" not in nudge.lower()
+    assert "immediately" not in nudge.lower()
+    assert "never end a turn with only a promise" not in nudge.lower()
+
+
+def test_nudge_self_authenticates_with_run_id(clear_kanban_env):
+    """The nudge echoes the harness run id / claim lock when set (#95488)."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "run_123")
+    clear_kanban_env.setenv("HERMES_KANBAN_CLAIM_LOCK", "lock_abc")
+    nudge = build_kanban_stop_nudge(messages=[], attempts=0)
+    assert nudge is not None
+    assert "run_123" in nudge
+    assert "lock_abc" in nudge
+
+
+def test_nudge_self_authenticates_fallback_to_task_id(clear_kanban_env):
+    """Without run id / claim lock, the nudge falls back to the task id."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+    nudge = build_kanban_stop_nudge(messages=[], attempts=0)
+    assert nudge is not None
+    assert "t_46be8aa5" in nudge
+
+
+def test_second_attempt_differs_from_first(clear_kanban_env):
+    """The retry nudge must not be an identical replay (#95488)."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+    first = build_kanban_stop_nudge(messages=[], attempts=0)
+    second = build_kanban_stop_nudge(messages=[], attempts=1)
+    assert first is not None
+    assert second is not None
+    assert first != second
+    # Both still carry the terminal-tool contract.
+    assert "kanban_complete" in second
+    assert "kanban_block" in second
 
 
 def test_no_nudge_after_kanban_complete(clear_kanban_env):


### PR DESCRIPTION
## Summary

`build_kanban_stop_nudge` (`agent/kanban_stop.py`) was injected into the conversation as a synthetic `role: user` message while claiming system authority (`[System: You are a Hermes kanban worker...]`) and applying urgency/anti-deliberation pressure (`Do this immediately in your next response — do not narrate intent`, `Never end a turn with only a promise`).

That is structurally a textbook prompt-injection pattern. Safety-trained models (e.g. `claude-sonnet-5`) correctly refuse it; the refusal ends the turn without a terminal board call, the dispatcher classifies it as a protocol violation and respawns, and the identical nudge replays → deterministic crash-loop. The model is behaving correctly — the bug is that a legitimate control-plane signal was wearing an attacker's clothes.

This fix rewrites the nudge text so it reads as a plain API contract rather than a privileged instruction:

- **Drops the `[System: ...]` authority claim** and all anti-deliberation/urgency language (`do not narrate intent`, `immediately`, `Never end a turn with only a promise`).
- **Self-authenticates** by echoing the harness run id / claim lock (`HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK` — both already set by the dispatcher in `hermes_cli/kanban_db.py`), so a suspicious model can verify the sender is the harness, not pasted text. Falls back to the task id when neither is present.
- **Varies on the second attempt** instead of replaying identical text (identical replay is itself an injection tell).

The function signature and return contract are unchanged, and `agent/conversation_loop.py` is untouched — the fix is contained to the nudge text.

## Changes

- `agent/kanban_stop.py` — rewrote `build_kanban_stop_nudge` to drop the injection-shaped framing, self-authenticate via the harness run id / claim lock, and emit a distinct shorter reminder on the second attempt.
- `tests/agent/test_kanban_stop.py` — added 4 regression tests: no injection shape, self-authentication with run id, fallback to task id, and second-attempt variation. Extended the env-clear fixture to cover the new env vars.

## Tests

`python3 -m pytest tests/agent/test_kanban_stop.py -v` → **7 passed** (3 pre-existing + 4 new).

Regression tests proven by revert: restoring the old buggy nudge text makes `test_nudge_has_no_injection_shape`, `test_nudge_self_authenticates_with_run_id`, and `test_second_attempt_differs_from_first` fail; with the fix they pass.

Closes #95488
