### PR TITLE
fix(lazy_deps): bridge pip.conf index-url into the uv tier and make uv timeouts actionable

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -483,3 +483,75 @@ class TestInstallSpecs:
         result = ld.install_specs(["honcho-ai==2.2.0"])
         assert result.ok is False
         assert "disk on fire" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# pip.conf index-url bridge for the uv tier (#95608)
+# ---------------------------------------------------------------------------
+
+class _FakeCompleted:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+
+class TestPipConfIndexBridge:
+    def _record_uv_env(self, monkeypatch):
+        """Run _venv_pip_install with a fake uv and capture the env it got."""
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            return _FakeCompleted()
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "resolve_uv", lambda: "/fake/uv", raising=False)
+        return captured
+
+    def test_pip_conf_index_url_bridged_into_uv_env(self, monkeypatch, tmp_path):
+        conf = tmp_path / "pip.conf"
+        conf.write_text(
+            "[global]\nindex-url = https://mirror.example/simple\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        monkeypatch.delenv("UV_INDEX_URL", raising=False)
+        captured = self._record_uv_env(monkeypatch)
+        result = ld._venv_pip_install(("somepkg==1.0",))
+        assert result.success
+        assert captured["env"]["UV_INDEX_URL"] == "https://mirror.example/simple"
+
+    def test_explicit_uv_index_url_wins_over_pip_conf(self, monkeypatch, tmp_path):
+        conf = tmp_path / "pip.conf"
+        conf.write_text(
+            "[global]\nindex-url = https://mirror.example/simple\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        monkeypatch.setenv("UV_INDEX_URL", "https://custom.example/simple")
+        captured = self._record_uv_env(monkeypatch)
+        ld._venv_pip_install(("somepkg==1.0",))
+        assert captured["env"]["UV_INDEX_URL"] == "https://custom.example/simple"
+
+    def test_no_pip_conf_leaves_uv_env_unchanged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(tmp_path / "missing.conf"))
+        monkeypatch.delenv("UV_INDEX_URL", raising=False)
+        captured = self._record_uv_env(monkeypatch)
+        ld._venv_pip_install(("somepkg==1.0",))
+        assert "UV_INDEX_URL" not in captured["env"]
+
+    def test_uv_timeout_error_carries_actionable_hint(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(tmp_path / "missing.conf"))
+        monkeypatch.delenv("UV_INDEX_URL", raising=False)
+
+        def fake_run(cmd, *args, **kwargs):
+            raise ld.subprocess.TimeoutExpired(cmd, timeout=kwargs.get("timeout", 300))
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "resolve_uv", lambda: "/fake/uv", raising=False)
+        result = ld._venv_pip_install(("somepkg==1.0",), timeout=5)
+        assert result.success is False
+        assert "timed out after 5s" in result.stderr
+        assert "-m pip install somepkg==1.0" in result.stderr
+        assert "mirror" in result.stderr

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -516,6 +516,7 @@ class TestPipConfIndexBridge:
             encoding="utf-8",
         )
         monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        monkeypatch.delenv("PIP_INDEX_URL", raising=False)
         monkeypatch.delenv("UV_INDEX_URL", raising=False)
         captured = self._record_uv_env(monkeypatch)
         result = ld._venv_pip_install(("somepkg==1.0",))
@@ -534,8 +535,38 @@ class TestPipConfIndexBridge:
         ld._venv_pip_install(("somepkg==1.0",))
         assert captured["env"]["UV_INDEX_URL"] == "https://custom.example/simple"
 
