### PR TITLE
fix(mcp-auth): let Indeed OAuth complete across root issuer slash variants

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -28,10 +28,30 @@ the bridge forwards responses correctly into the inner SDK generator.
 """
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 
 pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ("https://secure.indeed.com", "https://secure.indeed.com/", True),
+        ("https://secure.indeed.com/", "https://secure.indeed.com", True),
+        ("https://secure.indeed.com/tenant", "https://secure.indeed.com/tenant/", False),
+        ("https://secure.indeed.com", "https://SECURE.indeed.com/", False),
+        ("https://secure.indeed.com", "http://secure.indeed.com/", False),
+        ("https://secure.indeed.com", "https://secure.indeed.com:443/", False),
+        ("https://secure.indeed.com?tenant=a", "https://secure.indeed.com?tenant=a/", False),
+    ],
+)
+def test_equivalent_root_issuers_is_narrow(left, right, expected):
+    from tools.mcp_oauth_manager import _equivalent_root_issuers
+
+    assert _equivalent_root_issuers(left, right) is expected
 
 
 @pytest.mark.asyncio
@@ -203,6 +223,99 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
     )
 
     # Clean up the generator — we don't need to complete the full dance.
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_hermes_provider_accepts_root_issuer_trailing_slash_mismatch(
+    tmp_path, monkeypatch
+):
+    """A root ``/`` mismatch must not abort otherwise valid ASM discovery."""
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("indeed")
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            issuer="https://secure.indeed.com",
+        )
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="indeed",
+        server_url="https://mcp.indeed.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+    authorization_request = httpx.Request(
+        "GET", "https://secure.indeed.com/oauth/authorize"
+    )
+    provider._perform_authorization = AsyncMock(return_value=authorization_request)
+
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://mcp.indeed.com/mcp")
+    )
+    outbound = await flow.__anext__()
+    prm_request = await flow.asend(
+        httpx.Response(
+            401,
+            request=outbound,
+            headers={
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://mcp.indeed.com/'
+                    '.well-known/oauth-protected-resource"'
+                )
+            },
+        )
+    )
+    asm_request = await flow.asend(
+        httpx.Response(
+            200,
+            request=prm_request,
+            json={
+                "resource": "https://mcp.indeed.com/mcp",
+                "authorization_servers": ["https://secure.indeed.com/"],
+            },
+        )
+    )
+
+    next_request = await flow.asend(
+        httpx.Response(
+            200,
+            request=asm_request,
+            json={
+                "issuer": "https://secure.indeed.com",
+                "authorization_endpoint": (
+                    "https://secure.indeed.com/oauth/authorize"
+                ),
+                "token_endpoint": "https://secure.indeed.com/oauth/token",
+                "response_types_supported": ["code"],
+            },
+        )
+    )
+
+    assert next_request is authorization_request
+    assert provider.context.client_info is not None
+    assert str(provider.context.oauth_metadata.issuer) == "https://secure.indeed.com"
     await flow.aclose()
 
 

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -140,6 +140,62 @@ async def test_hermes_provider_forwards_asend_values(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_hermes_provider_does_not_read_ordinary_success_response(
+    tmp_path, monkeypatch
+):
+    """Issuer compatibility must not consume successful MCP payloads."""
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            issuer="https://secure.indeed.com",
+        )
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+    provider.context.auth_server_url = "https://secure.indeed.com/"
+
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://example.com/mcp")
+    )
+    outbound = await flow.__anext__()
+    response = httpx.Response(200, request=outbound)
+    response.aread = AsyncMock(
+        side_effect=AssertionError("ordinary MCP response body was consumed")
+    )
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(response)
+    response.aread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypatch):
     """A 401 response MUST flow into the inner generator and trigger the
     SDK's 401 recovery branch.

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -35,6 +35,7 @@ Design reference:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import threading
@@ -62,6 +63,31 @@ def _same_endpoint(a: str, b: str) -> bool:
         pa.scheme == pb.scheme
         and pa.netloc.lower() == pb.netloc.lower()
         and pa.path.rstrip("/") == pb.path.rstrip("/")
+    )
+
+
+def _equivalent_root_issuers(a: str, b: str) -> bool:
+    """Return whether issuer URLs differ only by the root path's slash.
+
+    RFC 8414 normally requires exact issuer string matching. This narrow
+    interoperability exception does not normalize scheme, authority, query,
+    fragment, or non-root paths, which can identify different issuers.
+    """
+    from urllib.parse import urlsplit
+
+    if not (a + "/" == b or b + "/" == a):
+        return False
+    try:
+        parsed = (urlsplit(a), urlsplit(b))
+    except ValueError:
+        return False
+    return all(
+        url.scheme
+        and url.netloc
+        and url.path in ("", "/")
+        and not url.query
+        and not url.fragment
+        for url in parsed
     )
 
 
