### PR TITLE
fix(desktop): keep SSH remotes connected across profile switches

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection } from './connection-apply'
+import {
+  applyConnectionChange,
+  applyPrimaryProfileChange,
+  commitConnectionFailure,
+  resolveTerminalConnection
+} from './connection-apply'
 
 function deferred() {
   let resolve!: () => void
@@ -63,6 +68,51 @@ describe('applyConnectionChange', () => {
       }
     })
     expect(events).toEqual(['cancel:worker', 'ssh:worker', 'pool:worker'])
+  })
+})
+
+describe('applyPrimaryProfileChange', () => {
+  it('drains and tears down the old SSH tunnel before the primary backend and reload', async () => {
+    const events: string[] = []
+
+    await expect(
+      applyPrimaryProfileChange({
+        cancelAndWait: async scope => events.push(`cancel:${scope}`),
+        nextProfile: 'worker',
+        previousSshScope: null,
+        reload: () => events.push('reload'),
+        resetPreviewReach: async () => events.push('preview'),
+        teardownPrimary: async () => events.push('primary'),
+        teardownSsh: async scope => events.push(`ssh:${scope}`),
+        writeProfile: profile => {
+          events.push(`write:${profile}`)
+
+          return profile
+        }
+      })
+    ).resolves.toBe('worker')
+    expect(events).toEqual(['write:worker', 'cancel:', 'preview', 'ssh:null', 'primary', 'reload'])
+  })
+
+  it('leaves SSH lifecycle untouched when the old profile route was not SSH', async () => {
+    const cancelAndWait = vi.fn()
+    const resetPreviewReach = vi.fn()
+    const teardownSsh = vi.fn()
+
+    await applyPrimaryProfileChange({
+      cancelAndWait,
+      nextProfile: 'worker',
+      previousSshScope: undefined,
+      reload: vi.fn(),
+      resetPreviewReach,
+      teardownPrimary: vi.fn(),
+      teardownSsh,
+      writeProfile: profile => profile
+    })
+
+    expect(cancelAndWait).not.toHaveBeenCalled()
+    expect(resetPreviewReach).not.toHaveBeenCalled()
+    expect(teardownSsh).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -27,6 +27,30 @@ async function applyConnectionChange({
   sendApplied()
 }
 
+async function applyPrimaryProfileChange({
+  cancelAndWait,
+  nextProfile,
+  previousSshScope,
+  reload,
+  resetPreviewReach,
+  teardownPrimary,
+  teardownSsh,
+  writeProfile
+}) {
+  const next = writeProfile(nextProfile)
+
+  if (previousSshScope !== undefined) {
+    await cancelAndWait(previousSshScope || '')
+    await resetPreviewReach()
+    await teardownSsh(previousSshScope)
+  }
+
+  await teardownPrimary()
+  reload()
+
+  return next
+}
+
 function commitConnectionFailure(current, starting, commit) {
   if (current !== starting) {
     return false
@@ -61,4 +85,10 @@ async function resolveTerminalConnectionForSender(webContentsId, getTarget, ensu
   )
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, resolveTerminalConnectionForSender }
+export {
+  applyConnectionChange,
+  applyPrimaryProfileChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  resolveTerminalConnectionForSender
+}

--- a/apps/desktop/electron/desktop-remote-route.test.ts
+++ b/apps/desktop/electron/desktop-remote-route.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { normalizeRegistry, REGISTRY_VERSION } from './connection-registry'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { primaryProfileSshScope, resolveDesktopRemoteRoute } from './desktop-remote-route'
 
 const tokenA = { encoding: 'plain', value: 'token-a' }
 const tokenB = { encoding: 'plain', value: 'token-b' }
@@ -151,6 +151,28 @@ test('global SSH treats an omitted port as 22 and checks the primary route', () 
 
   assert.equal(route?.kind, 'ssh')
   assert.equal(route?.connectionId, 'ssh-primary')
+})
+
+test('primary profile re-home selects the SSH scope that owns the old tunnel', () => {
+  const globalConfig = { mode: 'ssh', remote: { mode: 'ssh', host: 'global-box.test', user: 'hermes' } }
+
+  const profileConfig = {
+    mode: 'local',
+    profiles: { worker: { mode: 'ssh', host: 'worker-box.test', user: 'hermes' } }
+  }
+
+  assert.equal(
+    primaryProfileSshScope({ config: globalConfig, profile: 'worker', registry: registry('local', []) }),
+    null
+  )
+  assert.equal(
+    primaryProfileSshScope({ config: profileConfig, profile: 'worker', registry: registry('local', []) }),
+    'worker'
+  )
+  assert.equal(
+    primaryProfileSshScope({ config: { mode: 'local' }, profile: 'worker', registry: registry('local', []) }),
+    undefined
+  )
 })
 
 test('profile route omits identity when two registry entries match exactly', () => {

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -47,6 +47,21 @@ export interface DesktopRemoteRouteInput {
   registry: ConnectionRegistry
 }
 
+/**
+ * SSH transport scope owned by the primary backend before a hard profile
+ * re-home. Global SSH uses the shared null scope; a profile override owns its
+ * named scope. Undefined means the old primary route was not SSH-backed.
+ */
+export function primaryProfileSshScope(input: DesktopRemoteRouteInput): null | string | undefined {
+  const route = resolveDesktopRemoteRoute(input)
+
+  if (route?.kind !== 'ssh') {
+    return undefined
+  }
+
+  return route.source === 'profile' ? connectionScopeKey(input.profile) || 'default' : null
+}
+
 function withConnectionId<T extends object>(route: T, connectionId?: string): T & { connectionId?: string } {
   return connectionId ? { ...route, connectionId } : route
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -85,7 +85,7 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange } from './connection-apply'
+import { applyConnectionChange, applyPrimaryProfileChange } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -149,7 +149,7 @@ import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { primaryProfileSshScope, resolveDesktopRemoteRoute } from './desktop-remote-route'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -14069,13 +14069,33 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
-  const next = writeActiveDesktopProfile(name)
+  const previousProfile = primaryProfileKey()
 
+  const previousSshScope = primaryProfileSshScope({
+    config: readDesktopConnectionConfig(),
+    env: {
+      token: process.env.HERMES_DESKTOP_REMOTE_TOKEN,
+      url: process.env.HERMES_DESKTOP_REMOTE_URL
+    },
+    profile: previousProfile,
+    registry: readDesktopConnectionsRegistry()
+  })
   // Switching profiles is a backend re-home: relaunch the dashboard under the
-  // new HERMES_HOME. Pool backends keep their own homes, so only the primary
-  // is torn down.
-  await teardownPrimaryBackendAndWait()
-  mainWindow?.reload()
+  // new HERMES_HOME. An SSH-backed primary also owns a local forward to that
+  // backend; drain and close the OLD scope before the new profile can reuse or
+  // replace its remote serve process. Otherwise the forward survives while its
+  // remote port dies and every request through it resets (#95532).
+
+  const next = await applyPrimaryProfileChange({
+    cancelAndWait: scope => sshBootstrapCoordinator.cancelAndWait(scope),
+    nextProfile: name,
+    previousSshScope,
+    reload: () => mainWindow?.reload(),
+    resetPreviewReach: () => resetPreviewReach(),
+    teardownPrimary: () => teardownPrimaryBackendAndWait(),
+    teardownSsh: scope => teardownSshConnection(scope),
+    writeProfile: profile => writeActiveDesktopProfile(profile)
+  })
 
   return { profile: next }
 })


### PR DESCRIPTION
## What does this PR do?

Switching the Desktop primary profile over an SSH connection now closes the previous profile's local forward before the replacement backend starts. This prevents the Desktop from retaining a tunnel to a remote serve port that has already been reaped, which otherwise leaves requests failing with `ECONNRESET` until the app is fully restarted.

### Symptom

After switching between the default profile and a Bot profile on an SSH remote, the Desktop enters a connecting/failed loop and stops loading sessions or responding to chat requests. The remote SSH journal reports repeated `connect_to 127.0.0.1 port ... failed` messages.

### Impact

Desktop users connected through SSH can lose access to the remote gateway after a profile switch and must terminate all Hermes processes and restart the app to recover.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts:14071` / `hermes:profile:set`

**Causal chain:**
1. The user switches the Desktop primary profile while its backend is reached through SSH.
2. The handler persists the new profile and stops the previous primary backend, but leaves the previous route's SSH bootstrap and local forward alive.
3. The remote serve process is replaced while the retained local forward still targets its old remote port, so Desktop requests reset or repeatedly fail to connect.

**Why it is wrong:** The SSH forward and the remote serve backend are one transport lifecycle, but the hard profile re-home previously cleaned up only the backend half.

**Working sibling / contrast:** Applying a connection change already drains the matching SSH bootstrap and tears down its tunnel before changing the primary backend.

**Ruled out:** The failure also reproduces on a different network path, and the paired Desktop, sshd, and backend logs show a stale forwarded-port lifecycle rather than an intermittent ISP failure.

### Fix

Resolve the exact SSH scope owned by the old primary route before changing the stored profile. The profile-switch lifecycle now drains in-flight SSH bootstrap work, closes preview forwards and the old SSH transport, then tears down the primary backend and reloads. Non-SSH profile switches retain their previous behavior.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/desktop-remote-route.ts` - resolve whether the old primary route owns a global or profile-scoped SSH tunnel.
- `apps/desktop/electron/connection-apply.ts` - serialize profile persistence, SSH cleanup, backend teardown, and reload.
- `apps/desktop/electron/main.ts` - route hard profile switches through the coordinated lifecycle.
- Desktop Electron tests - cover scope selection, teardown ordering, and the non-SSH path.

## How to Test

1. Configure Desktop to connect to a Linux host through SSH.
2. Switch from the default profile to a Bot profile and back.
3. Confirm sessions and chat remain reachable and the old local SSH forward is closed during each hard re-home.
4. Run the automated checks:

```bash
cd apps/desktop
npx vitest run electron/desktop-remote-route.test.ts electron/connection-apply.test.ts
npm run typecheck
npx eslint electron/desktop-remote-route.ts electron/desktop-remote-route.test.ts electron/connection-apply.ts electron/connection-apply.test.ts electron/main.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop test, typecheck, and lint commands and all pass
- [x] I've added tests for my changes
- [x] I've tested the automated lifecycle coverage on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required; behavior and lifecycle contracts are documented in code
- [x] Config example changes are not applicable
- [x] Contributor guide changes are not applicable
- [x] I've considered Windows, macOS, and Linux SSH transport behavior
- [x] Tool description/schema changes are not applicable

## Screenshots / Logs

N/A - this is a main-process transport lifecycle fix with automated coverage.
