### PR TITLE
feat(skills): add UX/UI wireframe architect

### DIFF
--- a/optional-skills/web-development/ux-ui-wireframe-architect/SKILL.md
+++ b/optional-skills/web-development/ux-ui-wireframe-architect/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: ux-ui-wireframe-architect
+description: Plan low-fidelity wireframes for product interfaces.
+version: 1.0.0
+author: Gawaru. (@duong141001), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [ux, ui, wireframe, low-fidelity, information-architecture, mobile-first, dashboard, forms]
+    related_skills: [sketch, claude-design, adversarial-ux-test]
+---
+
+# UX/UI Wireframe Architect Skill
+
+Plan low-fidelity product interfaces around user goals, information hierarchy,
+interaction states, and task flow. This skill produces an approval-ready
+structural blueprint; it does not choose a brand aesthetic or silently turn the
+wireframe into production UI.
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- wireframe a screen, feature, workflow, dashboard, or data-entry form;
+- turn product requirements into information architecture and user flow;
+- define mobile-first behavior before visual design or implementation;
+- compare layout structures without color, imagery, or brand styling;
+- document states, permissions, responsive behavior, or edge cases for handoff;
+- create a text blueprint, Mermaid flow, or grayscale Tailwind skeleton.
+
+Do not use it as the primary skill when the requested output is:
+
+- a polished visual direction or high-fidelity prototype — use `claude-design`;
+- two or three interactive visual alternatives — use `sketch`;
+- a post-build hostile UX evaluation — use `adversarial-ux-test`;
+- production code after the layout is already approved.
+
+When the request combines wireframing and implementation, finish the wireframe
+and obtain explicit approval before loading an implementation skill or editing
+product code.
+
+## Prerequisites
+
+No external service or dependency is required.
+
+Before designing, inspect any supplied requirements, screenshots, routes,
+component inventory, design system, analytics summary, policy, or existing UI.
+Use `read_file`, `search_files`, and `vision_analyze` when those sources exist.
+Do not invent unavailable backend behavior, permissions, metrics, or content.
+
+Load the relevant reference files completely before producing the wireframe:
+
+- Always read `${HERMES_SKILL_DIR}/references/universal-rules.md`.
+- Read `${HERMES_SKILL_DIR}/references/specialized-patterns.md` for mobile,
+  B2B dashboards, complex forms, tables, or high-risk operations.
+- Read `${HERMES_SKILL_DIR}/references/output-templates.md` before generating
+  text, Mermaid, or Tailwind output.
+
+## How to Run
+
+Give the screen or flow, target users, platform, known constraints, and desired
+output format. If a missing choice materially changes the structure, ask a
+focused question; otherwise state the assumption and continue.
+
+Examples:
+
+- "Wireframe the mobile checkout flow for first-time buyers."
+- "Create a desktop B2B operations dashboard with filters and bulk actions."
+- "Turn this onboarding form into a low-fidelity Mermaid flow."
+- "Produce a responsive Tailwind skeleton after I approve the text blueprint."
+
+Default behavior:
+
+1. design mobile-first unless the task is explicitly desktop-only;
+2. produce a text blueprint first;
+3. cover relevant non-happy states;
+4. stop at an approval gate before high-fidelity design or implementation.
+
+## Quick Reference
+
+| Decision | Default |
+|---|---|
+| Fidelity | Structural low-fidelity only |
+| Palette | White, black, and approved grays only |
+| Media | `[X]` or `[Image Placeholder: purpose]` |
+| Typography | Title/header and body/placeholder levels |
+| Grid | 4 columns mobile, 8 tablet, 12 desktop |
+| Primary action | One dominant CTA per task state |
+| Output | Text blueprint |
+| Optional outputs | Mermaid flow or Tailwind skeleton |
+| State coverage | Loading, empty, error, success, disabled as relevant |
+| Accessibility | Target WCAG 2.2 AA behavior |
+| Approval | Required before visual styling or implementation |
+
+### Fidelity contract
+
+Use only:
+
+- `#FFFFFF`, `#000000`, `#F3F4F6`, `#E5E7EB`, `#9CA3AF`, and `#4B5563`;
+- solid or dashed grayscale borders;
+- spacing, alignment, labels, and placeholder geometry to express hierarchy;
+- explicit text labels for icons, images, charts, maps, video, and avatars.
+
+Do not add brand colors, gradients, shadows for decoration, illustration style,
+font branding, visual polish, or unapproved marketing copy. Never use color as
+the only carrier of state or priority.
+
+## Procedure
+
+### 1. Frame the problem
+
+State, in no more than five lines:
+
+- **Primary actor:** who is using the interface now;
+- **User goal:** the outcome they need, not merely the control they click;
+- **Primary CTA:** one core action for the current state;
+- **Platform and context:** mobile, tablet, desktop, environment, and frequency;
+- **Constraints and assumptions:** known rules plus only material assumptions.
+
+Separate facts from assumptions. Flag contradictions, missing permissions,
+unresolved business rules, and dependencies that block a reliable structure.
+
+### 2. Map the flow
+
+Describe the shortest successful path:
+
+```text
+Entry → Understand → Act → Validate → Confirm → Recover/continue
+```
+
+Add alternate and recovery paths only when they affect layout or decisions.
+For each transition, identify trigger, system response, visible feedback, and
+exit. Do not hide irreversible or high-risk actions inside the happy path.
+
+### 3. Build the information architecture
+
+List regions from highest to lowest priority. For every region, define:
+
+- purpose;
+- content or data required;
+- primary and secondary actions;
+- relationship to adjacent regions;
+- whether it is persistent, conditional, collapsible, or deferred.
+
+Prefer a clear reading and action order over equal-weight card grids. Group by
+user task and meaning, not by backend table or organizational ownership.
+
+### 4. Choose the surface pattern
+
+Name the primary surface before arranging blocks:
+
+- **Monitor:** observe changing status;
+- **Operate:** act on records or queues;
+- **Compare:** evaluate alternatives on aligned dimensions;
+- **Configure:** enter or change settings/data;
+- **Decide/Learn:** understand information or make a decision;
+- **Explore:** browse and filter an open result space;
+- **Command/Inspect:** work quickly on one object or via keyboard.
+
+A screen may support a secondary pattern, but one pattern must lead. Do not use
+a marketing hero composition for an operations dashboard.
+
+### 5. Draft the text blueprint
+
+Use the syntax in `references/output-templates.md`. Include:
+
+- screen name, platform, viewport assumption, and grid;
+- regions in reading order;
+- column spans or full-width behavior;
+- controls with explicit labels and hierarchy;
+- media placeholders and aspect ratios where relevant;
+- sticky, scroll, overflow, overlay, and keyboard behavior;
+- responsive transformation notes at the end of each region or screen.
+
+For a multi-screen task, draw every named screen and connect them with a user
+flow. Do not collapse a requested flow into one representative screen.
+
+### 6. Add the state and rule matrix
+
+Cover only states relevant to the task, but explicitly consider:
+
+- first use and returning use;
+- loading, progressive loading, and stale data;
+- empty, no-results, partial data, and offline states;
+- field, section, page, and system errors;
+- success, confirmation, undo, and retry;
+- disabled, read-only, insufficient permission, and expired session;
+- destructive confirmation, conflict, duplicate submission, and partial failure.
+
+For data-rich surfaces, add sort, filter, pagination or virtualization,
+selection, bulk-action, export, and refresh behavior where relevant.
+
+### 7. Review the structure
+
+Run these checks before delivery:
+
+1. Can a first-time user identify the purpose and next action quickly?
+2. Does reading order match visual and keyboard order?
+3. Is one CTA dominant in each task state?
+4. Are labels concrete and actions distinguishable?
+5. Can the user recover without losing valid work?
+6. Does the layout survive narrow width, long text, large data, and localization?
+7. Are permission, audit, tenant, privacy, and destructive-action boundaries visible?
+8. Does the wireframe remain understandable without color or imagery?
+
+Revise any failed check before presenting the result.
+
+### 8. Deliver and pause for approval
+
+Return, in this order:
+
+1. **User Goal & Key CTA**
+2. **Assumptions / Open Decisions**
+3. **Information Architecture**
+4. **User Flow**
+5. **Text-based Wireframe Blueprint**
+6. **State & Rule Matrix**
+7. **Responsive and Accessibility Notes**
+8. **Risks / Trade-offs**
+9. **Approval Gate**
+
+At the approval gate, ask the user to approve the structure or identify a
+specific revision. Do not proceed to colors, visual design, or production code
+unless the user has already approved the wireframe or explicitly waived the
+gate.
+
+## Pitfalls
+
+- **Claiming completeness:** no checklist contains every interface rule. Apply
+  the smallest relevant set and disclose omitted or unresolved concerns.
+- **Decoration disguised as hierarchy:** use layout, spacing, borders, and text
+  labels; do not introduce brand styling into low-fidelity work.
+- **Desktop shrunk to mobile:** reprioritize, stack, defer, and transform rather
+  than scaling a twelve-column page down.
+- **Happy-path-only design:** show states that change decisions, recovery, or
+  component geometry.
+- **Backend-shaped IA:** expose concepts and tasks users understand, not raw
+  schemas or service boundaries.
+- **Placeholder ambiguity:** every `[X]` states purpose, aspect ratio, and
+  optional/required status when it matters.
+- **Dense dashboard theater:** every KPI, chart, filter, and column must support
+  a real decision or action.
+- **Validation noise:** validate at the right time, preserve entered data, focus
+  the first invalid field, and summarize page-level errors.
+- **Hidden risk:** destructive, financial, permission-changing, cross-tenant,
+  or irreversible actions need explicit consequence and confirmation.
+- **Premature implementation:** a Tailwind skeleton is still a wireframe; do
+  not let it become an unreviewed production component.
+
+## Verification
+
+A complete result must satisfy all of the following:
+
+- the primary actor, goal, CTA, platform, and assumptions are explicit;
+- IA order and user flow agree with the blueprint;
+- every requested screen or step is represented;
+- only the approved grayscale palette is used;
+- media is represented by labeled placeholders;
+- grid and responsive transformations are stated;
+- relevant states, permissions, recovery, and accessibility are covered;
+- complex forms or dashboards use the specialized reference rules;
+- the final section contains an approval gate;
+- no brand treatment, fake backend state, or unsupported product claim appears.
+
+If Mermaid or Tailwind was requested, validate syntax or renderability with the
+available tools before claiming completion. If the user requested text only,
+verify internal consistency directly and return the blueprint in Markdown.

