### PR TITLE
fix(desktop): bound the onActiveConnectionInvalidated fallback getConnection() call

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   activeGateway,
   closeSecondaryGateways,
+  disposeSecondariesForConnection,
   ensureGatewayForAgent,
   isActivePrimary,
   requestGatewayForAgent
@@ -1136,6 +1137,65 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(callsBeforeDrop)
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('onActiveConnectionInvalidated: a fallback getConnection() that hangs rejects on its own instead of latching $connection forever (#93454 sibling)', async () => {
+    // Repro: the active connection is a registered secondary (e.g. a Bots-pane
+    // source). It gets removed/invalidated (disposeSecondariesForConnection),
+    // which falls back to redialing the primary profile via
+    // desktop.getConnection(fallbackProfile) — the one getConnection() await
+    // in this file the #93454 bound-every-IPC-round-trip sweep never reached.
+    // A wedged main-process round-trip here must reject instead of leaving
+    // $connection pointed at a promise that never settles.
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & {
+      getConnectionFor: ReturnType<typeof vi.fn>
+    }
+
+    desktop.getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      ...coderConn,
+      connectionId,
+      profile
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect($connection.get()).not.toBeNull()
+
+    let opening!: Promise<boolean>
+
+    act(() => {
+      opening = ensureGatewayForAgent('cloud', 'default')
+    })
+    await flushAsync()
+    await opening
+    expect(isActivePrimary()).toBe(false)
+
+    // The active secondary is about to be evicted; the fallback re-dial for
+    // the primary profile hangs indefinitely.
+    desktop.getConnection.mockImplementation(() => new Promise(() => undefined))
+
+    act(() => {
+      disposeSecondariesForConnection('cloud')
+    })
+    await flushAsync()
+
+    expect(isActivePrimary()).toBe(true)
+    expect(desktop.getConnection).toHaveBeenCalledWith('default')
+    // Still stuck behind the hung fallback dial — the invalidation handler's
+    // .then()/.catch() has not run yet.
+    expect($connection.get()).not.toBeNull()
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // fallback getConnection() must reject so the handler's catch publishes
+    // null, instead of latching $connection on a connection that will never
+    // resolve.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect($connection.get()).toBeNull()
   })
 
   it('a getConnection() that hangs on INITIAL boot rejects on its own after the reconnect-attempt timeout, not only when main eventually gives up (#93454)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -723,8 +723,15 @@ export function useGatewayBoot({
       },
       onActiveConnectionInvalidated: (fallbackProfile, invalidationEpoch) => {
         $activeGatewayProfile.set(fallbackProfile)
-        void desktop
-          .getConnection(fallbackProfile)
+        // Bounded like every other getConnection() call in this file (#93454):
+        // an eviction fallback (idle reap, connection removal, profile delete)
+        // must not latch the profile atom to a connection that never resolves
+        // if the main-process IPC round-trip wedges.
+        void withTimeout(
+          desktop.getConnection(fallbackProfile),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out resolving the fallback gateway connection'
+        )
           .then(connection => {
             if (!cancelled && gatewayActivationEpoch() === invalidationEpoch) {
               publish(connection)


### PR DESCRIPTION
## Summary

- `use-gateway-boot.ts`'s `onActiveConnectionInvalidated` handler re-dials the primary profile via a raw `desktop.getConnection(fallbackProfile)` call with no timeout, even though every other `getConnection()`/`resolveGatewayWsUrl()` await in this exact file (`attemptReconnect`, `boot`, `softSwitch`) has been bounded by `withTimeout(..., RECONNECT_ATTEMPT_TIMEOUT_MS, ...)` since the #93454 sweep (main-process IPC round-trips have no timeout of their own).
- This handler fires whenever the registry evicts the *active* connection (idle reap, connection removal, or a profile delete while that profile is foregrounded) and falls back to redialing the primary. If that fallback dial wedges the same way #93454 describes, `$connection` is never re-published (the `.then`/`.catch` never fires), leaving the UI silently pointed at a connection that will never resolve, with no way to recover short of an app restart.
- Wraps the same call with the file's existing `withTimeout`/`RECONNECT_ATTEMPT_TIMEOUT_MS`, matching the established pattern for every sibling call site in this file.

## Test plan

- [x] Added a regression test (`onActiveConnectionInvalidated: a fallback getConnection() that hangs rejects on its own instead of latching $connection forever`) that opens a secondary gateway, makes it the active connection, evicts it via `disposeSecondariesForConnection`, hangs the fallback `getConnection()` call, and asserts `$connection` transitions to `null` once the internal timeout elapses instead of staying latched forever.
- [x] Mutation-verified: reverted the fix, confirmed the new test fails with the connection staying latched (never becomes `null`); reapplied the fix, confirmed it passes.
- [x] `npx vitest run apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx` — 40/40 passing, no regressions.
- [x] `npx tsc -p . --noEmit` — clean.