### PR TITLE
fix(env): default HERMES_EXEC_ASK=1 for spawned worker subprocesses

### DIFF
--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -140,3 +140,28 @@ def test_e2e_scrubbed_env_resolves_bare_hermes_under_minimal_parent_path(monkeyp
     # duplicate the entry.
     env2 = build_subprocess_env(env, scrub_secrets=True)
     assert env2["PATH"].split(os.pathsep).count(bin_dir) == 1
+
+
+# ---------------------------------------------------------------------------
+# HERMES_EXEC_ASK default for spawned workers
+# ---------------------------------------------------------------------------
+
+
+def test_exec_ask_defaults_to_on_for_worker_children(monkeypatch):
+    """Regression (R1): a scheduler/cron process started by systemd — not via
+    start_gateway() — has no HERMES_EXEC_ASK in its env, so worker children
+    built by build_subprocess_env() inherited the parent verbatim and fell
+    open on dangerous commands. The factory must default ask-mode ON while
+    still honoring an explicit parent value.
+    """
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    env = build_subprocess_env()
+    assert env.get("HERMES_EXEC_ASK") == "1"
+
+
+def test_exec_ask_explicit_parent_value_is_honored(monkeypatch):
+    """An explicit parent value wins over the default (e.g. an explicit '0'
+    from a trusted automation parent must not be flipped back to '1')."""
+    monkeypatch.setenv("HERMES_EXEC_ASK", "0")
+    env = build_subprocess_env()
+    assert env.get("HERMES_EXEC_ASK") == "0"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -517,6 +517,14 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # spawn path (process_registry.spawn_local builds env via this function).
     _inject_session_context_env(sanitized)
 
+    # Gate dangerous commands for spawned worker subprocesses (cron jobs,
+    # delegate_task children, PTY spawns) even when the spawning scheduler was
+    # not started via start_gateway() (e.g. systemd/Cron services). Without this,
+    # worker subprocesses inherit the parent env verbatim and fall open (R1).
+    # start_gateway() sets os.environ["HERMES_EXEC_ASK"]; honor an explicit parent
+    # value, otherwise default workers to ask-mode. Non-secret, so safe to inject.
+    sanitized.setdefault("HERMES_EXEC_ASK", "1")
+
     # Filter PYTHONPATH before removing VIRTUAL_ENV: legacy Windows launchers
     # can run the gateway under a base interpreter while VIRTUAL_ENV identifies
     # the separate Hermes runtime venv.  The filter validates that relationship


### PR DESCRIPTION
## Problem

Worker children — cron job runs, `delegate_task` children, PTY spawns — build their environment via the single chokepoint `tools.environments.local.build_subprocess_env()`. That factory inherits the parent environment verbatim, **including the absence of `HERMES_EXEC_ASK`** whenever the spawning process was not started through `start_gateway()`.

`start_gateway()` (`gateway/run.py`) is currently the only place that sets `os.environ["HERMES_EXEC_ASK"] = "1"`. A scheduler launched by systemd or cron (a very common deployment) never goes through that path, so every worker it spawns silently runs with dangerous-command approval disabled — while interactive gateway sessions have it enabled. The security posture of a scheduled agent differs from its interactive one with no user-visible signal.

## Fix

Default ask-mode ON at the env chokepoint itself:

```python
sanitized.setdefault("HERMES_EXEC_ASK", "1")
```

- `setdefault` keeps an explicit parent value authoritative (trusted automation can still opt out with an explicit `"0"`).
- The value is non-secret behavioral config and passes the existing scrub blocklist untouched.
- No new env var is introduced; this only makes the existing one actually reach workers.

## Tests

Two regression tests in `tests/tools/test_build_subprocess_env.py`:

- `test_exec_ask_defaults_to_on_for_worker_children` — parent env without the var → factory output has `HERMES_EXEC_ASK=1`.
- `test_exec_ask_explicit_parent_value_is_honored` — explicit parent `"0"` is preserved.

All 9 tests in that file pass, plus the wider approval/exec-ask cluster (139 passed: `test_approval.py`, `test_cli_approval_exec_ask_leak.py`, `test_scheduler_cron_session_isolation.py`, `test_yolo_mode.py`).