### PR TITLE
fix(desktop): Linux launcher entry silently fails to open the app

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -76,14 +76,58 @@ def resolve_exec_command() -> str:
             # installer's bash wrapper). Launched from the .desktop entry that
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # ``sys.executable`` (NOT resolved: a venv's ``bin/python`` is a
+            # symlink to the base interpreter, and following it discards the
+            # venv's site-packages — the very thing the prefix exists to
+            # preserve) is the interpreter actually running Hermes. Prefix it
+            # only once it is proven to import hermes_cli on its own: it may
+            # only see the package through the current working directory (the
+            # bootstrap runtime interpreter run from the checkout does), and the
+            # DE launches with a cwd of its own choosing, so an unverified
+            # prefix trades one silent death for another.
+            interpreter = _running_interpreter()
+            if _interpreter_imports_hermes_cli(interpreter):
+                argv = [interpreter, str(resolved), "desktop"]
+            else:
+                argv = [str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [_running_interpreter(), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _running_interpreter() -> str:
+    """Absolute path to the interpreter running Hermes, venv symlink intact.
+
+    ``Path.resolve()`` is deliberately avoided: inside a virtual environment
+    ``bin/python`` is a symlink to the base interpreter, and invoking the
+    resolved target runs WITHOUT the venv's ``site-packages``. Only
+    ``os.path.abspath`` is applied, which makes the path absolute without
+    following links.
+    """
+    return os.path.abspath(sys.executable)
+
+
+def _interpreter_imports_hermes_cli(interpreter: str) -> bool:
+    """Whether ``interpreter`` can import ``hermes_cli`` independent of cwd.
+
+    Run the probe from a neutral directory with ``-I`` so neither the current
+    working directory nor a user site-packages tree can make an interpreter
+    look capable when the desktop entry's own launch context would not.
+    """
+    try:
+        result = subprocess.run(
+            [interpreter, "-I", "-c", "import hermes_cli"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            cwd=os.sep,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
 
 
 def _needs_interpreter(bin_path: Path) -> bool:
@@ -104,10 +148,33 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # python itself — leave it alone.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # already resolves correctly.
+    exe_dir = os.path.dirname(_running_interpreter())
+    if exe_dir in shebang:
+        return False
+    # Otherwise the shebang may still be right and sys.executable wrong: pip
+    # writes a console script's shebang to the environment it installed into,
+    # while the process writing this entry can be a DIFFERENT interpreter (the
+    # bootstrap runtime python) that only reaches hermes_cli through its cwd.
+    # An absolute shebang pointing into a real virtual environment is
+    # authoritative; only ``/usr/bin/env python3`` and bare system paths — the
+    # #90292 case — need the override.
+    return not _shebang_targets_virtualenv(shebang)
+
+
+def _shebang_targets_virtualenv(shebang: str) -> bool:
+    """Whether an absolute shebang points at an interpreter inside a venv.
+
+    A virtual environment is identified by ``pyvenv.cfg`` next to the ``bin``
+    directory holding the interpreter — the same marker CPython itself uses.
+    """
+    interpreter = shebang.lstrip("#!").strip().split()[0] if shebang.lstrip("#!").strip() else ""
+    if not interpreter.startswith("/") or interpreter.endswith("/env"):
+        return False
+    interpreter_path = Path(interpreter)
+    if not interpreter_path.is_file():
+        return False
+    return (interpreter_path.parent.parent / "pyvenv.cfg").is_file()
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8046,18 +8046,19 @@ def _force_adhoc_macos_signing(env: dict, *, source_mode: bool) -> bool:
 def _desktop_linux_needs_no_sandbox() -> bool:
     """Return True when Chromium/Electron should bypass the Linux sandbox.
 
-    Ubuntu 23.10+ can enable AppArmor's
-    ``apparmor_restrict_unprivileged_userns`` hardening, which breaks
-    Chromium/Electron's user-namespace sandbox for normal users unless the app
-    ships a working root-owned 4755 ``chrome-sandbox`` helper. In headless or
-    non-interactive CLI contexts we may be unable to ``sudo chown/chmod`` that
-    helper, so detect the host restriction and fall back to ``--no-sandbox``
-    rather than hard-failing the launcher.
+    Chromium sandboxes itself with unprivileged user namespaces when the host
+    allows them, and falls back to the root-owned 4755 ``chrome-sandbox``
+    helper when it does not. A host that permits neither — e.g. Ubuntu 23.10+
+    with AppArmor's ``apparmor_restrict_unprivileged_userns`` hardening on, or
+    a kernel with user namespaces disabled — leaves ``--no-sandbox`` as the only
+    way to start when we cannot ``sudo chown/chmod`` the helper (headless or
+    non-interactive CLI contexts). Detect that dead end rather than hard-failing
+    the launcher.
 
     We intentionally do NOT return True for root users here: running Electron as
     root without a sandbox is a qualitatively riskier path than launching as an
-    unprivileged desktop user on an AppArmor-restricted host. The root case
-    should remain an explicit user choice.
+    unprivileged desktop user on a hardened host. The root case should remain an
+    explicit user choice.
     """
     if os.environ.get("ELECTRON_DISABLE_SANDBOX", 0) == "1":
         return True
@@ -8066,11 +8067,12 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         return False
-    try:
-        with open("/proc/sys/kernel/apparmor_restrict_unprivileged_userns", encoding="utf-8") as f:
-            return f.read().strip() == "1"
-    except OSError:
-        return False
+    # No usable user-namespace sandbox and no usable SUID helper leaves
+    # ``--no-sandbox`` as the only way to start. AppArmor's
+    # ``apparmor_restrict_unprivileged_userns`` (Ubuntu 23.10+) is the common
+    # cause, but a kernel with namespaces disabled outright reaches the same
+    # dead end, so gate on the capability rather than on one distro's knob.
+    return not _desktop_linux_userns_sandbox_available()
 
 
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
@@ -8083,6 +8085,42 @@ def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> 
     except OSError:
         return False
     return stat.S_ISREG(sandbox_lstat.st_mode)
+
+
+def _desktop_linux_userns_sandbox_available() -> bool:
+    """Return True when Chromium can sandbox itself WITHOUT the SUID helper.
+
+    Chromium only needs the root-owned 4755 ``chrome-sandbox`` helper when it
+    cannot create unprivileged user namespaces. When it can, the namespace
+    sandbox is used and the SUID helper is never consulted — so demanding
+    ``sudo chown root`` on such a host buys no security and, from a
+    ``Terminal=false`` launcher entry, deterministically prevents the app from
+    starting at all (sudo has no TTY to prompt on).
+
+    A host qualifies when unprivileged user namespaces are permitted AND
+    AppArmor's ``apparmor_restrict_unprivileged_userns`` hardening (Ubuntu
+    23.10+) is not clamping them. Absent files mean the kernel lacks the knob,
+    which is the permissive case for that knob.
+    """
+    if sys.platform != "linux":
+        return False
+
+    def _read_int(path: str) -> int | None:
+        try:
+            with open(path, encoding="utf-8") as f:
+                return int(f.read().strip())
+        except (OSError, ValueError):
+            return None
+
+    if _read_int("/proc/sys/kernel/apparmor_restrict_unprivileged_userns") == 1:
+        return False
+    # Debian/Ubuntu-only knob; when present it must be enabled.
+    if _read_int("/proc/sys/kernel/unprivileged_userns_clone") == 0:
+        return False
+    max_userns = _read_int("/proc/sys/user/max_user_namespaces")
+    if max_userns is not None and max_userns <= 0:
+        return False
+    return True
 
 
 
@@ -8109,6 +8147,15 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return False
 
     if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    # Chromium only consults the SUID helper when it cannot use the
+    # unprivileged user-namespace sandbox. On a host where namespaces work
+    # (most non-Ubuntu distros), escalating to sudo buys nothing and hard-fails
+    # every non-TTY launch — notably the XDG desktop entry, which is
+    # Terminal=false and therefore can never answer a password prompt. Leave
+    # the helper alone and let Electron sandbox itself.
+    if _desktop_linux_userns_sandbox_available():
         return True
 
     sudo = shutil.which("sudo")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import builtins
+import io
 import subprocess
 import sys
 from pathlib import Path
@@ -1265,3 +1267,101 @@ def test_gui_password_store_bridge_is_linux_only(tmp_path, monkeypatch):
     mock_detect.assert_not_called()
     launch_env = mock_run.call_args_list[1].kwargs["env"]
     assert "HERMES_DESKTOP_PASSWORD_STORE" not in launch_env
+
+
+# ── Linux sandbox helper: userns-capable hosts must not require sudo ──
+
+
+def _fake_proc_reader(values: dict[str, str]):
+    """Build an ``open`` replacement that serves only the given /proc paths.
+
+    Any path not in ``values`` raises OSError, matching a kernel that lacks
+    that knob entirely.
+    """
+    real_open = builtins.open
+
+    def _fake_open(path, *args, **kwargs):
+        name = str(path)
+        if name.startswith("/proc/sys/"):
+            if name in values:
+                return io.StringIO(values[name])
+            raise FileNotFoundError(name)
+        return real_open(path, *args, **kwargs)
+
+    return _fake_open
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox helper is Linux-only")
+def test_sandbox_fixup_skips_sudo_when_userns_sandbox_available(tmp_path, monkeypatch):
+    """A host with working unprivileged user namespaces must NOT shell out to sudo.
+
+    Chromium consults the SUID ``chrome-sandbox`` helper only when it cannot
+    create user namespaces. Escalating anyway buys no security and hard-fails
+    every non-TTY launch (the XDG entry is Terminal=false and can never answer a
+    password prompt), so the app never opens from the GNOME/KDE launcher.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    exe = _make_packaged_executable(root, monkeypatch)
+    # Helper present but user-owned 0755 — the state electron-builder emits.
+    (exe.parent / "chrome-sandbox").chmod(0o755)
+
+    userns_ok = _fake_proc_reader({"/proc/sys/user/max_user_namespaces": "63379\n"})
+
+    with patch("builtins.open", side_effect=userns_ok), \
+         patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+         patch("hermes_cli.main.subprocess.run") as mock_run:
+        assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+
+    mock_run.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox helper is Linux-only")
+def test_sandbox_fixup_still_escalates_when_userns_is_clamped(tmp_path, monkeypatch):
+    """AppArmor-restricted hosts genuinely need the SUID helper — keep the sudo path."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    exe = _make_packaged_executable(root, monkeypatch)
+    (exe.parent / "chrome-sandbox").chmod(0o755)
+
+    clamped = _fake_proc_reader({
+        "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": "1\n",
+        "/proc/sys/user/max_user_namespaces": "63379\n",
+    })
+
+    with patch("builtins.open", side_effect=clamped), \
+         patch("hermes_cli.main.shutil.which", return_value="/usr/bin/sudo"), \
+         patch(
+             "hermes_cli.main.subprocess.run",
+             return_value=subprocess.CompletedProcess([], 0),
+         ) as mock_run:
+        assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+
+    assert [c.args[0][:2] for c in mock_run.call_args_list] == [
+        ["/usr/bin/sudo", "chown"],
+        ["/usr/bin/sudo", "chmod"],
+    ]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox helper is Linux-only")
+def test_no_sandbox_fallback_covers_userns_disabled_without_apparmor(monkeypatch):
+    """The ``--no-sandbox`` fallback must not be gated on one distro's knob.
+
+    Gating on ``apparmor_restrict_unprivileged_userns`` alone made the fallback
+    unreachable on any host lacking that file (all non-Debian distros), so a
+    failed fixup exited 1 with no window instead of degrading gracefully.
+    """
+    monkeypatch.delenv("ELECTRON_DISABLE_SANDBOX", raising=False)
+    no_userns = _fake_proc_reader({"/proc/sys/user/max_user_namespaces": "0\n"})
+
+    with patch("builtins.open", side_effect=no_userns):
+        assert cli_main._desktop_linux_needs_no_sandbox() is True
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux sandbox helper is Linux-only")
+def test_no_sandbox_not_requested_when_userns_sandbox_works(monkeypatch):
+    monkeypatch.delenv("ELECTRON_DISABLE_SANDBOX", raising=False)
+    userns_ok = _fake_proc_reader({"/proc/sys/user/max_user_namespaces": "63379\n"})
+
+    with patch("builtins.open", side_effect=userns_ok):
+        assert cli_main._desktop_linux_needs_no_sandbox() is False

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -94,6 +94,7 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 # silent (Terminal=false). The Exec line must prefix sys.executable for any
 # resolved bin that is a python script escaping the running venv.
 def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
+    import os
     import sys
 
     root = _make_project(tmp_path)
@@ -107,10 +108,106 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # NOT Path(...).resolve(): a venv's bin/python is a symlink to the base
+    # interpreter, and the resolved target cannot see the venv's site-packages.
+    # Prefixing with it would reintroduce the very ModuleNotFoundError the
+    # prefix exists to prevent.
+    interpreter = os.path.abspath(sys.executable)
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+def test_exec_interpreter_prefix_keeps_venv_symlink_unresolved(tmp_path, xdg_home, monkeypatch):
+    """Regression: the prefix must be the venv's own python, not its symlink target.
+
+    ``Path(sys.executable).resolve()`` follows ``<venv>/bin/python`` out to the
+    base interpreter, which has no access to the venv's ``site-packages``. The
+    resulting ``Exec=`` died with ``ModuleNotFoundError: No module named
+    'hermes_cli'`` — silently, because the entry is ``Terminal=false``.
+    """
+    root = _make_project(tmp_path)
+
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    base_interpreter = tmp_path / "base" / "bin" / "python3"
+    base_interpreter.parent.mkdir(parents=True)
+    base_interpreter.write_text("", encoding="utf-8")
+    base_interpreter.chmod(0o755)
+    venv_python = venv / "bin" / "python"
+    venv_python.symlink_to(base_interpreter)
+    (venv / "pyvenv.cfg").write_text("home = /base\n", encoding="utf-8")
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "_interpreter_imports_hermes_cli", lambda _i: True)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base_interpreter) not in exec_line
+
+
+def test_exec_omits_interpreter_prefix_when_it_cannot_import_hermes_cli(tmp_path, xdg_home, monkeypatch):
+    """Regression: a cwd-dependent interpreter must not be baked into ``Exec=``.
+
+    Hermes' bootstrap runtime python imports ``hermes_cli`` only because it is
+    started from the checkout. The DE launches with its own cwd, so prefixing
+    with that interpreter produced a launcher entry that always died on import.
+    Fall back to the launcher's own shebang instead.
+    """
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "_interpreter_imports_hermes_cli", lambda _i: False)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_leaves_foreign_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):
+    """A console script whose shebang names ANOTHER venv is already correct.
+
+    pip writes a console script's shebang to the environment it installed into.
+    The process writing this entry can legitimately be a different interpreter
+    (the bootstrap runtime python), so 'not my sys.executable' does not mean
+    'broken' — only ``/usr/bin/env python3`` and bare system paths do.
+    """
+    root = _make_project(tmp_path)
+
+    other_venv = tmp_path / "other-venv"
+    (other_venv / "bin").mkdir(parents=True)
+    other_python = other_venv / "bin" / "python3"
+    other_python.write_text("", encoding="utf-8")
+    other_python.chmod(0o755)
+    (other_venv / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text(f"#!{other_python}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{hermes_bin} desktop"
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):
@@ -130,12 +227,15 @@ def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypat
 
 
 def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):
