### PR TITLE
fix(browser): harden the real-profile launch path (follow-up to #95520)

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -250,7 +250,14 @@ def _detect_default_darwin() -> str | None:
         ["defaults", "read", "com.apple.LaunchServices/com.apple.launchservices.secure", "LSHandlers"],
     ):
         try:
-            out = subprocess.run(reader, capture_output=True, text=True, timeout=5).stdout.lower()
+            out = subprocess.run(
+                reader,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            ).stdout.lower()
         except Exception:
             out = ""
         for frag, browser in _DARWIN_BUNDLE_MAP:
@@ -267,7 +274,11 @@ def _detect_default_linux() -> str | None:
     try:
         out = subprocess.run(
             ["xdg-settings", "get", "default-web-browser"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
         ).stdout.strip().lower()
     except Exception:
         out = ""

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -10,6 +10,7 @@ import posixpath
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -198,6 +199,94 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
         if os.path.isdir(candidate):
             return candidate
     return candidates[0]
+
+
+# Google Chrome refuses --remote-debugging-port/-pipe on its DEFAULT user data
+# directory since 136 (chrome/browser/devtools/remote_debugging_server.cc,
+# GOOGLE_CHROME_BRANDING only; decided by path comparison, so pointing
+# --user-data-dir at the default location does not help). agent-browser needs
+# remote debugging, so a real-profile launch on branded Chrome hangs instead
+# of failing. Chromium and Brave builds do not enforce the block.
+CHROME_DEFAULT_PROFILE_DEBUG_BLOCK_MAJOR = 136
+
+_CHROMIUM_VERSION_RE = re.compile(r"(\d+)(?:\.\d+){2,3}")
+
+
+def chromium_major_version(exe: str) -> int | None:
+    """Best-effort major version of the Chromium binary at ``exe``.
+
+    POSIX: runs ``<exe> --version`` (prints e.g. ``Google Chrome
+    152.0.7977.64`` and exits). Windows: ``chrome.exe --version`` starts the
+    browser instead of printing, so read the versioned directory Chrome keeps
+    next to the executable (``…\\Application\\152.0.7977.64\\``). None when
+    the version cannot be determined.
+    """
+    if os.name != "nt":
+        try:
+            out = subprocess.run(
+                [exe, "--version"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            ).stdout
+        except Exception:
+            out = ""
+        match = _CHROMIUM_VERSION_RE.search(out or "")
+        if match:
+            return int(match.group(1))
+    try:
+        names = os.listdir(os.path.dirname(exe))
+    except OSError:
+        return None
+    majors = [
+        int(m.group(1))
+        for m in (_CHROMIUM_VERSION_RE.fullmatch(name) for name in names)
+        if m
+    ]
+    return max(majors) if majors else None
+
+
+def profile_lock_holder(data_dir: str) -> str | None:
+    """Describe the process holding Chromium's profile lock in ``data_dir``.
+
+    Returns None when the profile is free. Chromium allows a single browser
+    process per user-data-dir: a second launch hands its command line to the
+    first one and exits, which agent-browser surfaces as a launch timeout.
+    Checking up front turns that into an actionable message.
+
+    POSIX: ``SingletonLock`` is a symlink whose target is ``<host>-<pid>``.
+    The profile counts as in use when that pid is alive on this host; a stale
+    link left by a crash is ignored (Chromium replaces it itself). A lock
+    from another host is reported as in use. Windows: Chromium keeps
+    ``lockfile`` open, so failing to open it for writing means it is held.
+    """
+    if os.name == "nt":
+        lock = os.path.join(data_dir, "lockfile")
+        if not os.path.exists(lock):
+            return None
+        try:
+            with open(lock, "ab"):
+                return None
+        except OSError:
+            return "another Chromium process holds lockfile"
+    lock = os.path.join(data_dir, "SingletonLock")
+    try:
+        target = os.readlink(lock)
+    except OSError:
+        return None
+    host, sep, pid_text = target.rpartition("-")
+    if not sep or not pid_text.isdigit():
+        return None
+    pid = int(pid_text)
+    if host and host != socket.gethostname():
+        return f"a Chromium process on host {host} (pid {pid})"
+    import psutil
+
+    if not psutil.pid_exists(pid):
+        return None
+    return f"pid {pid}"
 
 
 def chromium_executable(browser: str, system: str | None = None) -> str | None:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -7,6 +7,7 @@ import ntpath
 import os
 import platform
 import posixpath
+import re
 import shlex
 import shutil
 import subprocess
@@ -103,13 +104,29 @@ _WINDOWS_PROGID_MAP = (
 )
 
 # Linux xdg default-web-browser .desktop name fragments → canonical key.
+# Includes the Flatpak application ids (``com.google.Chrome.desktop`` etc.),
+# which share none of the native package name fragments.
 _LINUX_DESKTOP_MAP = (
     ("google-chrome", "chrome"),
+    ("com.google.chrome", "chrome"),
     ("chromium", "chromium"),
     ("brave", "brave"),
     ("microsoft-edge", "edge"),
+    ("com.microsoft.edge", "edge"),
     ("msedge", "edge"),
 )
+
+# Where sandboxed Linux packages keep the profile instead of $XDG_CONFIG_HOME.
+_LINUX_FLATPAK_IDS = {
+    "chrome": "com.google.Chrome",
+    "chromium": "org.chromium.Chromium",
+    "brave": "com.brave.Browser",
+    "edge": "com.microsoft.Edge",
+}
+_LINUX_SNAP_PROFILE_PARTS = {
+    "chromium": ("snap", "chromium", "common", "chromium"),
+    "brave": ("snap", "brave", "current", ".config", "BraveSoftware", "Brave-Browser"),
+}
 
 # macOS LaunchServices bundle-id fragments → canonical key.
 _DARWIN_BUNDLE_MAP = (
@@ -149,10 +166,12 @@ def _real_profile_relparts(browser: str) -> tuple:
 def real_profile_data_dir(browser: str, system: str | None = None) -> str | None:
     """Return the default user-data-dir for a Chromium ``browser`` on ``system``.
 
-    Returns None for unknown browsers. Does not check existence — callers that
-    need that should stat the result. Paths are built with the TARGET system's
-    separator (posix for Darwin/Linux, backslash for Windows) so an explicit
-    ``system`` argument resolves correctly regardless of the host OS.
+    Returns None for unknown browsers. On Linux the native ($XDG_CONFIG_HOME),
+    snap and Flatpak locations are tried and the first existing one wins; the
+    native path is returned when none exists so the caller's error names it.
+    Darwin/Windows paths are not stat'ed. Paths are built with the TARGET
+    system's separator (posix for Darwin/Linux, backslash for Windows) so an
+    explicit ``system`` argument resolves correctly regardless of the host OS.
     """
     if browser not in _CHROMIUM_BROWSERS:
         return None
@@ -166,7 +185,19 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
         return ntpath.join(local, *win_parts)
     # Linux / other POSIX
     config = os.environ.get("XDG_CONFIG_HOME") or posixpath.join(home, ".config")
-    return posixpath.join(config, *linux_name.split("/"))
+    candidates = [posixpath.join(config, *linux_name.split("/"))]
+    snap_parts = _LINUX_SNAP_PROFILE_PARTS.get(browser)
+    if snap_parts:
+        candidates.append(posixpath.join(home, *snap_parts))
+    flatpak_id = _LINUX_FLATPAK_IDS.get(browser)
+    if flatpak_id:
+        candidates.append(
+            posixpath.join(home, ".var", "app", flatpak_id, "config", *linux_name.split("/"))
+        )
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return candidate
+    return candidates[0]
 
 
 def chromium_executable(browser: str, system: str | None = None) -> str | None:
@@ -223,7 +254,56 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
     return None
 
 
-def _detect_default_windows() -> str | None:
+# Pre-release channels are separate installs with their own profile
+# directories and their own identifiers: Chrome Beta/Dev/Canary register
+# ChromeBHTML / ChromeDHTML / ChromeSSHTM (chrome/install_static/
+# google_chrome_install_modes.h), Edge Beta/Dev MSEdgeBHTML / MSEdgeDHTML, and
+# on macOS/Linux the channel id merely extends the stable one
+# (com.google.chrome.canary, google-chrome-beta.desktop). The stable maps must
+# not swallow those — that would drive stable's profile while the user's
+# default browser is the channel build — so they are recognised first and
+# reported by name; the caller fails closed.
+_UNSUPPORTED_CHANNELS = (
+    ("chromebhtml", "Google Chrome Beta"),
+    ("chromedhtml", "Google Chrome Dev"),
+    ("chromesshtm", "Google Chrome Canary"),
+    ("msedgebhtml", "Microsoft Edge Beta"),
+    ("msedgedhtml", "Microsoft Edge Dev"),
+    ("msedgesshtm", "Microsoft Edge Canary"),
+    ("com.google.chrome.beta", "Google Chrome Beta"),
+    ("com.google.chrome.dev", "Google Chrome Dev"),
+    ("com.google.chrome.canary", "Google Chrome Canary"),
+    ("com.microsoft.edgemac.beta", "Microsoft Edge Beta"),
+    ("com.microsoft.edgemac.dev", "Microsoft Edge Dev"),
+    ("com.microsoft.edgemac.canary", "Microsoft Edge Canary"),
+    ("com.brave.browser.beta", "Brave Beta"),
+    ("com.brave.browser.dev", "Brave Dev"),
+    ("com.brave.browser.nightly", "Brave Nightly"),
+    ("google-chrome-beta", "Google Chrome Beta"),
+    ("google-chrome-unstable", "Google Chrome Dev"),
+    ("microsoft-edge-beta", "Microsoft Edge Beta"),
+    ("microsoft-edge-dev", "Microsoft Edge Dev"),
+    ("brave-browser-beta", "Brave Beta"),
+    ("brave-browser-dev", "Brave Dev"),
+    ("brave-browser-nightly", "Brave Nightly"),
+)
+
+
+def unsupported_channel(identifier: str | None) -> str | None:
+    """Name the pre-release channel behind a default-browser identifier.
+
+    ``identifier`` is the raw OS value (Windows ProgId, macOS bundle id,
+    Linux .desktop name). Returns e.g. ``"Google Chrome Beta"`` or None for
+    stable builds and non-Chromium browsers.
+    """
+    low = (identifier or "").lower()
+    for fragment, name in _UNSUPPORTED_CHANNELS:
+        if fragment in low:
+            return name
+    return None
+
+
+def _default_windows_progid() -> str | None:
     try:
         import winreg  # type: ignore
     except Exception:
@@ -237,40 +317,102 @@ def _detect_default_windows() -> str | None:
         winreg.CloseKey(key)
     except Exception:
         return None
-    low = str(prog_id or "").lower()
+    return str(prog_id or "") or None
+
+
+def _classify_windows_progid(prog_id: str | None) -> str | None:
+    if unsupported_channel(prog_id):
+        return None
+    low = (prog_id or "").lower()
     for prefix, browser in _WINDOWS_PROGID_MAP:
         if low.startswith(prefix):
             return browser
     return None
 
 
-def _detect_default_darwin() -> str | None:
-    # LaunchServices handler for the https scheme.
-    for reader in (
-        ["defaults", "read", "com.apple.LaunchServices/com.apple.launchservices.secure", "LSHandlers"],
-    ):
-        try:
-            out = subprocess.run(
-                reader,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=5,
-            ).stdout.lower()
-        except Exception:
-            out = ""
-        for frag, browser in _DARWIN_BUNDLE_MAP:
-            if frag in out and "https" in out:
-                return browser
-    # Fallback: first installed Chromium app wins.
-    for browser in _CHROMIUM_BROWSERS:
-        if chromium_executable(browser, "Darwin"):
-            return browser
+def _detect_default_windows() -> str | None:
+    return _classify_windows_progid(_default_windows_progid())
+
+
+_LS_HANDLERS_READER = (
+    "defaults",
+    "read",
+    "com.apple.LaunchServices/com.apple.launchservices.secure",
+    "LSHandlers",
+)
+
+
+def _launchservices_https_handler(dump: str) -> str | None:
+    """Return the bundle id registered for the ``https`` URL scheme.
+
+    ``dump`` is the ``defaults read … LSHandlers`` output: an array of
+    ``{ … }`` dictionaries, one per handler. Only the entry whose
+    ``LSHandlerURLScheme`` is ``https`` counts — a browser registered for
+    another scheme or a file type must not be mistaken for the default.
+    Returns None when no https handler is recorded, which is what macOS
+    stores while Safari (the implicit default) has never been replaced.
+    """
+    entries: list[str] = []
+    depth = 0
+    buf: list[str] = []
+    for ch in dump:
+        if ch == "{":
+            depth += 1
+            if depth == 1:
+                buf = []
+                continue
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                entries.append("".join(buf))
+                continue
+        if depth >= 1:
+            buf.append(ch)
+    for entry in entries:
+        low = entry.lower()
+        if not re.search(r'lshandlerurlscheme\s*=\s*"?https"?\s*;', low):
+            continue
+        # The nested LSHandlerPreferredVersions block carries "-" placeholders
+        # under the same key names; the real bundle id is the first non-"-".
+        for role in re.findall(r'lshandlerrole(?:all|viewer)\s*=\s*"?([a-z0-9.\-]+)"?\s*;', low):
+            if role != "-":
+                return role
+        return None
     return None
 
 
-def _detect_default_linux() -> str | None:
+def _default_darwin_bundle() -> str | None:
+    try:
+        out = subprocess.run(
+            list(_LS_HANDLERS_READER),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        ).stdout
+    except Exception:
+        return None
+    return _launchservices_https_handler(out)
+
+
+def _classify_darwin_bundle(bundle: str | None) -> str | None:
+    if not bundle or unsupported_channel(bundle):
+        return None
+    for frag, browser in _DARWIN_BUNDLE_MAP:
+        if bundle.startswith(frag):
+            return browser
+    # A non-Chromium https handler (Safari, Firefox, Arc, …): fail closed.
+    # No "first installed Chromium wins" fallback — that would drive a
+    # browser the user never made their default.
+    return None
+
+
+def _detect_default_darwin() -> str | None:
+    return _classify_darwin_bundle(_default_darwin_bundle())
+
+
+def _default_linux_desktop() -> str | None:
     try:
         out = subprocess.run(
             ["xdg-settings", "get", "default-web-browser"],
@@ -279,20 +421,48 @@ def _detect_default_linux() -> str | None:
             encoding="utf-8",
             errors="replace",
             timeout=5,
-        ).stdout.strip().lower()
+        ).stdout.strip()
     except Exception:
-        out = ""
+        return None
+    return out or None
+
+
+def _classify_linux_desktop(desktop: str | None) -> str | None:
+    if unsupported_channel(desktop):
+        return None
+    low = (desktop or "").lower()
     for frag, browser in _LINUX_DESKTOP_MAP:
-        if frag in out:
+        if frag in low:
             return browser
     return None
+
+
+def _detect_default_linux() -> str | None:
+    return _classify_linux_desktop(_default_linux_desktop())
+
+
+def default_browser_identifier(system: str | None = None) -> str | None:
+    """Return the raw OS identifier of the default https handler, or None.
+
+    Windows: the UserChoice ProgId; macOS: the LaunchServices bundle id;
+    Linux: the xdg .desktop name. Meant for diagnostics (e.g. naming an
+    unsupported channel in an error); ``detect_default_chromium`` is the
+    classifier.
+    """
+    system = system or platform.system()
+    if system == "Windows":
+        return _default_windows_progid()
+    if system == "Darwin":
+        return _default_darwin_bundle()
+    return _default_linux_desktop()
 
 
 def detect_default_chromium(system: str | None = None) -> str | None:
     """Return the canonical key of the default Chromium browser, or None.
 
-    None means the default browser is non-Chromium (Firefox, Safari) or could
-    not be determined — the caller fails closed rather than guessing.
+    None means the default browser is non-Chromium (Firefox, Safari), a
+    pre-release channel (see ``unsupported_channel``), or could not be
+    determined — the caller fails closed rather than guessing.
     """
     system = system or platform.system()
     if system == "Windows":

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -1,0 +1,251 @@
+"""Default-Chromium detection and profile-dir resolution (hermes_cli.browser_connect).
+
+These exercise the parsers with real command output shapes instead of
+patching the detectors themselves, so a change in what macOS / xdg report is
+caught here rather than in a user's browser session.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.browser_connect as bc
+
+
+def _ls_dump(*entries: str) -> str:
+    return "(\n" + ",\n".join(entries) + "\n)\n"
+
+
+def _handler(scheme: str, bundle: str) -> str:
+    return (
+        "    {\n"
+        "        LSHandlerPreferredVersions =         {\n"
+        '            LSHandlerRoleAll = "-";\n'
+        "        };\n"
+        f'        LSHandlerRoleAll = "{bundle}";\n'
+        f"        LSHandlerURLScheme = {scheme};\n"
+        "    }"
+    )
+
+
+def _content_type_handler(uti: str, bundle: str) -> str:
+    return (
+        "    {\n"
+        f'        LSHandlerContentType = "{uti}";\n'
+        f'        LSHandlerRoleViewer = "{bundle}";\n'
+        "    }"
+    )
+
+
+class TestLaunchServicesHttpsHandler:
+    def test_https_entry_wins_over_other_schemes(self):
+        dump = _ls_dump(
+            _handler("ftp", "com.google.chrome"),
+            _handler("https", "com.apple.safari"),
+        )
+        assert bc._launchservices_https_handler(dump) == "com.apple.safari"
+
+    def test_content_type_registration_is_not_an_https_handler(self):
+        dump = _ls_dump(_content_type_handler("public.html", "com.google.chrome"))
+        assert bc._launchservices_https_handler(dump) is None
+
+    def test_no_entries_means_no_recorded_handler(self):
+        assert bc._launchservices_https_handler("(\n)\n") is None
+        assert bc._launchservices_https_handler("") is None
+
+    def test_nested_dictionary_does_not_split_the_entry(self):
+        dump = _ls_dump(_handler("https", "com.microsoft.edgemac"))
+        assert bc._launchservices_https_handler(dump) == "com.microsoft.edgemac"
+
+
+class TestDetectDefaultDarwin:
+    def _run_with(self, dump: str):
+        class _Proc:
+            stdout = dump
+
+        return patch.object(bc.subprocess, "run", return_value=_Proc())
+
+    def test_chrome_as_https_handler(self):
+        with self._run_with(_ls_dump(_handler("https", "com.google.chrome"))):
+            assert bc._detect_default_darwin() == "chrome"
+
+    def test_safari_default_with_chrome_installed_fails_closed(self):
+        """The old fallback returned the first installed Chromium app; a
+        non-Chromium default must resolve to None even when Chrome exists."""
+        dump = _ls_dump(
+            _handler("https", "com.apple.safari"),
+            _handler("ftp", "com.google.chrome"),
+        )
+        with self._run_with(dump), \
+             patch.object(bc, "chromium_executable", return_value="/Applications/Google Chrome.app/x"):
+            assert bc._detect_default_darwin() is None
+
+    def test_no_handler_recorded_fails_closed(self):
+        with self._run_with("(\n)\n"), \
+             patch.object(bc, "chromium_executable", return_value="/Applications/Google Chrome.app/x"):
+            assert bc._detect_default_darwin() is None
+
+    def test_firefox_default_fails_closed(self):
+        with self._run_with(_ls_dump(_handler("https", "org.mozilla.firefox"))):
+            assert bc._detect_default_darwin() is None
+
+    def test_reader_failure_fails_closed(self):
+        with patch.object(bc.subprocess, "run", side_effect=OSError("no defaults")):
+            assert bc._detect_default_darwin() is None
+
+    @pytest.mark.parametrize(
+        "bundle,expected",
+        [
+            ("com.google.Chrome", "chrome"),
+            ("com.brave.Browser", "brave"),
+            ("com.microsoft.edgemac", "edge"),
+            ("org.chromium.Chromium", "chromium"),
+        ],
+    )
+    def test_bundle_map(self, bundle, expected):
+        with self._run_with(_ls_dump(_handler("https", bundle))):
+            assert bc._detect_default_darwin() == expected
+
+
+class TestPreReleaseChannels:
+    """Channel builds keep their own profile; the stable maps must neither
+    swallow them (macOS/Linux ids extend the stable id) nor report them as
+    'not a Chromium browser' (Windows ProgIds differ per channel)."""
+
+    @pytest.mark.parametrize(
+        "prog_id,expected",
+        [
+            ("ChromeHTML", "chrome"),
+            ("ChromeHTML.ABCDEF", "chrome"),
+            ("ChromeBHTML", None),
+            ("ChromeDHTML.X", None),
+            ("ChromeSSHTM", None),
+            ("MSEdgeHTM", "edge"),
+            ("MSEdgeBHTML", None),
+            ("MSEdgeDHTML", None),
+            ("BraveHTML", "brave"),
+            ("FirefoxURL-308046B0AF4A39CB", None),
+            (None, None),
+        ],
+    )
+    def test_windows_progid_classification(self, prog_id, expected):
+        assert bc._classify_windows_progid(prog_id) == expected
+
+    @pytest.mark.parametrize(
+        "prog_id,channel",
+        [
+            ("ChromeBHTML", "Google Chrome Beta"),
+            ("ChromeDHTML", "Google Chrome Dev"),
+            ("ChromeSSHTM.X", "Google Chrome Canary"),
+            ("MSEdgeBHTML", "Microsoft Edge Beta"),
+            ("MSEdgeDHTML", "Microsoft Edge Dev"),
+            ("ChromeHTML", None),
+            ("FirefoxURL", None),
+        ],
+    )
+    def test_windows_channel_names(self, prog_id, channel):
+        assert bc.unsupported_channel(prog_id) == channel
+
+    @pytest.mark.parametrize(
+        "bundle,expected,channel",
+        [
+            ("com.google.chrome", "chrome", None),
+            ("com.google.chrome.canary", None, "Google Chrome Canary"),
+            ("com.google.chrome.beta", None, "Google Chrome Beta"),
+            ("com.microsoft.edgemac", "edge", None),
+            ("com.microsoft.edgemac.beta", None, "Microsoft Edge Beta"),
+            ("com.brave.browser", "brave", None),
+            ("com.brave.browser.nightly", None, "Brave Nightly"),
+        ],
+    )
+    def test_darwin_bundle_classification(self, bundle, expected, channel):
+        assert bc._classify_darwin_bundle(bundle) == expected
+        assert bc.unsupported_channel(bundle) == channel
+
+    @pytest.mark.parametrize(
+        "desktop,expected,channel",
+        [
+            ("google-chrome.desktop", "chrome", None),
+            ("google-chrome-beta.desktop", None, "Google Chrome Beta"),
+            ("google-chrome-unstable.desktop", None, "Google Chrome Dev"),
+            ("microsoft-edge-dev.desktop", None, "Microsoft Edge Dev"),
+            ("brave-browser-nightly.desktop", None, "Brave Nightly"),
+            ("brave-browser.desktop", "brave", None),
+        ],
+    )
+    def test_linux_desktop_classification(self, desktop, expected, channel):
+        assert bc._classify_linux_desktop(desktop) == expected
+        assert bc.unsupported_channel(desktop) == channel
+
+    def test_identifier_is_exposed_for_diagnostics(self):
+        class _Proc:
+            stdout = "google-chrome-beta.desktop\n"
+
+        with patch.object(bc.subprocess, "run", return_value=_Proc()):
+            assert bc.default_browser_identifier("Linux") == "google-chrome-beta.desktop"
+            assert bc.detect_default_chromium("Linux") is None
+
+
+class TestDetectDefaultLinux:
+    def _run_with(self, output: str):
+        class _Proc:
+            stdout = output
+
+        return patch.object(bc.subprocess, "run", return_value=_Proc())
+
+    @pytest.mark.parametrize(
+        "desktop,expected",
+        [
+            ("google-chrome.desktop", "chrome"),
+            ("com.google.Chrome.desktop", "chrome"),
+            ("chromium_chromium.desktop", "chromium"),
+            ("org.chromium.Chromium.desktop", "chromium"),
+            ("brave-browser.desktop", "brave"),
+            ("com.brave.Browser.desktop", "brave"),
+            ("microsoft-edge.desktop", "edge"),
+            ("com.microsoft.Edge.desktop", "edge"),
+            ("firefox.desktop", None),
+            ("org.mozilla.firefox.desktop", None),
+            ("", None),
+        ],
+    )
+    def test_xdg_desktop_names(self, desktop, expected):
+        with self._run_with(desktop + "\n"):
+            assert bc._detect_default_linux() == expected
+
+    def test_missing_xdg_settings_fails_closed(self):
+        with patch.object(bc.subprocess, "run", side_effect=FileNotFoundError("xdg-settings")):
+            assert bc._detect_default_linux() is None
+
+
+class TestLinuxProfileDir:
+    def _env(self, monkeypatch, home):
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    def test_native_path_when_nothing_exists(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        assert bc.real_profile_data_dir("chromium", "Linux") == str(tmp_path / ".config" / "chromium")
+
+    def test_snap_chromium_profile_is_found(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        snap = tmp_path / "snap" / "chromium" / "common" / "chromium"
+        snap.mkdir(parents=True)
+        assert bc.real_profile_data_dir("chromium", "Linux") == str(snap)
+
+    def test_flatpak_chrome_profile_is_found(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        flatpak = tmp_path / ".var" / "app" / "com.google.Chrome" / "config" / "google-chrome"
+        flatpak.mkdir(parents=True)
+        assert bc.real_profile_data_dir("chrome", "Linux") == str(flatpak)
+
+    def test_native_profile_wins_when_present(self, tmp_path, monkeypatch):
+        self._env(monkeypatch, tmp_path)
+        native = tmp_path / ".config" / "BraveSoftware" / "Brave-Browser"
+        native.mkdir(parents=True)
+        (tmp_path / ".var" / "app" / "com.brave.Browser" / "config" / "BraveSoftware" / "Brave-Browser").mkdir(parents=True)
+        assert bc.real_profile_data_dir("brave", "Linux") == str(native)
+
+    def test_xdg_config_home_is_honoured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/home/t/.config")
+        assert bc.real_profile_data_dir("edge", "Linux") == "/home/t/.config/microsoft-edge"

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -4,6 +4,9 @@ These exercise the parsers with real command output shapes instead of
 patching the detectors themselves, so a change in what macOS / xdg report is
 caught here rather than in a user's browser session.
 """
+import os
+import socket
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -215,6 +218,76 @@ class TestDetectDefaultLinux:
     def test_missing_xdg_settings_fails_closed(self):
         with patch.object(bc.subprocess, "run", side_effect=FileNotFoundError("xdg-settings")):
             assert bc._detect_default_linux() is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SingletonLock symlink is the POSIX lock")
+class TestProfileLockHolder:
+    @staticmethod
+    def _dead_pid() -> int:
+        proc = subprocess.Popen(["true"])
+        proc.wait()
+        return proc.pid
+
+    def test_no_lock_is_free(self, tmp_path):
+        assert bc.profile_lock_holder(str(tmp_path)) is None
+
+    def test_live_pid_on_this_host_is_in_use(self, tmp_path):
+        os.symlink(f"{socket.gethostname()}-{os.getpid()}", tmp_path / "SingletonLock")
+        assert bc.profile_lock_holder(str(tmp_path)) == f"pid {os.getpid()}"
+
+    def test_stale_lock_from_dead_pid_is_free(self, tmp_path):
+        os.symlink(f"{socket.gethostname()}-{self._dead_pid()}", tmp_path / "SingletonLock")
+        assert bc.profile_lock_holder(str(tmp_path)) is None
+
+    def test_lock_from_another_host_is_in_use(self, tmp_path):
+        os.symlink("elsewhere-12345", tmp_path / "SingletonLock")
+        holder = bc.profile_lock_holder(str(tmp_path))
+        assert holder and "elsewhere" in holder
+
+    def test_unparsable_lock_is_ignored(self, tmp_path):
+        os.symlink("garbage", tmp_path / "SingletonLock")
+        assert bc.profile_lock_holder(str(tmp_path)) is None
+
+
+class TestChromiumMajorVersion:
+    def _run_with(self, output: str):
+        class _Proc:
+            stdout = output
+
+        return patch.object(bc.subprocess, "run", return_value=_Proc())
+
+    @pytest.mark.skipif(os.name == "nt", reason="--version is not run on Windows")
+    @pytest.mark.parametrize(
+        "output,expected",
+        [
+            ("Google Chrome 152.0.7977.64 \n", 152),
+            ("Chromium 151.0.7900.12 snap\n", 151),
+            ("Brave Browser 141.1.85.100\n", 141),
+            ("Microsoft Edge 150.0.3200.5\n", 150),
+        ],
+    )
+    def test_parses_version_output(self, tmp_path, output, expected):
+        exe = tmp_path / "chrome"
+        exe.write_text("", encoding="utf-8")
+        with self._run_with(output):
+            assert bc.chromium_major_version(str(exe)) == expected
+
+    def test_falls_back_to_versioned_directory(self, tmp_path):
+        """Windows layout: …\\Application\\<version>\\ next to chrome.exe."""
+        app = tmp_path / "Application"
+        app.mkdir()
+        (app / "chrome.exe").write_text("", encoding="utf-8")
+        (app / "140.0.7300.10").mkdir()
+        (app / "152.0.7977.64").mkdir()
+        (app / "SetupMetrics").mkdir()
+        with patch.object(bc.subprocess, "run", side_effect=OSError("cannot run")):
+            assert bc.chromium_major_version(str(app / "chrome.exe")) == 152
+
+    def test_unknown_when_nothing_matches(self, tmp_path):
+        exe = tmp_path / "chrome"
+        exe.write_text("", encoding="utf-8")
+        with self._run_with("garbage"):
+            assert bc.chromium_major_version(str(exe)) is None
 
 
 class TestLinuxProfileDir:

--- a/tests/tools/test_browser_extension_router_wiring.py
+++ b/tests/tools/test_browser_extension_router_wiring.py
@@ -36,7 +36,11 @@ def _route_spy(monkeypatch):
 
     monkeypatch.setattr(browser_tool, "routed_browser_handler", spy)
     monkeypatch.setattr(browser_cdp_tool, "routed_browser_handler", spy)
-    monkeypatch.setattr(browser_tool, "browser_navigate", lambda url="", task_id=None: "legacy-nav")
+    monkeypatch.setattr(
+        browser_tool,
+        "browser_navigate",
+        lambda url="", task_id=None, local_browser=False: "legacy-nav",
+    )
     monkeypatch.setattr(browser_cdp_tool, "browser_cdp", lambda *a, **k: "legacy-cdp")
     return calls
 

--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -96,7 +96,9 @@ class TestBrowserNavigateOpenTimeout:
         monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
         monkeypatch.setattr(bt, "_is_local_backend", lambda: True)
         monkeypatch.setattr(bt, "_is_local_sidecar_key", lambda key: False)
-        monkeypatch.setattr(bt, "_navigation_session_key", lambda task_id, url: task_id)
+        monkeypatch.setattr(
+            bt, "_navigation_session_key", lambda task_id, url, local_browser=False: task_id
+        )
         monkeypatch.setattr(bt, "_maybe_start_recording", lambda *a, **kw: None)
         monkeypatch.setattr(bt, "check_website_access", lambda url: None)
 

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -41,6 +41,35 @@ class TestRealProfileResolvers:
             assert bc.detect_default_chromium("Linux") is None
 
 
+class TestUseRealProfileConsent:
+    """The consent flag is re-read per call: revocation must not wait for a
+    process restart, and multiplexed profiles must not inherit each other's
+    consent through a module-level cache."""
+
+    def test_toggle_off_revokes_without_restart(self):
+        import tools.browser_tool as bt
+        reads = [
+            {"browser": {"use_real_profile": True}},
+            {"browser": {"use_real_profile": False}},
+        ]
+        with patch("hermes_cli.config.read_raw_config", side_effect=reads):
+            assert bt._use_real_profile() is True
+            assert bt._use_real_profile() is False
+
+    def test_string_false_is_off(self):
+        import tools.browser_tool as bt
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"use_real_profile": "false"}}):
+            assert bt._use_real_profile() is False
+
+    def test_missing_key_and_unreadable_config_are_off(self):
+        import tools.browser_tool as bt
+        with patch("hermes_cli.config.read_raw_config", return_value={"browser": {}}):
+            assert bt._use_real_profile() is False
+        with patch("hermes_cli.config.read_raw_config", side_effect=OSError("boom")):
+            assert bt._use_real_profile() is False
+
+
 class TestRealProfileLaunchArgs:
     def _reset(self):
         import tools.browser_tool as bt