--- a/optional-skills/web-development/ux-ui-wireframe-architect/references/output-templates.md
+++ b/optional-skills/web-development/ux-ui-wireframe-architect/references/output-templates.md
@@ -1,0 +1,333 @@
+# Wireframe Output Templates
+
+Use the smallest template that fully represents the requested screen or flow.
+Keep all user-facing output in the user's requested language.
+
+## Default delivery structure
+
+```markdown
+## User Goal & Key CTA
+- Primary actor: ...
+- Goal: ...
+- Primary CTA: ...
+- Platform: ...
+
+## Assumptions / Open Decisions
+- Confirmed: ...
+- Assumed: ...
+- Open decision: ...
+
+## Information Architecture
+1. ...
+2. ...
+
+## User Flow
+Entry → ... → Success
+Alternative/recovery: ...
+
+## Text-based Wireframe Blueprint
+...
+
+## State & Rule Matrix
+| Region/action | Loading | Empty | Error | Success | Permission |
+|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... |
+
+## Responsive and Accessibility Notes
+- ...
+
+## Risks / Trade-offs
+- ...
+
+## Approval Gate
+Approve this structure, or identify the screen/region to revise before visual
+styling or implementation.
+```
+
+## Text blueprint syntax
+
+```text
+============================================================
+[SCREEN: Screen name / Platform / Viewport assumption]
+[GRID: Mobile 4 | Tablet 8 | Desktop 12]
+[PRIMARY GOAL: ...]
+[PRIMARY CTA: ...]
+============================================================
+
+[REGION: HEADER / NAVIGATION]
+|-- Left (2 cols): [Logo Placeholder]
+|-- Center (7 cols): [Nav: Home | Features | Pricing]
+|-- Right (3 cols): [Button: Sign in] [Button Primary: Start]
+|-- Behavior: [sticky / scroll / collapse rule]
+|-- Mobile transform: [back + title + action / bottom nav / drawer]
+------------------------------------------------------------
+
+[REGION: MAIN TASK]
+|-- Left (7 cols):
+|   |-- [Header/Title]: Concrete task title
+|   |-- [Body]: Two-line explanation or current status
+|   |-- [Field: Email / label persistent / required]
+|   |-- [Button Primary: Specific action]
+|-- Right (5 cols):
+|   |-- [Image Placeholder: purpose, 16:9]
+|-- States: [loading | invalid | success | unavailable]
+|-- Keyboard/focus: [order and return behavior]
+------------------------------------------------------------
+
+[REGION: SUPPORTING CONTENT]
+|-- Col 1 (4 cols): [Header] + [Body]
+|-- Col 2 (4 cols): [Header] + [Body]
+|-- Col 3 (4 cols): [Header] + [Body]
+|-- Responsive: [stack by priority, not equal shrink]
+------------------------------------------------------------
+
+[REGION: FOOTER / SECONDARY ACTIONS]
+|-- Left (6 cols): [Help / status / legal]
+|-- Right (6 cols): [Secondary action] [Primary action]
+============================================================
+```
+
+### Syntax rules
+
+- Use `REGION` for page-level areas and nested indentation for groups.
+- Name position and column span only when they aid understanding.
+- Mark overlays as `[MODAL]`, `[DRAWER]`, `[POPOVER]`, or `[SHEET]` and state
+  trigger, dismissal, focus entry, and focus return.
+- Mark persistent behavior with `[STICKY]`, `[FIXED]`, or `[SCROLL REGION]`.
+- Label each control with its action or field meaning.
+- State responsive transformation after each affected region.
+- Use `[X]` only for a generic media box; prefer a descriptive image
+  placeholder when purpose matters.
+
+## Multi-screen flow template
+
+```text
+[FLOW: Flow name]
+
+[ENTRY A]
+    |
+    v
+[SCREEN 1: Orientation]
+    |-- Primary: [Action] --> [SCREEN 2]
+    |-- Exit: [Cancel] -----> [RETURN DESTINATION]
+    |-- Error: [Condition] -> [RECOVERY STATE]
+
+[SCREEN 2: Input / decision]
+    |-- Valid -------------> [SCREEN 3]
+    |-- Invalid -----------> [INLINE ERRORS + SUMMARY]
+    |-- Session expired ---> [RE-AUTH] -> [RESTORE SCREEN 2]
+
+[SCREEN 3: Review]
+    |-- Edit section ------> [SCREEN 2: targeted return]
+    |-- Confirm -----------> [SUBMITTING]
+
+[SUBMITTING]
+    |-- Success -----------> [CONFIRMATION]
+    |-- Partial failure ---> [RESULT SUMMARY + RETRY]
+    |-- Failure -----------> [PRESERVED INPUT + RETRY]
+```
+
+## Mermaid flow template
+
+Use Mermaid only when the user requests a block diagram or when a branching
+flow is materially clearer than text.
+
+```mermaid
+flowchart TD
+    A[Entry: context and user goal] --> B[Screen: understand task]
+    B --> C{Required input valid?}
+    C -- No --> D[Inline errors and error summary]
+    D --> B
+    C -- Yes --> E[Review scope and consequences]
+    E --> F{User confirms?}
+    F -- No --> B
+    F -- Yes --> G[Submitting: prevent duplicate action]
+    G --> H{Result}
+    H -- Success --> I[Confirmation and next action]
+    H -- Partial --> J[Per-item result and retry]
+    H -- Failure --> K[Preserve data and recover]
+```
+
+### Mermaid rules
+
+- Node labels describe user-visible states, not backend services.
+- Decision nodes are questions with explicit branches.
+- Include cancel, back, error, retry, and permission branches when relevant.
+- Keep the graph readable; split very large flows by phase.
+- Do not use color styling in low-fidelity output.
+
+## B2B dashboard blueprint
+
+```text
+============================================================
+[SCREEN: Operations Dashboard / Desktop / 12-column grid]
+[MODE: Monitor + Operate]
+============================================================
+
+[REGION: GLOBAL CONTEXT / 12 cols]
+|-- [Tenant/Workspace selector]
+|-- [Date range + timezone]
+|-- [Saved view]
+|-- [Data freshness + Refresh]
+------------------------------------------------------------
+
+[REGION: KPI STRIP / 12 cols]
+|-- KPI 1 (3 cols): [Label] [Value] [Comparison basis] [Drill-down]
+|-- KPI 2 (3 cols): [Label] [Value] [Comparison basis] [Drill-down]
+|-- KPI 3 (3 cols): [Label] [Value] [Comparison basis] [Drill-down]
+|-- KPI 4 (3 cols): [Label] [Value] [Comparison basis] [Drill-down]
+|-- States: [loading | stale | unavailable | permission-limited]
+------------------------------------------------------------
+
+[REGION: FILTER BAR / 12 cols]
+|-- [Search] [Frequent filters] [Advanced filters]
+|-- [Active filter chips] [Result count] [Clear]
+------------------------------------------------------------
+
+[REGION: BULK ACTION BAR / conditional / 12 cols]
+|-- [Selection scope + count]
+|-- [Compatible actions]
+|-- [Clear selection]
+------------------------------------------------------------
+
+[REGION: DATA TABLE / 12 cols]
+|-- Header: [Select] [Identity] [Status] [Owner] [Updated] [Actions]
+|-- Row: [Checkbox] [Primary label + metadata] [...] [Open details]
+|-- Footer: [Pagination / loaded count / page size]
+|-- States: [skeleton | empty | no results | partial | error | stale]
+|-- Keyboard: [row navigation / selection / action menu]
+|-- Mobile: [priority list -> detail screen]
+------------------------------------------------------------
+
+[REGION: DETAIL PANEL / conditional]
+|-- [Object identity + status]
+|-- [Tabs for peer views only]
+|-- [Timeline / audit / related records]
+|-- [Primary object action]
+|-- Close returns focus to originating row
+============================================================
+```
+
+## Complex form blueprint
+
+```text
+============================================================
+[SCREEN: Form name / Mobile-first / 4-column grid]
+[STRUCTURE: Single page | Step N of M]
+============================================================
+
+[REGION: ORIENTATION]
+|-- [Header/Title]
+|-- [Purpose and consequence]
+|-- [Progress: meaningful stages]
+|-- [Save state / last saved]
+------------------------------------------------------------
+
+[REGION: FIELD GROUP — meaning-based]
+|-- [Field: Persistent label / type / required-or-optional]
+|   |-- [Hint or example]
+|   |-- [Inline validation location]
+|-- [Conditional control]
+|   |-- If condition: [Dependent fields]
+|   |-- Hidden-value policy: [retain | clear | exclude]
+------------------------------------------------------------
+
+[REGION: ERROR SUMMARY / conditional]
+|-- [Header: Correct N items]
+|-- [Link/focus target: Field name — reason]
+------------------------------------------------------------
+
+[REGION: ACTION BAR]
+|-- Left: [Back] [Save and exit, if supported]
+|-- Right: [Button Primary: Continue / Review / Confirm]
+|-- Keyboard-open behavior: [visible / scroll into view]
+------------------------------------------------------------
+
+[STATE: SUBMITTING]
+|-- [Progress / duplicate prevention / cancel policy]
+
+[STATE: SUCCESS]
+|-- [Confirmation / receipt / next action]
+
+[STATE: FAILURE]
+|-- [Specific reason / preserved data / retry / support]
+============================================================
+```
+
+## Tailwind wireframe skeleton
+
+Generate code only when requested. Keep it structural, responsive, grayscale,
+and free of dependencies beyond the user's requested stack.
+
+```html
+<main class="min-h-screen bg-white text-gray-700">
+  <header class="border-b border-gray-300">
+    <div class="grid grid-cols-4 gap-4 p-4 md:grid-cols-8 lg:grid-cols-12">
+      <div class="col-span-2 border border-dashed border-gray-400 p-3">
+        [Logo Placeholder]
+      </div>
+      <nav class="col-span-2 md:col-span-4 lg:col-span-7">
+        [Navigation]
+      </nav>
+      <div class="col-span-4 flex gap-2 md:col-span-2 lg:col-span-3">
+        <button class="border border-gray-400 bg-gray-200 px-4 py-3">
+          Secondary action
+        </button>
+        <button class="border border-gray-700 bg-gray-300 px-4 py-3 text-black">
+          Primary action
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="grid grid-cols-4 gap-4 p-4 md:grid-cols-8 lg:grid-cols-12">
+    <div class="col-span-4 space-y-4 lg:col-span-7">
+      <h1 class="text-xl font-semibold text-black">[Header/Title]</h1>
+      <p>[Body Text/Placeholder]</p>
+      <div class="border border-gray-300 bg-gray-100 p-4">[Main task]</div>
+    </div>
+    <div
+      class="col-span-4 grid aspect-video place-items-center border border-dashed border-gray-400 bg-gray-200 lg:col-span-5"
+      role="img"
+      aria-label="Image placeholder"
+    >
+      [X]
+    </div>
+  </section>
+</main>
+```
+
+### Tailwind rules
+
+- Use `grid-cols-4 md:grid-cols-8 lg:grid-cols-12`.
+- Use `border border-dashed border-gray-400` for media and unfinished regions.
+- Use `bg-gray-100`, `bg-gray-200`, and `bg-gray-300` for structural fills.
+- Use `text-gray-700` and `text-black` for text hierarchy.
+- Include semantic elements, persistent labels, keyboard focus behavior, and
+  accessible names even in a skeleton.
+- Do not add brand color, gradient, decorative shadow, custom font, or visual
+  flourish.
+- Do not connect fake APIs or include fabricated records/statuses.
+
+## State and rule matrix template
+
+```markdown
+| Region/action | Trigger | Visible response | Recovery/exit | Permission/scope |
+|---|---|---|---|---|
+| Initial load | Screen opens | Region skeletons; context remains visible | Retry failed region | Show authorized scope only |
+| Empty | Valid query has zero records | Explain empty vs no-results | Create/clear filters if allowed | Hide unauthorized actions |
+| Submit | Valid confirmation | Disable duplicate submit; show progress | Cancel only if safe | Restate affected scope |
+| Partial failure | Multi-item action returns mixed result | Per-item success/failure summary | Retry failed subset | Preserve selection context |
+| Session expired | Protected action begins | Re-auth prompt | Restore task after auth | Do not reveal protected data |
+```
+
+## Approval wording
+
+End with a concise gate such as:
+
+> Wireframe approval: approve this structure, or name the screen/region to
+> revise. I will not apply brand styling or implement production UI until the
+> structure is approved.
+
+If the user explicitly waived the gate, record that fact and proceed only
+within the requested next phase.