+    import os
     import sys
 
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    # The running interpreter's own path, symlink intact — see
+    # test_exec_interpreter_prefix_keeps_venv_symlink_unresolved.
+    interpreter = os.path.abspath(sys.executable)
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))


### PR DESCRIPTION
fix(desktop): Linux launcher entry silently fails to open the app

`hermes desktop` never opens a window from the GNOME/KDE launcher entry on
a non-Ubuntu Linux host. Because the entry is `Terminal=false`, every failure
below is invisible: clicking the icon does nothing at all.

Three independent defects, each sufficient on its own.

1. The sandbox pre-flight escalates to sudo when it does not need to.

`_desktop_linux_sandbox_fixup()` unconditionally `sudo chown root:root` +
`chmod 4755` the `chrome-sandbox` helper whenever it is not already
root-owned — which is its state straight out of electron-builder. But
Chromium only consults the SUID helper when it cannot create unprivileged
user namespaces. On a host where namespaces work, the helper is never used,
so the escalation buys no security and costs the launch: sudo has no TTY
under `Terminal=false` and fails with

    sudo: a terminal is required to read the password

Gate the escalation on whether the userns sandbox is actually unavailable.
Verified on the reporting host that Electron starts and sandboxes correctly
with the helper left at `0755`: the zygotes land in a user namespace distinct
from the host's (`4026532717` vs `4026531837`).