@@ -501,6 +527,37 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
+        async def _align_equivalent_metadata_issuer(self, response: Any) -> None:
+            """Align the SDK's expected issuer for a root-slash-only mismatch."""
+            expected = self.context.auth_server_url
+            if expected is None or getattr(response, "status_code", None) != 200:
+                return
+            try:
+                payload = json.loads(await response.aread())
+            except (TypeError, ValueError):
+                return
+            actual = payload.get("issuer") if isinstance(payload, dict) else None
+            if isinstance(actual, str) and _equivalent_root_issuers(actual, expected):
+                self.context.auth_server_url = actual
+
+        async def _align_equivalent_bound_issuer(self, response: Any) -> None:
+            """Keep credentials bound across a root-slash-only PRM mismatch."""
+            client_info = self.context.client_info
+            bound = getattr(client_info, "issuer", None)
+            if not isinstance(bound, str) or getattr(response, "status_code", None) != 200:
+                return
+            try:
+                payload = json.loads(await response.aread())
+            except (TypeError, ValueError):
+                return
+            servers = payload.get("authorization_servers") if isinstance(payload, dict) else None
+            if not isinstance(servers, list):
+                return
+            for advertised in servers:
+                if isinstance(advertised, str) and _equivalent_root_issuers(bound, advertised):
+                    client_info.issuer = advertised
+                    return
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -538,6 +595,8 @@ def _make_hermes_provider_class() -> Optional[type]:
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
+                    await self._align_equivalent_bound_issuer(incoming)
+                    await self._align_equivalent_metadata_issuer(incoming)
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -136,7 +136,10 @@ def _make_hermes_provider_class() -> Optional[type]:
     MCP SDK's OAuth module is unavailable (e.g. older mcp versions).
     """
     try:
-        from mcp.client.auth.oauth2 import OAuthClientProvider
+        from mcp.client.auth.oauth2 import (
+            OAuthClientProvider,
+            build_oauth_authorization_server_metadata_discovery_urls,
+        )
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
 
@@ -558,6 +561,17 @@ def _make_hermes_provider_class() -> Optional[type]:
                     client_info.issuer = advertised
                     return
 
+        def _is_auth_metadata_request(self, request: Any) -> bool:
+            """Return whether a yielded request is SDK authorization metadata discovery."""
+            try:
+                candidates = build_oauth_authorization_server_metadata_discovery_urls(
+                    self.context.auth_server_url,
+                    self.context.server_url,
+                )
+                return str(request.url) in candidates
+            except (AttributeError, TypeError, ValueError):
+                return False
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -588,6 +602,7 @@ def _make_hermes_provider_class() -> Optional[type]:
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
             inner = super().async_auth_flow(request)
+            discovery_stage = None
             try:
                 outgoing = await inner.__anext__()
                 while True:
@@ -595,9 +610,22 @@ def _make_hermes_provider_class() -> Optional[type]:
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
-                    await self._align_equivalent_bound_issuer(incoming)
-                    await self._align_equivalent_metadata_issuer(incoming)
+                    if discovery_stage == "protected-resource":
+                        await self._align_equivalent_bound_issuer(incoming)
+                    elif discovery_stage == "authorization-server":
+                        await self._align_equivalent_metadata_issuer(incoming)
+
+                    challenged_original_request = (
+                        outgoing is request
+                        and getattr(incoming, "status_code", None) == 401
+                    )
                     outgoing = await inner.asend(incoming)
+                    if challenged_original_request:
+                        discovery_stage = "protected-resource"
+                    elif self._is_auth_metadata_request(outgoing):
+                        discovery_stage = "authorization-server"
+                    elif discovery_stage == "authorization-server":
+                        discovery_stage = None
             except StopAsyncIteration:
                 # Persist any metadata the SDK discovered lazily during the
                 # 401 branch so a subsequent cold-load skips discovery.


### PR DESCRIPTION
## What does this PR do?

Indeed MCP login aborts before authorization completes because its protected-resource metadata advertises `https://secure.indeed.com/` while its authorization-server metadata identifies `https://secure.indeed.com`. The MCP SDK correctly applies RFC 8414's exact string comparison, so Hermes now adds a deliberately narrow interoperability exception for an empty root path versus `/` and leaves all other issuer differences strict.

### Symptom

`hermes mcp login indeed` fails with `Authorization server metadata issuer mismatch: https://secure.indeed.com != https://secure.indeed.com/`.

### Impact

Users of Indeed's hosted MCP endpoint cannot complete OAuth login or cache tokens.

### Bug Cause

**Trigger:** `tools/mcp_oauth_manager.py:async_auth_flow` when the SDK receives authorization-server metadata after protected-resource discovery.

**Causal chain:**
1. Indeed's protected-resource metadata advertises an authorization server with a root trailing slash.
2. Its authorization-server metadata returns the same origin without that slash.
3. The SDK's RFC 8414 exact issuer check rejects the response, so browser authorization never completes.

**Why it is wrong:** RFC 8414 requires exact string comparison, but this server's two metadata documents use the two URI spellings of the same origin root. Broad URL normalization would be unsafe because path, authority, scheme, query, and fragment differences can identify distinct issuers.

**Working sibling / contrast:** Issuers that already match exactly continue through the SDK unchanged. Non-root path variants and any scheme, authority, port, query, or fragment difference remain mismatches.

**Ruled out:** The failure is not caused by token exchange or browser callback handling; the red regression test raises from metadata issuer validation before either step.

### Fix

Inspect the bidirectional OAuth flow's metadata responses before returning them to the SDK. Hermes aligns only root-slash-equivalent issuer strings, preserves credentials bound to that same issuer across protected-resource discovery, and otherwise retains the SDK's exact comparison. Regression coverage drives the real SDK auth generator through 401, protected-resource metadata, authorization-server metadata, and authorization request creation.

## Related Issue

Closes #95508

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth_manager.py` - recognize only empty-root versus `/` issuer variants during OAuth metadata discovery and credential binding.
- `tests/tools/test_mcp_oauth_bidirectional.py` - reproduce the Indeed flow and assert the compatibility boundary rejects non-equivalent issuer changes.

## How to Test

1. Run the MCP OAuth test suite:

```bash
scripts/run_tests.sh tests/tools/test_mcp_oauth*.py
```

2. Confirm 108 tests pass, including the full bidirectional metadata-discovery regression.
3. Run Ruff on the changed files:

```bash
python -m ruff check tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth_bidirectional.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by code documentation and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure Python URL and OAuth flow logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated regression coverage captures the failing and fixed OAuth flow.
