### PR TITLE
fix: memory consolidation failure must tell the user, not just the model

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -203,7 +203,22 @@ class TestMemoryConsolidationGracefulDegrade:
         assert r["success"] is False
         assert r["done"] is True
         assert "current_entries" not in r
-        assert "continue with your reply" in r["error"]
+        assert "tell the user" in r["error"]
+
+    def test_terminal_message_instructs_surfacing_to_user(self, store):
+        # Regression test: previously the terminal message only told the
+        # model to "continue with your reply," with nothing requiring it
+        # to mention the failure at all -- a dropped fact was silently
+        # indistinguishable from Alfred simply forgetting. Confirmed via
+        # real gateway logs (5 occurrences over 2 weeks on a chronically
+        # full store) that this produced zero user-visible signal.
+        store.add("memory", "fact A")
+        cap = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+        for _ in range(cap):
+            store.replace("memory", "nonexistent", "new")
+        r = store.replace("memory", "nonexistent", "new")
+        assert "NOT saved" in r["error"]
+        assert "tell the user" in r["error"]
 
 
     def test_apply_batch_failures_count_toward_budget(self, store):
@@ -220,7 +235,7 @@ class TestMemoryConsolidationGracefulDegrade:
         r = store.apply_batch("memory", bad_batch)
         assert r["success"] is False
         assert r["done"] is True
-        assert "continue with your reply" in r["error"]
+        assert "tell the user" in r["error"]
 
     def test_success_and_turn_boundary_reset_failure_budget(self, store):
         store.add("memory", "real entry")
@@ -233,7 +248,7 @@ class TestMemoryConsolidationGracefulDegrade:
         # Now a fresh failure is treated as the first again (still actionable).
         r = store.replace("memory", "nonexistent", "new")
         assert "current_entries" in r
-        assert "continue with your reply" not in r["error"]
+        assert "tell the user" not in r["error"]
 
         # Blow past the cap, then a new turn boundary resets the budget.
         for _ in range(cap + 1):
@@ -241,7 +256,7 @@ class TestMemoryConsolidationGracefulDegrade:
         store.reset_consolidation_failures()
         r = store.replace("memory", "nonexistent", "new")
         assert "current_entries" in r  # actionable again, not degraded
-        assert "continue with your reply" not in r["error"]
+        assert "tell the user" not in r["error"]
 
 
 class TestMemoryStorePersistence:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -209,6 +209,14 @@ class MemoryStore:
         exceeded, drop the retry instruction and return a TERMINAL result so the
         model stops looping memory calls and proceeds to answer the user — a
         failed memory side effect must never block the turn's reply (#42405).
+
+        The terminal result explicitly instructs the model to tell the user,
+        not just to move on quietly. Previously it only said "continue with
+        your reply" — visible to the model as a tool result, but nothing
+        required it to actually surface the failure, so a fact could be
+        dropped with zero user-visible signal (confirmed live: this path
+        fired 5 times over 2 weeks on a chronically-full store, one of which
+        silently dropped a repeated user correction).
         """
         self._consolidation_failures += 1
         if self._consolidation_failures <= self._MAX_CONSOLIDATION_FAILURES_PER_TURN:
@@ -218,9 +226,11 @@ class MemoryStore:
             "done": True,
             "error": (
                 f"Memory consolidation failed {self._consolidation_failures} times "
-                "this turn. Stop retrying memory calls — leave memory unchanged for "
-                "now and continue with your reply to the user. The fact can be saved "
-                "in a later turn."
+                "this turn — the store is full and this fact was NOT saved. Stop "
+                "retrying memory calls. You must briefly tell the user this in your "
+                "reply (e.g. \"couldn't save that — memory's full, some old notes "
+                "may need clearing\") so they know it wasn't actually remembered — "
+                "do not continue as if it was saved."
             ),
         }
 


### PR DESCRIPTION
## Summary
- `MemoryStore._consolidation_failure` returns a terminal result once the per-turn consolidation-failure cap is hit (`#42405`'s existing loop-prevention mechanism), instructing the model to stop retrying and "continue with your reply."
- That instruction is visible to the model as a tool result, but nothing required the model to actually mention the failure — a fact could be silently dropped with zero user-visible signal, indistinguishable from the assistant simply forgetting.
- Confirmed live on a real install: this path fired 5 times over 2 weeks on a chronically full store (96-99% capacity), one of which silently dropped a repeated user correction (a family-member naming preference) that the user had no way to discover short of grepping gateway logs.
- The terminal message now explicitly instructs the model to briefly tell the user the fact wasn't saved, with example phrasing, rather than letting it move on quietly.
- Also noted during investigation: `memory.flush_min_turns` is a dead config key — no code path reads it anywhere in the repo. Not touched in this PR (nothing to fix code-side), but worth removing from `config_defaults.py`/docs in a follow-up so it stops looking like it controls something.

## Test plan
- [x] `pytest tests/tools/test_memory_tool.py` — 42/42 passing, including 4 existing tests updated to match the new message content and 1 new regression test asserting the terminal message both states the fact was NOT saved and instructs telling the user
- [x] Verified the existing loop-prevention behavior (`#42405`) is unchanged — only the terminal message's wording changed, not the cap/counting logic

https://claude.ai/code/session_018UCv7yKSfHGfn4kCQe2UHj