### PR TITLE
chore: Ox Alpha removed from OpenRouter and Nous Portal pickers (model shut down)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,7 +133,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
-    ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),
@@ -306,11 +305,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-super-120b-a12b",
         # Sakana
         "sakana/fugu-ultra",
-        # Stealth — "Ox Alpha" reasoning model, free ($0/$0 on the portal),
-        # 1M ctx / 131K max output. Same model as OpenCode Zen's
-        # x-preview-f-free; metadata entries live under the bare "ox-alpha"
-        # slug (model_metadata.py / reasoning_timeouts.py).
-        "stealth/ox-alpha",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T20:49:36Z",
+  "updated_at": "2026-08-26T13:57:32Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -154,10 +154,6 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
-          "id": "stealth/ox-alpha",
-          "description": "free"
-        },
-        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },
@@ -286,9 +282,6 @@
         },
         {
           "id": "sakana/fugu-ultra"
-        },
-        {
-          "id": "stealth/ox-alpha"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Removes `stealth/ox-alpha` from the OpenRouter and Nous Portal model pickers.

Ox Alpha has officially shut down — merged. (Re-up of #95582, reverted in #95588 while the model was still live.)

## Changes
- `hermes_cli/models.py`: dropped `stealth/ox-alpha` from the curated OpenRouter list and `_PROVIDER_MODELS["nous"]`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (openrouter 42, nous 31)

Left intact on purpose: bare `ox-alpha` metadata (context window, reasoning timeout), the generic `stealth/` free-tier policy in `credits_tracker.py`, and OpenCode Zen's `x-preview-f-free` / Go's `ox-alpha-free` twins — manually-entered ids still behave correctly.

## Validation
| | Before | After |
|---|---|---|
| OpenRouter picker | lists stealth/ox-alpha | absent |
| Nous picker | lists stealth/ox-alpha | absent |
| tests/hermes_cli/test_model_catalog.py | — | 19 passed (manifest in sync) |

## Infographic

![Ox Alpha retired from catalogs](https://v3b.fal.media/files/b/0aa7e4ed/WJ2fXVeNcBzJKkrj_lkZk_IBaK4ehg.png)

