### PR TITLE
feat(terminal): add opt-in agent-bin override dir to subprocess PATH

### DIFF
--- a/tests/tools/test_local_env_agent_bin.py
+++ b/tests/tools/test_local_env_agent_bin.py
@@ -1,0 +1,196 @@
+"""Tests for the opt-in ``$HERMES_HOME/agent-bin`` PATH override slot.
+
+``agent-bin`` is a Hermes-owned prepend slot for the subprocess PATH the
+terminal tool (and the cron / background / PTY spawn path) builds. Dropping a
+shim there — a ``claude`` wrapper, a sandbox launcher, a telemetry shim — makes
+it win over the same-named CLI everywhere the agent shells out.
+
+Two properties matter and are asserted by calling the real functions:
+
+1. **Opt-in.** With no ``agent-bin`` directory the produced PATH is
+   byte-identical to what the untouched sibling helpers produce, so a default
+   install pays nothing.
+2. **Head of PATH.** With the directory present nothing precedes it — not the
+   hermes install dir, not any caller-supplied entry — because the whole point
+   is operator interception.
+
+The managed runtime dirs (``$HERMES_HOME/bin``, node) are deliberately
+*appended* instead, so "a tool the user deliberately put on their own PATH
+still wins" (25d0bcd4). These tests pin the hermes install dir and neutralise
+the Git Bash dir prepend so the asserted PATH layout is deterministic on every
+host rather than depending on whether a real ``hermes`` is on the runner's PATH.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import get_hermes_home
+from tools.environments import local as local_mod
+from tools.environments.local import (
+    _make_run_env,
+    _prepend_agent_bin_dir,
+    _sanitize_subprocess_env,
+)
+
+#: Stand-in for the resolved hermes console-script dir. Pinned so ordering
+#: assertions don't depend on the runner having a real ``hermes`` installed.
+HERMES_BIN_DIR = "/opt/hermes/bin"
+
+#: Caller-supplied PATH used by every test, so "before every caller-PATH
+#: entry" is a concrete assertion rather than a shape check.
+CALLER_PATH = os.pathsep.join(["/usr/bin", "/bin"])
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: the agent-bin prepend is a documented no-op on Windows",
+)
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_path_layout(monkeypatch):
+    """Pin the two other PATH contributors so agent-bin's position is testable."""
+    monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", HERMES_BIN_DIR)
+    monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [])
+
+
+@pytest.fixture
+def agent_bin() -> str:
+    """Create ``$HERMES_HOME/agent-bin`` and return its path.
+
+    The autouse ``_isolate_hermes_home`` fixture already points HERMES_HOME at
+    a per-test tempdir, so this creates the real directory the helper looks for
+    rather than mocking the lookup.
+    """
+    directory = get_hermes_home() / "agent-bin"
+    directory.mkdir()
+    return str(directory)
+
+
+def _run_env_path(env: dict | None = None) -> str:
+    """Return the PATH ``_make_run_env`` builds from ``CALLER_PATH``.
+
+    HERMES_HOME is carried into the cleared environ because the helper resolves
+    ``get_hermes_home()`` from the process environment.
+    """
+    process_env = {
+        "PATH": CALLER_PATH,
+        "HERMES_HOME": os.environ["HERMES_HOME"],
+    }
+    with patch.dict(os.environ, process_env, clear=True):
+        return _make_run_env(env or {})["PATH"]
+
+
+class TestDefaultInstallIsUnchanged:
+    """No agent-bin dir → the PATH string is what it was before this seam."""
+
+    @posix_only
+    def test_make_run_env_path_is_byte_identical(self):
+        # Rebuild the pre-change pipeline from the untouched sibling helpers:
+        # sane-path merge, then the hermes install dir prepend.
+        expected = local_mod._prepend_hermes_bin_dir(
+            local_mod._append_missing_sane_path_entries(CALLER_PATH)
+        )
+
+        assert _run_env_path() == expected
+
+    @posix_only
+    def test_sanitize_subprocess_env_path_is_byte_identical(self):
+        expected = local_mod._prepend_hermes_bin_dir(CALLER_PATH)
+
+        sanitized = _sanitize_subprocess_env({"PATH": CALLER_PATH})
+
+        assert sanitized["PATH"] == expected
+
+    @posix_only
+    def test_no_empty_entries_are_introduced(self):
+        """A PATH with empty components must not gain one from this seam.
+
+        An empty PATH element means "current working directory" to a POSIX
+        shell — the foot-gun ``_append_missing_sane_path_entries`` already
+        strips. Assert that stays true on the default path.
+        """
+        assert "" not in _run_env_path().split(os.pathsep)
+
+
+class TestAgentBinTakesPrecedence:
+    """agent-bin present → nothing precedes it."""
+
+    @posix_only
+    def test_make_run_env_puts_agent_bin_first(self, agent_bin):
+        entries = _run_env_path().split(os.pathsep)
+
+        assert entries[0] == agent_bin
+
+    @posix_only
+    def test_make_run_env_beats_hermes_install_dir_and_caller_entries(self, agent_bin):
+        entries = _run_env_path().split(os.pathsep)
+
+        for later in (HERMES_BIN_DIR, "/usr/bin", "/bin"):
+            assert entries.index(agent_bin) < entries.index(later), (
+                f"{later} must not precede the agent-bin override dir"
+            )
+
+    @posix_only
+    def test_sanitize_subprocess_env_puts_agent_bin_first(self, agent_bin):
+        """Cron / background / PTY spawns get the same override slot."""
+        sanitized = _sanitize_subprocess_env({"PATH": CALLER_PATH})
+        entries = sanitized["PATH"].split(os.pathsep)
+
+        assert entries[0] == agent_bin
+        assert entries.index(agent_bin) < entries.index(HERMES_BIN_DIR)
+
+    @posix_only
+    def test_appears_after_the_directory_is_created_mid_process(self):
+        """The dir is resolved per call, so an operator can add it live."""
+        before = _run_env_path().split(os.pathsep)
+        assert not any(entry.endswith("agent-bin") for entry in before)
+
+        directory = get_hermes_home() / "agent-bin"
+        directory.mkdir()
+
+        assert _run_env_path().split(os.pathsep)[0] == str(directory)
+
+    @posix_only
+    def test_no_empty_entries_are_introduced(self, agent_bin):
+        assert "" not in _run_env_path().split(os.pathsep)
+
+
+class TestPrependHelper:
+    """``_prepend_agent_bin_dir`` in isolation."""
+
+    @posix_only
+    def test_noop_when_directory_is_missing(self):
+        assert _prepend_agent_bin_dir(CALLER_PATH) == CALLER_PATH
+
+    @posix_only
+    def test_noop_on_empty_path_when_directory_is_missing(self):
+        assert _prepend_agent_bin_dir("") == ""
+
+    @posix_only
+    def test_prepends_when_directory_exists(self, agent_bin):
+        result = _prepend_agent_bin_dir(CALLER_PATH)
+
+        assert result == os.pathsep.join([agent_bin, CALLER_PATH])
+
+    @posix_only
+    def test_is_idempotent(self, agent_bin):
+        once = _prepend_agent_bin_dir(CALLER_PATH)
+
+        assert _prepend_agent_bin_dir(once) == once
+
+    @posix_only
+    def test_returns_input_unchanged_when_already_present(self, agent_bin):
+        """Membership dedupe: an existing entry keeps its position."""
+        existing = os.pathsep.join(["/usr/bin", agent_bin, "/bin"])
+
+        assert _prepend_agent_bin_dir(existing) == existing
+
+    @pytest.mark.windows_only
+    def test_noop_passthrough_on_windows(self, agent_bin):
+        """Windows PATH is a deliberate passthrough in the sibling helpers."""
+        native = os.pathsep.join([r"C:\Windows\System32", r"C:\Program Files\Git\bin"])
+
+        assert _prepend_agent_bin_dir(native) == native

