### PR TITLE
Add native, arm64-python interpretor for Hermes on WoA

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -379,6 +379,14 @@ $script:ResolvedPathReport = @{
     install_dir       = $InstallDir
 }
 
+# Derive the real CPU arch once.  Stage-Python / Install-Venv use it to
+# prefer native ARM64 Python on Windows-on-ARM (uv defaults to the emulated
+# x64 build there -- astral-sh/uv#12906).  Get-WindowsArch is defined below;
+# PowerShell resolves function calls at runtime.  Never throws: non-Windows
+# hosts (dev sandboxes, tests) just keep the variable empty.
+$script:WindowsPythonArch = ''
+try { $script:WindowsPythonArch = Get-WindowsArch } catch { }
+
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -1110,11 +1118,45 @@ function Resolve-AvailablePythonVersion {
         if (-not $ver -or $seen.ContainsKey($ver)) { continue }
         $seen[$ver] = $true
         try {
-            $found = & $UvCmd python find $ver 2>$null
+            # Qualified request first on ARM64 hosts: uv resolves a bare
+            # "3.11" to the emulated x64 build there (astral-sh/uv#12906),
+            # which would mask an available native aarch64 interpreter.
+            $found = $null
+            if ($script:WindowsPythonArch -eq 'arm64') {
+                $found = & $UvCmd python find "$ver-aarch64" 2>$null
+            }
+            if (-not $found) {
+                $found = & $UvCmd python find $ver 2>$null
+            }
             if ($found) { return $ver }
         } catch { }
     }
     return $null