@@ -330,8 +359,49 @@ class TestLocalBrowserRouting:
         self._reset()
         with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
              patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_get_cloud_provider", return_value=Mock()), \
+             patch.object(bt, "_url_is_private", return_value=False), \
              patch.object(bt, "_use_real_profile", return_value=True):
             key = bt._navigation_session_key("t1", "https://example.com", local_browser=True)
+        assert key == "t1::local"
+
+    def test_local_browser_without_cloud_provider_keeps_bare_session(self):
+        """Pure local backend: the bare session already is the (real-profile)
+        local Chromium; a second ``::local`` session would fight it for the
+        same user-data-dir."""
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
+             patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_get_cloud_provider", return_value=None), \
+             patch.object(bt, "_use_real_profile", return_value=True):
+            key = bt._navigation_session_key("t1", "https://example.com", local_browser=True)
+        assert key == "t1"
+
+    def test_local_browser_respects_private_url_opt_out(self):
+        """auto_local_for_private_urls: false is the user's LAN routing
+        decision; a model-supplied flag must not override it."""
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
+             patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_get_cloud_provider", return_value=Mock()), \
+             patch.object(bt, "_url_is_private", return_value=True), \
+             patch.object(bt, "_auto_local_for_private_urls", return_value=False), \
+             patch.object(bt, "_use_real_profile", return_value=True):
+            key = bt._navigation_session_key("t1", "http://192.168.1.1/admin", local_browser=True)
+        assert key == "t1"
+
+    def test_local_browser_private_url_follows_auto_local_when_allowed(self):
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_get_cdp_override_raw", return_value=""), \
+             patch.object(bt, "_is_camofox_mode", return_value=False), \
+             patch.object(bt, "_get_cloud_provider", return_value=Mock()), \
+             patch.object(bt, "_url_is_private", return_value=True), \
+             patch.object(bt, "_auto_local_for_private_urls", return_value=True), \
+             patch.object(bt, "_use_real_profile", return_value=True):
+            key = bt._navigation_session_key("t1", "http://192.168.1.1/admin", local_browser=True)
         assert key == "t1::local"
 
     def test_local_browser_ignored_without_consent(self):

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1,7 +1,7 @@
 """Tests for real-profile local browser resolution + routing."""
 import os
 import ntpath
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -46,6 +46,7 @@ class TestRealProfileLaunchArgs:
         import tools.browser_tool as bt
         bt._use_real_profile_resolved = False
         bt._cached_use_real_profile = False
