### PR TITLE
feat(observability): expose current Langfuse trace id to subprocess env

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -101,6 +101,16 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 # private-chat topic (those lanes route only with thread id + reply anchor).
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
+# Langfuse trace id of the CURRENT turn, published by the bundled
+# observability/langfuse plugin as it opens the turn's root trace. Carried here
+# rather than in a bare os.environ write so a subprocess spawned mid-turn (the
+# terminal tool's claude shim, execute_code) can stamp its own telemetry with
+# the exact spawning turn: HERMES_SESSION_ID says which conversation, this says
+# which turn inside it. Task-local like the identity vars above — concurrent
+# turns (MoA fan-out, gateway message tasks) each publish their own id, and the
+# process-global mirror is only a CLI/cron fallback.
+_SESSION_TURN_TRACE_ID: ContextVar = ContextVar("HERMES_LANGFUSE_TRACE_ID", default=_UNSET)
+
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
 _BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
     "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
@@ -156,6 +166,7 @@ _VAR_MAP = {
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
+    "HERMES_LANGFUSE_TRACE_ID": _SESSION_TURN_TRACE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
@@ -202,6 +213,47 @@ def set_current_session_id(session_id: str) -> None:
         pass
 
     os.environ["HERMES_SESSION_ID"] = session_id
+
+
+def set_current_turn_trace_id(trace_id: str) -> None:
+    """Publish the current turn's Langfuse trace id for spawned subprocesses.
+
+    Called by the bundled observability/langfuse plugin when it opens a turn's
+    root trace, and again with ``""`` when that trace finishes.  The subprocess
+    env bridge (``tools/environments/local._inject_session_context_env``) reads
+    the ContextVar, so a child process started during the turn — the terminal
+    tool's claude shim, execute_code — can stamp its own spans with the trace
+    that spawned it.  The ``os.environ`` mirror keeps the single-process CLI /
+    cron path working, where the bridge's fallback is the process env.
+
+    Delegated subagent children skip the mirror for the same reason
+    :func:`set_current_session_id` does: they run inside the parent process
+    under ``delegated_child_context()``, so a process-global write would replace
+    the parent turn's id for every later parent subprocess.  The ContextVar
+    write is task-local and stays correct for the child's own tools.
+
+    A trace id is a hex identifier, not a secret — it carries no content and
+    needs no redaction.
+    """
+    import os
+
+    value = str(trace_id or "")
+    _SESSION_TURN_TRACE_ID.set(value)
+
+    try:
+        from agent.delegation_context import is_delegated_child_context
+
+        if is_delegated_child_context():
+            return
+    except Exception:
+        pass
+
+    if value:
+        os.environ["HERMES_LANGFUSE_TRACE_ID"] = value
+    else:
+        # Drop rather than blank the mirror: a finished turn must leave nothing
+        # behind for a CLI/cron process whose bridge falls back to os.environ.
+        os.environ.pop("HERMES_LANGFUSE_TRACE_ID", None)
 
 
 @contextmanager
@@ -282,6 +334,11 @@ def set_session_vars(
         _SESSION_ID.set(session_id),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
+        # A freshly bound session has not started a turn trace yet. Binding it
+        # explicitly empty (rather than leaving it inherited) keeps a sibling
+        # task's published id out of the pre-trace window; the langfuse plugin
+        # fills it in via set_current_turn_trace_id once the root trace opens.
+        _SESSION_TURN_TRACE_ID.set(""),
         _SESSION_PROFILE.set(profile),
         _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
         _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
@@ -323,6 +380,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
+        _SESSION_TURN_TRACE_ID,
         _SESSION_PROFILE,
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -232,6 +232,13 @@ def set_current_turn_trace_id(trace_id: str) -> None:
     the parent turn's id for every later parent subprocess.  The ContextVar
     write is task-local and stays correct for the child's own tools.
 
+    Clearing writes ``""`` to the ContextVar rather than restoring ``_UNSET``,
+    so the var has two "absent" spellings: ``_UNSET`` (never published in this
+    context — the bridge strips the var, or falls back to ``os.environ`` when no
+    host is engaged) and ``""`` (published and finished — the bridge exports it
+    empty, masking any stale mirror).  Both read as "no active turn trace"; they
+    differ only in whether the ``os.environ`` fallback still applies.
+
     A trace id is a hex identifier, not a secret — it carries no content and
     needs no redaction.
     """

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -23,6 +23,12 @@ Optional env vars:
       sanitized - content with secret-pattern redaction + truncation
       full      - raw content (truncated only); explicit opt-in
   HERMES_LANGFUSE_DEBUG       - set to "true" for verbose logging
+
+Exported (not read) while a turn is traced:
+  HERMES_LANGFUSE_TRACE_ID    - the current turn's trace id, published into the
+      environment of subprocesses spawned during the turn so a child run (the
+      terminal tool's claude shim, execute_code) can stamp its own telemetry
+      and join back to the exact spawning turn.
 """
 from __future__ import annotations
 
@@ -880,10 +886,47 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
         return {}, {}
 
 
+def _publish_turn_trace_id(trace_id: str) -> None:
+    """Export this turn's trace id to subprocesses spawned during the turn.
+
+    Routed through ``gateway.session_context`` rather than written straight to
+    ``os.environ``: that layer owns the task-local ContextVar and the
+    subprocess-env bridge, so concurrent turns (MoA fan-out, gateway message
+    tasks) each publish their own id instead of racing one process-global slot.
+
+    Fail-open like every other path here — a Hermes build without the setter
+    must still trace.
+    """
+    try:
+        from gateway.session_context import set_current_turn_trace_id
+
+        set_current_turn_trace_id(trace_id)
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"publishing turn trace id failed: {exc}")
+
+
+def _unpublish_turn_trace_id(trace_id: str) -> None:
+    """Withdraw a finished turn's trace id (see :func:`_publish_turn_trace_id`).
+
+    Only clears when *trace_id* is still the published one, so a cleanup pass
+    that reaps another key's dangling trace (``on_session_end``) cannot
+    unpublish the id a live turn is still handing to its subprocesses.
+    """
+    try:
+        from gateway.session_context import get_session_env, set_current_turn_trace_id
+
+        if get_session_env("HERMES_LANGFUSE_TRACE_ID", "") != trace_id:
+            return
+        set_current_turn_trace_id("")
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"clearing turn trace id failed: {exc}")
+
+
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
                       api_mode: str, messages: Any, client: Langfuse,
                       turn_id: str = "", api_request_id: str = "") -> TraceState:
     trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
