### PR TITLE
fix(desktop): block review diffs outside repository

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 import { afterEach, test } from 'vitest'
 
-import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewList } from './git-review-ops'
+import { gitFor, repoStatus, resolveRenamePath, REVIEW_FILE_CAP, reviewDiff, reviewList } from './git-review-ops'
 
 const tempDirs: string[] = []
 
@@ -116,4 +116,17 @@ test('reviewList caps the file payload returned to the renderer', async () => {
   const result = await reviewList(dir, 'uncommitted', null, 'git')
 
   assert.equal(result.files.length, REVIEW_FILE_CAP)
+})
+
+test('reviewDiff does not expose files outside the repository', async () => {
+  const repo = makeRepo()
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-review-outside-'))
+  const outsideFile = path.join(outsideDir, 'secret.txt')
+
+  tempDirs.push(outsideDir)
+  fs.writeFileSync(outsideFile, 'HERMES_OUTSIDE_REPO_SECRET\n')
+
+  const diff = await reviewDiff(repo, outsideFile, 'uncommitted', null, false, 'git')
+
+  assert.equal(diff, '')
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -334,6 +334,24 @@ async function reviewDiff(repoPath, filePath, scope, baseRef, staged, gitBin) {
     return ''
   }
 
+  let resolvedFilePath
+
+  try {
+    resolvedFilePath = resolveRequestedPathForIpc(filePath, { baseDir: cwd, purpose: 'Review diff file' })
+  } catch {
+    return ''
+  }
+
+  const relativeFilePath = path.relative(cwd, resolvedFilePath)
+
+  if (
+    relativeFilePath === '..' ||
+    relativeFilePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeFilePath)
+  ) {
+    return ''
+  }
+
   const git = gitFor(cwd, gitBin)
   const safe = args => git.diff(args).catch(() => '')
 


### PR DESCRIPTION
## What does this PR do?

Prevents the desktop review diff IPC path from reading files outside the selected Git repository.

`reviewDiff()` validates `repoPath`, but previously accepted `filePath` directly. For an untracked path, the fallback executes:

`git diff --no-index -- /dev/null <filePath>`

Because `--no-index` is not constrained to the repository, a renderer-supplied absolute path outside the repository could cause local file contents to be returned as a unified diff.

This PR resolves the requested file path relative to the repository and rejects paths that escape the repository before invoking Git.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] Security hardening
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Resolve `reviewDiff()` file paths using the existing IPC path hardening helper with the repository as the base directory.
- Reject resolved paths that are outside the repository.
- Add a regression test proving that an external file cannot be exposed through `reviewDiff()`.

## How to Test

```bash
npx vitest run apps/desktop/electron/git-review-ops.test.ts
npm --prefix apps/desktop run typecheck
npm --prefix apps/desktop run test:desktop:platforms
```

Verified results:

- `git-review-ops.test.ts`: 10/10 tests passed.
- Desktop typecheck passed.
- Electron test suite: 129 test files passed, 2 skipped; 1833 tests passed, 6 skipped.

The regression test creates a temporary file outside the repository containing `HERMES_OUTSIDE_REPO_SECRET`.

Before the fix, `reviewDiff()` returned that content through the `git diff --no-index` fallback.

After the fix, the same request returns an empty diff.

## Checklist

- [x] I have tested the changes locally.
- [x] I have added a regression test for the bug.
- [x] Existing relevant tests pass.
- [x] Type checking passes.
- [x] The change is minimal and scoped to the affected behavior.
- [x] No unrelated files are included.
- [x] `git diff --check` passes.

## Documentation & Housekeeping

No documentation changes are required. This only tightens validation of an internal desktop IPC Git review operation.

## Screenshots / Logs

Before the fix:

```text
+HERMES_OUTSIDE_REPO_SECRET
```

After the fix, the request returns an empty diff.
