### PR TITLE
fix(auxiliary): keep user-defined custom provider name when base_url is supplied

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6694,6 +6694,9 @@ def resolve_provider_client(
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
+            # Use caller's explicit base_url when the named entry has none.
+            if not custom_base and explicit_base_url:
+                custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
@@ -8225,11 +8228,12 @@ def _resolve_task_provider_model(
         try:
             from hermes_cli.providers import get_provider
 
-            return get_provider(normalized) is not None
+            if get_provider(normalized) is not None:
+                return True
         except Exception:
             # Keep the high-risk provider-backed routes safe even if provider
             # catalog loading is unavailable during early import/test paths.
-            return normalized in {
+            if normalized in {
                 "anthropic",
                 "copilot",
                 "copilot-acp",
@@ -8238,7 +8242,18 @@ def _resolve_task_provider_model(
                 "openai-codex",
                 "qwen-oauth",
                 "xai-oauth",
-            }
+            }:
+                return True
+        # User-defined providers (config.yaml providers:/custom_providers) are
+        # first-class: don't rewrite the name to "custom" (that would 401 via
+        # OPENAI_API_KEY fallback). Keep the name so resolution hits the
+        # named-custom branch using the provider's own base_url + key_env.
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+
+            return _get_named_custom_provider(normalized) is not None
+        except Exception:
+            return False
 
     if provider:
         provider, base_url = _expand_direct_api_alias(provider, base_url)

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -408,3 +408,68 @@ class TestResolveProviderClientMainRuntimeCustom:
         assert model == "explicit-model"
         assert "explicit.example.com" in str(client.base_url)
         assert client.api_key == "sk-explicit"
+
+
+class TestUserDefinedProviderWithBaseUrl:
+    """Regression guard: a user-defined ``providers:`` entry (base_url +
+    key_env) paired with an explicit base_url (as the settings UI stamps it)
+    must keep its provider name — not be rewritten to ``"custom"``, which
+    would authenticate with OPENAI_API_KEY and 401 on key-required endpoints.
+    """
+
+    def test_providers_dict_entry_preserves_name_with_base_url(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MYRELAY_API_KEY", "sk-myrelay-real")
+        _write_config(tmp_path, {
+            "providers": {
+                "myrelay": {
+                    "name": "myrelay",
+                    "base_url": "https://my-relay.example.com/v1",
+                    "key_env": "MYRELAY_API_KEY",
+                },
+            },
+            "auxiliary": {"vision": {"provider": "myrelay", "model": "vision-model"}},
+        })
+        from agent.auxiliary_client import (
+            _resolve_task_provider_model,
+            resolve_vision_provider_client,
+        )
+
+        prov, model, base, key, _ = _resolve_task_provider_model(
+            "vision", "myrelay", "vision-model", base_url="https://my-relay.example.com/v1"
+        )
+        assert prov == "myrelay", f"provider rewritten to {prov!r}"
+        assert base == "https://my-relay.example.com/v1"
+
+        resolved_provider, client, resolved_model = resolve_vision_provider_client(
+            provider="myrelay", model="vision-model", base_url="https://my-relay.example.com/v1"
+        )
+        assert resolved_provider == "myrelay"
+        assert client is not None
+        assert resolved_model == "vision-model"
+        assert client.api_key not in (None, "", "no-key-required"), (
+            f"vision client fell back to placeholder key: {client.api_key!r}"
+        )
+        assert client.api_key == "sk-myrelay-real"
+
+    def test_providers_dict_entry_without_base_url_still_resolves(self, tmp_path, monkeypatch):
+        """Dashboard-style call (provider only, no caller base_url) must
+        keep working — the named-custom branch reads base_url from config."""
+        monkeypatch.setenv("MYRELAY_API_KEY", "sk-myrelay-real")
+        _write_config(tmp_path, {
+            "providers": {
+                "myrelay": {
+                    "name": "myrelay",
+                    "base_url": "https://my-relay.example.com/v1",
+                    "key_env": "MYRELAY_API_KEY",
+                },
+            },
+            "auxiliary": {"vision": {"provider": "myrelay", "model": "vision-model"}},
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        resolved_provider, client, resolved_model = resolve_vision_provider_client(
+            provider="myrelay", model="vision-model"
+        )
+        assert resolved_provider == "myrelay"
+        assert client is not None
+        assert client.api_key == "sk-myrelay-real"


### PR DESCRIPTION
## What does this PR do?

When the settings UI (or any caller) supplies a base_url alongside a user-defined custom provider (config.yaml providers: dict with key_env), auxiliary tasks (vision, compression, etc.) 401 on key-required endpoints.

Root cause: _resolve_task_provider_model -> _preserve_provider_with_base_url only recognized catalog providers plus a hardcoded allowlist, so a user-defined providers: entry returned False, the name was rewritten to "custom", and resolve_provider_client authenticated with OPENAI_API_KEY (unset) -> "no-key-required" placeholder -> 401.

Fix:
- _preserve_provider_with_base_url now also recognizes user-defined custom providers via _get_named_custom_provider, so the name is preserved and resolution routes to the named-custom branch (reads the provider's own key_env/key_cmd).
- The named-custom branch honors an explicit base_url when the entry carries none, so a UI-stamped endpoint still resolves.

Regression test added (tests/agent/test_auxiliary_named_custom_providers.py): asserts the provider name is preserved and the vision client authenticates with the provider's own key, for both UI-stamped and Dashboard-style calls.

Verified against real imports with a temp HERMES_HOME.

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- See above.

## How to Test

Regression test added.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: hermes-agent container <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


