### PR TITLE
fix(desktop): open Bot Chats converge to new messages without a remount (#93604 + stale-transcript family)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
 import {
   $activeSessionId,
@@ -22,6 +23,7 @@ import {
 import {
   type ActiveTranscriptRefreshDeps,
   reconcileActiveTranscript,
+  reconcileTileTranscripts as reconcileTileTranscriptsForTest,
   rehydrateLiveSessionStatuses,
   resolveActiveTranscriptSession,
   useBackgroundSync,
@@ -188,6 +190,106 @@ describe('active transcript refresh', () => {
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'hidden external answer'
     })
+  })
+
+  it('reconciles a workspace TILE transcript when sessions.changed ticks (#94255 review: behavior, not source-grep)', async () => {
+    $changeEventsAvailable.set(true)
+    // The tile's runtime differs from the active session — it is NOT the main
+    // pane surface, so only the tile reconcile path may update it.
+    const TILE_RUNTIME_ID = 'runtime-tile'
+    const TILE_STORED_ID = 'stored-tile'
+    $activeSessionId.set('runtime-something-else')
+    $selectedStoredSessionId.set('stored-other')
+
+    const states = new Map<string, ReturnType<typeof createClientSessionState>>()
+    states.set(TILE_RUNTIME_ID, createClientSessionState(TILE_STORED_ID))
+
+    let updaterCallCount = 0
+
+    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
+      (sessionId, updater) => {
+        updaterCallCount += 1
+        const current = {} as Parameters<typeof updater>[0]
+
+        return updater(current)
+      }
+    )
+    void updateSessionState
+
+    const signatureRef = { current: new Map<string, string>() }
+    const requestSequenceRef = { current: 0 }
+    const busyRef = { current: false }
+
+    vi.mocked(getLatestSessionMessages).mockImplementation(async (storedId: string) => {
+      if (storedId === TILE_STORED_ID) {
+        return {
+          messages: [
+            { content: 'tile question', role: 'user', timestamp: 1 },
+            { content: 'background delivery answer', role: 'assistant', timestamp: 2 }
+          ],
+          session_id: TILE_STORED_ID
+        } as never
+      }
+
+      return transcript('main-pane answer') as never
+    })
+
+    // Seed a tile so reconcileTileTranscripts has a target.
+    setSessions([]) // bot chats are hidden from $sessions — the whole point
+
+    await act(async () => {
+      await reconcileTileTranscriptsForTest({
+        tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
+        busyRef,
+        requestSequenceRef,
+        signatureRef,
+        updateSessionState
+      })
+    })
+
+    // Behavior assertions:
+    expect(updaterCallCount).toBeGreaterThan(0)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+  })
+
+  it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
+    $changeEventsAvailable.set(true)
+
+    const TILE_RUNTIME_ID = 'runtime-tile-2'
+    const TILE_STORED_ID = 'stored-tile-2'
+
+    const signatureRef = { current: new Map<string, string>() }
+    // Pre-seed the signature with what the mock returns → no-change tick.
+    const pre = {
+      messages: [
+        { content: 'q', role: 'user', timestamp: 1 },
+        { content: 'a', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: TILE_STORED_ID
+    }
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(pre as never)
+
+    // Compute the same signature the reconcile will compute, and pre-seed it.
+    const preSignature = sessionMessagesSignature(pre.messages as never)
+
+    signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
+
+    const updateSessionState = vi.fn()
+    const busyRef = { current: false }
+    const requestSequenceRef = { current: 0 }
+
+    await act(async () => {
+      await reconcileTileTranscriptsForTest({
+        tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
+        busyRef,
+        requestSequenceRef,
+        signatureRef,
+        updateSessionState
+      })
+    })
+
+    expect(updateSessionState).not.toHaveBeenCalled()
   })
 
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -3,7 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
-import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  setBusy,
+  setMessagingSessions,
+  setSessionOwnerHint,
+  setSessions
+} from '@/store/session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -31,13 +38,13 @@ const { getLatestSessionMessages } = await import('@/hermes')
 const ACTIVE_RUNTIME_ID = 'runtime-active'
 const ACTIVE_STORED_ID = 'stored-active'
 
-function transcript(answer: string) {
+function transcript(answer: string, sessionId = ACTIVE_STORED_ID) {
   return {
     messages: [
       { content: 'question', role: 'user', timestamp: 1 },
       { content: answer, role: 'assistant', timestamp: 2 }
     ],
-    session_id: ACTIVE_STORED_ID
+    session_id: sessionId
   }
 }
 
@@ -140,11 +147,58 @@ describe('active transcript refresh', () => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
   })
 
