### PR TITLE
test: ssh-ownership fake os.stat no longer hijacks traceback in concurrent threads (kills the flaky teardown ERROR)

### DIFF
--- a/tests/hermes_cli/test_ssh_ownership_endpoint.py
+++ b/tests/hermes_cli/test_ssh_ownership_endpoint.py
@@ -1,3 +1,4 @@
+import os
 from fastapi.testclient import TestClient
 
 from hermes_cli import web_server
@@ -31,7 +32,19 @@ def test_ssh_ownership_reports_replaced_runtime(monkeypatch):
     monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", "0123456789abcdef")
     monkeypatch.setattr(web_server, "_SSH_RUNTIME_MARKER", None)
     monkeypatch.setattr(web_server, "_SSH_RUNTIME_PURELIB", ("/venv/site-packages", 10, 20))
-    monkeypatch.setattr(web_server.os, "stat", lambda _path: type("Stat", (), {"st_dev": 10, "st_ino": 21})())
+    # Path-scoped: web_server.os IS the global os module, so a blanket
+    # os.stat patch also hijacks linecache/traceback in OTHER threads during
+    # the patch window — a daemon-thread exception then dies inside pytest's
+    # excepthook ("'Stat' object has no attribute 'st_size'", flaky teardown
+    # ERROR under xdist load). Only the purelib path gets the fake.
+    _real_stat = os.stat
+
+    def _fake_stat(path, *args, **kwargs):
+        if str(path) == "/venv/site-packages":
+            return type("Stat", (), {"st_dev": 10, "st_ino": 21})()
+        return _real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(web_server.os, "stat", _fake_stat)
     client = TestClient(web_server.app)
 
     response = client.get("/api/ssh/ownership", headers={"X-Hermes-Session-Token": token})


### PR DESCRIPTION
## Summary
The `test_ssh_ownership_reports_replaced_runtime` teardown ERROR that has been randomly reddening unrelated PRs is fixed: the test's blanket `os.stat` monkeypatch hijacked `linecache`/`traceback` in concurrent daemon threads, so any thread exception formatted during the patch window died inside pytest's excepthook with `'Stat' object has no attribute 'st_size'`. The fake stat is now scoped to the one path the test cares about; the assertion is unchanged.

Flake mechanics: `web_server.os` IS the global `os` module. While the patch is live, an unrelated daemon thread (e.g. a `_monitor` thread from a neighboring xdist test) raising an exception has its traceback formatted by `linecache.updatecache` → `os.stat(...).st_size` → AttributeError inside `threading.excepthook` → `PytestUnhandledThreadExceptionWarning` → teardown ERROR attributed to this test. Load-dependent, which is why it fires on CI and never locally.

**Live repro:** observed twice today on PR #95571 (a compression-only diff touching zero web_server/ssh code — both run URLs in the thread there), reproduced-by-mechanism rather than by race timing; 6/6 suite green with the scoped fake.

## Changes
- `tests/hermes_cli/test_ssh_ownership_endpoint.py`: path-scoped fake stat (real `os.stat` passthrough otherwise)

## Validation
| | Before | After |
|---|---|---|
| Patch blast radius | every `os.stat` caller in-process | `/venv/site-packages` only |
| Suite | 6/6 locally, flaky teardown ERROR under CI load | 6/6, excepthook path unpatched |

## Infographic

![Scope your mocks](https://v3b.fal.media/files/b/0aa7e4fa/pGd5MYpQguk_DwADVmpxI_e1hAuXSv.png)
