### PR TITLE
Broad file searches no longer trigger macOS privacy prompts — path-scoped, backend-aware pruning (salvage #75785)

### DIFF
--- a/contributors/emails/takealook97@naver.com
+++ b/contributors/emails/takealook97@naver.com
@@ -1,0 +1,1 @@
+deepeet-git

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -1,0 +1,163 @@
+"""macOS TCC-safe behavior for broad file searches."""
+
+from pathlib import Path
+
+import tools.file_operations as file_operations
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations, _macos_protected_search_exclusions
+
+
+class RecordingEnvironment:
+    def __init__(self, cwd):
+        self.cwd = str(cwd)
+        self.commands = []
+
+    def execute(self, command, cwd=None, **kwargs):
+        self.commands.append(command)
+        if command.startswith("test -e"):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v"):
+            return {"output": "yes\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+PROTECTED_NAMES = {
+    "Desktop",
+    "Documents",
+    "Downloads",
+    "Library",
+    "Movies",
+    "Music",
+    "Pictures",
+}
+
+
+def test_broad_home_search_excludes_macos_protected_folders(tmp_path):
+    home = tmp_path / "Users" / "alice"
+
+    exclusions = _macos_protected_search_exclusions(
+        str(home), cwd=str(tmp_path), home=str(home), platform="darwin"
+    )
+
+    assert {Path(item).parts[0] for item in exclusions} == PROTECTED_NAMES
+
+
+def test_explicit_protected_folder_search_is_not_excluded(tmp_path):
+    home = tmp_path / "Users" / "alice"
+
+    exclusions = _macos_protected_search_exclusions(
+        str(home / "Downloads"), cwd=str(tmp_path), home=str(home), platform="darwin"
+    )
+
+    assert exclusions == []
+
+
+def test_non_macos_search_has_no_implicit_exclusions(tmp_path):
+    home = tmp_path / "home" / "alice"
+
+    exclusions = _macos_protected_search_exclusions(
+        str(home), cwd=str(tmp_path), home=str(home), platform="linux"
+    )
+
+    assert exclusions == []
+
+
+def test_broad_file_search_passes_protected_globs_to_ripgrep(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    result = ops.search("*.txt", path=str(home), target="files")
+
+    rg_command = next(command for command in env.commands if command.startswith("rg --files"))
+    for dirname in PROTECTED_NAMES:
+        assert f"!{dirname}/**" in rg_command
+    assert result.warning is not None
+    assert "macOS protected folders" in result.warning
+
+
+def test_broad_content_search_passes_protected_globs_to_ripgrep(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    ops.search("needle", path=str(home), target="content")
+
+    rg_command = next(command for command in env.commands if command.startswith("set -o pipefail; rg"))
+    for dirname in PROTECTED_NAMES:
+        assert f"!{dirname}/**" in rg_command
+
+
+def test_legacy_ripgrep_file_fallback_keeps_protected_globs(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    ops.search("*.txt", path=str(home), target="files")
+
+    rg_commands = [command for command in env.commands if command.startswith("rg --files")]
+    assert len(rg_commands) == 2
+    for command in rg_commands:
+        assert "!Downloads/**" in command
+
+
+def test_grep_fallback_excludes_protected_directories(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+    ops.search("needle", path=str(home), target="content")
+
+    grep_command = next(command for command in env.commands if " grep " in command)
+    for dirname in PROTECTED_NAMES:
+        assert f"--exclude-dir='{dirname}'" in grep_command
+
+
+def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+    ops.search("*.txt", path=str(home), target="files")
+
+    find_commands = [command for command in env.commands if command.startswith("find ")]
+    assert find_commands
+    for command in find_commands:
+        assert str(home / "Downloads") in command
+        assert "-prune" in command
+
+
+def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypatch):
+    home = tmp_path / "Users" / "alice"
+    safe = home / "safe"
+    protected = home / "Downloads"
+    safe.mkdir(parents=True)
+    protected.mkdir()
+    (safe / "visible.txt").write_text("needle")
+    (protected / "protected.txt").write_text("needle")
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(home)))
+
+    result = ops.search("needle", path=str(home), target="content")
+
+    paths = [match.path for match in result.matches]
+    assert any("visible.txt" in path for path in paths)
+    assert all("protected.txt" not in path for path in paths)

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -110,7 +110,10 @@ def test_legacy_ripgrep_file_fallback_keeps_protected_globs(tmp_path, monkeypatc
         assert "!Downloads/**" in command
 
 
-def test_grep_fallback_excludes_protected_directories(tmp_path, monkeypatch):
+def test_grep_fallback_prunes_by_path_not_basename(tmp_path, monkeypatch):
+    """The grep fallback must NOT use --exclude-dir (basename-wide: it would
+    skip every nested dir named Downloads anywhere under the root). It routes
+    through find's path-scoped -prune instead."""
     home = tmp_path / "Users" / "alice"
     home.mkdir(parents=True)
     env = RecordingEnvironment(home)
@@ -121,9 +124,54 @@ def test_grep_fallback_excludes_protected_directories(tmp_path, monkeypatch):
 
     ops.search("needle", path=str(home), target="content")
 
-    grep_command = next(command for command in env.commands if " grep " in command)
+    pruned_command = next(command for command in env.commands if "-prune" in command)
     for dirname in PROTECTED_NAMES:
-        assert f"--exclude-dir='{dirname}'" in grep_command
+        # Path-scoped pruning: full protected path present, no basename-wide
+        # --exclude-dir for protected names.
+        assert str(home / dirname) in pruned_command
+        assert f"--exclude-dir={dirname}" not in pruned_command
+        assert f"--exclude-dir='{dirname}'" not in pruned_command
+
+
+def test_grep_pruned_search_still_finds_nested_protected_names(tmp_path, monkeypatch):
+    """A repo-internal directory literally named 'Downloads' must still be
+    searched by the pruned grep path — the exact regression --exclude-dir had."""
+    home = tmp_path / "Users" / "alice"
+    project = home / "work" / "repo" / "Downloads"
+    project.mkdir(parents=True)
+    (project / "notes.txt").write_text("needle here\n")
+    protected = home / "Downloads"
+    protected.mkdir()
+    (protected / "secret.txt").write_text("needle protected\n")
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(home)))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+    result = ops.search("needle", path=str(home), target="content")
+
+    matched_paths = [m.path for m in (result.matches or [])]
+    assert any("work/repo/Downloads/notes.txt" in p for p in matched_paths)
+    assert not any(str(protected / "secret.txt") in p for p in matched_paths)
+
+
+def test_remote_backend_never_prunes(tmp_path, monkeypatch):
+    """Non-local environments get no exclusions: platform facts describe the
+    controller, not the execution host (macOS controller + Linux SSH backend
+    must not prune the remote's Downloads)."""
+    home = tmp_path / "Users" / "alice"
+    home.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    env.is_local = False  # remote/container-shaped backend
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    result = ops.search("*.txt", path=str(home), target="files")
+
+    rg_command = next(command for command in env.commands if command.startswith("rg --files"))
+    assert "!Downloads/**" not in rg_command
+    assert result.warning is None
 
 
 def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -658,6 +658,13 @@ class BaseEnvironment(ABC):
     # Subclasses that embed stdin as a heredoc (Modal, Daytona) set this.
     _stdin_mode: str = "pipe"  # "pipe" or "heredoc"
 
+    # True only when commands execute on the SAME host as the Hermes process
+    # (LocalEnvironment). Controller-host facts (sys.platform, Path.home())
+    # only describe the execution target when this is True — remote/container
+    # backends must not inherit controller-side platform behavior (e.g. the
+    # macOS TCC search pruning in tools/file_operations.py).
+    is_local: bool = False
+
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1746,6 +1746,10 @@ class LocalEnvironment(BaseEnvironment):
 
     _profile_scoped_passthrough = True
 
+    # Commands run on the Hermes host itself — controller-side platform
+    # behavior (macOS TCC pruning, etc.) legitimately applies here.
+    is_local = True
+
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2890,7 +2890,20 @@ class ShellFileOperations(FileOperations):
         return result
 
     def _macos_search_exclusions(self, path: str) -> List[str]:
-        """Protected descendants to prune for this search root, if any."""
+        """Protected descendants to prune for this search root, if any.
+
+        Gated on ``env.is_local``: ``sys.platform``/``Path.home()`` describe
+        the CONTROLLER, but search commands execute on ``self.env``'s host — a
+        macOS controller driving a Linux container/SSH backend must not prune
+        the remote's (unprotected) Downloads, and TCC doesn't exist there
+        anyway. A Linux controller driving a macOS SSH host keeps today's
+        behavior (no pruning); detecting the remote OS is out of scope here.
+        Environments without the flag (test fakes, plugins) default to local
+        semantics — pruning is a warning-carrying skip, never data loss.
+        """
+        env = getattr(self, "env", None)
+        if env is not None and getattr(env, "is_local", True) is False:
+            return []
         cwd = getattr(self.env, "cwd", None) or self.cwd
         return _macos_protected_search_exclusions(
             path, cwd=cwd, home=_HOME, platform=sys.platform
@@ -3368,9 +3381,23 @@ class ShellFileOperations(FileOperations):
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
         cmd_parts.append("--exclude-dir='.*'")
-        for item in self._macos_search_exclusions(path):
-            dirname = item.split("/")[-1]
-            cmd_parts.append(f"--exclude-dir={self._escape_shell_arg(dirname)}")
+
+        # Protected-dir pruning CANNOT use --exclude-dir here: grep matches
+        # exclude-dir globs against BASENAMES anywhere in the tree, so
+        # --exclude-dir=Downloads would silently skip every nested directory
+        # named Downloads (a repo's own Downloads/ folder included), not just
+        # the protected home child. When exclusions apply (darwin broad-home
+        # search on a local backend), route through find's path-scoped -prune
+        # instead — same traversal-prevention the find backend uses.
+        protected_paths = [
+            os.path.normpath(os.path.join(path, item))
+            for item in self._macos_search_exclusions(path)
+        ]
+        if protected_paths:
+            return self._search_with_grep_pruned(
+                pattern, path, file_glob, limit, offset, output_mode, context,
+                protected_paths,
+            )
         
         # Add context if requested
         if context > 0:
@@ -3415,6 +3442,56 @@ class ShellFileOperations(FileOperations):
         # pipefail does not turn truncated results into false errors.
         cmd = "set -o pipefail; " + " ".join(cmd_parts)
         result = self._exec(cmd, timeout=60)
+        return self._parse_grep_search_output(result, output_mode, limit, offset, context)
+
+    def _search_with_grep_pruned(self, pattern: str, path: str, file_glob: Optional[str],
+                                 limit: int, offset: int, output_mode: str, context: int,
+                                 protected_paths: List[str]) -> SearchResult:
+        """grep fallback with PATH-scoped protected-dir pruning.
+
+        Files are enumerated by ``find`` with the same ``-path ... -prune``
+        expression the find backend uses (traversal never enters the protected
+        dirs, so macOS never sees an access attempt), then handed to grep via
+        ``-exec {} +``. This exists because grep's own ``--exclude-dir``
+        matches basenames anywhere in the tree — it cannot express "only the
+        home-level Downloads". Hidden directories are pruned to mirror the
+        plain path's ``--exclude-dir='.*'``. Trade-off: with ``-exec {} +``
+        find folds grep's exit code into its own generic non-zero, so a hard
+        grep error surfaces as an empty result rather than exit 2 — acceptable
+        for this darwin-local-broad-search-only branch.
+        """
+        grep_parts = ["grep", "-nHE"]
+        if context > 0:
+            grep_parts.extend(["-C", str(context)])
+        if output_mode == "files_only":
+            grep_parts.append("-l")
+        elif output_mode == "count":
+            grep_parts.append("-c")
+        grep_parts.append(self._escape_shell_arg(pattern))
+
+        prune_terms = " -o ".join(
+            f"-path {self._escape_shell_arg(item)}" for item in protected_paths
+        )
+        find_parts = [
+            "find", self._escape_shell_arg(path or "."),
+            f"\\( {prune_terms} \\) -prune", "-o",
+            "\\( -type d -name '.*' \\) -prune", "-o",
+            "-type f",
+        ]
+        if file_glob:
+            find_parts.extend(["-name", self._escape_shell_arg(file_glob)])
+        find_parts.extend(["-exec", *grep_parts, "{}", "+"])
+        fetch_limit = limit + offset + (200 if context > 0 else 0)
+        cmd = (
+            "set -o pipefail; " + " ".join(find_parts)
+            + f" 2>/dev/null | head -n {fetch_limit}"
+        )
+        result = self._exec(cmd, timeout=60)
+        return self._parse_grep_search_output(result, output_mode, limit, offset, context)
+
+    def _parse_grep_search_output(self, result, output_mode: str, limit: int,
+                                  offset: int, context: int) -> SearchResult:
+        """Shared grep output parsing for the plain and pruned variants."""
         stdout, limit_reason = _search_stdout_and_limit(result)
 
         # _exec merges stderr into stdout, so grep's diagnostic lines

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -29,6 +29,7 @@ import base64
 import binascii
 import os
 import re
+import sys
 import difflib
 import hashlib
 import json
@@ -52,6 +53,52 @@ from agent.file_safety import (
 # ---------------------------------------------------------------------------
 
 _HOME = str(Path.home())
+
+_MACOS_TCC_PROTECTED_HOME_DIRS = (
+    "Desktop",
+    "Documents",
+    "Downloads",
+    "Library",
+    "Movies",
+    "Music",
+    "Pictures",
+)
+
+
+def _macos_protected_search_exclusions(
+    path: str,
+    *,
+    cwd: Optional[str] = None,
+    home: Optional[str] = None,
+    platform: Optional[str] = None,
+) -> List[str]:
+    """Return protected home directories below a broad macOS search root.
+
+    Direct searches inside a protected directory remain allowed. Only an
+    ancestor search (for example ``$HOME`` or ``/Users``) receives exclusions,
+    preventing recursive tools from triggering unattended TCC prompts.
+    """
+    if (platform or sys.platform) != "darwin":
+        return []
+
+    home_path = Path(home or Path.home()).expanduser()
+    root = Path(path).expanduser()
+    if not root.is_absolute():
+        root = Path(cwd or os.getcwd()) / root
+    root = Path(os.path.normpath(str(root)))
+    home_path = Path(os.path.normpath(str(home_path)))
+
+    exclusions: List[str] = []
+    for dirname in _MACOS_TCC_PROTECTED_HOME_DIRS:
+        protected = home_path / dirname
+        try:
+            relative = protected.relative_to(root)
+        except ValueError:
+            continue
+        if relative.parts:
+            exclusions.append(relative.as_posix())
+    return exclusions
+
 
 WRITE_DENIED_PATHS = build_write_denied_paths(_HOME)
 
@@ -2827,10 +2874,27 @@ class ShellFileOperations(FileOperations):
             )
         
         if target == "files":
-            return self._search_files(pattern, path, limit, offset)
+            result = self._search_files(pattern, path, limit, offset)
         else:
-            return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+            result = self._search_content(pattern, path, file_glob, limit, offset,
+                                          output_mode, context)
+
+        exclusions = self._macos_search_exclusions(path)
+        if exclusions and not result.error:
+            skipped = ", ".join(item.split("/")[-1] for item in exclusions)
+            result.warning = (
+                "Skipped macOS protected folders during broad search to avoid "
+                f"an unattended privacy prompt: {skipped}. Search a protected "
+                "folder directly when access is intentional."
+            )
+        return result
+
+    def _macos_search_exclusions(self, path: str) -> List[str]:
+        """Protected descendants to prune for this search root, if any."""
+        cwd = getattr(self.env, "cwd", None) or self.cwd
+        return _macos_protected_search_exclusions(
+            path, cwd=cwd, home=_HOME, platform=sys.platform
+        )
     
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,
@@ -2997,7 +3061,20 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        # Prune protected directories before traversal so macOS never receives
+        # an access attempt (filtering matched paths after descent is too late).
+        protected_paths = [
+            os.path.normpath(os.path.join(path, item))
+            for item in self._macos_search_exclusions(path)
+        ]
+        prune_expr = ""
+        if protected_paths:
+            prune_terms = " -o ".join(
+                f"-path {self._escape_shell_arg(item)}" for item in protected_paths
+            )
+            prune_expr = f" \\( {prune_terms} \\) -prune -o"
+
+        cmd = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -3005,7 +3082,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -3060,9 +3137,15 @@ class ShellFileOperations(FileOperations):
             glob_pattern = pattern
 
         fetch_limit = limit + offset
+        exclusion_globs = " ".join(
+            f"--glob {self._escape_shell_arg(f'!{item}/**')}"
+            for item in self._macos_search_exclusions(path)
+        )
+        exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)}"
+            f"{exclusion_args} "
             f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
