### PR TITLE
fix(tools): keep the ENV-assignment redaction pass on execute_code output

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -353,8 +353,8 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         # ENV-assignment pass may mask that sentinel itself when the key name
         # is a secret keyword like KEY (#95509) — either form proves the real
         # value never reached the output, which the assertNotIn checks pin.
-        self.assertIn("KEY=", result["output"])
-        self.assertIn("TOK=", result["output"])
+        self.assertRegex(result["output"], r"KEY=(?:MISSING|\*{2,})")
+        self.assertRegex(result["output"], r"TOK=(?:MISSING|\*{2,})")
         self.assertNotIn("sk-should-not-leak", result["output"])
         self.assertNotIn("ant-should-not-leak", result["output"])
 
@@ -374,10 +374,11 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
             result = self._run(code, mode="project")
         self.assertEqual(result["status"], "success")
         # Sentinel 'MISSING' may itself be masked by the output redaction's
-        # ENV pass for secret-keyword key names (#95509); the assertNotIn
-        # checks below pin the actual no-leak invariant.
+        # ENV pass for secret-keyword key names (#95509); the regex pins that
+        # either the sentinel or the mask actively replaced the value, and
+        # the assertNotIn checks pin the actual no-leak invariant.
         for needle in ("KEY=", "TOK=", "SEC="):
-            self.assertIn(needle, result["output"])
+            self.assertRegex(result["output"], needle + r"(?:MISSING|\*{2,})")
         for leaked in ("sk-should-not-leak", "ant-should-not-leak", "ghp-should-not-leak"):
             self.assertNotIn(leaked, result["output"])
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -349,8 +349,12 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         }):
             result = self._run(code, mode="strict")
         self.assertEqual(result["status"], "success")
-        self.assertIn("KEY=MISSING", result["output"])
-        self.assertIn("TOK=MISSING", result["output"])
+        # The env filter emits 'MISSING', but the output redaction's
+        # ENV-assignment pass may mask that sentinel itself when the key name
+        # is a secret keyword like KEY (#95509) — either form proves the real
+        # value never reached the output, which the assertNotIn checks pin.
+        self.assertIn("KEY=", result["output"])
+        self.assertIn("TOK=", result["output"])
         self.assertNotIn("sk-should-not-leak", result["output"])
         self.assertNotIn("ant-should-not-leak", result["output"])
 
@@ -369,7 +373,10 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         }):
             result = self._run(code, mode="project")
         self.assertEqual(result["status"], "success")
-        for needle in ("KEY=MISSING", "TOK=MISSING", "SEC=MISSING"):
+        # Sentinel 'MISSING' may itself be masked by the output redaction's
+        # ENV pass for secret-keyword key names (#95509); the assertNotIn
+        # checks below pin the actual no-leak invariant.
+        for needle in ("KEY=", "TOK=", "SEC="):
             self.assertIn(needle, result["output"])
         for leaked in ("sk-should-not-leak", "ant-should-not-leak", "ghp-should-not-leak"):
             self.assertNotIn(leaked, result["output"])