--- a/optional-skills/web-development/ux-ui-wireframe-architect/references/specialized-patterns.md
+++ b/optional-skills/web-development/ux-ui-wireframe-architect/references/specialized-patterns.md
@@ -1,0 +1,309 @@
+# Specialized Wireframe Patterns
+
+Load the sections that match the requested surface. Combine patterns only when
+the same user task genuinely spans them.
+
+## Mobile-first interfaces
+
+### Start from priority, not compression
+
+1. Define the one task that must remain obvious on the narrowest supported
+   viewport.
+2. Place orientation and critical status before secondary navigation.
+3. Stack content in task order.
+4. Defer secondary detail through disclosure or a separate screen.
+5. Add wider layouts only when width enables useful simultaneity.
+
+### Navigation
+
+- Use a bottom navigation bar for three to five frequent peer destinations.
+- Use a top app bar for title, back, and one or two contextual actions.
+- Use drawers or "More" for infrequent destinations, not critical tasks.
+- Preserve system back behavior and deep-link state.
+- Do not hide the only path behind an unlabeled hamburger or gesture.
+
+### Touch and gesture
+
+- Prefer touch targets around 44 by 44 CSS pixels; never go below the applicable
+  WCAG 2.2 minimum without a documented exception.
+- Keep destructive actions away from frequent navigation.
+- Provide alternatives to swipe, drag, pinch, long-press, and hover.
+- State pressed, selected, disabled, loading, and focus behavior.
+
+### Viewport, keyboard, and safe areas
+
+- Account for notches, home indicators, browser chrome, and safe-area insets.
+- Define sticky CTA behavior when the software keyboard opens.
+- Keep the active field and its error visible above the keyboard.
+- Avoid fixed-height layouts that fail with large text or landscape rotation.
+- State whether headers, tabs, and action bars remain sticky while scrolling.
+
+### Mobile data presentation
+
+For wide desktop tables, choose one transformation deliberately:
+
+- priority columns plus horizontal scroll;
+- record cards with consistent label-value pairs;
+- master list followed by a detail screen;
+- grouped disclosure for secondary fields;
+- comparison mode limited to selected records.
+
+Do not squeeze every desktop column into a four-column mobile grid.
+
+### Mobile state checks
+
+Verify one-hand reach where relevant, interrupted sessions, offline/reconnect,
+slow networks, permission prompts, camera/file picker return paths, and
+orientation changes.
+
+## B2B dashboards
+
+### Identify the operating mode
+
+Choose the primary mode:
+
+- **Monitor:** scan health, trends, exceptions, and freshness.
+- **Operate:** select records, take actions, and resolve queues.
+- **Analyze:** compare dimensions, inspect causes, and export findings.
+- **Configure:** change rules, roles, mappings, or integrations.
+
+Dashboards often combine modes, but the dominant mode determines hierarchy.
+
+### Context bar
+
+Before KPIs or data, show any context that changes meaning:
+
+- organization, tenant, workspace, project, environment, or account;
+- date/time range and timezone;
+- saved view or active filter set;
+- data freshness and refresh state;
+- current role or permission boundary when consequential.
+
+Cross-tenant or production actions must make their scope unmistakable.
+
+### KPI rules
+
+Every KPI must answer a real question and expose:
+
+- label and unit;
+- value state: live, delayed, cached, estimated, or unavailable;
+- comparison basis and period when a delta is shown;
+- timestamp or freshness where material;
+- drill-down destination or explicit non-interactive status;
+- empty and error behavior.
+
+Avoid decorative metrics, unlabeled sparklines, and ambiguous red/green deltas.
+
+### Filter architecture
+
+- Put frequent filters in the primary filter bar.
+- Put advanced filters in a drawer or builder.
+- Show active filter chips and result count.
+- Provide clear-all without destroying a saved view unexpectedly.
+- Distinguish search, filter, sort, group, and view selection.
+- State whether filter changes apply immediately or require an Apply action.
+- Support saved views when users repeat complex filter combinations.
+- Decide whether filters are URL-shareable and whether they persist by user.
+
+### Data table contract
+
+Specify, where relevant:
+
+- row identity and primary label;
+- column priority, alignment, formatting, and truncation;
+- sort state and sortable columns;
+- selection rules across pages or filtered results;
+- pagination, infinite scroll, or virtualization;
+- column resize, reorder, pin, and visibility;
+- row action, bulk action, and detail navigation;
+- inline edit, save, cancel, conflict, and validation;
+- empty, no-results, loading, stale, partial, and error states;
+- keyboard navigation and screen-reader table semantics;
+- mobile transformation.
+
+Numeric columns align for comparison. Do not put several icon-only actions in
+every row; use one clear primary affordance plus a labeled overflow menu when
+needed.
+
+### Bulk actions
+
+- Keep the selection count visible.
+- Define whether selection means current page, loaded rows, or all filtered
+  results.
+- Show affected scope before execution.
+- Disable incompatible actions with an explanation.
+- Confirm destructive, external, or high-volume effects.
+- Report success, skipped records, partial failure, and retry options.
+- Preserve the filter and selection context after recoverable failure.
+
+### Drill-down and workspace continuity
+
+Use a side panel when the user benefits from preserving list context; use a
+full detail page when the object has deep navigation or long tasks. Keep object
+identity, position, filter state, and a reliable return path.
+
+### Roles, audit, and collaboration
+
+- Hide or disable actions according to the confirmed permission model; do not
+  imply authorization.
+- Explain permission failures without revealing protected data.
+- Surface actor, timestamp, scope, before/after values, and correlation context
+  in audit views where available.
+- Show ownership, assignment, comments, presence, locks, or conflict state only
+  when the product supports them.
+
+### Dashboard scale and performance
+
+Specify progressive loading by region, request cancellation after filter
+changes, stale-data handling, auto-refresh pause, large-data aggregation,
+export lifecycle, long-running jobs, and reconnect behavior.
+
+## Complex data-entry forms
+
+### Choose the form structure
+
+Use a single page when fields are limited, dependencies are visible, and the
+user benefits from scanning the whole form. Use a stepper or wizard when:
+
+- stages have distinct user goals;
+- later questions depend on earlier answers;
+- validation or review occurs by stage;
+- users need saved progress;
+- the task is long enough that chunking reduces cognitive load.
+
+Do not create steps solely to reduce visible field count. Avoid tabs for a
+strict sequence.
+
+### Field grouping and order
+
+- Group fields by user meaning and decision sequence.
+- Put prerequisites before dependent fields.
+- Keep labels persistent and examples close to inputs.
+- Mark optional fields explicitly when most fields are required, or required
+  fields explicitly when most are optional.
+- Use sensible defaults without assuming consent or legal agreement.
+- Keep destructive reset and cancel actions separate from save/continue.
+
+### Control selection
+
+- Text input: short unconstrained text.
+- Text area: long free-form content.
+- Radio: one visible choice from a small set.
+- Checkbox: independent choice or explicit acknowledgement.
+- Select/combobox: larger sets; support search when needed.
+- Toggle: immediate binary setting, not form submission consent.
+- Date/time: locale-aware input plus constraints and timezone context.
+- File upload: file types, size, progress, cancel, retry, replacement, and
+  security/privacy note.
+- Repeating group: clear add/remove/reorder behavior, limits, and item identity.
+
+Never use disabled inputs to communicate read-only values without explaining
+why they cannot be edited.
+
+### Validation timing
+
+- Validate syntax after blur or when enough input exists.
+- Validate cross-field and server rules at the earliest reliable point.
+- Do not show errors before the user has interacted unless submission reveals
+  them.
+- Keep error text next to the field and include a page/step summary for long
+  forms.
+- Focus the first invalid field after submission and preserve every valid value.
+- Distinguish warning, blocking error, and informational hint without relying
+  on color.
+
+### Conditional fields
+
+- Reveal dependent fields immediately after the controlling choice when
+  possible.
+- Explain why the field appeared and whether it is required.
+- Define whether hidden values are retained, cleared, or submitted.
+- Prevent inaccessible focus from landing in hidden regions.
+- Recalculate step completion and review summaries after conditions change.
+
+### Drafts and autosave
+
+Specify:
+
+- what triggers save;
+- local versus server persistence;
+- visible saving/saved/failed/offline state;
+- last-saved time;
+- retry and conflict behavior;
+- expiry and privacy of saved drafts;
+- unsaved-change warning on navigation;
+- whether another device or collaborator can modify the same draft.
+
+Do not claim autosave if the backend does not support it.
+
+### Multi-step flow
+
+Each step should include:
+
+- step title and purpose;
+- progress that reflects meaningful stages, not false precision;
+- back and continue behavior;
+- save-and-exit behavior when supported;
+- step-level errors;
+- dependencies on earlier answers;
+- final review before consequential submission.
+
+Back must not discard valid information. Skipping must explain its consequence.
+After submission, show a receipt or confirmation identifier when the domain
+provides one and define what can happen next.
+
+### High-risk and sensitive forms
+
+For financial, legal, identity, medical, permission, or irreversible actions:
+
+- explain why sensitive data is needed;
+- minimize collection;
+- mask secrets and identifiers;
+- expose scope, fees, timing, recipients, and consequences before confirmation;
+- require a clear acknowledgement when policy demands it;
+- support re-authentication or strong confirmation when appropriate;
+- provide a receipt, audit trail, cancellation window, or recovery path where
+  the product supports it.
+
+Never fabricate regulatory compliance or security guarantees in a wireframe.
+
+### Form state matrix
+
+At minimum consider:
+
+| State | Required structural response |
+|---|---|
+| Pristine | labels, defaults, requirements, and next action |
+| In progress | changed state, conditional fields, save status |
+| Invalid field | field message and correction |
+| Invalid step/page | summary plus focus routing |
+| Submitting | duplicate prevention and progress |
+| Success | confirmation, result, and next action |
+| Failure | preserved data, reason, retry, support path |
+| Offline | local behavior, limitation, reconnect |
+| Conflict | compare/reload/overwrite decision if supported |
+| Expired | re-authenticate without losing valid work where possible |
+
+## Search and result surfaces
+
+- Separate query input, active filters, sort, and result count.
+- Preserve query and filters through detail navigation.
+- Distinguish empty index from no matching results.
+- Offer a recovery action for no results: clear filters, broaden query, or
+  create a record when authorized.
+- Define typo handling, recent searches, suggestions, and privacy only if the
+  product supports them.
+
+## Destructive and irreversible actions
+
+For delete, revoke, transfer, publish, pay, submit, or permission changes:
+
+1. name the exact object and scope;
+2. state who or what is affected;
+3. state reversibility, delay, fee, or external side effect;
+4. require an appropriate confirmation proportional to risk;
+5. prevent duplicate execution;
+6. show completion, partial failure, and recovery/audit destination.
+
+Do not make cancel and destructive confirmation visually or spatially
+ambiguous.

