### PR TITLE
fix(desktop): validate fs openDir paths

### DIFF
--- a/apps/desktop/electron/fs-ipc.test.ts
+++ b/apps/desktop/electron/fs-ipc.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, test, vi } from 'vitest'
+
+const electronMock = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: any[]) => any>()
+
+  return {
+    handlers,
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: any[]) => any) => {
+        handlers.set(channel, handler)
+      })
+    },
+    shell: {
+      openPath: vi.fn(async (_path: string) => ''),
+      showItemInFolder: vi.fn(),
+      trashItem: vi.fn()
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: electronMock.ipcMain,
+  shell: electronMock.shell
+}))
+
+import { registerFsIpc } from './fs-ipc'
+
+afterEach(() => {
+  electronMock.handlers.clear()
+  vi.clearAllMocks()
+})
+
+test('openDir validates and uses the resolved path before creating or opening it', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-fs-opendir-'))
+  const resolved = path.join(root, 'plugins')
+  const expandUserPath = vi.fn((value: string) => `/expanded/${value}`)
+  const resolveRequestedPathForIpc = vi.fn(() => resolved)
+
+  try {
+    registerFsIpc({
+      hermesHome: root,
+      readActiveDesktopProfile: () => null,
+      expandUserPath,
+      resolveRequestedPathForIpc,
+      directoryExists: () => true,
+      resolveGitBinary: () => 'git'
+    })
+
+    const handler = electronMock.handlers.get('hermes:fs:openDir')
+    assert.ok(handler)
+
+    const result = await handler(undefined, '~/plugins')
+
+    assert.deepEqual(result, { ok: true })
+    assert.equal(expandUserPath.mock.calls[0]?.[0], '~/plugins')
+    assert.deepEqual(resolveRequestedPathForIpc.mock.calls[0], [
+      '/expanded/~/plugins',
+      { purpose: 'Open directory' }
+    ])
+    assert.equal(fs.existsSync(resolved), true)
+    assert.equal(electronMock.shell.openPath.mock.calls[0]?.[0], path.normalize(resolved))
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+
+test('openDir stops before opening when path validation rejects the input', async () => {
+  const resolveRequestedPathForIpc = vi.fn(() => {
+    throw new Error('blocked path')
+  })
+
+  registerFsIpc({
+    hermesHome: '/tmp/hermes',
+    readActiveDesktopProfile: () => null,
+    expandUserPath: (value: string) => value,
+    resolveRequestedPathForIpc,
+    directoryExists: () => true,
+    resolveGitBinary: () => 'git'
+  })
+
+  const handler = electronMock.handlers.get('hermes:fs:openDir')
+  assert.ok(handler)
+
+  const result = await handler(undefined, '\\\\?\\C:\\secret')
+
+  assert.deepEqual(result, { ok: false, error: 'blocked path' })
+  assert.equal(resolveRequestedPathForIpc.mock.calls.length, 1)
+  assert.equal(electronMock.shell.openPath.mock.calls.length, 0)
+})

--- a/apps/desktop/electron/fs-ipc.ts
+++ b/apps/desktop/electron/fs-ipc.ts
@@ -62,8 +62,9 @@ export function registerFsIpc({
     }
 
     try {
-      await fs.promises.mkdir(dir, { recursive: true })
-      const error = await shell.openPath(path.normalize(dir))
+      const resolved = resolveRequestedPathForIpc(expandUserPath(dir), { purpose: 'Open directory' })
+      await fs.promises.mkdir(resolved, { recursive: true })
+      const error = await shell.openPath(path.normalize(resolved))
 
       return error ? { ok: false, error } : { ok: true }
     } catch (error) {


### PR DESCRIPTION
## What does this PR do?

Routes the `hermes:fs:openDir` IPC handler through the existing filesystem path-validation pipeline before creating or opening a directory.

Previously, `openDir` passed the renderer-provided path directly to `fs.promises.mkdir()` and `shell.openPath()`. This bypassed `expandUserPath()` and `resolveRequestedPathForIpc()`, unlike other hardened filesystem IPC operations.

The handler now resolves and validates the requested path first, so invalid path syntax and blocked Windows device paths are rejected before any filesystem or shell operation occurs.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/fs-ipc.ts`
  - Expand and validate `openDir` paths with the existing IPC path-validation helper.
  - Use the validated resolved path for both directory creation and `shell.openPath()`.

- `apps/desktop/electron/fs-ipc.test.ts`
  - Verify `openDir` creates and opens the resolved path rather than the raw renderer input.
  - Verify path-validation failures stop before `shell.openPath()` is called.

## How to Test

1. Run the targeted Electron regression tests:
   `cd apps/desktop && npx vitest run --project electron electron/fs-ipc.test.ts`
   Expected: 2 tests pass.

2. Run Electron TypeScript validation:
   `cd apps/desktop && npx tsc -p tsconfig.electron.json --noEmit`
   Expected: exits successfully with no errors.

3. Run lint on the changed files:
   `cd apps/desktop && npx eslint electron/fs-ipc.ts electron/fs-ipc.test.ts`
   Expected: exits successfully with no errors.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted Electron regression tests:

`2 passed (2)`

Electron TypeScript validation and ESLint both complete successfully with no errors.