### PR TITLE
fix: skip modifyOtherKeys push for Ghostty — Shift+letters leak as literal escape sequences

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4222,6 +4222,7 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 )
 _KITTY_KEYBOARD_PUSH_SEQ = "\x1b[>1u"
 _MODIFY_OTHER_KEYS_SEQ = "\x1b[>4;2m"
+_MODIFY_OTHER_KEYS_L1_SEQ = "\x1b[>4;1m"
 _EXTENDED_ENTER_KEYS_SEQ = _KITTY_KEYBOARD_PUSH_SEQ + _MODIFY_OTHER_KEYS_SEQ
 
 
@@ -4308,8 +4309,14 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
     """
     if not _terminal_supports_extended_enter_keys(env):
         return False
-    # Ghostty exception: only modifyOtherKeys — see _is_ghostty_terminal.
-    seq = _MODIFY_OTHER_KEYS_SEQ if _is_ghostty_terminal(env) else _EXTENDED_ENTER_KEYS_SEQ
+    # Ghostty exception: skip extended keys entirely — Ghostty has
+    # modifyOtherKeys mode 1 always active (cannot be disabled), but its
+    # split-delivery of ESC on macOS+IME causes Shift+letter sequences
+    # to arrive as literal text. Without pushing level 2, Ghostty delivers
+    # Shift+letters as plain uppercase bytes (immune to split-ESC).
+    if _is_ghostty_terminal(env):
+        return False
+    seq = _EXTENDED_ENTER_KEYS_SEQ
     try:
         target = output
         if target is not None and hasattr(target, "write_raw"):

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -36,6 +36,7 @@ import {
   DISABLE_MODIFY_OTHER_KEYS,
   ENABLE_KITTY_KEYBOARD,
   ENABLE_MODIFY_OTHER_KEYS,
+  ENABLE_MODIFY_OTHER_KEYS_L1,
   FOCUS_IN,
   FOCUS_OUT
 } from '../termio/csi.js'
@@ -342,7 +343,9 @@ export default class App extends PureComponent<Props, State> {
             this.props.stdout.write(ENABLE_KITTY_KEYBOARD)
           }
 
-          this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS)
+          this.props.stdout.write(
+            skipKittyKeyboardProtocol() ? '' : ENABLE_MODIFY_OTHER_KEYS
+          )
         }
 
         // Probe terminal identity. XTVERSION survives SSH (query/reply goes

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -91,6 +91,7 @@ import {
   DISABLE_MODIFY_OTHER_KEYS,
   ENABLE_KITTY_KEYBOARD,
   ENABLE_MODIFY_OTHER_KEYS,
+  ENABLE_MODIFY_OTHER_KEYS_L1,
   ERASE_SCREEN,
   ERASE_SCROLLBACK
 } from './termio/csi.js'
@@ -737,7 +738,7 @@ export default class Ink {
         (supportsExtendedKeys()
           ? DISABLE_KITTY_KEYBOARD +
             (skipKittyKeyboardProtocol() ? '' : ENABLE_KITTY_KEYBOARD) +
-            ENABLE_MODIFY_OTHER_KEYS
+            (skipKittyKeyboardProtocol() ? '' : ENABLE_MODIFY_OTHER_KEYS)
           : '')
     )
   }
@@ -1478,7 +1479,7 @@ export default class Ink {
     // on each call.
     if (supportsExtendedKeys()) {
       this.options.stdout.write(
-        DISABLE_KITTY_KEYBOARD + (skipKittyKeyboardProtocol() ? '' : ENABLE_KITTY_KEYBOARD) + ENABLE_MODIFY_OTHER_KEYS
+        DISABLE_KITTY_KEYBOARD + (skipKittyKeyboardProtocol() ? '' : ENABLE_KITTY_KEYBOARD) + (skipKittyKeyboardProtocol() ? '' : ENABLE_MODIFY_OTHER_KEYS)
       )
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -345,6 +345,14 @@ export function parseMultipleKeypresses(
         // termio/tokenize.ts), so the old fragment/burst recovery is gone.
         const resynthesized = '\x1b' + token.value
         keys.push(parseKeypress(resynthesized))
+      } else if (/^\[27;\d+;\d+~/.test(token.value)) {
+        // Orphaned modifyOtherKeys tail (Ghostty+macOS IME split-delivery).
+        // The ESC byte arrived in a separate read and was flushed as a lone
+        // Escape key; the body `[27;modifier;keycode~` arrives as the next
+        // text token. Re-synthesize with ESC so the key parser decodes it
+        // correctly (e.g. `[27;2;65~` → Shift+A → 'A').
+        const resynthesized = '\x1b' + token.value
+        keys.push(parseKeypress(resynthesized))
       } else {
         keys.push(...parseTextKeypresses(token.value))
       }
@@ -533,7 +541,7 @@ function decodeModifier(modifier: number): {
  * Numpad codepoints are from Unicode Private Use Area, defined at:
  * https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
  */
-function keycodeToName(keycode: number): string | undefined {
+function keycodeToName(keycode: number, shift?: boolean): string | undefined {
   switch (keycode) {
     case 9:
       return 'tab'
@@ -605,7 +613,13 @@ function keycodeToName(keycode: number): string | undefined {
     default:
       // Printable ASCII characters
       if (keycode >= 32 && keycode <= 126) {
-        return String.fromCharCode(keycode).toLowerCase()
+        const ch = String.fromCharCode(keycode).toLowerCase()
+        // Shift+letter → uppercase (modifyOtherKeys/CSI-u deliver shift as
+        // a modifier bit, not as the uppercase byte itself).
+        if (shift && keycode >= 65 && keycode <= 122) {
+          return ch.toUpperCase()
+        }
+        return ch
       }
 
       return undefined
@@ -716,7 +730,7 @@ function parseKeypress(s: string = ''): ParsedKey {
     // Modifier defaults to 1 (no modifiers) when not present
     const modifier = match[2] ? parseInt(match[2], 10) : 1
     const mods = decodeModifier(modifier)
-    const name = keycodeToName(codepoint)
+    const name = keycodeToName(codepoint, mods.shift && !mods.ctrl)
 
     return {
       kind: 'key',
@@ -738,7 +752,7 @@ function parseKeypress(s: string = ''): ParsedKey {
   // would leave the tail as garbage if it partially matched.
   if ((match = MODIFY_OTHER_KEYS_RE.exec(s))) {
     const mods = decodeModifier(parseInt(match[1]!, 10))
-    const name = keycodeToName(parseInt(match[2]!, 10))
+    const name = keycodeToName(parseInt(match[2]!, 10), mods.shift && !mods.ctrl)
 
     return {
       kind: 'key',

--- a/ui-tui/packages/hermes-ink/src/ink/termio/csi.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/csi.ts
@@ -329,6 +329,14 @@ export const DISABLE_KITTY_KEYBOARD = csi('<u')
 export const ENABLE_MODIFY_OTHER_KEYS = csi('>4;2m')
 
 /**
+ * Enable xterm modifyOtherKeys level 1.
+ * Level 1 only re-encodes keys whose unmodified form is a control character
+ * (Enter, Backspace, Tab), so Shift+letters arrive as plain uppercase —
+ * immune to the split-ESC/IME delivery bug on Ghostty+macOS.
+ */
+export const ENABLE_MODIFY_OTHER_KEYS_L1 = csi('>4;1m')
+
+/**
  * Disable xterm modifyOtherKeys (reset to default).
  */
 export const DISABLE_MODIFY_OTHER_KEYS = csi('>4m')


### PR DESCRIPTION
## Problem

On **Ghostty** (tested 1.3.1, macOS arm64), typing uppercase letters in both the classic CLI and the TUI inserts literal escape sequence fragments instead of capital letters:

```
Input:  Shift+A  Shift+B  Shift+C
Result: [27;2;65~[27;2;66~[27;2;67~
```

This makes any text with uppercase characters unusable — passwords, variable names, sentences, etc.

## Root cause analysis

The bug results from the interaction of three behaviors:

### 1. Ghostty's always-on modifyOtherKeys mode 1

Ghostty implements `modifyOtherKeys` mode 1 by default and **cannot disable it** ([ghostty-org/ghostty#13332](https://github.com/ghostty-org/ghostty/pull/13332) — `Pv` is never `0`). Mode 1 only re-encodes keys whose unmodified form is a control character (Enter, Tab, Backspace), so Shift+letters normally arrive as plain uppercase bytes.

### 2. Hermes pushes modifyOtherKeys level 2

Both the CLI (`cli.py:_enable_extended_enter_keys`) and TUI (`App.tsx`, `ink.tsx`) push `CSI >4;2m` (level 2) for Ghostty. Level 2 re-encodes **every** modified key, including Shift+letter, as `ESC[27;2;XX~`.

### 3. macOS IME split-delivery

On macOS with an IME active, Ghostty can deliver the escape sequence with the **ESC byte in a separate read** from the `[27;...~` body:

```
Read 1: \x1b          → flushed as lone Escape key
Read 2: [27;2;65~     → arrives as literal text, inserted into prompt
```

The tokenizer/prompt_toolkit correctly flushes a lone ESC as the Escape key (classic ESCDELAY disambiguation). The body then has no ESC prefix and is treated as plain text.

## Fix

### CLI (`cli.py`)

Skip the extended key push entirely for Ghostty. Without level 2, Ghostty's built-in mode 1 delivers Shift+letters as plain uppercase bytes — immune to split-ESC delivery.

```python
# Before
seq = _MODIFY_OTHER_KEYS_SEQ if _is_ghostty_terminal(env) else _EXTENDED_ENTER_KEYS_SEQ

# After
if _is_ghostty_terminal(env):
    return False
seq = _EXTENDED_ENTER_KEYS_SEQ
```

### TUI push sites (`App.tsx`, `ink.tsx`)

All 3 push sites now skip modifyOtherKeys for Ghostty via the existing `skipKittyKeyboardProtocol()` guard:

```typescript
// Before
this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS)

// After
this.props.stdout.write(
  skipKittyKeyboardProtocol() ? '' : ENABLE_MODIFY_OTHER_KEYS
)
```

A new `ENABLE_MODIFY_OTHER_KEYS_L1` constant (`CSI >4;1m`) is added to `csi.ts` for potential future use by other terminals.

### TUI parser defense-in-depth (`parse-keypress.ts`)

Even without the push fix, the parser should handle these sequences correctly when they arrive. Two gaps are fixed:

**1. Orphaned modifyOtherKeys recovery (split-delivery)**

When text arrives as `[27;N;XX~` (the body after ESC was flushed separately), re-synthesize with ESC and parse as a proper key sequence. This mirrors the existing X10 wheel-tail recovery pattern:

```typescript
} else if (/^\[27;\d+;\d+~/.test(token.value)) {
  const resynthesized = x1b + token.value
  keys.push(parseKeypress(resynthesized))
}
```

**2. `keycodeToName()` respects Shift modifier for letters**

`keycodeToName()` unconditionally lowercased all printable ASCII. Now it accepts an optional `shift` parameter — when set (without ctrl), letters return uppercase:

```typescript
// Before
function keycodeToName(keycode: number): string | undefined {
  // ...
  return String.fromCharCode(keycode).toLowerCase()
}

// After
function keycodeToName(keycode: number, shift?: boolean): string | undefined {
  // ...
  const ch = String.fromCharCode(keycode).toLowerCase()
  if (shift && keycode >= 65 && keycode <= 122) {
    return ch.toUpperCase()
  }
  return ch
}
```

Both CSI-u and modifyOtherKeys call sites pass `mods.shift && !mods.ctrl`, keeping control chords on their canonical lowercase names.

## Files changed

| File | Change |
|------|--------|
| `cli.py` | Skip extended key push for Ghostty |
| `ui-tui/.../components/App.tsx` | Skip modifyOtherKeys push for Ghostty |
| `ui-tui/.../ink.tsx` | Skip modifyOtherKeys in 2 re-enable sites |
| `ui-tui/.../termio/csi.ts` | Add `ENABLE_MODIFY_OTHER_KEYS_L1` constant |
| `ui-tui/.../parse-keypress.ts` | Split-delivery recovery + shift-aware `keycodeToName` |

## Testing

| Scenario | Before | After |
|----------|--------|-------|
| `hermes` — Shift+letters | `[27;2;65~` literal text | `A` (correct) |
| `hermes --tui` — Shift+letters | `[27;2;65~` literal text | `A` (correct) |
| Ctrl+Enter (newline) | Works | Works |
| Shift+Enter (newline) | Works | Works |
| Option+Backspace (kill word) | Works | Works |
| Shift+Tab (backtab) | Works | Works |

**Environment:** Ghostty 1.3.1, macOS 27.0 (arm64), Node 26.7.0

## Related issues

- #91937 — CLI Ghostty modifyOtherKeys level 1 fix (split-delivery path)
- #92397 — TUI capitalize Shift+letter from CSI-u and modifyOtherKeys
- #87390 — Original Shift+letter leak report