### PR TITLE
fix(kanban): lease active task worktrees

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2434,6 +2434,13 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
             if current != target:
                 continue
             reason = line[len("locked"):].strip()
+            if reason.startswith("active Hermes Kanban task"):
+                # Kanban lifecycle owns this lock and releases it only when the
+                # task completes or is archived. Unlike ``hermes pid=...``
+                # locks it is intentionally not process-scoped: a task may be
+                # requeued across worker processes while retaining its source
+                # checkout. Attended/startup worktree GC must never steal it.
+                return "live"
             m = re.search(r"hermes pid=(\d+)", reason)
             if not m:
                 # Locked by something we don't recognize as a hermes session

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5953,6 +5953,107 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         pass  # best-effort — never block completion
 
 
+def _worktree_lock_reason(
+    repo_root: Path, worktree: Path
+) -> tuple[bool, Optional[str]]:
+    """Return ``(query_succeeded, lock_reason)`` for one registered worktree."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return False, None
+    if result.returncode != 0:
+        return False, None
+    target = worktree.resolve(strict=False)
+    current: Optional[Path] = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            current = Path(line[len("worktree "):]).resolve(strict=False)
+        elif current == target and (line == "locked" or line.startswith("locked ")):
+            return True, line[len("locked"):].strip()
+    return True, None
+
+
+def _remove_task_worktree_under_lifecycle_lock(
+    task_id: str,
+    worktree: Path,
+    repo_root: Path,
+    common_dir: Path,
+    branch_name: Optional[str],
+) -> None:
+    """Atomically arbitrate Kanban/router ownership before removing a tree."""
+    from .active_sessions import _FileLock
+
+    with _FileLock(common_dir / "hermes-worktree-lifecycle.lock"):
+        lock_known, lock_reason = _worktree_lock_reason(repo_root, worktree)
+        if not lock_known:
+            _log.warning(
+                "Preserving worktree for task %s: unable to verify lock ownership at %s",
+                task_id, worktree,
+            )
+            return
+        branch = (branch_name or "").strip() or f"wt/{task_id}"
+        expected_lock_reason = f"active Hermes Kanban task {branch}"
+        if lock_reason and lock_reason != expected_lock_reason:
+            _log.info(
+                "Preserving worktree for task %s: foreign lock at %s (%s)",
+                task_id, worktree, lock_reason,
+            )
+            return
+        if lock_reason:
+            unlock = subprocess.run(
+                [
+                    "git", "-C", str(repo_root), "worktree", "unlock",
+                    str(worktree),
+                ],
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                timeout=30,
+                check=False,
+            )
+            if unlock.returncode != 0:
+                _log.warning(
+                    "git worktree unlock failed for task %s at %s: %s",
+                    task_id, worktree,
+                    (unlock.stderr or unlock.stdout or "").strip(),
+                )
+                return
+        # No --force: git re-verifies dirtiness and any lock acquired after
+        # our owned unlock. The repo-scoped lifecycle lock serializes Hermes'
+        # Kanban/router lock transitions around this ownership decision.
+        result = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "worktree", "remove",
+                str(worktree),
+            ],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=60,
+            check=False,
+        )
+        if result.returncode != 0:
+            _log.warning(
+                "git worktree remove failed for task %s at %s: %s",
+                task_id, worktree,
+                (result.stderr or result.stdout or "").strip(),
+            )
+            return
+        _log.debug("Removed worktree workspace: %s", worktree)
+        if branch.startswith("wt/"):
+            subprocess.run(
+                ["git", "-C", str(repo_root), "branch", "-D", branch],
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                timeout=30,
+                check=False,
+            )
+
+
 def _cleanup_worktree_workspace(
     task_id: str, path: str, branch_name: Optional[str] = None
 ) -> None:
@@ -5985,33 +6086,9 @@ def _cleanup_worktree_workspace(
                 task_id, wp,
             )
             return
-        # No --force: the dirty/unpushed checks above run before removal, so
-        # git's own dirty guard re-verifies at removal time. If the tree
-        # became dirty between our check and the removal (TOCTOU), removal
-        # fails safe and the worktree is preserved.
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "worktree", "remove", str(wp)],
-            capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
-            timeout=60,
-            check=False,
+        _remove_task_worktree_under_lifecycle_lock(
+            task_id, wp, repo_root, common, branch_name
         )
-        if result.returncode != 0:
-            _log.warning(
-                "git worktree remove failed for task %s at %s: %s",
-                task_id, wp, (result.stderr or result.stdout or "").strip(),
-            )
-            return
-        _log.debug("Removed worktree workspace: %s", wp)
-        branch = (branch_name or "").strip() or f"wt/{task_id}"
-        if branch.startswith("wt/"):
-            subprocess.run(
-                ["git", "-C", str(repo_root), "branch", "-D", branch],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=30,
-                check=False,
-            )
     except Exception:
         pass  # best-effort — never block completion
 
@@ -7710,13 +7787,48 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
+def _lock_task_worktree(
+    repo_root: Path, target: Path, branch_name: str
+) -> None:
+    """Prevent non-owner cleanup from removing an active Kanban checkout."""
+    from .active_sessions import _FileLock
+
+    common = _git_common_dir(repo_root)
+    if common is None:
+        raise RuntimeError(f"cannot resolve git common dir for {repo_root}")
+    with _FileLock(common / "hermes-worktree-lifecycle.lock"):
+        result = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "worktree", "lock",
+                "--reason", f"active Hermes Kanban task {branch_name}",
+                str(target),
+            ],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=30,
+            check=False,
+        )
+        detail = (result.stderr or result.stdout or "").strip()
+        if result.returncode != 0:
+            lock_known, lock_reason = _worktree_lock_reason(repo_root, target)
+            if not (
+                lock_known
+                and lock_reason
+                and lock_reason == f"active Hermes Kanban task {branch_name}"
+            ):
+                raise RuntimeError(
+                    f"git worktree lock failed for {target}: {detail}"
+                )
+
+
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
-    """Materialize ``target`` as a linked git worktree under ``repo_root``."""
+    """Materialize and lifecycle-lock a task worktree under ``repo_root``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
         target_common = _git_common_dir(target)
         if target_common == repo_common:
