### PR TITLE
fix(plugins): clear a denied alias when enabling a plugin

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1444,26 +1444,30 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
 
-    already_enabled = key in enabled and key not in disabled
+    # The loader denies on the canonical key, the bare leaf, OR the manifest
+    # name, so this guard must consider every alias too. Checking only the key
+    # made a stale alias (for example ``superpowers`` left behind when an
+    # install moved the plugin to ``superpowers/.hermes-plugin``) report
+    # "already enabled" and skip the cleanup below, so the documented remedy
+    # `hermes plugins enable <name>` could never clear the deny entry.
+    aliases = {key, key.split("/")[-1]}
+    for entry in _discover_all_plugins():
+        # entry = (name, version, description, source, dir_path, key)
+        if entry[5] == key:
+            aliases.add(entry[0])
+            break
+
+    already_enabled = key in enabled and not (aliases & disabled)
 
     if not already_enabled:
         enabled.add(key)
-        disabled.discard(key)
         # Drop every alias of this plugin from the disabled list so an
         # explicit disable under a different form can't keep it off. The
         # loader's disable check matches on BOTH the canonical key
         # (``web/firecrawl``) AND the manifest name (``web-firecrawl``);
         # a stale entry under either form makes "explicit disable wins"
-        # (plugins.py) silently veto this enable. Discard the key, its
-        # bare leaf, and the manifest name. (#40190 follow-up.)
-        bare = key.split("/")[-1]
-        if bare != key:
-            disabled.discard(bare)
-        for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key)
-            if entry[5] == key:
-                disabled.discard(entry[0])
-                break
+        # (plugins.py) silently veto this enable. (#40190 follow-up.)
+        disabled -= aliases
         _save_enabled_set(enabled)
         _save_disabled_set(disabled)
         console.print(

--- a/tests/test_plugins_enable_clears_alias_deny.py
+++ b/tests/test_plugins_enable_clears_alias_deny.py
@@ -1,0 +1,79 @@
+"""`hermes plugins enable` must clear a stale deny entry under any alias.
+
+The loader (``hermes_cli/plugins.py``) denies a plugin when the canonical key
+OR the manifest name appears in ``plugins.disabled``, and an explicit disable
+always wins over ``plugins.enabled``. An install that moves a plugin to a path
+key can leave the old bare name behind in ``disabled``, which silently vetoes
+the plugin even though it is listed as enabled.
+
+The enable command is the documented remedy for that state, so its
+already-enabled guard has to consider every alias the loader denies on.
+Otherwise it reports "already enabled", skips the cleanup, and the deny entry
+can never be cleared through the CLI.
+"""
+
+import hermes_cli.plugins_cmd as plugins_cmd
+
+
+def _enable(monkeypatch, *, key, name, enabled, disabled):
+    """Run the enable command against in-memory config sets."""
+    saved = {"enabled": set(enabled), "disabled": set(disabled)}
+
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(saved["enabled"]))
+    monkeypatch.setattr(
+        plugins_cmd, "_get_disabled_set", lambda: set(saved["disabled"])
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_enabled_set",
+        lambda value: saved.__setitem__("enabled", set(value)),
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_save_disabled_set",
+        lambda value: saved.__setitem__("disabled", set(value)),
+    )
+    # entry = (name, version, description, source, dir_path, key)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_all_plugins",
+        lambda: [(name, "1.0", "test plugin", "user", "/tmp/plugin", key)],
+    )
+
+    monkeypatch.setattr(
+        plugins_cmd, "_resolve_plugin_key_and_source", lambda _name: (key, "user")
+    )
+    # Bundled plugins skip the capability prompt; "user" would prompt, so stop
+    # after the config write by declining the privileged grant explicitly.
+    plugins_cmd.cmd_enable(key, allow_tool_override=False)
+    return saved
+
+
+def test_enable_clears_a_stale_bare_name_from_disabled(monkeypatch):
+    """A bare name left in disabled must not survive enabling the path key."""
+    saved = _enable(
+        monkeypatch,
+        key="superpowers/.hermes-plugin",
+        name="superpowers",
+        enabled={"superpowers/.hermes-plugin"},
+        disabled={"superpowers"},
+    )
+
+    # The loader denies on the manifest name, so leaving it behind keeps the
+    # plugin off no matter what plugins.enabled says.
+    assert "superpowers" not in saved["disabled"]
+    assert "superpowers/.hermes-plugin" in saved["enabled"]
+
+
+def test_enable_is_a_noop_when_no_alias_is_denied(monkeypatch):
+    """Enabling a genuinely enabled plugin leaves config untouched."""
+    saved = _enable(
+        monkeypatch,
+        key="web/firecrawl",
+        name="web-firecrawl",
+        enabled={"web/firecrawl"},
+        disabled={"unrelated-plugin"},
+    )
+
+    assert saved["enabled"] == {"web/firecrawl"}
+    assert saved["disabled"] == {"unrelated-plugin"}


