### PR TITLE
revert: stealth/ox-alpha restored to catalogs (still live, reverts #95582)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
+    ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),
@@ -305,6 +306,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-super-120b-a12b",
         # Sakana
         "sakana/fugu-ultra",
+        # Stealth — "Ox Alpha" reasoning model, free ($0/$0 on the portal),
+        # 1M ctx / 131K max output. Same model as OpenCode Zen's
+        # x-preview-f-free; metadata entries live under the bare "ox-alpha"
+        # slug (model_metadata.py / reasoning_timeouts.py).
+        "stealth/ox-alpha",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-26T13:57:32Z",
+  "updated_at": "2026-08-21T20:49:36Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -154,6 +154,10 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
+          "id": "stealth/ox-alpha",
+          "description": "free"
+        },
+        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },
@@ -282,6 +286,9 @@
         },
         {
           "id": "sakana/fugu-ultra"
+        },
+        {
+          "id": "stealth/ox-alpha"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Restores stealth/ox-alpha to the OpenRouter and Nous Portal catalogs — the model is still live, removal in #95582 was premature.

Clean revert of 8e1bc8d34.