+            _lock_task_worktree(repo_root, target, branch_name)
             return
     target.parent.mkdir(parents=True, exist_ok=True)
     if _git_branch_exists(repo_root, branch_name):
@@ -7738,6 +7850,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         raise RuntimeError(
             f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
         )
+    _lock_task_worktree(repo_root, target, branch_name)
 
 
 def _resolve_worktree_workspace(
@@ -7794,6 +7907,13 @@ def _resolve_worktree_workspace(
     if requested.exists() and _is_linked_worktree_checkout(requested):
         actual_branch = _git_current_branch(requested)
         if actual_branch == branch_name:
+            existing_repo = _git_toplevel(requested)
+            if existing_repo is not None:
+                common = _git_common_dir(existing_repo)
+                if common is not None:
+                    _lock_task_worktree(
+                        common.parent, requested_resolved, branch_name
+                    )
             return requested_resolved, actual_branch
         # The requested path is an existing checkout of a DIFFERENT
         # task's branch. Decompose children inherit the root's

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7831,26 +7831,79 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
             _lock_task_worktree(repo_root, target, branch_name)
             return
     target.parent.mkdir(parents=True, exist_ok=True)
-    if _git_branch_exists(repo_root, branch_name):
-        cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
-    else:
-        cmd = [
-            "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
-        ]
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
-        timeout=60,
-        check=False,
-    )
-    if result.returncode != 0:
-        stderr = (result.stderr or result.stdout or "").strip()
-        raise RuntimeError(
-            f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
+
+    # Serialize Hermes lifecycle transitions and ask Git to publish the new
+    # worktree already locked.  Locking in a second command leaves an
+    # add-return/lock-start window where an independent pruner can remove the
+    # checkout; ``worktree add --lock`` closes that window at Git's boundary.
+    from .active_sessions import _FileLock
+    common = _git_common_dir(repo_root)
+    if common is None:
+        raise RuntimeError(f"cannot resolve git common dir for {repo_root}")
+    lock_reason = f"active Hermes Kanban task {branch_name}"
+    with _FileLock(common / "hermes-worktree-lifecycle.lock"):
+        if _git_branch_exists(repo_root, branch_name):
+            cmd = [
+                "git", "-C", str(repo_root), "worktree", "add",
+                "--lock", "--reason", lock_reason, str(target), branch_name,
+            ]
+        else:
+            cmd = [
+                "git", "-C", str(repo_root), "worktree", "add",
+                "--lock", "--reason", lock_reason, "-b", branch_name,
+                str(target), "HEAD",
+            ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=60,
+            check=False,
         )
-    _lock_task_worktree(repo_root, target, branch_name)
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(
+                f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
+            )
+
+
+def _adopt_nonterminal_task_worktrees(conn: sqlite3.Connection) -> None:
+    """Restore lifecycle locks for task worktrees created before lock leasing.
+
+    Dispatch is the restart/recovery boundary that sees every nonterminal
+    task.  Re-locking an existing checkout here closes the upgrade gap for
+    worktrees materialized by an older process, while branch verification
+    prevents a stale task row from claiming another task's checkout.
+    """
+    rows = conn.execute(
+        "SELECT id, workspace_path, branch_name FROM tasks "
+        "WHERE workspace_kind='worktree' AND workspace_path IS NOT NULL "
+        "AND status NOT IN ('done', 'archived', 'failed', 'cancelled')"
+    ).fetchall()
+    for row in rows:
+        target = Path(row["workspace_path"]).expanduser().resolve(strict=False)
+        branch = (row["branch_name"] or "").strip() or f"wt/{row['id']}"
+        try:
+            if not target.is_dir() or not _is_linked_worktree_checkout(target):
+                continue
+            if _git_current_branch(target) != branch:
+                _log.warning(
+                    "Refusing to adopt worktree for task %s: branch mismatch at %s",
+                    row["id"], target,
+                )
+                continue
+            common = _git_common_dir(target)
+            if common is None:
+                continue
+            _lock_task_worktree(common.parent, target, branch)
+        except Exception as exc:
+            # Recovery is fail-safe and best-effort: an unverifiable checkout
+            # is preserved by cleanup policy, and one bad row must not stall
+            # dispatch for unrelated projects.
+            _log.warning(
+                "Unable to adopt worktree lease for task %s at %s: %s",
+                row["id"], target, exc,
+            )
 
 
 def _resolve_worktree_workspace(
@@ -10090,6 +10143,8 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    if not dry_run:
+        _adopt_nonterminal_task_worktrees(conn)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -908,6 +908,13 @@ class TestWorktreeLockPredicate:
         p = self._mk_locked(git_repo, "hermes-foreign", "some other tool")
         assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "dead"
 
+    def test_active_kanban_lock_reason_returns_live(self, git_repo):
+        import cli
+        p = self._mk_locked(
+            git_repo, "custom-kanban-task", "active Hermes Kanban task"
+        )
+        assert cli._worktree_lock_is_live(str(git_repo), str(p)) == "live"
+
     def test_bad_repo_root_fails_safe_to_live(self, tmp_path):
         import cli
         # Not a git repo -> git query fails -> must report "live" (never delete)

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -75,9 +75,34 @@ def _branch_exists(repo: Path, branch: str) -> bool:
     return bool(out.strip())
 
 
+def _worktree_is_locked(repo: Path, worktree: Path) -> bool:
+    listing = _git("-C", str(repo), "worktree", "list", "--porcelain")
+    blocks = [block for block in listing.strip().split("\n\n") if block]
+    target = str(worktree.resolve())
+    return any(
+        block.splitlines()[0] == f"worktree {target}"
+        and any(line.startswith("locked") for line in block.splitlines()[1:])
+        for block in blocks
+    )
+
+
 # ---------------------------------------------------------------------------
 # _cleanup_worktree_workspace unit behavior
 # ---------------------------------------------------------------------------
+
+
+def test_materialized_task_worktree_is_locked_until_lifecycle_cleanup(repo: Path) -> None:
+    wt = _make_worktree(repo, "t_aabbccdd")
+    assert _worktree_is_locked(repo, wt)
+    attempted = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "remove", str(wt)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert attempted.returncode != 0
+    assert "locked working tree" in attempted.stderr
+    assert wt.is_dir()
 
 
 def test_clean_pushed_worktree_removed(repo: Path) -> None:
@@ -126,6 +151,48 @@ def test_non_git_dir_preserved(tmp_path: Path) -> None:
     plain.mkdir()
     kb._cleanup_worktree_workspace("t_ffff6666", str(plain))
     assert plain.is_dir()
+
+
+def test_foreign_locked_worktree_is_preserved(repo: Path) -> None:
+    wt = _make_worktree(repo, "t_f0f0f0f0")
+    _git("-C", str(repo), "worktree", "unlock", str(wt))
+    _git(
+        "-C", str(repo), "worktree", "lock", "--reason",
+        "active Hermes Kanban task wt/t_other", str(wt)
+    )
+    kb._cleanup_worktree_workspace("t_f0f0f0f0", str(wt))
+    assert wt.is_dir()
+    assert _worktree_is_locked(repo, wt)
+
+
+def test_relock_between_owned_unlock_and_remove_is_preserved(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wt = _make_worktree(repo, "t_12121212")
+    original_run = subprocess.run
+    relocked = False
+
+    def run_with_relock(args, *positional, **kwargs):
+        nonlocal relocked
+        result = original_run(args, *positional, **kwargs)
+        if (
+            not relocked
+            and isinstance(args, list)
+            and args[-3:-1] == ["worktree", "unlock"]
+            and args[-1] == str(wt)
+        ):
+            relocked = True
+            _git(
+                "-C", str(repo), "worktree", "lock", "--reason",
+                "coding router result", str(wt)
+            )
+        return result
+
+    monkeypatch.setattr(subprocess, "run", run_with_relock)
+    kb._cleanup_worktree_workspace("t_12121212", str(wt))
+    assert relocked
+    assert wt.is_dir()
+    assert _worktree_is_locked(repo, wt)
 
 
 def test_tree_dirtied_between_check_and_removal_preserved(

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -105,6 +105,85 @@ def test_materialized_task_worktree_is_locked_until_lifecycle_cleanup(repo: Path
     assert wt.is_dir()
 
 
+def test_task_worktree_is_locked_before_add_publishes(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A remover released as the add returns must see a Git-native lock.
+
+    The competing remove is a separate Git process, so it tests the Git-native
+    lock rather than the in-process advisory lifecycle lock.
+    """
+    target = repo / ".worktrees" / "t_addlock"
+
+    # Race: a competing `git worktree remove` arrives just as the add publishes
+    # the tree. It must be denied by the Git native lock, not by our advisory
+    # file lock (they protect disjoint concerns — the advisory lock serialises
+    # Kanban/router lock transitions; the Git lock is what repels non-owner
+    # cleanup at the repository level).
+    original_run = subprocess.run
+    competing_returncode: int | None = None
+
+    def run_with_competitor(args, *positional, **kwargs):
+        nonlocal competing_returncode
+        result = original_run(args, *positional, **kwargs)
+        if (
+            isinstance(args, list)
+            and "worktree" in args
+            and "add" in args
+            and str(target) in args
+            and result.returncode == 0
+        ):
+            competing = original_run(
+                ["git", "-C", str(repo), "worktree", "remove", str(target)],
+                capture_output=True, text=True, check=False,
+            )
+            competing_returncode = competing.returncode
+        return result
+
+    monkeypatch.setattr(subprocess, "run", run_with_competitor)
+    kb._ensure_git_worktree(repo, target, "wt/t_addlock")
+
+    assert competing_returncode not in (None, 0)
+    assert target.is_dir()
+    assert _worktree_is_locked(repo, target)
+
+
+def test_dispatch_adopts_unlocked_nonterminal_task_worktree(
+    kanban_home: Path, repo: Path
+) -> None:
+    """A restart adopts pre-upgrade task trees before later cleanup can reap them."""
+    target = repo / ".worktrees" / "t_upgrade"
+    _git(
+        "-C", str(repo), "worktree", "add", "-b", "wt/t_upgrade",
+        str(target), "HEAD",
+    )
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="pre-upgrade", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET id=?, status='blocked', workspace_kind='worktree', "
+                "workspace_path=?, branch_name=? WHERE id=?",
+                ("t_upgrade", str(target), "wt/t_upgrade", task_id),
+            )
+        kb.dispatch_once(
+            conn,
+            max_spawn=0,
+            reconcile_orphans=False,
+            spawn_fn=lambda *_args: None,
+        )
+        # Restart recovery is idempotent: a later dispatch tick recognizes its
+        # own lease rather than unlocking or replacing it.
+        kb.dispatch_once(
+            conn,
+            max_spawn=0,
+            reconcile_orphans=False,
+            spawn_fn=lambda *_args: None,
+        )
+
+    assert target.is_dir()
+    assert _worktree_is_locked(repo, target)
+
+
 def test_clean_pushed_worktree_removed(repo: Path) -> None:
     wt = _make_worktree(repo, "t_aaaa1111")
     kb._cleanup_worktree_workspace("t_aaaa1111", str(wt))


### PR DESCRIPTION
## Summary
- lifecycle-lock active Kanban task worktrees with task/branch-specific Git lock ownership
- serialize Kanban and coding-router worktree transitions through a shared repo-scoped file lock
- preserve foreign/unknown locks and teach attended worktree GC that active Kanban locks are live
- keep explicit lifecycle teardown safe by unlocking only the exact owner and retaining Git's no-force dirtiness/relock checks

## Incident
A bounded coding-router run used a registered Kanban task worktree as its source. During provider execution, both that canonical source checkout and the router's isolated result checkout disappeared before verification, producing `verification_failed`, empty changed files, and ENOENT errors. The installed router counterpart now uses the same lifecycle-lock protocol and leaves result worktrees locked until explicit cleanup.

## Verification
- RED: new task-worktree lock regression failed before implementation (`assert False`)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_teardown.py tests/hermes_cli/test_kanban_worktree_isolation.py tests/cli/test_worktree.py -q` — 73 passed
- installed router suite: `python3 -m unittest test_coding_worker` — 16 passed
- bounded router repro: `run-20260826T072107-81dd4084` reached `verified_no_commit`; source and isolated result both remain present and locked
- `git diff --check`
- `python -m compileall` on changed Python files
- independent review: PASS