--- a/tests/tools/test_local_env_agent_bin.py
+++ b/tests/tools/test_local_env_agent_bin.py
@@ -60,7 +60,7 @@ def _deterministic_path_layout(monkeypatch):
 def agent_bin() -> str:
     """Create ``$HERMES_HOME/agent-bin`` and return its path.
 
-    The autouse ``_isolate_hermes_home`` fixture already points HERMES_HOME at
+    The autouse ``_hermetic_environment`` fixture already points HERMES_HOME at
     a per-test tempdir, so this creates the real directory the helper looks for
     rather than mocking the lookup.
     """

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -550,7 +550,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # this invariant; Cron scripts use this sanitizer directly (#92998).
     path_key = _path_env_key(sanitized)
     if path_key is not None:
-        sanitized[path_key] = _prepend_hermes_bin_dir(sanitized.get(path_key, ""))
+        merged_path = _prepend_hermes_bin_dir(sanitized.get(path_key, ""))
+        # Opt-in operator override slot, applied last so it lands ahead of the
+        # hermes install dir. No-op unless $HERMES_HOME/agent-bin exists.
+        sanitized[path_key] = _prepend_agent_bin_dir(merged_path)
 
     _apply_windows_msys_bash_env_defaults(sanitized)
 
@@ -1186,6 +1189,54 @@ def _prepend_hermes_bin_dir(existing_path: str) -> str:
     return sep.join([bin_dir, *entries])
 
 