+  it('refreshes a hidden session through its unique complete owner route', async () => {
+    const hiddenStoredSessionId = 'hidden-bot-chat'
+    const ownerRoute = {
+      connectionId: 'ssh-bot-owner',
+      mode: 'remote' as const,
+      profile: 'bot-route',
+      targetProfile: 'bot-profile'
+    }
+    $changeEventsAvailable.set(true)
+    $activeSessionId.set(ACTIVE_RUNTIME_ID)
+    $selectedStoredSessionId.set(hiddenStoredSessionId)
+    setSessionOwnerHint(hiddenStoredSessionId, ownerRoute)
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(
+      transcript('hidden external answer', hiddenStoredSessionId) as never
+    )
+
+    renderSync(fixture.refresh, { activeStoredSessionId: hiddenStoredSessionId })
+
+    act(() => notifySessionsChanged())
+
+    await waitFor(() =>
+      expect(getLatestSessionMessages).toHaveBeenCalledWith(hiddenStoredSessionId, {
+        connectionId: ownerRoute.connectionId,
+        profile: ownerRoute.targetProfile
+      })
+    )
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'hidden external answer'
+    })
+  })
+
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {
     $changeEventsAvailable.set(true)
     $activeSessionId.set(ACTIVE_RUNTIME_ID)
     $selectedStoredSessionId.set(ACTIVE_STORED_ID)
-    setSessions([{ id: ACTIVE_STORED_ID, profile: 'desktop-profile', source: 'desktop' } as never])
+    setSessionOwnerHint(ACTIVE_STORED_ID, {
+      connectionId: 'stale-owner',
+      mode: 'remote',
+      profile: 'wrong-profile',
+      targetProfile: 'wrong-target'
+    })
+    setSessions([
+      {
+        connectionId: 'future-visible-owner',
+        id: ACTIVE_STORED_ID,
+        profile: 'desktop-profile',
+        source: 'desktop',
+        targetProfile: 'must-not-rewrite-visible-row'
+      } as never
+    ])
     const fixture = makeRefresh(resolveActiveTranscriptSession)
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('external answer') as never)
 
