### PR TITLE
fix(gateway): restore profile MCP tools after multiplex restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2246,6 +2246,33 @@ def _profile_runtime_scope(profile_home: "Path"):
         reset_hermes_home_override(home_token)
 
 
+async def _discover_gateway_mcp_tools(config: object) -> None:
+    """Discover MCP servers for every profile served by this gateway.
+
+    Executor threads do not inherit contextvars automatically.  Each profile
+    therefore installs its runtime scope before copying the context into the
+    worker that reads config.yaml and the profile-local OAuth token store.
+    """
+    from tools.mcp_tool import discover_mcp_tools
+
+    loop = asyncio.get_running_loop()
+    if not getattr(config, "multiplex_profiles", False):
+        await loop.run_in_executor(None, discover_mcp_tools)
+        return
+
+    for profile_name, profile_home in _multiplex_profile_homes(config):
+        try:
+            with _profile_runtime_scope(Path(profile_home)):
+                ctx = copy_context()
+                await loop.run_in_executor(None, ctx.run, discover_mcp_tools)
+        except Exception as exc:
+            logger.warning(
+                "MCP discovery failed for profile '%s': %s",
+                profile_name,
+                exc,
+            )
+
+
 def load_gateway_config_for_runner() -> "GatewayConfig":
     """Load gateway config for the process-level GatewayRunner.
 
@@ -23888,24 +23915,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         wrapper can invoke the same path whether the user confirmed via
         button, text reply, or has the confirm gate disabled.
         """
-        loop = asyncio.get_running_loop()
+        if getattr(self.config, "multiplex_profiles", False):
+            from hermes_constants import get_hermes_home_override
+
+            if not get_hermes_home_override():
+                profile_home = self._resolve_profile_home_for_source(event.source)
+                with _profile_runtime_scope(profile_home):
+                    return await self._execute_mcp_reload(event)
+
         try:
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.registry import registry
+
+            reload_scope = (
+                registry.current_scope_key()
+                if getattr(self.config, "multiplex_profiles", False)
+                else None
+            )
 
             # Capture old server names before shutdown
             with _lock:
-                old_servers = set(_servers.keys())
+                from tools.mcp_tool import _server_scope_keys
+                old_servers = {
+                    name
+                    for name in _servers
+                    if reload_scope is None or _server_scope_keys.get(name) == reload_scope
+                }
 
             # Read new config before shutting down, so we know what will be added/removed
             # Shutdown existing connections
-            await loop.run_in_executor(None, shutdown_mcp_servers)
+            await self._run_in_executor_with_context(
+                lambda: shutdown_mcp_servers(scope=reload_scope)
+            )
 
             # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+            new_tools = await self._run_in_executor_with_context(discover_mcp_tools)
 
             # Compute what changed
             with _lock:
-                connected_servers = set(_servers.keys())
+                connected_servers = {
+                    name
+                    for name in _servers
+                    if reload_scope is None or _server_scope_keys.get(name) == reload_scope
+                }
 
             added = connected_servers - old_servers
             removed = old_servers - connected_servers
@@ -23936,6 +23988,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _cache_lock is not None and _cache:
                     with _cache_lock:
                         for _sess_key, _entry in list(_cache.items()):
+                            if getattr(self.config, "multiplex_profiles", False):
+                                profile = event.source.profile or "default"
+                                expected_namespace = (
+                                    "main" if profile == "default" else profile
+                                )
+                                key_parts = str(_sess_key).split(":", 2)
+                                if (
+                                    len(key_parts) < 2
+                                    or key_parts[0] != "agent"
+                                    or key_parts[1] != expected_namespace
+                                ):
+                                    continue
                             try:
                                 _agent = _entry[0] if isinstance(_entry, tuple) else _entry
                             except Exception:
@@ -31472,9 +31536,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # heartbeats (Discord shard, Telegram polling) until it returned.
     # See #16856.
     try:
-        from tools.mcp_tool import discover_mcp_tools
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        await _discover_gateway_mcp_tools(runner.config)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _event(profile: str) -> MessageEvent:
+    return MessageEvent(
+        text="/reload-mcp",
+        message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="u1",
+            chat_id="c1",
+            chat_type="dm",
+            profile=profile,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_boot_discovers_mcp_for_every_multiplex_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gateway.run as gateway_run
+    from hermes_constants import get_hermes_home
+    from tools import mcp_tool
+
+    homes = []
+    for name in ("default", "worker"):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"mcp_servers:\n  {name}-server:\n    command: fake\n",
+            encoding="utf-8",
+        )
+        homes.append((name, home))
+
+    seen: list[tuple[Path, str]] = []
+
+    def fake_discover() -> list[str]:
+        home = get_hermes_home()
+        seen.append((home, threading.current_thread().name))
+        return [home.name]
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: homes,
+    )
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", fake_discover)
+
+    await gateway_run._discover_gateway_mcp_tools(
+        GatewayConfig(multiplex_profiles=True)
+    )
+
+    assert [home for home, _thread in seen] == [home for _name, home in homes]
+    assert all(thread != threading.current_thread().name for _home, thread in seen)
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_keeps_requesting_profile_scope_in_executor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gateway.run import GatewayRunner
+    from hermes_constants import get_hermes_home
+    from tools import mcp_tool
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    (worker_home / "config.yaml").write_text(
+        "mcp_servers:\n  worker-server:\n    command: fake\n",
+        encoding="utf-8",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner._resolve_profile_home_for_source = MagicMock(return_value=worker_home)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._async_session_store = SimpleNamespace(
+        get_or_create_session=MagicMock(side_effect=RuntimeError("skip transcript")),
+    )
+
+    seen: list[tuple[str, Path]] = []
+
+    def fake_shutdown(*, scope=None) -> None:
+        seen.append(("shutdown", get_hermes_home()))
+
+    def fake_discover() -> list[str]:
+        seen.append(("discover", get_hermes_home()))
+        return []
+
+    monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", fake_shutdown)
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", fake_discover)
+
+    result = await runner._execute_mcp_reload(_event("worker"))
+
+    assert "failed" not in result.lower()
+    assert seen == [("shutdown", worker_home), ("discover", worker_home)]
+    runner._resolve_profile_home_for_source.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_refreshes_only_requesting_profile_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+    from tools import mcp_tool
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._agent_cache_lock = threading.Lock()
+    worker_agent = SimpleNamespace(
+        tools=[], valid_tool_names=set(), enabled_toolsets=None, disabled_toolsets=None
+    )
+    other_agent = SimpleNamespace(
+        tools=[{"type": "function", "function": {"name": "other_only"}}],
+        valid_tool_names={"other_only"},
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+    )
+    runner._agent_cache = OrderedDict(
+        {
+            "agent:worker:telegram:dm:c1": (worker_agent, "sig-worker"),
+            "agent:other:telegram:dm:c1": (other_agent, "sig-other"),
+        }
+    )
+    runner._async_session_store = SimpleNamespace(
+        get_or_create_session=MagicMock(side_effect=RuntimeError("skip transcript")),
+    )
+
+    monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", lambda *, scope=None: None)
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", lambda: ["worker_tool"])
+    monkeypatch.setattr(
+        "model_tools.get_tool_definitions",
+        lambda **kwargs: [
+            {"type": "function", "function": {"name": "worker_tool"}}
+        ],
+    )
+
+    with _profile_runtime_scope(worker_home):
+        await runner._execute_mcp_reload(_event("worker"))
+
+    assert worker_agent.valid_tool_names == {"worker_tool"}
+    assert other_agent.valid_tool_names == {"other_only"}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2793,7 +2793,7 @@ class MCPServerTask:
                 # is currently owned by another server.
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=_mcp_registry_scope())
                 _forget_mcp_tool_server(tool_name)
 
             # 3. Re-register with the fresh list. The helper may skip names that
@@ -2811,7 +2811,7 @@ class MCPServerTask:
             for tool_name in old_tool_names - registered_name_set:
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=_mcp_registry_scope())
                 _forget_mcp_tool_server(tool_name)
             self._registered_tool_names = registered_names
 
@@ -4413,7 +4413,7 @@ class MCPServerTask:
         from tools.registry import registry
 
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=_mcp_registry_scope())
             _forget_mcp_tool_server(tool_name)
         self._registered_tool_names = []
 
@@ -4441,6 +4441,9 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 
 _servers: Dict[str, MCPServerTask] = {}
+# Profile owner for each live connection. Multiplex reloads use this to tear
+# down only the requesting profile's servers; single-profile owners are None.
+_server_scope_keys: Dict[str, Optional[str]] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
@@ -5215,6 +5218,20 @@ _mcp_thread: Optional[threading.Thread] = None
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
 