@@ -3073,7 +3156,8 @@ class ShellFileOperations(FileOperations):
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"rg --files -g {self._escape_shell_arg(glob_pattern)}"
+                f"{exclusion_args} "
                 f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
@@ -3146,6 +3230,10 @@ class ShellFileOperations(FileOperations):
         if context > 0:
             cmd_parts.extend(["-C", str(context)])
         
+        # Exclude macOS TCC-protected descendants during broad searches.
+        for item in self._macos_search_exclusions(path):
+            cmd_parts.extend(["--glob", self._escape_shell_arg(f"!{item}/**")])
+
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
             cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
@@ -3280,6 +3368,9 @@ class ShellFileOperations(FileOperations):
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
         cmd_parts.append("--exclude-dir='.*'")
+        for item in self._macos_search_exclusions(path):
+            dirname = item.split("/")[-1]
+            cmd_parts.append(f"--exclude-dir={self._escape_shell_arg(dirname)}")
         
         # Add context if requested
         if context > 0:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2746,7 +2746,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. On macOS, broad searches above the user home automatically skip TCC-protected folders (Desktop, Documents, Downloads, Library, Movies, Music, Pictures); target one directly when access is intentional.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
Broad `search_files` calls (e.g. searching `~` or `/Users`) no longer trip macOS TCC privacy prompts: the seven protected home directories are pruned from ancestor searches across all four backends (rg, legacy rg, grep, find), with a warning naming what was skipped and how to opt in. Direct searches inside a protected folder are untouched. Salvage of #75785 by @deepeet-git (commit cherry-picked, authorship preserved), plus the two fixes the review flagged as landing blockers.