--- a/tests/tools/test_code_execution_redaction.py
+++ b/tests/tools/test_code_execution_redaction.py
@@ -1,0 +1,127 @@
+"""Regression tests for execute_code output redaction (#95509).
+
+Both execute_code paths (remote and local) used ``code_file=True``, which
+skips the ENV-assignment pass — so a script that printed ``.env``-shaped
+``KEY=value`` lines passed opaque secret values through verbatim. The
+terminal tool already solves this class by switching to ``code_file=False``
+for env dumps; ``_redact_exec_output`` applies the same pass to sandbox
+stdout/stderr unconditionally. All secret-shaped literals below are
+synthetic and non-usable.
+"""
+
+from tools.code_execution_tool import _redact_exec_output
+
+
+def test_env_shaped_dump_is_masked():
+    """The reporter's exact failure shape: .env lines leak under code_file=True."""
+    out = _redact_exec_output(
+        "GITHUB_TOKEN=ghp_MAxxxx\n"
+        "GEMINI_API_KEY=AQ.AbC123...\n"
+        "GROQ_API_KEY=gsk_W8xyz"
+    )
+    assert "ghp_MAxxxx" not in out
+    assert "AQ.AbC123" not in out
+    assert "gsk_W8xyz" not in out
+    assert out.count("=") == 3  # keys survive, values masked
+
+
+def test_opaque_values_without_known_prefix_are_masked():
+    """Env-dump values with no recognized token prefix still get masked."""
+    out = _redact_exec_output(
+        "INTERNAL_SECRET=opaque_random_48char_value_no_known_prefix\n"
+        "DB_PASSWORD=hunter2style"
+    )
+    assert "opaque_random_48char_value_no_known_prefix" not in out
+    assert "hunter2style" not in out
+
+
+def test_programmatic_env_lookups_stay_readable():
+    """The #2852 guard: KEY=os.getenv('X') references names, not secrets."""
+    out = _redact_exec_output('GITHUB_TOKEN=os.getenv("GITHUB_TOKEN")')
+    assert out == 'GITHUB_TOKEN=os.getenv("GITHUB_TOKEN")'
+
+
+def test_plain_output_without_secret_keywords_is_unchanged():
+    """Prose keys and ordinary diagnostics must not be mangled."""
+    text = "processed 3 files\nauthor=Smith\ntotal=42\nOK"
+    assert _redact_exec_output(text) == text
+
+
+def test_both_execute_code_paths_use_the_env_pass():
+    """The remote and local redaction sites must route through the helper.
+
+    Pins the wiring, not just the helper: grep-level guarantee that neither
+    path regresses to a bare ``code_file=True`` call.
+    """
+    import inspect
+
+    import tools.code_execution_tool as cet
+
+    source = inspect.getsource(cet)
+    assert "redact_sensitive_text(stdout_text, code_file=True)" not in source
+    assert source.count("_redact_exec_output(") >= 3  # def + remote + local(stdout/stderr)
+
+
+def test_spilled_stdout_file_is_redacted(tmp_path, monkeypatch):
+    """Truncated output spills the FULL text to cache/exec — that file must
+    carry redacted text, because the result teaches the model to read_file
+    it, and read_file (file_read=True implies code_file=True) would skip
+    the ENV-assignment pass on spilled plaintext (#95509 rebased onto the
+    spillover pipeline).
+    """
+    import hermes_constants
+    from tools.code_execution_tool import _truncate_stdout_text
+
+    monkeypatch.setattr(
+        hermes_constants, "get_hermes_dir",
+        lambda *a, **k: tmp_path, raising=True,
+    )
+
+    secret_dump = "GITHUB_TOKEN=ghp_MAxxxx\nINTERNAL_SECRET=opaquevalue42\n"
+    payload = ("padding line that is not secret\n" * 3000) + secret_dump
+
+    # Production order: redact BEFORE truncation, so the spill file written
+    # inside _truncate_stdout_text stores the redacted text.
+    redacted = _redact_exec_output(payload)
+    inline, metadata = _truncate_stdout_text(redacted)
+
+    spill_path = metadata.get("stdout_spill_path")
+    assert spill_path, "expected truncation to spill the full output"
+    spilled = open(spill_path, encoding="utf-8").read()
+    assert "ghp_MAxxxx" not in spilled
+    assert "opaquevalue42" not in spilled
+    assert "GITHUB_TOKEN=" in spilled  # keys survive, values masked
+    assert "ghp_MAxxxx" not in inline
+    assert "opaquevalue42" not in inline
+
+
+def test_redaction_precedes_truncation_in_spill_paths():
+    """Both host-side spill callers must redact before truncating; ordering
+    is what keeps the spill file scrubbed, so pin it per function."""
+    import inspect
+
+    import tools.code_execution_tool as cet
+
+    for fname in ("_finish_remote_kernel_result", "_execute_remote"):
+        src = inspect.getsource(getattr(cet, fname))
+        assert "_redact_exec_output(stdout_text)" in src, fname
+        assert "_truncate_stdout_text(stdout_text)" in src, fname
+        assert (
+            src.index("_redact_exec_output(stdout_text)")
+            < src.index("_truncate_stdout_text(stdout_text)")
+        ), f"{fname}: redaction must run before truncation"
+
+
+def test_session_kernel_redaction_sites_use_the_env_pass():
+    """The session-kernel cell path (code_kernel) joined upstream after this
+    fix landed; its stdout/stderr/traceback redaction and the cell-spill
+    rewrite must all route through the helper — no bare ``code_file=True``.
+    """
+    import inspect
+
+    import tools.code_kernel as ck
+
+    source = inspect.getsource(ck)
+    assert "redact_sensitive_text(" not in source  # no bare calls bypass the helper
+    # stdout + stderr + traceback + cell-spill rewrite
+    assert source.count("_redact_exec_output(") >= 4

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1156,6 +1156,25 @@ def _format_interrupted_output(stdout_text: str) -> str:
     return f"{stdout_text}\n{marker}" if stdout_text else marker
 
 
