### PR TITLE
fix(fallback): log why try_activate_fallback declined instead of returning silently

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1789,6 +1789,10 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_activated = False
         agent._fallback_index = 0
         agent._rate_limit_backoff_count = 0  # reset exponential backoff counter
+        # Re-arm the "fallback not activated" diagnosis so a later, genuinely
+        # different decline warns again rather than being suppressed to DEBUG
+        # for the life of the process.
+        agent._fallback_unavailable_logged = False
 
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves
@@ -3133,6 +3137,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     agent._provider_fallback_active = False
     agent._provider_fallback_route = None
     agent._fallback_index = 0
+    # switch_model reassigns _fallback_chain below, which can change the
+    # diagnosis (exhausted -> empty); re-arm so the corrected message is not
+    # suppressed by the previous episode's latch.
+    agent._fallback_unavailable_logged = False
 
     # When the user deliberately swaps primary providers (e.g. openrouter
     # → anthropic), drop any fallback entries that target the OLD primary

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2534,9 +2534,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "fallback chain is empty (not configured, or every entry dropped "
             "as invalid at init)" if _chain_len == 0 else "fallback chain exhausted"
         )
+        # An empty chain is the normal state of a default install with no
+        # fallback_providers configured, so it must not write a config-sounding
+        # WARNING into errors.log on the first transient empty response. Real
+        # exhaustion — a chain that was configured and has now been walked to
+        # the end — is a genuine degradation and keeps WARNING.
+        _base_level = logging.INFO if _chain_len == 0 else logging.WARNING
+        # Cleared per episode alongside _fallback_index / _fallback_activated in
+        # restore_primary_runtime and switch_model, so a later, genuinely
+        # different incident warns again instead of being suppressed for the
+        # life of the process.
         _already = getattr(agent, "_fallback_unavailable_logged", False)
         logger.log(
-            logging.DEBUG if _already else logging.WARNING,
+            logging.DEBUG if _already else _base_level,
             "Fallback not activated: %s (index=%d, chain_len=%d, reason=%s)",
             _why,
             agent._fallback_index,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2509,6 +2509,41 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 _existing_cooldown,
                 time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S,
             )
+        # This return was silent, which makes the two ways it fires
+        # indistinguishable in a log: an empty chain, and a chain that was
+        # walked to the end.  Operationally those are opposite problems — one
+        # is "my config never loaded", the other is "every provider I have is
+        # failing" — and from outside both look identical: rate-limit errors
+        # with no "Fallback activated" line.  Chasing 27 such errors against
+        # zero activations is what motivated this (self-hosted, 2026-08-25);
+        # the answer was not in the logs at all.
+        #
+        # Logged once per agent, not once per call.  Callers invoke this on
+        # every iteration of `while retry_count < max_retries` (conversation_
+        # loop.py:3396 and 3470 among others) and most keep retrying when it
+        # returns False, so an unconditional WARNING here turns one transient
+        # empty response into N+1 lines in errors.log.  The first occurrence
+        # carries the diagnosis; the rest are DEBUG.
+        _chain_len = len(agent._fallback_chain)
+        # Deliberately NOT "not configured": agent_init drops entries missing
+        # provider/model, so a `models:`-for-`model:` typo also lands here with
+        # an empty chain.  Naming only the config-absent case would send an
+        # operator to re-add a chain they already wrote — the same misdiagnosis
+        # this log exists to prevent.
+        _why = (
+            "fallback chain is empty (not configured, or every entry dropped "
+            "as invalid at init)" if _chain_len == 0 else "fallback chain exhausted"
+        )
+        _already = getattr(agent, "_fallback_unavailable_logged", False)
+        logger.log(
+            logging.DEBUG if _already else logging.WARNING,
+            "Fallback not activated: %s (index=%d, chain_len=%d, reason=%s)",
+            _why,
+            agent._fallback_index,
+            _chain_len,
+            getattr(reason, "name", reason),
+        )
+        agent._fallback_unavailable_logged = True
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1


### PR DESCRIPTION
## Problem

`try_activate_fallback()` returns `False` from its chain-exhausted guard without logging anything. That makes two opposite problems indistinguishable from outside:

- the fallback chain is **empty** — config never loaded, or every entry was dropped as invalid at init;
- the chain was **walked to the end** — every configured provider failed.

Either way the operator sees rate-limit errors and no `Fallback activated` line, with nothing to say which. One means "fix your config", the other means "all your providers are down".

This cost real time on a self-hosted deployment (2026-08-25): **27 `RateLimitError` entries in 24h against zero fallback activations**, and the logs could not distinguish the two. The answer simply wasn't recorded anywhere.

## Change

One log line before the existing `return False`, naming which case fired and including `index`, `chain_len` and the failover `reason`.

```
Fallback not activated: fallback chain is empty (not configured, or every entry
dropped as invalid at init) (index=0, chain_len=0, reason=rate_limit)

Fallback not activated: fallback chain exhausted (index=9, chain_len=9, reason=rate_limit)
```

## Two things deliberately handled

**Logged once per agent, not once per call.** Callers invoke this on every iteration of `while retry_count < max_retries` (`conversation_loop.py:3396` and `:3470` among others) and most keep retrying when it returns `False`. An unconditional WARNING would turn one transient empty response into N+1 lines in `errors.log`. The first occurrence carries the diagnosis; the rest are DEBUG.

**The empty-chain wording avoids saying "not configured".** `agent_init.py` drops entries missing `provider`/`model`, so a `models:`-for-`model:` typo also lands here with an empty chain. Naming only the config-absent case would send an operator to re-add a chain they had already written — the same misdiagnosis this log exists to prevent.

## Risk

No control-flow change: the log sits after the cooldown arming and before the existing `return False`. Verified both branches against a stub agent, and that a repeat call on the same agent drops to DEBUG.

Note `tests/run_agent/test_provider_fallback.py` fails in my checkout for an unrelated environmental reason (`ModuleNotFoundError: concurrent_log_handler` at `hermes_logging.py:65`), present before this change.