+    _publish_turn_trace_id(trace_id)
     trace_input = _extract_last_user_message(messages)
     metadata = {
         "source": "hermes",
@@ -1129,6 +1172,9 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
         except Exception:
             pass
     finally:
+        # Withdraw before the flush so a finished turn's id can never reach a
+        # subprocess spawned by whatever runs next in this context.
+        _unpublish_turn_trace_id(state.trace_id)
         try:
             client.flush()
         except Exception:

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -908,16 +908,36 @@ def _publish_turn_trace_id(trace_id: str) -> None:
 def _unpublish_turn_trace_id(trace_id: str) -> None:
     """Withdraw a finished turn's trace id (see :func:`_publish_turn_trace_id`).
 
-    Only clears when *trace_id* is still the published one, so a cleanup pass
-    that reaps another key's dangling trace (``on_session_end``) cannot
-    unpublish the id a live turn is still handing to its subprocesses.
+    The id lives in two stores: the task-local ContextVar (authoritative for the
+    subprocess-env bridge once the session machinery is engaged) and the
+    process-global ``os.environ`` mirror (the CLI/cron fallback, skipped on the
+    delegated-child path).  They can hold different ids, so each is checked and
+    withdrawn on its own:
+
+    * ContextVar holds *trace_id* — the ordinary same-task finish.  Clear
+      through the setter, which drops the mirror too.
+    * Only the mirror holds *trace_id* — ``_finish_trace`` ran in a different
+      task than ``_start_root_trace`` published in (a session-end reap, or any
+      teardown deferred to a background task), so this task never had the id to
+      begin with.  Pop the mirror alone: blanking the ContextVar here would
+      unpublish whatever *this* task is publishing, which may be a live turn —
+      a delegated child's ContextVar-only publish leaves exactly that shape.
+    * Neither holds it — a newer turn has already published over it.  Nothing to
+      withdraw.
+
+    So a stale reap can never unpublish the id a live turn is still handing to
+    its subprocesses, and a cross-task finish still cleans up after itself.
+    Note the ContextVar has two "absent" spellings (``_UNSET`` before any bind,
+    ``""`` after a clear) and neither can carry an id across a task boundary —
+    only the mirror can, which is why it has to be consulted separately.
     """
     try:
         from gateway.session_context import get_session_env, set_current_turn_trace_id
 
-        if get_session_env("HERMES_LANGFUSE_TRACE_ID", "") != trace_id:
-            return
-        set_current_turn_trace_id("")
+        if get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == trace_id:
+            set_current_turn_trace_id("")
+        elif os.environ.get("HERMES_LANGFUSE_TRACE_ID") == trace_id:
+            os.environ.pop("HERMES_LANGFUSE_TRACE_ID", None)
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"clearing turn trace id failed: {exc}")
 

