### PR TITLE
fix(bot-mode): restore Windows Bot-to-Bot deliveries

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -238,6 +238,8 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     call = calls[0]
     assert call["background"] is True
     assert call["notify_on_complete"] is True
+    assert call["_host_local"] is True
+    assert Path(call["workdir"]) == Path(bot_mode_dm.__file__).resolve().parent.parent
     command = call["command"]
     mode, dm_file, transport_argv = _runner_parts(command)
     assert mode == "query-file"
@@ -466,6 +468,38 @@ def test_real_delivery_command_round_trip(tmp_path, stdin_file):
 
     assert result.returncode == 0
     assert observed.read_text(encoding="utf-8") == "secret λ\nsecond line"
+    assert not dm_file.exists()
+
+
+@pytest.mark.windows_only
+def test_delivery_command_round_trip_through_windows_local_shell(tmp_path):
+    """Native runner paths must survive the Git Bash process boundary."""
+    from tools.environments.local import _find_shell
+
+    dm_file = tmp_path / "message with spaces.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    observed = tmp_path / "observed with spaces.txt"
+    child = tmp_path / "child with spaces.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text('started', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    command = bot_mode_dm._delivery_command(
+        [sys.executable, str(child), str(observed)],
+        str(dm_file),
+        stdin_file=False,
+    )
+
+    result = subprocess.run(
+        [_find_shell(), "-lic", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert observed.read_text(encoding="utf-8") == "started"
     assert not dm_file.exists()
 
 

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -173,6 +173,73 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
     }]
 
 
+def test_host_local_background_command_bypasses_configured_backend(tmp_path, monkeypatch):
+    """Hermes control-plane children stay on the host when tools use Docker."""
+    calls = []
+
+    class FakeEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+    class FakeRegistry:
+        pending_watchers = []
+
+        def spawn_local(self, **kwargs):
+            calls.append(("local", kwargs))
+            return SimpleNamespace(id="proc_host", pid=1234)
+
+        def spawn_via_env(self, **kwargs):
+            calls.append(("configured", kwargs))
+            raise AssertionError("host-local command reached configured backend")
+
+    import tools.process_registry as process_registry_mod
+    import tools.self_repo_guard as self_repo_guard
+
+    task_id = "bot-delivery"
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "docker",
+            "docker_image": "python:3.11",
+            "cwd": str(tmp_path),
+            "timeout": 60,
+            "lifetime_seconds": 3600,
+        },
+    )
+    monkeypatch.setattr(
+        terminal_tool,
+        "_active_environments",
+        {f"host-local-{task_id}": FakeEnv()},
+    )
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value)
+    monkeypatch.setattr(terminal_tool, "_docker_has_host_access", lambda config: False)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": env_type == "local"},
+    )
+    monkeypatch.setattr(self_repo_guard, "guard_active", lambda: False)
+    monkeypatch.setattr(process_registry_mod, "process_registry", FakeRegistry())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="host-runner",
+            task_id=task_id,
+            workdir=str(tmp_path),
+            background=True,
+            _host_local=True,
+        )
+    )
+
+    assert result["session_id"] == "proc_host"
+    assert calls[0][0] == "local"
+    assert calls[0][1]["task_id"] == f"host-local-{task_id}"
+
+
 def test_safe_getcwd_falls_back_to_home_when_no_terminal_cwd(monkeypatch):
     def _boom():
         raise FileNotFoundError()

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -613,6 +613,12 @@ def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str
         dm_file,
         *argv,
     ]
+    if sys.platform == "win32":
+        # The tracked local backend uses Git Bash on native Windows. Forward
+        # slashes preserve native drive paths while remaining executable by
+        # that shell; backslash-form paths are parsed as command names and die
+        # with exit 127 before this runner starts.
+        runner_argv = [part.replace("\\", "/") for part in runner_argv]
     return shlex.join(runner_argv)
 
 
