### PR TITLE
fix(cli): keep one-shot parents alive for delegations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1456,6 +1456,109 @@ def _wait_for_oneshot_background_completions(cli) -> None:
         )
 
 
+def _drain_oneshot_async_delegations(
+    cli,
+    *,
+    run_turn,
+    owned_session_ids=None,
+) -> int:
+    """Keep a one-shot parent alive until its delegated work is adjudicated.
+
+    ``delegate_task`` completions are conversation turns, not mere process
+    notifications.  A ``-q``/``-Q`` parent that exits after its first response
+    interrupts process-local children during ``_run_cleanup`` and can never
+    inspect their verdicts.  Stay alive, route each owned completion through
+    the same notification rail as the interactive CLI, and run the resulting
+    synthetic turn before allowing teardown.  Follow-up turns may delegate
+    again, so the gate repeats until both the owned live set and notification
+    queue are empty.
+
+    The wait is intentionally not given a second arbitrary timeout: async
+    delegation already owns bounded capacity, stale-child detection, explicit
+    interruption, and provider/tool deadlines.  A shutdown signal still raises
+    through this loop and reaches the normal cleanup path.
+    """
+    from tools.async_delegation import has_live_for_session
+
+    session_id = str(
+        getattr(getattr(cli, "agent", None), "session_id", None)
+        or getattr(cli, "session_id", None)
+        or ""
+    )
+    if not session_id:
+        return 0
+
+    session_ids = {
+        str(item)
+        for item in (owned_session_ids or ())
+        if str(item or "")
+    }
+    session_ids.add(session_id)
+
+    def _owned_live() -> bool:
+        current_id = str(
+            getattr(getattr(cli, "agent", None), "session_id", None)
+            or getattr(cli, "session_id", None)
+            or ""
+        )
+        if current_id:
+            session_ids.add(current_id)
+        return any(
+            has_live_for_session(parent_session_id=owned_id)
+            for owned_id in tuple(session_ids)
+        )
+
+    processed = 0
+    live = _owned_live()
+    while True:
+        cli._drain_process_notifications("cli-one-shot")
+        drained = 0
+        while True:
+            try:
+                synthetic_message = cli._pending_input.get_nowait()
+            except queue.Empty:
+                break
+            if not synthetic_message:
+                continue
+            run_turn(synthetic_message)
+            processed += 1
+            drained += 1
+
+        if not live and drained == 0:
+            return processed
+
+        live = _owned_live()
+        if not live:
+            # Close the completion race: a worker may have transitioned to a
+            # terminal state immediately after the drain above but before the
+            # liveness read. Drain once more, then require a second stable
+            # no-live observation before exit.
+            cli._drain_process_notifications("cli-one-shot")
+            race_drained = 0
+            while True:
+                try:
+                    synthetic_message = cli._pending_input.get_nowait()
+                except queue.Empty:
+                    break
+                if not synthetic_message:
+                    continue
+                run_turn(synthetic_message)
+                processed += 1
+                race_drained += 1
+            live = _owned_live()
+            if not live and race_drained == 0:
+                logger.info(
+                    "One-shot async-delegation drain complete for session %s: "
+                    "processed=%d",
+                    session_id,
+                    processed,
+                )
+                return processed
+
+        if live:
+            time.sleep(0.1)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
@@ -21551,6 +21654,10 @@ def main(
                         # (they check agent.tool_progress_mode, initialized
                         # from display.tool_progress at construction).
                         cli.agent.tool_progress_mode = "off"
+                        oneshot_delegation_session_ids = {
+                            str(cli.session_id or ""),
+                            str(getattr(cli.agent, "session_id", "") or ""),
+                        }
                         try:
                             result = cli.agent.run_conversation(
                                 user_message=effective_query,
@@ -21570,19 +21677,11 @@ def main(
                         ):
                             cli.session_id = cli.agent.session_id
                         response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                        # Surface backend errors that produced no visible output
-                        # (e.g. invalid model slug → provider 4xx). Mirrors the
-                        # interactive CLI path. Write to stderr so piped stdout
-                        # stays clean for automation wrappers.
-                        if (
-                            not response
-                            and isinstance(result, dict)
-                            and result.get("error")
-                            and (result.get("failed") or result.get("partial"))
-                        ):
-                            print(f"Error: {result['error']}", file=sys.stderr)
-                        elif response:
-                            print(response)
+                        # Defer machine-readable stdout until every owned
+                        # delegation follow-up has completed. If a follow-up
+                        # adjudicates the child result, that is the one final
+                        # answer -Q should emit, not the earlier "still pending"
+                        # response plus a second answer.
 
                         # Kanban goal-loop mode: a worker spawned for a
                         # goal_mode card keeps working in THIS session until an
@@ -21596,6 +21695,58 @@ def main(
                                 _run_kanban_goal_loop_q(cli, response)
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
+
+                        quiet_followup_results = []
+                        quiet_agent = cli.agent
+                        assert quiet_agent is not None
+
+                        def _run_quiet_delegation_turn(synthetic_message):
+                            followup = quiet_agent.run_conversation(
+                                user_message=synthetic_message,
+                                conversation_history=cli.conversation_history,
+                            )
+                            quiet_followup_results.append(followup)
+                            if (
+                                getattr(cli.agent, "session_id", None)
+                                and cli.agent.session_id != cli.session_id
+                            ):
+                                cli.session_id = cli.agent.session_id
+                            return followup
+
+                        try:
+                            _drain_oneshot_async_delegations(
+                                cli,
+                                run_turn=_run_quiet_delegation_turn,
+                                owned_session_ids=oneshot_delegation_session_ids,
+                            )
+                        except KeyboardInterrupt:
+                            _emit_interrupted_session_end(
+                                cli,
+                                reason="keyboard_interrupt",
+                            )
+                            print(
+                                f"\nsession_id: {cli.session_id}",
+                                file=sys.stderr,
+                            )
+                            sys.exit(130)
+                        if quiet_followup_results:
+                            result = quiet_followup_results[-1]
+                        response = (
+                            result.get("final_response", "")
+                            if isinstance(result, dict)
+                            else str(result)
+                        )
+                        # Surface backend errors that produced no visible output
+                        # on stderr so -Q stdout remains one final answer.
+                        if (
+                            not response
+                            and isinstance(result, dict)
+                            and result.get("error")
+                            and (result.get("failed") or result.get("partial"))
+                        ):
+                            print(f"Error: {result['error']}", file=sys.stderr)
+                        elif response:
+                            print(response)
 
                         # Session ID goes to stderr so piped stdout is clean.
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
@@ -21649,8 +21800,21 @@ def main(
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
-                cli._print_exit_summary(clear_screen=False)
+                oneshot_delegation_session_ids = {str(cli.session_id or "")}
+                try:
+                    cli.chat(query, images=single_query_images or None)
+                    _drain_oneshot_async_delegations(
+                        cli,
+                        run_turn=cli.chat,
+                        owned_session_ids=oneshot_delegation_session_ids,
+                    )
+                    cli._print_exit_summary(clear_screen=False)
+                except KeyboardInterrupt:
+                    _emit_interrupted_session_end(
+                        cli,
+                        reason="keyboard_interrupt",
+                    )
+                    sys.exit(130)
         finally:
             _finalize_single_query(cli)
         return

--- a/run_agent.py
+++ b/run_agent.py
@@ -981,6 +981,7 @@ class AIAgent:
         return (
             self.quiet_mode
             and not self.tool_progress_callback
+            and not getattr(self, "suppress_status_output", False)
             and getattr(self, "platform", "") == "cli"
         )
 

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -100,6 +100,13 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
         "_finalize_single_query",
         lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
     )
+    monkeypatch.setattr(
+        cli_mod,
+        "_drain_oneshot_async_delegations",
+        lambda fake_cli, *, run_turn, owned_session_ids=None: calls.append(
+            ("drain", fake_cli.session_id)
+        ),
+    )
 
     cli_mod.main(query="hello", quiet=False, toolsets="terminal")
 
@@ -108,12 +115,68 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
         "query-label",
         "advisories",
         ("chat", "hello", None),
+        ("drain", "sq-test"),
         ("summary", False),  # <-- clear_screen=False for single-query
         ("finalize", "sq-test"),
     ]
     assert len(clear_calls) == 0, (
         "_clear_terminal_on_exit must NOT be called in single-query mode"
     )
+
+
+def test_single_query_delegation_drain_interrupt_exits_cleanly(monkeypatch):
+    calls = []
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_a, **_kw: None)
+            self.session_id = "sq-interrupt"
+            self.agent = SimpleNamespace(
+                session_id="sq-interrupt",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query))
+            return "done"
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append("summary")
+
+    def interrupt_drain(fake_cli, *, run_turn, owned_session_ids=None):
+        calls.append("drain")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_mod, "_drain_oneshot_async_delegations", interrupt_drain)
+    monkeypatch.setattr(
+        cli_mod,
+        "_emit_interrupted_session_end",
+        lambda fake_cli, *, reason: calls.append(("interrupted", reason)),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append("finalize"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+
+    assert exc.value.code == 130
+    assert calls == [
+        ("chat", "hello"),
+        "drain",
+        ("interrupted", "keyboard_interrupt"),
+        "finalize",
+    ]
 
 
 # ── Verify interactive mode still clears ────────────────────────────────────

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -1,8 +1,12 @@
 """Regression coverage for CLI async-delegation completion ownership."""
 
 import queue
+import threading
 
+import cli as cli_mod
 from cli import HermesCLI
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
 
 
 def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
@@ -74,3 +78,156 @@ def test_cli_completion_ownership_accepts_compression_lineage():
             "session_key": "pre-compression-session",
         }
     )