### PR DESCRIPTION
## What broke

`hermes plugins enable <name>` cannot re-enable a plugin whose old alias is still listed in `plugins.disabled`. It prints `Plugin '<key>' is already enabled.` and writes nothing, so the plugin stays denied.

I hit this on a real install. A plugin install moved `superpowers` to the path key `superpowers/.hermes-plugin` and left the bare name `superpowers` behind in `plugins.disabled`:

```yaml
plugins:
  enabled:  [ponytail, superpowers/.hermes-plugin, web-local-extract]
  disabled: [ponytail, superpowers]
```

The loader denies on the manifest name as well as the key (`hermes_cli/plugins.py`, "explicit disable always wins"), so the plugin never loaded. `hermes plugins list` still reported it as `enabled`, and every `skill_view("superpowers:<skill>")` call returned `not found` for five days before anyone noticed. The gateway log shows the first casualty 90 minutes after the install, then a trail of silent failures.

Running the remedy the error message itself recommends did not help:

```
$ hermes plugins enable superpowers
Plugin 'superpowers/.hermes-plugin' is already enabled.
```

I had to hand-edit `config.yaml` to recover.

## Root cause

`cmd_enable` already strips every alias from the disabled list (the #40190 follow-up), but the guard that decides whether to run that cleanup compares only the canonical key:

```python
already_enabled = key in enabled and key not in disabled
```

`superpowers/.hermes-plugin` is in `enabled` and is not itself in `disabled`, so the guard returns `True`, the cleanup is skipped, and the alias that actually causes the denial survives. The guard and the loader disagree about what "enabled" means.

## The fix

Compute the alias set once, use it for both the guard and the cleanup, so the guard matches what the loader denies on. Net effect is a smaller function: the alias walk moves up and replaces three separate `discard` calls with one set difference.

## Verification

Ran from a fresh worktree on `origin/main` at `2b8b4542e9`, with the repo venv.

- `tests/test_plugins_enable_clears_alias_deny.py` — 2 new tests, both pass.
- Teeth check: reverting only the guard line to the original makes `test_enable_clears_a_stale_bare_name_from_disabled` fail with `assert 'superpowers' not in {'superpowers'}` and the captured stdout `Plugin 'superpowers/.hermes-plugin' is already enabled.`, reproducing the reported symptom exactly. Restoring the fix turns it green.
- Sibling radius: `tests/test_plugins_enable_clears_alias_deny.py tests/test_plugins_manage_profile_scope.py tests/test_plugin_skills.py tests/test_plugin_utils.py` — 40 passed.
- `ruff check` on both changed files: `All checks passed!`
- `ruff format --check` on the new test file: clean.

## Known / out of scope

- `ruff format --check hermes_cli/plugins_cmd.py` reports the file as unformatted, but it does so on unmodified `origin/main` too (verified by stashing the change and re-running). The complaints are in unrelated regions such as line 57; reformatting the whole file would bury a 16-line fix in repo-wide churn. My hunk is not among them.
- The second-order question of whether `plugins.disabled` should reject an entry that is also in `plugins.enabled` at write time, or warn on the conflict at load time, is left alone. This change fixes the path a user is told to run; a louder loader-side warning is a separate, larger discussion.
- Not addressed: whatever wrote the conflicting config in the first place. I could not reproduce which install path left the stale alias, and guessing at it would be speculative.

## Environment

Agent-generated contribution.

- Model: claude-opus-5
- Harness: Hermes Agent 0.19.0
- Installed plugins: superpowers 6.3.0, ponytail 4.9.0, web-local-extract