--- a/optional-skills/web-development/ux-ui-wireframe-architect/references/universal-rules.md
+++ b/optional-skills/web-development/ux-ui-wireframe-architect/references/universal-rules.md
@@ -1,0 +1,322 @@
+# Universal Wireframe Rules
+
+Use this reference for every wireframe. These rules consolidate widely used
+human-interface principles, usability heuristics, responsive behavior, and
+accessibility constraints into structural decisions. They are not a claim to
+contain every rule from every design system.
+
+## Conflict order
+
+When rules conflict, resolve them in this order:
+
+1. law, safety, privacy, security, and accessibility;
+2. confirmed business rules and user permissions;
+3. primary user goal and critical task completion;
+4. platform conventions and an existing product design system;
+5. the defaults in this skill.
+
+Document the trade-off instead of silently averaging incompatible rules.
+
+## Low-fidelity system
+
+### Palette
+
+Use only:
+
+| Token | Value | Structural use |
+|---|---|---|
+| white | `#FFFFFF` | page and open space |
+| black | `#000000` | strongest text or outline |
+| gray-50 | `#F3F4F6` | subtle region fill |
+| gray-200 | `#E5E7EB` | separators and disabled fill |
+| gray-400 | `#9CA3AF` | placeholders and secondary text |
+| gray-600 | `#4B5563` | body text and controls |
+
+Do not infer success, warning, error, priority, selection, or disabled state
+from hue. Pair states with text, icon labels, border style, shape, or position.
+
+### Media and icons
+
+- Images: `[X]` or `[Image Placeholder: purpose, ratio]`.
+- Icons: `[Icon: accessible name]`; never use an unlabeled decorative glyph as
+  the only meaning carrier.
+- Charts: `[Chart Placeholder: question answered]`, followed by fallback value
+  or summary text.
+- Video/audio: name the media, duration if known, transcript/caption access,
+  and playback controls.
+- Avatars/logos: use labeled placeholders; do not synthesize identity assets.
+
+### Typography
+
+Use two semantic levels only:
+
+- **Header/Title:** page, section, group, or item heading.
+- **Body/Placeholder:** labels, values, descriptions, hints, metadata, and
+  feedback.
+
+Hierarchy may also use spacing, alignment, indentation, weight labels, and
+container boundaries. Do not design a branded type scale in a wireframe.
+
+### Grid and spacing
+
+- Mobile: four columns.
+- Tablet: eight columns.
+- Desktop: twelve columns.
+- Use a consistent spacing rhythm; name relative size (`xs`, `sm`, `md`, `lg`)
+  if exact pixels are not an implementation requirement.
+- Align related edges. Keep unrelated regions visually separated.
+- Prefer one main reading axis. Use split panes only when simultaneous context
+  materially helps the task.
+- State maximum content width or fluid behavior when it changes scanning.
+
+## User-centered framing
+
+### Match the real task
+
+Define the user's desired outcome, current context, frequency, expertise,
+constraints, and consequence of failure. Optimize frequent and critical paths
+without making rare recovery paths impossible.
+
+### Recognition over recall
+
+- Keep choices, status, context, and valid next actions visible.
+- Preserve user-entered values and previous selections where appropriate.
+- Use concrete labels instead of relying on memory, unexplained icons, or
+  hidden gestures.
+- Show examples and formatting requirements beside the relevant control.
+
+### Consistency and standards
+
+- Reuse established labels, locations, control behavior, and terminology.
+- Keep the same action in the same relative place across a flow.
+- Follow platform conventions unless a documented user need justifies a
+  deviation.
+- Do not use one component shape for incompatible meanings.
+
+### Affordance and mapping
+
+- Controls should look actionable even in grayscale.
+- Place effects near their causes and feedback near the action that produced it.
+- Map spatial controls to spatial results where possible.
+- Distinguish navigation, selection, editing, submission, and destructive
+  actions structurally and textually.
+
+### Choice and cognitive load
+
+- Present only choices required for the current decision.
+- Group related options, choose sensible defaults, and defer advanced settings.
+- Break large tasks into meaningful stages, not arbitrary screen counts.
+- Avoid simultaneous primary CTAs competing for attention.
+- Use progressive disclosure without hiding prerequisites or consequences.
+
+### Target size and proximity
+
+- Make frequent and important targets easy to acquire.
+- Target at least 24 by 24 CSS pixels for WCAG 2.2 target-size minimum where
+  exceptions do not apply; prefer about 44 by 44 for touch controls.
+- Provide spacing between adjacent destructive or opposite actions.
+- Keep labels with the controls they describe.
+
+## Information architecture
+
+### Region priority
+
+Arrange content by:
+
+1. orientation: where am I and what object/context is active;
+2. primary task: what should I do next;
+3. decision support: what information is needed to act;
+4. secondary actions and navigation;
+5. metadata, help, and advanced controls.
+
+Do not make every block a card. Use cards only when items are independently
+selectable, comparable, movable, or meaningfully grouped.
+
+### Labeling
+
+- Use the user's domain language, not implementation jargon.
+- Begin action labels with clear verbs.
+- Name destinations with nouns.
+- Avoid vague labels such as "Submit", "Continue", or "Manage" when a more
+  specific result can be stated.
+- Keep the same concept named consistently across screens.
+
+### Navigation
+
+- Show current location and available escape routes.
+- Keep top-level destinations stable.
+- Use tabs only for peer views of the same context, not sequential steps.
+- Use breadcrumbs for hierarchy, not history.
+- Preserve deep links and back behavior when the flow requires them.
+- Do not rely on hover for essential navigation or explanation.
+
+## Interaction and feedback
+
+### Visibility of system status
+
+For any action with noticeable delay, specify:
+
+- immediate acknowledgement;
+- loading or progress representation;
+- whether the user can leave, cancel, retry, or continue elsewhere;
+- success confirmation;
+- failure consequence and recovery.
+
+Use skeletons for known geometry, spinners for indeterminate compact work, and
+progress indicators for measurable multi-step work. Never show fake progress.
+
+### Error prevention and recovery
+
+- Prevent invalid choices when the rule is known and explain why.
+- Validate formatting locally without waiting for final submission when useful.
+- Confirm actions that are destructive, costly, irreversible, or affect others.
+- State the object, consequence, scope, and reversibility in confirmations.
+- Prefer undo for reversible operations.
+- Preserve valid data after an error.
+- Give a specific recovery action, not only an error code.
+
+### Control and freedom
+
+- Provide cancel/back/close behavior without silently discarding work.
+- Warn before losing unsaved changes.
+- Support undo or version history when the domain warrants it.
+- Do not trap focus or navigation.
+- Distinguish temporary dismissal from permanent opt-out.
+
+## State model
+
+Consider the following state families for each region or screen:
+
+| Family | Questions |
+|---|---|
+| Initial | First use, returning use, defaults, restored draft? |
+| Loading | Whole page, region, row, or action? Blocking or background? |
+| Data | Empty, populated, no results, partial, stale, very large? |
+| Input | Pristine, focused, changed, valid, invalid, disabled, read-only? |
+| Submission | Ready, submitting, duplicate, success, partial success, failed? |
+| Access | Signed out, expired, insufficient role, tenant mismatch? |
+| Connectivity | Offline, reconnecting, timed out, conflicting update? |
+| Risk | Destructive, financial, legal, permission-changing, irreversible? |
+
+Only render states that can occur, but do not omit them merely because product
+requirements are silent. Mark unresolved states as product decisions.
+
+## Responsive behavior
+
+Design content priority before breakpoints. For each region, state whether it:
+
+- stays fixed;
+- wraps;
+- stacks;
+- collapses into disclosure;
+- moves to a drawer, sheet, or separate screen;
+- becomes horizontally scrollable;
+- hides only after an explicit priority decision.
+
+Do not solve mobile by shrinking text or controls. Preserve task order, labels,
+focus order, and critical status. Test at narrow widths, zoom, long labels, and
+large text rather than only named device sizes.
+
+## Accessibility target
+
+Use WCAG 2.2 AA as the default behavioral target, while noting that a wireframe
+alone cannot certify compliance.
+
+### Structure
+
+- One clear page title and logical heading order.
+- Landmarks and regions with meaningful names.
+- Reading order, visual order, and DOM/focus order agree.
+- Repeated navigation and actions remain predictable.
+
+### Keyboard and focus
+
+- Every action is keyboard reachable.
+- Focus is visible and moves predictably.
+- Dialog focus enters, remains contained while open, and returns to the trigger.
+- Escape behavior is stated where dismissing is safe.
+- Skip links or equivalent shortcuts exist for repeated dense navigation.
+
+### Forms and instructions
+
+- Every control has a persistent label.
+- Required/optional status is textual.
+- Instructions appear before they are needed.
+- Errors identify the field, reason, and correction.
+- Error summaries link or move focus to invalid fields on long forms.
+- Do not rely on placeholder text as the label.
+
+### Nonvisual understanding
+
+- Status is announced or otherwise available to assistive technology.
+- Tables have headers and captions or context.
+- Charts provide a textual summary and underlying values when needed.
+- Icon-only controls have accessible names.
+- Drag operations have a non-drag alternative.
+
+### Timing and motion
+
+- Avoid time limits; when unavoidable, warn and allow extension.
+- Do not require precise or path-based gestures without an alternative.
+- Animation and auto-updating regions need pause/reduce-motion behavior when
+  relevant, even if motion is not drawn in the wireframe.
+
+## Content, localization, and trust
+
+### Content resilience
+
+- Use representative labels and data shapes, not lorem ipsum.
+- Allow text expansion of roughly 30–50 percent for localization.
+- Support multiline labels and values without overlap.
+- Avoid direction-dependent language such as "click the item on the right."
+- Account for right-to-left layout if the target locale requires it.
+- Specify date, time, currency, units, and number formatting assumptions.
+
+### Privacy and security
+
+- Minimize collection and reveal why sensitive data is needed.
+- Mask secrets by default and provide deliberate reveal/copy behavior.
+- Avoid exposing personal data in shared screens, notifications, exports, and
+  URLs.
+- Make tenant/workspace/account context visible before consequential actions.
+- Show session expiry, re-authentication, and permission failure recovery.
+- Do not imply access that the current role does not have.
+
+### Honest system behavior
+
+- Distinguish live, cached, estimated, delayed, and unavailable data.
+- Label preview-only or disconnected capabilities.
+- Never fabricate metrics, records, success states, integrations, or audit
+  history to fill a wireframe.
+- Make irreversible and external side effects explicit before confirmation.
+
+## Performance and scale
+
+Even a low-fidelity design should state behavior for:
+
+- slow initial load and progressive region loading;
+- large result sets, pagination, infinite scroll, or virtualization;
+- optimistic updates and rollback;
+- stale data and refresh timestamps;
+- concurrent edits and version conflict;
+- interrupted uploads or long-running operations;
+- low bandwidth and offline conditions when relevant.
+
+Perceived speed must not misrepresent actual completion.
+
+## Heuristic review
+
+Before delivery, review the wireframe against these questions:
+
+1. Is system status visible?
+2. Does language match the user's world?
+3. Can the user cancel, undo, or recover?
+4. Are patterns consistent?
+5. Are errors prevented where practical?
+6. Is recognition favored over recall?
+7. Are expert shortcuts possible without confusing new users?
+8. Is every region necessary?
+9. Are errors specific and actionable?
+10. Is help contextual and discoverable?
+11. Is the primary task accessible by keyboard and touch?
+12. Does the structure remain coherent with no color, imagery, or ideal data?

