### PR TITLE
fix(desktop): preserve venv interpreter path in Linux launcher

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,7 +78,8 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # Preserve the venv executable path: resolving its symlink can escape the venv.
+            argv = [str(Path(sys.executable).absolute()), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,8 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # Keep the venv path itself; resolving a symlink can select the base interpreter.
+    interpreter = str(Path(sys.executable).absolute())
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")


### PR DESCRIPTION
## Summary
- preserve the venv interpreter path when generating the Linux desktop launcher
- avoid resolving `sys.executable` through its symlink to the base Python
- update the launcher test expectation accordingly

## Why
When the current interpreter is the venv Python symlink, `Path(sys.executable).resolve()` writes the base Python path into the `.desktop` entry. Keeping the original absolute venv path ensures the launcher uses the interpreter with Hermes dependencies available.

## Test plan
- `uv run --extra dev pytest tests/hermes_cli/test_linux_desktop_entry.py -q`
  - 15 passed, 2 skipped
- `git diff --check`