+def _prepend_agent_bin_dir(existing_path: str) -> str:
+    """Prepend the opt-in ``$HERMES_HOME/agent-bin`` override dir if it exists.
+
+    A Hermes-owned slot at the very head of the PATH the agent's shells get, so
+    a shim dropped there — a ``claude``/``codex``/``opencode`` wrapper, a
+    sandbox launcher, a telemetry shim — transparently intercepts that CLI
+    everywhere the agent shells out, without every skill having to know the
+    wrapper's name.  The directory does not exist in a default install and this
+    is then a byte-for-byte no-op, so nobody pays for a feature they did not
+    opt into.
+
+    Deliberately a SEPARATE prepend rather than a change to the ordering in
+    ``_append_missing_sane_path_entries``.  The managed runtime dirs
+    (``$HERMES_HOME/bin``, the managed node) are *appended* on purpose so that
+    "a tool the user deliberately put on their own PATH still wins, and the
+    managed one only fills the gap" (25d0bcd4).  ``agent-bin`` has the opposite
+    intent — an operator override that must beat whatever else is installed —
+    so it gets its own opt-in slot and leaves that decision untouched.
+
+    Call this AFTER :func:`_prepend_hermes_bin_dir` at each PATH-building site:
+    both prepend, so the later call ends up first and ``agent-bin`` shadows even
+    the hermes install dir.
+
+    Resolved per call rather than cached, matching
+    :func:`_managed_runtime_path_entries`: ``get_hermes_home()`` is
+    profile-scoped, and an operator can create the directory mid-process.
+    No-op on Windows, where the native PATH is a deliberate passthrough in the
+    sibling helpers.  First-occurrence wins, so a PATH that already lists the
+    dir is returned unchanged.
+    """
+    if _IS_WINDOWS:
+        return existing_path
+    try:
+        from hermes_constants import get_hermes_home
+
+        agent_bin = get_hermes_home() / "agent-bin"
+        if not agent_bin.is_dir():
+            return existing_path
+        bin_dir = str(agent_bin)
+    except Exception:
+        return existing_path
+    sep = os.pathsep
+    entries = [e for e in existing_path.split(sep) if e] if existing_path else []
+    if bin_dir in entries:
+        return existing_path
+    return sep.join([bin_dir, *entries])
+
+
 def _managed_runtime_path_entries() -> list[str]:
     """Return existing Hermes-managed runtime dirs for the terminal subshell PATH.
 
@@ -1352,7 +1403,10 @@ def _make_run_env(env: dict) -> dict:
         # Ensure the hermes install dir is reachable so plugins can shell out
         # to bare ``hermes`` via the terminal tool even when the gateway was
         # launched without it on PATH (systemd, service managers, cron, etc.).
-        run_env[path_key] = _prepend_hermes_bin_dir(new_path)
+        new_path = _prepend_hermes_bin_dir(new_path)
+        # Opt-in operator override slot, applied last so it lands ahead of the
+        # hermes install dir. No-op unless $HERMES_HOME/agent-bin exists.
+        run_env[path_key] = _prepend_agent_bin_dir(new_path)
 
     _inject_context_hermes_home(run_env)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1218,6 +1218,13 @@ def _prepend_agent_bin_dir(existing_path: str) -> str:
     No-op on Windows, where the native PATH is a deliberate passthrough in the
     sibling helpers.  First-occurrence wins, so a PATH that already lists the
     dir is returned unchanged.
+
+    Trust boundary: this slot intercepts every CLI the agent shells out to at
+    higher precedence than the user's own tools, so it must be
+    trusted-operator-owned — never writable by the agent process or by
+    untrusted users unless that interception is the point.  The opt-in (the
+    directory is absent by default) is what keeps a default install outside
+    the boundary.
     """
     if _IS_WINDOWS:
         return existing_path


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in, Hermes-owned PATH prepend slot — `$HERMES_HOME/agent-bin` — to the subprocess PATH built for agent-spawned shells. The directory is prepended ahead of every other entry **only when it exists**, so a default install is byte-identical to today.