--- a/tests/skills/test_ux_ui_wireframe_architect_skill.py
+++ b/tests/skills/test_ux_ui_wireframe_architect_skill.py
@@ -1,0 +1,58 @@
+"""Behavior contracts for the UX/UI wireframe architect skill."""
+
+from agent.skill_utils import parse_frontmatter
+from tools.skills_hub import OptionalSkillSource
+
+
+IDENTIFIER = "official/web-development/ux-ui-wireframe-architect"
+SUPPORT_FILES = {
+    "SKILL.md",
+    "references/universal-rules.md",
+    "references/specialized-patterns.md",
+    "references/output-templates.md",
+}
+
+
+def test_official_source_discovers_wireframe_skill():
+    source = OptionalSkillSource()
+
+    meta = source.inspect(IDENTIFIER)
+
+    assert meta is not None
+    assert meta.name == "ux-ui-wireframe-architect"
+    assert meta.source == "official"
+    assert meta.trust_level == "builtin"
+    assert {"wireframe", "mobile-first", "dashboard", "forms"}.issubset(
+        set(meta.tags)
+    )
+
+
+def test_official_source_packages_all_wireframe_guidance():
+    source = OptionalSkillSource()
+
+    bundle = source.fetch(IDENTIFIER)
+
+    assert bundle is not None
+    assert bundle.name == "ux-ui-wireframe-architect"
+    assert bundle.source == "official"
+    assert bundle.trust_level == "builtin"
+    normalized_files = {path.replace("\\", "/"): content for path, content in bundle.files.items()}
+    assert SUPPORT_FILES.issubset(normalized_files)
+    assert all(normalized_files[path] for path in SUPPORT_FILES)
+
+
+def test_packaged_frontmatter_uses_supported_contract():
+    source = OptionalSkillSource()
+    bundle = source.fetch(IDENTIFIER)
+    assert bundle is not None
+
+    skill_md = bundle.files["SKILL.md"]
+    assert isinstance(skill_md, bytes)
+    frontmatter, body = parse_frontmatter(skill_md.decode("utf-8"))
+
+    assert frontmatter["name"] == bundle.name
+    assert len(frontmatter["description"]) <= 60
+    assert frontmatter["description"].endswith(".")
+    assert set(frontmatter["platforms"]) == {"linux", "macos", "windows"}
+    assert frontmatter["author"].split(",")[0].strip() != "Hermes Agent"
+    assert body.startswith("# UX/UI Wireframe Architect Skill")

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -238,6 +238,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed an in-page natural-language GUI copilot in web apps. |
+| [**ux-ui-wireframe-architect**](/docs/user-guide/skills/optional/web-development/web-development-ux-ui-wireframe-architect) | Plan low-fidelity wireframes for product interfaces. |
 
 ## yuanbao
 

