### PR TITLE
fix(mcp): invert stdio child liveness check that fast-failed live servers

### DIFF
--- a/tests/test_mcp_stdio_children_dead.py
+++ b/tests/test_mcp_stdio_children_dead.py
@@ -1,0 +1,59 @@
+"""Regression tests for MCPServerTask._stdio_children_dead (inverted liveness).
+
+A live stdio child must NOT trip the dead-children fast-fail; only when every
+tracked child has exited may the call be failed fast. The original logic
+returned True (dead) for a live pid, poisoning every stdio MCP server on its
+first call after connect.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tools.mcp_tool import MCPServerTask  # noqa: E402
+
+
+def _make_task(pids, http=False):
+    task = MCPServerTask.__new__(MCPServerTask)
+    task._stdio_child_pids = pids
+    # _is_http reads self._config: presence of "url" means HTTP transport
+    task._config = {"url": "http://example.invalid"} if http else {"command": "true"}
+    return task
+
+
+def test_alive_child_is_not_dead():
+    # our own pid is definitely alive
+    task = _make_task([os.getpid()])
+    assert task._stdio_children_dead() is False
+
+
+def test_all_children_exited_is_dead():
+    # pids from a range that cannot be alive (max pid + spawn-and-reap)
+    import subprocess
+
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    task = _make_task([proc.pid])
+    # NOTE: pid could theoretically be recycled between wait() and the check;
+    # psutil.pid_exists on a reaped child of this process is reliably False.
+    assert task._stdio_children_dead() is True
+
+
+def test_one_alive_among_dead_is_not_dead():
+    import subprocess
+
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    task = _make_task([proc.pid, os.getpid()])
+    assert task._stdio_children_dead() is False
+
+
+def test_no_pids_unknown_is_not_dead():
+    task = _make_task(None)
+    assert task._stdio_children_dead() is False
+
+
+def test_http_transport_is_not_dead():
+    task = _make_task([os.getpid()], http=True)
+    assert task._stdio_children_dead() is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,9 +2994,8 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            return False  # at least one child alive → don't fast-fail
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
## Symptom

Every stdio MCP server fast-fails its first tool call after (re)connect with:

```
MCP call failed: TimeoutError: MCP stdio subprocess for '<name>' has exited; failing the call fast instead of waiting 300s
```

even though `ps` shows the child process alive and `hermes mcp test <name>` connects cleanly. Because the fast-fail poisons the connection, the server is effectively unusable, and gateway restarts don't help — the freshly registered connection trips the same check on its first call. Side effect: MCP pools crash-loop (we observed ~18k stdio respawns in one day of `mcp-stderr.log`).

## Root cause

`MCPServerTask._stdio_children_dead()` in `tools/mcp_tool.py` has inverted logic: when `psutil.pid_exists(pid)` is true (child alive) it returns `True` (= "dead, fast-fail"), and the intended `return False` on the next line is unreachable:

```python
if not psutil.pid_exists(pid):
    continue  # this one is dead
return True  # alive (signal permission irrelevant for liveness)
return False  # at least one child alive   <-- unreachable
```

So the fast-fail path (#81995) fires precisely when it must not: for a healthy, live child.

## Fix

Return `False` (not dead → don't fast-fail) when any tracked child is alive; return `True` only when every tracked pid has exited. Also fixes `_watch_stdio_children`, which polls the same predicate and previously resolved immediately for live children.

## Tests

Added `tests/test_mcp_stdio_children_dead.py`: live pid → not dead; reaped child → dead; mixed → not dead; no pids / HTTP transport → not dead (unknown must not fast-fail). All 5 fail on the old logic (2 failures) and pass with the fix.

Verified end-to-end on a live install (macOS, stdio Python MCP server): before the fix every call fast-failed in ~0.02s across gateway restarts; after the fix calls succeed.