2. The `--no-sandbox` fallback is unreachable outside Debian/Ubuntu.

`_desktop_linux_needs_no_sandbox()` returned True only when
`/proc/sys/kernel/apparmor_restrict_unprivileged_userns` reads `1`. That file
does not exist on any non-Debian distro, so `OSError -> False`, so a genuinely
failed fixup fell to `sys.exit(1)` instead of degrading. Gate on the
capability (userns permitted at all) rather than on one distro's knob;
AppArmor-restricted hosts keep the exact behaviour they have today.

3. `Exec=` is written with an interpreter that cannot import `hermes_cli`.

`resolve_exec_command()` prefixed the launcher with
`Path(sys.executable).resolve()`. Two problems compound:

  - `.resolve()` follows `<venv>/bin/python` out to the base interpreter,
    which has no access to the venv's `site-packages`. The prefix meant to
    keep the venv is what discards it.
  - `sys.executable` may reach `hermes_cli` only through its cwd. Hermes'
    bootstrap runtime python does exactly that when run from the checkout,
    and the DE launches with a cwd of its own.

Both produce an `Exec=` that dies on `import hermes_cli`:

    ModuleNotFoundError: No module named 'hermes_cli'

Keep the venv symlink intact (`os.path.abspath`, not `.resolve()`), and probe
the interpreter with `-I` from `/` before trusting it; fall back to the
launcher's own shebang otherwise. Also stop treating "shebang is not my
sys.executable" as broken — pip writes a console script's shebang to the
environment it installed into, and an absolute shebang into a real venv
(identified by `pyvenv.cfg`) is authoritative. Only `/usr/bin/env python3`
and bare system paths — the original #90292 case — still need the override.

## Verification

Launched from an `env -i` shell carrying only the session variables a DE
provides, cwd `/`, against the packaged app:

  - 7 live processes, CDP port open, zero sudo prompts, zero import errors
  - renderer confirms a real paint: `{"title":"Hermes","vis":"visible",
    "rootKids":1,"theme":"nous","text":"SESSIONS BOTS New session ..."}`
  - zygotes in a separate user namespace, i.e. still sandboxed

## Tests

Nine tests across the two suites, RED-proofed in a `git worktree` at the
parent commit: 2 fail for defect 1+2 and 5 for defect 3 without the fix, all
pass with it. Regression coverage keeps the sudo path for AppArmor-clamped
hosts and keeps the interpreter prefix for the `/usr/bin/env python3` case.