--- a/website/docs/user-guide/skills/optional/web-development/web-development-ux-ui-wireframe-architect.md
+++ b/website/docs/user-guide/skills/optional/web-development/web-development-ux-ui-wireframe-architect.md
@@ -1,0 +1,286 @@
+---
+title: "Ux Ui Wireframe Architect — Plan low-fidelity wireframes for product interfaces"
+sidebar_label: "Ux Ui Wireframe Architect"
+description: "Plan low-fidelity wireframes for product interfaces"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Ux Ui Wireframe Architect
+
+Plan low-fidelity wireframes for product interfaces.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/web-development/ux-ui-wireframe-architect` |
+| Path | `optional-skills/web-development/ux-ui-wireframe-architect` |
+| Version | `1.0.0` |
+| Author | Gawaru. (@duong141001), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `ux`, `ui`, `wireframe`, `low-fidelity`, `information-architecture`, `mobile-first`, `dashboard`, `forms` |
+| Related skills | [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch), [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`adversarial-ux-test`](/docs/user-guide/skills/optional/dogfood/dogfood-adversarial-ux-test) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# UX/UI Wireframe Architect Skill
+
+Plan low-fidelity product interfaces around user goals, information hierarchy,
+interaction states, and task flow. This skill produces an approval-ready
+structural blueprint; it does not choose a brand aesthetic or silently turn the
+wireframe into production UI.
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- wireframe a screen, feature, workflow, dashboard, or data-entry form;
+- turn product requirements into information architecture and user flow;
+- define mobile-first behavior before visual design or implementation;
+- compare layout structures without color, imagery, or brand styling;
+- document states, permissions, responsive behavior, or edge cases for handoff;
+- create a text blueprint, Mermaid flow, or grayscale Tailwind skeleton.
+
+Do not use it as the primary skill when the requested output is:
+
+- a polished visual direction or high-fidelity prototype — use `claude-design`;
+- two or three interactive visual alternatives — use `sketch`;
+- a post-build hostile UX evaluation — use `adversarial-ux-test`;
+- production code after the layout is already approved.
+
+When the request combines wireframing and implementation, finish the wireframe
+and obtain explicit approval before loading an implementation skill or editing
+product code.
+
+## Prerequisites
+
+No external service or dependency is required.
+
+Before designing, inspect any supplied requirements, screenshots, routes,
+component inventory, design system, analytics summary, policy, or existing UI.
+Use `read_file`, `search_files`, and `vision_analyze` when those sources exist.
+Do not invent unavailable backend behavior, permissions, metrics, or content.
+
+Load the relevant reference files completely before producing the wireframe:
+
+- Always read `${HERMES_SKILL_DIR}/references/universal-rules.md`.
+- Read `${HERMES_SKILL_DIR}/references/specialized-patterns.md` for mobile,
+  B2B dashboards, complex forms, tables, or high-risk operations.
+- Read `${HERMES_SKILL_DIR}/references/output-templates.md` before generating
+  text, Mermaid, or Tailwind output.
+
+## How to Run
+
+Give the screen or flow, target users, platform, known constraints, and desired
+output format. If a missing choice materially changes the structure, ask a
+focused question; otherwise state the assumption and continue.
+
+Examples:
+
+- "Wireframe the mobile checkout flow for first-time buyers."
+- "Create a desktop B2B operations dashboard with filters and bulk actions."
+- "Turn this onboarding form into a low-fidelity Mermaid flow."
+- "Produce a responsive Tailwind skeleton after I approve the text blueprint."
+
+Default behavior:
+
+1. design mobile-first unless the task is explicitly desktop-only;
+2. produce a text blueprint first;
+3. cover relevant non-happy states;
+4. stop at an approval gate before high-fidelity design or implementation.
+
+## Quick Reference
+
+| Decision | Default |
+|---|---|
+| Fidelity | Structural low-fidelity only |
+| Palette | White, black, and approved grays only |
+| Media | `[X]` or `[Image Placeholder: purpose]` |
+| Typography | Title/header and body/placeholder levels |
+| Grid | 4 columns mobile, 8 tablet, 12 desktop |
+| Primary action | One dominant CTA per task state |
+| Output | Text blueprint |
+| Optional outputs | Mermaid flow or Tailwind skeleton |
+| State coverage | Loading, empty, error, success, disabled as relevant |
+| Accessibility | Target WCAG 2.2 AA behavior |
+| Approval | Required before visual styling or implementation |
+
+### Fidelity contract
+
+Use only:
+
+- `#FFFFFF`, `#000000`, `#F3F4F6`, `#E5E7EB`, `#9CA3AF`, and `#4B5563`;
+- solid or dashed grayscale borders;
+- spacing, alignment, labels, and placeholder geometry to express hierarchy;
+- explicit text labels for icons, images, charts, maps, video, and avatars.
+
+Do not add brand colors, gradients, shadows for decoration, illustration style,
+font branding, visual polish, or unapproved marketing copy. Never use color as
+the only carrier of state or priority.
+
+## Procedure
+
+### 1. Frame the problem
+
+State, in no more than five lines:
+
+- **Primary actor:** who is using the interface now;
+- **User goal:** the outcome they need, not merely the control they click;
+- **Primary CTA:** one core action for the current state;
+- **Platform and context:** mobile, tablet, desktop, environment, and frequency;
+- **Constraints and assumptions:** known rules plus only material assumptions.
+
+Separate facts from assumptions. Flag contradictions, missing permissions,
+unresolved business rules, and dependencies that block a reliable structure.
+
+### 2. Map the flow
+
+Describe the shortest successful path:
+
+```text
+Entry → Understand → Act → Validate → Confirm → Recover/continue
+```
+
+Add alternate and recovery paths only when they affect layout or decisions.
+For each transition, identify trigger, system response, visible feedback, and
+exit. Do not hide irreversible or high-risk actions inside the happy path.
+
+### 3. Build the information architecture
+
+List regions from highest to lowest priority. For every region, define:
+
+- purpose;
+- content or data required;
+- primary and secondary actions;
+- relationship to adjacent regions;
+- whether it is persistent, conditional, collapsible, or deferred.
+
+Prefer a clear reading and action order over equal-weight card grids. Group by
+user task and meaning, not by backend table or organizational ownership.
+
+### 4. Choose the surface pattern
+
+Name the primary surface before arranging blocks:
+
+- **Monitor:** observe changing status;
+- **Operate:** act on records or queues;
+- **Compare:** evaluate alternatives on aligned dimensions;
+- **Configure:** enter or change settings/data;
+- **Decide/Learn:** understand information or make a decision;
+- **Explore:** browse and filter an open result space;
+- **Command/Inspect:** work quickly on one object or via keyboard.
+
+A screen may support a secondary pattern, but one pattern must lead. Do not use
+a marketing hero composition for an operations dashboard.
+
+### 5. Draft the text blueprint
+
+Use the syntax in `references/output-templates.md`. Include:
+
+- screen name, platform, viewport assumption, and grid;
+- regions in reading order;
+- column spans or full-width behavior;
+- controls with explicit labels and hierarchy;
+- media placeholders and aspect ratios where relevant;
+- sticky, scroll, overflow, overlay, and keyboard behavior;
+- responsive transformation notes at the end of each region or screen.
+
+For a multi-screen task, draw every named screen and connect them with a user
+flow. Do not collapse a requested flow into one representative screen.
+
+### 6. Add the state and rule matrix
+
+Cover only states relevant to the task, but explicitly consider:
+
+- first use and returning use;
+- loading, progressive loading, and stale data;
+- empty, no-results, partial data, and offline states;
+- field, section, page, and system errors;
+- success, confirmation, undo, and retry;
+- disabled, read-only, insufficient permission, and expired session;
+- destructive confirmation, conflict, duplicate submission, and partial failure.
+
+For data-rich surfaces, add sort, filter, pagination or virtualization,
+selection, bulk-action, export, and refresh behavior where relevant.
+
+### 7. Review the structure
+
+Run these checks before delivery:
+
+1. Can a first-time user identify the purpose and next action quickly?
+2. Does reading order match visual and keyboard order?
+3. Is one CTA dominant in each task state?
+4. Are labels concrete and actions distinguishable?
+5. Can the user recover without losing valid work?
+6. Does the layout survive narrow width, long text, large data, and localization?
+7. Are permission, audit, tenant, privacy, and destructive-action boundaries visible?
+8. Does the wireframe remain understandable without color or imagery?
+
+Revise any failed check before presenting the result.
+
+### 8. Deliver and pause for approval
+
+Return, in this order:
+
+1. **User Goal & Key CTA**
+2. **Assumptions / Open Decisions**
+3. **Information Architecture**
+4. **User Flow**
+5. **Text-based Wireframe Blueprint**
+6. **State & Rule Matrix**
+7. **Responsive and Accessibility Notes**
+8. **Risks / Trade-offs**
+9. **Approval Gate**
+
+At the approval gate, ask the user to approve the structure or identify a
+specific revision. Do not proceed to colors, visual design, or production code
+unless the user has already approved the wireframe or explicitly waived the
+gate.
+
+## Pitfalls
+
+- **Claiming completeness:** no checklist contains every interface rule. Apply
+  the smallest relevant set and disclose omitted or unresolved concerns.
+- **Decoration disguised as hierarchy:** use layout, spacing, borders, and text
+  labels; do not introduce brand styling into low-fidelity work.
+- **Desktop shrunk to mobile:** reprioritize, stack, defer, and transform rather
+  than scaling a twelve-column page down.
+- **Happy-path-only design:** show states that change decisions, recovery, or
+  component geometry.
+- **Backend-shaped IA:** expose concepts and tasks users understand, not raw
+  schemas or service boundaries.
+- **Placeholder ambiguity:** every `[X]` states purpose, aspect ratio, and
+  optional/required status when it matters.
+- **Dense dashboard theater:** every KPI, chart, filter, and column must support
+  a real decision or action.
+- **Validation noise:** validate at the right time, preserve entered data, focus
+  the first invalid field, and summarize page-level errors.
+- **Hidden risk:** destructive, financial, permission-changing, cross-tenant,
+  or irreversible actions need explicit consequence and confirmation.
+- **Premature implementation:** a Tailwind skeleton is still a wireframe; do
+  not let it become an unreviewed production component.
+
+## Verification
+
+A complete result must satisfy all of the following:
+
+- the primary actor, goal, CTA, platform, and assumptions are explicit;
+- IA order and user flow agree with the blueprint;
+- every requested screen or step is represented;
+- only the approved grayscale palette is used;
+- media is represented by labeled placeholders;
+- grid and responsive transformations are stated;
+- relevant states, permissions, recovery, and accessibility are covered;
+- complex forms or dashboards use the specialized reference rules;
+- the final section contains an approval gate;
+- no brand treatment, fake backend state, or unsupported product claim appears.
+
+If Mermaid or Tailwind was requested, validate syntax or renderability with the
+available tools before claiming completion. If the user requested text only,
+verify internal consistency directly and return the blueprint in Markdown.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -606,6 +606,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy',
                     'user-guide/skills/optional/web-development/web-development-page-agent',