@@ -664,6 +670,8 @@ def _spawn_delivery(
             background=True,
             notify_on_complete=True,
             task_id=task_id,
+            workdir=str(Path(__file__).resolve().parent.parent),
+            _host_local=True,
         )
         try:
             parsed = json.loads(raw)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2828,6 +2828,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    _host_local: bool = False,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2875,13 +2876,18 @@ def terminal_tool(
 
         # Get configuration
         config = _get_env_config()
-        env_type = config["env_type"]
+        env_type = "local" if _host_local else config["env_type"]
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
         effective_task_id = _resolve_container_task_id(task_id)
+        if _host_local:
+            # Hermes-owned control-plane children must run beside the current
+            # interpreter, never inside the model's configured Docker/SSH/etc.
+            # Keep their environment cache separate from the configured backend.
+            effective_task_id = f"host-local-{effective_task_id}"
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``


### PR DESCRIPTION
## What does this PR do?

Native Windows Bot Mode can now launch `message_agent` deliveries even when the model terminal backend is Docker or another sandbox. The fixed-purpose delivery child stays on the host-local tracked process path, while preserving completion notifications, session routing, process IDs, and DM cleanup.

### Symptom

A Bot resolves a local teammate successfully, but the delivery child exits before the target Bot Chat receives the message. Docker/Linux or Git Bash is asked to execute host-native Windows interpreter and script paths, producing exit 127 or an equivalent `python.exe: command not found` failure.

### Impact

Affected native Windows Bot Mode installations cannot complete local Bot-to-Bot handoffs. The target Bot never receives the message even though roster resolution, canonical Bot Chat gating, and the `message_agent` schema all work.

### Bug Cause

**Trigger:** `tools/bot_mode_dm.py:_spawn_delivery` when a native Windows Bot sends a local `message_agent` delivery.

**Causal chain:**
1. `_delivery_command` builds a fixed-purpose runner from the host `sys.executable` and `tools/bot_mode_dm.py` path.
2. `_spawn_delivery` submits that host-bound command to `terminal_tool`, which selects the model's configured Docker, SSH, or local shell backend.
3. A non-host backend cannot execute Windows paths, and Git Bash cannot execute the backslash-form command reliably, so the runner exits before `_run_delivery` starts.

**Why it is wrong:** This runner is trusted Hermes control-plane work tied to the current installation and interpreter. It must not inherit execution semantics from the model-facing terminal backend.

**Working sibling / contrast:** The tracked local process registry already preserves background process IDs, output capture, and completion notification routing when commands run on the host.

**Ruled out:** The stale Docker preview-port conflict was removed independently, and target resolution plus Bot Chat gating succeed before this launch seam.

### Fix

- Add an internal-only host-local route to `terminal_tool` that uses a separate local environment cache instead of the configured model backend.
- Launch Bot delivery and waiter processes through that host-local route while retaining the existing notification setup.
- Normalize native Windows runner argv paths to forward slashes before the Git Bash boundary.
- Cover both configured-backend bypass and a real Windows Git Bash runner round trip.

## Related Issue

Closes #95568

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_mode_dm.py` - keep trusted delivery children on the host and normalize Windows runner paths.
- `tools/terminal_tool.py` - add an internal-only host-local background execution route with isolated environment caching.
- `tests/tools/test_bot_mode_dm.py` - verify host routing metadata and a native Windows Git Bash round trip.
- `tests/tools/test_terminal_task_cwd.py` - verify a configured Docker backend cannot capture a host-local control-plane child.

## How to Test

1. On native Windows, configure Bot Mode with a local teammate and set `terminal.backend` to Docker.
2. Send a native `message_agent` call from the canonical Bot Chat.
3. Verify the runner starts as a tracked host process, the target Bot receives the message, and the reply returns through the completion notification.
4. Run the focused automated coverage:

```bash
scripts/run_tests.sh tests/tools/test_terminal_task_cwd.py -q
scripts/run_tests.sh tests/tools/test_bot_mode_dm.py -q -k 'local_delivery_command_and_ack or peer_delivery_command or real_delivery_command_round_trip or spawn_failure or successful_spawn or windows_local_shell'
scripts/run_tests.sh tests/tools/test_bot_relay.py -q
scripts/run_tests.sh tests/tools/test_terminal_tool_pty_fallback.py -q
scripts/run_tests.sh tests/tools/test_notify_on_complete.py -q
```

The focused commands above pass with 63 tests on Windows 11. Ruff also passes on all four changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on focused affected suites and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A