## Changes
- `tools/file_operations.py` (@deepeet-git): `_macos_protected_search_exclusions()` — exclusions only when the search root is an ANCESTOR of home; rg glob exclusions, find `-prune`, result warning, schema note. 163-line test suite.
- Fixup commit (ours):
  - **grep backend defect fixed** — the PR used `--exclude-dir=Downloads`, which grep matches against basenames ANYWHERE in the tree, silently skipping a repo's own nested `Downloads/` folder. Protected-dir grep searches now route through find's path-scoped `-prune` (same traversal-prevention as the find backend) feeding grep via `-exec`. Live-filesystem regression test: nested `work/repo/Downloads/notes.txt` found, `~/Downloads` untouched — real find+grep on this box.
  - **execution-backend gating** — new `BaseEnvironment.is_local` flag (True on LocalEnvironment): `sys.platform`/`Path.home()` describe the controller, not the execution host, so a macOS controller driving a Linux SSH/container backend no longer prunes the remote's unprotected dirs. Flag-less environments (test fakes, plugins) keep local semantics — pruning is a warning-carrying skip, never data loss.
  - Rebase over main's `_escape_native_tool_arg` migration.

Policy check: only unprompted broad/ancestor traversals are pruned; explicit protected-dir searches work (pinned), and the warning tells the model how to opt in.

## Validation
| | Before (original PR) | After |
|---|---|---|
| Nested dir named "Downloads" | silently skipped by grep backend | searched (live-fs test) |
| macOS controller + remote backend | pruned remote's dirs | no pruning (is_local gate) |
| Tests | 8 (PR's) | 77 passed, 2 skipped (11 in the TCC suite) |

Sabotage-verified: restoring basename `--exclude-dir` fails 2 tests.

**Live repro:** premise verified on current main (search() has zero TCC handling); the pruned grep path exercised against a real filesystem with real find+grep here. The TCC prompt itself is macOS-only — flagged for a real-Mac spot check.

Credit: @deepeet-git. Closes #75785.

## Infographic

![Broad searches stop waking macOS privacy alarms](https://v3b.fal.media/files/b/0aa7e2b8/Epw7XK4FbGsDVQRz8g1_f_DNB6ekBE.png)