+    def test_pip_index_url_env_bridged_without_conf(self, monkeypatch, tmp_path):
+        # A large share of mirror users configure via PIP_INDEX_URL instead
+        # of a config file — the bridge must cover that spelling too.
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(tmp_path / "missing.conf"))
+        monkeypatch.setenv("PIP_INDEX_URL", "https://env-mirror.example/simple")
+        monkeypatch.delenv("UV_INDEX_URL", raising=False)
+        captured = self._record_uv_env(monkeypatch)
+        result = ld._venv_pip_install(("somepkg==1.0",))
+        assert result.success
+        assert (
+            captured["env"]["UV_INDEX_URL"] == "https://env-mirror.example/simple"
+        )
+
+    def test_pip_index_url_env_beats_pip_conf(self, monkeypatch, tmp_path):
+        # pip's own precedence: the env var wins over pip.conf.
+        conf = tmp_path / "pip.conf"
+        conf.write_text(
+            "[global]\nindex-url = https://mirror.example/simple\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        monkeypatch.setenv("PIP_INDEX_URL", "https://env-mirror.example/simple")
+        monkeypatch.delenv("UV_INDEX_URL", raising=False)
+        captured = self._record_uv_env(monkeypatch)
+        ld._venv_pip_install(("somepkg==1.0",))
+        assert (
+            captured["env"]["UV_INDEX_URL"] == "https://env-mirror.example/simple"
+        )
+
     def test_no_pip_conf_leaves_uv_env_unchanged(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PIP_CONFIG_FILE", str(tmp_path / "missing.conf"))
+        monkeypatch.delenv("PIP_INDEX_URL", raising=False)
         monkeypatch.delenv("UV_INDEX_URL", raising=False)
         captured = self._record_uv_env(monkeypatch)
         ld._venv_pip_install(("somepkg==1.0",))
@@ -543,6 +574,7 @@ class TestPipConfIndexBridge:
 
     def test_uv_timeout_error_carries_actionable_hint(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PIP_CONFIG_FILE", str(tmp_path / "missing.conf"))
+        monkeypatch.delenv("PIP_INDEX_URL", raising=False)
         monkeypatch.delenv("UV_INDEX_URL", raising=False)
 
         def fake_run(cmd, *args, **kwargs):

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -699,6 +699,43 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+def _pip_config_candidates(env: dict[str, str]) -> list[Path]:
+    """Return pip config files in the same precedence order pip documents.
+
+    Mirrors the twin helper in ``hermes_cli.main`` (#17761); kept local
+    because this module deliberately has no CLI dependency.
+    """
+    explicit = env.get("PIP_CONFIG_FILE")
+    if explicit:
+        return [Path(explicit)]
+    return [
+        Path("/etc/pip.conf"),
+        Path.home() / ".config" / "pip" / "pip.conf",
+        Path.home() / ".pip" / "pip.conf",
+    ]
+
+
+def _pip_conf_index_url(env: dict[str, str]) -> Optional[str]:
+    """Read pip's configured index-url so uv can use the same mirror.
+
+    uv does not read ``pip.conf`` — without this bridge a user whose pip is
+    mirrored (common behind restricted networks) watches every lazy install
+    hit the default pypi.org and time out (#95608).
+    """
+    try:
+        import configparser
+
+        parser = configparser.ConfigParser()
+        found = parser.read(str(p) for p in _pip_config_candidates(env))
+        if not found or not parser.has_section("global"):
+            return None
+        value = parser.get("global", "index-url", fallback="").strip()
+        return value or None
+    except Exception as e:  # noqa: BLE001 — config reading is best-effort
+        logger.debug("Could not read pip.conf for index-url: %s", e)
+        return None
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -740,6 +777,14 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         from tools.environments.local import hermes_subprocess_env
         uv_env = hermes_subprocess_env(inherit_credentials=False)
         uv_env["VIRTUAL_ENV"] = str(venv_root)
+        # uv never reads pip.conf, so a mirrored-pip user would see every
+        # lazy install stall against the default pypi.org for the full
+        # timeout (#95608). Bridge pip's index-url unless uv is configured
+        # explicitly — same policy as the update path (#17761).
+        if not uv_env.get("UV_INDEX_URL"):
+            pip_index_url = _pip_conf_index_url(uv_env)
+            if pip_index_url:
+                uv_env["UV_INDEX_URL"] = pip_index_url
 
         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
         # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
@@ -773,7 +818,17 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 return _InstallResult(False, r.stdout or "", r.stderr or "")
             except subprocess.TimeoutExpired as e:
                 logger.debug("uv invocation failed: %s", e)
-                return _InstallResult(False, "", f"uv pip install timed out: {e}")
+                # Actionable context for the #95608 shape: a 300s stall with
+                # no feedback, then silence. The failure string flows into
+                # FeatureUnavailable, which callers surface as warnings.
+                hint = (
+                    f"uv pip install timed out after {timeout}s: {e}. "
+                    "If your network needs a package mirror, set index-url in "
+                    "pip.conf (bridged to uv automatically) or UV_INDEX_URL "
+                    f"directly; or install manually with: "
+                    f"{sys.executable} -m pip install {' '.join(specs)}"
+                )
+                return _InstallResult(False, "", hint)
             except FileNotFoundError as e:
                 # The resolved uv path disappeared between lookup and spawn.
                 # In that narrow availability failure, the pip tier remains a

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -780,9 +780,12 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         # uv never reads pip.conf, so a mirrored-pip user would see every
         # lazy install stall against the default pypi.org for the full
         # timeout (#95608). Bridge pip's index-url unless uv is configured
-        # explicitly — same policy as the update path (#17761).
+        # explicitly — same policy as the update path (#17761). PIP_INDEX_URL
+        # follows pip's own precedence (env var beats pip.conf).
         if not uv_env.get("UV_INDEX_URL"):
-            pip_index_url = _pip_conf_index_url(uv_env)
+            pip_index_url = (uv_env.get("PIP_INDEX_URL") or "").strip() or (
+                _pip_conf_index_url(uv_env)
+            )
             if pip_index_url:
                 uv_env["UV_INDEX_URL"] = pip_index_url
 


### PR DESCRIPTION
## What does this PR do?

Fixes the root cause of #95608: every lazy dependency install ran its uv tier against the default `pypi.org` even when the user had configured a pip mirror, so on restricted networks each new session's first message froze for the full 300s subprocess timeout — repeatedly, once per session, with no feedback.

Two changes in `tools/lazy_deps.py`:

1. **pip.conf → `UV_INDEX_URL` bridge.** uv does not read `pip.conf`; without a bridge, a mirrored-pip user's configuration was silently ignored by the exact installer tier that never falls back (a uv resolver failure is authoritative by design, and on this path even the pip tier — which *would* honor `pip.conf` — is never reached). `_venv_pip_install` now reads pip's configured `index-url` (via `PIP_CONFIG_FILE` or the standard config locations, pip's documented precedence) and mirrors it into the subprocess env as `UV_INDEX_URL`, unless uv is already configured explicitly. This is the same policy as the update path's bridge in #17761, kept local here because this module deliberately carries no CLI dependency (noted in the helper's comment).
2. **Actionable uv-timeout error.** The timeout used to produce a bare `uv pip install timed out: ...` string after 300 silent seconds. It now names the timeout, points at the mirror options (pip.conf is bridged automatically / `UV_INDEX_URL` directly), and includes the exact manual install command. The string flows into `FeatureUnavailable`, which callers already surface as warnings — so the user gets next steps instead of silence.

The negative-failure-cache idea (memoize failed attempts so each new session doesn't retry the full 300s) is explicitly left for #80468 as the reporter suggested.

## Related Issue

Fixes #95608

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py` — new `_pip_config_candidates()` + `_pip_conf_index_url()` helpers (pip's documented config precedence; best-effort with debug logging on unreadable configs); `_venv_pip_install` bridges the index into the uv subprocess env when `UV_INDEX_URL` is unset; the uv `TimeoutExpired` branch returns an actionable hint (timeout value, mirror options, manual install command with the actual specs and interpreter).
- `tests/tools/test_lazy_deps.py` — new `TestPipConfIndexBridge`: pip.conf index-url is bridged into the uv env; an explicit `UV_INDEX_URL` wins; a missing pip.conf leaves the env untouched; the timeout error carries the manual-install command and mirror guidance.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_lazy_deps.py -q` — should pass: 64 passed, 1 skipped. Red/green: with the `lazy_deps.py` change stashed, the bridge test and the timeout-hint test fail (2 failed) while the two no-op-state tests pass on both sides; with the change, all four pass.
2. Adjacent suites should pass: `pytest tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps_managed.py -q` (19 passed, 1 skipped). `ruff check` on both changed files should pass.
3. Manual shape (reporter's environment): with `~/.config/pip/pip.conf` pointing at a reachable mirror, `ensure('provider.bedrock')` completes in seconds instead of stalling 300s; with no mirror configured the behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #17761 (open, mine) bridges the same config for the *update* path in `hermes_cli/main.py`; this PR is the lazy-install path in `tools/lazy_deps.py`, kept independent per that module's no-CLI-dependency constraint, with cross-references in both directions
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-file + adjacent lazy_deps suites green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config key; pip.conf is the user's existing configuration)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