+def _redact_exec_output(text: str) -> str:
+    """Redact sandbox output without losing the ENV-assignment pass.
+
+    ``execute_code`` output used ``code_file=True`` so echoed source code
+    wouldn't hit false positives, but that skip also let ``.env``-shaped
+    ``KEY=value`` dumps (produced by script logic reading credential stores,
+    not by shell command shape) pass through with their opaque values
+    verbatim — the terminal tool solves the same class by switching to
+    ``code_file=False`` for env-dump commands (#95509). The ENV pass's own
+    guards keep programmatic lookups (``KEY=os.getenv('X')``, #2852)
+    readable; the residual cost is constants with secret-shaped names
+    (``MAX_TOKENS=100`` → ``***``), which is strictly better than leaking
+    real credentials at a security boundary.
+    """
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(text, code_file=False)
+
+
 def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
                                  timeout: int, exec_start: float) -> str:
     """Post-process a remote-kernel cell result into the tool's JSON reply.
@@ -1165,7 +1184,6 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
     (kernel killed, state lost, next call fresh).
     """
     from tools.ansi_strip import strip_ansi
-    from agent.redact import redact_sensitive_text
 
     stdout_text = kernel_result.get("stdout", "") or ""
     stderr_text = kernel_result.get("stderr", "") or ""
@@ -1178,9 +1196,13 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
             stdout_text + "\n--- stderr ---\n" + stderr_text + traceback_text
         )
 
-    stdout_text, stdout_metadata = _truncate_stdout_text(stdout_text)
+    # Redact before truncation so the spillover file for truncated output
+    # carries redacted text (read_file implies code_file=True, which would
+    # skip the ENV pass on spilled plaintext otherwise) — same order as the
+    # per-call path.
     stdout_text = strip_ansi(stdout_text)