--- a/tests/gateway/test_turn_trace_id_env.py
+++ b/tests/gateway/test_turn_trace_id_env.py
@@ -1,0 +1,205 @@
+"""Turn-level trace correlation: HERMES_LANGFUSE_TRACE_ID reaches subprocesses.
+
+The bundled observability/langfuse plugin opens one Langfuse trace per turn and
+publishes its id via ``gateway.session_context.set_current_turn_trace_id``. A
+subprocess spawned during that turn (the terminal tool's claude shim,
+execute_code) must see the id in its environment so the child's own telemetry
+can be stamped with it and joined back to the exact spawning turn —
+``HERMES_SESSION_ID`` says which conversation, this says which turn inside it.
+
+The id rides the same ContextVar + subprocess-env-bridge machinery as the
+session identity vars (``_VAR_MAP`` →
+``tools.environments.local._inject_session_context_env``) rather than a bare
+``os.environ`` write, because ``os.environ`` is process-global: under a
+concurrent multi-session host two turns would race one slot and a child could be
+stamped with a sibling turn's trace. Companion coverage:
+tests/tools/test_local_env_session_leak.py (the strip-on-unset guard),
+tests/gateway/test_session_context_inheritance.py (the inheritance leak),
+tests/plugins/test_langfuse_plugin.py (the publishing half).
+"""
+
+import asyncio
+import os
+import subprocess
+import sys
+
+import pytest
+
+import gateway.session_context as sc
+from gateway.session_context import (
+    _UNSET,
+    _VAR_MAP,
+    get_session_env,
+    reset_session_vars,
+    set_current_turn_trace_id,
+    set_session_vars,
+)
+from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+TRACE_VAR = "HERMES_LANGFUSE_TRACE_ID"
+SESSION_VARS = list(_VAR_MAP.keys())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_context():
+    """Clean ContextVar + os.environ + engaged-latch slate per test, restored."""
+    saved_env = {k: os.environ.get(k) for k in SESSION_VARS}
+    saved_ctx = {name: var.get() for name, var in _VAR_MAP.items()}
+    saved_engaged = sc._session_context_engaged
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+    for name in SESSION_VARS:
+        os.environ.pop(name, None)
+    sc._session_context_engaged = True  # a concurrent multi-session host
+    try:
+        yield
+    finally:
+        for var, val in zip(_VAR_MAP.values(), saved_ctx.values()):
+            var.set(val)
+        sc._session_context_engaged = saved_engaged
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _echo_in_subprocess(env: dict) -> str:
+    """What a real child process reads for the trace var under *env*."""
+    result = subprocess.run(
+        [sys.executable, "-c",
+         f"import os; print(os.environ.get({TRACE_VAR!r}, '<absent>'))"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+# --------------------------------------------------------------------------- #
+# The feature: a bound turn trace id reaches the child
+# --------------------------------------------------------------------------- #
+
+def test_bound_turn_trace_id_reaches_a_real_subprocess():
+    set_session_vars(session_key="agent:main:cli", session_id="sess-1", source="cli")
+    set_current_turn_trace_id("0123456789abcdef0123456789abcdef")
+
+    assert _echo_in_subprocess(_make_run_env({})) == "0123456789abcdef0123456789abcdef"
+
+
+def test_background_spawn_path_also_carries_the_id():
+    """process_registry.spawn_local builds its env via _sanitize_subprocess_env."""
+    set_session_vars(session_key="agent:main:cli", session_id="sess-1", source="cli")
+    set_current_turn_trace_id("bgtrace0000")
+
+    sanitized = _sanitize_subprocess_env({"PATH": os.environ.get("PATH", "")})
+
+    assert sanitized.get(TRACE_VAR) == "bgtrace0000"
+
+
+def test_get_session_env_reads_the_published_id():
+    set_current_turn_trace_id("hexhexhex")
+    assert get_session_env(TRACE_VAR, "") == "hexhexhex"
+
+
+# --------------------------------------------------------------------------- #
+# No leak past the turn
+# --------------------------------------------------------------------------- #
+
+def test_cleared_turn_trace_id_does_not_reach_a_subprocess():
+    """What _finish_trace does: the finished turn's id must be gone."""
+    set_session_vars(session_key="agent:main:cli", session_id="sess-1", source="cli")
+    set_current_turn_trace_id("finished-turn-trace")
+    set_current_turn_trace_id("")
+
+    assert _echo_in_subprocess(_make_run_env({})) in ("", "<absent>")
+    assert os.environ.get(TRACE_VAR) is None, (
+        "clearing must drop the os.environ mirror, not blank it — a CLI/cron "
+        "process whose bridge falls back to the process env would still see it"
+    )
+
+
+def test_fresh_session_bind_does_not_inherit_a_sibling_id():
+    """set_session_vars starts a turn with no trace published yet."""
+    set_current_turn_trace_id("sibling-turn-trace")
+    set_session_vars(session_key="agent:main:cli", session_id="sess-2", source="cli")
+
+    assert get_session_env(TRACE_VAR, "") == ""
+    assert _make_run_env({}).get(TRACE_VAR) == ""
+
+
+def test_reset_session_vars_strips_the_id_from_the_child_env():
+    """The handler-entry reset drops an inherited id; engaged ⇒ strip, not inherit."""
+    set_current_turn_trace_id("inherited-turn-trace")
+    reset_session_vars()
+
+    assert TRACE_VAR not in _make_run_env({}), (
+        "an unbound turn under an engaged host must strip the var, not inherit "
+        "the process-global mirror of whichever turn wrote it last"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Concurrency: task-local, and delegated children don't clobber the parent
+# --------------------------------------------------------------------------- #
+
+def test_concurrent_turns_do_not_cross_contaminate():
+    """Two turns publishing at once each keep their own id (ContextVar, not global)."""
+    async def _turn(trace_id, ready, go):
+        set_session_vars(session_key=f"k:{trace_id}", session_id=trace_id, source="cli")
+        set_current_turn_trace_id(trace_id)
+        ready.set()
+        await go.wait()  # both turns have published; the global holds one of them
+        return _make_run_env({}).get(TRACE_VAR)
+
+    async def _main():
+        ready_a, ready_b, go = asyncio.Event(), asyncio.Event(), asyncio.Event()
+        task_a = asyncio.create_task(_turn("trace-A", ready_a, go))
+        task_b = asyncio.create_task(_turn("trace-B", ready_b, go))
+        await ready_a.wait()
+        await ready_b.wait()
+        go.set()
+        return await asyncio.gather(task_a, task_b)
+
+    seen_a, seen_b = asyncio.run(_main())
+
+    assert seen_a == "trace-A"
+    assert seen_b == "trace-B"
+
+
+def test_delegated_child_does_not_clobber_the_parent_mirror():
+    """A delegate_task child runs in-process; its id must stay task-local.
+
+    Mirrors set_current_session_id: writing the child's id to the process-global
+    os.environ would replace the parent turn's id for every parent subprocess
+    spawned after the child was built.
+    """
+    from agent.delegation_context import delegated_child_context
+
+    set_current_turn_trace_id("parent-turn-trace")
+    assert os.environ.get(TRACE_VAR) == "parent-turn-trace"
+
+    with delegated_child_context():
+        set_current_turn_trace_id("child-turn-trace")
+        # The child's own tools resolve the child id through the ContextVar …
+        assert get_session_env(TRACE_VAR, "") == "child-turn-trace"
+        assert _make_run_env({}).get(TRACE_VAR) == "child-turn-trace"
+        # … while the process-global mirror still belongs to the parent turn.
+        assert os.environ.get(TRACE_VAR) == "parent-turn-trace"
+
+
+# --------------------------------------------------------------------------- #
+# The shared bash snapshot must not persist a turn's id
+# --------------------------------------------------------------------------- #
+
+def test_snapshot_dump_unsets_the_turn_trace_id():
+    """One long-lived backend serves many turns; the snapshot is sourced by all.
+
+    Persisting the FIRST turn's id would make every later turn's command source
+    a stale trace, overriding the correct per-command Popen env.
+    """
+    from tools.environments.base import _export_dump_excluding_session_vars
+
+    assert TRACE_VAR in _export_dump_excluding_session_vars('"$tmp"')

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -2387,3 +2387,139 @@ class TestCanonicalCostExport:
         # explicit zeros are treated as authoritative by Langfuse and block
         # its own model-based estimation (#43129).
         assert response_cost == {}
+
+
+# ---------------------------------------------------------------------------
+# Turn trace id published to the session-context layer
+# ---------------------------------------------------------------------------
+
+class TestTurnTraceIdPublishing:
+    """The current turn's trace id must reach subprocesses spawned by the turn.
+
+    ``_start_root_trace`` hands the id to
+    ``gateway.session_context.set_current_turn_trace_id``, whose ContextVar the
+    subprocess-env bridge exports as ``HERMES_LANGFUSE_TRACE_ID``. That lets a
+    child run (the terminal tool's claude shim, execute_code) stamp its own
+    telemetry and join back to the exact spawning turn. See
+    tests/gateway/test_turn_trace_id_env.py for the bridge half.
+    """
+
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @pytest.fixture(autouse=True)
+    def _isolate_turn_trace_id(self):
+        import os
+
+        import gateway.session_context as sc
+
+        var = sc._VAR_MAP["HERMES_LANGFUSE_TRACE_ID"]
+        saved_ctx = var.get()
+        saved_env = os.environ.get("HERMES_LANGFUSE_TRACE_ID")
+        var.set(sc._UNSET)
+        os.environ.pop("HERMES_LANGFUSE_TRACE_ID", None)
+        try:
+            yield
+        finally:
+            var.set(saved_ctx)
+            if saved_env is None:
+                os.environ.pop("HERMES_LANGFUSE_TRACE_ID", None)
+            else:
+                os.environ["HERMES_LANGFUSE_TRACE_ID"] = saved_env
+
+    @staticmethod
+    def _client():
+        class _Span:
+            def update(self, **kw): pass
+            def end(self, **kw): pass
+            def update_trace(self, **kw): pass
+            def start_observation(self, **kw): return _Span()
+
+        class _RootCM:
+            def __enter__(self): return _Span()
+            def __exit__(self, *exc): return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return "abc123deadbeef"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+            def flush(self):
+                pass
+
+        return _Client()
+
+    def _start(self, mod, client):
+        return mod._start_root_trace(
+            "task-key", task_id="t1", session_id="s1", platform="cli",
+            provider="p", model="m", api_mode="chat",
+            messages=[{"role": "user", "content": "hi"}], client=client,
+            turn_id="turn-1",
+        )
+
+    def test_root_trace_publishes_id_to_session_context(self, monkeypatch):
+        from gateway.session_context import get_session_env
+
+        mod = self._fresh_plugin()
+        state = self._start(mod, self._client())
+
+        assert state.trace_id == "abc123deadbeef"
+        assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "abc123deadbeef"
+
+    def test_finish_trace_withdraws_the_id(self, monkeypatch):
+        from gateway.session_context import get_session_env
+
+        mod = self._fresh_plugin()
+        client = self._client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        state = self._start(mod, client)
+        mod._TRACE_STATE["task-key"] = state
+        assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "abc123deadbeef"
+
+        mod._finish_trace("task-key", output="done")
+
+        assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "", (
+            "a finished turn's trace id must not stay published for the next turn"
+        )
+
+    def test_finish_trace_leaves_a_live_turns_id_alone(self, monkeypatch):
+        """Reaping a dangling trace must not unpublish the live turn's id.
+
+        ``on_session_end`` finishes every lingering key, including turns that
+        never finalized. Clearing unconditionally there would strip the id that
+        a still-running turn is handing to its subprocesses.
+        """
+        from gateway.session_context import get_session_env, set_current_turn_trace_id
+
+        mod = self._fresh_plugin()
+        client = self._client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        stale = self._start(mod, client)
+        mod._TRACE_STATE["stale-key"] = stale
+        # A newer turn publishes its own id over the stale one.
+        set_current_turn_trace_id("live-turn-trace")
+
+        mod._finish_trace("stale-key")
+
+        assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "live-turn-trace"
+
+    def test_publishing_failure_never_breaks_tracing(self, monkeypatch):
+        """A Hermes build without the setter must still open the root trace."""
+        import gateway.session_context as sc
+
+        mod = self._fresh_plugin()
+        monkeypatch.delattr(sc, "set_current_turn_trace_id")
+
+        state = self._start(mod, self._client())
+
+        assert state is not None
+        assert state.trace_id == "abc123deadbeef"

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -2512,6 +2512,92 @@ class TestTurnTraceIdPublishing:
 
         assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "live-turn-trace"
 
+    def test_finish_trace_leaves_a_live_turns_id_alone_when_the_mirror_lags(self, monkeypatch):
+        """A stale reap must not blank a live turn whose env mirror lags behind.
+
+        A delegate_task child publishes its trace to the ContextVar only — the
+        process-global mirror deliberately keeps the parent's id (see
+        ``set_current_turn_trace_id``).  Reaping the parent's dangling trace from
+        inside the child's context therefore matches on the mirror, and clearing
+        on that match alone would blank the child's live ContextVar: the very
+        store the subprocess-env bridge treats as authoritative.  Withdraw the
+        mirror, leave the ContextVar.
+        """
+        import os
+
+        from agent.delegation_context import delegated_child_context
+        from gateway.session_context import get_session_env, set_current_turn_trace_id
+
+        mod = self._fresh_plugin()
+        client = self._client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        stale = self._start(mod, client)
+        mod._TRACE_STATE["stale-key"] = stale
+
+        with delegated_child_context():
+            # ContextVar-only publish: the mirror still holds the stale id.
+            set_current_turn_trace_id("live-child-trace")
+            assert os.environ.get("HERMES_LANGFUSE_TRACE_ID") == "abc123deadbeef"
+
+            mod._finish_trace("stale-key")
+
+            assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "live-child-trace", (
+                "withdrawing a stale id must not blank the live turn's ContextVar"
+            )
+            assert os.environ.get("HERMES_LANGFUSE_TRACE_ID") is None, (
+                "the stale id must still be withdrawn from the process-global mirror"
+            )
+
+    def test_finish_trace_withdraws_id_published_in_another_context(self, monkeypatch):
+        """A cross-task finish must still withdraw the finished turn's id.
+
+        ``_finish_trace`` can run in a different async task than the one that
+        opened the trace (``on_session_finalize`` / ``on_session_end`` reaping a
+        turn that never finalized). The finishing task's ContextVar is ``""``
+        (a fresh session bind), so the task-local read alone would miss the id;
+        the guard must fall back to the process-global ``os.environ`` mirror and
+        withdraw it there instead of leaving a stale id for the next turn.
+        """
+        import os
+
+        import gateway.session_context as sc
+        from gateway.session_context import get_session_env, set_session_vars
+
+        mod = self._fresh_plugin()
+        client = self._client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        state = self._start(mod, client)
+        mod._TRACE_STATE["task-key"] = state
+        assert os.environ.get("HERMES_LANGFUSE_TRACE_ID") == "abc123deadbeef"
+
+        # The finishing task bound a fresh session (ContextVar -> "") without
+        # touching the process-global mirror, which still holds the finished id.
+        # set_session_vars latches the process-wide "engaged" flag, which
+        # switches the subprocess-env bridge's leak policy for every later test
+        # in this process — restore it.
+        saved_engaged = sc._session_context_engaged
+        try:
+            set_session_vars(session_key="k:other", session_id="sess-other", source="cli")
+            assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == ""
+
+            mod._finish_trace("task-key")
+        finally:
+            sc._session_context_engaged = saved_engaged
+
+        assert os.environ.get("HERMES_LANGFUSE_TRACE_ID") is None, (
+            "a cross-task finish must withdraw the id from the env mirror, not "
+            "leave a stale trace id to leak to the next turn's subprocesses"
+        )
+        assert get_session_env("HERMES_LANGFUSE_TRACE_ID", "") == "", (
+            "the finishing task's own ContextVar must be left as it bound it"
+        )
+
     def test_publishing_failure_never_breaks_tracing(self, monkeypatch):
         """A Hermes build without the setter must still open the root trace."""
         import gateway.session_context as sc

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -578,12 +578,15 @@ def _cwd_marker(session_id: str) -> str:
 # set), not Hermes' per-turn session identity.
 #
 # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
-# as the Python-side contract for the exclusion set; the dump path unsets by
-# name/prefix instead of grepping declare lines (see below / issue #71296).
+# with one of these prefixes (or is HERMES_UI_SESSION_ID / HERMES_LANGFUSE_TRACE_ID).
+# Used by unit tests as the Python-side contract for the exclusion set; the dump
+# path unsets by name/prefix instead of grepping declare lines (see below /
+# issue #71296). HERMES_LANGFUSE_TRACE_ID is matched by full name, not by a
+# HERMES_LANGFUSE_ prefix, so the plugin's credential vars keep their existing
+# handling.
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
     "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|"
-    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_)"
+    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_|HERMES_LANGFUSE_TRACE_ID)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -635,7 +638,11 @@ def _export_dump_excluding_session_vars(
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
         "AI_AGENT HERMES_AGENT "
-        f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
+        # Per-turn Langfuse trace id: bridged fresh onto every command like the
+        # session vars, so persisting the first turn's id would make every later
+        # turn's subprocess ``source`` a stale trace and mis-join its telemetry.
+        "HERMES_UI_SESSION_ID HERMES_LANGFUSE_TRACE_ID"
+        f"{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"


### PR DESCRIPTION
## What

Exposes the current turn's Langfuse trace id to subprocesses spawned during that turn via a new `HERMES_LANGFUSE_TRACE_ID` environment variable. The bundled `observability/langfuse` plugin publishes the id when it opens a turn's root trace and withdraws it when the trace finishes.

## Why

Hermes spawns child processes mid-turn that emit their own telemetry — the terminal tool driving an external coding agent (Claude Code, etc.), `execute_code`, and so on. Today those children can be correlated to the Hermes *session* (`HERMES_SESSION_ID` already flows through the subprocess-env bridge) but not to the specific *turn* that spawned them. That gap makes it impossible to answer "which turn dispatched this child run" when auditing an agent trail.

This is the standard correlation pattern for black-box child agents that open their own root spans: the child stamps the parent's trace id onto its own telemetry as a resource attribute (`hermes.trace_id`), and the two are joined at query time. Session-level answers "which conversation"; turn-level answers "which exact turn, when, doing what".

## How

The turn's trace id is carried through the existing session-context machinery rather than written straight to `os.environ`, because that layer already owns the task-local ContextVar and the subprocess-env bridge:

- **`gateway/session_context.py`** — new `_SESSION_TURN_TRACE_ID` ContextVar plus a `_VAR_MAP["HERMES_LANGFUSE_TRACE_ID"]` entry; `set_current_turn_trace_id(trace_id)` mirrors `set_current_session_id` including the `is_delegated_child_context()` guard; bound to `""` in `set_session_vars` and reset in `clear_session_vars`.
- **`plugins/observability/langfuse/__init__.py`** — `_publish_turn_trace_id` / `_unpublish_turn_trace_id`, fail-open, called from `_start_root_trace` (after `create_trace_id`) and `_finish_trace` (in the `finally`, before flush). `_unpublish` only clears when the published id is still its own, so a cleanup pass can't withdraw a live turn's id.
- **`tools/environments/base.py`** — `HERMES_LANGFUSE_TRACE_ID` added to the snapshot-exclusion regex and unset list, matched by full name rather than a `HERMES_LANGFUSE_` prefix so the plugin's credential vars (`HERMES_LANGFUSE_PUBLIC_KEY`, etc.) keep their existing handling.

Because the new name sits in `_VAR_MAP`, the subprocess-env bridge and `reset_session_vars` pick it up automatically — no bridge edit needed.

## Correctness properties

- **Task-local** — concurrent turns (MoA fan-out, gateway message tasks) each publish their own id through the ContextVar; the process-global `os.environ` mirror is only the single-process CLI/cron fallback.
- **Delegation-safe** — delegated subagent children skip the `os.environ` mirror, matching `set_current_session_id`, so a child cannot clobber the parent's id.
- **Fail-open** — if the setter is absent (older build), tracing is unaffected.
- **Not secret** — a trace id is a hex identifier carrying no content; no redaction required.

## Tests

- `tests/gateway/test_turn_trace_id_env.py` — publish/unpublish lifecycle, bridge reachability, concurrency isolation, delegation suppression, `_UNSET` vs empty semantics.
- `tests/plugins/test_langfuse_plugin.py` — publishing/unpublishing and fail-open behaviour.
- Regression-verified against `tests/tools/test_snapshot_session_id_leak.py`, `tests/tools/test_local_env_session_leak.py`, and `tests/gateway/test_session_context_inheritance.py`.
- End-to-end: a subprocess spawned mid-trace reads the trace id; a subprocess spawned after finish reads empty.