This gives skills and deployments a supported way to transparently intercept or wrap the CLIs an agent invokes through the terminal tool (`claude`, `codex`, `opencode`, sandbox/telemetry wrappers) without shadowing the user's own `~/.local/bin`.

## Related Issue

Fixes #95585

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/environments/local.py` — new `_prepend_agent_bin_dir()` helper; called in both PATH-building sites (`_make_run_env` for the terminal tool, `_sanitize_subprocess_env` for cron/background/PTY spawns) after `_prepend_hermes_bin_dir`, so agent-bin lands at the head of PATH.
- `tests/tools/test_local_env_agent_bin.py` — 13 behaviour tests: byte-identical no-op without the dir, agent-bin-first ordering in both paths, idempotency/dedupe, empty-entry safety, mid-process creation, Windows passthrough.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_local_env_agent_bin.py tests/tools/test_local_env_blocklist.py`
2. Confirm the default path (no agent-bin dir) produces an unchanged PATH; create `$HERMES_HOME/agent-bin` and confirm it leads PATH in both the terminal-tool and cron spawn paths.

## Design notes

- **Why a separate prepend, not a change to the managed-dir ordering.** The managed runtime dirs (`~/.hermes/bin`, node, uv) are deliberately *appended* so "a tool the user deliberately put on their own PATH still wins" (25d0bcd4). `agent-bin` has the opposite intent — an operator override that must beat everything — so it gets its own opt-in slot and leaves that decision untouched.
- **Trust boundary.** Anyone who can write `$HERMES_HOME/agent-bin` can intercept every CLI the agent invokes, at higher precedence than the user's own tools. That is the same writer set as `$HERMES_HOME/bin` (already on PATH), and the slot is opt-in and empty by default, so a default install pays nothing.
- **No new config key or env var** — the dir is a fixed convention resolved via `get_hermes_home()`, so it is profile-scoped and follows the session home.

## Checklist

### Code

- [x] Conventional commit message
- [x] Searched for existing PRs (none touch PATH-level interception of agent-invoked tools)
- [x] Only changes related to this feature
- [x] Ran the focused subset via `scripts/run_tests.sh` (111 passed, 0 failed, 20 skipped)
- [x] Added tests (13)
- [x] Tested on Ubuntu (WSL2), Linux; `ruff check` clean on both files

### Documentation & Housekeeping

- [x] Docstrings carry the rationale — N/A README/docs
- [x] Cross-platform considered: Windows is a no-op passthrough (matching the sibling helpers); macOS runs the POSIX path (tests are `skipif(win32)`, not `linux_only`)
