### PR TITLE
feat(models): GLM-5.3-Flash selectable on OpenRouter and Nous Portal

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -117,6 +117,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("minimax/minimax-m3",                     ""),
     # Z-AI
     ("z-ai/glm-5.3",                           ""),
+    ("z-ai/glm-5.3-flash",                     ""),
     ("z-ai/glm-5.2",                           "default"),
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
@@ -294,6 +295,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "minimax/minimax-m3",
         # Z-AI
         "z-ai/glm-5.3",
+        "z-ai/glm-5.3-flash",
         "z-ai/glm-5.2",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-26T13:57:32Z",
+  "updated_at": "2026-08-26T14:32:05Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -118,6 +118,10 @@
         },
         {
           "id": "z-ai/glm-5.3",
+          "description": ""
+        },
+        {
+          "id": "z-ai/glm-5.3-flash",
           "description": ""
         },
         {
@@ -263,6 +267,9 @@
         },
         {
           "id": "z-ai/glm-5.3"
+        },
+        {
+          "id": "z-ai/glm-5.3-flash"
         },
         {
           "id": "z-ai/glm-5.2",


### PR DESCRIPTION
## Summary
`z-ai/glm-5.3-flash` is now selectable in the OpenRouter and Nous Portal model pickers.

## Changes
- `hermes_cli/models.py`: added to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`, slotted below `glm-5.3`, above `glm-5.2` (newest-first family ordering)
- `website/static/api/model-catalog.json`: regenerated (openrouter 43, nous 32)

Scoped to the two named providers. Verified skips (no new metadata needed): context resolves via the existing `glm-5.3` fuzzy key to 1,048,576 — matches OpenRouter live metadata (`max_completion_tokens` 131,072); both routes bill via `official_models_api` so no pricing snapshot; no GLM entries exist in `reasoning_timeouts.py` (matches siblings).

## Validation
| | Result |
|---|---|
| OpenRouter live /v1/models | serves z-ai/glm-5.3-flash (ctx 1,048,576, $0.075/M in, $0.25/M out) |
| Both pickers | entry present, correct position, no dupes |
| test_models / test_model_catalog / test_gmi_provider / test_usage_pricing | 163 passed |

## Infographic

![GLM-5.3-Flash added to catalogs](https://v3b.fal.media/files/b/0aa7e5b6/SBRN3wcCLqSzhY31zp80S_LbNkv8Vn.png)
