### PR TITLE
fix(mcp): inverted liveness check in _stdio_children_dead fails every stdio MCP tool call

### DIFF
--- a/tests/test_mcp_stdio_children_dead.py
+++ b/tests/test_mcp_stdio_children_dead.py
@@ -1,0 +1,40 @@
+"""Behavior tests for MCPServerTask._stdio_children_dead (#81995 fast-fail).
+
+Contract: returns True only when EVERY tracked stdio child is dead;
+returns False while at least one tracked child is alive.
+"""
+import os
+import sys
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _task_with_pids(monkeypatch, pids):
+    task = MCPServerTask("test-server")
+    monkeypatch.setattr(task, "_stdio_child_pids", set(pids), raising=False)
+    return task
+
+
+def test_returns_false_when_child_alive(monkeypatch):
+    """A live PID must yield False — this was inverted, failing every stdio
+    MCP tool call on hosts where psutil is installed (all Windows installs)."""
+    live_pid = os.getpid()  # our own interpreter is definitely running
+    task = _task_with_pids(monkeypatch, [live_pid])
+    assert task._stdio_children_dead() is False
+
+
+def test_returns_true_when_all_children_dead(monkeypatch):
+    task = _task_with_pids(monkeypatch, [-1])  # PID -1 never exists
+    assert task._stdio_children_dead() is True
+
+
+def test_returns_false_when_any_child_alive(monkeypatch):
+    dead, alive = -1, os.getpid()
+    task = _task_with_pids(monkeypatch, [dead, alive])
+    assert task._stdio_children_dead() is False
+
+
+def test_returns_false_without_tracked_pids(monkeypatch):
+    """No captured PIDs → unknown → must NOT fail fast."""
+    task = _task_with_pids(monkeypatch, [])
+    assert task._stdio_children_dead() is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,7 +2994,6 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## Problem

On hosts where `psutil` is installed (all Windows installs), **every** tool call on **every** stdio MCP server fails immediately with:

```
TimeoutError: MCP stdio subprocess for '<server>' has exited; failing the call fast instead of waiting 300s
```

The stdio subprocess is actually alive and healthy — the fast-fail check itself is broken.

## Root cause

`MCPServerTask._stdio_children_dead()` (`tools/mcp_tool.py`, introduced with the #81995 fast-fail) was meant to return `True` only when *every* tracked child PID is dead. But the loop returns `True` as soon as it finds a **live** pid, leaving the correct "at least one child alive → False" return unreachable below the early return:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True   # ← live pid found... reports "all dead"
    return False  # ← unreachable
return True
```

Net effect: in the normal case (child alive), `_stdio_children_dead()` reports True, so `_call()`'s fast-fail branch raises before ever contacting the perfectly healthy server.

## Reproduction

Windows + psutil: configure any stdio MCP server (reproduced with `comfy-mcp`). The server starts, tool discovery succeeds, then every `tools/call` fails instantly with `has exited; failing the call fast`. Instrumenting the tracked PIDs showed the child process stayed alive throughout.

## Fix

One line: return `False` when a live pid is found; fall through to `return True` only when no live pids remain.

## Testing

Added `tests/test_mcp_stdio_children_dead.py` — behavior contract for all four branches:
- live child → `False` (the inverted case)
- all children dead → `True`
- mixed → `False`
- no tracked PIDs → `False` (unknown → don't fail fast)

All 4 pass on Windows against a real `psutil.pid_exists` probe:
```
tests/test_mcp_stdio_children_dead.py::test_returns_false_when_child_alive PASSED
tests/test_mcp_stdio_children_dead.py::test_returns_true_when_all_children_dead PASSED
tests/test_mcp_stdio_children_dead.py::test_returns_false_when_any_child_alive PASSED
tests/test_mcp_stdio_children_dead.py::test_returns_false_without_tracked_pids PASSED
============================== 4 passed in 0.51s ==============================
```

End-to-end verified against a live local MCP server: after the fix, `server_info` returns full data over the real `MCPServerTask` path where it previously fast-failed.