### PR TITLE
fix(gateway): coerce SessionSource platform strings at construction

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -220,6 +220,15 @@ class SessionSource:
     delivered_via_upstream_relay: bool = False
 
     def __post_init__(self) -> None:
+        # ``platform`` is annotated ``Platform``; enforce that at runtime by
+        # coercing plain-string platforms (external callers, tests, plugins)
+        # instead of letting them crash later on ``platform.value`` access
+        # (e.g. the authz gate). Unknown values raise here, matching
+        # ``from_dict`` — a fail-fast construction error, not a mid-authz
+        # ``AttributeError``.
+        if isinstance(self.platform, str):
+            self.platform = Platform(self.platform)
+
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`
         # is the deprecated alias. Mirror whichever was provided onto the other
         # (scope_id wins on conflict) so internal readers of EITHER field see the

--- a/tests/gateway/test_session_source_platform_coercion.py
+++ b/tests/gateway/test_session_source_platform_coercion.py
@@ -1,0 +1,66 @@
+"""SessionSource.platform must be a Platform at runtime.
+
+The annotation was not enforced: a caller constructing SessionSource with a
+plain-string platform crashed with AttributeError on ``platform.value`` access
+inside the authz gate (gateway/authz_mixin.py) instead of getting a clean
+deny/authorize decision. __post_init__ now coerces valid strings and fails
+fast on unknown ones — matching the wire path (from_dict), which already
+raised ValueError for unknown platforms."""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_string_platform_is_coerced_and_authz_decides_cleanly(monkeypatch):
+    """A string platform no longer crashes the authz gate — it coerces to the
+    enum member, so ``platform.value`` access behaves like any other source."""
+    _clear_auth_env(monkeypatch)
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {
+        Platform.TELEGRAM: SimpleNamespace(
+            send=AsyncMock(),
+            authorization_is_upstream=False,
+            enforces_own_access_policy=False,
+        )
+    }
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    src = SessionSource(
+        platform="telegram", user_id="4", chat_id="12", chat_type="dm"
+    )
+    assert isinstance(src.platform, Platform)
+    assert src.platform is Platform.TELEGRAM
+
+    # No env allowlist configured and no pairing entry => clean deny, not
+    # an AttributeError escaping the gate.
+    assert runner._is_user_authorized(src) is False
+
+
+def test_unknown_platform_string_fails_fast_at_construction():
+    """Invalid values raise at construction like from_dict does, rather than
+    surfacing later as an AttributeError mid-authorization."""
+    with pytest.raises(ValueError):
+        SessionSource(platform="not-a-platform", chat_id="12")
+
+
+def test_enum_platform_passes_through_unchanged():
+    src = SessionSource(platform=Platform.SLACK, chat_id="12")
+    assert src.platform is Platform.SLACK


### PR DESCRIPTION
## Summary

Enforces the `SessionSource.platform: Platform` annotation at runtime. A caller constructing `SessionSource(platform="telegram")` with a plain string previously crashed the authz gate with an `AttributeError` on `source.platform.value` (`gateway/authz_mixin.py:607`) instead of producing a clean deny/authorize decision — fail-closed in effect, but by crash rather than denial.

Closes #95555.

## Change

- `SessionSource.__post_init__` coerces valid platform strings to `Platform` members; unknown values raise `ValueError` at construction — matching the existing `from_dict` wire-path behavior.
- Fixes all `~85` `.platform.value` access sites across gateway code at one point.
- Enum sources are untouched. `object.__new__` mock sources bypass `__init__`/`__post_init__`, so existing test fixtures are unaffected.

## Validation

```
scripts/run_tests.sh tests/gateway/test_session_source_platform_coercion.py -q
# 3 tests passed

scripts/run_tests.sh tests/gateway/test_session_source_platform_coercion.py tests/gateway/test_session.py -q
# 68 tests passed, 0 failed
```

New tests cover: string platform coerces and authz decides cleanly; unknown platform string raises `ValueError` at construction; enum passes through unchanged.