### PR TITLE
fix(checkpoints): don't unlink safe-restore delete_targets before the checkout half succeeds

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -557,6 +557,46 @@ class TestSafeRestore:
         assert "stubborn.txt" not in result["restored_files"]
         assert result["failed_deletes"] == ["stubborn.txt"]
 
+    def test_safe_restore_does_not_delete_when_the_checkout_half_fails(
+        self, mgr, work_dir, monkeypatch,
+    ):
+        """A failed git checkout must not leave delete_targets unlinked.
+
+        The two halves of a safe restore are independent, uncoordinated
+        filesystem operations: deleting agent-created files (unlink, not
+        git-tracked) and checking out changed-but-still-present files (git
+        checkout). Deleting before confirming the checkout half succeeds means
+        a checkout failure (e.g. a concurrent checkpoint operation holding the
+        shared store's index lock) reports "Restore failed" while files have
+        already been permanently destroyed — the opposite of what a failed,
+        no-op-looking restore should mean.
+        """
+        base = self._checkpoint(mgr, work_dir)
+
+        # Lands in checkout_targets: present in the checkpoint, changed since
+        # by Hermes (must be ledger-recorded or safe_restore_plan treats it as
+        # a user edit and skips it entirely).
+        (work_dir / "main.py").write_text("agent version\n")
+        mgr.record_agent_write(str(work_dir / "main.py"))
+        # Lands in delete_targets: agent-created, absent from the checkpoint.
+        doomed = work_dir / "doomed.txt"
+        doomed.write_text("agent scratch\n")
+        mgr.record_agent_write(str(doomed))
+
+        real_run_git = _run_git
+
+        def failing_checkout(args, *a, **kw):
+            if args and args[0] == "checkout":
+                return False, "", "fatal: Unable to create '.../index.lock': File exists."
+            return real_run_git(args, *a, **kw)
+
+        monkeypatch.setattr("tools.checkpoint_manager._run_git", failing_checkout)
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is False
+        assert doomed.exists(), "safe restore deleted a file even though checkout failed"
+        assert doomed.read_text() == "agent scratch\n"
+
     def test_unsafe_restore_overwrites_everything(self, mgr, work_dir):
         base = self._checkpoint(mgr, work_dir)
         (work_dir / "main.py").write_text("agent version\n")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1182,16 +1182,6 @@ class CheckpointManager:
                     kept_oversize.append(rel)
                 else:
                     delete_targets.append(rel)
-            for rel in delete_targets:
-                try:
-                    target = Path(abs_dir) / rel
-                    if target.is_file() or target.is_symlink():
-                        target.unlink()
-                except OSError as exc:
-                    logger.warning(
-                        "Safe restore: could not remove %s: %s", rel, exc,
-                    )
-                    failed_deletes.append(rel)
             if not checkout_targets:
                 ok, stdout, err = True, "", ""
             else:
@@ -1200,6 +1190,22 @@ class CheckpointManager:
                     store, abs_dir, timeout=_GIT_TIMEOUT * 2,
                     index_file=index_file,
                 )
+            # Only delete once the checkout half is known to succeed: these
+            # unlinks are not part of the git-tracked checkout and can't be
+            # undone by retrying it, so a checkout failure must not destroy
+            # files while still reporting "Restore failed" as if nothing
+            # had happened.
+            if ok:
+                for rel in delete_targets:
+                    try:
+                        target = Path(abs_dir) / rel
+                        if target.is_file() or target.is_symlink():
+                            target.unlink()
+                    except OSError as exc:
+                        logger.warning(
+                            "Safe restore: could not remove %s: %s", rel, exc,
+                        )
+                        failed_deletes.append(rel)
         else:
             ok, stdout, err = _run_git(
                 ["checkout", commit_hash, "--", file_path if file_path else "."],


### PR DESCRIPTION
## Summary

- `CheckpointManager.restore(safe=True)` splits changed paths into `checkout_targets` (present in the checkpoint) and `delete_targets` (agent-created files absent from it), then previously unlinked every `delete_targets` path **before** attempting the `git checkout` of `checkout_targets`.
- If that checkout then failed — a concurrent checkpoint operation holding the shared store's index lock, a timeout, anything `_run_git` can return `ok=False` for — the function returned `{"success": False, "error": "Restore failed: ..."}` with no mention that files had already been permanently deleted. The user sees a failed, apparently no-op restore while agent-created files are gone, recoverable only via the pre-rollback snapshot the function takes just before this (and the error message gives no hint that's necessary).
- `checkout_targets` and `delete_targets` are disjoint by construction — every path in `restore_paths` lands in exactly one of `checkout_targets` / `delete_targets` / `kept_oversize`. So moving the delete loop to run only after a successful checkout is behaviorally identical on the success path (the two operations don't interact) and closes the silent-data-loss window on the failure path.

## Test plan

- [x] Added `test_safe_restore_does_not_delete_when_the_checkout_half_fails`, which mocks `_run_git` to fail only the `checkout` invocation, and asserts an agent-created `delete_targets` file survives (and `result["success"] is False`).
- [x] Mutation-verified: reverted the fix, confirmed the new test fails (the file is deleted even though checkout fails); reapplied the fix, confirmed it passes.
- [x] `pytest tests/tools/test_checkpoint_manager.py` — 54/54 passing, no regressions.
- [x] `pytest tests/hermes_cli/test_checkpoints_prune.py tests/agent/test_tool_executor_checkpoint_paths.py` — 4/4 passing.
- [x] `ruff check tools/checkpoint_manager.py tests/tools/test_checkpoint_manager.py` — clean.