### PR TITLE
fix(web_server): dashboards no longer stay bricked after a build lands (#82614, salvage #82666)

### DIFF
--- a/contributors/emails/codexbt1@gmail.com
+++ b/contributors/emails/codexbt1@gmail.com
@@ -1,0 +1,1 @@
+codexbt

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17846,18 +17846,28 @@ def mount_spa(application: FastAPI):
     # SPA, even if a dist is lying around from a prior `dashboard`/build. Take
     # the no-frontend path so only the JSON-RPC/WS/API surface is reachable.
     _headless = os.environ.get("HERMES_SERVE_HEADLESS") == "1"
-    if _headless or not WEB_DIST.exists():
+    if _headless:
         _msg = (
             "Headless backend (hermes serve): web UI disabled — use "
             "`hermes dashboard` for the browser UI."
-            if _headless
-            else "Frontend not built. Run: cd web && npm run build"
         )
 
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
             return JSONResponse({"error": _msg}, status_code=404)
         return
+
+    # A missing WEB_DIST is deliberately NOT a mount-time terminal state
+    # (#82614): a long-lived `hermes dashboard --skip-build` process that
+    # survives a `git pull` (or starts before the first build) used to
+    # install a permanent no_frontend catch-all here and could never
+    # recover — every route answered 404 "Frontend not built" until the
+    # process was restarted, even after `npm run build` completed. The SPA
+    # routes below all cope with a missing dist per-request (`_serve_index`
+    # returns the same 404 JSON when index.html is unreadable; the asset
+    # mounts use check_dir=False and 404 on missing files), so mounting
+    # them unconditionally makes the dashboard recover the moment a build
+    # appears on disk — no restart needed.
 
     _index_path = WEB_DIST / "index.html"
 
@@ -17974,7 +17984,12 @@ def mount_spa(application: FastAPI):
             return response
 
     application.mount(
-        "/assets", _ImmutableAssetFiles(directory=WEB_DIST / "assets"), name="assets"
+        "/assets",
+        # check_dir=False: the dist (and its assets/ dir) may not exist yet —
+        # the whole point of the dynamic recheck (#82614). StaticFiles then
+        # 404s per-request until a build appears instead of raising at mount.
+        _ImmutableAssetFiles(directory=WEB_DIST / "assets", check_dir=False),
+        name="assets",
     )
 
     @application.get("/{full_path:path}")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5072,3 +5072,28 @@ class TestSessionPatchUnread:
     def test_patch_hidden_alone_is_accepted(self):
         resp = self.auth_client.patch("/api/sessions/s1", json={"hidden": True})
         assert resp.status_code == 200
+
+
+def test_mount_spa_dynamic_web_dist_recheck(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from hermes_cli import web_server
+
+    app = FastAPI()
+    dist = tmp_path / "web_dist"
+    monkeypatch.setattr(web_server, "WEB_DIST", dist)
+
+    web_server.mount_spa(app)
+    client = TestClient(app)
+
+    # 1. missing build -> 404
+    res1 = client.get("/")
+    assert res1.status_code == 404
+    assert res1.json()["error"] == "Frontend not built. Run: cd web && npm run build"
+
+    # 2. build created dynamically -> 200
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / "index.html").write_text("<html><body>Test</body></html>")
+    res2 = client.get("/")
+    assert res2.status_code == 200
+    assert "Test" in res2.text


### PR DESCRIPTION
## Summary

A dashboard started without a web build (or one that survived a `git pull` that wiped/moved the dist) now recovers the moment a build lands on disk — previously `hermes dashboard --skip-build` could serve JSON 404 "Frontend not built" on every route forever, with remote Desktop clients seeing ERR_EMPTY_RESPONSE, until the process was restarted (#82614; direction from #82666 by @codexbt). Fleet relevance (#91277): a long-lived remote dashboard bricked by an update is one of the "remote gateway serves stale/broken state" family.

Root cause: `mount_spa` checked `WEB_DIST.exists()` ONCE at mount time; on a miss it installed a permanent catch-all — the check never ran again for the life of the process, even after `npm run build` completed.

## Changes

- `hermes_cli/web_server.py`: the missing-dist branch is reserved for the headless-serve contract only. SPA routes now mount unconditionally and cope with a missing dist per-request — `_serve_index`'s existing unreadable-index guard returns the same 404 JSON, and the `/assets` mount gains `check_dir=False` so StaticFiles 404s per-request instead of raising at mount. The dashboard recovers automatically when a build appears; headless `hermes serve` stays dark by design.
- `tests/hermes_cli/test_web_server.py`: @codexbt's regression test cherry-picked as-is (missing build → 404, build created mid-process → 200).

Salvage note: #82666's rebase (done for a reviewer's stale-diff complaint) accidentally dropped its product hunk, leaving only the test. The test commit is his, authorship preserved; the product commit rebuilds the behavior it pins, adapted to the current `mount_spa` (headless guard preserved, recovery via unconditional mounting rather than a per-request `exists()`).

## Validation

| | Result |
|---|---|
| Full web_server suite at head | 171/171 passed |
| A/B (web_server.py reverted to merge-base, test kept) | regression test FAILED — bug shape proven |
| Live E2E | real uvicorn + real `mount_spa`, WEB_DIST absent at boot: 404 "Frontend not built" → build written mid-run → same process serves index (200) and `/assets` files (200), zero restart |

**Live repro:** live server — before: mount-time catch-all makes the 404 permanent; after: recovery on the next request once the build exists.

Fixes #82614. Credit: @codexbt (#82666).

## Infographic

![Reboot-less](https://v3b.fal.media/files/b/0aa7e197/bUqNEyF1YTiarCFcIaHvP_pcnfmxn4.png)
