### PR TITLE
macOS users learn the one-switch Full Disk Access fix — doctor reports it, setup teaches it

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1202,6 +1202,55 @@ def check_macos_tcc_anchor(should_fix: bool = False) -> None:
         check_warn(f"macOS TCC anchor check failed: {e}")
 
 
+def check_macos_full_disk_access() -> None:
+    """One-grant guidance: Full Disk Access silences every folder prompt.
+
+    macOS TCC prompts per-category (Desktop, then Downloads, then Documents,
+    ...), so first-run agents drip-feed permission dialogs as they touch each
+    folder. ONE Full Disk Access grant covers all of them, permanently — and
+    with the stable signing identities now in place (#73681/#95091/#95131),
+    it survives updates too. This check probes whether the terminal context
+    already has FDA and, when it doesn't, prints the exact one-switch setup
+    with the System Settings deep link.
+
+    Probe: readability of ``~/Library/Application Support/com.apple.TCC`` —
+    the TCC database directory itself is FDA-gated, readable ONLY with the
+    grant, and (critically) probing it with os.access/listdir does NOT
+    trigger a prompt: TCC prompts fire for protected-CATEGORY paths (Desktop
+    etc.), while the TCC dir simply returns EPERM without one. Silent on
+    non-macOS.
+    """
+    if sys.platform != "darwin":
+        return
+    tcc_dir = Path.home() / "Library" / "Application Support" / "com.apple.TCC"
+    try:
+        os.listdir(tcc_dir)
+        has_fda = True
+    except PermissionError:
+        has_fda = False
+    except OSError:
+        # Missing dir / other error: can't tell — stay silent rather than
+        # nag on an indeterminate probe.
+        return
+    if has_fda:
+        check_ok(
+            "macOS Full Disk Access granted",
+            "(no per-folder permission prompts will occur)",
+        )
+        return
+    check_info(
+        "One switch silences all macOS folder prompts: grant your terminal "
+        "app Full Disk Access and Hermes will never trip per-folder dialogs "
+        "(Desktop/Downloads/Documents/...) again. Open: System Settings → "
+        "Privacy & Security → Full Disk Access — or run:\n"
+        "      open \"x-apple.systempreferences:com.apple.preference"
+        ".security?Privacy_AllFiles\"\n"
+        "    then enable your terminal (and Hermes.app if you use Desktop), "
+        "and restart them once. With Hermes' stable signing identities the "
+        "grant survives every update."
+    )
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1375,6 +1424,10 @@ def run_doctor(args):
     # macOS TCC anchor (issue #85345): uv-managed interpreter paths move on
     # every patch bump and orphan TCC grants. Silent on non-macOS.
     check_macos_tcc_anchor(should_fix)
+
+    # macOS Full Disk Access (issue #52010 follow-up): one grant silences
+    # every per-folder prompt permanently. Silent on non-macOS.
+    check_macos_full_disk_access()
 
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3425,9 +3425,37 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
     print_info("  Configure all settings:    hermes setup")
     if gateway_choice != 0:
         print_info("  Connect Telegram/Discord:  hermes setup gateway")
+    _print_macos_fda_tip()
     print()
 
     _print_setup_summary(config, hermes_home)
+
+
+def _print_macos_fda_tip() -> None:
+    """One-time macOS onboarding tip: a single Full Disk Access grant kills
+    every per-folder permission prompt, permanently (issue #52010 follow-up).
+
+    Uses the same prompt-free probe as doctor's check_macos_full_disk_access
+    (the TCC db dir is FDA-gated but probing it never triggers a dialog).
+    Silent on non-macOS and when FDA is already granted or indeterminate.
+    """
+    if sys.platform != "darwin":
+        return
+    tcc_dir = Path.home() / "Library" / "Application Support" / "com.apple.TCC"
+    try:
+        os.listdir(tcc_dir)
+        return  # already granted — nothing to teach
+    except PermissionError:
+        pass
+    except OSError:
+        return  # indeterminate — don't nag
+    print()
+    print_info("  macOS tip: silence ALL folder permission prompts with one switch —")
+    print_info("  System Settings → Privacy & Security → Full Disk Access → enable")
+    print_info("  your terminal (and Hermes.app if you use Desktop), or run:")
+    print_info("    open \"x-apple.systempreferences:com.apple.preference"
+               ".security?Privacy_AllFiles\"")
+    print_info("  The grant is permanent — it survives every Hermes update.")
 
 
 def _blank_slate_minimal_toolsets(config: dict):