+        bt._real_profile_args_cache = None
 
     def test_consent_off_is_noop(self):
         import tools.browser_tool as bt
@@ -58,10 +59,23 @@ class TestRealProfileLaunchArgs:
         import tools.browser_tool as bt
         self._reset()
         with patch.object(bt, "_use_real_profile", return_value=True), \
-             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None):
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None), \
+             patch("hermes_cli.browser_connect.default_browser_identifier", return_value="firefox.desktop"):
             args, err = bt._real_profile_launch_args()
         assert args == []
         assert err and "not a supported Chromium" in err
+
+    def test_pre_release_channel_is_named_in_the_error(self):
+        """Chrome Beta/Dev/Canary and Edge Beta/Dev are separate installs with
+        their own profiles; say which one it is instead of 'not a Chromium'."""
+        import tools.browser_tool as bt
+        self._reset()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value=None), \
+             patch("hermes_cli.browser_connect.default_browser_identifier", return_value="ChromeBHTML.H1"):
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "Google Chrome Beta" in err and "stable channels" in err
 
     def test_chromium_default_injects_profile(self, tmp_path):
         import tools.browser_tool as bt
@@ -71,7 +85,8 @@ class TestRealProfileLaunchArgs:
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
-             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"):
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"), \
+             patch("hermes_cli.browser_connect.chromium_major_version", return_value=None):
             args, err = bt._real_profile_launch_args()
         assert err is None
         assert "--profile" in args and str(data_dir) in args