+}
+
+# Return $true when uv can provide a native ARM64 interpreter for $Ver.
+# Finds first (cheap); only downloads when nothing is installed, and only
+# reports success when the post-install find actually resolves.  The
+# x64/unqualified requests are left to the callers, so this can never
+# install an interpreter that nobody asks for.
+function Test-NativeArm64PythonAvailable {
+    param([string]$Ver)
+    try {
+        if (& $UvCmd python find "$Ver-aarch64" 2>$null) { return $true }
+    } catch { }
+
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $UvCmd python install "$Ver-aarch64" *> $null
+        $ErrorActionPreference = $prevEAP
+    } catch {
+        $ErrorActionPreference = $prevEAP
+    }
+
+    try {
+        return [bool](& $UvCmd python find "$Ver-aarch64" 2>$null)
+    } catch { return $false }
 }
 
 function Test-Python {
@@ -1122,7 +1164,17 @@ function Test-Python {
     
     # Let uv find or install Python
     try {
-        $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        $pythonPath = $null
+        $qualifiedVer = $null
+        if ($script:WindowsPythonArch -eq 'arm64') {
+            # Native ARM64 first: a bare request resolves to the emulated
+            # x64 build on Windows-on-ARM (astral-sh/uv#12906).
+            $pythonPath = & $UvCmd python find "$PythonVersion-aarch64" 2>$null
+            if ($pythonPath) { $qualifiedVer = $PythonVersion }
+        }
+        if (-not $pythonPath) {
+            $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        }
         if ($pythonPath) {
             $ver = & $pythonPath --version 2>$null
             Write-Success "Python found: $ver"
@@ -1132,6 +1184,14 @@ function Test-Python {
     
     # Python not found -- use uv to install it (no admin needed!)
     Write-Info "Python $PythonVersion not found, installing via uv..."
+    if (-not $qualifiedVer -and $script:WindowsPythonArch -eq 'arm64') {
+        if (Test-NativeArm64PythonAvailable -Ver $PythonVersion) {
+            $qualifiedVer = $PythonVersion
+        } else {
+            Write-Warn "No native ARM64 build of Python $PythonVersion; falling back to x64 (emulated)"
+        }
+    }
+    $installTarget = if ($qualifiedVer) { "$qualifiedVer-aarch64" } else { $PythonVersion }
     # Capture EAP outside the try block so the catch's restore call always
     # has a meaningful value (see Install-Uv for the full rationale).
     $prevEAP = $ErrorActionPreference
@@ -1147,13 +1207,13 @@ function Test-Python {
         # semantics or stderr noise.  This fix was previously landed as
         # commit ec1714e71 and then lost in a release squash; reapplied here.
         $ErrorActionPreference = "Continue"
-        $uvOutput = & $UvCmd python install $PythonVersion 2>&1
+        $uvOutput = & $UvCmd python install $installTarget 2>&1
         $uvExitCode = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP
 
         # Check if Python is now available (more reliable than exit code
         # since uv may return non-zero due to "already installed" etc.)
-        $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        $pythonPath = & $UvCmd python find $installTarget 2>$null
         if ($pythonPath) {
             $ver = & $pythonPath --version 2>$null
             Write-Success "Python installed: $ver"
@@ -1175,7 +1235,13 @@ function Test-Python {
     Write-Info "Trying to find any existing Python 3.10+..."
     foreach ($fallbackVer in $PythonFallbackVersions) {
         try {
-            $pythonPath = & $UvCmd python find $fallbackVer 2>$null
+            $pythonPath = $null
+            if ($script:WindowsPythonArch -eq 'arm64') {
+                $pythonPath = & $UvCmd python find "$fallbackVer-aarch64" 2>$null
+            }
+            if (-not $pythonPath) {
+                $pythonPath = & $UvCmd python find $fallbackVer 2>$null
+            }
             if ($pythonPath) {
                 $ver = & $pythonPath --version 2>$null
                 Write-Success "Found fallback: $ver"
@@ -2432,7 +2498,17 @@ function Install-Venv {
         $script:PythonVersion = $resolved
     }
 
-    Write-Info "Creating virtual environment with Python $PythonVersion..."
+    $venvPythonRequest = $PythonVersion
+    if ($script:WindowsPythonArch -eq 'arm64') {
+        # A bare request resolves to the emulated x64 build on
+        # Windows-on-ARM (astral-sh/uv#12906), so pin the native build when
+        # one exists.  Resolve-AvailablePythonVersion probes qualified
+        # requests first, so a resolved version implies the aarch64 build
+        # is available for it; Install-Venv re-resolves in its own process.
+        $venvPythonRequest = "$PythonVersion-aarch64"
+    }
+
+    Write-Info "Creating virtual environment with Python $venvPythonRequest..."
     
     Push-Location $InstallDir
 
@@ -2555,12 +2631,21 @@ function Install-Venv {
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $venvPythonRequest }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit
     # ok=true) when the venv was never created.
     $venvExitCode = $LASTEXITCODE
+    # A qualified build can be unavailable for the resolved version (e.g. 3.10
+    # has no aarch64 release, or a stale cache entry). The unqualified request
+    # still lands on the emulated x64 build, which works -- just slower.
+    if ($venvExitCode -ne 0 -and $venvPythonRequest -ne $PythonVersion) {
+        Write-Warn "Creating venv with $venvPythonRequest failed; retrying with $PythonVersion"
+        Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+        $venvExitCode = $LASTEXITCODE
+        $venvPythonRequest = $PythonVersion
+    }
     if ($venvExitCode -ne 0) {
         throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
     }
@@ -2571,6 +2656,19 @@ function Install-Venv {
     $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
     if (-not (Test-Path -LiteralPath $venvPythonExe -PathType Leaf)) {
         throw "uv reported success but venv interpreter is missing at $venvPythonExe"
+    }
+
+    # Surface an emulated interpreter instead of failing the install: uv
+    # falls back to x64 builds on Windows-on-ARM whenever the requested
+    # version has no native aarch64 build (astral-sh/uv#12906).
+    if ($script:WindowsPythonArch -eq 'arm64') {
+        $venvArch = ''
+        try {
+            $venvArch = (& $venvPythonExe -c "import platform; print(platform.machine())" 2>$null) -join ''
+        } catch { }
+        if ($venvArch -and $venvArch -notmatch 'ARM64') {
+            Write-Warn "venv interpreter is $venvArch on a $script:WindowsPythonArch host; it will run under emulation"
+        }
     }
 
     # The replacement has a working interpreter, but the transaction is only

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -379,14 +379,6 @@ $script:ResolvedPathReport = @{
     install_dir       = $InstallDir
 }
 
-# Derive the real CPU arch once.  Stage-Python / Install-Venv use it to
-# prefer native ARM64 Python on Windows-on-ARM (uv defaults to the emulated
-# x64 build there -- astral-sh/uv#12906).  Get-WindowsArch is defined below;
-# PowerShell resolves function calls at runtime.  Never throws: non-Windows
-# hosts (dev sandboxes, tests) just keep the variable empty.
-$script:WindowsPythonArch = ''
-try { $script:WindowsPythonArch = Get-WindowsArch } catch { }
-
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -462,6 +454,20 @@ function Get-WindowsArch {
             if ([Environment]::Is64BitOperatingSystem) { return "x64" } else { return "x86" }
         }
     }
+}
+
+# Derive the real CPU arch now that Get-WindowsArch is defined above.
+# (Must run AFTER the function statement: during a single top-down script
+# pass a function is only registered once its definition line executes, so a
+# call placed earlier in the file is a "command not found" that the catch
+# swallows and leaves this empty.)  Stage-Python / Install-Venv use it to
+# prefer native ARM64 Python on Windows-on-ARM, where uv defaults to the
+# emulated x64 build (astral-sh/uv#12906).  Never throws: non-Windows hosts
+# (dev sandboxes, tests) just keep the variable empty.
+$script:WindowsPythonArch = ''
+try { $script:WindowsPythonArch = Get-WindowsArch } catch { }
+if ($script:WindowsPythonArch -eq 'arm64') {
+    Write-Info "Windows-on-ARM detected; preferring native ARM64 Python"
 }
 
 # ============================================================================

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1165,15 +1165,24 @@ function Test-Python {
     # Let uv find or install Python
     try {
         $pythonPath = $null
-        $qualifiedVer = $null
+        $emulatedPath = $null
         if ($script:WindowsPythonArch -eq 'arm64') {
             # Native ARM64 first: a bare request resolves to the emulated
             # x64 build on Windows-on-ARM (astral-sh/uv#12906).
             $pythonPath = & $UvCmd python find "$PythonVersion-aarch64" 2>$null
-            if ($pythonPath) { $qualifiedVer = $PythonVersion }
         }
         if (-not $pythonPath) {
-            $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+            $found = & $UvCmd python find $PythonVersion 2>$null
+            if ($found) {
+                if ($script:WindowsPythonArch -eq 'arm64') {
+                    # An emulated interpreter alone is not a final answer on
+                    # ARM64 hosts: fall through to the install phase, which
+                    # prefers a native build when one is available.
+                    $emulatedPath = $found
+                } else {
+                    $pythonPath = $found
+                }
+            }
         }
         if ($pythonPath) {
             $ver = & $pythonPath --version 2>$null
@@ -1183,15 +1192,17 @@ function Test-Python {
     } catch { }
     
     # Python not found -- use uv to install it (no admin needed!)
+    # On ARM64 hosts an emulated interpreter found above ($emulatedPath) does
+    # not stop the install: a native build is preferred when available.
     Write-Info "Python $PythonVersion not found, installing via uv..."
-    if (-not $qualifiedVer -and $script:WindowsPythonArch -eq 'arm64') {
+    $installTarget = $PythonVersion
+    if ($script:WindowsPythonArch -eq 'arm64') {
         if (Test-NativeArm64PythonAvailable -Ver $PythonVersion) {
-            $qualifiedVer = $PythonVersion
+            $installTarget = "$PythonVersion-aarch64"
         } else {
             Write-Warn "No native ARM64 build of Python $PythonVersion; falling back to x64 (emulated)"
         }
     }
-    $installTarget = if ($qualifiedVer) { "$qualifiedVer-aarch64" } else { $PythonVersion }
     # Capture EAP outside the try block so the catch's restore call always
     # has a meaningful value (see Install-Uv for the full rationale).
     $prevEAP = $ErrorActionPreference

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2824,9 +2824,112 @@ function Restore-VenvBackup {
     }
 }
 
+function Find-OpenSslLayout {
+    # SLP layouts vary by version (flat lib\/include\ vs per-runtime
+    # lib\UCRT\<arch>\), so locate the import lib and header roots by
+    # scanning instead of assuming paths.
+    param([string]$Root)
+    if (-not (Test-Path -LiteralPath $Root)) { return $null }
+    $libFile = Get-ChildItem -LiteralPath $Root -Recurse -Filter "libssl.lib" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $libFile) { return $null }
+    $sslHeader = Get-ChildItem -LiteralPath $Root -Recurse -Filter "ssl.h" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $sslHeader) { return $null }
+    # ssl.h sits in an openssl\ subdir; its parent is the include root
+    return @{ Root = $Root; LibDir = $libFile.DirectoryName; IncludeDir = $sslHeader.Directory.Parent.FullName }
+}
+
+function Install-WoaOpenSsl {
+    # cryptography is pinned at 50.x for CVE fixes and has no win_arm64
+    # wheel (last one: 46.0.3; native builds tracked in
+    # pyca/cryptography#15350), so on Windows-on-ARM uv builds it from
+    # source and the cargo build (openssl-sys) needs a native OpenSSL on
+    # disk.  SLP's ARM SKUs are Full and Light only (no Dev); Light is
+    # runtime DLLs, so the Full build is required for headers + import
+    # libs.  Its MSI installs to C:\Program Files\OpenSSL-Win64-ARM
+    # regardless of INSTALLDIR, then we export OPENSSL_DIR (plus the
+    # lib/include roots) so the build finds it.  Drop this once 50.x
+    # ships a win_arm64 wheel.
+    # Non-fatal by design: a failure here defers to the cargo build step,
+    # which fails with its own (clear) error.
+    if ($env:OS -ne "Windows_NT" -or $script:WindowsPythonArch -ne "arm64") { return }
+
+    # Honor an existing OpenSSL: OPENSSL_DIR set by the user, a previous
+    # install of ours, or a system-wide install.  SLP's MSI ignores
+    # INSTALLDIR and defaults to C:\Program Files\OpenSSL-Win64-ARM on
+    # this arch, so that root is searched too.
+    foreach ($candidate in @($env:OPENSSL_DIR, (Join-Path $HermesHome "openssl"), "C:\Program Files\OpenSSL-Win64-ARM", "C:\Program Files\OpenSSL")) {
+        if (-not $candidate) { continue }
+        $layout = Find-OpenSslLayout -Root $candidate
+        if ($layout) {
+            $env:OPENSSL_DIR = $candidate
+            $env:OPENSSL_LIB_DIR = $layout.LibDir
+            $env:OPENSSL_INCLUDE_DIR = $layout.IncludeDir
+            Write-Info "OpenSSL found at $candidate (needed to build cryptography from source)"
+            return
+        }
+    }
+
+    $msiName = "Win64ARMOpenSSL-3_6_4.msi"
+    $downloadUrl = "https://slproweb.com/download/$msiName"
+    $expectedSha256 = "a39997d97d1255e6ac427d6d82e7367ae33fc7c6451ba0256573a5ec78a18cb2"
+    $msiDir = Join-Path $HermesHome "openssl"
+    $msiPath = "$env:TEMP\$msiName"
+
+    Write-Info "cryptography has no win_arm64 wheel; installing OpenSSL 3.6.4 (Full, ~220 MB) for the source build..."
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $msiPath -UseBasicParsing
+    } catch {
+        Write-Warn "Could not download $msiName ($downloadUrl): $($_.Exception.Message)"
+        Write-Warn "Install OpenSSL for ARM64 from https://slproweb.com/products/Win32OpenSSL.html, set OPENSSL_DIR to its folder, then re-run"
+        return
+    }
+    $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $expectedSha256) {
+        Write-Warn "SHA256 mismatch for $msiName (got $actualSha256); not installing"
+        Remove-Item -LiteralPath $msiPath -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    # SLP's MSI ignores INSTALLDIR and installs to its own default
+    # (C:\Program Files\OpenSSL-Win64-ARM on this arch); no admin rights
+    # needed in practice.  msiexec exit 3010 is success + pending reboot.
+    $proc = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -NoNewWindow -Wait -PassThru
+    if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+        Write-Warn "OpenSSL installer exited with $($proc.ExitCode). Install it manually from https://slproweb.com/products/Win32OpenSSL.html, set OPENSSL_DIR to its folder, then re-run"
+        Remove-Item -LiteralPath $msiPath -Force -ErrorAction SilentlyContinue
+        return
+    }
+    Remove-Item -LiteralPath $msiPath -Force -ErrorAction SilentlyContinue
+    if ($proc.ExitCode -eq 3010) {
+        Write-Warn "OpenSSL installed; a reboot is pending before it will work"
+    }
+
+    # The MSI installs to its own default root; search the likely ones.
+    $layout = $null
+    $searchRoots = @("C:\Program Files\OpenSSL-Win64-ARM", "C:\Program Files\OpenSSL", (Join-Path $HermesHome "openssl"), (Join-Path $env:LOCALAPPDATA "Program Files\OpenSSL"))
+    foreach ($root in $searchRoots) {
+        if (-not $root) { continue }
+        $layout = Find-OpenSslLayout -Root $root
+        if ($layout) { $msiDir = $root; break }
+    }
+    if (-not $layout) {
+        Write-Warn "OpenSSL installed but libssl.lib / ssl.h could not be located (searched: $($searchRoots -join ', ')); the cryptography build will still fail until a usable OpenSSL is on disk (list with: Get-ChildItem -Recurse <install dir>)"
+        return
+    }
+    $env:OPENSSL_DIR = $msiDir
+    $env:OPENSSL_LIB_DIR = $layout.LibDir
+    $env:OPENSSL_INCLUDE_DIR = $layout.IncludeDir
+    Write-Success "OpenSSL ready at $msiDir (lib: $($layout.LibDir), include: $($layout.IncludeDir))"
+}
+
 function Install-Dependencies {
     Write-Info "Installing dependencies..."
-    
+
+    # WoA: cryptography's source build needs OPENSSL_DIR in THIS process.
+    # Stages can run as separate powershell.exe invocations, so an export
+    # from an earlier stage would not reach uv's build environment.
+    Install-WoaOpenSsl
+
     Push-Location $InstallDir
     
     if (-not $NoVenv) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -457,18 +457,21 @@ function Get-WindowsArch {
 }
 
 # Derive the real CPU arch now that Get-WindowsArch is defined above.
-# (Must run AFTER the function statement: during a single top-down script
+# (Must run AFTER the function statements: during a single top-down script
 # pass a function is only registered once its definition line executes, so a
 # call placed earlier in the file is a "command not found" that the catch
 # swallows and leaves this empty.)  Stage-Python / Install-Venv use it to
 # prefer native ARM64 Python on Windows-on-ARM, where uv defaults to the
 # emulated x64 build (astral-sh/uv#12906).  Never throws: non-Windows hosts
 # (dev sandboxes, tests) just keep the variable empty.
-$script:WindowsPythonArch = ''
-try { $script:WindowsPythonArch = Get-WindowsArch } catch { }
-if ($script:WindowsPythonArch -eq 'arm64') {
-    Write-Info "Windows-on-ARM detected; preferring native ARM64 Python"
+function Resolve-WindowsPythonArch {
+    $script:WindowsPythonArch = ''
+    try { $script:WindowsPythonArch = Get-WindowsArch } catch { }
+    if ($script:WindowsPythonArch -eq 'arm64') {
+        Write-Info "Windows-on-ARM detected; preferring native ARM64 Python"
+    }
 }
+$script:WindowsPythonArch = ''
 
 # ============================================================================
 
@@ -4918,6 +4921,8 @@ function Main {
 # structured JSON error frame instead of a bare exception.
 
 try {
+    # After all function definitions are registered, so Stage-* can use it.
+    Resolve-WindowsPythonArch
     if ($Ensure -ne "") {
         if ($PSBoundParameters.ContainsKey("Stage")) {
             Write-Err "Cannot use -Ensure and -Stage simultaneously"


### PR DESCRIPTION
## What does this PR do?

Replaces x64-based emulation with native arm64-based Hermes (by virtue of being a python package and changing the interpretor). Arm64-native builds will give better performance compared to emulated counterparts.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #95569

## Type of Change

<!-- Check the one that applies. -->

- [x] 🚀  Performance improvement (native is better than emulated)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

Concrete changes made to `install.ps1`

1. Explicitly install2 python aarch64 on windows-on-arm systems in uv. This is favored over setting UV_PYTHON=arm64 to make it isolated to hermes: https://github.com/astral-sh/uv/issues/12906#issuecomment-3587439179
2. cryptography needs to be build from scratch (no [arm64-packages for WoA published since 46.0.3](https://github.com/pyca/cryptography/pull/15350)). cryptography requires OPENSLL, and thus this needs to be installed. I didn't investigate if there is a slimmer alternative available than installing from https://slproweb.com/products/Win32OpenSSL.html

Not sure if/how these will translate to good dev UX, but end-users should be fine

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Execute install.ps1 on WoA system
2. Inspect python.exe when invoking hermes


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Arm64<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="757" height="60" alt="image" src="https://github.com/user-attachments/assets/d7040a66-419c-4f4a-b62a-44367736d4b0" />