--- a/tests/hermes_cli/test_macos_fda_guidance.py
+++ b/tests/hermes_cli/test_macos_fda_guidance.py
@@ -1,0 +1,97 @@
+"""macOS Full Disk Access onboarding guidance (issue #52010 follow-up).
+
+One FDA grant silences every per-folder TCC prompt permanently. Doctor
+reports the state and prints the one-switch setup; `hermes setup` surfaces
+the same tip at onboarding. The probe must never itself trigger a prompt —
+it reads the FDA-gated TCC db directory, which returns EPERM (no dialog)
+without the grant.
+"""
+
+import io
+import contextlib
+
+import hermes_cli.doctor as doctor_mod
+from hermes_cli.setup import _print_macos_fda_tip
+
+
+def _capture(fn):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        fn()
+    return buf.getvalue()
+
+
+class TestDoctorFdaCheck:
+    def test_silent_on_non_macos(self, monkeypatch):
+        monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
+        out = _capture(doctor_mod.check_macos_full_disk_access)
+        assert out == ""
+
+    def test_granted_reports_ok(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        tcc = tmp_path / "Library" / "Application Support" / "com.apple.TCC"
+        tcc.mkdir(parents=True)
+        monkeypatch.setattr(doctor_mod.Path, "home", classmethod(lambda cls: tmp_path))
+        out = _capture(doctor_mod.check_macos_full_disk_access)
+        assert "Full Disk Access granted" in out
+        assert "Privacy_AllFiles" not in out
+
+    def test_denied_prints_one_switch_guidance(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        tcc = tmp_path / "Library" / "Application Support" / "com.apple.TCC"
+        tcc.mkdir(parents=True)
+        monkeypatch.setattr(doctor_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+        def _eperm(path):
+            raise PermissionError(13, "Operation not permitted", str(path))
+
+        monkeypatch.setattr(doctor_mod.os, "listdir", _eperm)
+        out = _capture(doctor_mod.check_macos_full_disk_access)
+        assert "Full Disk Access" in out
+        assert "Privacy_AllFiles" in out
+        assert "System Settings" in out
+
+    def test_indeterminate_probe_is_silent(self, monkeypatch, tmp_path):
+        """Missing TCC dir (weird install) must not nag."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(doctor_mod.Path, "home", classmethod(lambda cls: tmp_path))
+        # tmp_path has no Library/Application Support/com.apple.TCC →
+        # FileNotFoundError (an OSError that is not PermissionError).
+        out = _capture(doctor_mod.check_macos_full_disk_access)
+        assert out == ""
+
+
+class TestSetupFdaTip:
+    def test_silent_on_non_macos(self, monkeypatch):
+        import hermes_cli.setup as setup_mod
+
+        monkeypatch.setattr(setup_mod.sys, "platform", "linux")
+        out = _capture(_print_macos_fda_tip)
+        assert out == ""
+
+    def test_silent_when_already_granted(self, monkeypatch, tmp_path):
+        import hermes_cli.setup as setup_mod
+
+        monkeypatch.setattr(setup_mod.sys, "platform", "darwin")
+        tcc = tmp_path / "Library" / "Application Support" / "com.apple.TCC"
+        tcc.mkdir(parents=True)
+        monkeypatch.setattr(setup_mod.Path, "home", classmethod(lambda cls: tmp_path))
+        out = _capture(_print_macos_fda_tip)
+        assert out == ""
+
+    def test_tip_printed_when_denied(self, monkeypatch, tmp_path):
+        import hermes_cli.setup as setup_mod
+
+        monkeypatch.setattr(setup_mod.sys, "platform", "darwin")
+        tcc = tmp_path / "Library" / "Application Support" / "com.apple.TCC"
+        tcc.mkdir(parents=True)
+        monkeypatch.setattr(setup_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+        def _eperm(path):
+            raise PermissionError(13, "Operation not permitted", str(path))
+
+        monkeypatch.setattr(setup_mod.os, "listdir", _eperm)
+        out = _capture(_print_macos_fda_tip)
+        assert "Full Disk Access" in out
+        assert "Privacy_AllFiles" in out
+        assert "survives every Hermes update" in out

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -540,6 +540,19 @@ macOS/Windows signing and notarization run automatically when the relevant crede
 
 ### macOS permissions and local rebuilds (TCC)
 
+**Silence every folder prompt with one switch.** macOS prompts per-category
+(Desktop, then Downloads, then Documents, ...) as Hermes touches each folder.
+A single **Full Disk Access** grant covers all of them, permanently — and
+with Hermes' stable signing identities it survives every update:
+
+1. System Settings → **Privacy & Security → Full Disk Access** (or run
+   `open "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"`)
+2. Enable your terminal app — and **Hermes.app** if you use Desktop.
+3. Fully quit and relaunch them once.
+
+`hermes doctor` reports whether the current terminal context already has the
+grant, and `hermes setup` shows this tip on macOS when it doesn't.
+
 macOS remembers permission grants (Full Disk Access, Desktop/Downloads/Documents,
 Accessibility, Automation, microphone) against the app's *code-signing identity*,
 not its path. Locally built and self-updated apps are signed with a stable


### PR DESCRIPTION
## Summary
The last piece of the macOS permissions campaign: Hermes now teaches macOS users the one-switch fix — a single Full Disk Access grant covers every folder prompt (Desktop/Downloads/Documents/...), permanently, and with the stable signing identities landed this week it survives every update. Nothing in the product surfaced that; users got the OS's drip-feed of per-folder dialogs instead. Follow-up to #52010.

## Changes
- `hermes_cli/doctor.py`: `check_macos_full_disk_access()` — reports whether the current terminal context has FDA; when missing, prints the one-switch setup with the `Privacy_AllFiles` System Settings deep link. Prompt-free probe: readability of the FDA-gated `~/Library/Application Support/com.apple.TCC` dir, which returns EPERM without ever showing a dialog (TCC only prompts on protected-CATEGORY paths). Silent on non-macOS/indeterminate.
- `hermes_cli/setup.py`: same probe at the end of onboarding — the moment users are primed for system setup. Silent when already granted.
- `website/docs/user-guide/desktop.md`: the TCC section now leads with the one-switch guidance.
- 7 tests: granted / denied / indeterminate / non-macOS across both surfaces.

Built on this week's substrate: #95091 (cert-anchored identity), #95128 (doctor DR diagnosis), #95131/#95478 (interpreter anchor + repair signing) — the FDA grant these instructions produce is durable precisely because of those.

## Validation
| | Before | After |
|---|---|---|
| FDA discoverability | none — per-folder prompts drip-feed | doctor reports + setup teaches, deep link included |
| Probe side effects | n/a | none (EPERM path, never a dialog) |

- `tests/hermes_cli/test_macos_fda_guidance.py` + full doctor suite: 72 passed
- **Live repro:** probe semantics (EPERM without dialog on the TCC dir) are documented macOS TCC behavior and pinned via mocked PermissionError; the real-dialog-free property needs a Mac spot check — run `hermes doctor` on a machine without FDA and confirm no prompt appears.

## Infographic

![One switch, zero folder prompts](https://v3b.fal.media/files/b/0aa7e2eb/6dEfZDaTQeyqGzmgITiLj_nVB4Q79r.png)