@@ -87,12 +102,228 @@ class TestRealProfileLaunchArgs:
         assert args == []
         assert err and "profile directory was not found" in err
 
+    def test_missing_executable_fails_closed(self, tmp_path):
+        """No resolvable binary must not fall through to ``--profile`` alone —
+        agent-browser would then open the real profile with its bundled
+        Chromium (one-way profile migration)."""
+        import tools.browser_tool as bt
+        self._reset()
+        data_dir = tmp_path / "chrome-user-data"
+        data_dir.mkdir()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value=None):
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "executable could not be located" in err
+
+    def _chrome_ready(self, tmp_path, major):
+        import tools.browser_tool as bt
+        self._reset()
+        data_dir = tmp_path / "chrome-user-data"
+        data_dir.mkdir(exist_ok=True)
+        version = Mock(return_value=major)
+        ctx = [
+            patch.object(bt, "_use_real_profile", return_value=True),
+            patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"),
+            patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)),
+            patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"),
+            patch("hermes_cli.browser_connect.chromium_major_version", version),
+        ]
+        return bt, ctx, version
+
+    def test_google_chrome_136_plus_fails_closed(self, tmp_path):
+        """Branded Chrome refuses remote debugging on its default profile dir;
+        agent-browser would hang waiting for DevToolsActivePort (reproduced
+        by the reviewer on Chrome 152)."""
+        from contextlib import ExitStack
+        bt, ctx, _ = self._chrome_ready(tmp_path, 152)
+        with ExitStack() as stack:
+            for c in ctx:
+                stack.enter_context(c)
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "Google Chrome 152" in err and "hang" in err
+
+    def test_google_chrome_before_136_launches(self, tmp_path):
+        from contextlib import ExitStack
+        bt, ctx, _ = self._chrome_ready(tmp_path, 130)
+        with ExitStack() as stack:
+            for c in ctx:
+                stack.enter_context(c)
+            args, err = bt._real_profile_launch_args()
+        assert err is None and "--profile" in args
+
+    def test_unknown_chrome_version_is_not_blocked(self, tmp_path):
+        from contextlib import ExitStack
+        bt, ctx, _ = self._chrome_ready(tmp_path, None)
+        with ExitStack() as stack:
+            for c in ctx:
+                stack.enter_context(c)
+            args, err = bt._real_profile_launch_args()
+        assert err is None and "--profile" in args
+
+    def test_version_gate_only_applies_to_google_chrome(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        data_dir = tmp_path / "brave-user-data"
+        data_dir.mkdir()
+        version = Mock(return_value=152)
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="brave"), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/brave"), \
+             patch("hermes_cli.browser_connect.chromium_major_version", version):
+            args, err = bt._real_profile_launch_args()
+        assert err is None and "--profile" in args
+        version.assert_not_called()
+
+    def test_profile_in_use_fails_closed(self, tmp_path):
+        """A running browser on the profile would make Chromium hand off and
+        exit; agent-browser then retries into a timeout. Say so up front."""
+        import tools.browser_tool as bt
+        self._reset()
+        data_dir = tmp_path / "chrome-user-data"
+        data_dir.mkdir()
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
+             patch("hermes_cli.browser_connect.profile_lock_holder", return_value="pid 4242"), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"):
+            args, err = bt._real_profile_launch_args()
+        assert args == []
+        assert err and "open in another Chromium process (pid 4242)" in err
+
+    def test_resolution_is_cached_per_process(self, tmp_path):
+        """Detection shells out to the OS; it must run once, not per command,
+        and the launch flags must stay identical (agent-browser hashes them)."""
+        import tools.browser_tool as bt
+        from unittest.mock import Mock
+        self._reset()
+        data_dir = tmp_path / "chrome-user-data"
+        data_dir.mkdir()
+        detect = Mock(return_value="chrome")
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", detect), \
+             patch("hermes_cli.browser_connect.real_profile_data_dir", return_value=str(data_dir)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/google-chrome"), \
+             patch("hermes_cli.browser_connect.chromium_major_version", return_value=None):
+            first = bt._real_profile_launch_args()
+            second = bt._real_profile_launch_args()
+        assert first == second and first[1] is None
+        assert detect.call_count == 1
+
+    def test_cache_drops_when_consent_turns_off(self, tmp_path):
+        import tools.browser_tool as bt
+        self._reset()
+        bt._real_profile_args_cache = (["--profile", "/x"], None)
+        with patch.object(bt, "_use_real_profile", return_value=False):
+            assert bt._real_profile_launch_args() == ([], None)
+        assert bt._real_profile_args_cache is None
+
+
+class TestRunBrowserCommandInjection:
+    """_run_browser_command must inject the resolved flags on local launches,
+    fail closed on resolver errors — except for ``close``, which has to reach
+    an already-running daemon."""
+
+    def _run(self, tmp_path, command, profile_result, chromium_installed=True):
+        import json
+        import os
+        from unittest.mock import MagicMock, mock_open
+        import tools.browser_tool as bt
+
+        captured = {}
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return proc
+
+        fake_session = {"session_name": "test-session", "session_id": "id", "cdp_url": None}
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._chromium_installed", return_value=chromium_installed), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("tools.browser_tool._real_profile_launch_args", return_value=profile_result), \
+             patch("hermes_constants.Path.home", return_value=tmp_path), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(os.environ, {"PATH": "/usr/bin:/bin", "HOME": str(tmp_path),
+                                     "HERMES_HOME": str(tmp_path / "hh")}, clear=True), \
+             patch("builtins.open", mock_open(read_data=json.dumps({"success": True}))):
+            result = bt._run_browser_command("t", command, [])
+        return result, captured.get("cmd")
+
+    def test_profile_flags_land_in_argv(self, tmp_path):
+        result, cmd = self._run(
+            tmp_path, "open", (["--profile", "/p", "--executable-path", "/bin/chrome"], None)
+        )
+        assert result.get("success") is True
+        assert cmd[1:7] == ["--session", "test-session", "--profile", "/p",
+                            "--executable-path", "/bin/chrome"]
+
+    def test_resolver_error_fails_closed_before_launch(self, tmp_path):
+        result, cmd = self._run(tmp_path, "open", ([], "no chromium default"))
+        assert result == {"success": False, "error": "no chromium default"}
+        assert cmd is None
+
+    def test_close_still_reaches_agent_browser_on_resolver_error(self, tmp_path):
+        result, cmd = self._run(tmp_path, "close", ([], "no chromium default"))
+        assert cmd is not None and cmd[1:5] == ["--session", "test-session", "--json", "close"]
+        assert "--profile" not in cmd
+
+    def test_real_browser_binary_skips_the_bundled_chromium_gate(self, tmp_path):
+        """A consented launch runs the user's own browser; the bundled-Chromium
+        check must neither block it nor trigger the ~170 MB auto-install."""
+        import tools.browser_tool as bt
+        autoinstall = Mock(return_value=False)
+        with patch.object(bt, "_is_local_mode", return_value=True), \
+             patch.object(bt, "_maybe_autoinstall_chromium", autoinstall):
+            result, cmd = self._run(
+                tmp_path, "open",
+                (["--profile", "/p", "--executable-path", "/Applications/Google Chrome.app/x"], None),
+                chromium_installed=False,
+            )
+        assert result.get("success") is True
+        assert cmd is not None and "--executable-path" in cmd
+        autoinstall.assert_not_called()
+
+    def test_gate_still_applies_without_a_real_binary(self, tmp_path):
+        import tools.browser_tool as bt
+        with patch.object(bt, "_is_local_mode", return_value=True), \
+             patch.object(bt, "_maybe_autoinstall_chromium", return_value=False), \
+             patch.object(bt, "_running_in_docker", return_value=False):
+            result, cmd = self._run(tmp_path, "open", ([], None), chromium_installed=False)
+        assert result.get("success") is False
+        assert "Chromium browser is missing" in result["error"]
+        assert cmd is None
+
+    def test_lightpanda_engine_conflicts_with_real_profile(self, tmp_path):
+        """agent-browser rejects --profile for Lightpanda; surface a config
+        conflict instead of letting the Chrome fallback drop the profile."""
+        import tools.browser_tool as bt
+        with patch.object(bt, "_get_browser_engine", return_value="lightpanda"):
+            result, cmd = self._run(
+                tmp_path, "open", (["--profile", "/p", "--executable-path", "/bin/chrome"], None)
+            )
+        assert result.get("success") is False
+        assert "lightpanda" in result["error"]
+        assert cmd is None
+
 
 class TestLocalBrowserRouting:
     def _reset(self):
         import tools.browser_tool as bt
         bt._use_real_profile_resolved = False
         bt._cached_use_real_profile = False
