### PR TITLE
fix(desktop): legacy display-name group members no longer seat duplicate ghost bots (#92794)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6463,7 +6463,17 @@ function groupChatMemberBots(group, roster, metaByName) {
   const remote = []
 
   for (const descriptor of stored) {
-    const key = botRosterKey(descriptor)
+    // Legacy descriptors can carry a FRIENDLY name as `name` (older builds
+    // persisted display names — #92794: `name: '大司命'` for slug `taiyi`).
+    // Key-matching alone then seats the descriptor as a ghost NEXT TO its own
+    // live row ("4 bots" in a 2-bot room), and anything that passes ghost
+    // identity onward targets a profile that does not exist on disk.
+    // Normalize first: a same-connection roster row whose friendly names
+    // include the descriptor's name IS this member. The next persistence
+    // pass (durableGroupChatMembers writes from the seated roster) rewrites
+    // the stored descriptor to the slug, so the repair is self-healing.
+    const resolved = resolveLegacyMemberDescriptor(descriptor, roster)
+    const key = botRosterKey(resolved)
 
     if (seated.has(key)) {
       continue
@@ -6473,10 +6483,55 @@ function groupChatMemberBots(group, roster, metaByName) {
     // A selected-but-offline ghost intentionally carries only enough identity
     // to paint the roster. Never let it replace the room's durable descriptor,
     // which owns the full handle/title used by mentions and remote sync.
-    remote.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || descriptor)
+    remote.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || resolved)
   }
 
   return [...local, ...remote]
+}
+
+/** A stored member descriptor, resolved against the live roster when its
+ *  `name` is not a real slug (#92794). Exact key matches pass through
+ *  untouched; only a descriptor whose key matches NO roster row is re-tried
+ *  by friendly name against rows on the same connection. Unresolvable
+ *  descriptors return as-is — they stay visible-but-degraded ghosts and must
+ *  never be used as a `profile:` target. */
+function resolveLegacyMemberDescriptor(descriptor, roster) {
+  const rows = roster || []
+
+  if (rows.some(bot => botRosterKey(bot) === botRosterKey(descriptor))) {
+    return descriptor
+  }
+
+  const wanted = String(descriptor?.name || '').trim().toLowerCase()
+
+  if (!wanted) {
+    return descriptor
+  }
+
+  // Connection scope: a descriptor WITH a connectionId only matches rows on
+  // that connection (two `default`s on different machines must never merge).
+  // A descriptor WITHOUT one predates connection scoping entirely — those
+  // rooms only ever contained this machine's bots, so local (non-remote)
+  // rows are the legal candidate set.
+  const descriptorConnection = String(descriptor?.connectionId || '')
+  const candidates = rows.filter(bot => {
+    if (bot?.ghost) {
+      return false
+    }
+
+    return descriptorConnection
+      ? String(bot?.connectionId || '') === descriptorConnection
+      : !bot?.remoteSource
+  })
+  const match = candidates.find(
+    bot =>
+      // Case-drifted slug ('Testbot' persisted for profile 'testbot') …
+      String(bot?.name || '').trim().toLowerCase() === wanted ||
+      // … or a friendly name persisted as `name` ('大司命' for 'taiyi').
+      botFriendlyNames(bot).some(name => String(name || '').trim().toLowerCase() === wanted)
+  )
+
+  return match || descriptor
 }
 
 /** Persist source-qualified identities for every selected member. The active

--- a/apps/desktop/src/plugins/hermes-bots/tests/legacy-member-normalize.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/legacy-member-normalize.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #92794: older builds persisted group members with a FRIENDLY name as
+// `name` (e.g. `name: '大司命'` for the profile slug `taiyi`). Key matching
+// alone seats such a descriptor as a ghost NEXT TO its own live roster row
+// ("4 bots" in a 2-bot room — reproduced live), and any path that passes the
+// ghost's identity onward targets a profile that does not exist on disk.
+// resolveLegacyMemberDescriptor() re-tries an unmatched descriptor by
+// friendly name against same-connection roster rows before seating.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+const NL = String.fromCharCode(10)
+
+function stripImports(source) {
+  const out = []
+  let inImportBlock = false
+  for (const line of source.split(NL)) {
+    if (inImportBlock) {
+      if (line.includes(' from ')) inImportBlock = false
+      continue
+    }
+    if (line.startsWith('import ')) {
+      if (!line.includes(' from ')) inImportBlock = true
+      continue
+    }
+    out.push(line)
+  }
+  return out.join(NL)
+}
+
+function load({ groups, meta = {} }) {
+  const start = pluginSource.indexOf('function groupChatMemberBots(')
+  const end = pluginSource.indexOf('/** Persist source-qualified identities', start)
+  assert.notEqual(start, -1)
+  assert.notEqual(end, -1)
+
+  const context = {
+    $groupChats: { get: () => groups },
+    $botMeta: { get: () => meta },
+    botGroups: m => (m && Array.isArray(m.groups) ? m.groups : []),
+    botRosterMeta: (bot, metaByName) => metaByName?.[bot?.name] || null,
+    botRosterKey: bot => `${bot?.connectionId || 'legacy'}::${bot?.name || 'default'}`,
+    botFriendlyNames: bot => [
+      bot?.ui_meta?.['hermes-bots']?.title,
+      // localTitle: the real impl reads the Bot Mode title from $botMeta for
+      // local rows — mirror that so meta-titled bots resolve like production.
+      !bot?.remoteSource ? context.$botMeta.get()?.[bot?.name]?.title : null,
+      bot?.title,
+      bot?.display_name
+    ]
+  }
+  const section = stripImports(pluginSource.slice(start, end))
+    .concat(NL + 'globalThis.__m = { groupChatMemberBots, resolveLegacyMemberDescriptor };' + NL)
+  vm.runInNewContext(section, context, { filename: 'member-seat.js' })
+  return context.__m
+}
+
+const TAIYI = {
+  connectionId: 'local',
+  name: 'taiyi',
+  display_name: '大司命',
+  remoteSource: false
+}
+const TESTBOT = { connectionId: 'local', name: 'testbot', display_name: '', remoteSource: false }
+
+test('legacy display-name descriptors seat their live row once, not as extra ghosts', () => {
+  const { groupChatMemberBots } = load({
+    groups: {
+      room: {
+        // The legacy shape: friendly names persisted as `name`.
+        members: [
+          { connectionId: 'local', name: '大司命', handle: '大司命' },
+          { connectionId: 'local', name: 'Testbot', handle: 'Testbot' }
+        ]
+      }
+    },
+    roster: [TAIYI, TESTBOT],
+    meta: {
+      taiyi: { groups: ['room'] },
+      testbot: { groups: ['room'], title: 'Testbot' }
+    }
+  })
+
+  const seated = groupChatMemberBots('room', [TAIYI, TESTBOT], {
+    taiyi: { groups: ['room'] },
+    testbot: { groups: ['room'], title: 'Testbot' }
+  })
+
+  // Two members, not four: each legacy descriptor resolved to its live row.
+  // (vm-realm arrays fail assert.deepEqual on prototype identity — compare
+  // via JSON, per the harness contract in the field notes.)
+  assert.equal(seated.length, 2, `seated ${seated.map(b => b.name)}`)
+  assert.equal(JSON.stringify(seated.map(b => b.name).sort()), JSON.stringify(['taiyi', 'testbot']))
+})
+
+test('a genuinely unknown descriptor still seats as a degraded ghost', () => {
+  const { groupChatMemberBots } = load({
+    groups: { room: { members: [{ connectionId: 'gone', name: 'vanished' }] } },
+    roster: [TAIYI],
+    meta: { taiyi: { groups: ['room'] } }
+  })
+
+  const seated = groupChatMemberBots('room', [TAIYI], { taiyi: { groups: ['room'] } })
+  assert.equal(seated.length, 2)
+  assert.ok(seated.some(b => b.name === 'vanished'), 'orphan ghost preserved')
+})
+
+test('a connectionless pre-scoping descriptor resolves against local rows', () => {
+  // The oldest legacy shape: no connectionId at all (pre-connection-scoping
+  // rooms only ever held this machine's bots). Reproduced live: such ghosts
+  // keyed as legacy::<display-name> and doubled the seated roster.
+  const { resolveLegacyMemberDescriptor } = load({ groups: {}, roster: [] })
+  const resolved = resolveLegacyMemberDescriptor({ name: '大司命' }, [TAIYI])
+  assert.equal(resolved.name, 'taiyi')
+})
+
+test('friendly-name matching never crosses connections', () => {
+  const remoteTwin = { connectionId: 'other-box', name: 'shadow', display_name: '大司命', remoteSource: true }
+  const { resolveLegacyMemberDescriptor } = load({ groups: {}, roster: [] })
+
+  const resolved = resolveLegacyMemberDescriptor(
+    { connectionId: 'local', name: '大司命' },
+    [remoteTwin]
+  )
+  // Same friendly name on ANOTHER connection must not capture the member.
+  assert.equal(resolved.name, '大司命')
+  assert.equal(resolved.connectionId, 'local')
+})
+
+test('exact slug descriptors pass through untouched', () => {
+  const { resolveLegacyMemberDescriptor } = load({ groups: {}, roster: [] })
+  const descriptor = { connectionId: 'local', name: 'taiyi', route: { targetProfile: 'taiyi' } }
+  assert.equal(resolveLegacyMemberDescriptor(descriptor, [TAIYI]), descriptor)
+})


### PR DESCRIPTION
## Summary
Group rooms whose members were persisted under FRIENDLY names by older builds now seat their real bot exactly once, instead of doubling the roster with unreachable ghosts (#92794).

Root cause: older builds stored group member descriptors with a display name as `name` (e.g. `name: '大司命'` for profile slug `taiyi`), some predating connection scoping entirely (no `connectionId`). `groupChatMemberBots()` keyed descriptors verbatim, so a legacy descriptor never matched its own live roster row and seated as a ghost NEXT TO it — "4 bots" in a 2-bot room, and any path passing ghost identity onward targeted a profile that doesn't exist on disk (the reporter's `profiles/大司命/ does not exist`).

## Changes
- `plugin.js`: `resolveLegacyMemberDescriptor()` — a descriptor whose key matches no roster row is re-tried by case-drifted slug or friendly name (`botFriendlyNames` precedence) against rows on its own connection; connectionless pre-scoping descriptors match local rows only. Exact-key descriptors pass through untouched. Unresolvable descriptors still seat as degraded ghosts and are never used as `profile:` targets. The next persistence pass (`durableGroupChatMembers` writes from the seated roster) rewrites storage to slugs — the repair self-heals.
- `tests/legacy-member-normalize.test.mjs` (new, 5 tests): display-name dedupe, connectionless legacy shape, cross-connection isolation (same friendly name on another box must NOT capture the member), unknown-descriptor ghost preservation, exact-slug pass-through.

## Validation
| | Before (sabotage run) | After |
|---|---|---|
| new test file | 4/4 fail (5th added post-live-find) | 5/5 pass |
| full plugin suite | — | 575 pass / 0 fail |
| eslint on changed files | — | clean |

**Live repro (real Electron + backend):** room storage corrupted to the legacy shape (`大司命`/`Testbot` as names, later merged with slug descriptors → 4 stored members). Before: room seats "4 bots". After: "2 bots", and after one turn the persisted members self-healed to `["taiyi","testbot"]` on disk. The live pass also caught a gap the first implementation missed — the oldest descriptors carry NO connectionId, which strict same-connection matching skipped; the shipped matcher handles that shape and the 5th test pins it.

Turn-level note: on current main the friendly-name-spawn half of the original report is NOT reproducible (member turns resolve through the live roster; both bots replied with slug-keyed spawns and zero `does not exist` errors in a full live round) — the seating duplication above was the remaining real defect.

## Infographic

![Ghost busted](https://v3b.fal.media/files/b/0aa7e2a8/ujauw2gwigf6WZJ7mJWd0_uRZ8iVpj.png)
