### PR TITLE
fix(desktop): suppress composer auto-focus in hidden keep-alive tabs

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
 import { $connection } from '@/store/session'
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 
 import { useComposerActions } from '../../hooks/use-composer-actions'
 import type { QueueEditState } from '../composer-utils'
@@ -292,5 +293,66 @@ describe('useComposerDraft — a closing composer hands the focus-bus key back',
     unmount()
 
     expect(getActiveComposer()).toBe('tile:other')
+  })
+})
+
+describe('useComposerDraft — a hidden keep-alive tab never auto-focuses its composer', () => {
+  afterEach(() => {
+    cleanup()
+    mainComposerScope.clear()
+    markActiveComposer('main')
+  })
+
+  function renderScopedHidden(target: ComposerTarget, hidden: boolean) {
+    const scope: ComposerScope = { ...MAIN_COMPOSER_SCOPE, target }
+
+    return render(
+      <PaneVisibleContext.Provider value={!hidden}>
+        <ComposerScopeProvider value={scope}>
+          <ProbeHarness
+            activeQueueSessionKey="session-tile"
+            onLayoutSnapshot={() => undefined}
+            sessionId="session-tile"
+          />
+        </ComposerScopeProvider>
+      </PaneVisibleContext.Provider>
+    )
+  }
+
+  it('does not claim the focus bus when the composer mounts inside a hidden pane', () => {
+    renderScopedHidden('tile:bg', true)
+
+    // The auto-focus effect must skip a background tab entirely: claiming the
+    // bus would both steal OS focus (focusInput calls .focus()) and misroute
+    // every subsequent 'active' request to the buried composer.
+    expect(getActiveComposer()).toBe('main')
+  })
+
+  it('still claims the bus when the same composer becomes visible', () => {
+    const { rerender } = renderScopedHidden('tile:fg', true)
+
+    expect(getActiveComposer()).toBe('main')
+
+    // Tab switch fronts this pane — PaneVisibleContext flips true, the effect
+    // re-runs with paneVisible now true, and the composer takes over.
+    rerender(
+      <PaneVisibleContext.Provider value={true}>
+        <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, target: 'tile:fg' }}>
+          <ProbeHarness
+            activeQueueSessionKey="session-tile"
+            onLayoutSnapshot={() => undefined}
+            sessionId="session-tile"
+          />
+        </ComposerScopeProvider>
+      </PaneVisibleContext.Provider>
+    )
+
+    expect(getActiveComposer()).toBe('tile:fg')
+  })
+
+  it('claims the bus on mount when visible (the regression guard for the fix itself)', () => {
+    renderScopedHidden('tile:vis', false)
+
+    expect(getActiveComposer()).toBe('tile:vis')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -9,6 +9,7 @@ import '@/store/suggestion-providers/skill'
 import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import {
@@ -181,11 +182,23 @@ export function useComposerDraft({
     [paintDraft]
   )
 
+  // Gate on keep-alive visibility: an inactive tab's composer stays MOUNTED
+  // (hidden behind `data-pane-hidden`), so without this check a background
+  // session whose turn just finished (`inputDisabled` flipping false) or that
+  // recovered from a gateway reconnect re-runs this effect and calls
+  // `.focus()` — yanking keyboard focus off the tab the user is typing in.
+  // `usePaneVisible` reads the same visibility policy every document-wide
+  // lookup obeys (see pane-visibility.ts) and defaults to true for surfaces
+  // outside a tab stack, so tiles, pop-outs, and secondary windows are
+  // unaffected. The user's own click into the composer still focuses it via
+  // ChatBar's onFocus; only programmatic auto-focus is suppressed here.
+  const paneVisible = usePaneVisible()
+
   useEffect(() => {
-    if (!inputDisabled) {
+    if (!inputDisabled && paneVisible) {
       focusInput()
     }
-  }, [focusInput, focusKey, focusRequestId, inputDisabled])
+  }, [focusInput, focusKey, focusRequestId, inputDisabled, paneVisible])
 
   // The mirror of the `markActiveComposer` above: give the key back when this
   // composer goes away (a session tile closing, a pane unmounting). Covers both


### PR DESCRIPTION
## Problem
Typing across two session tabs in bot mode caused glitches and lost keyboard focus.

## Root cause
Hidden keep-alive tabs keep their composer mounted. When a background session's turn finished (`inputDisabled` flipping false) or it recovered from a gateway reconnect, the composer's auto-focus effect re-ran and called `.focus()` — stealing keyboard focus from the tab the user was actively typing in.

## Fix
Gate the programmatic auto-focus in `useComposerDraft` on `usePaneVisible()`:
- A hidden tab's composer never claims the focus bus on mount or re-enable.
- Becoming visible (tab switch) correctly claims it.
- Tiles, pop-outs, and secondary windows default to visible and are unaffected.
- User-initiated focus (clicking into the composer) is untouched — ChatBar `onFocus` still handles that.

## Testing
- New tests in `use-composer-draft.test.tsx`: hidden mount doesn't claim focus; visibility flip claims it; visible mount claims it. All 9 pass.
- Full desktop suite: 19 pre-existing failures across 7 files were verified to fail identically on pristine `main` (stash + rerun of the affected files) — none caused by this change.