### PR TITLE
fix(deadline): remove the dead second SuspectableBackend class shadowing the Phase 3a Protocol

### DIFF
--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -648,32 +648,3 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
         except Exception:
             continue
     return signalled
-
-
-class SuspectableBackend:
-    """Protocol for backends whose connection state can be *poisoned* by a
-    race (teardown-vs-keepalive, auth-lock corruption) without the backend
-    itself being dead.
-
-    The contract is **cheap-mark, lazy-verify**: noticing a poisoned state
-    must never do I/O — ``mark_suspect`` just latches a reason string. The
-    NEXT caller pays for verification once, via ``ensure_healthy``: a cheap
-    health probe that either clears the suspicion (backend was fine) or
-    forces a reconnect/recycle before the call proceeds. This is what keeps
-    a single race from permanently parking a connection (#81051/#77765/
-    #84132): instead of parking on the ambiguous event, the backend is
-    marked suspect and recycled exactly once on next use.
-    """
-
-    def mark_suspect(self, reason: str) -> None:
-        """Latch a suspicion about this backend. Must be cheap (no I/O)."""
-        raise NotImplementedError
-
-    async def ensure_healthy(self, timeout: float = 5.0) -> bool:
-        """Verify a suspect backend before reuse.
-
-        Returns True when the backend is healthy (clearing the suspicion);
-        returns False after forcing a reconnect/recycle so the caller's
-        normal no-session path handles the rebuild. Must not raise.
-        """
-        raise NotImplementedError

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -545,6 +545,26 @@ class TestSequentialToolTimeoutResolver:
 # ---------------------------------------------------------------------------
 
 
+def test_suspectable_backend_name_is_not_shadowed():
+    """`agent.deadline.SuspectableBackend` must resolve to the Phase 3a
+    Protocol (sync `ensure_healthy(self) -> bool`), not a second, unrelated
+    `class SuspectableBackend` defined later in the module. A later Phase 3b
+    adopter independently redefined the same name as a concrete async class
+    (`ensure_healthy(self, timeout=5.0)`), which silently shadowed the
+    Protocol at module scope — nothing subclasses or imports either by name
+    today, so the collision caused no runtime breakage yet, but it would
+    hand the wrong (and differently-shaped) type to the next `from
+    agent.deadline import SuspectableBackend` consumer.
+    """
+    import inspect
+
+    from agent.deadline import SuspectableBackend
+
+    assert getattr(SuspectableBackend, "_is_protocol", False) is True
+    assert not inspect.iscoroutinefunction(SuspectableBackend.ensure_healthy)
+    assert "timeout" not in inspect.signature(SuspectableBackend.ensure_healthy).parameters
+
+
 class _RecordingBackend:
     """Minimal SuspectableBackend: records mark_suspect calls."""
 


### PR DESCRIPTION
## Summary

- `agent/deadline.py` defines `SuspectableBackend` **twice**:
  - The Phase 3a (#85125, PR #93796) `Protocol`, with a **sync** `ensure_healthy(self) -> bool`.
  - A second, unrelated concrete class further down the same module, added by the MCP Phase 3b adopter (#85125 3b, PR #94184), with an **async** `ensure_healthy(self, timeout: float = 5.0) -> bool` and different issue references (#81051/#77765/#84132) in its own docstring — clearly written independently, without noticing the name collision with the Protocol already in the file.
- Since Python executes class statements top-to-bottom, the second definition silently shadows the first at module scope. `agent.deadline.SuspectableBackend` currently resolves to the async concrete class, not the documented Phase 3a Protocol.
- Verified this causes no live behavior change today: `grep -rn "SuspectableBackend"` across the tree shows the name is referenced in exactly two places, both the class definitions themselves. The merged MCP adopter (`tools/mcp_tool.py`) implements the same-shaped contract directly on its own connection class (duck-typing) rather than importing or subclassing `agent.deadline.SuspectableBackend`, and the currently-open browser adopter (#94183) does the same. So nothing is broken *yet* — but the collision leaves the wrong (and differently-shaped) class resolvable under that name for the next consumer that imports it for a type hint, exactly what an incrementally-adopted Protocol like this is meant to support.
- Fix: remove the dead second class. It's provably unused (confirmed via the grep above), so this is a pure deletion with no call-site changes needed anywhere.

## Test plan

- [x] Added `test_suspectable_backend_name_is_not_shadowed` (`tests/agent/test_deadline.py`), asserting `agent.deadline.SuspectableBackend` resolves to the Protocol (`_is_protocol is True`, sync `ensure_healthy`, no `timeout` parameter).
- [x] Mutation-verified: reverted the fix, confirmed the new test fails (`_is_protocol` is `False` because the async concrete class wins); reapplied the fix, confirmed it passes.
- [x] `pytest tests/agent/test_deadline.py` — 54/54 passing, no regressions.
- [x] `pytest tests/tools/ -k mcp` — 643 passing, 2 pre-existing skips, confirming the MCP adopter (which duck-types the contract rather than importing the class) is unaffected.
- [x] `ruff check agent/deadline.py tests/agent/test_deadline.py` — clean.