@@ -157,6 +211,7 @@ describe('active transcript refresh', () => {
         text: 'external answer'
       })
     )
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'desktop-profile')
   })
 
   it('does not add a periodic transcript poll to local/Desktop sessions', async () => {
@@ -239,6 +294,12 @@ describe('active transcript refresh', () => {
 
 describe('reconcileActiveTranscript', () => {
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
+    setSessionOwnerHint(ACTIVE_STORED_ID, {
+      connectionId: 'stale-messaging-owner',
+      mode: 'remote',
+      profile: 'wrong-profile',
+      targetProfile: 'wrong-target'
+    })
     setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
     const fixture = makeRefresh(resolveActiveTranscriptSession)
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('telegram answer') as never)
@@ -248,6 +309,85 @@ describe('reconcileActiveTranscript', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'messaging-profile')
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'telegram answer'
+    })
+  })
+
+  it('fails closed when a hidden session id has multiple owner hints', async () => {
+    const ambiguousStoredSessionId = 'ambiguous-hidden-chat'
+    setSessionOwnerHint(ambiguousStoredSessionId, {
+      connectionId: 'owner-a',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    setSessionOwnerHint(ambiguousStoredSessionId, {
+      connectionId: 'owner-b',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = ambiguousStoredSessionId
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('uses the presentation profile when a hidden owner has no target profile', async () => {
+    const hiddenStoredSessionId = 'hidden-no-target'
+    setSessionOwnerHint(hiddenStoredSessionId, {
+      connectionId: 'owner-no-target',
+      mode: 'remote',
+      profile: 'presentation-profile'
+    })
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(hiddenStoredSessionId, {
+      connectionId: 'owner-no-target',
+      profile: 'presentation-profile'
+    })
+  })
+
+  it('reads and publishes only the active hidden owner when another owner coexists', async () => {
+    const ownerAStoredSessionId = 'owner-a-chat'
+    const ownerBStoredSessionId = 'owner-b-hidden-chat'
+    const ownerBRoute = {
+      connectionId: 'owner-b',
+      mode: 'remote' as const,
+      profile: 'bot-route',
+      targetProfile: 'bot-b'
+    }
+    setSessions([{ id: ownerAStoredSessionId, profile: 'bot-a', source: 'desktop' } as never])
+    setSessionOwnerHint(ownerAStoredSessionId, {
+      connectionId: 'owner-a',
+      mode: 'remote',
+      profile: 'bot-route',
+      targetProfile: 'bot-a'
+    })
+    setSessionOwnerHint(ownerBStoredSessionId, ownerBRoute)
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = ownerBStoredSessionId
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(
+      transcript('owner B answer', ownerBStoredSessionId) as never
+    )
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledTimes(1)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ownerBStoredSessionId, {
+      connectionId: ownerBRoute.connectionId,
+      profile: ownerBRoute.targetProfile
+    })
+    expect(fixture.updateSessionState).toHaveBeenCalledWith(
+      ACTIVE_RUNTIME_ID,
+      expect.any(Function),
+      ownerBStoredSessionId
+    )
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'owner B answer'
     })
   })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -56,13 +56,16 @@ function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession
   const signatureRef = { current: new Map<string, string>() }
   const state = createClientSessionState(ACTIVE_STORED_ID)
   const states = new Map([[ACTIVE_RUNTIME_ID, state]])
+  const updateSessionStateRef = {
+    updateSessionState: vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
+      const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
+      states.set(sessionId, next)
 
-  const updateSessionState = vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
-    const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
-    states.set(sessionId, next)
+      return next
+    })
+  }
+  const { updateSessionState } = updateSessionStateRef
 
-    return next
-  })
 
   const refresh = () =>
     reconcileActiveTranscript({
@@ -89,6 +92,12 @@ function useSyncHarness({
   activeStoredSessionId: string | null
   refreshActiveTranscript: () => Promise<void>
 }) {
+  const updateSessionState: Parameters<typeof useBackgroundSync>[0]['updateSessionState'] = vi.fn(
+    (sessionId, updater) => {
+      const current = {} as Parameters<typeof updater>[0]
+      return updater(current)
+    }
+  )
   useBackgroundSync({
     activeConnectionId: 'local',
     activeGatewayProfile: 'default',
@@ -103,7 +112,8 @@ function useSyncHarness({
     refreshHermesConfig: vi.fn(),
     refreshMessagingSessions: vi.fn(),
     refreshSessions: vi.fn(),
-    requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+    updateSessionState,
+      requestGateway: vi.fn(async () => ({ sessions: [] })) as never
   })
 }
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -75,23 +75,31 @@ export interface ActiveTranscriptRefreshDeps {
  * pair, so no resolution step is needed; refreshes are signature-gated per
  * tile so a no-change event costs nothing, and a busy tile is skipped (its own
  * stream owns the view while streaming).
+ *
+ * Sequencing note (#94255 review): all tiles SHARE one request sequence, so a
+ * second tick arriving mid-read invalidates every in-flight read from the
+ * first (latest-wins — same discipline as the main pane path). Under rapid
+ * tick bursts only the final tick lands updates; that is intended, since each
+ * tick re-reads from storage anyway.
  */
 export async function reconcileTileTranscripts({
   requestSequenceRef,
   busyRef,
   signatureRef,
-  updateSessionState
+  updateSessionState,
+  tiles: tilesOverride
 }: {
   busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
+  tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
 }): Promise<void> {
-  const tiles = $sessionTiles.get()
+  const tiles = tilesOverride ?? $sessionTiles.get()
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
@@ -113,15 +121,24 @@ export async function reconcileTileTranscripts({
 
     const requestId = ++requestSequenceRef.current
 
+    // With a tiles override (test path), the live $sessionTiles check can't
+    // see the synthetic tile — treat override tiles as present.
+    const stillPresent = tilesOverride
+      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+
     try {
       const latest = await getLatestSessionMessages(storedSessionId)
 
       if (
         requestId !== requestSequenceRef.current ||
         busyRef.current ||
-        $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId) === false
+        !stillPresent
       ) {
-        // Tile closed or superseded mid-read — discard.
+        // Tile closed or superseded mid-read — discard AND prune its
+        // signature so the map doesn't grow one entry per ever-opened tile
+        // for the app's lifetime (#94255 review point 3).
+        signatureRef.current.delete(`tile:${storedSessionId}`)
         continue
       }
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
-import { getLatestSessionMessages } from '@/hermes'
+import { getLatestSessionMessages, type ProfileScope } from '@/hermes'
 import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
@@ -16,9 +16,11 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  getSessionOwnerHint,
   sessionMatchesStoredId,
   setCurrentCwd
 } from '@/store/session'
+import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   publishSessionState,
@@ -30,15 +32,23 @@ import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
 
 interface ActiveTranscriptSession {
+  ownerRoute?: SessionProfileRoute
   profile?: string | null
 }
 
-/** Resolve an active transcript from either local recents or messaging slices. */
+/** Resolve an active transcript from visible rows or its unique hidden owner. */
 export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
-  return (
+  const visible =
     $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
     $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-  )
+
+  if (visible) {
+    return { profile: visible.profile }
+  }
+
+  const ownerRoute = getSessionOwnerHint(storedSessionId)
+
+  return ownerRoute ? { ownerRoute, profile: ownerRoute.profile } : undefined
 }
 
 export interface ActiveTranscriptRefreshDeps {
@@ -82,7 +92,13 @@ export async function reconcileActiveTranscript({
   requestSequenceRef.current = requestId
 
   try {
-    const latest = await getLatestSessionMessages(storedSessionId, stored.profile)
+    const profileScope: ProfileScope = stored.ownerRoute
+      ? {
+          connectionId: stored.ownerRoute.connectionId,
+          profile: stored.ownerRoute.targetProfile ?? stored.ownerRoute.profile
+        }
+      : stored.profile
+    const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 
     if (
       requestId !== requestSequenceRef.current ||
@@ -93,7 +109,15 @@ export async function reconcileActiveTranscript({
       return
     }
 
-    const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
+    const signatureKey = stored.ownerRoute
+      ? JSON.stringify([
+          stored.ownerRoute.connectionId,
+          stored.ownerRoute.profile,
+          stored.ownerRoute.targetProfile ?? '',
+          stored.ownerRoute.mode ?? '',
+          storedSessionId
+        ])
+      : `${stored.profile ?? 'default'}:${storedSessionId}`
     const signature = sessionMessagesSignature(latest.messages)
 
     if (signatureRef.current.get(signatureKey) === signature) {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -490,10 +490,10 @@ export function useBackgroundSync({
   // transcript signatures, so no-change ticks and closed tiles cost nothing.
   const tileRequestSequenceRef = useRef(0)
   const tileSignatureRef = useRef(new Map<string, string>())
-  const activeTranscriptBusyRef = useRef(false)
-  useEffect(() => {
-    activeTranscriptBusyRef.current = activeTranscriptBusy
-  }, [activeTranscriptBusy])
+  // Read $busy.get() directly inside the reconcile loop instead of mirroring
+  // the atom into a ref (lint: no-restricted-syntax — refs synced from atoms
+  // lag one render). The reconcile runs on tick, not render, so .get() is
+  // always current.
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -639,7 +639,7 @@ export function useBackgroundSync({
       // (#93942 scenario A). Signature-gated per tile, so no-change ticks
       // cost nothing.
       void reconcileTileTranscripts({
-        busyRef: activeTranscriptBusyRef,
+        busyRef: { get current() { return $busy.get() } },
         requestSequenceRef: tileRequestSequenceRef,
         signatureRef: tileSignatureRef,
         updateSessionState
@@ -666,7 +666,7 @@ export function useBackgroundSync({
         window.clearTimeout(timer)
       }
     }
-  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh])
+  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh, updateSessionState])
 
   // Keep the cron-jobs section live without a user action (scheduler ticks in
   // the background). cron.changed (jobs.json moved: CRUD or a scheduler tick's

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -23,6 +23,7 @@ import {
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
+  $sessionTiles,
   publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS,
   setSessionStalled
@@ -63,6 +64,89 @@ export interface ActiveTranscriptRefreshDeps {
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
+}
+
+/**
+ * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
+ * slice 1). Bot canonical chats live here — never in $sessions /
+ * $messagingSessions (they carry the core `hidden` flag), so the main-pane
+ * reconcile path's resolveSession() bails on them and a background delivery
+ * never reaches an open bot chat. Each tile carries its own stored↔runtime id
+ * pair, so no resolution step is needed; refreshes are signature-gated per
+ * tile so a no-change event costs nothing, and a busy tile is skipped (its own
+ * stream owns the view while streaming).
+ */
+export async function reconcileTileTranscripts({
+  requestSequenceRef,
+  busyRef,
+  signatureRef,
+  updateSessionState
+}: {
+  busyRef: MutableRefObject<boolean>
+  requestSequenceRef: MutableRefObject<number>
+  signatureRef: MutableRefObject<Map<string, string>>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}): Promise<void> {
+  const tiles = $sessionTiles.get()
+
+  for (const tile of tiles) {
+    const storedSessionId = tile.storedSessionId
+    const runtimeSessionId = tile.runtimeId
+
+    if (!runtimeSessionId) {
+      // Resume not yet bound — the tile's own stream owns the view.
+      continue
+    }
+
+    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+      continue
+    }
+
+    if ($activeSessionId.get() === runtimeSessionId) {
+      // The main pane reconcile already owns this surface.
+      continue
+    }
+
+    const requestId = ++requestSequenceRef.current
+
+    try {
+      const latest = await getLatestSessionMessages(storedSessionId)
+
+      if (
+        requestId !== requestSequenceRef.current ||
+        busyRef.current ||
+        $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId) === false
+      ) {
+        // Tile closed or superseded mid-read — discard.
+        continue
+      }
+
+      const signatureKey = `tile:${storedSessionId}`
+      const signature = sessionMessagesSignature(latest.messages)
+
+      if (signatureRef.current.get(signatureKey) === signature) {
+        continue
+      }
+
+      signatureRef.current.set(signatureKey, signature)
+      const messages = toChatMessages(latest.messages)
+
+      updateSessionState(
+        runtimeSessionId,
+        state => ({
+          ...state,
+          messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
+        }),
+        storedSessionId
+      )
+    } catch {
+      // Non-fatal: the next change event retries.
+    }
+  }
 }
 
 /** Reconcile one persisted transcript snapshot into the currently viewed session. */
@@ -322,6 +406,11 @@ interface BackgroundSyncParams {
   refreshMessagingSessions: () => Promise<unknown> | unknown
   refreshSessions: () => Promise<unknown> | unknown
   requestGateway: GatewayRequester
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
 }
 
 /** Poll a callback while the tab is visible, on `intervalMs`; re-checks on tab
@@ -389,13 +478,22 @@ export function useBackgroundSync({
   refreshHermesConfig,
   refreshMessagingSessions,
   refreshSessions,
-  requestGateway
+  requestGateway,
+  updateSessionState
 }: BackgroundSyncParams): void {
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
   const sessionsChangeTick = useStore($sessionsChangeTick)
   const activeTranscriptBusy = useStore($busy)
   const activeTranscriptRefreshPendingRef = useRef<string | null>(null)
+  // Tile reconcile state (#93942 slice 1): shared sequence guard + per-tile
+  // transcript signatures, so no-change ticks and closed tiles cost nothing.
+  const tileRequestSequenceRef = useRef(0)
+  const tileSignatureRef = useRef(new Map<string, string>())
+  const activeTranscriptBusyRef = useRef(false)
+  useEffect(() => {
+    activeTranscriptBusyRef.current = activeTranscriptBusy
+  }, [activeTranscriptBusy])
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -536,6 +634,16 @@ export function useBackgroundSync({
       void refreshSessions()
       void refreshMessagingSessions()
       requestActiveTranscriptRefresh(true)
+      // Bot canonical chats live in workspace tiles, never in the main-pane
+      // selection — without this they never see background deliveries
+      // (#93942 scenario A). Signature-gated per tile, so no-change ticks
+      // cost nothing.
+      void reconcileTileTranscripts({
+        busyRef: activeTranscriptBusyRef,
+        requestSequenceRef: tileRequestSequenceRef,
+        signatureRef: tileSignatureRef,
+        updateSessionState
+      })
     }
 
     const unsubscribe = $sessionsChangeTick.listen(() => {

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -825,7 +825,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshHermesConfig,
     refreshMessagingSessions,
     refreshSessions,
-    requestGateway
+    requestGateway,
+    updateSessionState
   })
 
   // Electron-main / OS / cross-window integrations: update polling, ⌘W close,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -4,12 +4,14 @@ import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { followActiveSessionCwd } from '@/store/projects'
 import {
+  $activeSessionId,
   $currentCwd,
   $currentModel,
   $currentProvider,
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
+  setActiveSessionId,
   setCurrentBranch,
   setCurrentCwdTransient,
   setCurrentFastMode,
@@ -65,6 +67,48 @@ function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined
     .some(session => sessionMatchesStoredId(session, infoStoredSessionId) && sessionMatchesStoredId(session, selected))
 }
 
+/**
+ * Adopt a rebuilt runtime back into the open pane (#93942 scenario B).
+ *
+ * A mid-conversation model/provider switch rebuilds the agent runtime: the
+ * new runtime emits `session.info` (and every later event) under a NEW
+ * explicit session_id while the pane still holds the dead one as its active
+ * id — so `isActiveEvent` is false for the same conversation and the view
+ * stops receiving live updates until a full resume. When an incoming
+ * `session.info` lineage-matches the selected conversation but carries a
+ * different runtime id, and the OLD runtime shows no live turn (not busy,
+ * not streaming), re-bind: adopt the new id as the active session id,
+ * keeping the durable selection untouched. A live turn on the old runtime
+ * (overlap window during a manual switch) refuses the adoption.
+ */
+function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext): boolean {
+  const { deps, explicitSid, isActiveEvent, payload } = ctx
+
+  if (!explicitSid || isActiveEvent || typeof payload?.stored_session_id !== 'string') {
+    return false
+  }
+
+  const selected = $selectedStoredSessionId.get()
+
+  if (!selected || !sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+    return false
+  }
+
+  const activeId = $activeSessionId.get()
+  const oldState = activeId ? deps.sessionStateByRuntimeIdRef.current.get(activeId) : undefined
+
+  // Only a dead old runtime may be adopted over: hijacking a streaming turn
+  // would split one conversation's events across two panes.
+  if (oldState?.busy || oldState?.awaitingResponse || oldState?.streamId) {
+    return false
+  }
+
+  setActiveSessionId(explicitSid)
+  ctx.deps.activeSessionIdRef.current = explicitSid
+
+  return true
+}
+
 /** session.info / session.usage / session.title. */
 export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, explicitSid, isActiveEvent, occurredAt, fromActiveSource } = ctx
@@ -81,9 +125,16 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   } = deps
 
   if (event.type === 'session.info') {
+    // A rebuilt runtime (mid-conversation model/provider switch) speaks under
+    // a NEW session_id. Before scoping anything by isActiveEvent, check
+    // whether this event is the rebuilt runtime announcing itself for the
+    // conversation already on screen — if so, re-bind the pane so every
+    // subsequent isActiveEvent gate keeps matching (#93942 scenario B).
+    const rebound = maybeRebindPaneToRebuiltRuntime(ctx)
+
     // Apply session-scoped fields when the event targets the active
     // session, OR when it's a global broadcast and we have no session.
-    const apply = explicitSid ? isActiveEvent : !activeSessionIdRef.current
+    const apply = (explicitSid ? isActiveEvent : !activeSessionIdRef.current) || rebound
     const statePatch = sessionInfoStatePatch(payload)
     const hasStatePatch = hasSessionInfoStatePatch(statePatch)
     const modelChanged = typeof payload?.model === 'string'

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5641,12 +5641,20 @@ async function openStoredBotChat(owner, storedId, summary) {
   // asks the SDK layer to retry that same wait internally, BEFORE it arms the
   // core stranded-session overlay: a plugin-side retry can't do this because
   // only host.openSession sees the resume-exhausted latch that overlay reads.
+  //
+  // forceResume: an explicit bot switch must never trust a cached transcript.
+  // The SDK's surface-health check passes whenever ANY non-empty transcript is
+  // painted, including a stale snapshot the session-states cache kept from the
+  // previous time this bot was open — which left the pane showing old messages
+  // until an app restart (hermes-agent#93604). A resume is cheap and
+  // idempotent, so on this explicit user navigation we always request one.
   await host.openSession(storedId, {
     ...(route ? { route } : {}),
     profile: name,
     intent: 'tab',
     awaitHydration: true,
     expectHistory,
+    forceResume: true,
     keepAllProfilesScope: true,
     workspaceMode: 'bots',
     workspaceOwnerKey: ownerKey,

--- a/apps/desktop/src/plugins/hermes-bots/tests/remote-routing-races.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/remote-routing-races.test.mjs
@@ -80,6 +80,7 @@ function load({ requestProfile, agents, profileRoutes } = {}) {
     .concat(`
       globalThis.__race = {
         $botMeta,
+        botActivitySession,
         botConnectionRoute,
         botRosterKey,
         botSelectionKey,
@@ -280,6 +281,41 @@ test('non-identity alias resolves the canonical chat by NAME on the backend prof
   assert.equal(lookup[1].include_hidden, true)
   const opened = runtime.calls.find(call => call[0] === 'openSession')
   assert.equal(opened[1], 'worker-chat-tip', 'the lineage tip opens; the registry row stays the identity')
+})
+
+test('canonical sidebar activity and an explicit bot switch converge on a forced-resume open', async () => {
+  const bot = {
+    ...remoteBot,
+    canonical_session: { id: 'bot-chat', last_active: 20, preview: 'new canonical activity' },
+    last_session: { id: 'old-visible-chat', last_active: 10, preview: 'stale visible activity' }
+  }
+  const runtime = load({
+    requestProfile: async (_route, method) => {
+      if (method === 'session.list') {
+        return {
+          sessions: [{ id: 'bot-chat', resolved_id: 'bot-chat-tip', title: 'Bot Chat', message_count: 4 }]
+        }
+      }
+
+      return {}
+    }
+  })
+
+  assert.equal(
+    runtime.context.__race.botActivitySession(bot).id,
+    'bot-chat',
+    'the sidebar activity tile follows the hidden canonical chat'
+  )
+
+  const result = await runtime.context.__race.openBotCanonicalChat(bot)
+  const opened = runtime.calls.find(call => call[0] === 'openSession')
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), { registryId: 'bot-chat', openedId: 'bot-chat-tip' })
+  assert.equal(opened[1], 'bot-chat-tip', 'the explicit switch opens the canonical lineage tip')
+  assert.equal(opened[2].awaitHydration, true)
+  assert.equal(opened[2].expectHistory, true)
+  assert.equal(opened[2].forceResume, true, 'a cached stale runtime must never suppress session.resume')
+  assert.equal(opened[2].route.connectionId, 'remote-a', 'resume stays on the canonical chat owner')
 })
 
 test('remote canonical lookup failure rejects instead of minting on the remote source', async () => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -316,6 +316,15 @@ let openSessionGeneration = 0
 export interface PluginOpenSessionOptions {
   awaitHydration?: boolean
   expectHistory?: boolean
+  /** Always request a sequenced session.resume after the open, even when the
+   *  surface already looks healthy. The healthy check trusts any non-empty
+   *  cached transcript, so an explicit bot-switch re-open can paint a STALE
+   *  snapshot kept by the session-states cache and skip the refresh entirely
+   *  (#93604 — Bot Chat shows old messages until app restart). Resume is
+   *  cheap and idempotent (the route-resume effect consumes redundant
+   *  requests as no-ops), so callers who know the user explicitly navigated
+   *  here set this to guarantee freshness. Only honored with awaitHydration. */
+  forceResume?: boolean
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
@@ -910,7 +919,12 @@ export const host = {
             Boolean($activeSessionId.get()) &&
             (!expectHistory || $messages.get().length > 0)
 
-          if (options.awaitHydration && !surfaceHealthy) {
+          // surfaceHealthy trusts ANY non-empty cached transcript, so it
+          // cannot distinguish a fresh transcript from a stale snapshot the
+          // session-states cache kept across a bot switch (#93604). Callers
+          // that represent an explicit user navigation pass forceResume to
+          // skip the heuristic entirely; the resume is idempotent either way.
+          if (options.awaitHydration && (options.forceResume || !surfaceHealthy)) {
             requestSessionResume(storedSessionId, ownerRoute || undefined)
           }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -714,6 +714,51 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('forces a resume on an explicit bot switch even when a cached transcript looks healthy (#93604)', async () => {
+    // Bot-switch shape from the field: the previous visit left a non-empty
+    // snapshot in the session-states cache, so the surface passes every
+    // health check while painting STALE messages. The heuristic alone skips
+    // the resume; the explicit-navigation caller must be able to force it.
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-stale-snapshot')
+    setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    await Promise.resolve()
+    expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
+
+    await opening
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('still trusts a healthy surface when the caller does not force a resume', async () => {
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-live')
+    setMockAtom($messages, [{ id: 'live-history', parts: [], role: 'assistant' }] as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    await Promise.resolve()
+    expect(requestSessionResume).not.toHaveBeenCalled()
+
+    await opening
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('resolves a history-bearing wake on transcript paint without waiting for the runtime (paint-first)', async () => {
     vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 

--- a/contributors/emails/hermes@lift-off.co.uk
+++ b/contributors/emails/hermes@lift-off.co.uk
@@ -1,0 +1,1 @@
+A-Snegin

--- a/tests/desktop/test_bots_chat_live_append.py
+++ b/tests/desktop/test_bots_chat_live_append.py
@@ -1,0 +1,79 @@
+"""Regression tests for #93942 slice 1 — Bot Mode open chat pane never picks
+up background deliveries.
+
+Mechanism (traced on 85a55e2b30-era main, re-verified through 03b87d666d):
+
+* Background DMs deliver via a separate ``hermes -p <profile> chat``
+  subprocess (``tools/bot_relay.py::local_delivery_command``) that writes the
+  turn straight to the session DB. No gateway stream event reaches the desktop.
+* The gateway broadcasts ``sessions.changed`` on state.db mtime movement, and
+  the desktop's tick handler calls ``requestActiveTranscriptRefresh(true)`` —
+  but that refresh covers ONLY the MAIN pane's selection
+  (``activeStoredSessionId = selectedStoredSessionId``, wiring.tsx).
+* Bot canonical chats open as workspace tiles (``workspaceMode: 'bots'``,
+  never the main selection), AND ``resolveActiveTranscriptSession()`` bails
+  when the session is absent from ``$sessions``/``$messagingSessions`` — which
+  bot chats always are (they carry the core ``hidden`` flag,
+  plugin.js "Bot Mode sessions are ALWAYS hidden").
+
+Double exclusion ⇒ the sessions.changed refresh silently no-ops for exactly
+the conversation the user is staring at.
+
+Fix contract (slice 1): the sessions.changed tick must also reconcile the
+transcripts of VISIBLE workspace tiles — signature-gated like the main pane,
+keyed off each tile's stored↔runtime id pair — without touching messaging
+polls, roster cadence, or the main-pane path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _bg_sync_source() -> str:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "apps"
+        / "desktop"
+        / "src"
+        / "app"
+        / "contrib"
+        / "hooks"
+        / "use-background-sync.ts"
+    ).read_text(encoding="utf-8")
+
+
+def test_sessions_changed_tick_covers_workspace_tiles():
+    """The $sessionsChangeTick listener must refresh tile transcripts too, not
+    only the main pane's active transcript."""
+    src = _bg_sync_source()
+
+    # Locate the tick listener block.
+    m = re.search(r"\$sessionsChangeTick\.listen\(", src)
+    assert m, "sessions.changed listener must exist"
+
+    # The run() it invokes must include a per-tile reconciliation call in
+    # addition to requestActiveTranscriptRefresh. Pre-fix, `run()` touches
+    # refreshSessions/refreshMessagingSessions/requestActiveTranscriptRefresh
+    # only — no tile path.
+    run_start = src.rfind("const run = () => {", 0, m.start())
+    body = src[run_start : src.find("}", m.start())]
+
+    assert re.search(r"[Tt]ile", body), (
+        "pre-fix state: sessions.changed refresh covers the main pane only; "
+        "open workspace tiles (bot canonical chats) are never reconciled "
+        "(#93942 scenario A)"
+    )
+
+
+def test_tile_reconciliation_is_signature_gated():
+    """Tile refreshes must be signature-gated (no-change events must not churn
+    every visible tile), matching the main pane's reconcile discipline."""
+    src = _bg_sync_source()
+
+    # The fix introduces a signature-gated tile reconciler; assert its guard
+    # exists near the tile handling code.
+    assert re.search(r"[Tt]ile[A-Za-z]*Signature|signature.*tile", src, re.IGNORECASE) or (
+        "signatureRef" in src and "[Tt]ile" in src
+    ), "tile reconciliation must be signature-gated like the main pane path"

--- a/tests/desktop/test_bots_chat_stream_rekey.py
+++ b/tests/desktop/test_bots_chat_stream_rekey.py
@@ -64,10 +64,54 @@ def test_rebind_is_guarded_against_live_turns():
     still streaming/busy — only a dead runtime may be adopted over."""
     src = _session_info_source()
 
-    # The guard reads the previous runtime's cached state before adopting.
-    m = re.search(r"rebind[A-Za-z]*|adoptRebuiltRuntime|sessionStateByRuntimeIdRef", src)
-
-    assert m and "busy" in src[m.start() : m.start() + 2000] or "state?.busy" in src, (
-        "pre-fix state: no guarded adoption path exists; the re-bind must check "
-        "the outgoing runtime's busy/streaming state before switching"
+    # Locate the rebind helper's body precisely, then assert its guard inside.
+    fn = re.search(
+        r"function maybeRebindPaneToRebuiltRuntime\([^)]*\): boolean \{", src
     )
+    assert fn, (
+        "pre-fix state: no maybeRebindPaneToRebuiltRuntime adoption path "
+        "exists; the rebuilt runtime is never adopted into the open pane"
+    )
+
+    body_start = fn.end()
+    next_fn = min(
+        (i for i in (src.find("\nfunction ", body_start), src.find("\nexport function ", body_start)) if i != -1),
+        default=-1,
+    )
+    assert next_fn != -1, "re-anchor needed: rebind helper is no longer followed by another function"
+
+    body = src[body_start:next_fn]
+
+    # The busy/awaiting/streaming guard must appear INSIDE the helper body —
+    # not merely somewhere in the file (fixes the precedence hazard the
+    # #94417 review flagged in the original draft of this assertion).
+    guard = re.search(r"oldState\?\.(busy|awaitingResponse|streamId)", body)
+
+    assert guard, (
+        "the re-bind helper must check the outgoing runtime's busy/streaming "
+        "state before switching; adopting over a live turn would split one "
+        "conversation across two panes"
+    )
+
+
+def test_rebind_requires_stored_session_id_lineage():
+    """The gateway always stamps stored_session_id on session.info (server.py:
+    'stored_session_id': session_key or ''), but an empty string must NOT be
+    adopted as lineage proof — only a real stored id may trigger the re-bind."""
+    src = _session_info_source()
+
+    fn = re.search(r"function maybeRebindPaneToRebuiltRuntime\([^)]*\): boolean \{", src)
+    assert fn, "rebind helper missing"
+    body_start = fn.end()
+    body = src[body_start : min(
+        (i for i in (src.find("\nfunction ", body_start), src.find("\nexport function ", body_start)) if i != -1),
+        default=-1,
+    )]
+
+    # The early return guards on the field being a non-empty usable string via
+    # the typeof check + downstream sessionInfoDescribesSelectedSession('' →
+    # null → wildcard refusal).
+    assert 'typeof payload?.stored_session_id !== "string"' in body or (
+        "typeof payload?.stored_session_id !== 'string'" in body
+    ), "rebind must refuse events without a string stored_session_id"
+

--- a/tests/desktop/test_bots_chat_stream_rekey.py
+++ b/tests/desktop/test_bots_chat_stream_rekey.py
@@ -1,0 +1,73 @@
+"""Regression tests for #93942 slice 2 — open chat pane never follows a runtime
+rebuild after a mid-conversation model switch.
+
+Mechanism (traced on 41447a6d70):
+
+* A mid-conversation model/provider switch rebuilds the agent runtime. The
+  rebuilt runtime emits its ``session.info`` (and all later stream events)
+  under a NEW explicit ``session_id``; the old id is dead.
+* The pane's identity is the pair ``(activeSessionIdRef, selectedStoredSessionIdRef)``.
+  After the rebuild, incoming events carry an explicit sid that no longer
+  equals ``activeSessionIdRef.current``, so ``isActiveEvent`` is False for every
+  subsequent event of the SAME conversation — view-scoped side effects stop,
+  and the pane keeps listening on a dead runtime until a full resume.
+* Existing machinery covers compression rotation only:
+  ``ensureSessionState`` fires the stored-id rotation signal when the SAME
+  runtime's stored id rotates — but a model-switch rebuild produces a NEW
+  runtime with a NEW stored id, which is invisible to that path.
+
+Fix contract: when a ``session.info`` event's lineage
+(``sessionMatchesStoredId`` on ``stored_session_id``) matches the currently
+selected conversation but its runtime id differs from the active one, re-bind
+the pane: adopt the new runtime id as the active session id (keeping the same
+durable selection), so live events keep flowing to the view without a resume.
+Guarded to only fire when the old runtime is dead (no busy/streaming state) so
+an overlapping turn is never hijacked mid-flight.
+
+Together with #94255 (slice 1), this closes #93942.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "apps" / "desktop" / "src"
+
+
+def _session_info_source() -> str:
+    return (
+        ROOT / "app" / "session" / "hooks" / "use-message-stream" / "gateway-event" / "session-info.ts"
+    ).read_text(encoding="utf-8")
+
+
+def test_session_info_rebinds_pane_to_rebuilt_runtime():
+    """A session.info whose lineage matches the selected conversation but whose
+    runtime id differs from the active one must trigger the re-bind path."""
+    src = _session_info_source()
+
+    # The fix adds a lineage-checked re-bind call in handleSessionInfoEvent,
+    # distinct from the cwd-claim helper (#71254). Pre-fix there is exactly one
+    # sessionInfoDescribesSelectedSession use site (cwd claim); post-fix a
+    # second consumer exists for the re-bind.
+    uses = len(re.findall(r"sessionInfoDescribesSelectedSession\(", src))
+
+    assert uses >= 3, (
+        "pre-fix state: session.info lineage matching is used only for the cwd "
+        "claim; a rebuilt runtime (model switch) under a new session_id is "
+        "never adopted back into the open pane (#93942 scenario B)"
+    )
+
+
+def test_rebind_is_guarded_against_live_turns():
+    """The re-bind must not hijack a conversation while its OLD runtime is
+    still streaming/busy — only a dead runtime may be adopted over."""
+    src = _session_info_source()
+
+    # The guard reads the previous runtime's cached state before adopting.
+    m = re.search(r"rebind[A-Za-z]*|adoptRebuiltRuntime|sessionStateByRuntimeIdRef", src)
+
+    assert m and "busy" in src[m.start() : m.start() + 2000] or "state?.busy" in src, (
+        "pre-fix state: no guarded adoption path exists; the re-bind must check "
+        "the outgoing runtime's busy/streaming state before switching"
+    )


### PR DESCRIPTION
## Summary
An open Bot Chat pane now converges to reality — background writes appear without a remount, switching bots repaints fresh instead of stale, workspace tiles reconcile on `sessions.changed`, and a mid-conversation model switch re-binds the pane to the rebuilt runtime. Consolidates the §3 "stale transcript" family: fixes #93604 (P2), #93942, the render half of #93856, and #93618-item3.

Root cause (verified on current main + live): `resolveActiveTranscriptSession()` in `use-background-sync.ts` only searched the visible session lists, so a hidden canonical Bot Chat never matched and `reconcileActiveTranscript()` returned before ever fetching — the roster preview knew about new messages while the open pane stayed frozen forever.

Consolidates FOUR overlapping open PRs, all cherry-picked with authorship preserved:
- #93687 (@teknium1) — force `session.resume` on explicit bot-switch open (base) + #93859 (@A-Snegin) — stale-runtime split tests
- #93779 (@Wenfengcheng) — owner-hint fallback so hidden sessions refresh through their unique complete owner route
- #94255 (@beplee) — workspace-tile transcripts reconcile on `sessions.changed` (+ behavior tests)
- #94417 (@beplee) — re-bind the open pane to the rebuilt runtime after a model switch (+ hardened assertions)

## Changes
- `use-background-sync.ts`: owner-hint fallback in the resolver; tile reconcile pass keyed off `sessions.changed`; signature pruning.
- `plugin.js` + `sdk/index.ts`: explicit bot-switch opens force `session.resume` (never paint a cached stale transcript); profile-routing tests.
- `session-info.ts`: model-switch runtime rebuild re-keys the open pane's stream binding.
- Tests: vitest behavior suites for each seam + plugin vm tests + two desktop pytest harnesses from the contributor PRs.

## Validation
| | Result |
|---|---|
| vitest (touched surfaces) | 46 files / 770 tests pass |
| plugin suite | 576 pass / 0 fail |
| eslint (changed files) | 0 errors |

**Live repro (real Electron + backend, CDP):** opened Testbot's Bot Chat, appended a marker message to its session out-of-band via SessionDB. On origin/main: marker appeared ONLY in the roster preview (`inAside: true, inMain: false`) — the open pane never converged (#93604's exact symptom). On this branch: the marker renders in the open BOT CHAT transcript.

Closes #93604. Addresses #93942 and the render half of #93856 (their remaining scenarios get verified against this before closing). Original PRs #93687/#93779/#94255/#94417/#93859 to be closed with credit after merge.

## Infographic

![The stale transcript lesson](https://v3b.fal.media/files/b/0aa7e547/Z12ttkHVvuM7vEWOHzs6a_2muc5car.png)
