### PR TITLE
fix(desktop): preserve group turn reason codes

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7945,8 +7945,14 @@ async function runGroupChatRounds(group, members, thread) {
             clearBotAttention(groupMemberKey(member))
           }
         } catch (error) {
-          recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
-          noteBotAttention(groupMemberKey(member), error?.message || error)
+          const reason = String(error?.data?.reason || '').trim()
+          recordGroupActivity(group, {
+            kind: 'failed',
+            member: member.name,
+            thread,
+            ...(reason ? { reason } : {})
+          })
+          noteBotAttention(groupMemberKey(member), reason || error?.message || error)
           reply = null // a failed turn is a pass, never a room error
         }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-attention-badge.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-attention-badge.test.mjs
@@ -133,8 +133,11 @@ test('hooks: relay delivery and group member turns note/clear attention', () => 
   assert.match(drain, /\.\.\.\(reason \? \{ reason \} : \{\}\)/)
 
   // Group member turn boundary: failure notes under the member key; a real
-  // reply clears it.
-  assert.match(pluginSource, /noteBotAttention\(groupMemberKey\(member\), error\?\.message \|\| error\)/)
+  // reply clears it. Typed gateway reasons take precedence over text parsing.
+  assert.match(
+    pluginSource,
+    /noteBotAttention\(groupMemberKey\(member\), reason \|\| error\?\.message \|\| error\)/
+  )
   assert.match(pluginSource, /clearBotAttention\(groupMemberKey\(member\)\)/)
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript = () => '(pass)') {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
+      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, $botAttention, GROUP_ACTIVITY_LIMIT };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -162,6 +162,40 @@ test('a failed member turn records failed instead of a phantom reply', async () 
 
   const events = feed(gc, 'Flaky')
   assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
+})
+
+test('a failed member turn preserves and prefers its typed reason', async () => {
+  const gc = load(profile => {
+    if (profile === 'builder') {
+      const error = new Error('generic gateway failure')
+      error.data = { reason: 'provider_auth_or_access' }
+      throw error
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Typed failure', MEMBERS, 'anyone around?')
+  await drain(gc, 'Typed failure')
+
+  const failed = feed(gc, 'Typed failure').find(e => e.kind === 'failed' && e.member === 'builder')
+  assert.equal(failed.reason, 'provider_auth_or_access')
+  assert.equal(Object.values(gc.$botAttention.get())[0]?.reason, 'provider_auth_or_access')
+})
+
+test('an untyped failed member turn keeps the message-classification fallback', async () => {
+  const gc = load(profile => {
+    if (profile === 'builder') {
+      throw new Error('No LLM provider configured')
+    }
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Untyped failure', MEMBERS, 'anyone around?')
+  await drain(gc, 'Untyped failure')
+
+  const failed = feed(gc, 'Untyped failure').find(e => e.kind === 'failed' && e.member === 'builder')
+  assert.equal(failed.reason, undefined)
+  assert.equal(Object.values(gc.$botAttention.get())[0]?.reason, 'missing_config')
 })
 
 test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {


### PR DESCRIPTION
## What does this PR do?

Desktop Bot Mode now preserves the typed `error.data.reason` from direct group-member turn failures. The runtime Activity event receives that reason, and the existing attention classifier prefers it over re-parsing free-text error messages. Untyped errors retain the current message/error fallback and failed turns remain passes at the room level.

Exact base: `86ae906e88b280215067c5f9726f2f8cec6178b3`
Exact head: `177cba5657a8092b1e78268972a43d8988f7217e`

This is distinct from #92795, which displays a bounded free-text error detail, and composes with it by retaining the machine-readable reason separately. #95314 owns hosted-room architecture rather than this current renderer-owned error boundary.

## Related Issue

Fixes #95420

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: preserve non-empty typed failure reasons on runtime Activity events and prefer them for attention classification.
- `apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs`: cover typed-reason propagation plus the untyped message fallback through the real group-turn harness.
- `apps/desktop/src/plugins/hermes-bots/tests/bot-attention-badge.test.mjs`: keep the adjacent hook contract aligned with typed-reason priority.

## How to Test

1. On the exact base with only the new regression applied, run `node --test apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs`: 9 pass / 1 fail because the failed Activity event has `reason === undefined`.
2. On this head, run the same command: 10/10 pass; typed `provider_auth_or_access` reaches both Activity and attention, while an untyped missing-provider error still classifies through its message.
3. Run `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` (572/572 pass), `npm run typecheck` from `apps/desktop` (all three TypeScript projects pass), Node syntax checks, `git diff --check`, and changed-file TruffleHog scans (0 findings).

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass — N/A: this is a Desktop JavaScript-only change; the complete bundled Bot Mode suite and Desktop typecheck pass.
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 26.5.2 arm64, Node 22.23.0

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A: no user-facing contract changes
- [x] I have updated `cli-config.yaml.example` — N/A: no config changes
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` — N/A: no architecture/workflow changes
- [x] I have considered cross-platform impact — runtime-only JavaScript data propagation with no OS APIs
- [x] I have updated tool descriptions/schemas — N/A: no tool changes

## Screenshots / Logs

The candidate changes no visual copy or layout. `npx prettier --check` reports the same pre-existing whole-file drift for these legacy plugin files on the unchanged base and candidate; the patch does not bulk-format unrelated code.