+        bt._real_profile_args_cache = None
 
     def test_local_browser_forces_sidecar_with_consent(self):
         import tools.browser_tool as bt

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -347,6 +347,95 @@ class TestRunBrowserCommandInjection:
         assert cmd is None
 
 
+class TestBrowserNavigateAudit:
+    """Navigation results say when they ran on the real profile, and the
+    consent-off note survives failures — the cases it actually explains."""
+
+    def _wire(self, monkeypatch, *, session, open_result, consent, local_backend=True):
+        import json
+        import tools.browser_tool as bt
+
+        def fake_run(task_id, command, args, timeout=None):
+            if command == "open":
+                return open_result
+            return {"success": True, "data": {}}
+
+        monkeypatch.setattr(bt, "_run_browser_command", fake_run)
+        monkeypatch.setattr(bt, "_get_session_info", lambda key: session)
+        monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(bt, "_is_local_backend", lambda: local_backend)
+        monkeypatch.setattr(bt, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(
+            bt, "_navigation_session_key", lambda task_id, url, local_browser=False: task_id
+        )
+        monkeypatch.setattr(bt, "_maybe_start_recording", lambda *a, **kw: None)
+        monkeypatch.setattr(bt, "check_website_access", lambda url: None)
+        monkeypatch.setattr(bt, "_use_real_profile", lambda: consent)
+        monkeypatch.setattr(bt, "_last_active_session_key", {})
+        return bt, json
+
+    def test_local_session_under_consent_is_stamped(self, monkeypatch):
+        bt, json = self._wire(
+            monkeypatch,
+            session={"_first_nav": True, "features": {}},
+            open_result={"success": True, "data": {"title": "t", "url": "https://example.com"}},
+            consent=True,
+        )
+        out = json.loads(bt.browser_navigate("https://example.com", task_id="t1"))
+        assert out["success"] is True
+        assert out["used_real_profile"] is True
+
+    def test_cloud_session_is_never_stamped(self, monkeypatch):
+        bt, json = self._wire(
+            monkeypatch,
+            session={"_first_nav": True, "features": {}, "cdp_url": "wss://cloud"},
+            open_result={"success": True, "data": {"title": "t", "url": "https://example.com"}},
+            consent=True,
+        )
+        out = json.loads(bt.browser_navigate("https://example.com", task_id="t1"))
+        assert "used_real_profile" not in out
+
+    def test_no_consent_means_no_stamp(self, monkeypatch):
+        bt, json = self._wire(
+            monkeypatch,
+            session={"_first_nav": True, "features": {}},
+            open_result={"success": True, "data": {"title": "t", "url": "https://example.com"}},
+            consent=False,
+        )
+        out = json.loads(bt.browser_navigate("https://example.com", task_id="t1"))
+        assert "used_real_profile" not in out
+
+    def test_consent_off_note_survives_open_failure(self, monkeypatch):
+        bt, json = self._wire(
+            monkeypatch,
+            session={"_first_nav": True, "features": {}},
+            open_result={"success": False, "error": "boom"},
+            consent=False,
+        )
+        out = json.loads(bt.browser_navigate("https://example.com", task_id="t1", local_browser=True))
+        assert out == {
+            "success": False,
+            "error": "boom",
+            "note": out["note"],
+        }
+        assert "use_real_profile is off" in out["note"]
+
+    def test_consent_off_note_survives_private_url_block(self, monkeypatch):
+        bt, json = self._wire(
+            monkeypatch,
+            session={"_first_nav": True, "features": {}},
+            open_result={"success": True, "data": {}},
+            consent=False,
+            local_backend=False,
+        )
+        monkeypatch.setattr(bt, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(bt, "_is_safe_url", lambda url: False)
+        out = json.loads(bt.browser_navigate("http://192.168.1.1/admin", task_id="t1", local_browser=True))
+        assert out["success"] is False
+        assert "private or internal address" in out["error"]
+        assert "use_real_profile is off" in out["note"]
+
+
 class TestLocalBrowserRouting:
     def _reset(self):
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1025,8 +1025,8 @@ def _is_local_backend() -> bool:
 _auto_local_for_private_urls_resolved = False
 _cached_auto_local_for_private_urls: bool = True
 
-_use_real_profile_resolved = False
-_cached_use_real_profile: bool = False
+# browser.use_real_profile itself is read per call (consent switch, see
+# _use_real_profile); only the derived launch flags are cached:
 # (args, error) from _resolve_real_profile_launch_args, or None when unresolved.
 _real_profile_args_cache: Optional[tuple] = None
 
@@ -1435,25 +1435,28 @@ def _auto_local_for_private_urls() -> bool:
 def _use_real_profile() -> bool:
     """Return whether the user consented to real-profile local browsing.
 
-    Reads ``browser.use_real_profile`` (default False) once and caches it. When
-    True, local Chromium launches point agent-browser at the user's REAL
+    Reads ``browser.use_real_profile`` (default False) on every call. This is
+    a consent switch, so it is deliberately not cached for the process:
+    turning it off has to revoke immediately (the desktop save path writes
+    config.yaml and does not restart the backend), and the profile
+    multiplexer scopes config per turn through a ContextVar, so a cached
+    value would hand one profile's consent to another. Callers that need the
+    derived launch flags to stay identical across commands cache those
+    instead (see _real_profile_launch_args).
+
+    When True, local Chromium launches point agent-browser at the user's REAL
     default-browser profile, and the browser tools' ``local_browser`` argument
     is honored.
     """
-    global _use_real_profile_resolved, _cached_use_real_profile
-    if _use_real_profile_resolved:
-        return _cached_use_real_profile
-
-    _use_real_profile_resolved = True
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
-        if isinstance(browser_cfg, dict) and "use_real_profile" in browser_cfg:
-            _cached_use_real_profile = bool(browser_cfg.get("use_real_profile"))
+        if isinstance(browser_cfg, dict):
+            return is_truthy_value(browser_cfg.get("use_real_profile"), default=False)
     except Exception as e:
         logger.debug("Could not read use_real_profile from config: %s", e)
-    return _cached_use_real_profile
+    return False
 
 
 def _real_profile_launch_args() -> tuple:
@@ -1643,10 +1646,14 @@ def _navigation_session_key(task_id: str, url: str, local_browser: bool = False)
     continues to serve public URLs.
 
     ``local_browser=True`` (the model-facing arg) forces the ``::local`` sidecar
-    regardless of the URL — but ONLY when the user consented to real-profile
+    for the backend choice — but ONLY when the user consented to real-profile
     browsing (``browser.use_real_profile``). Without consent the flag is ignored
     (the caller surfaces a note); it never silently routes to the real profile.
-    A CDP override or Camofox mode still owns the session and is not overridden.
+    It does not override the private-URL policy: a private URL is still routed
+    exactly as ``browser.auto_local_for_private_urls`` says. Without a cloud
+    provider the bare session is already local (and already carries the real
+    profile when consented), so the flag adds nothing there. A CDP override or
+    Camofox mode still owns the session and is not overridden.
     """
     if task_id is None:
         task_id = "default"
@@ -1654,10 +1661,18 @@ def _navigation_session_key(task_id: str, url: str, local_browser: bool = False)
         return task_id
     if _is_camofox_mode():
         return task_id
-    if local_browser and _use_real_profile():
-        return f"{task_id}{_LOCAL_SUFFIX}"
     if _get_cloud_provider() is None:
+        # Already local. A second ``::local`` session for the same task would
+        # contend with the bare one for the same user-data-dir.
         return task_id
+    if local_browser and _use_real_profile():
+        # Every private-URL gate in browser_navigate keys off the sidecar
+        # key, so honouring the flag for a private URL while the user opted
+        # out of auto-local routing would turn a model-supplied argument
+        # into a LAN policy override.
+        if _url_is_private(url) and not _auto_local_for_private_urls():
+            return task_id
+        return f"{task_id}{_LOCAL_SUFFIX}"
     if not _auto_local_for_private_urls():
         return task_id
     if not _url_is_private(url):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1027,6 +1027,8 @@ _cached_auto_local_for_private_urls: bool = True
 
 _use_real_profile_resolved = False
 _cached_use_real_profile: bool = False
+# (args, error) from _resolve_real_profile_launch_args, or None when unresolved.
+_real_profile_args_cache: Optional[tuple] = None
 
 
 def _get_browser_engine() -> str:
@@ -1462,22 +1464,59 @@ def _real_profile_launch_args() -> tuple:
     Returns ``([], <message>)`` when the default browser is non-Chromium or its
     profile/binary cannot be located, so the caller can fail closed with a
     clear reason. Returns ``([], None)`` when consent is off (no-op).
+
+    The resolution is cached for the process: it shells out to the OS
+    default-browser query and _run_browser_command calls this for every
+    agent-browser command, and agent-browser hashes the launch flags per
+    session, so they must be identical from one command to the next. The
+    cache is dropped when consent turns off and by cleanup_all_browsers().
     """
+    global _real_profile_args_cache
     if not _use_real_profile():
+        _real_profile_args_cache = None
         return [], None
+    if _real_profile_args_cache is None:
+        _real_profile_args_cache = _resolve_real_profile_launch_args()
+    return _real_profile_args_cache
+
+
+def _real_profile_provides_executable() -> bool:
+    """True when consent is on and the resolver found the user's own browser
+    binary — the launch then uses that binary, not the bundled Chromium."""
+    args, err = _real_profile_launch_args()
+    return not err and "--executable-path" in args
+
+
+def _resolve_real_profile_launch_args() -> tuple:
+    """Uncached resolver behind _real_profile_launch_args (consent assumed)."""
     from hermes_cli.browser_connect import (
+        CHROME_DEFAULT_PROFILE_DEBUG_BLOCK_MAJOR,
         chromium_executable,
+        chromium_major_version,
+        default_browser_identifier,
         detect_default_chromium,
+        profile_lock_holder,
         real_profile_data_dir,
+        unsupported_channel,
     )
 
     browser = detect_default_chromium()
     if browser is None:
+        channel = unsupported_channel(default_browser_identifier())
+        if channel:
+            return [], (
+                f"browser.use_real_profile is on, but your default browser is "
+                f"{channel}. Real-profile browsing supports the stable channels "
+                "of Chrome, Edge, Brave and Chromium only — pre-release channels "
+                "keep separate profiles. Make a stable Chromium your default "
+                "browser, or turn the toggle off."
+            )
         return [], (
             "browser.use_real_profile is on, but your default browser is not a "
-            "supported Chromium browser (Chrome, Edge, Brave, Chromium). "
-            "Real-profile browsing requires a Chromium default; set one or turn "
-            "the toggle off."
+            "supported Chromium browser (Chrome, Edge, Brave, Chromium) or "
+            "could not be determined (no xdg-settings / LaunchServices answer, "
+            "e.g. on a headless host). Real-profile browsing requires a Chromium "
+            "default; set one or turn the toggle off."
         )
     data_dir = real_profile_data_dir(browser)
     if not data_dir or not os.path.isdir(data_dir):
@@ -1487,11 +1526,42 @@ def _real_profile_launch_args() -> tuple:
             f"({data_dir!r}). Launch that browser at least once, or turn the "
             "toggle off."
         )
-    args = ["--profile", data_dir]
+    holder = profile_lock_holder(data_dir)
+    if holder:
+        return [], (
+            f"browser.use_real_profile is on, but the {browser} profile at "
+            f"{data_dir!r} is open in another Chromium process ({holder}). "
+            "Chromium allows one process per profile directory — close your "
+            f"{browser} (and any other Hermes session using it) first, or turn "
+            "the toggle off."
+        )
     exe = chromium_executable(browser)
-    if exe:
-        args += ["--executable-path", exe]
-    return args, None
+    if not exe:
+        # Without the real binary agent-browser would open the real profile
+        # with whatever Chromium it finds (its own download, Playwright's
+        # cache) — a one-way profile migration for the user's browser, and
+        # on Windows the app-bound cookies would not decrypt anyway.
+        return [], (
+            f"browser.use_real_profile is on and your default browser is "
+            f"'{browser}', but its executable could not be located. Refusing "
+            "to open the real profile with a different Chromium build. "
+            f"Reinstall {browser} or turn the toggle off."
+        )
+    if browser == "chrome":
+        major = chromium_major_version(exe)
+        if major is not None and major >= CHROME_DEFAULT_PROFILE_DEBUG_BLOCK_MAJOR:
+            # Branded Chrome would start, refuse remote debugging on its
+            # default profile dir, and agent-browser would wait for a
+            # DevToolsActivePort that never appears — a silent hang.
+            return [], (
+                f"browser.use_real_profile is on, but Google Chrome {major} "
+                "refuses remote debugging on its default profile directory "
+                f"(since Chrome {CHROME_DEFAULT_PROFILE_DEBUG_BLOCK_MAJOR}), and "
+                "agent-browser needs remote debugging to drive it — the launch "
+                "would hang instead of failing. Make Chromium or Brave your "
+                "default browser, or turn the toggle off."
+            )
+    return ["--profile", data_dir, "--executable-path", exe], None
 
 
 def _url_is_private(url: str) -> bool:
@@ -2946,8 +3016,15 @@ def _run_browser_command(
     # Local mode with no Chromium on disk: fail fast with an actionable
     # message instead of hanging for _command_timeout seconds per call.
     # Skip when engine=lightpanda — LP doesn't need Chromium for navigation.
+    # Skip it when the real-profile consent already resolved the user's own
+    # browser binary: that launch never touches the bundled Chromium, and on
+    # macOS/Windows desktops the real Chrome/Edge/Brave lives in
+    # /Applications or Program Files, which _chromium_installed() does not
+    # probe — the gate would otherwise download ~170 MB the launch never
+    # uses, or block outright with lazy installs off.
     if (
         _is_local_mode()
+        and not _real_profile_provides_executable()
         and not _chromium_installed()
         and _get_browser_engine() != "lightpanda"
         and not _maybe_autoinstall_chromium()
@@ -2996,9 +3073,30 @@ def _run_browser_command(
         # Chromium profile so their live logins/cookies are available. Fails
         # closed (returns an error) if the default browser is non-Chromium or
         # its profile can't be located, rather than silently using a throwaway.
+        # ``close`` must still reach agent-browser: a daemon launched before
+        # the resolution started failing (toggle flipped, browser removed)
+        # would otherwise outlive the Python-side session entry.
         _profile_args, _profile_err = _real_profile_launch_args()
-        if _profile_err:
+        if _profile_err and command != "close":
             return {"success": False, "error": _profile_err}
+        if (
+            _profile_args
+            and command != "close"
+            and (_engine_override or _get_browser_engine()) == "lightpanda"
+        ):
+            # agent-browser refuses --profile for the Lightpanda engine
+            # ("Profiles are not supported with Lightpanda"); letting that
+            # error trigger the Chrome fallback would open a throwaway
+            # session without the profile the user consented to.
+            return {
+                "success": False,
+                "error": (
+                    "browser.use_real_profile needs the Chrome engine: "
+                    "agent-browser does not support profiles with "
+                    "browser.engine: lightpanda. Set browser.engine to auto "
+                    "or chrome, or turn the toggle off."
+                ),
+            }
         if _profile_args:
             backend_args += _profile_args
 
@@ -5193,6 +5291,8 @@ def cleanup_all_browsers() -> None:
     _chromium_autoinstall_attempted = False
     _cached_browser_engine = None
     _browser_engine_resolved = False
+    global _real_profile_args_cache
+    _real_profile_args_cache = None
 
 # ============================================================================
 # Requirements Check

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3561,17 +3561,24 @@ def browser_navigate(url: str, task_id: Optional[str] = None, local_browser: boo
     if local_browser and not _use_real_profile():
         real_profile_note = (
             "local_browser was requested but browser.use_real_profile is off; "
-            "using the default browser backend. Enable real-profile browsing in "
-            "Settings → Browser to honor this."
+            "using the default browser backend. Set browser.use_real_profile: "
+            "true in config.yaml (desktop app: Settings → Browser) to honor this."
         )
     nav_session_key = _navigation_session_key(
         effective_task_id, url, local_browser=local_browser
     )
     auto_local_this_nav = _is_local_sidecar_key(nav_session_key)
 
+    def _failure(payload: Dict[str, Any]) -> str:
+        # The consent-off note matters most on the failures it explains
+        # (blocked private URL, launch error); never lose it there.
+        if real_profile_note:
+            payload["note"] = real_profile_note
+        return json.dumps(payload, ensure_ascii=False)
+
     sensitive_query_key = _sensitive_query_param_name(url)
     if sensitive_query_key and not _is_local_backend() and not auto_local_this_nav:
-        return json.dumps({
+        return _failure({
             "success": False,
             "error": (
                 "Blocked: URL contains a credential-like query parameter "
@@ -3602,7 +3609,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None, local_browser: boo
         and not _allow_private_urls()
         and not _is_safe_url(url)
     ):
-        return json.dumps({
+        return _failure({
             "success": False,
             "error": "Blocked: URL targets a private or internal address",
         })
@@ -3692,6 +3699,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None, local_browser: boo
         }
         if real_profile_note:
             response["note"] = real_profile_note
+        # Audit trail: a local session under consent ran on the real profile
+        # (the launch would have failed closed otherwise). Cloud/CDP sessions
+        # never do.
+        if not session_info.get("cdp_url") and _use_real_profile():
+            response["used_real_profile"] = True
         # Remember only a successful, non-blocked navigation as the task owner.
         # Failed opens and blocked redirects must not retarget follow-up clicks
         # or snapshots to a newly-created but irrelevant session.
@@ -3747,10 +3759,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None, local_browser: boo
 
         return json.dumps(response, ensure_ascii=False)
     else:
-        return json.dumps({
+        return _failure({
             "success": False,
             "error": result.get("error", "Navigation failed")
-        }, ensure_ascii=False)
+        })
 
 
 def browser_snapshot(

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -503,6 +503,8 @@ Navigate to a URL. Must be called before any other browser tool. Initializes the
 Navigate to https://github.com/NousResearch
 ```
 
+Optional argument `local_browser: true` — run this navigation in a local session on your real browser profile even when a cloud provider is configured. Only honoured when `browser.use_real_profile` is on (see [Real Browser Profile](#real-browser-profile-consent-gated)); otherwise ignored with a `note` in the result.
+
 :::tip
 For simple information retrieval, prefer `web_search` or `web_extract` — they are faster and cheaper. Use browser tools when you need to **interact** with a page (click buttons, fill forms, handle dynamic content).
 :::
@@ -729,6 +731,38 @@ Headed mode does two things:
 2. **Keeps the window open between turns.** Normally the browser session is cleaned up after every agent reply; in headed mode the per-turn cleanup is skipped so you can watch the agent work, intervene manually (sign-in challenges, CAPTCHAs), and keep login state warm across the conversation.
 
 Idle sessions are still reaped after `browser.inactivity_timeout` (default 120s of no browser activity), and all sessions are closed on shutdown. Headed mode only affects the local browser — cloud sessions (Browserbase) are unaffected.
+
+## Real Browser Profile (consent-gated)
+
+By default the local browser runs in a throwaway profile: no logins, no cookies, nothing shared with the browser you use yourself. You can opt in to driving your **real default Chromium profile** instead — its logins, cookies and history become available to the agent:
+
+```yaml
+browser:
+  use_real_profile: true  # default: false
+```
+
+The desktop app exposes the same switch under **Settings → Browser**. The setting is read on every launch, so turning it off takes effect immediately.
+
+What it does:
+
+- Every local Chromium launch — the built-in tools, and the local sidecar that hybrid routing spawns under a cloud provider — runs with `--profile <your default browser's user-data-dir>` and `--executable-path <that browser's binary>`.
+- The default browser is detected per OS (Windows `UserChoice`, macOS LaunchServices `https` handler, Linux `xdg-settings`). Only Chromium-family browsers are supported: Chrome, Edge, Brave, Chromium (native packages, snap and Flatpak on Linux).
+- The `browser_navigate` tool accepts `local_browser: true`. With consent on, it forces a local real-profile session for a public URL even when a cloud provider is configured. Private URLs still follow `auto_local_for_private_urls`; without consent the flag is ignored and the result carries a `note` saying so.
+- Navigation results that ran on the real profile include `"used_real_profile": true`.
+
+It fails closed — with a message naming the reason — when:
+
+- the default browser is not a Chromium-family browser (Firefox, Safari, Arc …) or cannot be determined (no `xdg-settings` on a headless box);
+- the profile directory or the browser binary cannot be located;
+- the profile is currently open in another Chromium process (your own browser, or another Hermes session — Chromium allows one process per profile directory, so close it first);
+- the default browser is **Google Chrome 136 or newer**. Since 136 branded Chrome refuses remote debugging on its default profile directory, and agent-browser needs remote debugging — the launch would hang instead of failing. Chromium and Brave builds do not enforce that block (Edge is untested), so the check only applies to Google Chrome;
+- `browser.engine` is `lightpanda` (agent-browser does not support profiles there).
+
+Caveats worth knowing:
+
+- This drives the live profile in place — the agent's cookies, history and site data land in your real browser profile.
+- agent-browser launches Chromium with a mock keychain, so cookies your browser encrypted with the OS keychain (macOS Keychain, GNOME Keyring / KWallet on Linux) may not decrypt inside the automated session. Windows (DPAPI) is unaffected.
+- With consent on, any page the agent visits sees your logged-in state. This is a convenience, not an isolation boundary — treat it like handing someone your browser.
 
 ## Stealth Features
 


### PR DESCRIPTION
Follow-up to #95520, stacked on `browser-real-profile` (base = `cf7d308`). It keeps the PR's design — consent toggle, in-place real profile, `local_browser` routed through the existing `::local` sidecar — and closes the concrete gaps from the reviews ([mine](https://github.com/NousResearch/hermes-agent/pull/95520#issuecomment-5425348479), [unsupportedpastels' + empirical results](https://github.com/NousResearch/hermes-agent/pull/95520#issuecomment-5425477670), [Adolanium's](https://github.com/NousResearch/hermes-agent/pull/95520#issuecomment-5425685824)).

Five commits, grouped by area as suggested in the discussion below; each group carries its own tests and can be cherry-picked on its own, except that the launch-path group imports two helpers from the detection group (order: 1, 2, 3 · 4 and 5 are independent).

## Commits

| # | Commit | Closes |
|---|--------|--------|
| 1 | `fix(browser): pass encoding to detector subprocesses and accept local_browser in test spies` | the three CI failures on the PR head (Windows-footguns lint, `test_browser_extension_router_wiring` ×2, `test_browser_open_timeout`) |
| 2 | `fix(browser): detect the default browser fail-closed on macOS, Linux packaging and pre-release channels` | macOS https handler parsed per entry, installed-browser fallback dropped (mine 5 / pastels 4, 9) · snap/Flatpak profile dirs and Flatpak desktop ids (mine 11 / pastels 13) · Chrome Beta/Dev/Canary, Edge Beta/Dev recognised by their own identifiers instead of mapping to stable (Adolanium 2) |
| 3 | `fix(browser): harden the real-profile launch path — fail closed, resolve once, refuse what cannot work` | missing binary → fail closed (pastels 5) · resolution once per process, `close` reachable (mine 8 / pastels 7) · Lightpanda conflict (mine 8) · `SingletonLock` pre-flight naming the pid (mine 3 / pastels 2) · Google Chrome ≥ 136 refused with the reason instead of hanging (mine 1 / pastels 1) · bundled-Chromium gate skipped when the real binary resolved (Adolanium 1) · channel named in the error |
| 4 | `fix(browser): keep local_browser inside the private-URL policy and read consent per use` | `local_browser` no longer overrides `auto_local_for_private_urls: false` and no longer spawns a second session on a pure-local backend (mine 4, 3b) · consent re-read per use: revocation without restart, multiplex-safe (mine 7 / pastels 6, 8) |
| 5 | `feat(browser): document the real-profile toggle, stamp used_real_profile, keep the consent note on failures` | docs (mine 10) · `"used_real_profile": true` on navigations that ran on the real profile (pastels 12b) · consent note also on failed/blocked navigations and pointing at the config key, not only the desktop page (pastels 14, Adolanium "small") |

## What changes for a user

- Toggle off: unchanged (inert).
- Toggle on: every launch still goes through the same consent path, but the failure modes are messages instead of hangs/timeouts — non-Chromium or undetectable default, pre-release channel (named), missing profile dir, missing binary, profile currently open (names the pid), Google Chrome ≥ 136 (names the version and the reason), Lightpanda engine.
- The bundled-Chromium check no longer downloads ~170 MB or blocks when the user's own browser binary is the one being launched.
- `local_browser` no longer creates a second session on a pure-local backend, and no longer routes a private URL to the host when `auto_local_for_private_urls: false` — it only switches the backend for URLs the user's policy already allows locally.
- Turning the toggle off takes effect on the next launch; multiplexed profiles resolve their own value.
- Successful navigations on the real profile carry `"used_real_profile": true`; the "consent is off" note is also attached to failed/blocked navigations.

## Verification

- `pytest tests/tools/test_browser_real_profile.py tests/tools/test_browser_extension_router_wiring.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_browser_open_timeout.py tests/tools/test_browser_cloud_fallback.py tests/tools/test_browser_extension_router.py tests/hermes_cli/test_browser_connect_default_chromium.py tests/hermes_cli/test_browser_connect_dual_stack.py tests/scripts/test_footgun_subprocess_encoding.py` → 141 passed at the head; the five browser/detector files also pass at each of the five commits individually. The real-profile file grows from 12 to 44 tests; the new `test_browser_connect_default_chromium.py` feeds real `defaults read` / `xdg-settings` output shapes, real ProgIds (`ChromeBHTML`, `MSEdgeBHTML`) and a real `SingletonLock` symlink instead of patching the detectors.
- `ruff check` clean on all touched files; `scripts/check-windows-footguns.py` clean on both modules (it caught an `os.kill(pid, 0)` in the first draft of the lock check → `psutil.pid_exists`); `ty check` diagnostics on the two modules are identical to the PR base.
- Not run: the desktop suite (no change to `apps/desktop`), the broad Python suite. `tests/tools/test_browser_homebrew_paths.py` has 3 failures on my box that are identical on the unmodified PR head (noexec `/tmp`, no agent-browser binary) — CI has them green.
- No real-browser launch on my side; the Chrome ≥ 136 and lock behaviour rely on the reviewer's reproduction plus the Chromium/agent-browser sources cited in the commit messages. Side note: the first CI run of this PR failed exactly once — the runner has a real Google Chrome 151 and the version gate refused it in the PR's own injection test; that test now stubs the version lookup.

## Deliberately not in here (maintainer calls)

- The bigger design question from the reviews — in-place drive vs. agent-browser's profile *copy* (`--profile <name>` gives the copy and the real keychain, and sidesteps the Chrome ≥ 136 block and the lock) — is untouched. Commit 3 only turns the hang into a message.
- agent-browser still launches with `--password-store=basic --use-mock-keychain` for a path profile; lifting that needs an agent-browser change. The docs state the consequence (OS-keychain cookies may not decrypt on macOS / keyring Linux).
- Full support for pre-release channels (their own profile dirs and binaries per OS) rather than naming them and failing closed.
- A single shared session for the real profile (concurrent tasks), `restrict_evaluate` coupling, a per-use confirmation, protecting the config key from agent writes, and the desktop locale entries (`ar/ja/zh/zh-hant`) — happy to add any of these if wanted.