+
+
+def test_oneshot_drain_waits_for_owned_delegation_and_runs_completion(monkeypatch):
+    """A one-shot parent must consume the required child result before exit."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "parent-session"
+    cli._pending_input = queue.Queue()
+
+    live_checks = iter([True, True, False, False])
+    selector_calls = []
+    drain_calls = []
+    responses = []
+
+    def has_live_for_session(**selectors):
+        selector_calls.append(selectors)
+        return next(live_checks)
+
+    def drain(consumer):
+        drain_calls.append(consumer)
+        if len(drain_calls) == 2:
+            cli._pending_input.put("delegation completion")
+
+    monkeypatch.setattr(
+        "tools.async_delegation.has_live_for_session",
+        has_live_for_session,
+    )
+    monkeypatch.setattr(cli, "_drain_process_notifications", drain)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    count = cli_mod._drain_oneshot_async_delegations(
+        cli,
+        run_turn=lambda message: responses.append(message),
+    )
+
+    assert count == 1
+    assert responses == ["delegation completion"]
+    assert drain_calls == ["cli-one-shot", "cli-one-shot", "cli-one-shot"]
+    assert selector_calls
+    assert all(
+        call == {"parent_session_id": "parent-session"}
+        for call in selector_calls
+    )
+
+
+def test_oneshot_drain_is_noop_without_owned_delegations(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "parent-session"
+    cli._pending_input = queue.Queue()
+    turns = []
+
+    monkeypatch.setattr(
+        "tools.async_delegation.has_live_for_session",
+        lambda **_selectors: False,
+    )
+    monkeypatch.setattr(cli, "_drain_process_notifications", lambda _consumer: None)
+
+    assert cli_mod._drain_oneshot_async_delegations(
+        cli,
+        run_turn=turns.append,
+    ) == 0
+    assert turns == []
+
+
+def test_oneshot_drain_real_dispatch_delivers_before_return():
+    """Exercise dispatch -> completion queue -> CLI synthetic follow-up end to end."""
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    gate = threading.Event()
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "parent-session"
+    cli._session_db = None
+    cli._pending_input = queue.Queue()
+    turns = []
+
+    def runner():
+        gate.wait(timeout=5)
+        return {
+            "status": "completed",
+            "summary": "review verdict",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+            "model": "test-model",
+        }
+
+    dispatched = ad.dispatch_async_delegation(
+        goal="review candidate",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="test-model",
+        session_key="parent-session",
+        parent_session_id="parent-session",
+        runner=runner,
+        max_async_children=1,
+    )
+    timer = threading.Timer(0.05, gate.set)
+    assert dispatched["status"] == "dispatched"
+    timer.start()
+    try:
+        assert cli_mod._drain_oneshot_async_delegations(
+            cli,
+            run_turn=turns.append,
+        ) == 1
+        assert len(turns) == 1
+        assert "ASYNC DELEGATION" in turns[0]
+        assert "review verdict" in turns[0]
+        assert ad.active_count() == 0
+    finally:
+        gate.set()
+        timer.cancel()
+        ad._reset_for_tests()
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_oneshot_drain_keeps_pre_rotation_parent_identity(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "post-rotation-session"
+    cli._pending_input = queue.Queue()
+    drain_calls = []
+    selector_calls = []
+    responses = []
+
+    def has_live_for_session(**selectors):
+        selector_calls.append(selectors)
+        return (
+            selectors.get("parent_session_id") == "pre-rotation-session"
+            and len(drain_calls) < 2
+        )
+
+    def drain(_consumer):
+        drain_calls.append(True)
+        if len(drain_calls) == 2:
+            cli._pending_input.put("pre-rotation completion")
+
+    monkeypatch.setattr(
+        "tools.async_delegation.has_live_for_session",
+        has_live_for_session,
+    )
+    monkeypatch.setattr(cli, "_drain_process_notifications", drain)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _seconds: None)
+
+    processed = cli_mod._drain_oneshot_async_delegations(
+        cli,
+        run_turn=responses.append,
+        owned_session_ids={"pre-rotation-session"},
+    )
+
+    assert processed == 1
+    assert responses == ["pre-rotation completion"]
+    assert {"parent_session_id": "pre-rotation-session"} in selector_calls

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -113,12 +113,21 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         def _print_exit_summary(self, clear_screen=True):
             calls.append("summary")
 
+    def drain_delegations(fake_cli, *, run_turn, owned_session_ids=None):
+        calls.append(("drain", fake_cli.session_id))
+        run_turn("delegation completion")
+
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         cli_mod,
         "_finalize_single_query",
         lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_drain_oneshot_async_delegations",
+        drain_delegations,
     )
 
     cli_mod.main(query="hello", quiet=False, toolsets="terminal")
@@ -128,6 +137,8 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         "query-label",
         "advisories",
         ("chat", "hello", None),
+        ("drain", "single-query-session"),
+        ("chat", "delegation completion", None),
         "summary",
         ("finalize", "single-query-session"),
     ]
@@ -184,6 +195,10 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
             calls.append(("init", kwargs))
             return True
 
+    def drain_delegations(fake_cli, *, run_turn, owned_session_ids=None):
+        calls.append(("drain", fake_cli.session_id))
+        run_turn("delegation completion")
+
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
@@ -193,6 +208,11 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
         "_finalize_single_query",
         lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
     )
+    monkeypatch.setattr(
+        cli_mod,
+        "_drain_oneshot_async_delegations",
+        drain_delegations,
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         cli_mod.main(query="hello", quiet=True, toolsets="terminal")
@@ -200,4 +220,65 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert exc_info.value.code == 1
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
+    assert ("drain", "quiet-session") in calls
+    assert ("run", "delegation completion", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def test_quiet_single_query_emits_only_final_delegation_followup(monkeypatch, capsys):
+    calls = []
+
+    class FakeAgent:
+        session_id = "quiet-session"
+
+        def run_conversation(self, user_message, conversation_history):
+            calls.append(user_message)
+            if user_message == "delegation completion":
+                return {"final_response": "complete", "failed": False}
+            return {"final_response": "pending", "failed": False}
+
+    class FakeCLI:
+        def __init__(self, **kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = kwargs.get("session_id") or "quiet-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.agent = None
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **kwargs):
+            self.agent = FakeAgent()
+            return True
+
+    def drain_delegations(fake_cli, *, run_turn, owned_session_ids=None):
+        calls.append("drain")
+        run_turn("delegation completion")
+
+    monkeypatch.setattr(cli, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(
+        cli,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append("finalize"),
+    )
+    monkeypatch.setattr(cli, "_drain_oneshot_async_delegations", drain_delegations)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out.strip() == "complete"
+    assert calls == ["hello", "drain", "delegation completion", "finalize"]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1864,6 +1864,14 @@ class TestExecuteToolCalls:
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
 
+    def test_quiet_tool_output_suppressed_in_parseable_quiet_mode(self, agent):
+        agent.quiet_mode = True
+        agent.platform = "cli"
+        agent.tool_progress_callback = None
+        agent.suppress_status_output = True
+
+        assert agent._should_emit_quiet_tool_messages() is False
+
 
 
     def test_vprint_suppressed_in_parseable_quiet_mode(self, agent):


### PR DESCRIPTION
## Summary

- keep one-shot `-q`/`-Q` parents alive while session-owned async delegations remain live
- reconcile completion notifications through follow-up turns before final cleanup
- preserve pre-rotation, post-rotation, and nested delegation ownership
- retain clean SIGINT/SIGTERM interruption behavior
- ensure parseable quiet mode emits only the final reconciled payload

## Why

A one-shot Hermes parent could return its preliminary answer and run normal CLI cleanup while a process-local delegated batch was still unresolved. The child completion then arrived after the parent had exited.

## Verification

- focused lifecycle/delegation suites: 59 passed
- CLI + async-delegation suites: 1,358 passed, 0 failed, 9 platform-specific skipped
- parseable-quiet regression: 1 passed
- Python compilation: passed
- `git diff --check`: passed
- added-line secret scan: zero findings
- independent identity-bound read-only review: GO, zero findings
- live installed smoke: real child dispatch, 35.76 s parent lifetime, completion re-entry, exit 0, stdout exactly `CHILD_OK`, no tool-progress leakage

## Safety

- no gateway restart required; this changes one-shot CLI lifecycle only
- explicit interrupt remains available and maps to the existing clean interruption path
- tests cover identity rotation, nested/live delegation draining, final quiet output, and interruption
