### PR TITLE
fix(desktop): claim-guard every remaining ensureRegistryBackend()/ensureBackend() call in Electron main

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -140,4 +140,61 @@ describe('main.ts wiring for #90812', () => {
     expect(body).toContain('backendDialClaims.run(backendScopeKey(id, profile)')
     expect(body).toContain('ensureRegistryBackend(id, profile)')
   })
+
+  // The four IPC/probe surfaces below call ensureRegistryBackend()/ensureBackend()
+  // directly, bypassing backendDialClaims entirely — so a renderer's guarded
+  // reconnect dial and one of these can independently race the SAME
+  // ensureRegistryBackend() await-before-pool-check window (main.ts) and each
+  // bootstrap its own SSH tunnel / remote dashboard for the same
+  // (connectionId, profile) scope.
+
+  it('routes a media-stream connection resolve through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('resolveRemoteConnection: ({ connectionId, profile }) =>')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 300)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connectionId, profile)')
+    expect(body).toContain('ensureRegistryBackend(connectionId, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes a terminal-pane backend resolve through the single-owner claim on both the registry and local branches', () => {
+    const handlerStart = mainSource.indexOf('async function ensureTerminalBackend(webContentsId: number) {')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 900)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(windowRoute.connectionId, windowRoute.profile)')
+    expect(body).toContain('ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)')
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(null, profile)')
+    expect(body).toContain('ensureBackend(profile)')
+  })
+
+  it('routes the roster-enumeration probe through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function enumerateRegistryAgentSources')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 3_700)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
+    expect(body).toContain('ensureRegistryBackend(connection.id, null)')
+    expect(body).toContain("getJsonForBackend(descriptor, '/api/profiles'")
+  })
+
+  it('routes the connections update-all dispatch through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:connections:update-all',")
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 2_000)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
+    expect(body).toContain('ensureRegistryBackend(connection.id, null)')
+    expect(body).toContain("postJsonForBackend(descriptor, '/api/hermes/update'")
+  })
+
+  it('routes every registry-scoped REST dispatch (hermes:api) through the single-owner claim', () => {
+    const handlerStart = mainSource.indexOf('async function dispatchRegistryApiRequest(')
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 900)
+
+    expect(body).toContain('backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile)')
+    expect(body).toContain('ensureRegistryBackend(registryConnectionId, routeProfile)')
+  })
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1334,8 +1334,13 @@ function registerMediaProtocol() {
 
       return resolvedPath
     },
+    // Claim-guarded (#90812): a media stream load can race a renderer's own
+    // reconnect dial for the same (connectionId, profile) scope; coalescing
+    // here avoids bootstrapping a second SSH tunnel / remote dashboard.
     resolveRemoteConnection: ({ connectionId, profile }) =>
-      connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
+      backendDialClaims.run(backendScopeKey(connectionId, profile), () =>
+        connectionId ? ensureRegistryBackend(connectionId, profile) : ensureBackend(profile)
+      )
   })
 
   protocol.handle(MEDIA_PROTOCOL, handler)
@@ -9623,11 +9628,18 @@ function activeSshTerminalTarget(webContentsId?: number) {
 async function ensureTerminalBackend(webContentsId: number) {
   const windowRoute = windowConnectionRoutes.get(webContentsId)
 
+  // Claim-guarded (#90812): opening a terminal pane can race a renderer's own
+  // reconnect dial for the same (connectionId, profile) scope; coalescing
+  // here avoids bootstrapping a second SSH tunnel / remote dashboard.
   if (windowRoute?.registryScoped && windowRoute.connectionId) {
-    return ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)
+    return backendDialClaims.run(backendScopeKey(windowRoute.connectionId, windowRoute.profile), () =>
+      ensureRegistryBackend(windowRoute.connectionId, windowRoute.profile)
+    )
   }
 
-  return ensureBackend(windowRoute?.profile ?? primaryProfileKey())
+  const profile = windowRoute?.profile ?? primaryProfileKey()
+
+  return backendDialClaims.run(backendScopeKey(null, profile), () => ensureBackend(profile))
 }
 
 // Loopback reach for the browser pane. Scoped to the SSH connection that
@@ -13909,8 +13921,15 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             }
           }
 
+          // Claim-guarded (#90812): this ~5s roster poll can race a renderer's
+          // own reconnect dial for the same connection; coalescing avoids
+          // bootstrapping a second SSH tunnel / remote dashboard.
           const descriptor: any = await withEnumerationDeadline(
-            Promise.resolve(ensureRegistryBackend(connection.id, null))
+            Promise.resolve(
+              backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+                ensureRegistryBackend(connection.id, null)
+              )
+            )
           )
 
           const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
