### PR TITLE
fix(macos): materialize TCC anchor aliases as real-file copies

### DIFF
--- a/hermes_cli/macos_tcc_anchor.py
+++ b/hermes_cli/macos_tcc_anchor.py
@@ -21,9 +21,15 @@ which still provides the stdlib exactly as it does today.
 The anchor self-heals: when ``hermes update`` / ``hermes doctor`` runs and the
 venv python is a symlink again (uv re-created it) or the recorded source no
 longer matches the current interpreter (patch bump), the copy is refreshed.
-Versioned alias symlinks (``python3``, ``python3.11``, ...) inside the venv bin
-dir are re-pointed at the anchor so no alias resolves back into the versioned
-store.
+Versioned alias names (``python3``, ``python3.11``, ...) inside the venv bin
+dir are materialized as real-file copies of the anchor.  They must NOT be
+symlinks: invoking the copied interpreter through a symlink makes CPython's
+getpath lose the venv prefix on affected python-build-standalone builds —
+startup dies with ``ModuleNotFoundError: No module named 'encodings'`` and
+the stdlib resolves to the build-time ``/install`` prefix (issue #95541).
+Real-file copies boot on every build, keep the anchor's identifier-pinned
+signature (TCC attribution stays on the stable venv path), and survive
+updates in place.
 
 All functions are no-ops on non-macOS and for interpreters that are not
 uv-managed (Homebrew/system Python has a stable path already).  This module is
@@ -36,6 +42,7 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -185,37 +192,52 @@ def _anchor_marker(venv_bin: Path) -> Path:
     return venv_bin / _MARKER_NAME
 
 
-def _repoint_aliases(venv_bin: Path, anchor: Path) -> None:
-    """Re-point uv alias symlinks at the stable anchor.
+def _copy_alias(venv_bin: Path, name: str, anchor: Path) -> None:
+    """Materialize *name* as a real-file copy of *anchor* (atomic rename)."""
+    tmp = venv_bin / f".{name}.tcc-tmp"
+    try:
+        shutil.copy2(anchor, tmp)
+        os.chmod(tmp, anchor.stat().st_mode | 0o111)
+        os.replace(tmp, venv_bin / name)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
-    ``python3`` / ``python3.11`` inside the venv bin dir currently resolve into
-    the versioned store; anything spawned through them would still churn TCC.
-    Only symlinks that resolve into the uv store are touched.
+
+def _materialize_aliases(venv_bin: Path, anchor: Path, *, refresh: bool = False) -> None:
+    """Materialize uv alias names as real-file copies of the anchor.
+
+    Aliases must be real files, never symlinks: invoking the anchor copy
+    through a symlink (``python3`` -> ``python``) makes CPython getpath lose
+    the venv prefix on affected interpreter builds — startup dies with
+    ``ModuleNotFoundError: encodings`` (issue #95541).  Real-file copies boot
+    on every build and preserve the anchor's identifier-pinned signature, so
+    TCC attribution stays on the stable venv path instead of churning back to
+    the versioned store.
+
+    *refresh* re-copies aliases that are already real files — used when the
+    anchor itself was just refreshed (patch bump) so aliases cannot go stale.
+    Without it, only missing names and leftover symlinks are repaired.
     """
     # Union of the running interpreter's expected aliases and every versioned
     # alias actually on disk — a store built by a different Python minor than
-    # the one running this code must still get its aliases repointed.
+    # the one running this code must still get its aliases materialized.
     names = set(_sibling_names())
     try:
-        names.update(p.name for p in venv_bin.glob("python3.*") if p.is_symlink())
+        names.update(
+            p.name
+            for p in venv_bin.glob("python3.*")
+            if re.fullmatch(r"python3(\.\d+)?", p.name)
+        )
     except OSError:
         pass
     for name in sorted(names):
         alias = venv_bin / name
         try:
-            if not alias.is_symlink():
-                continue
-            if not _is_uv_macos_store(str(alias.resolve(strict=False))):
-                continue
-            tmp = venv_bin / f".{name}.tcc-tmp"
-            try:
-                os.symlink(anchor.name, tmp)
-                os.replace(tmp, alias)
-            except OSError:
-                try:
-                    tmp.unlink(missing_ok=True)
-                except OSError:
-                    pass
+            if refresh or alias.is_symlink() or not alias.exists():
+                _copy_alias(venv_bin, name, anchor)
         except OSError:
             continue
 
@@ -253,7 +275,7 @@ def _install_anchor(venv_dir: Path, source_file: Path) -> None:
             logger.debug("anchor copy signing skipped", exc_info=True)
         os.replace(tmp_path, venv_py)
         _anchor_marker(venv_bin).write_text(str(source_file), encoding="utf-8")
-        _repoint_aliases(venv_bin, venv_py)
+        _materialize_aliases(venv_bin, venv_py, refresh=True)
     except Exception:
         try:
             tmp_path.unlink(missing_ok=True)
@@ -292,6 +314,10 @@ def ensure_tcc_anchor(project_root: Path | None = None) -> Path | None:
             if marker.is_file() and marker.read_text(encoding="utf-8").strip() == str(
                 source_file
             ):
+                # Repair aliases left as symlinks by the symlink-based
+                # predecessor implementation (issue #95541) or missing
+                # outright; up-to-date real-file copies are left untouched.
+                _materialize_aliases(venv_py.parent, venv_py)
                 return venv_py
         except OSError:
             pass

--- a/tests/hermes_cli/test_macos_tcc_anchor.py
+++ b/tests/hermes_cli/test_macos_tcc_anchor.py
@@ -8,6 +8,10 @@ macOS.
 """
 
 import os
+import platform
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -195,9 +199,12 @@ class TestEnsureTccAnchor:
         assert marker.read_text(encoding="utf-8").strip() == str(
             store_bin / "python3.11"
         )
-        # Alias symlinks no longer resolve into the versioned store.
+        # Aliases are materialized as real-file copies of the anchor: a
+        # symlink to the anchor copy breaks CPython getpath at startup
+        # (issue #95541), while a symlink into the store would churn TCC.
         alias = venv_py.parent / "python3"
-        assert not tcc._is_uv_macos_store(str(alias.resolve(strict=False)))
+        assert alias.is_file() and not alias.is_symlink()
+        assert alias.read_bytes() == venv_py.read_bytes()
 
     def test_idempotent(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)
@@ -212,6 +219,25 @@ class TestEnsureTccAnchor:
         assert anchored == venv_py
         assert venv_py.is_file() and not venv_py.is_symlink()
         assert marker.read_text(encoding="utf-8") == before
+
+    def test_repairs_alias_symlinks_left_by_predecessor(self, tmp_path, monkeypatch):
+        """Anchors installed by the symlink-based predecessor left python3 as
+        a symlink pointing at the anchor copy — the on-disk shape that makes
+        every console script die with ModuleNotFoundError: encodings at
+        startup (issue #95541).  Idempotent runs must repair it."""
+        _darwin(monkeypatch)
+        store_bin = _build_store(tmp_path)
+        root = _build_checkout(tmp_path, store_bin=store_bin, anchored=True)
+        venv_bin = root / ".venv" / "bin"
+        venv_py = venv_bin / "python"
+        assert (venv_bin / "python3").is_symlink()  # predecessor shape
+
+        anchored = tcc.ensure_tcc_anchor(root)
+
+        assert anchored == venv_py
+        alias = venv_bin / "python3"
+        assert alias.is_file() and not alias.is_symlink()
+        assert alias.read_bytes() == venv_py.read_bytes()
 
     def test_reanchors_after_patch_bump(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)
@@ -234,6 +260,11 @@ class TestEnsureTccAnchor:
         assert venv_py.read_bytes() == new_py.read_bytes()
         marker = venv_py.parent / ".tcc-anchor-source"
         assert marker.read_text(encoding="utf-8").strip() == str(new_py)
+        # Aliases are refreshed alongside the anchor — a stale alias copy
+        # would keep running the previous patch build.
+        alias = venv_py.parent / "python3"
+        assert alias.is_file() and not alias.is_symlink()
+        assert alias.read_bytes() == new_py.read_bytes()
 
     def test_skips_homebrew_interpreter(self, tmp_path, monkeypatch):
         _darwin(monkeypatch)
@@ -353,3 +384,72 @@ class TestDoctorCheck:
         doctor.check_macos_tcc_anchor(should_fix=False)  # must not raise
         out = capsys.readouterr().out
         assert "macOS TCC anchor check failed" in out
+
+
+class TestAnchoredAliasesBootE2E:
+    """Real-interpreter proof that anchored aliases stay bootable (#95541).
+
+    The fake-store fixtures above cannot catch getpath boot failures — the
+    crash only appears when a real CPython binary is invoked through the
+    alias.  Here the running interpreter's real base binary is copied into a
+    fake uv-store layout (stdlib provided via a ``lib`` symlink), a real venv
+    shape is anchored, and every entry point is actually executed.
+    """
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only anchor")
+    def test_python_entry_points_boot_after_anchor(self, tmp_path):
+        minor = f"python3.{sys.version_info.minor}"
+        base = Path(sys.base_prefix)
+        real_py = base / "bin" / minor
+        if not real_py.is_file() or real_py.is_symlink():
+            pytest.skip(f"no real base interpreter binary at {real_py}")
+        if not (base / "lib" / minor / "os.py").is_file():
+            pytest.skip("base stdlib not in the expected lib layout")
+
+        store = (
+            tmp_path
+            / "uv"
+            / "python"
+            / f"cpython-{platform.python_version()}-macos-aarch64-none"
+        )
+        store_bin = store / "bin"
+        store_bin.mkdir(parents=True)
+        shutil.copy2(real_py, store_bin / minor)
+        os.symlink(base / "lib", store / "lib")
+
+        root = tmp_path / "checkout"
+        venv = root / ".venv"
+        venv_bin = venv / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv / "lib" / minor / "site-packages").mkdir(parents=True)
+        (venv / "pyvenv.cfg").write_text(
+            f"home = {store_bin}\nversion = {platform.python_version()}\n",
+            encoding="utf-8",
+        )
+        os.symlink(store_bin / minor, venv_bin / "python")
+        os.symlink("python", venv_bin / "python3")
+        os.symlink("python", venv_bin / minor)
+
+        # Some uv-store builds link libpython dynamically via
+        # @executable_path/../lib (issue #95425); the anchored copy then
+        # needs that dylib reachable from the venv.  Mirror it so this test
+        # isolates the getpath boot failure rather than the dyld one.
+        libpython = base / "lib" / f"lib{minor}.dylib"
+        if libpython.is_file():
+            os.symlink(libpython, venv / "lib" / libpython.name)
+
+        anchored = tcc.ensure_tcc_anchor(root)
+        assert anchored is not None
+
+        for name in ("python", "python3", minor):
+            probe = subprocess.run(
+                [str(venv_bin / name), "-c",
+                 "import encodings, sys; print(sys.prefix)"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            assert probe.returncode == 0, (
+                f"{name} failed to boot after anchoring:\n{probe.stderr}"
+            )
+            assert str(venv) in probe.stdout


### PR DESCRIPTION
## Summary

The macOS TCC anchor (#85416) replaces `venv/bin/python` with a real-file copy of the uv-store interpreter, but leaves `python3` / `python3.11` as symlinks. Invoking the copied interpreter **through a symlink** makes CPython's getpath lose the venv prefix on affected python-build-standalone builds: startup dies with

```
Could not find platform independent libraries <prefix>
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
ModuleNotFoundError: No module named 'encodings'
```

and `sys.prefix` resolves to the build-time `/install` prefix. Console scripts are sh polyglots that `exec python3`, so the entire CLI surface (`hermes`, `hermes --tui`, `pytest`, ...) dies while entry points spawning `python` directly (Desktop backend) keep working.

## Root cause, reproduced

Clean-room fixture (real interpreter copied into a fake uv-store layout, real venv shape), invoking the same copied binary four ways:

| Invocation | Result |
|---|---|
| real file (`venv/bin/python`) | ✅ boots |
| same-dir symlink → copy (`python3`) | ❌ `ModuleNotFoundError: encodings` |
| external-dir symlink → copy | ❌ same crash |
| hardlink → copy | ✅ boots |

The failure is **build-dependent**: it reproduces with the cpython-3.11.15 managed-runtime build, while a cpython-3.11.13 uv-store build boots through the same symlink layout — which is likely why the original anchor validation missed it. Either way, symlinking to the copy is not a layout CPython can be trusted to boot from.

## Fix

Materialize the aliases as **real-file copies of the anchor** (atomic temp+rename), instead of symlinks:

- Real-file copies boot on every build (verified live: an install dead with the `encodings` crash was repaired by replacing the alias symlinks with copies of the anchor; `hermes --version` / `--help` / `--tui` boot normally, `codesign -v` passes on the copies).
- Copies keep the anchor's identifier-pinned signature, so TCC attribution stays on the stable venv path — pointing aliases back at the versioned store binary (as in #95358) would put CLI-spawned processes back on a cdhash-keyed path that changes every patch bump, re-opening #85345 for the entire console-script surface.
- Aliases are refreshed whenever the anchor is re-copied (patch bump), so they cannot go stale; idempotent `ensure_tcc_anchor` runs repair leftover symlink aliases (the broken on-disk shape) without touching up-to-date copies.

## Validation

- `pytest tests/hermes_cli/test_macos_tcc_anchor.py` — 25 passed (3 pre-existing tests updated to the real-file contract, 2 new unit tests: predecessor-symlink repair, patch-bump alias refresh).
- New macOS E2E (`TestAnchoredAliasesBootE2E`): copies the running interpreter's real base binary into a fake uv-store layout (stdlib via `lib` symlink, `libpython` dylib mirrored when the build links it dynamically, cf. #95425), anchors a real venv shape, then executes `python` / `python3` / `python3.11` asserting each boots with the venv as `sys.prefix`.
- RED evidence: the 3 updated/new unit tests fail on un-fixed `main`; the symlink-invocation crash was reproduced out-of-tree with the managed-runtime 3.11.15 binary.
- `ruff check` and `git diff --check` clean.

Fixes #95541. See also #95425 (the dyld/libpython variant — orthogonal; alias copies live in the same `bin` dir, so whatever provisions `libpython` for the anchor covers the aliases too) and #95358 (alternative, partial fix).