-    stdout_text = redact_sensitive_text(stdout_text, code_file=True)
+    stdout_text = _redact_exec_output(stdout_text)
+    stdout_text, stdout_metadata = _truncate_stdout_text(stdout_text)
 
     duration = round(time.monotonic() - exec_start, 2)
     result: Dict[str, Any] = {
@@ -1388,17 +1410,19 @@ def _execute_remote(
 
     # --- Post-process output (same as local path) ---
 
-    stdout_text, stdout_metadata = _truncate_stdout_text(stdout_text)
-
     # Strip ANSI escape sequences
     from tools.ansi_strip import strip_ansi
     stdout_text = strip_ansi(stdout_text)
 
-    # Redact secrets. code_file=True: execute_code output is code-execution
-    # output that often echoes source/config — skip false-positive ENV/JSON/
-    # f-string-template redaction while still masking real credentials.
-    from agent.redact import redact_sensitive_text
-    stdout_text = redact_sensitive_text(stdout_text, code_file=True)
+    # Redact secrets. _redact_exec_output keeps the ENV-assignment pass on
+    # so .env-shaped dumps printed by script logic are masked (#95509).
+    # Redaction runs before truncation so the spillover file written for
+    # truncated output carries redacted text — read_file uses file_read=True,
+    # which implies code_file=True and would skip the ENV pass on spilled
+    # plaintext otherwise.
+    stdout_text = _redact_exec_output(stdout_text)
+
+    stdout_text, stdout_metadata = _truncate_stdout_text(stdout_text)
 
     # Build response
     result: Dict[str, Any] = {
@@ -1907,14 +1931,13 @@ def execute_code(
         stderr_text = strip_ansi(stderr_text)
 
         # Redact secrets (API keys, tokens, etc.) from sandbox output.
-        # The sandbox env-var filter (lines 434-454) blocks os.environ access,
-        # but scripts can still read secrets from disk (e.g. open('~/.hermes/.env')).
+        # The sandbox env-var filter blocks os.environ access, but scripts
+        # can still read secrets from disk (e.g. open('~/.hermes/.env')).
         # This ensures leaked secrets never enter the model context.
-        # code_file=True: this is code-execution output — skip false-positive
-        # ENV/JSON/f-string-template redaction; real credentials still masked.
-        from agent.redact import redact_sensitive_text
-        stdout_text = redact_sensitive_text(stdout_text, code_file=True)
-        stderr_text = redact_sensitive_text(stderr_text, code_file=True)
+        # _redact_exec_output keeps the ENV-assignment pass on so .env-shaped
+        # dumps printed by script logic are masked (#95509).
+        stdout_text = _redact_exec_output(stdout_text)
+        stderr_text = _redact_exec_output(stderr_text)
 
         # Build response
         result: Dict[str, Any] = {

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -650,10 +650,10 @@ def execute_in_session_kernel(
     host stays bounded even for owners that never toggle or reset.
     """
     from tools.code_execution_tool import (
+        _redact_exec_output,
         _sandbox_failure_hint,
         _truncate_stdout_text,
     )
-    from agent.redact import redact_sensitive_text
     from tools.ansi_strip import strip_ansi
 
     owner = _resolve_owner(task_id)
@@ -746,8 +746,12 @@ def execute_in_session_kernel(
             if stderr_raw:
                 cell_stderr = cell_stderr + stderr_raw
 
-            stdout_text = redact_sensitive_text(strip_ansi(stdout_text), code_file=True)
-            cell_stderr = redact_sensitive_text(strip_ansi(cell_stderr), code_file=True)
+            # ENV-assignment redaction stays on (#95509): cell output can
+            # carry .env-shaped dumps produced by script logic, same as the
+            # per-call path. Redaction runs before truncation so the
+            # host-side spillover file carries redacted text.
+            stdout_text = _redact_exec_output(strip_ansi(stdout_text))
+            cell_stderr = _redact_exec_output(strip_ansi(cell_stderr))
             stdout_text, stdout_metadata = _truncate_stdout_text(stdout_text)
 
             cell_status = payload.get("status", "")
@@ -768,17 +772,34 @@ def execute_in_session_kernel(
 
             # Cell-side spill (runner clipped before replying): surface the
             # full-output path with the same read_file recipe as the
-            # host-side spill in _truncate_stdout_text.
+            # host-side spill in _truncate_stdout_text. The runner writes
+            # raw stdout, so scrub the spill file in place before handing
+            # the path to the model — read_file implies code_file=True and
+            # would skip the ENV-assignment pass on spilled plaintext.
             cell_spill = str(payload.get("stdout_spill_path", "") or "")
             if cell_spill and payload.get("stdout_clipped"):
-                result["stdout_spill_path"] = cell_spill
-                result["warning"] = (
-                    "Cell stdout exceeded the inline cap; head shown. FULL "
-                    f"output saved to {cell_spill} — page it with "
-                    f'read_file(path="{cell_spill}", offset=...) instead of '
-                    "re-running. (Kernel state persists: printing a narrower "
-                    "slice next call is often cheaper.)"
-                )
+                try:
+                    with open(cell_spill, "r", encoding="utf-8",
+                              errors="replace") as f:
+                        spill_text = f.read()
+                    redacted_spill = _redact_exec_output(spill_text)
+                    tmp_spill = cell_spill + ".redacted"
+                    with open(tmp_spill, "w", encoding="utf-8") as f:
+                        f.write(redacted_spill)
+                    os.replace(tmp_spill, cell_spill)
+                except OSError:
+                    # Best-effort like the runner's own spill write: surface
+                    # the path only when it exists and is readable.
+                    cell_spill = ""
+                if cell_spill:
+                    result["stdout_spill_path"] = cell_spill
+                    result["warning"] = (
+                        "Cell stdout exceeded the inline cap; head shown. FULL "
+                        f"output saved to {cell_spill} — page it with "
+                        f'read_file(path="{cell_spill}", offset=...) instead of '
+                        "re-running. (Kernel state persists: printing a narrower "
+                        "slice next call is often cheaper.)"
+                    )
 
             if status == "timeout":
                 message = (
@@ -796,7 +817,7 @@ def execute_in_session_kernel(
                 result["output"] = _format_interrupted_output(stdout_text)
                 result["error"] = "Interrupted; the session kernel was killed and its state was lost."
             elif cell_status == "error":
-                trace = redact_sensitive_text(strip_ansi(str(payload.get("traceback", ""))), code_file=True)
+                trace = _redact_exec_output(strip_ansi(str(payload.get("traceback", ""))))
                 result["status"] = "error"
                 result["exit_code"] = 1
                 result["error"] = trace or "Cell raised an exception."


### PR DESCRIPTION
## What does this PR do?

Both `execute_code` paths redacted their output with `code_file=True`, which deliberately skips the ENV-assignment pass to avoid false positives on echoed source code. That skip also lets `.env`-shaped `KEY=value` dumps — printed by script logic reading credential stores, not by shell command shape — pass through with their opaque values verbatim. The reporter measured three real leak incidents on one install (a full Gemini key, partial GitHub and Groq keys).

The terminal tool already solves this class: `redact_terminal_output()` switches to `code_file=False` whenever the command is an env dump or reads a `.env` file. `execute_code` has no shell command to inspect, so this PR applies the ENV pass unconditionally via a small `_redact_exec_output()` helper at both redaction sites (remote stdout; local stdout+stderr) — the fail-closed direction for a security boundary.

Trade-off, per the issue: the ENV pass's own guards keep programmatic lookups readable (`KEY=os.getenv('X')` is untouched, #2852), and plain prose/diagnostic keys (`author=Smith`, `total=42`) are unchanged — the residual cost is constants with secret-shaped names (`MAX_TOKENS=100` → `MAX_TOKENS=***`), which is strictly better than leaking real credentials.

Two existing security-invariant tests used the sentinel string `MISSING` under secret-keyword key names (`KEY=MISSING`) to assert the sandbox env filter worked; the ENV pass now correctly masks that sentinel too (`KEY=***`). Their actual no-leak invariant (`assertNotIn` the real secret values) is unchanged and still pinned; only the fragile sentinel-presence assertion was relaxed to a line-prefix check, with comments explaining why.

## Related Issue

Fixes #95509

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/code_execution_tool.py` — new `_redact_exec_output()` helper (`code_file=False`, keeping the ENV-assignment pass); the remote-path stdout redaction and the local-path stdout/stderr redaction now route through it instead of bare `redact_sensitive_text(..., code_file=True)`.
- `tests/tools/test_code_execution_redaction.py` — new fail-closed regression file: the reporter's exact `.env`-dump shape is masked, opaque non-prefix values are masked, `os.getenv` lookups stay readable, plain output is unchanged, and a wiring test pins that neither path regresses to a bare `code_file=True` call.
- `tests/tools/test_code_execution_modes.py` — the two `test_api_keys_scrubbed_in_*` tests now assert the line prefix (`KEY=`) instead of the `MISSING` sentinel (which the ENV pass masks for secret-keyword key names); the `assertNotIn` real-secret invariants are untouched.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_code_execution_redaction.py -q` — should pass: 5 passed with the fix; on unmodified `main` the file fails at collection (the helper does not exist), i.e. red/green verified.
2. `.venv/bin/python -m pytest tests/tools/test_code_execution_modes.py tests/tools/test_code_execution.py -q` — should pass: 81 passed + 7 subtests, including both `test_api_keys_scrubbed_in_*` security invariants (`sk-should-not-leak` / `ant-should-not-leak` / `ghp-should-not-leak` never appear in output).
3. `.venv/bin/python -m pytest tests/agent/test_redact.py -q` — should pass: 97 passed (redaction core unchanged).
4. Observed result of the issue's repro through the helper: `GITHUB_TOKEN=ghp_MAxxxx / GEMINI_API_KEY=AQ.AbC123... / GROQ_API_KEY=gsk_W8xyz` → all three values masked, keys preserved; opaque values with no known prefix (`INTERNAL_SECRET=opaque_...`, `DB_PASSWORD=...`) → masked.
5. `ruff check` on the three changed files — should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches `code_execution_tool`'s output redaction; the env-dump detection PRs target the terminal tool's command-shape switch
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file suites + adjacent redact suites green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
