### PR TITLE
fix(desktop): keep Files rail aligned with session tabs

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -1,8 +1,12 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { group, split } from '@/components/pane-shell/tree/model'
+import { $layoutTree, activateTreePane, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
 import type { HermesReadDirResult } from '@/global'
-import { $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd } from '@/store/session'
+import { $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd, setSessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+import { makeSessionInfo } from '@/test/session-info'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -19,6 +23,10 @@ describe('RightSidebarPane', () => {
     $connection.set(null)
     $selectedStoredSessionId.set(null)
     $workspaceCwdOwner.set(null)
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+    setSessions([])
+    noteActiveTreeGroup(null)
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -30,6 +38,10 @@ describe('RightSidebarPane', () => {
     $connection.set(null)
     $selectedStoredSessionId.set(null)
     $workspaceCwdOwner.set(null)
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+    setSessions([])
+    noteActiveTreeGroup(null)
     setCurrentCwd('')
     resetProjectTreeState()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -68,5 +80,51 @@ describe('RightSidebarPane', () => {
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('re-roots the Files tree when a top session tab is focused', async () => {
+    const alphaCwd = '/Users/test/Projects/alpha-workspace'
+    const betaCwd = '/Users/test/Projects/beta-project'
+
+    setSessions([
+      makeSessionInfo({ cwd: alphaCwd, id: 'alpha-session' }),
+      makeSessionInfo({ cwd: betaCwd, id: 'beta-session' })
+    ])
+    $selectedStoredSessionId.set('alpha-session')
+    $workspaceCwdOwner.set('alpha-session')
+    setCurrentCwd(alphaCwd)
+    $sessionTiles.set([{ storedSessionId: 'beta-session' }])
+    $layoutTree.set(
+      split('row', [
+        group(['workspace', 'session-tile:beta-session'], {
+          active: 'workspace',
+          id: 'main'
+        }),
+        group(['files'], { active: 'files', id: 'files-zone' })
+      ])
+    )
+    noteActiveTreeGroup('main')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith(alphaCwd))
+    expect(screen.getByText('alpha-workspace')).toBeTruthy()
+
+    act(() => activateTreePane('main', 'session-tile:beta-session'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith(betaCwd))
+    expect(screen.getByText('beta-project')).toBeTruthy()
+    expect(screen.queryByText('alpha-workspace')).toBeNull()
+
+    // Using the Files rail changes keyboard focus to its zone, but must not
+    // detach the rail from the active top session tab.
+    act(() => noteActiveTreeGroup('files-zone'))
+    await waitFor(() => expect(screen.getByText('beta-project')).toBeTruthy())
+    expect(readDir.mock.calls.at(-1)?.[0]).toBe(betaCwd)
+
+    act(() => activateTreePane('main', 'workspace'))
+
+    await waitFor(() => expect(screen.getByText('alpha-workspace')).toBeTruthy())
+    expect(screen.queryByText('beta-project')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,8 +13,10 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+import { $connection, $selectedStoredSessionId } from '@/store/session'
+import { $workspaceContextStoredSessionId, sessionFilesystemSharesAmbientConnection } from '@/store/session-states'
 
+import { useSessionWorkspaceCwd } from '../session/hooks/use-focused-workspace-cwd'
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
 import { ProjectTree } from './files/tree'
@@ -29,14 +31,21 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
-  const currentCwd = useStore($currentCwd).trim()
+  const connection = useStore($connection)
+  const workspaceStoredSessionId = useStore($workspaceContextStoredSessionId)
+  const currentCwd = useSessionWorkspaceCwd(workspaceStoredSessionId)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
-  const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
-  // A transition intentionally retains the old CWD until the new session
-  // confirms its workspace. Do not issue a filesystem read against that path:
-  // under a gateway switch it may belong to a different remote machine.
-  const hasWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  // Ordinary top tabs share the ambient Files bridge, so their focused CWD can
+  // re-root the tree immediately. An explicitly owner-routed remote tile can
+  // belong to another machine; fail closed until Files supports owner-routed
+  // filesystem calls rather than browsing the ambient backend by mistake.
+  const workspaceSessionUsesAmbientFilesystem =
+    !workspaceStoredSessionId ||
+    workspaceStoredSessionId === selectedStoredSessionId ||
+    sessionFilesystemSharesAmbientConnection(workspaceStoredSessionId, connection)
+
+  const hasWorkspace = Boolean(currentCwd) && workspaceSessionUsesAmbientFilesystem
 
   const {
     collapseAll,

--- a/apps/desktop/src/app/session/hooks/use-focused-workspace-cwd.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-focused-workspace-cwd.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveFocusedWorkspaceCwd } from './use-focused-workspace-cwd'
+
+const base = {
+  focusedRowCwd: '',
+  focusedStateCwd: '',
+  focusedStateStoredId: null,
+  focusedStoredSessionId: null,
+  liveCwdSharesFocusLineage: false,
+  primaryCwd: '/primary',
+  selectedStoredSessionId: 'primary-session',
+  workspaceCwdOwner: 'primary-session'
+}
+
+describe('resolveFocusedWorkspaceCwd', () => {
+  it('uses the primary CWD only while its ownership token matches the selected session', () => {
+    expect(resolveFocusedWorkspaceCwd(base)).toBe('/primary')
+    expect(resolveFocusedWorkspaceCwd({ ...base, workspaceCwdOwner: 'previous-session' })).toBe('')
+  })
+
+  it('keeps the live primary CWD ahead of its launch row after an in-session relocation', () => {
+    expect(resolveFocusedWorkspaceCwd({ ...base, focusedRowCwd: '/primary-at-launch' })).toBe('/primary')
+  })
+
+  it('uses a focused tile row instead of inheriting the primary workspace', () => {
+    expect(
+      resolveFocusedWorkspaceCwd({
+        ...base,
+        focusedRowCwd: '/workspaces/beta-project',
+        focusedStoredSessionId: 'beta-session'
+      })
+    ).toBe('/workspaces/beta-project')
+
+    expect(resolveFocusedWorkspaceCwd({ ...base, focusedStoredSessionId: 'detached-session' })).toBe('')
+  })
+
+  it('ignores a lagging runtime CWD that belongs to the previously focused session', () => {
+    expect(
+      resolveFocusedWorkspaceCwd({
+        ...base,
+        focusedRowCwd: '/workspaces/beta-project',
+        focusedStateCwd: '/workspaces/alpha-project',
+        focusedStateStoredId: 'alpha-session',
+        focusedStoredSessionId: 'beta-session'
+      })
+    ).toBe('/workspaces/beta-project')
+  })
+
+  it('accepts a live CWD from the focused session lineage', () => {
+    expect(
+      resolveFocusedWorkspaceCwd({
+        ...base,
+        focusedRowCwd: '/workspaces/beta-project',
+        focusedStateCwd: '/workspaces/beta-project/.worktrees/fix',
+        focusedStateStoredId: 'beta-child-session',
+        focusedStoredSessionId: 'beta-root-session',
+        liveCwdSharesFocusLineage: true
+      })
+    ).toBe('/workspaces/beta-project/.worktrees/fix')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-focused-workspace-cwd.ts
+++ b/apps/desktop/src/app/session/hooks/use-focused-workspace-cwd.ts
@@ -1,0 +1,120 @@
+import { useStore } from '@nanostores/react'
+
+import { useStoreSelector } from '@/lib/use-session-slice'
+import {
+  $activeSessionId,
+  $currentCwd,
+  $selectedStoredSessionId,
+  $sessions,
+  $workspaceCwdOwner,
+  idsShareLineage,
+  sessionMatchesStoredId
+} from '@/store/session'
+import { $focusedStoredSessionId, $sessionStates, $sessionTiles } from '@/store/session-states'
+
+interface FocusedWorkspaceCwdInput {
+  focusedRowCwd: string
+  focusedStateCwd: string
+  focusedStateStoredId: null | string
+  focusedStoredSessionId: null | string
+  liveCwdSharesFocusLineage: boolean
+  primaryCwd: string
+  selectedStoredSessionId: null | string
+  workspaceCwdOwner: null | string
+}
+
+/**
+ * Resolve the workspace shown by session-scoped chrome.
+ *
+ * A focused tile owns its own workspace and must never inherit the primary
+ * chat's retained CWD. The primary may use `$currentCwd` only while the CWD's
+ * ownership token still matches the selected session; this preserves the
+ * existing fail-closed switch behavior while a new session is activating.
+ */
+export function resolveFocusedWorkspaceCwd({
+  focusedRowCwd,
+  focusedStateCwd,
+  focusedStateStoredId,
+  focusedStoredSessionId,
+  liveCwdSharesFocusLineage,
+  primaryCwd,
+  selectedStoredSessionId,
+  workspaceCwdOwner
+}: FocusedWorkspaceCwdInput): string {
+  const primaryFocused = !focusedStoredSessionId || focusedStoredSessionId === selectedStoredSessionId
+
+  const liveCwdBelongsToFocus =
+    Boolean(focusedStateCwd) &&
+    (!focusedStoredSessionId ||
+      !focusedStateStoredId ||
+      focusedStateStoredId === focusedStoredSessionId ||
+      liveCwdSharesFocusLineage)
+
+  const primaryCwdBelongsToSelection = (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+
+  return (
+    (liveCwdBelongsToFocus ? focusedStateCwd : '') ||
+    (primaryFocused && primaryCwdBelongsToSelection ? primaryCwd : '') ||
+    focusedRowCwd ||
+    ''
+  ).trim()
+}
+
+/** Resolve one session surface's workspace without borrowing another session's CWD. */
+export function useSessionWorkspaceCwd(focusedStoredSessionId: null | string): string {
+  const primaryCwd = useStore($currentCwd)
+  const workspaceCwdOwner = useStore($workspaceCwdOwner)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const primaryRuntimeId = useStore($activeSessionId)
+
+  const tileRuntimeId = useStoreSelector($sessionTiles, tiles =>
+    focusedStoredSessionId && focusedStoredSessionId !== selectedStoredSessionId
+      ? (tiles.find(tile => tile.storedSessionId === focusedStoredSessionId)?.runtimeId ?? null)
+      : null
+  )
+
+  const focusedRuntimeId =
+    focusedStoredSessionId && focusedStoredSessionId !== selectedStoredSessionId ? tileRuntimeId : primaryRuntimeId
+
+  const focusedStateCwd = useStoreSelector(
+    $sessionStates,
+    states => (focusedRuntimeId ? states[focusedRuntimeId]?.cwd?.trim() : '') || ''
+  )
+
+  const focusedStateStoredId = useStoreSelector(
+    $sessionStates,
+    states => (focusedRuntimeId ? states[focusedRuntimeId]?.storedSessionId?.trim() : null) || null
+  )
+
+  const focusedRowCwd = useStoreSelector($sessions, sessions => {
+    if (!focusedStoredSessionId) {
+      return ''
+    }
+
+    return sessions.find(session => sessionMatchesStoredId(session, focusedStoredSessionId))?.cwd?.trim() || ''
+  })
+
+  const liveCwdSharesFocusLineage = useStoreSelector($sessions, sessions => {
+    if (!focusedStoredSessionId || !focusedStateStoredId) {
+      return false
+    }
+
+    return idsShareLineage(focusedStoredSessionId, focusedStateStoredId, sessions)
+  })
+
+  return resolveFocusedWorkspaceCwd({
+    focusedRowCwd,
+    focusedStateCwd,
+    focusedStateStoredId,
+    focusedStoredSessionId,
+    liveCwdSharesFocusLineage,
+    primaryCwd,
+    selectedStoredSessionId,
+    workspaceCwdOwner
+  })
+}
+
+/** The keyboard-focused chat's workspace, used by focus-sensitive status chrome. */
+export function useFocusedWorkspaceCwd(): string {
+  return useSessionWorkspaceCwd(useStore($focusedStoredSessionId))
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router'
 
 import { ConnectionSwitcher } from '@/app/chat/sidebar/connection-switcher'
 import type { CommandCenterSection } from '@/app/command-center'
+import { useFocusedWorkspaceCwd } from '@/app/session/hooks/use-focused-workspace-cwd'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
@@ -27,13 +28,11 @@ import {
   $activeSessionId,
   $busy,
   $connection,
-  $currentCwd,
   $currentUsage,
   $selectedStoredSessionId,
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
-  idsShareLineage,
   sessionMatchesStoredId
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
@@ -97,10 +96,6 @@ export function useStatusbarItems({
   const sessionsShowing = useStore($paneVisible('sessions'))
   const botsShowing = useStore($paneVisible('hermes-bots:pane'))
   const primaryBusy = useStore($busy)
-  // Draft / primary composer atom — used only while the focused surface is the
-  // primary (or a draft with no runtime slice yet). A focused TILE keeps its
-  // own cwd in `$sessionStates` and must not paint the primary's workspace.
-  const primaryCwd = useStore($currentCwd)
   const primaryUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
@@ -143,16 +138,10 @@ export function useStatusbarItems({
   // reports new usage — far rarer than a delta — so its reference is a valid
   // bail-out key on its own.
   const focusedUsage = useStoreSelector($focusedSessionState, state => state?.usage ?? null)
-  const focusedStateCwd = useStoreSelector($focusedSessionState, state => state?.cwd?.trim() || '')
-
-  // Runtime slices carry the stored id they were bound for. During a primary
-  // tab switch the runtime id can lag a frame behind the new selection — the
-  // slice still describes the PREVIOUS chat. Gate live cwd on ownership so we
-  // never paint session A's workspace while the tab already shows session B.
-  const focusedStateStoredId = useStoreSelector($focusedSessionState, state => state?.storedSessionId?.trim() || null)
 
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const primaryFocused = !focusedStoredSessionId || focusedStoredSessionId === selectedStoredSessionId
+  const currentCwd = useFocusedWorkspaceCwd()
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : focusedBusy
@@ -173,54 +162,12 @@ export function useStatusbarItems({
       : null
   )
 
-  const focusedRowCwd = useStoreSelector($sessions, sessions => {
-    if (!focusedStoredSessionId) {
-      return ''
-    }
-
-    const row = sessions.find(s => sessionMatchesStoredId(s, focusedStoredSessionId))
-
-    return row?.cwd?.trim() || ''
-  })
-
-  // Live runtime cwd is authoritative once it belongs to the focused chat
-  // (agent can relocate mid-turn). Until then — cold tabs, mid-switch lag —
-  // the stored session row is the selection's project. Primary drafts fall
-  // through to `$currentCwd`. A focused TILE must never inherit the primary's
-  // workspace — an empty tile cwd stays empty rather than lying about another
-  // project's path.
-  //
-  // Lineage match is a pure derivation of ($sessions + the two ids). Select it
-  // so a session-list write only re-renders when the answer actually flips —
-  // not on every title/archive refresh of an unrelated row.
-  const liveCwdSharesFocusLineage = useStoreSelector($sessions, sessions => {
-    if (!focusedStoredSessionId || !focusedStateStoredId) {
-      return false
-    }
-
-    return idsShareLineage(focusedStoredSessionId, focusedStateStoredId, sessions)
-  })
-
-  const liveCwdBelongsToFocus =
-    Boolean(focusedStateCwd) &&
-    (!focusedStoredSessionId ||
-      !focusedStateStoredId ||
-      focusedStateStoredId === focusedStoredSessionId ||
-      liveCwdSharesFocusLineage)
-
-  const currentCwd = (
-    (liveCwdBelongsToFocus ? focusedStateCwd : '') ||
-    focusedRowCwd ||
-    (primaryFocused ? primaryCwd : '') ||
-    ''
-  ).trim()
-
   // Derive the workspace's project name from the already-cached project tree
   // (backend truth via projects.*), so the status item labels by project without
-  // a second per-session copy of the same fact. Re-derives whenever the cwd or
-  // the tree changes; null (no named project) falls back to the cwd leaf below.
-  const projectTree = useStore($projectTree)
-  const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
+  // a second per-session copy of the same fact. Subscribe to re-render when the
+  // tree changes; null (no named project) falls back to the cwd leaf below.
+  useStore($projectTree)
+  const projectName = projectNameForCwd(currentCwd)
 
   const sessionStartedAt = primaryFocused
     ? primarySessionStartedAt

--- a/apps/desktop/src/components/pane-shell/tree/pane-toggle-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/pane-toggle-visibility.test.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { registry } from '@/contrib/registry'
+import { $fileBrowserOpen, $revealInTreeRequest, revealFileInTree, setFileBrowserOpen } from '@/store/layout'
 
 import { group, split } from './model'
 import {
@@ -40,6 +41,7 @@ beforeEach(() => {
   window.localStorage.clear()
   $dismissedPanes.set(new Set())
   $hiddenTreePanes.set(new Set())
+  $revealInTreeRequest.set(null)
 
   for (const [id, data] of [
     ['workspace', { placement: 'main', uncloseable: true }],
@@ -73,6 +75,27 @@ describe('a hide-style pane stacked behind a sibling tab', () => {
     togglePaneVisible('review')
 
     expect(isPaneVisible('review')).toBe(true)
+  })
+})
+
+describe('an explicit file-tree reveal', () => {
+  it('fronts the tree when its open flag is already true', () => {
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['files', 'review'], { active: 'review', id: 'g-right' })
+      ])
+    )
+
+    setFileBrowserOpen(true)
+
+    expect($fileBrowserOpen.get()).toBe(true)
+    expect(isPaneVisible('files')).toBe(false)
+
+    revealFileInTree('/work/file.ts')
+
+    expect(isPaneVisible('files')).toBe(true)
+    expect($revealInTreeRequest.get()).toBe('/work/file.ts')
   })
 })
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -537,6 +537,7 @@ export const $revealInTreeRequest = atom<null | string>(null)
 
 export function revealFileInTree(path: string): void {
   setFileBrowserOpen(true)
+  revealTreePane(FILES_PANE_ID)
   $revealInTreeRequest.set(path)
 }
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -2,13 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
-import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
   $sessionTiles,
+  $workspaceContextStoredSessionId,
   blankDraftTile,
   clearAllSessionStates,
   focusedSessionNeedsRoute,
@@ -26,6 +27,7 @@ import {
   requestForOwnedSession,
   resetTileRuntimeBindings,
   selectionHomesToWorkspace,
+  sessionFilesystemSharesAmbientConnection,
   type SessionTileDelegate,
   sessionTileOwnerRoute,
   setSessionTileDelegate,
@@ -387,6 +389,43 @@ describe('selectionHomesToWorkspace', () => {
   })
 })
 
+describe('$workspaceContextStoredSessionId', () => {
+  afterEach(() => {
+    noteActiveTreeGroup(null)
+    $layoutTree.set(null)
+    $selectedStoredSessionId.set(null)
+  })
+
+  it('keeps workspace tools attached to the active top tab while a tool zone is focused', () => {
+    $selectedStoredSessionId.set('alpha')
+    $layoutTree.set(
+      split('row', [
+        group(['workspace', tilePane('beta')], { active: tilePane('beta'), id: 'main' }),
+        group(['files'], { active: 'files', id: 'files-zone' })
+      ])
+    )
+
+    noteActiveTreeGroup('main')
+    expect($workspaceContextStoredSessionId.get()).toBe('beta')
+
+    noteActiveTreeGroup('files-zone')
+    expect($workspaceContextStoredSessionId.get()).toBe('beta')
+  })
+
+  it('returns to the primary selection when the workspace tab is active', () => {
+    $selectedStoredSessionId.set('alpha')
+    $layoutTree.set(
+      split('row', [
+        group(['workspace', tilePane('beta')], { active: 'workspace', id: 'main' }),
+        group(['files'], { active: 'files', id: 'files-zone' })
+      ])
+    )
+
+    noteActiveTreeGroup('files-zone')
+    expect($workspaceContextStoredSessionId.get()).toBe('alpha')
+  })
+})
+
 describe('nextSessionTileForWorkspace (⌘W promotion source)', () => {
   afterEach(() => {
     $layoutTree.set(null)
@@ -737,5 +776,41 @@ describe('isSessionRemote (#94640)', () => {
     setSessions([{ id: 'stored-2', profile: 'loki' } as never])
 
     expect(isSessionRemote('stored-2')).toBe(true)
+  })
+})
+
+describe('sessionFilesystemSharesAmbientConnection', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+    setSessions([])
+    $connection.set(null)
+  })
+
+  it('allows an ordinary session with no exact owner route to use the ambient Files bridge', () => {
+    expect(sessionFilesystemSharesAmbientConnection('ordinary-session')).toBe(true)
+  })
+
+  it('fails closed when a focused tile belongs to another remote connection', () => {
+    $connection.set({ connectionId: 'office', mode: 'remote', profile: 'default' } as never)
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'homelab', mode: 'remote', profile: 'default' },
+        storedSessionId: 'remote-tile'
+      }
+    ])
+
+    expect(sessionFilesystemSharesAmbientConnection('remote-tile')).toBe(false)
+  })
+
+  it('allows the exact active remote connection and profile', () => {
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default' } as never)
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'homelab', mode: 'remote', profile: 'default' },
+        storedSessionId: 'remote-tile'
+      }
+    ])
+
+    expect(sessionFilesystemSharesAmbientConnection('remote-tile')).toBe(true)
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -30,6 +30,7 @@ import {
   revealTreePane
 } from '@/components/pane-shell/tree/store'
 import type { WorkspaceMode } from '@/contrib/types'
+import type { HermesConnection } from '@/global'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
@@ -998,6 +999,41 @@ export function isSessionRemote(sessionId: null | string | undefined): boolean {
 }
 
 /**
+ * Whether the global Files bridge can safely browse `sessionId` on the ambient
+ * connection. Local profile pools share Electron's filesystem. Remote reads,
+ * however, route through the active connection + profile, so an exact owner on
+ * another remote route must fail closed instead of browsing the wrong machine.
+ */
+export function sessionFilesystemSharesAmbientConnection(
+  sessionId: null | string | undefined,
+  ambient: HermesConnection | null = $connection.get()
+): boolean {
+  const owner = knownOwnerForSession(sessionId)
+  const ambientMode = ambient?.mode ?? 'local'
+
+  if (!owner) {
+    return true
+  }
+
+  if (typeof owner === 'string') {
+    return ambientMode === 'local' || normalizeProfileKey(owner) === normalizeProfileKey(ambient?.profile)
+  }
+
+  const ownerConnectionId = owner.connectionId.trim()
+  const ownerIsLocal = owner.mode === 'local' || !ownerConnectionId || ownerConnectionId === LOCAL_CONNECTION_ID
+
+  if (ownerIsLocal) {
+    return ambientMode !== 'remote'
+  }
+
+  if (ambientMode !== 'remote' || ownerConnectionId !== ambient?.connectionId?.trim()) {
+    return false
+  }
+
+  return normalizeProfileKey(owner.targetProfile ?? owner.profile) === normalizeProfileKey(ambient.profile)
+}
+
+/**
  * Dispatch a session-scoped RPC through the OWNER of `sessionId` (tile route →
  * hint → connection-tagged row / known profile). This is the client half of
  * #91684: approval.respond (and siblings) sent on the ambient socket land on
@@ -1569,6 +1605,32 @@ export const $focusedStoredSessionId = computed(
     const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
 
     return active?.startsWith(TILE_PANE_PREFIX) ? active.slice(TILE_PANE_PREFIX.length) : selected
+  }
+)
+
+/**
+ * Session that owns workspace-attached tools such as Files. A click inside a
+ * side/tool zone must not retarget those tools back to the primary chat: when
+ * the interacted zone is not a chat strip, follow the active tab stacked with
+ * `workspace`. This is deliberately separate from `$focusedStoredSessionId`,
+ * whose keyboard/status semantics still fall back to the primary on tool focus.
+ */
+export const $workspaceContextStoredSessionId = computed(
+  [$activeTreeGroup, $layoutTree, $selectedStoredSessionId],
+  (groupId, tree, selected) => {
+    const interacted = groupId && tree ? findGroup(tree, groupId)?.active : undefined
+
+    if (interacted?.startsWith(TILE_PANE_PREFIX)) {
+      return interacted.slice(TILE_PANE_PREFIX.length)
+    }
+
+    if (interacted === 'workspace') {
+      return selected
+    }
+
+    const workspaceActive = tree ? findGroupOfPane(tree, 'workspace')?.active : undefined
+
+    return workspaceActive?.startsWith(TILE_PANE_PREFIX) ? workspaceActive.slice(TILE_PANE_PREFIX.length) : selected
   }
 )
 


### PR DESCRIPTION
## Summary

- Front the real Files pane before publishing a Reveal in File Tree selection request.
- Resolve the Files rail workspace from the active session tab instead of always using the primary sidebar-selected session.
- Keep workspace-attached tools bound to that tab while the Files zone itself has keyboard focus.
- Fail closed when a focused session belongs to a different remote filesystem route.

## Problem

With sessions from different workspace roots open as top tabs, clicking a tab changed the visible chat and focus-sensitive status bar, but the Files rail remained rooted at the primary sidebar-selected session. Selecting the same session from the session list worked because that path promoted it into the primary workspace and updated `$currentCwd`.

Reveal in File Tree also selected a path without first ensuring the actual Files pane was visible, so a hidden pane could consume the one-shot request.

## Implementation

- Add one session-workspace resolver with explicit precedence for live runtime CWD, primary CWD ownership, and stored-session row fallback.
- Separate keyboard-focused session state from the session context that owns workspace tools.
- Re-root `RightSidebarPane` from the workspace-tool context while preserving the primary session's authoritative `$currentCwd` behavior.
- Guard the global Files bridge against cross-remote owner mismatches.
- Make `revealFileInTree()` reveal the Files pane before setting the selection request.

## Verification

- Focused regression suite: 66 tests passed.
- Full renderer suite: 5,977 tests passed.
- Electron-platform suite: 1,834 passed, 6 skipped.
- TypeScript checks passed.
- ESLint passed with zero errors.
- Prettier and `git diff --check` passed.
- Live macOS acceptance verified tab switching between two sessions with different workspace roots, interaction inside the Files rail, return to the primary tab, and sidebar session selection.
