### PR TITLE
feat(browser): consent-gated real Chromium profile for local browsing + local_browser arg

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -1,6 +1,7 @@
 import {
   Box,
   Brain,
+  Globe,
   type IconComponent,
   Lock,
   MessageCircle,
@@ -426,7 +427,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   },
   browser: {
     allowPrivateUrls: 'Browser Private URLs',
-    autoLocalForPrivateUrls: 'Local Browser For Private URLs'
+    autoLocalForPrivateUrls: 'Local Browser For Private URLs',
+    useRealProfile: 'Use My Real Browser Profile'
   },
   checkpoints: {
     enabled: 'File Checkpoints',
@@ -554,6 +556,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     repoScanExcludePaths: 'Folders and their descendants to skip during repository discovery.'
   },
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
+  browser: {
+    useRealProfile:
+      "Local browser use drives your real default browser profile — its logins, cookies, and history. Backend-independent: applies whenever a local Chromium is used, and lets the agent choose a local real-profile session even under a cloud backend. Only Chromium browsers (Chrome, Edge, Brave, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
+  },
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',
     maxTurns: 'Upper bound for tool-calling turns before Hermes stops a run.'
@@ -667,9 +673,17 @@ export const SECTIONS: DesktopConfigSection[] = [
       'command_allowlist',
       'security.redact_secrets',
       'security.allow_private_urls',
-      'browser.allow_private_urls',
-      'browser.auto_local_for_private_urls',
       'checkpoints.enabled'
+    ]
+  },
+  {
+    id: 'browser',
+    label: 'Browser',
+    icon: Globe,
+    keys: [
+      'browser.use_real_profile',
+      'browser.allow_private_urls',
+      'browser.auto_local_for_private_urls'
     ]
   },
   {

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import ntpath
 import os
 import platform
 import posixpath
@@ -11,6 +12,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from hermes_constants import get_hermes_home
 
@@ -74,6 +76,219 @@ _LINUX_BROWSER_GROUPS = (
 
 _LINUX_BIN_NAMES = tuple(name for names, _ in _LINUX_BROWSER_GROUPS for name in names)
 _LINUX_INSTALL_PATHS = tuple(path for _, paths in _LINUX_BROWSER_GROUPS for path in paths)
+
+
+# ---------------------------------------------------------------------------
+# Real-profile (default Chromium) resolution
+#
+# Used by the browser tool's ``browser.use_real_profile`` consent path: when a
+# local Chromium is launched, point agent-browser at the user's REAL default
+# browser profile (``--profile <user-data-dir>`` + ``--executable-path``) so
+# their live logins/cookies are available. Only Chromium-family browsers are
+# supported; a non-Chromium default (Firefox, Safari) resolves to None and the
+# caller fails closed with a clear message.
+# ---------------------------------------------------------------------------
+
+# Canonical Chromium browser keys we support for real-profile driving.
+_CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium")
+
+# Windows UserChoice ProgId prefixes → canonical browser key. Matched
+# case-insensitively by prefix so channel/version suffixes (e.g.
+# ``ChromeHTML.X``, ``MSEdgeHTM``) still resolve.
+_WINDOWS_PROGID_MAP = (
+    ("chromehtml", "chrome"),
+    ("msedgehtm", "edge"),
+    ("bravehtml", "brave"),
+    ("chromiumhtm", "chromium"),
+)
+
+# Linux xdg default-web-browser .desktop name fragments → canonical key.
+_LINUX_DESKTOP_MAP = (
+    ("google-chrome", "chrome"),
+    ("chromium", "chromium"),
+    ("brave", "brave"),
+    ("microsoft-edge", "edge"),
+    ("msedge", "edge"),
+)
+
+# macOS LaunchServices bundle-id fragments → canonical key.
+_DARWIN_BUNDLE_MAP = (
+    ("com.google.chrome", "chrome"),
+    ("com.microsoft.edgemac", "edge"),
+    ("com.brave.browser", "brave"),
+    ("org.chromium.chromium", "chromium"),
+)
+
+
+def _real_profile_relparts(browser: str) -> tuple:
+    """(mac_support_subdir, windows_localappdata_parts, linux_config_name)."""
+    return {
+        "chrome": (
+            ("Google", "Chrome"),
+            ("Google", "Chrome", "User Data"),
+            "google-chrome",
+        ),
+        "edge": (
+            ("Microsoft Edge",),
+            ("Microsoft", "Edge", "User Data"),
+            "microsoft-edge",
+        ),
+        "brave": (
+            ("BraveSoftware", "Brave-Browser"),
+            ("BraveSoftware", "Brave-Browser", "User Data"),
+            "BraveSoftware/Brave-Browser",
+        ),
+        "chromium": (
+            ("Chromium",),
+            ("Chromium", "User Data"),
+            "chromium",
+        ),
+    }[browser]
+
+
+def real_profile_data_dir(browser: str, system: str | None = None) -> str | None:
+    """Return the default user-data-dir for a Chromium ``browser`` on ``system``.
+
+    Returns None for unknown browsers. Does not check existence — callers that
+    need that should stat the result. Paths are built with the TARGET system's
+    separator (posix for Darwin/Linux, backslash for Windows) so an explicit
+    ``system`` argument resolves correctly regardless of the host OS.
+    """
+    if browser not in _CHROMIUM_BROWSERS:
+        return None
+    system = system or platform.system()
+    mac_parts, win_parts, linux_name = _real_profile_relparts(browser)
+    home = os.path.expanduser("~")
+    if system == "Darwin":
+        return posixpath.join(home, "Library", "Application Support", *mac_parts)
+    if system == "Windows":
+        local = os.environ.get("LOCALAPPDATA") or ntpath.join(home, "AppData", "Local")
+        return ntpath.join(local, *win_parts)
+    # Linux / other POSIX
+    config = os.environ.get("XDG_CONFIG_HOME") or posixpath.join(home, ".config")
+    return posixpath.join(config, *linux_name.split("/"))
+
+
+def chromium_executable(browser: str, system: str | None = None) -> str | None:
+    """Return the first present executable for a Chromium ``browser``."""
+    if browser not in _CHROMIUM_BROWSERS:
+        return None
+    system = system or platform.system()
+
+    def first_present(paths: tuple) -> str | None:
+        for p in paths:
+            if p and os.path.isfile(p):
+                return p
+        return None
+
+    if system == "Darwin":
+        app = {
+            "chrome": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "chromium": "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "brave": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "edge": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        }[browser]
+        return app if os.path.isfile(app) else None
+    if system == "Windows":
+        groups = {
+            "chrome": (("Google", "Chrome", "Application", "chrome.exe"),),
+            "chromium": (("Chromium", "Application", "chrome.exe"), ("Chromium", "Application", "chromium.exe")),
+            "brave": (("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),),
+            "edge": (("Microsoft", "Edge", "Application", "msedge.exe"),),
+        }[browser]
+        bases = [
+            os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+            os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
+            os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")),
+        ]
+        cands = tuple(os.path.join(base, *parts) for base in bases for parts in groups)
+        return first_present(cands)
+    # Linux
+    linux = {
+        "chrome": ("google-chrome", "google-chrome-stable"),
+        "chromium": ("chromium-browser", "chromium"),
+        "brave": ("brave-browser", "brave-browser-stable", "brave"),
+        "edge": ("microsoft-edge", "microsoft-edge-stable"),
+    }[browser]
+    for name in linux:
+        found = shutil.which(name)
+        if found:
+            return found
+    # fall back to the known absolute paths from the launch tables
+    for names, paths in _LINUX_BROWSER_GROUPS:
+        if any(n in linux for n in names):
+            hit = first_present(tuple(paths))
+            if hit:
+                return hit
+    return None
+
+
+def _detect_default_windows() -> str | None:
+    try:
+        import winreg  # type: ignore
+    except Exception:
+        return None
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice",
+        )
+        prog_id, _ = winreg.QueryValueEx(key, "ProgId")
+        winreg.CloseKey(key)
+    except Exception:
+        return None
+    low = str(prog_id or "").lower()
+    for prefix, browser in _WINDOWS_PROGID_MAP:
+        if low.startswith(prefix):
+            return browser
+    return None
+
+
+def _detect_default_darwin() -> str | None:
+    # LaunchServices handler for the https scheme.
+    for reader in (
+        ["defaults", "read", "com.apple.LaunchServices/com.apple.launchservices.secure", "LSHandlers"],
+    ):
+        try:
+            out = subprocess.run(reader, capture_output=True, text=True, timeout=5).stdout.lower()
+        except Exception:
+            out = ""
+        for frag, browser in _DARWIN_BUNDLE_MAP:
+            if frag in out and "https" in out:
+                return browser
+    # Fallback: first installed Chromium app wins.
+    for browser in _CHROMIUM_BROWSERS:
+        if chromium_executable(browser, "Darwin"):
+            return browser
+    return None
+
+
+def _detect_default_linux() -> str | None:
+    try:
+        out = subprocess.run(
+            ["xdg-settings", "get", "default-web-browser"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip().lower()
+    except Exception:
+        out = ""
+    for frag, browser in _LINUX_DESKTOP_MAP:
+        if frag in out:
+            return browser
+    return None
+
+
+def detect_default_chromium(system: str | None = None) -> str | None:
+    """Return the canonical key of the default Chromium browser, or None.
+
+    None means the default browser is non-Chromium (Firefox, Safari) or could
+    not be determined — the caller fails closed rather than guessing.
+    """
+    system = system or platform.system()
+    if system == "Windows":
+        return _detect_default_windows()
+    if system == "Darwin":
+        return _detect_default_darwin()
+    return _detect_default_linux()
 
 
 def get_chrome_debug_candidates(system: str) -> list[str]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -575,6 +575,17 @@ DEFAULT_CONFIG = {
         "engine": "auto",
         "auto_local_for_private_urls": True,  # When a cloud provider is set, auto-spawn local Chromium for LAN/localhost URLs instead of sending them to the cloud
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
+        # Consent to drive the user's REAL default-Chromium profile in local
+        # mode. When true, any local Chromium launch (built-in tools, or a
+        # local sidecar spawned under a cloud backend) uses the default
+        # browser's real user-data-dir — exposing that profile's live logins,
+        # cookies, and history to automation. Backend-independent. Only
+        # Chromium-family default browsers are supported (Chrome, Edge, Brave,
+        # Chromium); a non-Chromium default (e.g. Firefox) fails closed with a
+        # clear message. Default false. Also gates the browser tools'
+        # ``local_browser`` argument. Toggle in the desktop Settings → Browser
+        # section.
+        "use_real_profile": False,
         "allow_unsafe_evaluate": False,  # Legacy override: when true, browser_console(expression=...) bypasses the restrict_evaluate denylist entirely
         "restrict_evaluate": False,  # Opt-in denylist blocking sensitive JS primitives (cookies/storage/clipboard/network/form values) in browser_console(expression=...)
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1,0 +1,122 @@
+"""Tests for real-profile local browser resolution + routing."""
+import os
+import ntpath
+from unittest.mock import patch
+
+import pytest
+
+
+class TestRealProfileResolvers:
+    def test_data_dir_windows(self):
+        import hermes_cli.browser_connect as bc
+        with patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\T\AppData\Local"}, clear=False):
+            got = bc.real_profile_data_dir("chrome", "Windows")
+        # Use ntpath basename checks so this passes on Linux CI too.
+        assert got.endswith(ntpath.join("Google", "Chrome", "User Data")) or got.endswith(
+            "Google\\Chrome\\User Data"
+        )
+
+    def test_data_dir_linux_edge(self):
+        import hermes_cli.browser_connect as bc
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/home/t/.config"}, clear=False):
+            got = bc.real_profile_data_dir("edge", "Linux")
+        assert got == "/home/t/.config/microsoft-edge"
+
+    def test_data_dir_unknown_browser_is_none(self):
+        import hermes_cli.browser_connect as bc
+        assert bc.real_profile_data_dir("firefox", "Windows") is None
+
+    def test_detect_default_windows_progid_maps(self):
+        import hermes_cli.browser_connect as bc
+        # Non-Windows host: _detect_default_windows short-circuits via winreg
+        # ImportError → None. Assert the ProgId map itself is correct instead.
+        m = dict(bc._WINDOWS_PROGID_MAP)
+        assert m["chromehtml"] == "chrome"
+        assert m["msedgehtm"] == "edge"
+        assert m["bravehtml"] == "brave"
+
+    def test_detect_default_non_chromium_is_none(self):
+        import hermes_cli.browser_connect as bc
+        with patch.object(bc, "_detect_default_linux", return_value=None):
+            assert bc.detect_default_chromium("Linux") is None
+
+
+class TestRealProfileLaunchArgs:
+    def _reset(self):
+        import tools.browser_tool as bt
+        bt._use_real_profile_resolved = False
+        bt._cached_use_real_profile = False
+
+    def test_consent_off_is_noop(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=False):
+            args, err = bt._real_profile_launch_args()
+        assert args == [] and err is None
+
+    def test_non_chromium_default_fails_closed(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None):
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "not a supported Chromium" in err
+
+    def test_chromium_default_injects_profile(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        data_dir = tmp_path / "chrome-user-data"
+        data_dir.mkdir()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"):
+            args, err = bt._real_profile_launch_args()
+        assert err is None
+        assert "--profile" in args and str(data_dir) in args
+        assert "--executable-path" in args and "/usr/bin/google-chrome" in args
+
+    def test_missing_profile_dir_fails_closed(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(tmp_path / "nope")):
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "profile directory was not found" in err
+
+
+class TestLocalBrowserRouting:
+    def _reset(self):
+        import tools.browser_tool as bt
+        bt._use_real_profile_resolved = False
+        bt._cached_use_real_profile = False
+
+    def test_local_browser_forces_sidecar_with_consent(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
+             patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_use_real_profile", return_value=True):
+            key = bt._navigation_session_key("t1", "https://example.com", local_browser=True)
+        assert key == "t1::local"
+
+    def test_local_browser_ignored_without_consent(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
+             patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_use_real_profile", return_value=False), \
+             patch.object(bt, "_get_cloud_provider", return_value=None):
+            key = bt._navigation_session_key("t1", "https://example.com", local_browser=True)
+        assert key == "t1"
+
+    def test_cdp_override_still_wins_over_local_browser(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value="ws://x"), \
+             patch.object(bt, "_use_real_profile", return_value=True):
+            key = bt._navigation_session_key("t1", "https://example.com", local_browser=True)
+        assert key == "t1"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1025,6 +1025,9 @@ def _is_local_backend() -> bool:
 _auto_local_for_private_urls_resolved = False
 _cached_auto_local_for_private_urls: bool = True
 
+_use_real_profile_resolved = False
+_cached_use_real_profile: bool = False
+
 
 def _get_browser_engine() -> str:
     """Return the configured browser engine (``auto``, ``lightpanda``, or ``chrome``).
@@ -1427,6 +1430,70 @@ def _auto_local_for_private_urls() -> bool:
     return _cached_auto_local_for_private_urls
 
 
+def _use_real_profile() -> bool:
+    """Return whether the user consented to real-profile local browsing.
+
+    Reads ``browser.use_real_profile`` (default False) once and caches it. When
+    True, local Chromium launches point agent-browser at the user's REAL
+    default-browser profile, and the browser tools' ``local_browser`` argument
+    is honored.
+    """
+    global _use_real_profile_resolved, _cached_use_real_profile
+    if _use_real_profile_resolved:
+        return _cached_use_real_profile
+
+    _use_real_profile_resolved = True
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict) and "use_real_profile" in browser_cfg:
+            _cached_use_real_profile = bool(browser_cfg.get("use_real_profile"))
+    except Exception as e:
+        logger.debug("Could not read use_real_profile from config: %s", e)
+    return _cached_use_real_profile
+
+
+def _real_profile_launch_args() -> tuple:
+    """Resolve (profile_args, error) for a real-profile local launch.
+
+    Returns ``(["--profile", <data_dir>, "--executable-path", <bin>], None)``
+    when consent is on and the default browser is a resolvable Chromium.
+    Returns ``([], <message>)`` when the default browser is non-Chromium or its
+    profile/binary cannot be located, so the caller can fail closed with a
+    clear reason. Returns ``([], None)`` when consent is off (no-op).
+    """
+    if not _use_real_profile():
+        return [], None
+    from hermes_cli.browser_connect import (
+        chromium_executable,
+        detect_default_chromium,
+        real_profile_data_dir,
+    )
+
+    browser = detect_default_chromium()
+    if browser is None:
+        return [], (
+            "browser.use_real_profile is on, but your default browser is not a "
+            "supported Chromium browser (Chrome, Edge, Brave, Chromium). "
+            "Real-profile browsing requires a Chromium default; set one or turn "
+            "the toggle off."
+        )
+    data_dir = real_profile_data_dir(browser)
+    if not data_dir or not os.path.isdir(data_dir):
+        return [], (
+            f"browser.use_real_profile is on and your default browser is "
+            f"'{browser}', but its profile directory was not found "
+            f"({data_dir!r}). Launch that browser at least once, or turn the "
+            "toggle off."
+        )
+    args = ["--profile", data_dir]
+    exe = chromium_executable(browser)
+    if exe:
+        args += ["--executable-path", exe]
+    return args, None
+
+
 def _url_is_private(url: str) -> bool:
     """Return True when the URL's host resolves to a private/LAN/loopback address.
 
@@ -1490,7 +1557,7 @@ def _url_is_private(url: str) -> bool:
         return False
 
 
-def _navigation_session_key(task_id: str, url: str) -> str:
+def _navigation_session_key(task_id: str, url: str, local_browser: bool = False) -> str:
     """Pick the session key that should handle ``url`` for ``task_id``.
 
     Returns the bare task_id unless ALL of these are true:
@@ -1504,6 +1571,12 @@ def _navigation_session_key(task_id: str, url: str) -> str:
     When all are true, returns ``f"{task_id}::local"`` so the hybrid-routing
     path spawns a local Chromium sidecar while the cloud session (if any)
     continues to serve public URLs.
+
+    ``local_browser=True`` (the model-facing arg) forces the ``::local`` sidecar
+    regardless of the URL — but ONLY when the user consented to real-profile
+    browsing (``browser.use_real_profile``). Without consent the flag is ignored
+    (the caller surfaces a note); it never silently routes to the real profile.
+    A CDP override or Camofox mode still owns the session and is not overridden.
     """
     if task_id is None:
         task_id = "default"
@@ -1511,6 +1584,8 @@ def _navigation_session_key(task_id: str, url: str) -> str:
         return task_id
     if _is_camofox_mode():
         return task_id
+    if local_browser and _use_real_profile():
+        return f"{task_id}{_LOCAL_SUFFIX}"
     if _get_cloud_provider() is None:
         return task_id
     if not _auto_local_for_private_urls():
@@ -2197,6 +2272,11 @@ BROWSER_TOOL_SCHEMAS = [
                 "url": {
                     "type": "string",
                     "description": "The URL to navigate to (e.g., 'https://example.com')"
+                },
+                "local_browser": {
+                    "type": "boolean",
+                    "description": "Use the user's real local browser profile (their logins/cookies) via a local Chromium session, even if a cloud backend is configured. Only honored when the user has consented (browser.use_real_profile); otherwise ignored.",
+                    "default": False
                 }
             },
             "required": ["url"]
@@ -2912,6 +2992,15 @@ def _run_browser_command(
         backend_args = ["--session", session_info["session_name"]]
         if _is_headed_mode():
             backend_args.append("--headed")
+        # Real-profile consent: point agent-browser at the user's real default
+        # Chromium profile so their live logins/cookies are available. Fails
+        # closed (returns an error) if the default browser is non-Chromium or
+        # its profile can't be located, rather than silently using a throwaway.
+        _profile_args, _profile_err = _real_profile_launch_args()
+        if _profile_err:
+            return {"success": False, "error": _profile_err}
+        if _profile_args:
+            backend_args += _profile_args
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:
@@ -3307,13 +3396,17 @@ def evaluate_url_safety(url: str) -> Optional[dict]:
     return None
 
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: Optional[str] = None, local_browser: bool = False) -> str:
     """
     Navigate to a URL in the browser.
 
     Args:
         url: The URL to navigate to
         task_id: Task identifier for session isolation
+        local_browser: Force a local Chromium session using the user's real
+            default-browser profile, even when a cloud backend is configured.
+            Honored only if the user consented via ``browser.use_real_profile``;
+            ignored (with a note) otherwise.
 
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
@@ -3349,7 +3442,18 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     # cloud provider never sees the URL in that case.  Can also be opted
     # out globally via ``browser.allow_private_urls`` in config.
     effective_task_id = task_id or "default"
-    nav_session_key = _navigation_session_key(effective_task_id, url)
+    # local_browser is honored only with real-profile consent; note when the
+    # agent asked for it but consent is off so the behavior isn't silently lost.
+    real_profile_note = None
+    if local_browser and not _use_real_profile():
+        real_profile_note = (
+            "local_browser was requested but browser.use_real_profile is off; "
+            "using the default browser backend. Enable real-profile browsing in "
+            "Settings → Browser to honor this."
+        )
+    nav_session_key = _navigation_session_key(
+        effective_task_id, url, local_browser=local_browser
+    )
     auto_local_this_nav = _is_local_sidecar_key(nav_session_key)
 
     sensitive_query_key = _sensitive_query_param_name(url)
@@ -3473,6 +3577,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "url": final_url,
             "title": title
         }
+        if real_profile_note:
+            response["note"] = real_profile_note
         # Remember only a successful, non-blocked navigation as the task owner.
         # Failed opens and blocked redirects must not retarget follow-up clicks
         # or snapshots to a newly-created but irrelevant session.
@@ -5475,7 +5581,7 @@ registry.register(
     handler=lambda args, **kw: routed_browser_handler(
         "browser_navigate",
         args,
-        fallback=lambda: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+        fallback=lambda: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id"), local_browser=bool(args.get("local_browser", False))),
         **_browser_router_kw(kw),
     ),
     check_fn=check_browser_navigate_requirements,


### PR DESCRIPTION
Adds a backend-independent, consent-gated way to drive the user's **real default-Chromium profile** (their logins/cookies) for local browser use.

## What the user asked for
1. A GUI/config toggle (backend-independent, in the Browser settings section). When on, local Chromium browsing always uses the default Chromium browser's real profile. Fails if the default browser is non-Chromium (e.g. Firefox).
2. A consent-gated `local_browser: bool` tool arg so the agent can force a local real-profile session even under a cloud backend — same spirit as the existing localhost/LAN→local fallback.
3. Chromium-family only: Chrome, Edge, Brave, Chromium.

## How it works
The local backend (`agent-browser`) natively supports `--profile <user-data-dir>` (persists real cookies/logins) and `--executable-path`. So this needs **no CDP chrome://inspect toggle and no cua-driver dependency** — a local launch just points at the real profile dir + browser binary.

- **`browser.use_real_profile`** (new config, default false). Consent gate. When on, every local Chromium launch — built-in tools, or a local sidecar spawned under a cloud backend — appends `--profile <real-default-profile>` + `--executable-path <binary>`.
- **Default-browser + profile resolution** (`hermes_cli/browser_connect.py`): `detect_default_chromium()` (Windows UserChoice ProgId, macOS LaunchServices, Linux `xdg-settings`), `real_profile_data_dir()`, `chromium_executable()` for all four browsers, per-OS. Non-Chromium default → resolves to None → **fail closed** with a message naming the browser and the toggle.
- **`local_browser` arg** on `browser_navigate`: routes through the existing `::local` sidecar mechanism (same one used for private-URL→local today), but only when consent is granted. Requested without consent → ignored, with a `note` in the result (never silently routes the real profile). A CDP override or Camofox mode still owns the session.
- **Desktop GUI**: new backend-independent **Browser** settings section (Globe icon) with the real-profile toggle plus the two existing browser routing keys, moved out of Safety for cohesion. Renders as a Switch from the boolean config value; label + risk-describing description added to `FIELD_LABELS`/`FIELD_DESCRIPTIONS`.

## Scope / honest boundaries
- Full real-profile support lands for the **built-in browser tools** (both requirements). **Browser Use CLI mode (`browser_exec`)** attaches only via CDP, and real-profile-over-CDP hits Chrome ≥136's default-user-data-dir remote-debugging block — which requires the chrome://inspect-toggle route. That's deliberately deferred (documented follow-up); this PR does not claim to cover `browser_exec`.
- Security framing (agreed): a consent-gated local convenience, not a hardened isolation boundary. The description says so.
- **Profile-lock note (risk):** Chromium refuses a second process on a user-data-dir already open. If the user's browser is running, `--profile` on the real dir may fail; agent-browser surfaces that. We do not silently fork the profile (avoids the token-fork class from #85963).

## Files
- `hermes_cli/config_defaults.py` — `browser.use_real_profile` (default false).
- `hermes_cli/browser_connect.py` — resolvers + default-browser detection (per-OS, POSIX/NT path-correct via posixpath/ntpath so an explicit `system` arg resolves right on any host).
- `tools/browser_tool.py` — `_use_real_profile()`, `_real_profile_launch_args()`, local-launch injection (fail-closed), `local_browser` on `_navigation_session_key` + `browser_navigate` + schema + dispatch, consent-miss note.
- `apps/desktop/src/app/settings/constants.ts` — Browser section + labels/description.
- `tests/tools/test_browser_real_profile.py` — 12 tests.

## Verification
- `tests/tools/test_browser_real_profile.py`: 12 passed (resolvers per-OS, consent on/off, non-Chromium fail-closed, missing-dir fail-closed, `local_browser` routing with/without consent, CDP-override precedence).
- `tests/tools/test_browser_hybrid_routing.py`: 10 passed — no regression from the `_navigation_session_key` signature change (new param defaulted).
- Desktop field-copy transform validated (`browser.use_real_profile` → `browser.useRealProfile`, matches the added label/description entries). Full desktop vitest not run here (node_modules not installed in the worktree); CI runs it.
- Caught + fixed a real cross-platform path bug during testing: the resolver now builds target-OS-correct separators instead of the host's.

Not run: broad suite (per maintainer preference — targeted checks only).
