### PR TITLE
fix(cli): make plain-char modifyOtherKeys aliases insert the char, not the sequence

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -176,6 +176,48 @@ def install_cmd_backspace_alias() -> int:
     return changed
 
 
+def _patch_call_handler_data_for_char_aliases() -> None:
+    """Make plain-character aliases insert the character, not the sequence.
+
+    ``Vt100Parser._call_handler`` builds ``KeyPress(key, insert_text)`` with
+    ``insert_text`` set to the RAW escape sequence that mapped to ``key``.
+    For enum-valued aliases (``Keys.ControlA`` ...) bindings act on the key
+    and the data never reaches the buffer. The plain-string aliases
+    installed here (Shift+letter → ``"A"``, Shift+Space → ``" "``) have no
+    enum, so prompt_toolkit's default ``self-insert`` binding inserts
+    ``event.data`` — the raw sequence — and Shift+A under modifyOtherKeys=2
+    typed ``^[[27;2;65~`` into the prompt instead of ``A`` (#95550). Rewrite
+    the data to the character itself so the KeyPress matches
+    prompt_toolkit's printable-key convention (``key == data``).
+
+    Idempotent; only rewrites single-character string keys whose data is a
+    multi-char escape sequence, so enum aliases, tuple aliases, and plain
+    per-character feeds are untouched.
+    """
+    try:
+        from prompt_toolkit.input import vt100_parser as _vt100_mod
+    except Exception:
+        return
+    if getattr(_vt100_mod, "_hermes_char_alias_data_patched", False):
+        return
+
+    _orig_call_handler = _vt100_mod.Vt100Parser._call_handler
+
+    def _call_handler(self, key, insert_text):
+        if (
+            isinstance(key, str)
+            and len(key) == 1
+            and isinstance(insert_text, str)
+            and len(insert_text) > 1
+            and insert_text.startswith("\x1b")
+        ):
+            insert_text = key
+        return _orig_call_handler(self, key, insert_text)
+
+    _vt100_mod.Vt100Parser._call_handler = _call_handler
+    _vt100_mod.Vt100Parser._hermes_char_alias_data_patched = True
+
+
 def install_modify_other_keys_aliases() -> int:
     """Map Ctrl+key and Alt+key sequences emitted under ``modifyOtherKeys`` level 2
     and Kitty CSI-u to the same ``Keys``.* values that the raw control bytes
@@ -491,6 +533,11 @@ def install_modify_other_keys_aliases() -> int:
     # created before this install (or in earlier tests) can't misparse.
     if changed:
         _clear_vt100_prefix_cache()
+
+    # Plain-character aliases must insert the character, not the raw
+    # sequence (see the patch docstring). Applied even when changed == 0 so
+    # an already-populated table still gets the data fix.
+    _patch_call_handler_data_for_char_aliases()
 
     return changed
 

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -560,3 +560,53 @@ def test_lock_bits_on_cmd_backspace_alias():
     assert _parse("\x1b[127;137u") == [Keys.ControlU]  # Cmd+Backspace + NumLock
     assert _parse("\x1b[127;73u") == [Keys.ControlU]   # Cmd+Backspace + Caps
     assert _parse("\x1b[3;137~") == [Keys.ControlK]    # Cmd+FwdDel + NumLock
+
+
+# ---------------------------------------------------------------------------
+# KeyPress DATA for plain-character aliases (#95550)
+#
+# The tests above assert only ``kp.key``; that blind spot let the real bug
+# through: ``Vt100Parser._call_handler`` sets ``kp.data`` to the RAW escape
+# sequence, and prompt_toolkit's default ``self-insert`` binding inserts
+# ``event.data`` — so Shift+A typed ``^[[27;2;65~`` into the live prompt
+# while every alias test stayed green. These pins assert key == data.
+# ---------------------------------------------------------------------------
+
+def _parse_full(byte_seq: str):
+    """Feed bytes through the VT100 parser and return full KeyPress objects."""
+    out = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return out
+
+
+@pytest.mark.parametrize("letter", [chr(c) for c in range(ord('a'), ord('z') + 1)])
+def test_modify_other_keys_shift_letter_data_is_the_uppercase(letter):
+    """self-insert types event.data — it must be the char, not the sequence."""
+    upper = letter.upper()
+    for seq in (f"\x1b[27;2;{ord(letter)}~", f"\x1b[{ord(letter)};2u"):
+        presses = _parse_full(seq)
+        assert [(kp.key, kp.data) for kp in presses] == [(upper, upper)], seq
+
+
+def test_shift_space_data_is_the_space():
+    """Shift+Space maps to the plain " " alias — same key==data requirement."""
+    presses = _parse_full("\x1b[27;2;32~")
+    assert [(kp.key, kp.data) for kp in presses] == [(" ", " ")]
+
+
+def test_enum_alias_data_stays_the_raw_sequence():
+    """The data rewrite is scoped to plain single-char string aliases only:
+    enum-valued aliases (c-a) keep the sequence as data — bindings act on
+    the key, and rewriting enum data would lose information."""
+    presses = _parse_full("\x1b[27;5;97~")
+    assert presses[0].key == Keys.ControlA
+    assert presses[0].data == "\x1b[27;5;97~"
+
+
+def test_plain_character_feed_data_unchanged():
+    """A normal single-char feed (no alias involved) keeps key == data == char."""
+    presses = _parse_full("x")
+    assert [(kp.key, kp.data) for kp in presses] == [("x", "x")]


### PR DESCRIPTION
## What does this PR do?

Fixes the live-input half of #95550: under `modifyOtherKeys=2` (pushed so Shift+Enter is distinguishable), typing Shift+letter inserted the raw escape sequence (`^[[27;2;65~`) into the prompt instead of the character. This was reproducible headlessly (tmux send-keys + capture-pane) on any terminal, not just Ghostty.

The root cause is different from (and narrower than) the two gaps the report hypothesized — the bracketed-paste feed patch and the prefix-match cache are both innocent, verified by bisection and live instrumentation:

- `install_modify_other_keys_aliases()` maps Shift+letter sequences to **plain string values** (`ANSI_SEQUENCES["\x1b[27;2;65~"] = "A"`).
- prompt_toolkit's `Vt100Parser._call_handler` builds `KeyPress(key, data)` with **`data` set to the raw escape sequence** that mapped to the key.
- prompt_toolkit's default `self-insert` binding inserts **`event.data`**, not `event.key` — so the sequence itself went into the buffer.

In other words, these aliases never actually worked as intended; they were unreachable before the Ghostty modifyOtherKeys-only push (`1a8fea3ce2`) exposed them. The existing alias tests stayed green throughout because they assert only `kp.key` — the blind spot is pinned by the new tests.

The fix adds an idempotent `_call_handler` wrap in `pt_input_extras` (applied at the end of `install_modify_other_keys_aliases`, so the whole modifyOtherKeys story stays in one module): when the mapped key is a single-character string and the data is a multi-char escape sequence, the data becomes the character — restoring prompt_toolkit's printable-key convention (`key == data`). Enum-valued aliases (Ctrl+letter → `Keys.ControlA`), tuple aliases, and plain per-character feeds are untouched (scope-pinned by tests).

Live verification: with the fix, the headless tmux repro (`send-keys -l $'\x1b[27;2;65~'`) shows `❯ A` at the prompt instead of `❯ ^[[27;2;65~`.

Not addressed here (pre-existing, documented in the alias installer): Shift+**symbol** codepoints (`ESC[27;2;126~` etc.) remain deliberately unmapped — the comment reserves them as layout-specific policy ("better to leak than wrong input"), so extending the table to the printable ASCII range is a maintainer layout-policy call. This PR's data fix makes that extension one-liner-safe if it's ever taken (any future string-valued alias automatically inserts correctly).

## Related Issue

Fixes #95550

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/pt_input_extras.py` — new `_patch_call_handler_data_for_char_aliases()` (idempotent wrap of `Vt100Parser._call_handler`: single-char string key + multi-char escape data → data = key), invoked at the end of `install_modify_other_keys_aliases()` even when the table install is a no-op, with the root cause documented in its docstring.
- `tests/cli/test_modify_other_keys_aliases.py` — new `_parse_full` helper plus four data pins: all 26 Shift+letters (both sequence formats) emit `KeyPress(upper, upper)`; Shift+Space emits `(" ", " ")`; enum aliases keep the raw sequence as data (scope pin); plain char feeds keep `key == data == char`.

## How to Test

1. `.venv/bin/python -m pytest tests/cli/test_modify_other_keys_aliases.py -q` — should pass: 242 passed. Red/green: with the `pt_input_extras.py` change stashed, the 27 new data pins fail (26 letters + Shift+Space) while the two scope pins pass on both sides.
2. Headless live repro (the issue's own recipe): run the classic CLI in tmux, send `tmux send-keys -t <session> -l $'\x1b[27;2;65~'`, capture the pane. Observed result: before the fix the prompt line reads `❯ ^[[27;2;65~`; after the fix it reads `❯ A`.
3. `.venv/bin/python -m pytest tests/hermes_cli/test_input_sanitize.py -q` — should pass (5 passed). `ruff check` on both changed files should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches the modifyOtherKeys alias data path; the report's suspect commits are exonerated by bisection
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file suite + adjacent input suites green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