+
+def _mcp_registry_scope() -> Optional[str]:
+    """Return the active profile registry scope in multiplex mode."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        if not is_multiplex_active():
+            return None
+        from tools.registry import registry
+
+        return registry.current_scope_key()
+    except Exception:
+        return None
+
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard
 # ---------------------------------------------------------------------------
@@ -5931,7 +5948,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         from tools.registry import registry
 
         for tool_name in phantom_names:
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=_mcp_registry_scope())
             _forget_mcp_tool_server(tool_name)
         logger.info(
             "MCP server '%s': deregistered %d phantom cached tool(s) not "
@@ -7304,6 +7321,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=candidate["check_fn"],
             is_async=False,
             description=candidate["schema"]["description"],
+            scope=_mcp_registry_scope(),
         )
 
         # The pre-check above is advisory only. Multiple servers connect in
@@ -7461,6 +7479,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            scope=_mcp_registry_scope(),
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
@@ -7494,6 +7513,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
+            scope=_mcp_registry_scope(),
         )
         if registry.get_toolset_for_tool(util_name) != toolset_name:
             continue
@@ -7561,6 +7581,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
         _servers[name] = server
+        _server_scope_keys[name] = _mcp_registry_scope()
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
@@ -8270,27 +8291,28 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
     return staged_engine_names
 
 
-def shutdown_mcp_servers():
-    """Close all MCP server connections and stop the background loop.
+def shutdown_mcp_servers(*, scope: Optional[str] = None):
+    """Close MCP connections, optionally for one multiplex profile only.
 
     Each server Task is signalled to exit its ``async with`` block so that
     the anyio cancel-scope cleanup happens in the same Task that opened it.
-    All servers are shut down in parallel via ``asyncio.gather``.
+    A scoped reload leaves other profiles' connections and loop ownership
+    intact; process shutdown keeps the historical all-server behavior.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        selected = {
+            name: server
+            for name, server in _servers.items()
+            if scope is None or _server_scope_keys.get(name) == scope
+        }
+        servers_snapshot = list(selected.values())
 
-    # Fast path: nothing to shut down. The connect-cooldown maps can still
-    # be populated here — a server that failed to connect is never recorded
-    # in ``_servers`` (that is the very premise of the #50394 cooldown), so
-    # "no live servers" is the MOST likely state in which stale backoff
-    # entries exist. Clear them so a post-shutdown restart re-attempts every
-    # configured server immediately.
     if not servers_snapshot:
-        with _lock:
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
-        _stop_mcp_loop()
+        if scope is None:
+            with _lock:
+                _server_connect_retry_after.clear()
+                _server_connect_failures.clear()
+            _stop_mcp_loop()
         return
 
     async def _shutdown():
@@ -8304,12 +8326,12 @@ def shutdown_mcp_servers():
                     "Error closing MCP server '%s': %s", server.name, result,
                 )
         with _lock:
-            _servers.clear()
-            # Drop connect-retry cooldowns too: a full shutdown/restart
-            # should re-attempt every server immediately, not honour a
-            # stale per-server backoff from before the restart (#50394).
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+            for name in selected:
+                _servers.pop(name, None)
+                _server_scope_keys.pop(name, None)
+            if scope is None:
+                _server_connect_retry_after.clear()
+                _server_connect_failures.clear()
 
     with _lock:
         loop = _mcp_loop
@@ -8326,15 +8348,14 @@ def shutdown_mcp_servers():
             except BaseException as exc:
                 logger.debug("Error during MCP shutdown: %s", exc)
 
-    # Unconditional final sweep: whether the async ``_shutdown`` ran,
-    # timed out, or was never scheduled (loop already stopped), a full
-    # shutdown must leave no stale connect-cooldown state behind — the
-    # next start should re-attempt every server immediately (#50394).
-    with _lock:
-        _server_connect_retry_after.clear()
-        _server_connect_failures.clear()
-
-    _stop_mcp_loop()
+    if scope is None:
+        # A full process shutdown must leave no stale retry state behind.
+        with _lock:
+            _server_connect_retry_after.clear()
+            _server_connect_failures.clear()
+        _stop_mcp_loop()
+    else:
+        _stop_mcp_loop_if_idle()
 
 
 def _kill_orphaned_mcp_children(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -881,7 +881,7 @@ class ToolRegistry:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
 
-    def deregister(self, name: str) -> None:
+    def deregister(self, name: str, *, scope: Optional[str] = None) -> None:
         """Remove a tool from the registry.
 
         Also cleans up the toolset check if no other tools remain in the
@@ -905,13 +905,23 @@ class ToolRegistry:
                 if caller_owner is not None
                 else None
             )