@@ -14064,7 +14083,11 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
             return { ...base, ok: result?.ok !== false, detail: result?.message || 'update started' }
           }
 
-          const descriptor: any = await ensureRegistryBackend(connection.id, null)
+          // Claim-guarded (#90812): coalesce with a concurrent renderer dial
+          // for the same connection instead of bootstrapping a second backend.
+          const descriptor: any = await backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+            ensureRegistryBackend(connection.id, null)
+          )
 
           const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', {}, { timeoutMs: 15_000 })
 
@@ -14701,7 +14724,13 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
-  const connection: any = await ensureRegistryBackend(registryConnectionId, routeProfile)
+  // Claim-guarded (#90812): every registry-scoped REST call funnels through
+  // here, so it can race a renderer's own WS reconnect dial for the same
+  // (connectionId, profile) scope; coalescing avoids bootstrapping a second
+  // SSH tunnel / remote dashboard.
+  const connection: any = await backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile), () =>
+    ensureRegistryBackend(registryConnectionId, routeProfile)
+  )
 
   const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
 


### PR DESCRIPTION
## Summary

#90812's `BackendDialClaims` coalesces concurrent backend dials for one `(connectionId, profile)` scope so two renderer windows racing a reconnect spawn one backend instead of two. The merged fix (#95497) wired it into exactly three entry points: `hermes:connection`, `hermes:connection:for`, and the power-resume pool rebuild.

`ensureRegistryBackend()` itself has a genuine await-then-check race: it does `await reuseMatchingPrimarySshBackend(...)` (a real event-loop yield) *before* its pool-entry check-and-set for SSH/registry-scoped sources — this is exactly the window the claim exists to close. Grepping every raw call site of `ensureRegistryBackend()`/`ensureBackend()` in `main.ts` turned up five more real production callers that still invoke it directly, unguarded:

1. `resolveRemoteConnection` (media-protocol connection resolver) — resolves the backend for a `media://` stream load.
2. `ensureTerminalBackend` — resolves the backend for a terminal pane.
3. The roster-enumeration probe inside `enumerateRegistryAgentSources` — polls every ~5s per connection.
4. The connections update-all dispatch (`hermes:connections:update-all`).
5. `dispatchRegistryApiRequest` — every registry-scoped `hermes:api` REST call.

Any of these racing a guarded dial (or each other) for the same `(connectionId, profile)` scope can each independently bootstrap their own SSH tunnel / remote dashboard for the same connection — the exact "competing lifecycle probes repeatedly tear down each other's tunnel" symptom class #90812 describes, just reached through one of these paths instead of two renderer windows. The roster-enumeration probe in particular fires on its own ~5s timer, so it's a realistic, frequent way to land in this window whenever a user also opens a terminal, streams media, or the update-all dispatch runs against a registry connection.

Fix: wrap each of the five call sites with `backendDialClaims.run(backendScopeKey(...), () => ...)`, matching the exact pattern already used at the three existing call sites.

## Deliberately out of scope

`ensureRegistryBackend()` also calls itself recursively inside its own dispatch-time health-probe reconnect branch (coordinated by `registryDispatchRevalidation`, not `backendDialClaims`) when an existing pooled entry fails a live health check. I left that path unguarded: it has its own reentrancy semantics I haven't fully modeled, and wrapping a recursive self-call to the same function these five new call sites dial into risks a subtler bug than the one being fixed. Flagging it here in case a maintainer wants a targeted follow-up.

I also confirmed no overlap with the concurrently open #95564 (Magnum Phase 1-2 supervisor work): it only touches `hermes:connection`/`hermes:connection:for` (routing them through a new `gatewaySupervisor.activate()` layer that still delegates to `BackendDialClaims` underneath, per its own PR description) and doesn't touch any of the five call sites this PR fixes.

## Test plan

- [x] Added 5 source-inspection tests to `backend-dial-claim.test.ts` (matching this file's existing pattern for verifying main.ts wiring), one per call site, asserting each is routed through `backendDialClaims.run(backendScopeKey(...))`.
- [x] Mutation-verified: reverted `main.ts`, confirmed all 5 new tests fail (the other 9 pre-existing tests in the file still pass); reapplied the fix, confirmed all 14 pass.
- [x] `npx vitest run apps/desktop/electron/` — 1781/1788 passing (6 pre-existing skips); the 1 failure (`remote-lifecycle.test.ts`'s installer-wrapper pid test) reproduces identically on unmodified `upstream/main`, confirmed pre-existing and unrelated.
- [x] `npx tsc -p tsconfig.electron.json --noEmit` — clean.