### PR TITLE
fix(desktop): reconnect no longer adopts an SSH backend whose venv was replaced (#82429, salvage #82644)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9529,9 +9529,7 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
   try {
     const proof: any = await fetchJson(`${baseUrl}/api/ssh/ownership`, token)
 
-    return proof?.ok === true && proof.sshOwnerNonce === spawnNonce && proof.protocolVersion === 1
-      ? 'authenticated-ok'
-      : 'authenticated-stale'
+    return remoteLifecycle.classifySshReuseProof(proof, spawnNonce)
   } catch (error: any) {
     if (/^(401|403|404):/.test(String(error?.message || ''))) {
       return 'authenticated-stale'

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -10,6 +10,7 @@ import { test } from 'vitest'
 import { profileSshOverride } from './connection-config'
 import {
   buildSpawnCommand,
+  classifySshReuseProof,
   cleanupStale,
   connect,
   disconnect,
@@ -40,6 +41,23 @@ import {
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
 const exec = promisify(execCallback)
+
+test('SSH reuse proof rejects a backend whose runtime was replaced', () => {
+  assert.equal(
+    classifySshReuseProof(
+      { ok: true, sshOwnerNonce: SPAWN_NONCE, protocolVersion: 1, runtimeIntact: false },
+      SPAWN_NONCE
+    ),
+    'authenticated-stale'
+  )
+})
+
+test('SSH reuse proof remains compatible when runtime state is absent', () => {
+  assert.equal(
+    classifySshReuseProof({ ok: true, sshOwnerNonce: SPAWN_NONCE, protocolVersion: 1 }, SPAWN_NONCE),
+    'authenticated-ok'
+  )
+})
 
 function ownedLock(over: any = {}) {
   return {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -46,6 +46,15 @@ const READY_POLL_INTERVAL_MS = 750
 // Keep startup portable: restricted hosts retain their existing limit.
 const REMOTE_NOFILE_SOFT_LIMIT = 65_536
 
+function classifySshReuseProof(proof, spawnNonce) {
+  return proof?.ok === true &&
+    proof.sshOwnerNonce === spawnNonce &&
+    proof.protocolVersion === PROTOCOL_VERSION &&
+    proof.runtimeIntact !== false
+    ? 'authenticated-ok'
+    : 'authenticated-stale'
+}
+
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
 }
@@ -977,6 +986,7 @@ async function connect(deps) {
 export {
   adoptOwnedServedToken,
   buildSpawnCommand,
+  classifySshReuseProof,
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -38,6 +38,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import threading
 import time
@@ -543,6 +544,7 @@ def _resolve_session_token() -> str:
 _SESSION_TOKEN = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 _SSH_OWNER_NONCE: Optional[str] = None
+_SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
 
 
 def _apply_ssh_session_token(token: str) -> None:
@@ -552,8 +554,27 @@ def _apply_ssh_session_token(token: str) -> None:
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
-    global _SSH_OWNER_NONCE
+    global _SSH_OWNER_NONCE, _SSH_RUNTIME_PURELIB
     _SSH_OWNER_NONCE = nonce
+    _SSH_RUNTIME_PURELIB = None
+    if nonce:
+        try:
+            purelib = sysconfig.get_paths()["purelib"]
+            stat = os.stat(purelib)
+            _SSH_RUNTIME_PURELIB = (purelib, stat.st_dev, stat.st_ino)
+        except (KeyError, OSError):
+            pass
+
+
+def _ssh_runtime_intact() -> bool:
+    if _SSH_RUNTIME_PURELIB is None:
+        return True
+    purelib, device, inode = _SSH_RUNTIME_PURELIB
+    try:
+        stat = os.stat(purelib)
+    except OSError:
+        return False
+    return (stat.st_dev, stat.st_ino) == (device, inode)
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the
@@ -3578,7 +3599,12 @@ async def get_ssh_ownership(request: Request):
     _require_token(request)
     if not _SSH_OWNER_NONCE:
         raise HTTPException(status_code=404, detail="SSH ownership is not active")
-    return {"ok": True, "sshOwnerNonce": _SSH_OWNER_NONCE, "protocolVersion": 1}
+    return {
+        "ok": True,
+        "sshOwnerNonce": _SSH_OWNER_NONCE,
+        "protocolVersion": 1,
+        "runtimeIntact": _ssh_runtime_intact(),
+    }
 
 
 @app.get("/api/health")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -545,6 +545,7 @@ _SESSION_TOKEN = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 _SSH_OWNER_NONCE: Optional[str] = None
 _SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
+_SSH_RUNTIME_MARKER: Optional[str] = None
 
 
 def _apply_ssh_session_token(token: str) -> None:
@@ -554,27 +555,52 @@ def _apply_ssh_session_token(token: str) -> None:
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
-    global _SSH_OWNER_NONCE, _SSH_RUNTIME_PURELIB
+    global _SSH_OWNER_NONCE, _SSH_RUNTIME_PURELIB, _SSH_RUNTIME_MARKER
     _SSH_OWNER_NONCE = nonce
     _SSH_RUNTIME_PURELIB = None
+    _SSH_RUNTIME_MARKER = None
     if nonce:
         try:
             purelib = sysconfig.get_paths()["purelib"]
-            stat = os.stat(purelib)
-            _SSH_RUNTIME_PURELIB = (purelib, stat.st_dev, stat.st_ino)
         except (KeyError, OSError):
+            return
+        # Primary identity: a marker FILE written into site-packages now.
+        # A replaced venv (rm -rf && recreate — same OR different Python
+        # version) loses the marker deterministically, while pip installs
+        # into the live venv leave it untouched (no false stales). A bare
+        # (dev, ino) snapshot of the directory is NOT sufficient on its
+        # own: ext4 reuses directory inodes immediately, so the exact
+        # reported repro (`rm -rf venv && uv venv`) can land on the same
+        # inode and pass undetected (proven live during salvage).
+        try:
+            marker = os.path.join(purelib, f".hermes-ssh-runtime-{nonce}")
+            with open(marker, "w", encoding="utf-8") as fh:
+                fh.write(f"pid={os.getpid()}\n")
+            _SSH_RUNTIME_MARKER = marker
+        except OSError:
+            pass  # read-only site-packages — fall back to the stat snapshot
+        try:
+            st = os.stat(purelib)
+            _SSH_RUNTIME_PURELIB = (purelib, st.st_dev, st.st_ino)
+        except OSError:
             pass
 
 
 def _ssh_runtime_intact() -> bool:
+    # Marker file is the deterministic signal when we managed to write one.
+    if _SSH_RUNTIME_MARKER is not None:
+        return os.path.isfile(_SSH_RUNTIME_MARKER)
+    # Fallback (read-only site-packages): directory identity snapshot.
+    # Weaker — inode reuse can mask a same-filesystem recreate — but still
+    # catches cross-device moves and version-bump path changes.
     if _SSH_RUNTIME_PURELIB is None:
         return True
     purelib, device, inode = _SSH_RUNTIME_PURELIB
     try:
-        stat = os.stat(purelib)
+        st = os.stat(purelib)
     except OSError:
         return False
-    return (stat.st_dev, stat.st_ino) == (device, inode)
+    return (st.st_dev, st.st_ino) == (device, inode)
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the

--- a/tests/hermes_cli/test_ssh_ownership_endpoint.py
+++ b/tests/hermes_cli/test_ssh_ownership_endpoint.py
@@ -29,6 +29,7 @@ def test_ssh_ownership_reports_replaced_runtime(monkeypatch):
     token = "t" * 64
     monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
     monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", "0123456789abcdef")
+    monkeypatch.setattr(web_server, "_SSH_RUNTIME_MARKER", None)
     monkeypatch.setattr(web_server, "_SSH_RUNTIME_PURELIB", ("/venv/site-packages", 10, 20))
     monkeypatch.setattr(web_server.os, "stat", lambda _path: type("Stat", (), {"st_dev": 10, "st_ino": 21})())
     client = TestClient(web_server.app)
@@ -37,6 +38,84 @@ def test_ssh_ownership_reports_replaced_runtime(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["runtimeIntact"] is False
+
+
+def test_ssh_runtime_marker_detects_recreated_venv_even_with_reused_inode(
+    tmp_path, monkeypatch
+):
+    """The exact #82429 repro: rm -rf venv && recreate. On ext4 the new
+    site-packages directory routinely REUSES the old inode (proven live
+    during salvage), so the stat snapshot alone reports intact. The marker
+    file is the deterministic tier: it dies with the old tree."""
+    purelib = tmp_path / "venv" / "lib" / "site-packages"
+    purelib.mkdir(parents=True)
+    monkeypatch.setattr(
+        web_server.sysconfig,
+        "get_paths",
+        lambda *a, **k: {"purelib": str(purelib)},
+    )
+
+    web_server._apply_ssh_owner_nonce("0123456789abcdef")
+    try:
+        assert web_server._ssh_runtime_intact() is True
+
+        # Replace the venv; the recreated directory may reuse the inode.
+        import shutil
+
+        shutil.rmtree(tmp_path / "venv")
+        purelib.mkdir(parents=True)
+
+        assert web_server._ssh_runtime_intact() is False, (
+            "marker tier must catch a recreated venv regardless of inode reuse"
+        )
+    finally:
+        web_server._apply_ssh_owner_nonce(None)
+
+
+def test_ssh_runtime_marker_survives_in_place_installs(tmp_path, monkeypatch):
+    """pip/uv installs INTO the live venv must not read as a replacement."""
+    purelib = tmp_path / "venv" / "lib" / "site-packages"
+    purelib.mkdir(parents=True)
+    monkeypatch.setattr(
+        web_server.sysconfig,
+        "get_paths",
+        lambda *a, **k: {"purelib": str(purelib)},
+    )
+
+    web_server._apply_ssh_owner_nonce("0123456789abcdef")
+    try:
+        (purelib / "newpkg").mkdir()  # a package landing in the live venv
+        assert web_server._ssh_runtime_intact() is True
+    finally:
+        web_server._apply_ssh_owner_nonce(None)
+
+
+def test_ssh_runtime_readonly_purelib_falls_back_to_stat(tmp_path, monkeypatch):
+    """When site-packages is unwritable the marker can't be placed; the
+    stat-snapshot fallback still arms (weaker, never a false stale)."""
+    purelib = tmp_path / "venv" / "lib" / "site-packages"
+    purelib.mkdir(parents=True)
+    monkeypatch.setattr(
+        web_server.sysconfig,
+        "get_paths",
+        lambda *a, **k: {"purelib": str(purelib)},
+    )
+    real_open = open
+
+    def refuse_marker(path, *a, **k):
+        if ".hermes-ssh-runtime-" in str(path):
+            raise OSError(30, "Read-only file system")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr("builtins.open", refuse_marker)
+
+    web_server._apply_ssh_owner_nonce("0123456789abcdef")
+    try:
+        assert web_server._SSH_RUNTIME_MARKER is None
+        assert web_server._SSH_RUNTIME_PURELIB is not None
+        assert web_server._ssh_runtime_intact() is True
+    finally:
+        web_server._apply_ssh_owner_nonce(None)
 
 
 def test_ssh_ownership_endpoint_is_absent_without_owner_nonce(monkeypatch):

--- a/tests/hermes_cli/test_ssh_ownership_endpoint.py
+++ b/tests/hermes_cli/test_ssh_ownership_endpoint.py
@@ -21,7 +21,22 @@ def test_ssh_ownership_endpoint_requires_token_and_returns_exact_nonce(monkeypat
         "ok": True,
         "sshOwnerNonce": nonce,
         "protocolVersion": 1,
+        "runtimeIntact": True,
     }
+
+
+def test_ssh_ownership_reports_replaced_runtime(monkeypatch):
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", "0123456789abcdef")
+    monkeypatch.setattr(web_server, "_SSH_RUNTIME_PURELIB", ("/venv/site-packages", 10, 20))
+    monkeypatch.setattr(web_server.os, "stat", lambda _path: type("Stat", (), {"st_dev": 10, "st_ino": 21})())
+    client = TestClient(web_server.app)
+
+    response = client.get("/api/ssh/ownership", headers={"X-Hermes-Session-Token": token})
+
+    assert response.status_code == 200
+    assert response.json()["runtimeIntact"] is False
 
 
 def test_ssh_ownership_endpoint_is_absent_without_owner_nonce(monkeypatch):


### PR DESCRIPTION
## Summary

The Desktop no longer reattaches to an SSH backend whose venv was replaced under it (#82429; salvage of #82644 by @toprakeker, his commit cherry-picked with authorship preserved). Previously the reconnect ownership probe checked only nonce + protocol, so a backend whose runtime had been gutted (`rm -rf venv && uv venv`, Python minor bump) passed reuse forever — every agent init then died on a stale certifi path, and the user had to SIGKILL a process they didn't know existed. Fleet relevance (#91277): the SSH remote reattach path is exactly where "backend serves a dead runtime" was invisible.

## Changes

- `hermes_cli/web_server.py`: the `/api/ssh/ownership` proof gains `runtimeIntact`. **Follow-up (ours):** his design snapshotted site-packages' `(st_dev, st_ino)` — which does not survive contact with ext4: a recreated directory routinely REUSES the freed inode, so the exact reported repro passed undetected (proven live during salvage — the E2E's replaced venv came back with the identical inode). Primary identity is now a marker file written into site-packages at nonce activation: dies deterministically with the old tree on any replacement, survives in-place pip/uv installs. The stat snapshot stays as the read-only-site-packages fallback.
- `apps/desktop/electron/remote-lifecycle.ts` + `main.ts` (his, unchanged): `classifySshReuseProof()` extracted as a testable seam; only an explicit `runtimeIntact: false` rejects → older remotes without the field stay accepted. `authenticated-stale` routes to the existing `cleanupStale` teardown, so the husk is torn down and a fresh backend spawns.
- Tests: his 3 (2 vitest classifier + 1 endpoint) + our 3 (recreated-venv-with-reused-inode — the live-proven case; in-place install stays intact; read-only fallback arms).

## Validation

| | Result |
|---|---|
| Python endpoint suite | 6/6 passed |
| Desktop electron suite (remote-lifecycle) | 75/75 passed (author had not run them; they pass) |
| eslint on touched TS | clean |
| Live E2E | real uvicorn server with SSH ownership active: intact → `runtimeIntact: true` (marker on disk) → in-place install → still true → `rm -rf venv && recreate` under the live process → `false`. The same E2E run against the original inode-only design FAILED (inode reused, replacement invisible) — which is what forced the marker design |

**Live repro:** live server, venv genuinely replaced beneath it — before (inode design): replacement undetected; after (marker design): proof flips false and the client classifies `authenticated-stale`.

Fixes #82429. Credit: @toprakeker (design direction, client classifier, endpoint shape). Related: #80984 (SIGTERM-trapping cleanupStale) is the complementary teardown half, unaffected.

## Infographic

![Runtime integrity ward](https://v3b.fal.media/files/b/0aa7e24e/2MUyJjfb3LGaWcm7PkOjO_5xagjBdq.png)
