### PR TITLE
fix: add MiniMax-M2.7-highspeed to minimax-cn provider model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -446,6 +446,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax-cn": [
         "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
         "MiniMax-M2",


### PR DESCRIPTION
## Summary
minimax-oauth has MiniMax-M2.7-highspeed in its model list, but minimax-cn was missing it, making highspeed models inaccessible via the China domestic endpoint.

## Fix
Added MiniMax-M2.7-highspeed to _PROVIDER_MODELS["minimax-cn"] in hermes_cli/models.py.

## Testing
- Local build confirms the model now appears in the minimax-cn provider model list
- Backend restart required after upgrade to pick up the change