+                    'user-guide/skills/optional/web-development/web-development-ux-ui-wireframe-architect',
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary

- add an optional `ux-ui-wireframe-architect` skill for grayscale, low-fidelity product wireframes
- cover mobile-first interfaces, B2B dashboards, complex forms, data tables, accessibility, responsive behavior, and failure states through progressively loaded references
- add behavior tests for official catalog discovery, resource packaging, and frontmatter contracts
- add the generated skill documentation, optional catalog entry, and sidebar entry

## Why optional

Wireframing is a specialized workflow rather than a daily-driver capability for most Hermes users. Keeping it under `optional-skills/web-development/` avoids default prompt overhead while making it installable through the official Skills Hub.

## Overlap assessment

This intentionally stops at information architecture, user flow, interaction states, responsive transformations, and a low-fidelity approval gate. It does not provide brand direction, high-fidelity visual craft, or production UI implementation. That boundary makes it complementary to existing `sketch` / `claude-design` skills and to #85144, which targets interface visual-design quality.

## Validation

- `scripts/run_tests.sh tests/skills/test_ux_ui_wireframe_architect_skill.py tests/skills/test_authoring_standards.py -q` — 1,187 passed
- `scan_skill(..., source='official')` — safe, builtin trust, 0 findings
- `ascii-guard==2.3.0 lint --exclude-code-blocks docs` — 403 files checked, 0 errors
- `npm run build:fast` in `website/` — success; existing `/docs/llms.txt` and `/docs/llms-full.txt` warnings only
- `git diff --cached --check` — clean

## Notes

A direct website `npm run typecheck` is not an independent CI gate and currently fails on untouched baseline issues: TypeScript 6's `baseUrl` deprecation, missing `JSX` namespace declarations, and a generated `userStories.json` that is produced by prebuild. The actual Docusaurus CI build path completed successfully.