+            if (
+                caller_owner is not None
+                and scope is not None
+                and scope != caller_scope
+            ):
+                raise PermissionError(
+                    f"Plugin module {caller_mod!r} cannot deregister tools "
+                    "outside its own profile scope."
+                )
+            effective_scope = scope if scope is not None else caller_scope
             target = (
-                self._scoped_tools.get(caller_scope, {})
-                if caller_scope is not None
+                self._scoped_tools.get(effective_scope, {})
+                if effective_scope is not None
                 else self._tools
             )
             entry = target.get(name)
-            if entry is None and caller_scope is not None:
+            if entry is None and effective_scope is not None:
                 if name in self._tools:
                     raise PermissionError(
                         f"Scoped plugin module {caller_mod!r} cannot deregister "
@@ -952,13 +962,13 @@ class ToolRegistry:
                         f"opt-in (allow_tool_override)."
                     )
             del target[name]
-            if caller_scope is not None and not target:
-                self._scoped_tools.pop(caller_scope, None)
+            if effective_scope is not None and not target:
+                self._scoped_tools.pop(effective_scope, None)
             # Drop the toolset check and aliases if this was the last tool in
             # that toolset.
             toolset_still_exists = any(
                 e.toolset == entry.toolset
-                for e in self._merged_tools(caller_scope).values()
+                for e in self._merged_tools(effective_scope).values()
             )
             if not toolset_still_exists:
                 self._toolset_checks.pop(entry.toolset, None)


### PR DESCRIPTION
## What does this PR do?

Multiplexed gateways now discover MCP servers from every served profile instead of reading only the process-level home. Profile-routed `/reload-mcp` operations keep the requesting profile's config and token scope across executor hops, reconnect only that profile's servers, and refresh only that profile's cached agents.

### Symptom

After a multiplexed gateway restart, MCP servers configured only in `profiles/<name>/config.yaml` are never registered for that profile. `/reload-mcp` also reads the default home, so the affected profile cannot recover its tools without copying config and OAuth tokens into the default home.

### Impact

Profile-routed gateway sessions cannot use their configured MCP tools. Copying token stores into the default home creates duplicate refresh-token owners and can cause OAuth refresh races.

### Bug Cause

**Trigger:** `gateway/run.py` gateway startup discovery and `GatewayRunner._execute_mcp_reload`

**Causal chain:**
1. A multiplexed gateway serves a profile whose `mcp_servers` config exists only under that profile home.
2. Startup and reload call `discover_mcp_tools()` through a bare executor hop, which does not inherit the profile home contextvar.
3. MCP discovery reads only the default config, so the profile's tools are absent from its agent snapshot.

**Why it is wrong:** Multiplex routing already installs profile-local config and secret scopes for turns, but MCP discovery escaped that boundary and dynamic MCP registrations were process-global.

**Working sibling / contrast:** Multiplex cron execution enters `_profile_runtime_scope` before per-profile work, so cron-triggered MCP discovery can see the correct profile config and token store.

**Ruled out:** Invalid OAuth credentials do not explain the missing registration because no connection attempt or registration log occurs until config and tokens are copied into the default home.

### Fix

- Iterate the authoritative multiplex profile set at gateway boot and copy each profile runtime context into the discovery executor.
- Keep `/reload-mcp` inside the requesting profile scope and preserve that context in executor work.
- Register MCP tools in the existing per-home registry overlay, track live connection ownership, and support profile-scoped shutdown.
- Refresh only cached agents whose session namespace belongs to the requesting profile.

## Related Issue

Closes #95518

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - add per-profile boot discovery and profile-scoped reload behavior.
- `tools/mcp_tool.py` - scope dynamic registrations and connection shutdown by profile home.
- `tools/registry.py` - allow trusted internal callers to deregister a specific profile overlay while preserving plugin ownership checks.
- `tests/gateway/test_multiplex_mcp_discovery.py` - cover boot discovery, executor context propagation, and cache refresh isolation.

## How to Test

1. Configure an MCP server only in a named profile and enable gateway multiplexing.
2. Restart the gateway and verify the profile-routed session receives that MCP tool while another profile does not.
3. Run `/reload-mcp` from the named profile and verify the same profile config is reloaded without changing another profile's cached tools.
4. Automated tests already run locally (50 passed):

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py tests/tools/test_registry.py -q
scripts/run_tests.sh tests/tools/test_mcp_tool.py -k 'tools_registered_in_registry or shutdown_deregisters_registered_tools or shutdown_is_parallel or utility_tools_registered or register_mcp_servers_tracks_parallel_flag' -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the automated path on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by code docstrings and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; schemas are unchanged

## Screenshots / Logs

N/A - automated regression coverage exercises the gateway behavior directly.
